### PR TITLE
DOCS-6382 Remove trailing-backslash hard breaks in maxscale

### DIFF
--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-about-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-about-mariadb-maxscale.md
@@ -1,48 +1,48 @@
 # About MariaDB MaxScale
 
-**MariaDB MaxScale** is a database proxy that forwards database statements to\
+**MariaDB MaxScale** is a database proxy that forwards database statements to
 one or more database servers.
 
-The forwarding is performed using rules based on the semantic understanding of\
-the database statements and on the roles of the servers within the backend\
+The forwarding is performed using rules based on the semantic understanding of
+the database statements and on the roles of the servers within the backend
 cluster of databases.
 
-MariaDB MaxScale is designed to provide, transparently to applications, load\
-balancing and high availability functionality. MariaDB MaxScale has a scalable\
-and flexible architecture, with plugin components to support different protocols\
+MariaDB MaxScale is designed to provide, transparently to applications, load
+balancing and high availability functionality. MariaDB MaxScale has a scalable
+and flexible architecture, with plugin components to support different protocols
 and routing approaches.
 
 MariaDB MaxScale makes extensive use of the asynchronous I/O capabilities of the\
-Linux operating system, combined with a fixed number of worker threads. _epoll_\
-is used to provide the event driven framework for the input and output via\
+Linux operating system, combined with a fixed number of worker threads. _epoll_
+is used to provide the event driven framework for the input and output via
 sockets.
 
-Many of the services provided by MariaDB MaxScale are implemented as external\
-shared object modules loaded at runtime. These modules support a fixed\
-interface, communicating the entry points via a structure consisting of a set of\
-function pointers. This structure is called the "module object". Additional\
+Many of the services provided by MariaDB MaxScale are implemented as external
+shared object modules loaded at runtime. These modules support a fixed
+interface, communicating the entry points via a structure consisting of a set of
+function pointers. This structure is called the "module object". Additional
 modules can be created to work with MariaDB MaxScale.
 
-Commonly used module types are _protocol_, _router_ and _filter_. Protocol\
-modules implement the communication between clients and MariaDB MaxScale, and\
-between MariaDB MaxScale and backend servers. Routers inspect the queries from\
-clients and decide the target backend. The decisions are usually based on\
-routing rules and backend server status. Filters work on data as it passes\
-through MariaDB MaxScale. Filter are often used for logging queries or modifying\
+Commonly used module types are _protocol_, _router_ and _filter_. Protocol
+modules implement the communication between clients and MariaDB MaxScale, and
+between MariaDB MaxScale and backend servers. Routers inspect the queries from
+clients and decide the target backend. The decisions are usually based on
+routing rules and backend server status. Filters work on data as it passes
+through MariaDB MaxScale. Filter are often used for logging queries or modifying
 server responses.
 
-A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,\
+A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,
 issues and communicate with the MariaDB MaxScale community. Send email to [maxscale@googlegroups.com](mailto:maxscale@googlegroups.com) or use the [forum](https://groups.google.com/forum/#!forum/maxscale) interface.
 
 Bugs can be reported in the MariaDB Jira [jira.mariadb.org](https://jira.mariadb.org)
 
 ### Installing MariaDB MaxScale
 
-Information about installing MariaDB MaxScale, either from a repository or by\
+Information about installing MariaDB MaxScale, either from a repository or by
 building from source code, is included in the [MariaDB MaxScale Installation\
 Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-installation-guide.md).
 
-The same guide also provides basic information on running MariaDB MaxScale. More\
+The same guide also provides basic information on running MariaDB MaxScale. More
 detailed information about configuring MariaDB MaxScale can be found in the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale.md
@@ -1,42 +1,42 @@
 # Limitations and Known Issues within MariaDB MaxScale
 
-This document lists known issues and limitations in MariaDB MaxScale and its\
-plugins. Since limitations are related to specific plugins, this document is\
+This document lists known issues and limitations in MariaDB MaxScale and its
+plugins. Since limitations are related to specific plugins, this document is
 divided into several sections.
 
 ### Configuration limitations
 
-In versions 2.1.2 and earlier, the configuration files are limited to 1024\
+In versions 2.1.2 and earlier, the configuration files are limited to 1024
 characters per line. This limitation was increased to 16384 characters in\
 MaxScale 2.1.3. MaxScale 2.3.0 increased this limit to 16777216 characters.
 
-In versions 2.2.12 and earlier, the section names in the configuration files\
-were limited to 49 characters. This limitation was increased to 1023 characters\
+In versions 2.2.12 and earlier, the section names in the configuration files
+were limited to 49 characters. This limitation was increased to 1023 characters
 in MaxScale 2.2.13.
 
 #### Multiple MaxScales on same server
 
-Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to\
-the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale\
-instances to listen on the same network port if the directories used by both\
-instances are completely separate and there are no conflicts which can cause\
-unexpected splitting of connections. This will only happen if users explicitly\
-tell MaxScale to ignore the default directories and will not happen in normal\
+Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to
+the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale
+instances to listen on the same network port if the directories used by both
+instances are completely separate and there are no conflicts which can cause
+unexpected splitting of connections. This will only happen if users explicitly
+tell MaxScale to ignore the default directories and will not happen in normal
 use.
 
 ### Security limitations
 
 #### MariaDB 10.2
 
-The parser of MaxScale correctly parses `WITH` statements, but fails to\
+The parser of MaxScale correctly parses `WITH` statements, but fails to
 collect columns, functions and tables used in the `SELECT` defining the`WITH` clause.
 
-Consequently, the database firewall will **not** block `WITH` statements\
+Consequently, the database firewall will **not** block `WITH` statements
 where the `SELECT` of the `WITH` clause refers to forbidden columns.
 
 ### MariaDB Default Values
 
-MaxScale assumes that certain configuration parameters in MariaDB are set to\
+MaxScale assumes that certain configuration parameters in MariaDB are set to
 their default values. These include but are not limited to:
 
 * `autocommit`: Autocommit is enabled for all new connections.
@@ -44,21 +44,21 @@ their default values. These include but are not limited to:
 
 ### Query Classification
 
-Follow the [MXS-1350](https://jira.mariadb.org/browse/MXS-1350) Jira issue\
+Follow the [MXS-1350](https://jira.mariadb.org/browse/MXS-1350) Jira issue
 to track the progress on this limitation.
 
-XA transactions are not detected as transactions by MaxScale. This means\
-that all XA commands will be treated as unknown commands and will be\
-treated as operations that potentially modify the database (in the case of\
+XA transactions are not detected as transactions by MaxScale. This means
+that all XA commands will be treated as unknown commands and will be
+treated as operations that potentially modify the database (in the case of
 readwritesplit, the statements are routed to the master).
 
 MaxScale **will not** track the XA transaction state which means that any\
-SELECT queries done inside an XA transaction can be routed to servers that\
+SELECT queries done inside an XA transaction can be routed to servers that
 are not part of the XA transaction.
 
-This limitation can be avoided on the client side by disabling autocommit\
-before any XA transactions are done. The following example shows how a\
-simple XA transaction is done via MaxScale by disabling autocommit for the\
+This limitation can be avoided on the client side by disabling autocommit
+before any XA transactions are done. The following example shows how a
+simple XA transaction is done via MaxScale by disabling autocommit for the
 duration of the XA transaction.
 
 ```
@@ -73,16 +73,16 @@ SET autocommit=1;
 
 ### Prepared Statements
 
-For its proper functioning, MaxScale needs in general to be aware of the\
-transaction state and _autocommit_ mode. In order to be that, MaxScale\
+For its proper functioning, MaxScale needs in general to be aware of the
+transaction state and _autocommit_ mode. In order to be that, MaxScale
 parses statements going through it.
 
-However, if a transaction is committed or rolled back, or the autocommit\
-mode is changed using a prepared statement, MaxScale will miss that and its\
-internal state will be incorrect, until the transaction state or autocommit\
+However, if a transaction is committed or rolled back, or the autocommit
+mode is changed using a prepared statement, MaxScale will miss that and its
+internal state will be incorrect, until the transaction state or autocommit
 mode is changed using an explicit statement.
 
-For instance, after the following sequence of commands, MaxScale will still\
+For instance, after the following sequence of commands, MaxScale will still
 think _autocommit_ is on:
 
 ```
@@ -91,7 +91,7 @@ PREPARE hide_autocommit FROM "set autocommit=0"
 EXECUTE hide_autocommit
 ```
 
-To ensure that MaxScale functions properly, do not commit or rollback a\
+To ensure that MaxScale functions properly, do not commit or rollback a
 transaction or change the autocommit mode using a prepared statement.
 
 ### Protocol limitations
@@ -99,70 +99,70 @@ transaction or change the autocommit mode using a prepared statement.
 #### Limitations with MySQL/MariaDB Protocol support (MariaDBClient)
 
 * Compression is not included in the server handshake.
-* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept\
-  it. If the ID matches a MaxScale session ID, it will be closed by sending\
-  modified `KILL` commands of the same type to all backend server to which the\
-  session in question is connected to. This results in behavior that is similar\
-  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,\
+* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept
+  it. If the ID matches a MaxScale session ID, it will be closed by sending
+  modified `KILL` commands of the same type to all backend server to which the
+  session in question is connected to. This results in behavior that is similar
+  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,
   all connections with a matching username will be closed instead.
-* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type\
-  statements. If a query by a query ID is to be killed, it needs to be done\
+* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type
+  statements. If a query by a query ID is to be killed, it needs to be done
   directly on the backend databases.
 * Any `KILL` commands executed using a prepared statement are ignored by\
-  MaxScale. If any are executed, it is highly likely that the wrong connection\
+  MaxScale. If any are executed, it is highly likely that the wrong connection
   ends up being killed.
-* If a `KILL` connection kills a session that is connected to a readwritesplit\
-  service that has `transaction_replay` or `delayed_retry` enabled, it is\
-  possible that the query is retried even if the connection is killed. To avoid\
+* If a `KILL` connection kills a session that is connected to a readwritesplit
+  service that has `transaction_replay` or `delayed_retry` enabled, it is
+  possible that the query is retried even if the connection is killed. To avoid
   this, use `KILL QUERY` instead.
-* A `KILL` on one service can cause a connection from another service to be\
+* A `KILL` on one service can cause a connection from another service to be
   closed even if it uses a different protocol.
-* The change user command (COM\_CHANGE\_USER) only works with standard\
+* The change user command (COM\_CHANGE\_USER) only works with standard
   authentication.
-* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session\
-  ends up in an inconsistent state. This can happen if the password of the\
-  target user is changed and MaxScale uses old user account data when processing\
-  the change user. In such a situation, MaxScale and server will disagree on the\
+* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session
+  ends up in an inconsistent state. This can happen if the password of the
+  target user is changed and MaxScale uses old user account data when processing
+  the change user. In such a situation, MaxScale and server will disagree on the
   current user. This can affect e.g. reconnections.
 
 ### Authenticator limitations
 
 #### Limitations in the MySQL authenticator (MariaDBAuth)
 
-* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use\
+* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use
   a new authentication protocol which does not support pre-4.1 style passwords.
 * When users have different passwords based on the host from which they connect\
-  MariaDB MaxScale is unable to determine which password it should use to connect\
-  to the backend database. This results in failed connections and unusable\
+  MariaDB MaxScale is unable to determine which password it should use to connect
+  to the backend database. This results in failed connections and unusable
   usernames in MariaDB MaxScale.
 
 ### Filter limitations
 
 #### Database Firewall limitations (dbfwfilter)
 
-The Database Firewall filter does not support multi-statements. Using them will\
+The Database Firewall filter does not support multi-statements. Using them will
 result in an error being sent to the client.
 
 #### Tee filter limitations (tee)
 
-The Tee filter does not support binary protocol prepared statements. The\
-execution of a prepared statements through a service that uses the tee filter is\
-not guaranteed to succeed on the service where the filter branches to as it does\
+The Tee filter does not support binary protocol prepared statements. The
+execution of a prepared statements through a service that uses the tee filter is
+not guaranteed to succeed on the service where the filter branches to as it does
 on the original service.
 
-This possibility exists due to the fact that the binary protocol prepared\
-statements are identified by a server-generated ID. The ID sent to the client\
-from the main service is not guaranteed to be the same that is sent by the\
+This possibility exists due to the fact that the binary protocol prepared
+statements are identified by a server-generated ID. The ID sent to the client
+from the main service is not guaranteed to be the same that is sent by the
 branch service.
 
 ### Monitor limitations
 
-A server can only be monitored by one monitor. Two or more monitors monitoring\
+A server can only be monitored by one monitor. Two or more monitors monitoring
 the same server is considered an error.
 
 #### Limitations with Galera Cluster Monitoring (galeramon)
 
-The default master selection is based only on MIN(wsrep\_local\_index). This\
+The default master selection is based only on MIN(wsrep\_local\_index). This
 can be influenced with the server priority mechanic described in the [Galera Monitor](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-galera-monitor.md) manual.
 
 ### Router limitations

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-authentication-modules.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-authentication-modules.md
@@ -3,45 +3,45 @@
 This document describes general MySQL protocol authentication in MaxScale. For\
 REST-api authentication, see the [configuration guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) and the [REST-api guide](../mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-rest-api.md).
 
-Similar to the MariaDB Server, MaxScale uses authentication plugins to implement\
-different authentication schemes for incoming clients. The same plugins also\
-handle authenticating the clients to backend servers. The authentication plugins\
+Similar to the MariaDB Server, MaxScale uses authentication plugins to implement
+different authentication schemes for incoming clients. The same plugins also
+handle authenticating the clients to backend servers. The authentication plugins
 available in MaxScale are [standard MySQL password](mariadb-maxscale-2106-maxscale-2106-mariadbmysql-authenticator.md),[GSSAPI](mariadb-maxscale-2106-maxscale-2106-gssapi-client-authenticator.md) and [pluggable authentication modules (PAM)](mariadb-maxscale-2106-maxscale-2106-pam-authenticator.md).
 
-Most of the authentication processing is performed on the protocol level, before\
-handing it over to one of the plugins. This shared part is described in this\
+Most of the authentication processing is performed on the protocol level, before
+handing it over to one of the plugins. This shared part is described in this
 document. For information on an individual plugin, see its documentation.
 
 ### User account management
 
-Every MaxScale service with a MariaDB protocol listener requires knowledge of\
-the user accounts defined on the backend databases. The service maintains this\
+Every MaxScale service with a MariaDB protocol listener requires knowledge of
+the user accounts defined on the backend databases. The service maintains this
 information in an internal component called the _user account manager_ (UAM).\
-The UAM queries relevant data from the _mysql_-database of the backends and\
-stores it. Typically, only the current master server is queried, as all servers\
-are assumed to have the same users. The service settings _user_ and _password_\
+The UAM queries relevant data from the _mysql_-database of the backends and
+stores it. Typically, only the current master server is queried, as all servers
+are assumed to have the same users. The service settings _user_ and _password_
 define the credentials used when fetching user accounts.
 
-The service uses the stored data when authenticating clients, checking their\
-passwords and database access rights. This results in an authentication process\
-very similar to the MariaDB Server itself. Unauthorized users are generally\
-detected already at the MaxScale level instead of the backend servers. This may\
+The service uses the stored data when authenticating clients, checking their
+passwords and database access rights. This results in an authentication process
+very similar to the MariaDB Server itself. Unauthorized users are generally
+detected already at the MaxScale level instead of the backend servers. This may
 not apply in some cases, for example if MaxScale is using old user account data.
 
-If authentication fails, the UAM updates its data from a backend. MaxScale may\
-attempt authenticating the client again with the refreshed data without\
-communicating the first failure to the client. This transparent user data update\
+If authentication fails, the UAM updates its data from a backend. MaxScale may
+attempt authenticating the client again with the refreshed data without
+communicating the first failure to the client. This transparent user data update
 does not always work, in which case the client should try to log in again.
 
-As the UAM is shared between all listeners of a service, its settings are\
-defined in the service configuration. For more information, search the [configuration guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
-for _users\_refresh\_time_, _users\_refresh\_interval_ and_auth\_all\_servers_. Other settings which affect how the UAM connects to backends\
-are the global settings _auth\_connect\_timeout_ and _local\_address_, and\
+As the UAM is shared between all listeners of a service, its settings are
+defined in the service configuration. For more information, search the [configuration guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
+for _users\_refresh\_time_, _users\_refresh\_interval_ and_auth\_all\_servers_. Other settings which affect how the UAM connects to backends
+are the global settings _auth\_connect\_timeout_ and _local\_address_, and
 the various server-level ssl-settings.
 
 #### Required grants
 
-To properly fetch user account information, the MaxScale service user must be\
+To properly fetch user account information, the MaxScale service user must be
 able to read from various tables in the _mysql_-database: _user_, _db_,_tables\_priv_, _columns\_priv_, _procs\_priv_, _proxies\_priv_ and _roles\_mapping_.\
 The user should also have the _SHOW DATABASES_-grant.
 
@@ -66,23 +66,23 @@ GRANT ALL ON infinidb_vtable.* TO 'maxscale'@'maxscalehost';
 ### Limitations and troubleshooting
 
 When a client logs in to MaxScale, MaxScale sees the client's IP address. When\
-MaxScale then connects the client to backends (using the client's username and\
+MaxScale then connects the client to backends (using the client's username and
 password), the backends see the connection coming from the IP address of\
-MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this\
-is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),\
+MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this
+is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),
 authentication to backends will fail.
 
 There are two primary ways to deal with this:
 
-1. Duplicate user accounts. For every user account with a restricted hostname an\
+1. Duplicate user accounts. For every user account with a restricted hostname an
    equivalent user account for MaxScale is added (`'alice'@'maxscale-ip'`).
 2. Use [proxy protocol](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
 
-Option 1 limits the passwords for user accounts with shared usernames. Such\
+Option 1 limits the passwords for user accounts with shared usernames. Such
 accounts must use the same password since they will effectively share the\
 MaxScale-to-backend user account. Option 2 requires server support.
 
-See [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)\
+See [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 for additional information on how to solve authentication issues.
 
 #### Wildcard database grants
@@ -90,14 +90,14 @@ for additional information on how to solve authentication issues.
 MaxScale supports wildcards `_` and `%` for database-level grants. As with\
 MariaDB Server, `grant select on test_.* to 'alice'@'%';` gives access to _test\__ as well as _test1_, _test2_ and so on. If the GRANT command escapes the
 wildcard (`grant select on` test\_`.* to 'alice'@'%';`) both MaxScale and the\
-MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`\
+MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`
 are only interpreted as wildcards when the grant is to a database:`grant select on` test\_`.t1 to 'alice'@'%';` only grants access to the_test\_.t1_-table, not to _test1.t1_.
 
 ### Authenticator options
 
-The listener configuration defines authentication options which only affect the\
-listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an\
-individual authentication plugin or the authentication as a whole. The latter\
+The listener configuration defines authentication options which only affect the
+listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an
+individual authentication plugin or the authentication as a whole. The latter
 are explained below. Multiple options can be given as a comma-separated list.
 
 ```
@@ -111,20 +111,20 @@ authenticator_options=skip_authentication=true,lower_case_table_names=1
 * Dynamic: No
 * Default: `false`
 
-If enabled, MaxScale will not check the\
+If enabled, MaxScale will not check the
 passwords of incoming clients and just assumes that they are correct.\
-Wrong passwords are instead detected when MaxScale tries to authenticate to the\
+Wrong passwords are instead detected when MaxScale tries to authenticate to the
 backend servers.
 
-This setting is mainly meant for failure tolerance in situations where the\
-password check is performed outside of MaxScale. If, for example, MaxScale\
-cannot use an LDAP-server but the backend databases can, enabling this setting\
-allows clients to log in. Even with this setting enabled, a user account\
+This setting is mainly meant for failure tolerance in situations where the
+password check is performed outside of MaxScale. If, for example, MaxScale
+cannot use an LDAP-server but the backend databases can, enabling this setting
+allows clients to log in. Even with this setting enabled, a user account
 matching the incoming client username and IP must exist on the backends for\
 MaxScale to accept the client.
 
 This setting is incompatible with standard MariaDB/MySQL authentication plugin\
-(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to\
+(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to
 backend servers using standard authentication.
 
 ```
@@ -138,12 +138,12 @@ authenticator_options=skip_authentication=true
 * Dynamic: No
 * Default: `true`
 
-If disabled, MaxScale does not require that a\
+If disabled, MaxScale does not require that a
 valid user account entry for incoming clients exists on the backends.\
-Specifically, only the client username needs to match a user account,\
+Specifically, only the client username needs to match a user account,
 hostname/IP is ignored.
 
-This setting may be used to force clients to connect through MaxScale. Normally,\
+This setting may be used to force clients to connect through MaxScale. Normally,
 creating the user _jdoe@%_ will allow the user _jdoe_ to connect from any\
 IP-address. By disabling _match\_host_ and replacing the user with _jdoe@maxscale-IP_, the user can still connect from any client IP but will be
 forced to go through MaxScale.
@@ -159,29 +159,29 @@ authenticator_options=match_host=false
 * Dynamic: No
 * Default: `0`
 
-Controls database name matching for authentication\
-when an incoming client logs in to a non-empty database. The setting functions\
-similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)\
+Controls database name matching for authentication
+when an incoming client logs in to a non-empty database. The setting functions
+similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)
 and should be set to the value used by the backends.
 
 The setting accepts the values 0, 1 or 2:
 
 * `0`: case-sensitive matching (default)
-* `1`: convert the requested database name to lower case before using case-insensitive\
+* `1`: convert the requested database name to lower case before using case-insensitive
   matching. Assumes that database names on the server are stored in lower case.
 * `2`: use case-insensitive matching.
 
-_true_ and _false_ are also accepted for backwards compatibility. These map to 1\
+_true_ and _false_ are also accepted for backwards compatibility. These map to 1
 and 0, respectively.
 
-The identifier names are converted using an ASCII-only function. This means that\
+The identifier names are converted using an ASCII-only function. This means that
 non-ASCII characters will retain their case-sensitivity.
 
-Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior\
-of `lower_case_table_names=1` is identical with how the MariaDB server\
-behaves. In older releases the comparisons were done in a case-sensitive manner\
-after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes\
-it a safe alternative to use when a mix of older and newer MaxScale versions is\
+Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior
+of `lower_case_table_names=1` is identical with how the MariaDB server
+behaves. In older releases the comparisons were done in a case-sensitive manner
+after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes
+it a safe alternative to use when a mix of older and newer MaxScale versions is
 being used.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-gssapi-client-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-gssapi-client-authenticator.md
@@ -1,24 +1,24 @@
 # MaxScale 21.06 GSSAPI Client Authenticator
 
-GSSAPI is an authentication protocol that is commonly implemented with Kerberos\
-on Unix or Active Directory on Windows. This document describes GSSAPI\
+GSSAPI is an authentication protocol that is commonly implemented with Kerberos
+on Unix or Active Directory on Windows. This document describes GSSAPI
 authentication in MaxScale. The authentication module name in MaxScale is_GSSAPIAuth_.
 
 ### Preparing the GSSAPI system
 
-For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short\
+For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short
 guide on how to set up Kerberos for MaxScale.
 
-The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB\
-documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)\
+The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB
+documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)
 is a good example on how to set it up.
 
-The next step is to copy the keytab file from the server where MariaDB is\
-installed to the server where MaxScale is located. The keytab file must be\
-placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an\
+The next step is to copy the keytab file from the server where MariaDB is
+installed to the server where MaxScale is located. The keytab file must be
+placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an
 authenticator option.
 
-The location of the keytab file can be changed with the KRB5\_KTNAME environment\
+The location of the keytab file can be changed with the KRB5\_KTNAME environment
 variable: [keytab\_def.html](https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html)
 
 To take GSSAPI authentication into use, add the following to the listener.
@@ -39,10 +39,10 @@ The principal name should be the same as on the MariaDB servers.
 * Dynamic: No
 * Default: `mariadb/localhost.localdomain`
 
-The service principal name to send to the client. This parameter is a string\
+The service principal name to send to the client. This parameter is a string
 parameter which is used by the client to request the token.
 
-This parameter _must_ be the same as the principal name that the backend MariaDB\
+This parameter _must_ be the same as the principal name that the backend MariaDB
 server uses.
 
 #### `gssapi_keytab_path`
@@ -52,10 +52,10 @@ server uses.
 * Dynamic: No
 * Default: Kerberos Default
 
-Keytab file location. This should be an absolute path to the file containing the\
-keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that\
+Keytab file location. This should be an absolute path to the file containing the
+keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that
 multiple listeners with GSSAPIAuth will override each other. If using multiple\
-GSSAPI authenticators, either do not set this option or use the same value for\
+GSSAPI authenticators, either do not set this option or use the same value for
 all listeners.
 
 ```
@@ -64,23 +64,23 @@ authenticator_options=principal_name=mymariadb@EXAMPLE.COM,gssapi_keytab_path=/h
 
 ### Implementation details
 
-Read the [Authentication Modules](mariadb-maxscale-2106-maxscale-2106-authentication-modules.md) document for more\
+Read the [Authentication Modules](mariadb-maxscale-2106-maxscale-2106-authentication-modules.md) document for more
 details on how authentication modules work in MaxScale.
 
 #### GSSAPI authentication
 
-The GSSAPI plugin authentication starts when the database server sends the\
-service principal name in the AuthSwitchRequest packet. The principal name will\
+The GSSAPI plugin authentication starts when the database server sends the
+service principal name in the AuthSwitchRequest packet. The principal name will
 usually be in the form `service@REALM.COM`.
 
-The client searches its local cache for a token for the service or may request\
-it from the GSSAPI server. If found, the client sends the token to the database\
-server. The database server verifies the authenticity of the token using its\
+The client searches its local cache for a token for the service or may request
+it from the GSSAPI server. If found, the client sends the token to the database
+server. The database server verifies the authenticity of the token using its
 keytab file and sends the final OK packet to the client.
 
 ### Building the module
 
-The GSSAPI authenticator modules require the GSSAPI development libraries\
+The GSSAPI authenticator modules require the GSSAPI development libraries
 (krb5-devel on CentOS 7).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-mariadbmysql-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-mariadbmysql-authenticator.md
@@ -1,12 +1,12 @@
 # MaxScale 21.06 MariaDB/MySQL Authenticator
 
-The _MariaDBAuth_-module implements the client and backend authentication for the\
-server plugin _mysql\_native\_password_. This is the default authentication\
+The _MariaDBAuth_-module implements the client and backend authentication for the
+server plugin _mysql\_native\_password_. This is the default authentication
 plugin used by both MariaDB and MySQL.
 
 ### Authenticator options
 
-The following settings may be given in the _authenticator\_options_ of the\
+The following settings may be given in the _authenticator\_options_ of the
 listener.
 
 #### `log_password_mismatch`
@@ -16,10 +16,10 @@ listener.
 * Dynamic: No
 * Default: `false`
 
-The service setting _log\_auth\_warnings_ must\
-also be enabled for this setting to have effect. When both settings are enabled,\
-password hashes are logged if a client gives a wrong password. This feature may\
-be useful when diagnosing authentication issues. It should only be enabled on a\
+The service setting _log\_auth\_warnings_ must
+also be enabled for this setting to have effect. When both settings are enabled,
+password hashes are logged if a client gives a wrong password. This feature may
+be useful when diagnosing authentication issues. It should only be enabled on a
 secure system as the logging of password hashes may be a security risk.
 
 #### `cache_dir`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-pam-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-pam-authenticator.md
@@ -1,15 +1,15 @@
 # MaxScale 21.06 PAM Authenticator
 
 Pluggable authentication module (PAM) is a general purpose authentication API.\
-An application using PAM can authenticate a user without knowledge about the\
-underlying authentication implementation. The actual authentication scheme is\
-defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be\
-quite elaborate. MaxScale supports a very limited form of the PAM protocol,\
+An application using PAM can authenticate a user without knowledge about the
+underlying authentication implementation. The actual authentication scheme is
+defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be
+quite elaborate. MaxScale supports a very limited form of the PAM protocol,
 which this document details.
 
 ### Configuration
 
-The MaxScale PAM module requires little configuration. All that is required\
+The MaxScale PAM module requires little configuration. All that is required
 is to change the listener authenticator module to "PAMAuth".
 
 ```
@@ -25,14 +25,14 @@ address=123.456.789.10
 port=12345
 ```
 
-MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_\
-set to "pam" in the _mysql.user_-table. The PAM service name of a user is read\
-from the _authetication\_string_-column. The matching PAM service in the\
-operating system PAM config is used for authenticating the user. If the\_authetication\_string\_ for a user is empty, the fallback service "mysql" is\
+MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_
+set to "pam" in the _mysql.user_-table. The PAM service name of a user is read
+from the _authetication\_string_-column. The matching PAM service in the
+operating system PAM config is used for authenticating the user. If the\_authetication\_string\_ for a user is empty, the fallback service "mysql" is
 used.
 
-PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)\
-for more information. A simple service definition used for testing this module\
+PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)
+for more information. A simple service definition used for testing this module
 is below.
 
 ```
@@ -48,8 +48,8 @@ account         required        pam_unix.so
 * Default: `false`
 
 If enabled, MaxScale communicates with the client as if using [mysql\_clear\_password](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/1-connecting/connection#mysql_clear_password-plugin).\
-This setting has no effect on MaxScale-to-backend communication, which adapts to\
-either "dialog" or "mysql\_clear\_password", depending on which one the backend\
+This setting has no effect on MaxScale-to-backend communication, which adapts to
+either "dialog" or "mysql\_clear\_password", depending on which one the backend
 suggests. This setting is meant to be used with the similarly named MariaDB\
 Server setting.
 
@@ -74,11 +74,11 @@ This setting defines the authentication mode used. Two values are supported:
 authenticator_options=pam_mode=password_2FA
 ```
 
-If set to "password\_2FA", any users authenticating via PAM will be asked two\
-passwords ("Password" and "Verification code") during login. MaxScale uses the\
+If set to "password\_2FA", any users authenticating via PAM will be asked two
+passwords ("Password" and "Verification code") during login. MaxScale uses the
 normal password when either the local PAM api or a backend asks for "Password".\
-MaxScale answers any other password prompt (e.g. "Verification code") with the\
-second password. See [the limitations section](mariadb-maxscale-2106-maxscale-2106-pam-authenticator.md#implementation-details-and-limitations)\
+MaxScale answers any other password prompt (e.g. "Verification code") with the
+second password. See [the limitations section](mariadb-maxscale-2106-maxscale-2106-pam-authenticator.md#implementation-details-and-limitations)
 for more details. Two-factor mode is incompatible with\_pam\_use\_cleartext\_plugin\_.
 
 #### `pam_backend_mapping`
@@ -89,7 +89,7 @@ for more details. Two-factor mode is incompatible with\_pam\_use\_cleartext\_plu
 * Values: `none`, `mariadb`
 * Default: `none`
 
-Defines backend authentication mapping, i.e. switch of authentication method\
+Defines backend authentication mapping, i.e. switch of authentication method
 between client-to-MaxScale and MaxScale-to-backend. Supported values:
 
 * `none` No mapping
@@ -99,28 +99,28 @@ between client-to-MaxScale and MaxScale-to-backend. Supported values:
 authenticator_options=pam_backend_mapping=mariadb
 ```
 
-If set to "mariadb", MaxScale will authenticate clients to backends using\
+If set to "mariadb", MaxScale will authenticate clients to backends using
 standard MariaDB authentication. Authentication to MaxScale itself still uses\
-PAM. MaxScale asks the local PAM system if the client username was mapped\
-to another username during authentication, and use the mapped username when\
-logging in to backends. Passwords for the mapped users can be given in a file,\
-see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to\
-authenticate without a password. Because of this, normal PAM users and mapped\
+PAM. MaxScale asks the local PAM system if the client username was mapped
+to another username during authentication, and use the mapped username when
+logging in to backends. Passwords for the mapped users can be given in a file,
+see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to
+authenticate without a password. Because of this, normal PAM users and mapped
 users cannot be used on the same listener.
 
-Because the client still needs to authenticate to MaxScale normally, an\
-anonymous user may be required. If the backends do not allow such a user, one\
+Because the client still needs to authenticate to MaxScale normally, an
+anonymous user may be required. If the backends do not allow such a user, one
 can be manually added using the service setting [user\_accounts\_file](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
 
-To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be\
-installed separately. It is included in recent MariaDB Server packages and can\
-also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)\
-for more information on how to configure the module. If the goal is to only map\
-users from PAM to MariaDB in MaxScale, then configuring user mapping\
+To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be
+installed separately. It is included in recent MariaDB Server packages and can
+also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)
+for more information on how to configure the module. If the goal is to only map
+users from PAM to MariaDB in MaxScale, then configuring user mapping
 on just the machine running MaxScale is enough.
 
-Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md),\
-as it is easier to configure. `pam_backend_mapping` should only be used when\
+Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md),
+as it is easier to configure. `pam_backend_mapping` should only be used when
 the user mapping needs to be defined by pam.
 
 #### `pam_mapped_pw_file`
@@ -130,19 +130,19 @@ the user mapping needs to be defined by pam.
 * Dynamic: No
 * Default: None
 
-Path to a json-text file with user passwords. Default value is empty, which\
+Path to a json-text file with user passwords. Default value is empty, which
 disables the feature.
 
 ```
 authenticator_options=pam_mapped_pw_file=/home/root/passwords.json,pam_backend_mapping=mariadb
 ```
 
-This feature only works together with `pam_backend_mapping=mariadb`. The file is\
-only read during listener creation (typically MaxScale start) or when a listener\
-is modified during runtime. The file should contain passwords for the mapped\
-users. When a client is authenticating, MaxScale searches the password data for a\
-matching username. If one is found, MaxScale uses the supplied password when\
-logging in to backends. Otherwise, MaxScale tries to authenticate without a\
+This feature only works together with `pam_backend_mapping=mariadb`. The file is
+only read during listener creation (typically MaxScale start) or when a listener
+is modified during runtime. The file should contain passwords for the mapped
+users. When a client is authenticating, MaxScale searches the password data for a
+matching username. If one is found, MaxScale uses the supplied password when
+logging in to backends. Otherwise, MaxScale tries to authenticate without a
 password.
 
 One array, "users\_and\_passwords", is read from the file. Each array element in the array must define the following fields:
@@ -169,105 +169,105 @@ An example file is below.
 
 ### Anonymous user mapping
 
-When backend authenticator mapping is not in use\
-(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator\
+When backend authenticator mapping is not in use
+(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator
 supports a limited version of [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
 It requires less configuration but is also less accurate than proper mapping.\
 Anonymous mapping is enabled in MaxScale if the following user exists:
 
 * Empty username (e.g. `''@'%'` or `''@'myhost.com'`)
 * `plugin = 'pam'`
-* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one\
+* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one
   row with `GRANT PROXY ON ...`)
 
-When the authenticator detects such users, anonymous account mapping is enabled\
-for the hosts of the anonymous users. To verify this, enable the info log\
-(`log_info=1` in MaxScale config file). When a client is logging in using the\
-anonymous user account, MaxScale will log a message starting with "Found\
+When the authenticator detects such users, anonymous account mapping is enabled
+for the hosts of the anonymous users. To verify this, enable the info log
+(`log_info=1` in MaxScale config file). When a client is logging in using the
+anonymous user account, MaxScale will log a message starting with "Found
 matching anonymous user ...".
 
-When mapping is on, the MaxScale PAM authenticator does not require client\
-accounts to exist in the `mysql.user`-table received from the backend. MaxScale\
-only requires that the hostname of the incoming client matches the host field of\
-one of the anonymous users (comparison performed using `LIKE`). If a match is\
-found, MaxScale attempts to authenticate the client to the local machine with\
-the username and password supplied. The PAM service used for authentication is\
-read from the `authentication_string`-field of the anonymous user. If\
-authentication was successful, MaxScale then uses the username and password to\
+When mapping is on, the MaxScale PAM authenticator does not require client
+accounts to exist in the `mysql.user`-table received from the backend. MaxScale
+only requires that the hostname of the incoming client matches the host field of
+one of the anonymous users (comparison performed using `LIKE`). If a match is
+found, MaxScale attempts to authenticate the client to the local machine with
+the username and password supplied. The PAM service used for authentication is
+read from the `authentication_string`-field of the anonymous user. If
+authentication was successful, MaxScale then uses the username and password to
 log to the backends.
 
-Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2106-maxscale-2106-pam-authenticator.md#configuration). This means,\
-that if a user is found and the authentication fails, anonymous authentication\
-is not attempted even when it could use a different PAM service with a different\
+Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2106-maxscale-2106-pam-authenticator.md#configuration). This means,
+that if a user is found and the authentication fails, anonymous authentication
+is not attempted even when it could use a different PAM service with a different
 outcome.
 
-Setting up PAM group mapping for the MariaDB server is a more involved process\
+Setting up PAM group mapping for the MariaDB server is a more involved process
 as the server requires details on which Unix user or group is mapped to which\
-MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)\
-for more details. Performing all the steps in the guide also on the MaxScale\
-machine is not required, as the MaxScale PAM plugin only checks that the client\
-host matches an anonymous user and that the client (with the username and\
-password it provided) can log into the local PAM configuration. If using normal\
-password authentication, simply generating the Unix user and password should be\
+MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)
+for more details. Performing all the steps in the guide also on the MaxScale
+machine is not required, as the MaxScale PAM plugin only checks that the client
+host matches an anonymous user and that the client (with the username and
+password it provided) can log into the local PAM configuration. If using normal
+password authentication, simply generating the Unix user and password should be
 enough.
 
 ### Implementation details and limitations
 
 The general PAM authentication scheme is difficult for a proxy such as MaxScale.\
-An application using the PAM interface needs to define a _conversation function_\
-to allow the OS PAM modules to communicate with the client, possibly exchanging\
-multiple messages. This works when a client logs in to a normal server, but not\
+An application using the PAM interface needs to define a _conversation function_
+to allow the OS PAM modules to communicate with the client, possibly exchanging
+multiple messages. This works when a client logs in to a normal server, but not
 with MaxScale since it needs to autonomously log into multiple backends. For\
-MaxScale to successfully log into the servers, the messages and answers need to\
-be predefined. The passwords given to MaxScale need to work as is when MaxScale\
+MaxScale to successfully log into the servers, the messages and answers need to
+be predefined. The passwords given to MaxScale need to work as is when MaxScale
 logs into the backends. This requirement prevents the use of one-time passwords.
 
-The MaxScale PAM authentication module supports two password modes. In normal\
+The MaxScale PAM authentication module supports two password modes. In normal
 mode, client authentication begins with MaxScale sending an\
-AuthSwitchRequest packet. In addition to the command, the packet contains the\
-client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)\
-and the message "Password: ". In the next packet, the client should send the\
-password, which MaxScale will forward to the PAM api running on the local\
-machine. If the password is correct, an OK packet is sent to the client. If the\
-local PAM api asks for additional credentials as is typical in two-factor\
-authentication schemes, authentication fails. Informational messages such as\
-password expiration notifications are allowed. These are simply printed to the\
+AuthSwitchRequest packet. In addition to the command, the packet contains the
+client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)
+and the message "Password: ". In the next packet, the client should send the
+password, which MaxScale will forward to the PAM api running on the local
+machine. If the password is correct, an OK packet is sent to the client. If the
+local PAM api asks for additional credentials as is typical in two-factor
+authentication schemes, authentication fails. Informational messages such as
+password expiration notifications are allowed. These are simply printed to the
 log.
 
-On the backend side, MaxScale expects the servers to act as MaxScale did towards\
-the client. The servers should send an AuthSwitchRequest packet as defined\
-above, MaxScale responds with the password received by the client authenticator\
-and finally backend replies with OK. Informational messages from backends are\
+On the backend side, MaxScale expects the servers to act as MaxScale did towards
+the client. The servers should send an AuthSwitchRequest packet as defined
+above, MaxScale responds with the password received by the client authenticator
+and finally backend replies with OK. Informational messages from backends are
 only printed to the info-log.
 
 #### Two-factor authentication support
 
-MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the\
-client to log in to the local PAM api as well as all the backends, the code must\
-be reusable. This prevents the use of any kind of centrally checked one-use\
-codes. Time-based codes work, assuming the backends are checking the codes\
+MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the
+client to log in to the local PAM api as well as all the backends, the code must
+be reusable. This prevents the use of any kind of centrally checked one-use
+codes. Time-based codes work, assuming the backends are checking the codes
 independently of each other. Automatic reconnection features (e.g.\
-readwritesplit-router) will not work, as the code has likely changed since\
+readwritesplit-router) will not work, as the code has likely changed since
 original authentication.
 
-Optionally, the PAM configuration on the backend servers can be weakened such\
-that the servers only asks for the normal password. This way, MaxScale will\
-check the 2FA-code of the incoming client, while MaxScale logs into the backends\
+Optionally, the PAM configuration on the backend servers can be weakened such
+that the servers only asks for the normal password. This way, MaxScale will
+check the 2FA-code of the incoming client, while MaxScale logs into the backends
 using only the password.
 
-Due to technical reasons, MaxScale does not forward the password prompts from\
+Due to technical reasons, MaxScale does not forward the password prompts from
 the PAM api to the client. MaxScale will always ask for "Password" and\
-"Verification code", even if the PAM api asks for other items. This prevents the\
+"Verification code", even if the PAM api asks for other items. This prevents the
 use of authentication schemes where a specific question must be answered (e.g.\
-"Input code Nr. 5"). This is not a significant limitation, as such schemes would\
+"Input code Nr. 5"). This is not a significant limitation, as such schemes would
 not work with backend servers anyway.
 
 ### Test tool
 
-MaxScale binary directory contains the _test\_pam\_login_-executable. This simple\
-program asks for a username, password and PAM service and then uses the given\
-credentials to login to the given service. _test\_pam\_login_ uses the same code\
-as MaxScale itself to communicate with the OS PAM interface and may be useful\
+MaxScale binary directory contains the _test\_pam\_login_-executable. This simple
+program asks for a username, password and PAM service and then uses the given
+credentials to login to the given service. _test\_pam\_login_ uses the same code
+as MaxScale itself to communicate with the OS PAM interface and may be useful
 for diagnosing PAM login issues.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-connectors/mariadb-maxscale-2106-maxscale-2106-maxscale-cdc-connector.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-connectors/mariadb-maxscale-2106-maxscale-2106-maxscale-cdc-connector.md
@@ -4,29 +4,29 @@ The C++ connector for the [MariaDB MaxScale](https://mariadb.com/products/techno
 
 ### Usage
 
-The CDC connector is a single-file connector which allows it to be relatively\
+The CDC connector is a single-file connector which allows it to be relatively
 easily embedded into existing applications.
 
-To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
+To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
 and install the `maxscale-cdc-connector` package.
 
 ### API Overview
 
-A CDC connection object is prepared by instantiating the `CDC::Connection`\
-class. To create the actual connection, call the `CDC::Connection::connect`\
+A CDC connection object is prepared by instantiating the `CDC::Connection`
+class. To create the actual connection, call the `CDC::Connection::connect`
 method of the class.
 
-After the connection has been created, call the `CDC::Connection::read` method\
-to get a row of data. The `CDC::Row::length` method tells how many values a row\
-has and `CDC::Row::value` is used to access that value. The field name of a\
-value can be extracted with the `CDC::Row::key` method and the current GTID of a\
+After the connection has been created, call the `CDC::Connection::read` method
+to get a row of data. The `CDC::Row::length` method tells how many values a row
+has and `CDC::Row::value` is used to access that value. The field name of a
+value can be extracted with the `CDC::Row::key` method and the current GTID of a
 row of data is retrieved with the `CDC::Row::gtid` method.
 
 To close the connection, destroy the instantiated object.
 
 ### Examples
 
-The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)\
+The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)
 that demonstrates basic usage of the MaxScale CDC Connector.
 
 ### Dependencies
@@ -65,7 +65,7 @@ sudo zypper install -y libjansson-devel openssl-devel cmake make gcc-c++ git
 
 ### Building and Packaging
 
-To build and package the connector as a library, follow MaxScale build\
+To build and package the connector as a library, follow MaxScale build
 instructions with the exception of adding `-DTARGET_COMPONENT=devel` to the\
 CMake call.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-design-documents/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-plugin-development-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-design-documents/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-plugin-development-guide.md
@@ -1,91 +1,91 @@
 # MariaDB MaxScale Plugin Development Guide
 
-This document and the attached example code explain prospective plugin\
-developers the MariaDB MaxScale plugin API and also present and explain some\
-best practices and possible pitfalls in module development. We predict that_filters_ and _routers_ are the module types developers are most likely to work\
+This document and the attached example code explain prospective plugin
+developers the MariaDB MaxScale plugin API and also present and explain some
+best practices and possible pitfalls in module development. We predict that_filters_ and _routers_ are the module types developers are most likely to work
 on, so the APIs of these two are discussed in detail.
 
 ### Introduction
 
-MariaDB MaxScale is designed to be an extensible program. Much, if not most, of\
-the actual processing is done by plugin modules. Plugins receive network data,\
-process it and relay it to its destination. The MaxScale core loads plugins,\
-manages client sessions and threads and, most importantly, offers a selection of\
-functions for the plugins to call upon. This collection of functions is called\
+MariaDB MaxScale is designed to be an extensible program. Much, if not most, of
+the actual processing is done by plugin modules. Plugins receive network data,
+process it and relay it to its destination. The MaxScale core loads plugins,
+manages client sessions and threads and, most importantly, offers a selection of
+functions for the plugins to call upon. This collection of functions is called
 the _MaxScale Public Interface_ or just **MPI** for short.
 
-The plugin modules are shared libraries (.so-files) implementing a set of\
-interface functions, the plugin API. Different plugin types have different APIs,\
-although there are similarities. The MPI is a set of C and C++ header files,\
-from which the module code includes the ones required. MariaDB MaxScale is\
-written in C/C++ and the plugin API is in pure C. Although it is possible\
-to write plugins in any language capable of exposing a C interface and\
-dynamically binding to the core program, in this document we assume plugin\
+The plugin modules are shared libraries (.so-files) implementing a set of
+interface functions, the plugin API. Different plugin types have different APIs,
+although there are similarities. The MPI is a set of C and C++ header files,
+from which the module code includes the ones required. MariaDB MaxScale is
+written in C/C++ and the plugin API is in pure C. Although it is possible
+to write plugins in any language capable of exposing a C interface and
+dynamically binding to the core program, in this document we assume plugin
 modules are written in C++.
 
 The _RoundRobinRouter_ is a practical example of a simple router plugin. The\
 RoundRobinRouter is compiled, installed and ran in [section\
-5.1](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-plugin-development-guide.md#hands-on-example:-roundrobinrouter). The source for the router is located\
+5.1](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-plugin-development-guide.md#hands-on-example:-roundrobinrouter). The source for the router is located
 in the `examples`-folder.
 
 ### Module categories
 
-This section lists all the module types and summarises their core tasks. The\
+This section lists all the module types and summarises their core tasks. The
 modules are listed in the order a client packet would typically travel through.\
-For more information about a particular module type, see the corresponding\
-folder in `MaxScale/Documentation/`, located in the main MariaDB MaxScale\
+For more information about a particular module type, see the corresponding
+folder in `MaxScale/Documentation/`, located in the main MariaDB MaxScale
 repository.
 
 **Protocol** modules implement I/O between clients and MaxScale, and between\
-MaxScale and backend servers. Protocol modules read and write to socket\
-descriptors using raw I/O functions provided by the MPI, and implement\
+MaxScale and backend servers. Protocol modules read and write to socket
+descriptors using raw I/O functions provided by the MPI, and implement
 protocol-specific I/O functions to be used through a common interface. The\
-Protocol module API is defined in `protocol.h`. Currently, the only implemented\
+Protocol module API is defined in `protocol.h`. Currently, the only implemented
 database protocol is _MySQL_.
 
-**Authenticator** modules retrieve user account information from the backend\
+**Authenticator** modules retrieve user account information from the backend
 databases, store it and use it to authenticate connecting clients. MariaDB\
-MaxScale includes authenticators for MySQL (normal and GSSApi). The\
+MaxScale includes authenticators for MySQL (normal and GSSApi). The
 authenticator API is defined in `authenticator.h`.
 
-**Filter** modules process data from clients before routing. A data buffer may\
-travel through multiple filters before arriving in a router. For a data buffer\
-going from a backend to the client, the router receives it first and the\
-filters receive it in reverse order. MaxScale includes a healthly selection of\
+**Filter** modules process data from clients before routing. A data buffer may
+travel through multiple filters before arriving in a router. For a data buffer
+going from a backend to the client, the router receives it first and the
+filters receive it in reverse order. MaxScale includes a healthly selection of
 filters ranging from logging, overwriting query data and caching. The filter\
 API is defined in `filter.h`.
 
-**Router** modules route packets from the last filter in the filter chain to\
-backends and reply data from backends to the last filter. The routing decisions\
-may be based on a variety of conditions; typically packet contents and backend\
-status are the most significant factors. Routers are often used for load\
+**Router** modules route packets from the last filter in the filter chain to
+backends and reply data from backends to the last filter. The routing decisions
+may be based on a variety of conditions; typically packet contents and backend
+status are the most significant factors. Routers are often used for load
 balancing, dividing clients and even individual queries between backends.\
-Routers use protocol functions to write to backends, making them somewhat\
+Routers use protocol functions to write to backends, making them somewhat
 protocol-agnostic. The router API is defined in `router.h`.
 
-**Monitor** modules do not process data flowing through MariaDB MaxScale, but\
-support the other modules in their operation by updating the status of the\
-backend servers. Monitors are ran in their own threads to minimize\
-interference to the worker threads. They periodically connect to all their\
+**Monitor** modules do not process data flowing through MariaDB MaxScale, but
+support the other modules in their operation by updating the status of the
+backend servers. Monitors are ran in their own threads to minimize
+interference to the worker threads. They periodically connect to all their
 assigned backends, query their status and write the results in global structs.\
 The monitor API is defined in `monitor.h`.
 
 ### Common definitions and headers
 
-Generally, most type definitions, macros and functions exposed by the MPI to be\
-used by modules are prefixed with **MXS**. This should avoid name collisions\
+Generally, most type definitions, macros and functions exposed by the MPI to be
+used by modules are prefixed with **MXS**. This should avoid name collisions
 in the case a module includes many symbols from the MPI.
 
 Every compilation unit in a module should begin with `#define MXS_MODULE_NAME "<name>"`. This definition will be used by log macros for clarity, prepending`<name>` to every log message. Next, the module should`#include <maxscale/cppdefs.h>` (for C++) or `#include <maxscale/cdefs.h>` (for\
-C). These headers contain compilation environment dependent definitions and\
-global constants, and include some generally useful headers. Including one of\
+C). These headers contain compilation environment dependent definitions and
+global constants, and include some generally useful headers. Including one of
 them first in every source file enables later global redefinitions across all\
-MaxScale modules. If your module is composed of multiple source files, the above\
-should be placed to a common header file included in the beginning of the source\
-files. The file with the module API definition should also include the header\
+MaxScale modules. If your module is composed of multiple source files, the above
+should be placed to a common header file included in the beginning of the source
+files. The file with the module API definition should also include the header
 for the module type, e.g. `filter.h`.
 
-Other common MPI header files required by most modules are listed in the table\
+Other common MPI header files required by most modules are listed in the table
 below.
 
 | Header       | Contents                            |
@@ -103,73 +103,73 @@ below.
 
 #### Module information container
 
-A module must implement the `MXS_CREATE_MODULE()`-function, which returns a\
-pointer to a `MXS_MODULE`-structure. This function is called by the module\
-loader during program startup. `MXS_MODULE` (type defined in `modinfo.h`)\
-contains function pointers to further module entrypoints, miscellaneous\
-information about the module and the configuration parameters accepted by the\
-module. This function must be exported without C++ name mangling, so in C++ code\
+A module must implement the `MXS_CREATE_MODULE()`-function, which returns a
+pointer to a `MXS_MODULE`-structure. This function is called by the module
+loader during program startup. `MXS_MODULE` (type defined in `modinfo.h`)
+contains function pointers to further module entrypoints, miscellaneous
+information about the module and the configuration parameters accepted by the
+module. This function must be exported without C++ name mangling, so in C++ code
 it should be defined `extern "C"`.
 
-The information container describes the module in general and is constructed\
-once during program execution. A module may have multiple _instances_ with\
-different values for configuration parameters. For example, a filter module can\
-be used with two different configurations in different services (or even in the\
-same service). In this case the loader uses the same module information\
+The information container describes the module in general and is constructed
+once during program execution. A module may have multiple _instances_ with
+different values for configuration parameters. For example, a filter module can
+be used with two different configurations in different services (or even in the
+same service). In this case the loader uses the same module information
 container for both but creates two module instances.
 
 The MariaDB MaxScale configuration file `maxscale.cnf` is parsed by the core.\
-The core also checks that all the defined parameters are of the correct type for\
-the module. For this, the `MXS_MODULE`-structure includes a list of parameters\
-accepted by the module, defining parameter names, types and default values. In\
-the actual module code, parameter values should be extracted using functions\
+The core also checks that all the defined parameters are of the correct type for
+the module. For this, the `MXS_MODULE`-structure includes a list of parameters
+accepted by the module, defining parameter names, types and default values. In
+the actual module code, parameter values should be extracted using functions
 defined in `config.h`.
 
 ### Module API
 
 #### Overview
 
-This section explains some general concepts encountered when implementing a\
-module API. For more detailed information, see the module specific subsection,\
+This section explains some general concepts encountered when implementing a
+module API. For more detailed information, see the module specific subsection,
 header files or the doxygen documentation.
 
-Modules with configuration data define an _INSTANCE_ object, which is created by\
-the module code in a `createInstance`-function or equivalent. The instance\
-creation function is called during MaxScale startup, usually when creating\
-services. MaxScale core holds the module instance data in the`SERVICE`-structure (or other higher level construct) and gives it as a\
-parameter when calling functions from the module in question. The instance\
-structure should contain all non-client-specific information required by the\
-functions of the module. The core does not know what the object contains (since\
-it is defined by the module itself), nor will it modify the pointer or the\
+Modules with configuration data define an _INSTANCE_ object, which is created by
+the module code in a `createInstance`-function or equivalent. The instance
+creation function is called during MaxScale startup, usually when creating
+services. MaxScale core holds the module instance data in the`SERVICE`-structure (or other higher level construct) and gives it as a
+parameter when calling functions from the module in question. The instance
+structure should contain all non-client-specific information required by the
+functions of the module. The core does not know what the object contains (since
+it is defined by the module itself), nor will it modify the pointer or the
 referenced object in any way.
 
-Modules dealing with client-specific data require a _SESSION_ object for every\
-client. As with the instance data, the definition of the module session\
+Modules dealing with client-specific data require a _SESSION_ object for every
+client. As with the instance data, the definition of the module session
 structure is up to the module writer and MaxScale treats it as an opaque type.\
-Usually the session contains status indicators and any resources required by the\
-client. MaxScale core has its own `MXS_SESSION` object, which tracks a variety\
-of client related information. The `MXS_SESSION` is given as a parameter to\
-module-specific session creation functions and is required for several typical\
+Usually the session contains status indicators and any resources required by the
+client. MaxScale core has its own `MXS_SESSION` object, which tracks a variety
+of client related information. The `MXS_SESSION` is given as a parameter to
+module-specific session creation functions and is required for several typical
 operations such as connecting to backends.
 
-Descriptor control blocks (`DCB`), are generalized I/O descriptor types. DCBs\
-store the file descriptor, state, remote address, username, session, and other\
-data. DCBs are created whenever a new socket is created. Typically this happens\
-when a new client connects or MaxScale connects the client session to backend\
-servers. The module writer should use DCB handling functions provided by the MPI\
-to manage connections instead of calling general networking libraries. This\
-ensures that I/O is handled asynchronously by epoll. In general, module code\
-should avoid blocking I/O, _sleep_, _yield_ or other potentially costly\
+Descriptor control blocks (`DCB`), are generalized I/O descriptor types. DCBs
+store the file descriptor, state, remote address, username, session, and other
+data. DCBs are created whenever a new socket is created. Typically this happens
+when a new client connects or MaxScale connects the client session to backend
+servers. The module writer should use DCB handling functions provided by the MPI
+to manage connections instead of calling general networking libraries. This
+ensures that I/O is handled asynchronously by epoll. In general, module code
+should avoid blocking I/O, _sleep_, _yield_ or other potentially costly
 operations, as the same thread is typically used for many client sessions.
 
-Network data such as client queries and backend replies are held in a buffer\
-container called `GWBUF`. Multiple GWBUFs can form a linked list with type\
-information and properties in each GWBUF-node. Each node includes a pointer to a\
-reference counted shared buffer (`SHARED_BUF`), which finally points to a slice\
-of the actual data. In effect, multiple GWBUF-chains can share some data while\
-keeping some parts private. This construction is meant to minimize the need for\
-data copying and makes it easy to append more data to partially received data\
-packets. Plugin writers should use the MPI to manipulate GWBUFs. For more\
+Network data such as client queries and backend replies are held in a buffer
+container called `GWBUF`. Multiple GWBUFs can form a linked list with type
+information and properties in each GWBUF-node. Each node includes a pointer to a
+reference counted shared buffer (`SHARED_BUF`), which finally points to a slice
+of the actual data. In effect, multiple GWBUF-chains can share some data while
+keeping some parts private. This construction is meant to minimize the need for
+data copying and makes it easy to append more data to partially received data
+packets. Plugin writers should use the MPI to manipulate GWBUFs. For more
 information on the GWBUF, see [Filter and Router](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-plugin-development-guide.md#filter-and-router).
 
 #### General module management
@@ -181,21 +181,21 @@ int thread_init()
 void thread_finish()
 ```
 
-These four functions are present in all `MXS_MODULE` structs and are not part of\
-the API of any individual module type. `process_init` and `process_finish` are\
+These four functions are present in all `MXS_MODULE` structs and are not part of
+the API of any individual module type. `process_init` and `process_finish` are
 called by the module loader right after loading a module and just before\
-MaxScale terminates, respectively. Usually, these can be set to null in`MXS_MODULE` unless the module needs some general initializations before\
-creating any instances. `thread_init` and `thread_finish` are thread-specific\
+MaxScale terminates, respectively. Usually, these can be set to null in`MXS_MODULE` unless the module needs some general initializations before
+creating any instances. `thread_init` and `thread_finish` are thread-specific
 equivalents.
 
 ```
 void diagnostics(INSTANCE *instance, DCB *dcb)
 ```
 
-A diagnostics printing routine is present in nearly all module types, although\
-with varying signatures. This entrypoint should print various statistics and\
-status information about the module instance `instance` in string form. The\
-target of the printing is the given DCB, and printing should be implemented by\
+A diagnostics printing routine is present in nearly all module types, although
+with varying signatures. This entrypoint should print various statistics and
+status information about the module instance `instance` in string form. The
+target of the printing is the given DCB, and printing should be implemented by
 calling `dcb_printf`.
 
 #### Protocol
@@ -217,19 +217,19 @@ int32_t connlimit(struct dcb *, int limit)
 ```
 
 Protocol modules are laborous to implement due to their low level nature. Each\
-DCB maintains pointers to the correct protocol functions to be used with it,\
+DCB maintains pointers to the correct protocol functions to be used with it,
 allowing the DCB to be used in a protocol-independent manner.
 
-`read`, `write_ready`, `error` and `hangup` are _epoll_ handlers for their\
-respective events. `write` implements writing and is usually called in a router\
-module. `accept` is a listener socker handler. `connect` is used during session\
+`read`, `write_ready`, `error` and `hangup` are _epoll_ handlers for their
+respective events. `write` implements writing and is usually called in a router
+module. `accept` is a listener socker handler. `connect` is used during session
 creation when connecting to backend servers. `listen` creates a listener socket.`close` closes a DCB created by `accept`, `connect` or `listen`.
 
-In the ideal case modules other than the protocol modules themselves should not\
-be protocol-specific. This is currently difficult to achieve, since many actions\
-in the modules are dependent on protocol-speficic details. In the future,\
-protocol modules may be expanded to implement a generic query parsing and\
-information API, allowing filters and routers to be used with different SQL\
+In the ideal case modules other than the protocol modules themselves should not
+be protocol-specific. This is currently difficult to achieve, since many actions
+in the modules are dependent on protocol-speficic details. In the future,
+protocol modules may be expanded to implement a generic query parsing and
+information API, allowing filters and routers to be used with different SQL
 variants.
 
 #### Authenticator
@@ -249,14 +249,14 @@ int reauthenticate(struct dcb *, const char *user, uint8_t *token,
                    uint8_t *output, size_t output_len);
 ```
 
-Authenticators must communicate with the client or the backends and implement\
-authentication. The authenticators can be divided to client and backend modules,\
-although the two types are linked and must be used together. Authenticators are\
+Authenticators must communicate with the client or the backends and implement
+authentication. The authenticators can be divided to client and backend modules,
+although the two types are linked and must be used together. Authenticators are
 also dependent on the protocol modules.
 
 #### Filter and Router
 
-Filter and router APIs are nearly identical and are presented together. Since\
+Filter and router APIs are nearly identical and are presented together. Since
 these are the modules most likely to be implemented by plugin developers, their\
 APIs are discussed in more detail.
 
@@ -265,10 +265,10 @@ INSTANCE* createInstance(SERVICE* service, char** options)
 void destroyInstance(INSTANCE* instance)
 ```
 
-`createInstance` should read the `options` and initialize an instance object for\
-use with `service`. Often, simply saving the configuration values to fields is\
-enough. `destroyInstance` is called when the service using the module is\
-deallocated. It should free any resources claimed by the instance. All sessions\
+`createInstance` should read the `options` and initialize an instance object for
+use with `service`. Often, simply saving the configuration values to fields is
+enough. `destroyInstance` is called when the service using the module is
+deallocated. It should free any resources claimed by the instance. All sessions
 created by this instance should be closed before calling the destructor.
 
 ```
@@ -277,11 +277,11 @@ void closeSession(INSTANCE* instance, SESSION* session)
 void freeSession(INSTANCE* instance, SESSION* session)
 ```
 
-These functions manage sessions. `newSession` should allocate a router or filter\
-session attached to the client session represented by `mxs_session`. MaxScale\
-will pass the returned pointer to all the API entrypoints that process user data\
-for the particular client. `closeSession` should close connections the session\
-has opened and release any resources specific to the served client. The_SESSION_ structure allocated in `newSession` should not be deallocated by`closeSession` but in `freeSession`. These two are called in succession\
+These functions manage sessions. `newSession` should allocate a router or filter
+session attached to the client session represented by `mxs_session`. MaxScale
+will pass the returned pointer to all the API entrypoints that process user data
+for the particular client. `closeSession` should close connections the session
+has opened and release any resources specific to the served client. The_SESSION_ structure allocated in `newSession` should not be deallocated by`closeSession` but in `freeSession`. These two are called in succession
 by the core.
 
 ```
@@ -290,55 +290,55 @@ clientReply(INSTANCE* instance, SESSION session, GWBUF* queue, const mxs::ReplyR
 uint64_t getCapabilities(INSTANCE* instance)
 ```
 
-`routeQuery` is called for client requests which should be routed to backends,\
-and `clientReply` for backend reply packets which should be routed to the\
-client. For some modules, MaxScale itself is the backend. For filters, these can\
+`routeQuery` is called for client requests which should be routed to backends,
+and `clientReply` for backend reply packets which should be routed to the
+client. For some modules, MaxScale itself is the backend. For filters, these can
 be NULL, in which case the filter will be skipped for that packet type.
 
-`routeQuery` is often the most complicated function in a router, as it\
-implements the routing logic. It typically considers the client request `queue`,\
-the router settings in `instance` and the session state in `session` when making\
-a routing decision. For filters as well, `routeQuery` typically implements the\
-main logic, although the routing target is constant. For router modules,`routeQuery` should send data forward with `dcb->func.write()`. Filters should\
+`routeQuery` is often the most complicated function in a router, as it
+implements the routing logic. It typically considers the client request `queue`,
+the router settings in `instance` and the session state in `session` when making
+a routing decision. For filters as well, `routeQuery` typically implements the
+main logic, although the routing target is constant. For router modules,`routeQuery` should send data forward with `dcb->func.write()`. Filters should
 directly call `routeQuery` for the next filter or router in the chain.
 
-`clientReply` processes data flowing from backend back to client. For routers,\
-this function is often much simpler than `routeQuery`, since there is only one\
-client to route to. Depending on the router, some packets may not be routed to\
+`clientReply` processes data flowing from backend back to client. For routers,
+this function is often much simpler than `routeQuery`, since there is only one
+client to route to. Depending on the router, some packets may not be routed to
 the client. For example, if a client query was routed to multiple backends,\
 MaxScale will receive multiple replies while the client only expects one.\
-Routers should pass the reply packet to the last filter in the chain (reversed\
-order) using the function `mxs_route_reply`. Filters should call the`clientReply` of the previous filter in the chain. There is no need for filters\
-to worry about being the first filter in the chain, as this is handled\
+Routers should pass the reply packet to the last filter in the chain (reversed
+order) using the function `mxs_route_reply`. Filters should call the`clientReply` of the previous filter in the chain. There is no need for filters
+to worry about being the first filter in the chain, as this is handled
 transparently by the session creation routine.
 
-Application data is not always received in complete packets from the network\
-stack. How partial packets are handled by the receiving protocol module depends\
-on the attached filters and the router, communicated by their`getCapabilities`-functions. `getCapabilities` should return a bitfield\
-resulting from ORring the individual capabilities. `routing.hh` lists the allowed\
+Application data is not always received in complete packets from the network
+stack. How partial packets are handled by the receiving protocol module depends
+on the attached filters and the router, communicated by their`getCapabilities`-functions. `getCapabilities` should return a bitfield
+resulting from ORring the individual capabilities. `routing.hh` lists the allowed
 capability flags.
 
-If a router or filter sets no capabilities, `routeQuery` or `clientReply` may be\
-called to route partial packets. If the routing logic does not require any\
-information on the contents of the packets or even tracking the number of\
-packets, this may be fine. For many cases though, receiving a data packet in a\
-complete GWBUF chain or in one contiguous GWBUF is required. The former can be\
-requested by `getCapabilities` returning _RCAP\_TYPE\_STMT_, the latter by_RCAP\_TYPE\_CONTIGUOUS_. Separate settings exist for queries and replies. For\
-replies, an additional value, _RCAP\_TYPE\_RESULTSET\_OUTPUT_ is defined. This\
+If a router or filter sets no capabilities, `routeQuery` or `clientReply` may be
+called to route partial packets. If the routing logic does not require any
+information on the contents of the packets or even tracking the number of
+packets, this may be fine. For many cases though, receiving a data packet in a
+complete GWBUF chain or in one contiguous GWBUF is required. The former can be
+requested by `getCapabilities` returning _RCAP\_TYPE\_STMT_, the latter by_RCAP\_TYPE\_CONTIGUOUS_. Separate settings exist for queries and replies. For
+replies, an additional value, _RCAP\_TYPE\_RESULTSET\_OUTPUT_ is defined. This
 requests the protocol module to gather partial results into one result set.\
-Enforcing complete packets will delay processing, since the protocol module will\
-have to wait for the entire data packet to arrive before sending it down the\
+Enforcing complete packets will delay processing, since the protocol module will
+have to wait for the entire data packet to arrive before sending it down the
 processing chain.
 
 ```
 bool handleError(INSTANCE* instance, SESSION* session, GWBUF* errmsgbuf, mxs::Endpoint* problem, const mxs::Reply& reply);
 ```
 
-This router-only entrypoint is called if a network error occurs in one of the\
-backend server connections in use by the session. When the entrypoint is called,\
-the router should try to continue the session if possible. If the session can\
-continue operating normally, the function should return `true`. If the router\
-cannot continue routing queries, for example due to a complete cluster outage,\
+This router-only entrypoint is called if a network error occurs in one of the
+backend server connections in use by the session. When the entrypoint is called,
+the router should try to continue the session if possible. If the session can
+continue operating normally, the function should return `true`. If the router
+cannot continue routing queries, for example due to a complete cluster outage,
 the function should return `false` which will cause the whole session to close.
 
 #### Monitor
@@ -349,12 +349,12 @@ void stopMonitor(MXS_MONITOR *monitor)
 void diagnostics(DCB *, const MXS_MONITOR *)
 ```
 
-Monitor modules typically run a repeated monitor routine with a used defined\
-interval. The `MXS_MONITOR` is a standard monitor definition used for all\
-monitors and contains a void pointer for storing module specific data.`startMonitor` should create a new thread for itself using functions in the MPI\
-and have it regularly run a monitor loop. In the beginning of every monitor\
-loop, the monitor should lock the `SERVER`-structures of its servers. This\
-prevents any administrative action from interfering with the monitor during its\
+Monitor modules typically run a repeated monitor routine with a used defined
+interval. The `MXS_MONITOR` is a standard monitor definition used for all
+monitors and contains a void pointer for storing module specific data.`startMonitor` should create a new thread for itself using functions in the MPI
+and have it regularly run a monitor loop. In the beginning of every monitor
+loop, the monitor should lock the `SERVER`-structures of its servers. This
+prevents any administrative action from interfering with the monitor during its
 pass.
 
 ### Compiling, installing and running
@@ -364,32 +364,32 @@ The requirements for compiling a module are:_The public headers (MPI)_ A compati
 * Libraries required by the public headers
 
 Some of the public header files themselves include headers from other libraries.\
-These libraries need to be installed and it may be required to point out their\
+These libraries need to be installed and it may be required to point out their
 location to gcc. Some of the more commonly required libraries are:
 
 * _MySQL Connector-C_, used by the MySQL protocol module
 * _pcre2 regular expressions_ (libpcre2-dev), used for example by the header`modutil.h`
 
-After all dependencies are accounted for, the module should compile with a\
+After all dependencies are accounted for, the module should compile with a
 command similar to
 
 ```
 gcc -I /usr/local/include/mariadb -shared -fPIC -g -o libmymodule.so mymodule.cpp
 ```
 
-Large modules composed of several source files and using additional libraries\
-may require a more complicated compilation scheme, but that is outside the scope\
-of this document. The result of compiling a plugin should be a single shared\
+Large modules composed of several source files and using additional libraries
+may require a more complicated compilation scheme, but that is outside the scope
+of this document. The result of compiling a plugin should be a single shared
 library file.
 
-The compiled .so-file needs to be copied to the MaxScale library folder, which\
-is `/usr/local/lib/maxscale` by default. MaxScale expects the filename to be`lib<name>.so`, where `<name>` must match the module name given in the\
+The compiled .so-file needs to be copied to the MaxScale library folder, which
+is `/usr/local/lib/maxscale` by default. MaxScale expects the filename to be`lib<name>.so`, where `<name>` must match the module name given in the
 configuration file.
 
 #### Hands-on example: RoundRobinRouter
 
-In this example, the RoundRobinRouter is compiled, installed and tested. The\
-software environment this section was written and tested is listed below. Any\
+In this example, the RoundRobinRouter is compiled, installed and tested. The
+software environment this section was written and tested is listed below. Any
 recent Linux setup should be applicable.
 
 * Linux Mint 18
@@ -400,14 +400,14 @@ recent Linux setup should be applicable.
 * MaxScale plugin development headers (in `usr/include/maxscale`)
 
 **Step 1** Compile RoundRobinRouter with `$gcc -I /usr/local/include/mariadb -shared -fPIC -g -o libroundrobinrouter.so roundrobinrouter.cpp`.\
-Assuming all headers were found, the shared library `libroundrobinrouter.so`\
+Assuming all headers were found, the shared library `libroundrobinrouter.so`
 is produced.
 
 **Step 2** Copy the compiled module to the MaxScale module directory: `$sudo cp libroundrobinrouter.so /usr/local/lib/maxscale`.
 
-**Step 3** Modify the MaxScale configuration file to use the RoundRobinRouter as\
-a router. Example service and listener definitions are below. The _servers_\
-and _write\_backend_-lines should be configured according to the actual backend\
+**Step 3** Modify the MaxScale configuration file to use the RoundRobinRouter as
+a router. Example service and listener definitions are below. The _servers_
+and _write\_backend_-lines should be configured according to the actual backend
 configuration.
 
 ```
@@ -537,7 +537,7 @@ maxctrl
 MaxScale> call command roundrobinrouter test_command "one" 0
 ```
 
-The result of the `test_command "one" 0` is printed to the terminal MaxScale is\
+The result of the `test_command "one" 0` is printed to the terminal MaxScale is
 running in:
 
 ```
@@ -549,22 +549,22 @@ Argument 1: type 'boolean' value 'false'
 
 ### Summary and conclusion
 
-Plugins offer a way to extend MariaDB MaxScale whenever the standard modules are\
-found insufficient. The plugins need only implement a set API, can be\
-independently compiled and installation is simply a file copy with some\
+Plugins offer a way to extend MariaDB MaxScale whenever the standard modules are
+found insufficient. The plugins need only implement a set API, can be
+independently compiled and installation is simply a file copy with some
 configuration file modifications.
 
-Out of the different plugin types, filters are the easiest to implement. They\
-work independently and have few requirements. Protocol and authenticator modules\
-require indepth knowledge of the database protocol they implement. Router module\
+Out of the different plugin types, filters are the easiest to implement. They
+work independently and have few requirements. Protocol and authenticator modules
+require indepth knowledge of the database protocol they implement. Router module
 complexity depends on the routing logic requirements.
 
-The provided RoundRobinRouter example code should serve as a valid starting\
-point for both filters and routers. Studying the MaxScale Public Interface\
-headers to get a general idea of what services the core provides for plugins,\
+The provided RoundRobinRouter example code should serve as a valid starting
+point for both filters and routers. Studying the MaxScale Public Interface
+headers to get a general idea of what services the core provides for plugins,
 is also highly recommended.
 
-Lastly, MariaDB MaxScale is an open-source project, so code contributions can be\
+Lastly, MariaDB MaxScale is an open-source project, so code contributions can be
 accepted if they fulfill the [requirements](https://github.com/mariadb-corporation/MaxScale/wiki/Contributing).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-cache.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-cache.md
@@ -4,34 +4,34 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-From MaxScale version 2.2.11 onwards, the cache filter is no longer\
-considered experimental. The following changes to the default behaviour\
+From MaxScale version 2.2.11 onwards, the cache filter is no longer
+considered experimental. The following changes to the default behaviour
 have also been made:
 
 * The default value of `cached_data` is now `thread_specific` (used to be`shared`).
 * The default value of `selects` is now `assume_cacheable` (used to be`verify_cacheable`).
 
 The cache filter is a simple cache that is capable of caching the result of\
-SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,\
+SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,
 without the queries being routed to any server.
 
 By _default_ the cache will be used and populated in the following circumstances:
 
 * There is no explicit transaction active, that is, autocommit is used,
 * there is an explicitly read-only transaction (that is,`START TRANSACTION READ ONLY`) active, or
-* there is a transaction active and no statement that modifies the database\
+* there is a transaction active and no statement that modifies the database
   has been performed.
 
-In practice, the last bullet point basically means that if a transaction has\
+In practice, the last bullet point basically means that if a transaction has
 been started with `BEGIN`, `START TRANSACTION` or `START TRANSACTION READ WRITE`, then the cache will be used and populated until the first `UPDATE`,`INSERT` or `DELETE` statement is encountered.
 
-That is, in default mode the cache effectively causes the system to behave\
-as if the _isolation level_ would be `READ COMMITTED`, irrespective of what\
+That is, in default mode the cache effectively causes the system to behave
+as if the _isolation level_ would be `READ COMMITTED`, irrespective of what
 the isolation level of the backends actually is.
 
 The default behaviour can be altered using the configuration parameter [cache\_in\_transactions](mariadb-maxscale-2106-cache.md#cache_in_transactions).
 
-By default it is assumed that all `SELECT` statements are cacheable, which\
+By default it is assumed that all `SELECT` statements are cacheable, which
 means that also statements like `SELECT LOCALTIME` are cached. Please check [selects](mariadb-maxscale-2106-cache.md#selects) for how to change the default behaviour.
 
 ### Limitations
@@ -50,34 +50,34 @@ Multi-statements are always sent to the backend and their result is**not** cache
 
 The cache is **not** aware of grants.
 
-The implication is that unless the cache has been explicitly configured\
-who the caching should apply to, the presence of the cache may provide\
+The implication is that unless the cache has been explicitly configured
+who the caching should apply to, the presence of the cache may provide
 a user with access to data he should not have access to.
 
 Please read the section [Security](mariadb-maxscale-2106-cache.md#security-1) for more detailed information.
 
-However, from 2.5 onwards it is possible to configure the cache to cache\
-the data of each user separately, which effectively means that there can\
-be no unintended sharing. Please see [users](mariadb-maxscale-2106-cache.md#users) for how to change\
+However, from 2.5 onwards it is possible to configure the cache to cache
+the data of each user separately, which effectively means that there can
+be no unintended sharing. Please see [users](mariadb-maxscale-2106-cache.md#users) for how to change
 the default behaviour.
 
 #### `information_schema`
 
-When [invalidation](mariadb-maxscale-2106-cache.md#invalidation) is enabled, SELECTs targeting tables\
-in `information_schema` are not cached. The reason is that as the content\
-of the tables changes as the side-effect of something else, the cache would\
+When [invalidation](mariadb-maxscale-2106-cache.md#invalidation) is enabled, SELECTs targeting tables
+in `information_schema` are not cached. The reason is that as the content
+of the tables changes as the side-effect of something else, the cache would
 not know when to invalidate the cache-entries.
 
 ### Invalidation
 
-Since MaxScale 2.5, the cache is capable of invalidating entries in the\
-cache when a modification (UPDATE, INSERT or DELETE) that may affect those\
+Since MaxScale 2.5, the cache is capable of invalidating entries in the
+cache when a modification (UPDATE, INSERT or DELETE) that may affect those
 entries is made.
 
-The cache invalidation works on the table-level, that is, a modification\
-made to a particular table will cause all cache entries that refer to that\
-table to be invalidated, irrespective of whether the modification actually\
-has an impact on the cache entries or not. For instance, suppose the result\
+The cache invalidation works on the table-level, that is, a modification
+made to a particular table will cause all cache entries that refer to that
+table to be invalidated, irrespective of whether the modification actually
+has an impact on the cache entries or not. For instance, suppose the result
 of the following SELECT has been cached
 
 ```
@@ -90,55 +90,55 @@ An insert like
 INSERT INTO t SET a=42;
 ```
 
-will cause the cache entry containing the result of that SELECT to be\
+will cause the cache entry containing the result of that SELECT to be
 invalidated even if the INSERT actually does not affect it. Please see [invalidate](mariadb-maxscale-2106-cache.md#invalidate) for how to enable the invalidation.
 
-When invalidation has been enabled MaxScale must be able to completely\
-parse a SELECT statement for its results to be stored in the cache. The\
-reason is that in order to be able to invalidate cache entries, MaxScale\
-must know what tables a SELECT statement depends upon. Consequently, if\
-(and only if) invalidation has been enabled and MaxScale fails to parse a\
+When invalidation has been enabled MaxScale must be able to completely
+parse a SELECT statement for its results to be stored in the cache. The
+reason is that in order to be able to invalidate cache entries, MaxScale
+must know what tables a SELECT statement depends upon. Consequently, if
+(and only if) invalidation has been enabled and MaxScale fails to parse a
 statement, the result of that particular statement will not be cached.
 
 When invalidation has been enabled, MaxScale will also parse all UPDATE,\
-INSERT and DELETE statements, in order to find out what tables are\
-modified. If that parsing fails, MaxScale will _by default_ clear the\
-entire cache. The reason is that unless MaxScale can completely parse\
-the statement it cannot know what tables are modified and hence not what\
-cache entries should be invalidated. Consequently, to prevent stale data\
-from being returned, the entire cache is cleared. The default behaviour\
+INSERT and DELETE statements, in order to find out what tables are
+modified. If that parsing fails, MaxScale will _by default_ clear the
+entire cache. The reason is that unless MaxScale can completely parse
+the statement it cannot know what tables are modified and hence not what
+cache entries should be invalidated. Consequently, to prevent stale data
+from being returned, the entire cache is cleared. The default behaviour
 can be changed using the configuration parameter [clear\_cache\_on\_parse\_errors](mariadb-maxscale-2106-cache.md#clear_cache_on_parse_errors).
 
-Note that what threading approach is used has a big impact on the\
-invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2106-cache.md#threads-users-and-invalidation)\
+Note that what threading approach is used has a big impact on the
+invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2106-cache.md#threads-users-and-invalidation)
 for how the threading approach affects the invalidation.
 
-Note also that since the invalidation may not, depending on how the\
-cache has been configured, be visible to all sessions of all users, it\
+Note also that since the invalidation may not, depending on how the
+cache has been configured, be visible to all sessions of all users, it
 is still important to configure a reasonable [soft](mariadb-maxscale-2106-cache.md#soft_ttl) and [hard](mariadb-maxscale-2106-cache.md#hard_ttl) TTL.
 
 #### Best Efforts
 
-The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the\
-cache in all circumstances reflects the state in the actual database,\
-would require that the operations involving the cache and the MariaDB\
+The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the
+cache in all circumstances reflects the state in the actual database,
+would require that the operations involving the cache and the MariaDB
 server are synchronized, which would cause an unacceptable overhead.
 
 What _best efforts_ means in this context is best illustrated using an example.
 
-Suppose a client executes the statement `SELECT * FROM tbl` and that the result\
-is cached. Next time that or any other client executes the same statement, the\
-result is returned from the cache and the MariaDB server will not be accessed\
+Suppose a client executes the statement `SELECT * FROM tbl` and that the result
+is cached. Next time that or any other client executes the same statement, the
+result is returned from the cache and the MariaDB server will not be accessed
 at all.
 
-If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the\
-cached value for the `SELECT` statement above and all other statements that are\
-dependent upon `tbl` will be invalidated. That is, the next time someone executes\
+If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the
+cached value for the `SELECT` statement above and all other statements that are
+dependent upon `tbl` will be invalidated. That is, the next time someone executes
 the statement `SELECT * FROM tbl` the result will again be fetched from the\
 MariaDB server and stored to the cache.
 
-However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`\
-at the same time someone else executes the `INSERT ...` statement. A possible\
+However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`
+at the same time someone else executes the `INSERT ...` statement. A possible
 chain of events is as follows:
 
 ```
@@ -149,7 +149,7 @@ MaxScale -> DB                                   SELECT COUNT(*) FROM tbl
 MaxScale -> DB        INSERT ...
 ```
 
-That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of\
+That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of
 each other, the events may be re-ordered as far as the cache is concerned.
 
 ```
@@ -157,16 +157,16 @@ MaxScale -> Cache     Delete invalidated values
 MaxScale -> Cache                                Store result and invalidation key
 ```
 
-That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the\
+That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the
 situation _before_ the insert and will thus not be correct.
 
-The stale result will be returned until the value has reached its _time-to-live_\
+The stale result will be returned until the value has reached its _time-to-live_
 or its invalidation is caused by some update operation.
 
 ### Configuration
 
-The cache is simple to add to any existing service. However, some experimentation\
-may be required in order to find the configuration settings that provide\
+The cache is simple to add to any existing service. However, some experimentation
+may be required in order to find the configuration settings that provide
 the maximum benefit.
 
 ```
@@ -184,21 +184,21 @@ type=service
 filters=Cache
 ```
 
-Each configured cache filter uses a storage of its own. That is, if there\
-are two services, each configured with a specific cache filter, then,\
-even if queries target the very same servers the cached data will not\
+Each configured cache filter uses a storage of its own. That is, if there
+are two services, each configured with a specific cache filter, then,
+even if queries target the very same servers the cached data will not
 be shared.
 
-Two services can use the same cache filter, but then either the services\
-should use the very same servers _or_ a completely different set of servers,\
-where the used table names are different. Otherwise there can be unintended\
+Two services can use the same cache filter, but then either the services
+should use the very same servers _or_ a completely different set of servers,
+where the used table names are different. Otherwise there can be unintended
 sharing.
 
 #### Filter Parameters
 
 The cache filter has no mandatory parameters but a range of optional ones.\
-Note that it is advisable to specify `max_size` to prevent the cache from\
-using up all memory there is, in case there is very little overlap among the\
+Note that it is advisable to specify `max_size` to prevent the cache from
+using up all memory there is, in case there is very little overlap among the
 queries.
 
 **`storage`**
@@ -208,8 +208,8 @@ queries.
 * Dynamic: No
 * Default: `storage_inmemory`
 
-The name of the module that provides the storage for the cache. That\
-module will be loaded and provided with the value of `storage_options` as\
+The name of the module that provides the storage for the cache. That
+module will be loaded and provided with the value of `storage_options` as
 argument. For instance:
 
 ```
@@ -225,8 +225,8 @@ See [Storage](mariadb-maxscale-2106-cache.md#storage-1) for what storage modules
 * Dynamic: No
 * Default:
 
-A string that is provided verbatim to the storage module specified in `storage`,\
-when the module is loaded. Note that the needed arguments and their format depend\
+A string that is provided verbatim to the storage module specified in `storage`,
+when the module is loaded. Note that the needed arguments and their format depend
 upon the specific module.
 
 **`hard_ttl`**
@@ -236,8 +236,8 @@ upon the specific module.
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Hard time to live_; the maximum amount of time the cached\
-result is used before it is discarded and the result is fetched from the\
+_Hard time to live_; the maximum amount of time the cached
+result is used before it is discarded and the result is fetched from the
 backend (and cached). See also `soft_ttl` below.
 
 ```
@@ -251,21 +251,21 @@ hard_ttl=60s
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Soft time to live_; the amount of time - in seconds - the cached result is\
-used before it is refreshed from the server. When `soft_ttl` has passed, the\
+_Soft time to live_; the amount of time - in seconds - the cached result is
+used before it is refreshed from the server. When `soft_ttl` has passed, the
 result will be refreshed when the _first_ client requests the value.
 
-However, as long as `hard_ttl` has not passed, _all_ other clients requesting\
-the same value will use the result from the cache while it is being fetched\
-from the backend. That is, as long as `soft_ttl` but not `hard_ttl` has passed,\
-even if several clients request the same value at the same time, there will be\
+However, as long as `hard_ttl` has not passed, _all_ other clients requesting
+the same value will use the result from the cache while it is being fetched
+from the backend. That is, as long as `soft_ttl` but not `hard_ttl` has passed,
+even if several clients request the same value at the same time, there will be
 just one request to the backend.
 
 ```
 soft_ttl=60s
 ```
 
-The default value is `0`, which means no limit. If the value of `soft_ttl` is\
+The default value is `0`, which means no limit. If the value of `soft_ttl` is
 larger than `hard_ttl` it will be adjusted down to the same value.
 
 **`max_resultset_rows`**
@@ -275,7 +275,7 @@ larger than `hard_ttl` it will be adjusted down to the same value.
 * Dynamic: No
 * Default: `0` (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 stored in the cache. A resultset larger than this, will not be stored.
 
 ```
@@ -290,14 +290,14 @@ max_resultset_rows=1000
 * Default: `0` (no limit)
 
 Specifies the maximum size of a resultset, for it to be stored in the cache.\
-A resultset larger than this, will not be stored. The size can be specified\
+A resultset larger than this, will not be stored. The size can be specified
 as described [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
 
 ```
 max_resultset_size=128Ki
 ```
 
-Note that the value of `max_resultset_size` should not be larger than the\
+Note that the value of `max_resultset_size` should not be larger than the
 value of `max_size`.
 
 **`max_count`**
@@ -307,12 +307,12 @@ value of `max_size`.
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum number of items the cache may contain. If the limit has been\
+The maximum number of items the cache may contain. If the limit has been
 reached and a new item should be stored, then an older item will be evicted.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
-is used, then the total number of cached items is #threads \* the value\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
+is used, then the total number of cached items is #threads \* the value
 of `max_count`.
 
 ```
@@ -326,12 +326,12 @@ max_count=1000
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum size the cache may occupy. If the limit has been reached and a new\
+The maximum size the cache may occupy. If the limit has been reached and a new
 item should be stored, then some older item(s) will be evicted to make space.\
 The size can be specified as described [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
 is used, then the total size is #threads \* the value of `max_size`.
 
 ```
@@ -345,7 +345,7 @@ max_size=100Mi
 * Dynamic: No
 * Default: `""` (no rules)
 
-Specifies the path of the file where the caching rules are stored. A relative\
+Specifies the path of the file where the caching rules are stored. A relative
 path is interpreted relative to the _data directory_ of MariaDB MaxScale.
 
 ```
@@ -360,22 +360,22 @@ rules=/path/to/rules-file
 * Values: `shared`, `thread_specific`
 * Default: `thread_specific`
 
-An enumeration option specifying how data is shared between threads. The\
+An enumeration option specifying how data is shared between threads. The
 allowed values are:
 
-* `shared`: The cached data is shared between threads. On the one hand\
-  it implies that there will be synchronization between threads, on\
+* `shared`: The cached data is shared between threads. On the one hand
+  it implies that there will be synchronization between threads, on
   the other hand that all threads will use data fetched by any thread.
-* `thread_specific`: The cached data is specific to a thread. On the\
-  one hand it implies that no synchronization is needed between threads,\
-  on the other hand that the very same data may be fetched and stored\
+* `thread_specific`: The cached data is specific to a thread. On the
+  one hand it implies that no synchronization is needed between threads,
+  on the other hand that the very same data may be fetched and stored
   multiple times.
 
 ```
 cached_data=shared
 ```
 
-Default is `thread_specific`. See `max_count` and `max_size` what implication\
+Default is `thread_specific`. See `max_count` and `max_size` what implication
 changing this setting to `shared` has.
 
 **`selects`**
@@ -386,35 +386,35 @@ changing this setting to `shared` has.
 * Values: `assume_cacheable`, `verify_cacheable`
 * Default: `assume_cacheable`
 
-An enumeration option specifying what approach the cache should take with\
+An enumeration option specifying what approach the cache should take with
 respect to `SELECT` statements. The allowed values are:
 
-* `assume_cacheable`: The cache can assume that all `SELECT` statements,\
+* `assume_cacheable`: The cache can assume that all `SELECT` statements,
   without exceptions, are cacheable.
-* `verify_cacheable`: The cache can not assume that all `SELECT`\
+* `verify_cacheable`: The cache can not assume that all `SELECT`
   statements are cacheable, but must verify that.
 
 ```
 selects=verify_cacheable
 ```
 
-Default is `assume_cacheable`. In this case, all `SELECT` statements are\
-assumed to be cacheable and will be parsed _only_ if some specific rule\
+Default is `assume_cacheable`. In this case, all `SELECT` statements are
+assumed to be cacheable and will be parsed _only_ if some specific rule
 requires that.
 
-If `verify_cacheable` is specified, then all `SELECT` statements will be\
-parsed and only those that are safe for caching - e.g. do _not_ call any\
-non-cacheable functions or access any non-cacheable variables - will be\
+If `verify_cacheable` is specified, then all `SELECT` statements will be
+parsed and only those that are safe for caching - e.g. do _not_ call any
+non-cacheable functions or access any non-cacheable variables - will be
 subject to caching.
 
-If `verify_cacheable` has been specified, the cache will not be used in\
+If `verify_cacheable` has been specified, the cache will not be used in
 the following circumstances:
 
 * The `SELECT` uses any of the following functions: `BENCHMARK`,`CONNECTION_ID`, `CONVERT_TZ`, `CURDATE`, `CURRENT_DATE`, `CURRENT_TIMESTAMP`,`CURTIME`, `DATABASE`, `ENCRYPT`, `FOUND_ROWS`, `GET_LOCK`, `IS_FREE_LOCK`,`IS_USED_LOCK`, `LAST_INSERT_ID`, `LOAD_FILE`, `LOCALTIME`, `LOCALTIMESTAMP`,`MASTER_POS_WAIT`, `NOW`, `RAND`, `RELEASE_LOCK`, `SESSION_USER`, `SLEEP`,`SYSDATE`, `SYSTEM_USER`, `UNIX_TIMESTAMP`, `USER`, `UUID`, `UUID_SHORT`.
 * The `SELECT` accesses any of the following fields: `CURRENT_DATE`,`CURRENT_TIMESTAMP`, `LOCALTIME`, `LOCALTIMESTAMP`
 * The `SELECT` uses system or user variables.
 
-Note that parsing all `SELECT` statements carries a performance\
+Note that parsing all `SELECT` statements carries a performance
 cost. Please read [performance](mariadb-maxscale-2106-cache.md#performance) for more details.
 
 **`cache_in_transactions`**
@@ -425,21 +425,21 @@ cost. Please read [performance](mariadb-maxscale-2106-cache.md#performance) for 
 * Values: `never`, `read_only_transactions`, `all_transactions`
 * Default: `all_transactions`
 
-An enumeration option specifying how the cache should behave when there\
+An enumeration option specifying how the cache should behave when there
 are active transactions:
 
-* `never`: When there is an active transaction, no data will be returned\
+* `never`: When there is an active transaction, no data will be returned
   from the cache, but all requests will always be sent to the backend.\
   The cache will be populated inside explicitly read-only transactions.\
-  Inside transactions that are not explicitly read-only, the cache will\
+  Inside transactions that are not explicitly read-only, the cache will
   be populated until the first non-SELECT statement.
-* `read_only_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be populated, but not used\
+* `read_only_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be populated, but not used
   until the first non-SELECT statement.
-* `all_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be used and populated until the\
+* `all_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be used and populated until the
   first non-SELECT statement.
 
 ```
@@ -448,7 +448,7 @@ cache_in_transactions=never
 
 Default is `all_transactions`.
 
-The values `read_only_transactions` and `all_transactions` have roughly the\
+The values `read_only_transactions` and `all_transactions` have roughly the
 same effect as changing the isolation level of the backend to `read_committed`.
 
 **`debug`**
@@ -458,8 +458,8 @@ same effect as changing the isolation level of the backend to `read_committed`.
 * Dynamic: No
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the cache\
-can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the cache
+can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -490,9 +490,9 @@ enabled=false
 
 Default is `true`.
 
-The value affects the initial state of the MaxScale user\
-variables using which the behaviour of the cache can be modified\
-at runtime. Please see [Runtime Configuration](mariadb-maxscale-2106-cache.md#runtime-configuration)\
+The value affects the initial state of the MaxScale user
+variables using which the behaviour of the cache can be modified
+at runtime. Please see [Runtime Configuration](mariadb-maxscale-2106-cache.md#runtime-configuration)
 for details.
 
 **`invalidate`**
@@ -503,7 +503,7 @@ for details.
 * Values: `never`, `current`
 * Default: `never`
 
-An enumeration option specifying how the cache should invalidate\
+An enumeration option specifying how the cache should invalidate
 cache entries.
 
 ```
@@ -514,18 +514,18 @@ cache entries.
   not.
 ```
 
-The effect of `current` depends upon the value of `cached_data`. If the value\
-is `shared`, that is, all threads share the same cache, then the effect of an\
+The effect of `current` depends upon the value of `cached_data`. If the value
+is `shared`, that is, all threads share the same cache, then the effect of an
 invalidation is immediately visible to all sessions, as there is just one cache.\
-However, if the value is `thread_specific`, then an invalidation will affect only\
+However, if the value is `thread_specific`, then an invalidation will affect only
 the cache that the session happens to be using.
 
-If it is important and _sufficient_ that an application immediately sees a change\
-that it itself has caused, then a combination of `invalidate=current`\
+If it is important and _sufficient_ that an application immediately sees a change
+that it itself has caused, then a combination of `invalidate=current`
 and `cached_data=thread_specific` can be used.
 
-If it is important that an application _immediately_ sees all changes, irrespective\
-of who has caused them, then a combination of `invalidate=current`\
+If it is important that an application _immediately_ sees all changes, irrespective
+of who has caused them, then a combination of `invalidate=current`
 and `cached_data=shared` _must_ be used.
 
 **`clear_cache_on_parse_errors`**
@@ -535,18 +535,18 @@ and `cached_data=shared` _must_ be used.
 * Dynamic: No
 * Default: `true`
 
-This boolean option specifies how the cache should behave in case of\
+This boolean option specifies how the cache should behave in case of
 parsing errors when invalidation has been enabled.
 
-* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE\
+* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE
   statement then all cached data will be cleared.
-* `false`: A failure to parse an UPDATE/INSERT/DELETE statement\
+* `false`: A failure to parse an UPDATE/INSERT/DELETE statement
   is ignored and no invalidation will take place due that statement.
 
 The default value is `true`.
 
-Changing the value to `false` may mean that stale data is returned from\
-the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement\
+Changing the value to `false` may mean that stale data is returned from
+the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement
 affects entries in the cache.
 
 **`users`**
@@ -557,7 +557,7 @@ affects entries in the cache.
 * Values: `mixed`, `isolated`
 * Default: `mixed`
 
-An enumeration option specifying how the cache should cache data for\
+An enumeration option specifying how the cache should cache data for
 different users.
 
 ```
@@ -568,11 +568,11 @@ different users.
   no unintended sharing.
 ```
 
-Note that if `isolated` has been specified, then each user will\
-conceptually have a cache of his own, which is populated\
-independently from each other. That is, if two users make the\
-same query, then the data will be fetched twice and also stored\
-twice. So, a `isolated` cache will in general use more memory and\
+Note that if `isolated` has been specified, then each user will
+conceptually have a cache of his own, which is populated
+independently from each other. That is, if two users make the
+same query, then the data will be fetched twice and also stored
+twice. So, a `isolated` cache will in general use more memory and
 cause more traffic to the backend compared to a `mixed` cache.
 
 **`timeout`**
@@ -582,7 +582,7 @@ cause more traffic to the backend compared to a `mixed` cache.
 * Dynamic: No
 * Default: `5s`
 
-The _timeout_ used when performing operations to distributed storages\
+The _timeout_ used when performing operations to distributed storages
 such as _redis_ or _memcached_.
 
 ```
@@ -595,19 +595,19 @@ The duration can be specified as explained [here](../mariadb-maxscale-21-06-gett
 
 #### Runtime Configuration
 
-The cache filter can be configured at runtime by executing SQL commands. If\
-there is more than one cache filter in a service, only the first cache filter\
-will be able to process the variables. The remaining filters will not see them\
+The cache filter can be configured at runtime by executing SQL commands. If
+there is more than one cache filter in a service, only the first cache filter
+will be able to process the variables. The remaining filters will not see them
 and thus configuring them at runtime is not possible.
 
 **`@maxscale.cache.populate`**
 
-Using the variable `@maxscale.cache.populate` it is possible to specify at\
-runtime whether the cache should be populated or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.populate` it is possible to specify at
+runtime whether the cache should be populated or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be populated.
 
 ```
@@ -617,10 +617,10 @@ SET @maxscale.cache.populate=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-In the example above, the first `SELECT` will always be sent to the\
-server and the result will be cached, provided the actual cache rules\
-specifies that it should be. The second `SELECT` may be served from the\
-cache, depending on the value of `@maxscale.cache.use` (and the cache\
+In the example above, the first `SELECT` will always be sent to the
+server and the result will be cached, provided the actual cache rules
+specifies that it should be. The second `SELECT` may be served from the
+cache, depending on the value of `@maxscale.cache.use` (and the cache
 rules).
 
 The value of `@maxscale.cache.populate` can be queried
@@ -633,12 +633,12 @@ but only _after_ it has been explicitly set once.
 
 **`@maxscale.cache.use`**
 
-Using the variable `@maxscale.cache.use` it is possible to specify at\
-runtime whether the cache should be used or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.use` it is possible to specify at
+runtime whether the cache should be used or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be used.
 
 ```
@@ -648,15 +648,15 @@ SET @maxscale.cache.use=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-The first `SELECT` will be served from the cache, providing the rules\
-specify that the statement should be cached, the cache indeed contains\
+The first `SELECT` will be served from the cache, providing the rules
+specify that the statement should be cached, the cache indeed contains
 the result and the date is not stale (as specified by the _TTL_).
 
-If the data is stale, the `SELECT` will be sent to the server **and**\
+If the data is stale, the `SELECT` will be sent to the server **and**
 the cache entry will be updated, irrespective of the value of`@maxscale.cache.populate`.
 
-If `@maxscale.cache.use` is `true` but the result is not found in the\
-cache, and the result is subsequently fetched from the server, the\
+If `@maxscale.cache.use` is `true` but the result is not found in the
+cache, and the result is subsequently fetched from the server, the
 result will **not** be added to the cache, unless`@maxscale.cache.populate` is also `true`.
 
 The value of `@maxscale.cache.use` can be queried
@@ -669,12 +669,12 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.soft_ttl`**
 
-Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime\
-to specify _in seconds_ what _soft ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `soft_ttl`. That is,\
+Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime
+to specify _in seconds_ what _soft ttl_ should be applied. Its initial
+value is the value of the configuration parameter `soft_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _soft ttl_ should be applied.
 
 ```
@@ -684,13 +684,13 @@ SET @maxscale.cache.soft_ttl=60;
 SELECT c, d FROM important;
 ```
 
-When data is `SELECT`ed from the unimportant table `unimportant`, the data\
-will be returned from the cache provided it is no older than 10 minutes,\
-but when data is `SELECT`ed from the important table `important`, the\
+When data is `SELECT`ed from the unimportant table `unimportant`, the data
+will be returned from the cache provided it is no older than 10 minutes,
+but when data is `SELECT`ed from the important table `important`, the
 data will be returned from the cache provided it is no older than 1 minute.
 
-Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`\
-in the sense that if the former is less that the latter, then _soft ttl_\
+Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`
+in the sense that if the former is less that the latter, then _soft ttl_
 will, when used, be adjusted down to the value of _hard ttl_.
 
 The value of `@maxscale.cache.soft_ttl` can be queried
@@ -703,16 +703,16 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.hard_ttl`**
 
-Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime\
-to specify _in seconds_ what _hard ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `hard_ttl`. That is,\
+Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime
+to specify _in seconds_ what _hard ttl_ should be applied. Its initial
+value is the value of the configuration parameter `hard_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _hard ttl_ should be applied.
 
-Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,\
-is important to ensure that the former is at least as large as the latter\
+Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,
+is important to ensure that the former is at least as large as the latter
 and for best overall performance that it is larger.
 
 ```
@@ -732,11 +732,11 @@ but only after it has explicitly been set once.
 
 **Client Driven Caching**
 
-With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible\
+With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible
 to make the caching completely client driven.
 
-Provide no `rules` file, which means that _all_ `SELECT` statements are\
-subject to caching and that all users receive data from the cache. Set\
+Provide no `rules` file, which means that _all_ `SELECT` statements are
+subject to caching and that all users receive data from the cache. Set
 the startup mode of the cache to _disabled_.
 
 ```
@@ -756,10 +756,10 @@ SELECT e, f FROM tbl3;
 SET @maxscale.cache.populate=FALSE;
 ```
 
-Note that those `SELECT`s must return something in order for the\
+Note that those `SELECT`s must return something in order for the
 statement to be _marked_ for caching.
 
-After this, the value of `@maxscale.cache.use` will decide whether\
+After this, the value of `@maxscale.cache.use` will decide whether
 or not the cache is considered.
 
 ```
@@ -768,12 +768,12 @@ SELECT a, b FROM tbl1;
 SET @maxscale.cache.use=FALSE;
 ```
 
-With `@maxscale.cache.use` being `true`, the cache is considered\
-and the result returned from there, if not stale. If it is stale,\
+With `@maxscale.cache.use` being `true`, the cache is considered
+and the result returned from there, if not stale. If it is stale,
 the result is fetched from the server and the cached entry is updated.
 
-By setting a very long _TTL_ it is possible to prevent the cache\
-from ever considering an entry to be stale and instead manually\
+By setting a very long _TTL_ it is possible to prevent the cache
+from ever considering an entry to be stale and instead manually
 cause the cache to be updated when needed.
 
 ```
@@ -785,8 +785,8 @@ SET @maxscale.cache.populate=FALSE;
 
 ### Threads, Users and Invalidation
 
-What caching approach is used and how different users are treated\
-has a significant impact on the behaviour of the cache. In the\
+What caching approach is used and how different users are treated
+has a significant impact on the behaviour of the cache. In the
 following the implication of different combinations is explained.
 
 | cached\_data/users | mixed                                                                                                                          | isolated                                                                                                                        |
@@ -796,14 +796,14 @@ following the implication of different combinations is explained.
 
 #### Invalidation
 
-Invalidation takes place only in the current cache, so how _visible_\
+Invalidation takes place only in the current cache, so how _visible_
 the invalidation is, depends upon the configuration value of`cached_data`.
 
 **`cached_data=thread_specific`**
 
-The invalidation is visible only to the sessions that are handled by\
-the same worker thread where the invalidation occurred. Sessions of the\
-same or other users that are handled by different worker threads will\
+The invalidation is visible only to the sessions that are handled by
+the same worker thread where the invalidation occurred. Sessions of the
+same or other users that are handled by different worker threads will
 not see the new value before the TTL causes the value to be refreshed.
 
 **`cache_data=shared`**
@@ -814,8 +814,8 @@ The invalidation is immediately visible to all sessions of all users.
 
 The caching rules are expressed as a JSON object or as an array of JSON objects.
 
-There are two decisions to be made regarding the caching; in what circumstances\
-should data be stored to the cache and in what circumstances should the data in\
+There are two decisions to be made regarding the caching; in what circumstances
+should data be stored to the cache and in what circumstances should the data in
 the cache be used.
 
 Expressed in JSON this looks as follows
@@ -839,9 +839,9 @@ or, in case an array is used, as
 ]
 ```
 
-The `store` field specifies in what circumstances data should be stored to\
-the cache and the `use` field specifies in what circumstances the data in\
-the cache should be used. In both cases, the value is a JSON array containing\
+The `store` field specifies in what circumstances data should be stored to
+the cache and the `use` field specifies in what circumstances the data in
+the cache should be used. In both cases, the value is a JSON array containing
 objects.
 
 If an array of rule objects is specified, then, when looking for a rule that\
@@ -851,14 +851,14 @@ deciding whether data in the cache should be used.
 
 #### When to Store
 
-By default, if no rules file have been provided or if the `store` field is\
-missing from the object, the results of all queries will be stored to the\
-cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter\
+By default, if no rules file have been provided or if the `store` field is
+missing from the object, the results of all queries will be stored to the
+cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter
 parameters.
 
-By providing a `store` field in the JSON object, the decision whether to\
-store the result of a particular query to the cache can be controlled in\
-a more detailed manner. The decision to cache the results of a query can\
+By providing a `store` field in the JSON object, the decision whether to
+store the result of a particular query to the cache can be controlled in
+a more detailed manner. The decision to cache the results of a query can
 depend upon
 
 * the database,
@@ -882,21 +882,21 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`\
+If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`
 or `unlike`, then _value_ is interpreted as a _pcre2_ regular expression.\
-Note though that if _attribute_ is `database`, `table` or `column`, then\
-the string is interpreted as a name, where a dot `.` denotes qualification\
+Note though that if _attribute_ is `database`, `table` or `column`, then
+the string is interpreted as a name, where a dot `.` denotes qualification
 or scoping.
 
-The objects in the `store` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `store` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 result of the query in question will be stored to the cache.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then the result of the query is not stored to the cache.
 
-Note that as the query itself is used as the key, although the following\
+Note that as the query itself is used as the key, although the following
 queries
 
 ```
@@ -910,7 +910,7 @@ USE db1;
 SELECT * FROM tbl
 ```
 
-target the same table and produce the same results, they will be cached\
+target the same table and produce the same results, they will be cached
 separately. The same holds for queries like
 
 ```
@@ -923,13 +923,13 @@ and
 SELECT * FROM tbl WHERE b = 3 AND a = 2;
 ```
 
-as well. Although they conceptually are identical, there will be two\
+as well. Although they conceptually are identical, there will be two
 cache entries.
 
-Note that if a column has been specified in a rule, then a statement\
+Note that if a column has been specified in a rule, then a statement
 will match _irrespective_ of where that particular column appears.\
-For instance, if a rule specifies that the result of statements referring\
-to the column _a_ should be cached, then the following statement will\
+For instance, if a rule specifies that the result of statements referring
+to the column _a_ should be cached, then the following statement will
 match
 
 ```
@@ -944,7 +944,7 @@ SELECT b FROM tbl WHERE a > 5;
 
 **Qualified Names**
 
-When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,\
+When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,
 dot (`.`) denotes qualification or scope.
 
 In practice that means that if _attribute_ is `database` then _value_ may\
@@ -953,20 +953,20 @@ dot, used for separating the database and table names respectively, and\
 if _attribute_ is `column` then _value_ may contain one or two dots, used\
 for separating table and column names, or database, table and column names.
 
-Note that if a qualified name is used as a _value_, then all parts of the\
-name must be available for a match. Currently Maria DB MaxScale may not\
-always be capable of deducing in what table a particular column is. If\
-that is the case, then a value like `tbl.field` may not necessarily\
+Note that if a qualified name is used as a _value_, then all parts of the
+name must be available for a match. Currently Maria DB MaxScale may not
+always be capable of deducing in what table a particular column is. If
+that is the case, then a value like `tbl.field` may not necessarily
 be a match even if the field is `field` and the table actually is `tbl`.
 
 **Implication of the default database**
 
-If the rules concerns the `database`, then only if the statement refers\
+If the rules concerns the `database`, then only if the statement refers
 to _no_ specific database, will the default database be considered.
 
 **Regexp Matching**
 
-The string used for matching the regular expression contains as much\
+The string used for matching the regular expression contains as much
 information as there is available. For instance, in a situation like
 
 ```
@@ -1006,8 +1006,8 @@ Cache all queries _not_ targeting a particular table
 }
 ```
 
-That will exclude queries targeting table _tbl1_ irrespective of which\
-database it is in. To exclude a table in a particular database, specify\
+That will exclude queries targeting table _tbl1_ irrespective of which
+database it is in. To exclude a table in a particular database, specify
 the table name using a qualified name.
 
 ```
@@ -1036,16 +1036,16 @@ Cache all queries containing a WHERE clause
 }
 ```
 
-Note that will actually cause all queries that contain WHERE anywhere,\
+Note that will actually cause all queries that contain WHERE anywhere,
 to be cached.
 
 #### When to Use
 
-By default, if no rules file have been provided or if the `use` field is\
+By default, if no rules file have been provided or if the `use` field is
 missing from the object, all users may be returned data from the cache.
 
-By providing a `use` field in the JSON object, the decision whether to use\
-data from the cache can be controlled in a more detailed manner. The decision\
+By providing a `use` field in the JSON object, the decision whether to use
+data from the cache can be controlled in a more detailed manner. The decision
 to use data from the cache can depend upon
 
 * the user.
@@ -1066,7 +1066,7 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account\
+If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account
 string, that is, `%` means indicates wildcard, but if _op_ is `like` or`unlike` it is simply assumed _value_ is a pcre2 regular expression.
 
 For instance, the following are equivalent:
@@ -1085,26 +1085,26 @@ For instance, the following are equivalent:
 }
 ```
 
-Note that if _op_ is `=` or `!=` then the usual assumptions apply,\
-that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_\
-or _unlike_ is used, then no assumptions apply, but the string is\
+Note that if _op_ is `=` or `!=` then the usual assumptions apply,
+that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_
+or _unlike_ is used, then no assumptions apply, but the string is
 used verbatim as a regular expression.
 
-The objects in the `use` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `use` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 data in the cache will be used, subject to the value of `ttl`.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then data in the cache will not be used.
 
-Note that `use` is relevant only if the query is subject to caching,\
-that is, if all queries are cached or if a query matches a particular\
+Note that `use` is relevant only if the query is subject to caching,
+that is, if all queries are cached or if a query matches a particular
 rule in the `store` array.
 
 **Examples**
 
-Use data from the cache for all users except `admin` (actually `'admin'@'%'`),\
+Use data from the cache for all users except `admin` (actually `'admin'@'%'`),
 regardless of what host the `admin` user comes from.
 
 ```
@@ -1121,15 +1121,15 @@ regardless of what host the `admin` user comes from.
 
 ### Security
 
-As the cache is not aware of grants, unless the cache has been explicitly\
-configured who the caching should apply to, the presence of the cache\
+As the cache is not aware of grants, unless the cache has been explicitly
+configured who the caching should apply to, the presence of the cache
 may provide a user with access to data he should not have access to.\
 Note that the following applies _only_ if `users=mixed` has been configured.\
-If `users=isolated` has been configured, then there can never be any\
+If `users=isolated` has been configured, then there can never be any
 unintended sharing between users.
 
-Suppose there is a table `access` that the user _alice_ has access to,\
-but the user _bob_ does not. If _bob_ tries to access the table, he will\
+Suppose there is a table `access` that the user _alice_ has access to,
+but the user _bob_ does not. If _bob_ tries to access the table, he will
 get an error as reply:
 
 ```
@@ -1137,8 +1137,8 @@ MySQL [testdb]> select * from access;
 ERROR 1142 (42000): SELECT command denied to user 'bob'@'localhost' for table 'access'
 ```
 
-If we now setup caching for the table, using the simplest possible rules\
-file, _bob_ will get access to data from the table, provided he executes\
+If we now setup caching for the table, using the simplest possible rules
+file, _bob_ will get access to data from the table, provided he executes
 a select identical with one _alice_ has executed.
 
 For instance, suppose the rules look as follows:
@@ -1155,7 +1155,7 @@ For instance, suppose the rules look as follows:
 }
 ```
 
-If _alice_ now queries the table, she will get the result, which also will\
+If _alice_ now queries the table, she will get the result, which also will
 be cached:
 
 ```
@@ -1167,7 +1167,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-If _bob_ now executes the very same query, and the result is still in the\
+If _bob_ now executes the very same query, and the result is still in the
 cache, it will be returned to him.
 
 ```
@@ -1187,7 +1187,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-That can be prevented, by explicitly declaring in the rules that the caching\
+That can be prevented, by explicitly declaring in the rules that the caching
 should be applied to _alice_ only.
 
 ```
@@ -1209,24 +1209,24 @@ should be applied to _alice_ only.
 }
 ```
 
-With these rules in place, _bob_ is again denied access, since queries\
+With these rules in place, _bob_ is again denied access, since queries
 targeting the table `access` will in his case not be served from the cache.
 
 ### Storage
 
 There are two types of storages that can be used; _local_ and _shared_.
 
-The only _local_ storage implementation is `storage_inmemory` that simply\
-stores the cache values in memory. The storage is not persistent and is\
-destroyed when MaxScale terminates. Since the storage exists in the MaxScale\
+The only _local_ storage implementation is `storage_inmemory` that simply
+stores the cache values in memory. The storage is not persistent and is
+destroyed when MaxScale terminates. Since the storage exists in the MaxScale
 process, it is very fast and provides almost always a performance benefit.
 
-Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)\
+Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)
 and [redis](https://redis.io/) respectively.
 
 The shared storages are accessed across the network and consequently it is _not_ self-evident that their use will provide any performance benefit.
-Namely, irrespective of whether the data is fetched from the cache or from\
-the server there will be a network hop and often that network hop is, as far\
+Namely, irrespective of whether the data is fetched from the cache or from
+the server there will be a network hop and often that network hop is, as far
 as the performance goes, what costs the most.
 
 The presence of a shared cache _may_ provide a performance benefit
@@ -1235,12 +1235,12 @@ The presence of a shared cache _may_ provide a performance benefit
 * if the used SELECT statements are heavy (that is, take a significant amount of time) to process for the database server, or
 * if the presence of the cache reduces the overall load of an otherwise overloaded database server.
 
-As a general rule a _shared_ storage should not be used without first\
+As a general rule a _shared_ storage should not be used without first
 assessing its value using a realistic workload.
 
 #### `storage_inmemory`
 
-This simple storage module uses the standard memory allocator for storing\
+This simple storage module uses the standard memory allocator for storing
 the cached data.
 
 ```
@@ -1251,12 +1251,12 @@ This storage module takes no arguments.
 
 #### `storage_memcached`
 
-This storage module uses [memcached](https://memcached.org/) for storing the\
+This storage module uses [memcached](https://memcached.org/) for storing the
 cached data.
 
-Multiple MaxScale instances can share the same memcached server and items\
+Multiple MaxScale instances can share the same memcached server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
@@ -1271,11 +1271,11 @@ storage=storage_memcached
 `storage_memcached` has the following optional arguments:
 
 * `max_value_size` using which the maximum size of a cached value is specified.\
-  By default, the maximum size of a value stored to memcached is 1MB, but that\
-  configured to be something else. The value of `max_value_size` will be used\
-  for capping `max_resultset_size`, that is, unless memcached is configured to\
-  allow larger values that 1M and `max_value_size` has been set accordingly,\
-  only resultsets up to 1MB in size will be cached. The value can be specified\
+  By default, the maximum size of a value stored to memcached is 1MB, but that
+  configured to be something else. The value of `max_value_size` will be used
+  for capping `max_resultset_size`, that is, unless memcached is configured to
+  allow larger values that 1M and `max_value_size` has been set accordingly,
+  only resultsets up to 1MB in size will be cached. The value can be specified
   as documented [here](https://mariadb.com/kb/Getting-Started/Configuration-Guide/#sizes).
 
 Example:
@@ -1291,35 +1291,35 @@ storage_options="server=192.168.1.31:11211, max_value_size=10M"
 
 **Security**
 
-_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and\
-the memcached server is encrypted. Consequently, _anybody_ with access to the\
+_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and
+the memcached server is encrypted. Consequently, _anybody_ with access to the
 memcached server or to the network have access to the cached data.
 
 #### `storage_redis`
 
-This storage module uses [redis](https://redis.io/) for storing the\
+This storage module uses [redis](https://redis.io/) for storing the
 cached data.
 
-Multiple MaxScale instances can share the same redis server and items\
+Multiple MaxScale instances can share the same redis server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
 storage=storage_redis
 ```
 
-If `storage_redis` cannot connect to the Redis server, caching will silently\
-be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2106-cache.md#timeout)\
+If `storage_redis` cannot connect to the Redis server, caching will silently
+be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2106-cache.md#timeout)
 interval.
 
-If a timeout error occurs during an operation, reconnecting will be attempted\
-after a delay, which will be an increasing multiple of `timeout`. For example,\
-if `timeout` is the default 5 seconds, then reconnection attempts will first\
-be made after 10 seconds, then after 15 seconds, then 20 and so on. However,\
-once 60 seconds have been reached, the delay will no longer be increased but\
-the delay will stay at one minute. Note that each time a reconnection attempt\
-is made, unless the reason for the timeout has disappeared, the client will be\
+If a timeout error occurs during an operation, reconnecting will be attempted
+after a delay, which will be an increasing multiple of `timeout`. For example,
+if `timeout` is the default 5 seconds, then reconnection attempts will first
+be made after 10 seconds, then after 15 seconds, then 20 and so on. However,
+once 60 seconds have been reached, the delay will no longer be increased but
+the delay will stay at one minute. Note that each time a reconnection attempt
+is made, unless the reason for the timeout has disappeared, the client will be
 stalled for `timeout` seconds.
 
 `storage_redis` has the following mandatory arguments:
@@ -1333,8 +1333,8 @@ Example:
 storage_options="server=192.168.1.31:6379"
 ```
 
-Note that Redis should be configured with no idle timeout or with a timeout that\
-is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which\
+Note that Redis should be configured with no idle timeout or with a timeout that
+is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which
 will hurt both the functionality and the performance.
 
 **Limitations**
@@ -1344,12 +1344,12 @@ will hurt both the functionality and the performance.
 
 **Invalidation**
 
-`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2106-cache.md#best-efforts)\
-are of greater significance since also the communication between the cache and the\
+`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2106-cache.md#best-efforts)
+are of greater significance since also the communication between the cache and the
 cache storage is asynchronous and takes place over the network.
 
-_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation\
-mode), redis must be flushed as otherwise there will be entries in the cache that\
+_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation
+mode), redis must be flushed as otherwise there will be entries in the cache that
 will not be affected by the invalidation.
 
 ```
@@ -1358,13 +1358,13 @@ $ redis-cli flushall
 
 **Security**
 
-_Neither_ the data in the redis server _nor_ the traffic between MaxScale and\
-the redis server is encrypted. Consequently, _anybody_ with access to the\
+_Neither_ the data in the redis server _nor_ the traffic between MaxScale and
+the redis server is encrypted. Consequently, _anybody_ with access to the
 redis server or to the network have access to the cached data.
 
 ### Example
 
-In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size\
+In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size
 of the cached data is `50` mebibytes. The rules for the cache are in the file`cache_rules.json`.
 
 #### Configuration
@@ -1404,16 +1404,16 @@ The rules specify that the data of the table `sbtest` should be cached.
 
 ### Performance
 
-When the cache filter was introduced, the most significant factor affecting\
+When the cache filter was introduced, the most significant factor affecting
 the performance of the cache was whether the statements needed to be parsed.\
-Initially, all statements were parsed in order to exclude `SELECT` statements\
-that use non-cacheable functions, access non-cacheable variables or refer\
-to system or user variables. Later, the default value of the `selects` parameter\
+Initially, all statements were parsed in order to exclude `SELECT` statements
+that use non-cacheable functions, access non-cacheable variables or refer
+to system or user variables. Later, the default value of the `selects` parameter
 was changed to `assume_cacheable`, to maximize the default performance.
 
-With the default configuration, the cache itself will not cause the statements\
-to be parsed. However, even with `assume_cacheable` configured, a rule referring\
-specifically to a _database_, _table_ or _column_ will still cause the\
+With the default configuration, the cache itself will not cause the statements
+to be parsed. However, even with `assume_cacheable` configured, a rule referring
+specifically to a _database_, _table_ or _column_ will still cause the
 statement to be parsed.
 
 For instance, a simple rule like
@@ -1448,15 +1448,15 @@ If the rule is instead expressed using a regular expression
 
 then the statement will not be parsed.
 
-However, when the [query classifier cache](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
-was introduced, the parsing cost was significantly reduced and\
-currently the cost for parsing and regular expression matching\
+However, when the [query classifier cache](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
+was introduced, the parsing cost was significantly reduced and
+currently the cost for parsing and regular expression matching
 is roughly the same.
 
-In the following is a table with numbers giving a rough picture\
+In the following is a table with numbers giving a rough picture
 of the relative cost of different approaches.
 
-In the table, _regexp match_ means that the cacheable statements\
+In the table, _regexp match_ means that the cacheable statements
 were picked out using a rule like
 
 ```
@@ -1467,7 +1467,7 @@ were picked out using a rule like
 }
 ```
 
-while _exact match_ means that the cacheable statements were picked out using a\
+while _exact match_ means that the cacheable statements were picked out using a
 rule like
 
 ```
@@ -1480,12 +1480,12 @@ rule like
 
 The exact match rule requires all statements to be parsed.
 
-As the purpose of the test is to illustrate the overhead of\
-different approaches, the rules were formulated so that\
+As the purpose of the test is to illustrate the overhead of
+different approaches, the rules were formulated so that
 all SELECT statements would match.
 
 Note that these figures were obtained by running sysbench,\
-MaxScale and the server in the same computer, so they are\
+MaxScale and the server in the same computer, so they are
 only indicative.
 
 | selects           | Rule         | qps |
@@ -1499,18 +1499,18 @@ only indicative.
 
 For comparison, without caching, the qps is `33`.
 
-As can be seen, due to the query classifier cache there is\
+As can be seen, due to the query classifier cache there is
 no difference between exact and regex based matching.
 
 #### Summary
 
 For maximum performance:
 
-* Arrange the situation so that the default `selects=assume_cacheable`\
+* Arrange the situation so that the default `selects=assume_cacheable`
   can be used, and use no rules.
 
-Otherwise it is mostly a personal preference whether exact or regex\
-based rules are used. However, one should always test with real data\
+Otherwise it is mostly a personal preference whether exact or regex
+based rules are used. However, one should always test with real data
 and real queries before choosing one over the other.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-binlog-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-binlog-filter.md
@@ -4,22 +4,22 @@ This filter was introduced in MariaDB MaxScale 2.3.0.
 
 ### Overview
 
-The `binlogfilter` can be combined with a `binlogrouter` service to selectively\
+The `binlogfilter` can be combined with a `binlogrouter` service to selectively
 replicate the binary log events to slave servers.
 
-The filter uses two settings, _match_ and _exclude_, to determine which events\
-are replicated. If a binlog event does not match or is excluded, the event is\
-replaced with an empty data event. The empty event is always 35 bytes which\
+The filter uses two settings, _match_ and _exclude_, to determine which events
+are replicated. If a binlog event does not match or is excluded, the event is
+replaced with an empty data event. The empty event is always 35 bytes which
 translates to a space reduction in most cases.
 
-When statement-based replication is used, any query events that are filtered out\
-are replaced with a SQL comment. This causes the query event to do nothing and\
-thus the event will not modify the contents of the database. The GTID position\
-of the replicating database will still advance which means that downstream\
+When statement-based replication is used, any query events that are filtered out
+are replaced with a SQL comment. This causes the query event to do nothing and
+thus the event will not modify the contents of the database. The GTID position
+of the replicating database will still advance which means that downstream
 servers replicating from it keep functioning correctly.
 
-The filter works with both row based and statement based replication but we\
-recommend using row based replication with the binlogfilter. This guarantees\
+The filter works with both row based and statement based replication but we
+recommend using row based replication with the binlogfilter. This guarantees
 that there are no ambiguities in the event filtering.
 
 ### Configuration
@@ -42,18 +42,18 @@ Include queries that match the regex. See next entry, `exclude`, for more inform
 
 Exclude queries that match the regex.
 
-If neither `match` nor `exclude` are defined, the filter does nothing and all events\
-are replicated. This filter does not accept regular expression options as a separate\
-setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for\
+If neither `match` nor `exclude` are defined, the filter does nothing and all events
+are replicated. This filter does not accept regular expression options as a separate
+setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for
 more information.
 
-The two settings are matched against the database and table name concatenated\
-with a period. For example, the string the patterns are matched against for the\
+The two settings are matched against the database and table name concatenated
+with a period. For example, the string the patterns are matched against for the
 database `test` and table `t1` is `test.t1`.
 
-For statement based replication, the pattern is matched against all the tables\
-in the statements. If any of the tables matches the _match_ pattern, the event\
-is replicated. If any of the tables matches the _exclude_ pattern, the event is\
+For statement based replication, the pattern is matched against all the tables
+in the statements. If any of the tables matches the _match_ pattern, the event
+is replicated. If any of the tables matches the _exclude_ pattern, the event is
 not replicated.
 
 #### `rewrite_src`
@@ -73,28 +73,28 @@ See the next entry, `rewrite_dest`, for more information.
 * Default: None
 
 `rewrite_src` and `rewrite_dest` control the statement rewriting of the binlogfilter.\
-The `rewrite_src` setting is a PCRE2 regular expression that is matched against\
-the default database and the SQL of statement based replication events (query\
+The `rewrite_src` setting is a PCRE2 regular expression that is matched against
+the default database and the SQL of statement based replication events (query
 events). `rewrite_dest` is the replacement string which supports the normal\
-PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,\
+PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,
 etc.).
 
 Both `rewrite_src` and `rewrite_dest` must be defined to enable statement rewriting.
 
-When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)\
-must be used. The filter will disallow replication for all slaves that attempt\
+When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)
+must be used. The filter will disallow replication for all slaves that attempt
 to replicate with traditional file-and-position based replication.
 
-The replacement is done both on the default database as well as the SQL\
-statement in the query event. This means that great care must be taken when\
-defining the rewriting rules. To prevent accidental modification of the SQL into\
-a form that is no longer valid, use database and table names that never occur in\
+The replacement is done both on the default database as well as the SQL
+statement in the query event. This means that great care must be taken when
+defining the rewriting rules. To prevent accidental modification of the SQL into
+a form that is no longer valid, use database and table names that never occur in
 the inserted data and is never used as a constant value.
 
 ### Example Configuration
 
-With the following configuration, only events belonging to database `customers`\
-are replicated. In addition to this, events for the table `orders` are excluded\
+With the following configuration, only events belonging to database `customers`
+are replicated. In addition to this, events for the table `orders` are excluded
 and thus are not replicated.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-consistent-critical-read-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-consistent-critical-read-filter.md
@@ -4,41 +4,41 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Consistent Critical Read (CCR) filter allows consistent critical reads to be\
+The Consistent Critical Read (CCR) filter allows consistent critical reads to be
 done through MaxScale while still allowing scaleout of non-critical reads.
 
-When the filter detects a statement that would modify the database, it attaches\
-a routing hint to all following statements done by that connection. This routing\
-hint guides the routing module to route the statement to the master server where\
-data is guaranteed to be in an up-to-date state. Writes from one session do not,\
+When the filter detects a statement that would modify the database, it attaches
+a routing hint to all following statements done by that connection. This routing
+hint guides the routing module to route the statement to the master server where
+data is guaranteed to be in an up-to-date state. Writes from one session do not,
 by default, propagate to other sessions.
 
-_Note:_ This filter does not work with prepared statements. Only text protocol\
+_Note:_ This filter does not work with prepared statements. Only text protocol
 queries are handled by this filter.
 
 #### Controlling the Filter with SQL Comments
 
-The triggering of the filter can be limited further by adding MaxScale supported\
-comments to queries and/or by using regular expressions. The query comments take\
-precedence: if a comment is found it is obeyed even if a regular expression\
+The triggering of the filter can be limited further by adding MaxScale supported
+comments to queries and/or by using regular expressions. The query comments take
+precedence: if a comment is found it is obeyed even if a regular expression
 parameter might give a different result. Even a comment cannot cause a\
-SELECT-query to trigger the filter. Such a comment is considered an error and\
+SELECT-query to trigger the filter. Such a comment is considered an error and
 ignored.
 
-The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-hint-syntax.md)\
-and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a\
-query has a MaxScale supported comment line which defines the parameter `ccr`,\
-that comment is caught by the CCR-filter. Parameter values `match` and `ignore`\
-are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)\
+The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-hint-syntax.md)
+and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a
+query has a MaxScale supported comment line which defines the parameter `ccr`,
+that comment is caught by the CCR-filter. Parameter values `match` and `ignore`
+are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)
 on receiving the write query. For example, the query
 
 ```
 INSERT INTO departments VALUES ('d1234', 'NewDepartment'); -- maxscale ccr=ignore
 ```
 
-would normally cause the filter to trigger, but does not because of the\
-comment. The `match`-comment typically has no effect, since write queries by\
-default trigger the filter anyway. It can be used to override an ignore-type\
+would normally cause the filter to trigger, but does not because of the
+comment. The `match`-comment typically has no effect, since write queries by
+default trigger the filter anyway. It can be used to override an ignore-type
 regular expression that would otherwise prevent triggering.
 
 ### Filter Parameters
@@ -52,19 +52,19 @@ The CCR filter has no mandatory parameters.
 * Dynamic: Yes
 * Default: `60s`
 
-The time window during which queries are routed to the master. The duration\
-can be specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+The time window during which queries are routed to the master. The duration
+can be specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 but the value will always be rounded to the nearest second.\
-If no explicit unit has been specified, the value is interpreted as seconds\
+If no explicit unit has been specified, the value is interpreted as seconds
 in MaxScale 2.4. In subsequent versions a value without a unit may be rejected.\
 The default value for this parameter is 60 seconds.
 
-When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new\
-data modifying SQL statement is processed within the time window, the timer is\
+When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new
+data modifying SQL statement is processed within the time window, the timer is
 reset to the value of _time_.
 
-Enabling this parameter in combination with the _count_ parameter causes both\
-the time window and number of queries to be inspected. If either of the two\
+Enabling this parameter in combination with the _count_ parameter causes both
+the time window and number of queries to be inspected. If either of the two
 conditions are met, the query is re-routed to the master.
 
 #### `count`
@@ -77,10 +77,10 @@ conditions are met, the query is re-routed to the master.
 The number of SQL statements to route to master after detecting a data modifying\
 SQL statement. This feature is disabled by default.
 
-After processing a data modifying SQL statement, a counter is set to the value\
-of _count_ and all statements are routed to the master. Each executed statement\
-after a data modifying SQL statement cause the counter to be decremented. Once\
-the counter reaches zero, the statements are routed normally. If a new data\
+After processing a data modifying SQL statement, a counter is set to the value
+of _count_ and all statements are routed to the master. Each executed statement
+after a data modifying SQL statement cause the counter to be decremented. Once
+the counter reaches zero, the statements are routed normally. If a new data
 modifying SQL statement is processed, the counter is reset to the value of_count_.
 
 #### `match`, `ignore`
@@ -90,9 +90,9 @@ modifying SQL statement is processed, the counter is reset to the value of_count
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
-control which statements trigger statement re-routing. Only non-SELECT statements are\
-inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works\
+These [regular expression settings](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
+control which statements trigger statement re-routing. Only non-SELECT statements are
+inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works
 similarly.
 
 ```
@@ -118,16 +118,16 @@ Regular expression options for `match` and `ignore`.
 * Dynamic: Yes
 * Default: `false`
 
-`global` is a boolean parameter that when enabled causes writes from one\
-connection to propagate to all other connections. This can be used to work\
-around cases where one connection writes data and another reads it, expecting\
+`global` is a boolean parameter that when enabled causes writes from one
+connection to propagate to all other connections. This can be used to work
+around cases where one connection writes data and another reads it, expecting
 the write done by the other connection to be visible.
 
 This parameter only works with the `time` parameter. The use of `global` and`count` at the same time is not allowed and will be treated as an error.
 
 ### Example Configuration
 
-Here is a minimal filter configuration for the CCRFilter which should solve most\
+Here is a minimal filter configuration for the CCRFilter which should solve most
 problems with critical reads after writes.
 
 ```
@@ -137,13 +137,13 @@ module=ccrfilter
 time=5
 ```
 
-With this configuration, whenever a connection does a write, all subsequent\
+With this configuration, whenever a connection does a write, all subsequent
 reads done by that connection will be forced to the master for 5 seconds.
 
-This prevents read scaling until the modifications have been replicated to the\
-slaves. For best performance, the value of _time_ should be slightly greater\
-than the actual replication lag between the master and its slaves. If the number\
-of critical read statements is known, the _count_ parameter could be used to\
+This prevents read scaling until the modifications have been replicated to the
+slaves. For best performance, the value of _time_ should be slightly greater
+than the actual replication lag between the master and its slaves. If the number
+of critical read statements is known, the _count_ parameter could be used to
 control the number reads that are sent to the master.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-database-firewall-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-database-firewall-filter.md
@@ -4,21 +4,21 @@ This filter is deprecated in MariaDB MaxScale 6 and will be removed in MaxScale 
 
 ### Overview
 
-The Database Firewall filter is used to block queries that match a set of\
-rules. It can be used to prevent harmful queries from reaching the backend\
-database instances or to limit access to the database based on a more flexible\
-set of rules compared to the traditional GRANT-based privilege system. Currently\
+The Database Firewall filter is used to block queries that match a set of
+rules. It can be used to prevent harmful queries from reaching the backend
+database instances or to limit access to the database based on a more flexible
+set of rules compared to the traditional GRANT-based privilege system. Currently
 the filter does not support multi-statements.
 
-Note that the firewall filter should be viewed as a best-effort solution\
-intended for protecting against accidental misuse rather than malicious\
+Note that the firewall filter should be viewed as a best-effort solution
+intended for protecting against accidental misuse rather than malicious
 attacks.
 
 ### Configuration
 
-The Database Firewall filter only requires minimal configuration in the\
-maxscale.cnf file. The actual rules of the Database Firewall filter are located\
-in a separate text file. The following is an example of a Database Firewall\
+The Database Firewall filter only requires minimal configuration in the
+maxscale.cnf file. The actual rules of the Database Firewall filter are located
+in a separate text file. The following is an example of a Database Firewall
 filter configuration in maxscale.cnf.
 
 ```
@@ -42,19 +42,19 @@ The Database Firewall filter has one mandatory parameter, `rules`.
 
 **`rules`**
 
-A path to a file with the rule definitions in it. The file should be readable by\
-the user MariaDB MaxScale is run with. If a relative path is given, the path is\
-interpreted relative to the module configuration directory. The default module\
+A path to a file with the rule definitions in it. The file should be readable by
+the user MariaDB MaxScale is run with. If a relative path is given, the path is
+interpreted relative to the module configuration directory. The default module
 configuration directory is _/etc/maxscale.modules.d_.
 
 **`action`**
 
-This parameter is optional and determines what action is taken when a query\
-matches a rule. The value can be either `allow`, which allows all matching\
-queries to proceed but blocks those that don't match, or `block`, which blocks\
+This parameter is optional and determines what action is taken when a query
+matches a rule. The value can be either `allow`, which allows all matching
+queries to proceed but blocks those that don't match, or `block`, which blocks
 all matching queries, or `ignore` which allows all queries to proceed.
 
-The following statement types will always be allowed through when `action` is\
+The following statement types will always be allowed through when `action` is
 set to `allow`:
 
 * COM\_CHANGE\_USER: The user is changed for an active connection
@@ -66,10 +66,10 @@ set to `allow`:
 * COM\_QUIT: Client closes connection
 * COM\_SET\_OPTION: Client multi-statements are being configured
 
-You can have both blacklist and whitelist functionality by configuring one\
-filter with `action=allow` and another one with `action=block`. You can then use\
-different rule files with each filter, one for blacklisting and another one for\
-whitelisting. After this you only have to add both of these filters to a service\
+You can have both blacklist and whitelist functionality by configuring one
+filter with `action=allow` and another one with `action=block`. You can then use
+different rule files with each filter, one for blacklisting and another one for
+whitelisting. After this you only have to add both of these filters to a service
 in the following way.
 
 ```
@@ -94,26 +94,26 @@ action=block
 rules=/home/user/blacklist-rules.txt
 ```
 
-If a query is blocked, the filter will return an error to the client with the\
+If a query is blocked, the filter will return an error to the client with the
 error number 1141 and an SQL state of HY000.
 
 **`log_match`**
 
-Log all queries that match a rule. For the `any` matching mode, the name of the\
-rule that matched is logged and for other matching modes, the name of the last\
-matching rule is logged. In addition to the rule name the matched user and the\
+Log all queries that match a rule. For the `any` matching mode, the name of the
+rule that matched is logged and for other matching modes, the name of the last
+matching rule is logged. In addition to the rule name the matched user and the
 query itself is logged. The log messages are logged at the notice level.
 
 **`log_no_match`**
 
-Log all queries that do not match a rule. The matched user and the query is\
+Log all queries that do not match a rule. The matched user and the query is
 logged. The log messages are logged at the notice level.
 
 **`treat_string_as_field`**
 
-This optional parameter specifies how the database firewall should treat\
-strings. If true, they will be handled as fields, which will cause column\
-blocking rules to match even if `ANSI_QUOTES` has been enabled and `"` is\
+This optional parameter specifies how the database firewall should treat
+strings. If true, they will be handled as fields, which will cause column
+blocking rules to match even if `ANSI_QUOTES` has been enabled and `"` is
 used instead of backtick.
 
 ```
@@ -122,14 +122,14 @@ treat_string_as_field=false
 
 The default value is `true`.
 
-Note that this may cause a false positive, if a "true" string contains the\
+Note that this may cause a false positive, if a "true" string contains the
 name of a column to be blocked.
 
 **`treat_string_arg_as_field`**
 
-This optional parameter specifies how the database firewall should treat\
-strings used as arguments to functions. If true, they will be handled\
-as fields, which will cause function column blocking rules to match even\
+This optional parameter specifies how the database firewall should treat
+strings used as arguments to functions. If true, they will be handled
+as fields, which will cause function column blocking rules to match even
 even if `ANSI_QUOTES` has been enabled and `"` is used instead of backtick.
 
 ```
@@ -138,16 +138,16 @@ treat_string_arg_as_field=false
 
 The default value is `true`.
 
-Note that this may cause a false positive, if a "true" string contains the\
+Note that this may cause a false positive, if a "true" string contains the
 name of a column to be blocked.
 
 **`strict`**
 
-Whether to treat unsupported SQL or multi-statement SQL as an error. This is a\
+Whether to treat unsupported SQL or multi-statement SQL as an error. This is a
 boolean parameter and the default value is `true`.
 
-When disabled, SQL that cannot be fully parsed is allowed to pass if the rules\
-do not cause it to be blocked. This can be used to provide a best-effort mode\
+When disabled, SQL that cannot be fully parsed is allowed to pass if the rules
+do not cause it to be blocked. This can be used to provide a best-effort mode
 where uncertainly about the SQL is allowed.
 
 ### Rule syntax
@@ -161,21 +161,21 @@ rule NAME match RULE [at_times VALUE...] [on_queries {select|update|insert|delet
 Where _NAME_ is the identifier for this rule and _RULE_ is the mandatory rule definition.
 
 Rules are identified by their name and have mandatory parts and optional parts.\
-You can add comments to the rule files by adding the `#` character at\
+You can add comments to the rule files by adding the `#` character at
 the beginning of the line. Trailing comments are not supported.
 
-The first step of defining a rule is to start with the keyword `rule` which\
-identifies this line of text as a rule. The second token is identified as\
-the name of the rule. After that the mandatory token `match` is required\
+The first step of defining a rule is to start with the keyword `rule` which
+identifies this line of text as a rule. The second token is identified as
+the name of the rule. After that the mandatory token `match` is required
 to mark the start of the actual rule definition.
 
-The rule definition must contain exactly one mandatory rule parameter. It can\
+The rule definition must contain exactly one mandatory rule parameter. It can
 also contain one of each type of optional rule parameter.
 
 #### Mandatory rule parameters
 
-The Database Firewall filter's rules expect a single mandatory parameter for a\
-rule. You can define multiple rules to cover situations where you would like to\
+The Database Firewall filter's rules expect a single mandatory parameter for a
+rule. You can define multiple rules to cover situations where you would like to
 apply multiple mandatory rules to a query.
 
 **`wildcard`**
@@ -192,7 +192,7 @@ rule examplerule match wildcard
 
 **`columns`**
 
-This rule expects a list of values after the `columns` keyword. These values are\
+This rule expects a list of values after the `columns` keyword. These values are
 interpreted as column names and if a query targets any of these, it is matched.
 
 **Example**
@@ -205,10 +205,10 @@ rule examplerule match columns name salary
 
 **`function`**
 
-This rule expects a list of values after the `function` keyword. These values\
-are interpreted as function names and if a query uses any of these, it is\
-matched. The symbolic comparison operators (`<`, `>`, `>=` etc.) are also\
-considered functions whereas the text versions (`NOT`, `IS`, `IS NOT` etc.) are\
+This rule expects a list of values after the `function` keyword. These values
+are interpreted as function names and if a query uses any of these, it is
+matched. The symbolic comparison operators (`<`, `>`, `>=` etc.) are also
+considered functions whereas the text versions (`NOT`, `IS`, `IS NOT` etc.) are
 not considered functions.
 
 **Example**
@@ -221,10 +221,10 @@ rule examplerule match function sum count
 
 **`not_function`**
 
-This rule expects a list of values after the `not_function` keyword. These values\
-are interpreted as function names and if a query uses any function other than these,\
-it is matched. The symbolic comparison operators (`<`, `>`, `>=` etc.) are also\
-considered functions whereas the text versions (`NOT`, `IS`, `IS NOT` etc.) are\
+This rule expects a list of values after the `not_function` keyword. These values
+are interpreted as function names and if a query uses any function other than these,
+it is matched. The symbolic comparison operators (`<`, `>`, `>=` etc.) are also
+considered functions whereas the text versions (`NOT`, `IS`, `IS NOT` etc.) are
 not considered functions.
 
 If the rule is given no values, then the rule will match a query using any function.
@@ -245,8 +245,8 @@ rule examplerule match not_function
 
 **`uses_function`**
 
-This rule expects a list of column names after the keyword. If any of the\
-columns are used with a function, the rule will match. This rule can be\
+This rule expects a list of column names after the keyword. If any of the
+columns are used with a function, the rule will match. This rule can be
 used to prevent the use of a column with a function.
 
 **Example**
@@ -259,8 +259,8 @@ rule examplerule match uses_function name address
 
 **`function` and `columns`**
 
-This rule combines the `function` and `columns` type rules to match if one\
-of the listed columns uses one of the listed functions. The rule expects\
+This rule combines the `function` and `columns` type rules to match if one
+of the listed columns uses one of the listed functions. The rule expects
 the `function` and `columns` keywords both followed by a list of values.
 
 **Example**
@@ -273,17 +273,17 @@ rule examplerule match function sum columns name address
 
 **`not_function` and `columns`**
 
-This rule combines the `not_function` and `columns` type rules to match if\
-one of the listed columns is used in conjunction with functions other than\
-the listed ones. The rule expects the `not_function` and `columns` keywords\
+This rule combines the `not_function` and `columns` type rules to match if
+one of the listed columns is used in conjunction with functions other than
+the listed ones. The rule expects the `not_function` and `columns` keywords
 both followed by a list of values.
 
-If `not_function` is not provided with a list of values, then the rule\
+If `not_function` is not provided with a list of values, then the rule
 matches if any of the columns is used with any function.
 
 **Example**
 
-Match if any other function but _length_ is used with the _name_ or _address_\
+Match if any other function but _length_ is used with the _name_ or _address_
 columns:
 
 ```
@@ -299,8 +299,8 @@ rule examplerule match not_function columns ssn
 **`regex`**
 
 This rule blocks all queries matching the regular expression. The regex string expects a\
-PCRE2 syntax regular expression. For more information about PCRE2 syntax, read the [PCRE2 documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html). Unlike\
-typical MaxScale regex parameters, the value should be enclosed in single or double\
+PCRE2 syntax regular expression. For more information about PCRE2 syntax, read the [PCRE2 documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html). Unlike
+typical MaxScale regex parameters, the value should be enclosed in single or double
 quotes, not in `/.../`. Any compilation options must be included in the pattern itself.
 
 **Example**
@@ -315,9 +315,9 @@ rule examplerule match regex '.*select.*from.*accounts.*'
 
 This rule has been DEPRECATED. Please use the Throttle Filter instead.
 
-The limit\_queries rule expects three parameters. The first parameter is the\
-number of allowed queries during the time period. The second is the time period\
-in seconds and the third is the amount of time in seconds for which the rule is\
+The limit\_queries rule expects three parameters. The first parameter is the
+number of allowed queries during the time period. The second is the time period
+in seconds and the third is the amount of time in seconds for which the rule is
 considered active and blocking.
 
 **WARNING:** Using `limit_queries` in `action=allow` is not supported.
@@ -332,8 +332,8 @@ rule examplerule match limit_queries 50 5 100
 
 **`no_where_clause`**
 
-This rule inspects the query and blocks it if it has no WHERE clause. For\
-example, this would disallow a `DELETE FROM ...` query without a `WHERE`\
+This rule inspects the query and blocks it if it has no WHERE clause. For
+example, this would disallow a `DELETE FROM ...` query without a `WHERE`
 clause. This does not prevent wrongful usage of the `WHERE` clause e.g. `DELETE FROM ... WHERE 1=1`.
 
 **Example**
@@ -346,20 +346,20 @@ rule examplerule match no_where_clause
 
 #### Optional rule parameters
 
-Each mandatory rule accepts one or more optional parameters. These are to be\
+Each mandatory rule accepts one or more optional parameters. These are to be
 defined after the mandatory part of the rule.
 
 **`at_times`**
 
-This rule expects a list of time ranges that define the times when the rule in\
-question is active. The time formats are expected to be ISO-8601 compliant and\
-to be separated by a single dash (the - character). For example, to define the\
-active period of a rule to be 5pm to 7pm, you would include `at times 17:00:00-19:00:00` in the rule definition. The rule uses local time to check if\
+This rule expects a list of time ranges that define the times when the rule in
+question is active. The time formats are expected to be ISO-8601 compliant and
+to be separated by a single dash (the - character). For example, to define the
+active period of a rule to be 5pm to 7pm, you would include `at times 17:00:00-19:00:00` in the rule definition. The rule uses local time to check if
 the rule is active and has a precision of one second.
 
 **`on_queries`**
 
-This limits the rule to be active only on certain types of queries. The possible\
+This limits the rule to be active only on certain types of queries. The possible
 values are:
 
 | Keyword | Matching operations   |
@@ -384,13 +384,13 @@ The `users` directive defines the users to which the rule should be applied.
 
 `users NAME... match { any | all | strict_all } rules RULE...`
 
-The first keyword is `users`, which identifies this line as a user definition\
+The first keyword is `users`, which identifies this line as a user definition
 line.
 
-The second component is a list of user names and network addresses in the format_`user`_`@`_`0.0.0.0`_. The first part is the user name and the second part is\
-the network address. You can use the `%` character as the wildcard to enable\
-user name matching from any address or network matching for all users. After the\
-list of users and networks the keyword match is expected. This means that the\
+The second component is a list of user names and network addresses in the format_`user`_`@`_`0.0.0.0`_. The first part is the user name and the second part is
+the network address. You can use the `%` character as the wildcard to enable
+user name matching from any address or network matching for all users. After the
+list of users and networks the keyword match is expected. This means that the
 following user definitions are supported:
 
 * `user@host`
@@ -399,64 +399,64 @@ following user definitions are supported:
 
 Partial wildcards, e.g. `user@192.%` are not supported.
 
-As MaxScale listens to the IPv6 all address by default, IPv4 addresses will be\
-mapped into the IPv6 space. This means that the IPv4 address `192.168.0.1` will\
-show up in MaxScale as `::ffff:192.168.0.1`. Take this into account when\
+As MaxScale listens to the IPv6 all address by default, IPv4 addresses will be
+mapped into the IPv6 space. This means that the IPv4 address `192.168.0.1` will
+show up in MaxScale as `::ffff:192.168.0.1`. Take this into account when
 defining the `users` directives.
 
-After this either the keyword `any`, `all` or `strict_all` is expected. This\
-defined how the rules are matched. If `any` is used when the first rule is\
-matched the query is considered as matched and the rest of the rules are\
-skipped. If instead the `all` keyword is used all rules must match for the query\
-to be considered as matched. The `strict_all` is the same as `all` but it checks the rules\
-from left to right in the order they were listed. If one of these does not\
-match, the rest of the rules are not checked. This could be useful in situations\
-where you would for example combine `limit_queries` and `regex` rules. By using`strict_all` you can have the `regex` rule first and the `limit_queries` rule\
-second. This way the rule only matches if the `regex` rule matches enough times\
+After this either the keyword `any`, `all` or `strict_all` is expected. This
+defined how the rules are matched. If `any` is used when the first rule is
+matched the query is considered as matched and the rest of the rules are
+skipped. If instead the `all` keyword is used all rules must match for the query
+to be considered as matched. The `strict_all` is the same as `all` but it checks the rules
+from left to right in the order they were listed. If one of these does not
+match, the rest of the rules are not checked. This could be useful in situations
+where you would for example combine `limit_queries` and `regex` rules. By using`strict_all` you can have the `regex` rule first and the `limit_queries` rule
+second. This way the rule only matches if the `regex` rule matches enough times
 for the `limit_queries` rule to match.
 
-After the matching part comes the rules keyword after which a list of rule names\
-is expected. This allows reusing of the rules and enables varying levels of\
+After the matching part comes the rules keyword after which a list of rule names
+is expected. This allows reusing of the rules and enables varying levels of
 query restriction.
 
-If a particular _NAME_ appears on several `users` lines, then when an\
-actual user matches that name, the rules of each line are checked\
-independently until there is a match for the statement in question. That\
-is, the rules of each `users` line are treated in an _OR_ fashion with\
+If a particular _NAME_ appears on several `users` lines, then when an
+actual user matches that name, the rules of each line are checked
+independently until there is a match for the statement in question. That
+is, the rules of each `users` line are treated in an _OR_ fashion with
 respect to each other.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md) documentation for
 details about module commands.
 
 The dbfwfilter supports the following module commands.
 
 #### `rules/reload FILTER [FILE]`
 
-Load a new rule file or reload the current rules. New rules are only taken into\
-use if they are successfully loaded and in cases where loading of the rules\
-fail, the old rules remain in use. The _FILTER_ parameter is the filter instance\
-whose rules are reloaded. The _FILE_ argument is an optional path to a rule file\
+Load a new rule file or reload the current rules. New rules are only taken into
+use if they are successfully loaded and in cases where loading of the rules
+fail, the old rules remain in use. The _FILTER_ parameter is the filter instance
+whose rules are reloaded. The _FILE_ argument is an optional path to a rule file
 and if it is not defined, the current rule file is used.
 
 #### `rules FILTER`
 
-Shows the current statistics of the rules. The _FILTER_ parameter is the filter\
+Shows the current statistics of the rules. The _FILTER_ parameter is the filter
 instance to inspect.
 
 ### Use Cases
 
 #### Use Case 1 - Prevent rapid execution of specific queries
 
-To prevent the excessive use of a database we want to set a limit on the rate of\
-queries. We only want to apply this limit to certain queries that cause unwanted\
+To prevent the excessive use of a database we want to set a limit on the rate of
+queries. We only want to apply this limit to certain queries that cause unwanted
 behaviour. To achieve this we can use a regular expression.
 
-First we define the limit on the rate of queries. The first parameter for the\
-rule sets the number of allowed queries to 10 queries and the second parameter\
-sets the rate of sampling to 5 seconds. If a user executes queries faster than\
-this, any further queries that match the regular expression are blocked for 60\
+First we define the limit on the rate of queries. The first parameter for the
+rule sets the number of allowed queries to 10 queries and the second parameter
+sets the rate of sampling to 5 seconds. If a user executes queries faster than
+this, any further queries that match the regular expression are blocked for 60
 seconds.
 
 ```
@@ -464,7 +464,7 @@ rule limit_rate_of_queries match limit_queries 10 5 60
 rule query_regex match regex '.*select.*from.*user_data.*'
 ```
 
-To apply these rules we combine them into a single rule by adding a `users` line\
+To apply these rules we combine them into a single rule by adding a `users` line
 to the rule file.
 
 ```
@@ -473,15 +473,15 @@ users %@% match all rules limit_rate_of_queries query_regex
 
 #### Use Case 2 - Only allow deletes with a where clause
 
-We have a table which contains all the managers of a company. We want to prevent\
-accidental deletes into this table where the where clause is missing. This poses\
-a problem, we don't want to require all the delete queries to have a where\
-clause. We only want to prevent the data in the managers table from being\
+We have a table which contains all the managers of a company. We want to prevent
+accidental deletes into this table where the where clause is missing. This poses
+a problem, we don't want to require all the delete queries to have a where
+clause. We only want to prevent the data in the managers table from being
 deleted without a where clause.
 
-To achieve this, we need two rules. The first rule defines that all delete\
-operations must have a where clause. This rule alone does us no good so we need\
-a second one. The second rule blocks all queries that match a regular\
+To achieve this, we need two rules. The first rule defines that all delete
+operations must have a where clause. This rule alone does us no good so we need
+a second one. The second rule blocks all queries that match a regular
 expression.
 
 ```
@@ -489,7 +489,7 @@ rule safe_delete match no_where_clause on_queries delete
 rule managers_table match regex '.*from.*managers.*'
 ```
 
-When we combine these two rules we get the result we want. To combine these two\
+When we combine these two rules we get the result we want. To combine these two
 rules add the following line to the rule file.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-hintfilter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-hintfilter.md
@@ -4,14 +4,14 @@ This filter adds routing hints to a service. The filter has no parameters.
 
 ## Hint Syntax
 
-**Note:** If a query has more than one comment only the first comment is\
-processed. Always place any MaxScale related comments first before any other\
+**Note:** If a query has more than one comment only the first comment is
+processed. Always place any MaxScale related comments first before any other
 comments that might appear in the query.
 
 ### Comments and comment types
 
-The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and\
-they need to be enabled by passing the `--comments` or `-c` option to it. Most,\
+The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and
+they need to be enabled by passing the `--comments` or `-c` option to it. Most,
 if not all, connectors keep all comments intact in executed queries.
 
 ```
@@ -19,10 +19,10 @@ if not all, connectors keep all comments intact in executed queries.
 mariadb --comments -u my-user -psecret -e "SELECT @@hostname -- maxscale route to server db1"
 ```
 
-For comment types, use either `--` (notice the whitespace after the double\
+For comment types, use either `--` (notice the whitespace after the double
 hyphen) or `#` after the semicolon or `/* ... */` before the semicolon.
 
-Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character\
+Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character
 after the start tag or before the end tag but adding the whitespace is advised.
 
 ### Hint body
@@ -33,12 +33,12 @@ All hints must start with the `maxscale` tag.
 -- maxscale <hint body>
 ```
 
-The hints have two types, ones that define a server type and others that contain\
+The hints have two types, ones that define a server type and others that contain
 name-value pairs.
 
 #### Routing destination hints
 
-These hints will instruct the router to route a query to a certain type of a\
+These hints will instruct the router to route a query to a certain type of a
 server.
 
 ```
@@ -51,8 +51,8 @@ server.
 -- maxscale route to master
 ```
 
-A `master` value in a routing hint will route the query to a master server. This\
-can be used to direct read queries to a master server for a up-to-date result\
+A `master` value in a routing hint will route the query to a master server. This
+can be used to direct read queries to a master server for a up-to-date result
 with no replication lag.
 
 **Route to slave**
@@ -61,8 +61,8 @@ with no replication lag.
 -- maxscale route to slave
 ```
 
-A `slave` value will route the query to a slave server. Please note that the\
-hints will override any decisions taken by the routers which means that it is\
+A `slave` value will route the query to a slave server. Please note that the
+hints will override any decisions taken by the routers which means that it is
 possible to force writes to a slave server.
 
 **Route to named server**
@@ -71,7 +71,7 @@ possible to force writes to a slave server.
 -- maxscale route to server <server name>
 ```
 
-A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in\
+A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in
 maxscale.cnf. If the server is not used by the service, the hint is ignored.
 
 **Route to last used server**
@@ -80,8 +80,8 @@ maxscale.cnf. If the server is not used by the service, the hint is ignored.
 -- maxscale route to last
 ```
 
-A `last` value will route the query to the server that processed the last\
-query. This hint can be used to force certain queries to be grouped to the same\
+A `last` value will route the query to the server that processed the last
+query. This hint can be used to force certain queries to be grouped to the same
 server.
 
 **Name-value hints**
@@ -90,13 +90,13 @@ server.
 -- maxscale <param>=<value>
 ```
 
-These control the behavior and affect the routing decisions made by the\
-router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower\
+These control the behavior and affect the routing decisions made by the
+router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower
 replication lag than this parameter's value.
 
 ### Hint stack
 
-Hints can be either single-use hints, which makes them affect only one query, or\
+Hints can be either single-use hints, which makes them affect only one query, or
 named hints, which can be pushed on and off a stack of active hints.
 
 Defining named hints:
@@ -123,7 +123,7 @@ You can define and activate a hint in a single command using the following:
 -- maxscale <hint name> begin <hint content>
 ```
 
-You can also push anonymous hints onto the stack which are only used as long as\
+You can also push anonymous hints onto the stack which are only used as long as
 they are on the stack:
 
 ```
@@ -132,14 +132,14 @@ they are on the stack:
 
 ## Prepared Statements
 
-The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared\
+The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared
 statements.
 
 ### Binary Protocol
 
-With binary protocol prepared statements, a routing hint in the prepared\
-statement is applied to the execution of the statement but not the preparation\
-of it. The preparation of the statement is routed normally and is sent to all\
+With binary protocol prepared statements, a routing hint in the prepared
+statement is applied to the execution of the statement but not the preparation
+of it. The preparation of the statement is routed normally and is sent to all
 servers.
 
 For example, when the following prepared statement is prepared with the MariaDB\
@@ -165,13 +165,13 @@ Support for direct execution of prepared statements was added in MaxScale\
 
 ### Text Protocol
 
-Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL\
-commands) behave differently. If a `PREPARE` command has a routing hint, it will\
-be routed according to the routing hint. Any subsequent `EXECUTE` command will\
-not be affected by the routing hint in the `PREPARE` statement. This means they\
+Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL
+commands) behave differently. If a `PREPARE` command has a routing hint, it will
+be routed according to the routing hint. Any subsequent `EXECUTE` command will
+not be affected by the routing hint in the `PREPARE` statement. This means they
 must have their own routing hints.
 
-The following example is the recommended method of executing text protocol\
+The following example is the recommended method of executing text protocol
 prepared statements with hints:
 
 ```
@@ -185,7 +185,7 @@ The `PREPARE` is routed normally and will be routed to all servers. The`EXECUTE`
 
 ### Routing `SELECT` queries to master
 
-In this example, MariaDB MaxScale is configured with the readwritesplit router\
+In this example, MariaDB MaxScale is configured with the readwritesplit router
 and the hint filter.
 
 ```
@@ -202,9 +202,9 @@ type=filter
 module=hintfilter
 ```
 
-Behind MariaDB MaxScale is a master server and a slave server. If there is\
-replication lag between the master and the slave, read queries sent to the slave\
-might return old data. To guarantee up-to-date data, we can add a routing hint\
+Behind MariaDB MaxScale is a master server and a slave server. If there is
+replication lag between the master and the slave, read queries sent to the slave
+might return old data. To guarantee up-to-date data, we can add a routing hint
 to the query.
 
 ```
@@ -212,9 +212,9 @@ INSERT INTO table1 VALUES ("John","Doe",1);
 SELECT * FROM table1; -- maxscale route to master
 ```
 
-The first INSERT query will be routed to the master. The following SELECT query\
-would normally be routed to the slave but with the added routing hint it will be\
-routed to the master. This way we can do an INSERT and a SELECT right after it\
+The first INSERT query will be routed to the master. The following SELECT query
+would normally be routed to the slave but with the added routing hint it will be
+routed to the master. This way we can do an INSERT and a SELECT right after it
 and still get up-to-date data.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-insert-stream-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-insert-stream-filter.md
@@ -4,10 +4,10 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The _insertstream_ filter converts bulk inserts into CSV data streams that are\
-consumed by the backend server via the LOAD DATA LOCAL INFILE mechanism. This\
-leverages the speed advantage of LOAD DATA LOCAL INFILE over regular inserts\
-while also reducing the overall network traffic by condensing the inserted\
+The _insertstream_ filter converts bulk inserts into CSV data streams that are
+consumed by the backend server via the LOAD DATA LOCAL INFILE mechanism. This
+leverages the speed advantage of LOAD DATA LOCAL INFILE over regular inserts
+while also reducing the overall network traffic by condensing the inserted
 values into CSV.
 
 **Note**: This is an experimental filter module
@@ -18,11 +18,11 @@ This filter has no parameters.
 
 ### Details of Operation
 
-The filter translates all INSERT statements done inside an explicit transaction\
-into LOAD DATA LOCAL INFILE streams. The file name used in the request will\
+The filter translates all INSERT statements done inside an explicit transaction
+into LOAD DATA LOCAL INFILE streams. The file name used in the request will
 always be _maxscale.data_.
 
-The following example is translated into a LOAD DATA LOCAL INFILE request\
+The following example is translated into a LOAD DATA LOCAL INFILE request
 followed by two CSV rows.
 
 ```
@@ -31,10 +31,10 @@ INSERT INTO test.t1 VALUES (1, "hello"), (2, "world");
 COMMIT;
 ```
 
-Multiple inserts to the same table are combined into a single stream. This\
+Multiple inserts to the same table are combined into a single stream. This
 allows for efficient bulk loading with simple insert statements.
 
-The following example will use only one LOAD DATA LOCAL INFILE request followed\
+The following example will use only one LOAD DATA LOCAL INFILE request followed
 by four CSV rows.
 
 ```
@@ -44,11 +44,11 @@ INSERT INTO test.t1 VALUES (3, "foo"), (4, "bar");
 COMMIT;
 ```
 
-Non-INSERT statements executed inside the transaction will close the streaming\
-of the data. Avoid interleaving SELECT statements with INSERT statements inside\
+Non-INSERT statements executed inside the transaction will close the streaming
+of the data. Avoid interleaving SELECT statements with INSERT statements inside
 transactions.
 
-The following example has to use two LOAD DATA LOCAL INFILE requests, each\
+The following example has to use two LOAD DATA LOCAL INFILE requests, each
 followed by two CSV rows.
 
 **Note:** Avoid doing this!
@@ -63,8 +63,8 @@ COMMIT;
 
 #### Estimating Network Bandwidth Reduction
 
-The more inserts that are streamed, the more efficient this filter is. The\
-saving in network bandwidth in bytes can be estimated with the following\
+The more inserts that are streamed, the more efficient this filter is. The
+saving in network bandwidth in bytes can be estimated with the following
 formula:
 
 ```
@@ -80,7 +80,7 @@ Positive values indicate savings in network bandwidth usage.
 
 ### Example Configuration
 
-The filter has no parameters so it is extremely simple to configure. The\
+The filter has no parameters so it is extremely simple to configure. The
 following example shows the required filter configuration.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-lua-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-lua-filter.md
@@ -2,34 +2,34 @@
 
 The luafilter is a filter that calls a set of functions in a Lua script.
 
-Read the [Lua language documentation](https://www.lua.org/docs.html) for\
+Read the [Lua language documentation](https://www.lua.org/docs.html) for
 information on how to write Lua scripts.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Filter Parameters
 
-The luafilter has two parameters. They control which scripts will be called by\
-the filter. Both parameters are optional but at least one should be defined. If\
-both `global_script` and `session_script` are defined, the entry points in both\
+The luafilter has two parameters. They control which scripts will be called by
+the filter. Both parameters are optional but at least one should be defined. If
+both `global_script` and `session_script` are defined, the entry points in both
 scripts will be called.
 
 #### `global_script`
 
-The global Lua script. The parameter value is a path to a readable Lua script\
+The global Lua script. The parameter value is a path to a readable Lua script
 which will be executed.
 
-This script will always be called with the same global Lua state and it can be\
+This script will always be called with the same global Lua state and it can be
 used to build a global view of the whole service.
 
 #### `session_script`
 
-The session level Lua script. The parameter value is a path to a readable Lua\
+The session level Lua script. The parameter value is a path to a readable Lua
 script which will be executed once for each session.
 
-Each session will have its own Lua state meaning that each session can have a\
+Each session will have its own Lua state meaning that each session can have a
 unique Lua environment. Use this script to do session specific tasks.
 
 ### Lua Script Calling Convention
@@ -37,36 +37,36 @@ unique Lua environment. Use this script to do session specific tasks.
 The entry points for the Lua script expect the following signatures:
 
 * `nil createInstance()` - global script only, called when MaxScale is started
-  * The global script will be loaded in this function and executed once on a\
+  * The global script will be loaded in this function and executed once on a
     global level before calling the createInstance function in the Lua script.
 * `nil newSession(string, string)` - new session is created
-  * After the session script is loaded, the newSession function in the Lua\
-    scripts is called. The first parameter is the username of the client and\
+  * After the session script is loaded, the newSession function in the Lua
+    scripts is called. The first parameter is the username of the client and
     the second parameter is the client's network address.
 * `nil closeSession()` - session is closed
   * The `closeSession` function in the Lua scripts will be called.
 * `(nil | bool | string) routeQuery(string)` - query is being routed
-  * The Luafilter calls the `routeQuery` functions of both the session and the\
-    global script. The query is passed as a string parameter to the\
-    routeQuery Lua function and the return values of the session specific\
-    function, if any were returned, are interpreted. If the first value is\
-    bool, it is interpreted as a decision whether to route the query or to\
-    send an error packet to the client. If it is a string, the current query\
-    is replaced with the return value and the query will be routed. If nil is\
+  * The Luafilter calls the `routeQuery` functions of both the session and the
+    global script. The query is passed as a string parameter to the
+    routeQuery Lua function and the return values of the session specific
+    function, if any were returned, are interpreted. If the first value is
+    bool, it is interpreted as a decision whether to route the query or to
+    send an error packet to the client. If it is a string, the current query
+    is replaced with the return value and the query will be routed. If nil is
     returned, the query is routed normally.
 * `nil clientReply()` - reply to a query is being routed
   * This function calls the `clientReply` function of the Lua scripts.
 * `string diagnostic()` - global script only, print diagnostic information
-  * This will call the matching `diagnostics` entry point in the Lua script. If\
+  * This will call the matching `diagnostics` entry point in the Lua script. If
     the Lua function returns a string, it will be printed to the client.
 
-These functions, if found in the script, will be called whenever a call to the\
+These functions, if found in the script, will be called whenever a call to the
 matching entry point is made.
 
 **Script Template**
 
-Here is a script template that can be used to try out the luafilter. Copy it\
-into a file and add `global_script=<path to script>` into the filter\
+Here is a script template that can be used to try out the luafilter. Copy it
+into a file and add `global_script=<path to script>` into the filter
 configuration. Make sure the file is readable by the `maxscale` user.
 
 ```
@@ -100,19 +100,19 @@ end
 The luafilter exposes three functions that can be called from the Lua script.
 
 * `string lua_qc_get_type_mask()`
-* Returns the type of the current query being executed as a string. The values\
-  are the string versions of the query types defined in query\_classifier.h\
+* Returns the type of the current query being executed as a string. The values
+  are the string versions of the query types defined in query\_classifier.h
   are separated by vertical bars (`|`).\
   This function can only be called from the `routeQuery` entry point.
 * `string lua_qc_get_operation()`
-* Returns the current operation type as a string. The values are defined in\
+* Returns the current operation type as a string. The values are defined in
   query\_classifier.h.\
   This function can only be called from the `routeQuery` entry point.
 * `string lua_get_canonical()`
 * Returns the canonical version of a query by replacing all user-defined constant values with question marks.\
   This function can only be called from the `routeQuery` entry point.
 * `number id_gen()`
-* This function generates unique integers that can be used to distinct\
+* This function generates unique integers that can be used to distinct
   sessions from each other.
 
 ### Example Configuration and Script

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-masking.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-masking.md
@@ -4,15 +4,15 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-With the _masking_ filter it is possible to obfuscate the returned\
+With the _masking_ filter it is possible to obfuscate the returned
 value of a particular column.
 
-For instance, suppose there is a table _person_ that, among other\
-columns, contains the column _ssn_ where the social security number\
+For instance, suppose there is a table _person_ that, among other
+columns, contains the column _ssn_ where the social security number
 of a person is stored.
 
-With the masking filter it is possible to specify that when the _ssn_\
-field is queried, a masked value is returned unless the user making\
+With the masking filter it is possible to specify that when the _ssn_
+field is queried, a masked value is returned unless the user making
 the query is a specific one. That is, when making the query
 
 ```
@@ -41,44 +41,44 @@ the _ssn_ would be masked, as in
 ...
 ```
 
-Note that the masking filter should be viewed as a best-effort solution\
-intended for protecting against accidental misuse rather than malicious\
+Note that the masking filter should be viewed as a best-effort solution
+intended for protecting against accidental misuse rather than malicious
 attacks.
 
 ### Security
 
-From MaxScale 2.3 onwards, the masking filter will reject statements\
+From MaxScale 2.3 onwards, the masking filter will reject statements
 that use functions in conjunction with columns that should be masked.\
-Allowing function usage provides a way for circumventing the masking,\
+Allowing function usage provides a way for circumventing the masking,
 unless a firewall filter is separately configured and installed.
 
-Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2106-maxscale-2106-masking.md#prevent_function_usage)\
+Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2106-maxscale-2106-masking.md#prevent_function_usage)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will check the\
-definition of user variables and reject statements that define a user\
+From MaxScale 2.3.5 onwards, the masking filter will check the
+definition of user variables and reject statements that define a user
 variable using a statement that refers to columns that should be masked.
 
-Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2106-maxscale-2106-masking.md#check_user_variables)\
+Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2106-maxscale-2106-masking.md#check_user_variables)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine unions\
-and if the second or subsequent SELECT refer to columns that should\
+From MaxScale 2.3.5 onwards, the masking filter will examine unions
+and if the second or subsequent SELECT refer to columns that should
 be masked, the statement will be rejected.
 
-Please see the configuration parameter [check\_unions](mariadb-maxscale-2106-maxscale-2106-masking.md#check_unions)\
+Please see the configuration parameter [check\_unions](mariadb-maxscale-2106-maxscale-2106-masking.md#check_unions)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine subqueries\
-and if a subquery refers to columns that should be masked, the statement\
+From MaxScale 2.3.5 onwards, the masking filter will examine subqueries
+and if a subquery refers to columns that should be masked, the statement
 will be rejected.
 
-Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2106-maxscale-2106-masking.md#check_subqueries)\
+Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2106-maxscale-2106-masking.md#check_subqueries)
 for how to change the default behaviour.
 
-Note that in order to ensure that it is not possible to get access to\
-masked data, the privileges of the users should be minimized. For instance,\
-if a user can create tables and perform inserts, he or she can execute\
+Note that in order to ensure that it is not possible to get access to
+masked data, the privileges of the users should be minimized. For instance,
+if a user can create tables and perform inserts, he or she can execute
 something like
 
 ```
@@ -89,16 +89,16 @@ SELECT revealed_ssn FROM cheat;
 
 to get access to the cleartext version of a masked field `ssn`.
 
-From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that\
+From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that
 cannot be fully parsed.
 
-Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2106-maxscale-2106-masking.md#require_fully_parsed)\
+Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2106-maxscale-2106-masking.md#require_fully_parsed)
 for how to change the default behaviour.
 
-From MaxScale 2.3.7 onwards, the masking filter will treat any strings\
+From MaxScale 2.3.7 onwards, the masking filter will treat any strings
 passed to functions as if they were fields. The reason is that as the\
-MaxScale query classifier is not aware of whether `ANSI_QUOTES` is\
-enabled or not, it is possible to bypass the masking by turning that\
+MaxScale query classifier is not aware of whether `ANSI_QUOTES` is
+enabled or not, it is possible to bypass the masking by turning that
 option on.
 
 ```
@@ -106,32 +106,32 @@ mysql> set @@sql_mode = 'ANSI_QUOTES';
 mysql> select concat("ssn") from managers;
 ```
 
-Before this change, the content of the field `ssn` would have been\
+Before this change, the content of the field `ssn` would have been
 returned in clear text even if the column should have been masked.
 
-Note that this change will mean that there may be false positives\
-if `ANSI_QUOTES` is not enabled and a string argument happens to\
+Note that this change will mean that there may be false positives
+if `ANSI_QUOTES` is not enabled and a string argument happens to
 be the same as the name of a field to be masked.
 
 Please see the configuration parameter\
-\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)\
+\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)
 for how to change the default behaviour.
 
 ### Limitations
 
-The masking filter can _only_ be used for masking columns of the following\
-types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no\
+The masking filter can _only_ be used for masking columns of the following
+types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no
 masking will be performed.
 
-Currently, the masking filter can only work on packets whose payload is less\
-than 16MB. If the masking filter encounters a packet whose payload is exactly\
-that, thus indicating a situation where the payload is delivered in multiple\
-packets, the value of the parameter `large_payloads` specifies how the masking\
+Currently, the masking filter can only work on packets whose payload is less
+than 16MB. If the masking filter encounters a packet whose payload is exactly
+that, thus indicating a situation where the payload is delivered in multiple
+packets, the value of the parameter `large_payloads` specifies how the masking
 filter should handle the situation.
 
 ### Configuration
 
-The masking filter is taken into use with the following kind of\
+The masking filter is taken into use with the following kind of
 configuration setup.
 
 ```
@@ -157,7 +157,7 @@ The masking filter has one mandatory parameter - `rules`.
 * Dynamic: Yes
 
 Specifies the path of the file where the masking rules are stored.\
-A relative path is interpreted relative to the _module configuration directory_\
+A relative path is interpreted relative to the _module configuration directory_
 of MariaDB MaxScale. The default module configuration directory is_/etc/maxscale.modules.d_.
 
 ```
@@ -172,8 +172,8 @@ rules=/path/to/rules-file
 * Values: `never`, `always`
 * Default: `never`
 
-With this optional parameter the masking filter can be instructed to log\
-a warning if a masking rule matches a column that is not of one of the\
+With this optional parameter the masking filter can be instructed to log
+a warning if a masking rule matches a column that is not of one of the
 allowed types.
 
 ```
@@ -188,17 +188,17 @@ warn_type_mismatch=always
 * Values: `ignore`, `abort`
 * Default: `abort`
 
-This optional parameter specifies how the masking filter should treat\
-payloads larger than `16MB`, that is, payloads that are delivered in\
+This optional parameter specifies how the masking filter should treat
+payloads larger than `16MB`, that is, payloads that are delivered in
 multiple MySQL protocol packets.
 
-The values that can be used are `ignore`, which means that columns in\
-such payloads are not masked, and `abort`, which means that if such\
-payloads are encountered, the client connection is closed. The default\
+The values that can be used are `ignore`, which means that columns in
+such payloads are not masked, and `abort`, which means that if such
+payloads are encountered, the client connection is closed. The default
 is `abort`.
 
-Note that the aborting behaviour is applied only to resultsets that\
-contain columns that should be masked. There are _no_ limitations on\
+Note that the aborting behaviour is applied only to resultsets that
+contain columns that should be masked. There are _no_ limitations on
 resultsets that do not contain such columns.
 
 ```
@@ -212,23 +212,23 @@ large_payload=ignore
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should behave\
-if a column that should be masked, is used in conjunction with some\
-function. As the masking filter works _only_ on the basis of the\
-information in the returned result-set, if the name of a column is\
-not present in the result-set, then the masking filter cannot mask a\
-value. This means that the masking filter basically can be bypassed\
+This optional parameter specifies how the masking filter should behave
+if a column that should be masked, is used in conjunction with some
+function. As the masking filter works _only_ on the basis of the
+information in the returned result-set, if the name of a column is
+not present in the result-set, then the masking filter cannot mask a
+value. This means that the masking filter basically can be bypassed
 with a query like:
 
 ```
 SELECT CONCAT(masked_column) FROM tbl;
 ```
 
-If the value of `prevent_function_usage` is `true`, then all\
-statements that contain functions referring to masked columns will\
-be rejected. As that means that also queries using potentially\
-harmless functions, such as `LENGTH(masked_column)`, are rejected\
-as well, this feature can be turned off. In that case, the firewall\
+If the value of `prevent_function_usage` is `true`, then all
+statements that contain functions referring to masked columns will
+be rejected. As that means that also queries using potentially
+harmless functions, such as `LENGTH(masked_column)`, are rejected
+as well, this feature can be turned off. In that case, the firewall
 filter should be setup to allow or reject the use of certain functions.
 
 ```
@@ -242,19 +242,19 @@ prevent_function_usage=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
-behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a\
+This optional parameter specifies how the masking filter should
+behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a
 statement that cannot be fully parsed,
 
-If true, then statements that cannot be fully parsed (due to a\
+If true, then statements that cannot be fully parsed (due to a
 parser limitation) will be blocked.
 
 ```
 require_fully_parsed=false
 ```
 
-Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered\
-less effective, as it with a statement that can not be fully parsed may be\
+Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered
+less effective, as it with a statement that can not be fully parsed may be
 possible to bypass the protection that they are intended to provide.
 
 **`treat_string_arg_as_field`**
@@ -264,9 +264,9 @@ possible to bypass the protection that they are intended to provide.
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should treat\
-strings used as arguments to functions. If true, they will be handled\
-as fields, which will cause fields to be masked even if `ANSI_QUOTES` has\
+This optional parameter specifies how the masking filter should treat
+strings used as arguments to functions. If true, they will be handled
+as fields, which will cause fields to be masked even if `ANSI_QUOTES` has
 been enabled and `"` is used instead of backtick.
 
 ```
@@ -280,7 +280,7 @@ treat_string_arg_as_field=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to user variables. If true, then a statement like
 
 ```
@@ -300,7 +300,7 @@ check_user_variables=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to UNIONs. If true, then a statement like
 
 ```
@@ -320,7 +320,7 @@ check_unions=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to subqueries. If true, then a statement like
 
 ```
@@ -337,7 +337,7 @@ check_subqueries=false
 
 The masking rules are expressed as a JSON object.
 
-The top-level object is expected to contain a key `rules` whose\
+The top-level object is expected to contain a key `rules` whose
 value is an array of rule objects.
 
 ```
@@ -346,8 +346,8 @@ value is an array of rule objects.
 }
 ```
 
-Each rule in the rules array is a JSON object, expected to\
-contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two\
+Each rule in the rules array is a JSON object, expected to
+contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two
 latter ones optional.
 
 ```
@@ -365,15 +365,15 @@ latter ones optional.
 
 #### `replace`
 
-The value of this key is an object that specifies the column\
-whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The\
+The value of this key is an object that specifies the column
+whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The
 value of these keys must be a string.
 
-If only `column` is specified, then a column with that name\
-matches irrespective of the table and database. If `table`\
-is specified, then the column matches only if it is in a table\
-with the specified name, and if `database` is specified when\
-the column matches only if it is in a database with the\
+If only `column` is specified, then a column with that name
+matches irrespective of the table and database. If `table`
+is specified, then the column matches only if it is in a table
+with the specified name, and if `database` is specified when
+the column matches only if it is in a database with the
 specified name.
 
 ```
@@ -393,10 +393,10 @@ specified name.
 }
 ```
 
-**NOTE** If a rule contains a table/database then if the resultset\
-does _not_ contain table/database information, it will always be\
-considered a match if the column matches. For instance, given the\
-rule above, if there is a table `person2`, also containing an `ssn`\
+**NOTE** If a rule contains a table/database then if the resultset
+does _not_ contain table/database information, it will always be
+considered a match if the column matches. For instance, given the
+rule above, if there is a table `person2`, also containing an `ssn`
 field, then a query like
 
 ```
@@ -409,24 +409,24 @@ will not return masked values, but a query like
 SELECT ssn FROM person UNION SELECT ssn FROM person2;
 ```
 
-will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is\
+will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is
 observed even with a nonsensical query like
 
 ```
 SELECT ssn FROM person2 UNION SELECT ssn FROM person2;
 ```
 
-even if nothing from `person2` should be masked. The reason is that\
-as the resultset contains no table information, the values must be\
-masked if the column name matches, as otherwise the masking could\
+even if nothing from `person2` should be masked. The reason is that
+as the resultset contains no table information, the values must be
+masked if the column name matches, as otherwise the masking could
 easily be circumvented with a query like
 
 ```
 SELECT ssn FROM person UNION SELECT ssn FROM person;
 ```
 
-The optional key `match` makes partial replacement of the original\
-value possible: only the matched part would be replaced\
+The optional key `match` makes partial replacement of the original
+value possible: only the matched part would be replaced
 with the fill character.\
 The `match` value must be a valid pcre2 regular expression.
 
@@ -442,14 +442,14 @@ The `match` value must be a valid pcre2 regular expression.
 
 #### `obfuscate`
 
-The obfuscate rule allows the obfuscation of the value\
+The obfuscate rule allows the obfuscation of the value
 by passing it through an obfuscation algorithm.\
 Current solution uses a non-reversible obfuscation approach.
 
-However, note that although it is in principle impossible to obtain the\
-original value from the obfuscated one, if the range of possible original\
-values is limited, it is straightforward to figure out the possible\
-original values by running all possible values through the obfuscation\
+However, note that although it is in principle impossible to obtain the
+original value from the obfuscated one, if the range of possible original
+values is limited, it is straightforward to figure out the possible
+original values by running all possible values through the obfuscation
 algorithm and then comparing the results.
 
 The minimal configuration is:
@@ -474,20 +474,20 @@ SELECT name from db1.tbl1;`
 
 #### `with`
 
-The value of this key is an object that specifies what the value of the matched\
-column should be replaced with for the `replace` rule. Currently, the object\
+The value of this key is an object that specifies what the value of the matched
+column should be replaced with for the `replace` rule. Currently, the object
 is expected to contain either the key `value` or the key `fill`.\
 The value of both must be a string with length greater than zero.\
 If both keys are specified, `value` takes precedence.\
 If `fill` is not specified, the default `X` is used as its value.
 
-If `value` is specified, then its value is used to replace the actual value\
-verbatim and the length of the specified value must match the actual returned\
+If `value` is specified, then its value is used to replace the actual value
+verbatim and the length of the specified value must match the actual returned
 value (from the server) exactly. If the lengths do not match, the value of`fill` is used to mask the actual value.
 
-When the value of `fill` (fill-value) is used for masking the returned value,\
-the fill-value is used as many times as necessary to match the length of the\
-return value. If required, only a part of the fill-value may be used in the end\
+When the value of `fill` (fill-value) is used for masking the returned value,
+the fill-value is used as many times as necessary to match the length of the
+return value. If required, only a part of the fill-value may be used in the end
 of the mask value to get the lengths to match.
 
 ```
@@ -530,8 +530,8 @@ of the mask value to get the lengths to match.
 
 #### `applies_to`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is applied to. Each string\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is applied to. Each string
 should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -547,13 +547,13 @@ should be a MariaDB account string, that is, `%` is a wildcard.
 }
 ```
 
-If this key is not specified, then the masking is performed for all\
+If this key is not specified, then the masking is performed for all
 users, except the ones exempted using the key `exempted`.
 
 #### `exempted`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is _not_ applied to. Each\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is _not_ applied to. Each
 string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -571,14 +571,14 @@ string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md) documentation for details\
+Read [Module Commands](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md) documentation for details
 about module commands.
 
 The masking filter supports the following module commands.
 
 #### `reload`
 
-Reload the rules from the rules file. The new rules are taken into use\
+Reload the rules from the rules file. The new rules are taken into use
 only if the loading succeeds without any errors.
 
 ```
@@ -590,8 +590,8 @@ MariaDB MaxScale configuration file.
 
 ### Example
 
-In the following we configure a masking filter _MyMasking_ that should always log a\
-warning if a masking rule matches a column that is of a type that cannot be masked,\
+In the following we configure a masking filter _MyMasking_ that should always log a
+warning if a masking rule matches a column that is of a type that cannot be masked,
 and that should abort the client connection if a resultset package is larger than\
 16MB. The rules for the masking filter are in the file `masking_rules.json`.
 
@@ -613,9 +613,9 @@ filters=MyMasking
 
 #### `masking_rules.json`
 
-The rules specify that the data of a column whose name is `ssn`, should\
-be replaced with the string _012345-ABCD_. If the length of the data is\
-not exactly the same as the length of the replacement value, then the\
+The rules specify that the data of a column whose name is `ssn`, should
+be replaced with the string _012345-ABCD_. If the length of the data is
+not exactly the same as the length of the replacement value, then the
 data should be replaced with as many _X_ characters as needed.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-maxrows.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-maxrows.md
@@ -4,11 +4,11 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Maxrows filter is capable of restricting the amount of rows that a SELECT,\
+The Maxrows filter is capable of restricting the amount of rows that a SELECT,
 a prepared statement or stored procedure could return to the client application.
 
-If a resultset from a backend server has more rows than the configured limit\
-or the resultset size exceeds the configured size,\
+If a resultset from a backend server has more rows than the configured limit
+or the resultset size exceeds the configured size,
 an empty result will be sent to the client.
 
 ### Configuration
@@ -38,7 +38,7 @@ Optional parameters are:
 * Dynamic: Yes
 * Default: (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 returned to the user.
 
 If a resultset is larger than this an empty result will be sent instead.
@@ -54,8 +54,8 @@ max_resultset_rows=1000
 * Dynamic: Yes
 * Default: `64Ki`
 
-Specifies the maximum size a resultset can have in order\
-to be sent to the client. A resultset larger than this, will\
+Specifies the maximum size a resultset can have in order
+to be sent to the client. A resultset larger than this, will
 not be sent: an empty resultset will be sent instead.
 
 ```
@@ -70,7 +70,7 @@ max_resultset_size=128Ki
 * Values: `empty`, `error`, `ok`
 * Default: `empty`
 
-Specifies what the filter sends to the client when the\
+Specifies what the filter sends to the client when the
 rows or size limit is hit, possible values:
 
 * an empty result set
@@ -91,8 +91,8 @@ ERROR 1415 (0A000): Row limit/size exceeded for query: select * from test.t4
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the Maxrows\
-filter can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the Maxrows
+filter can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -107,7 +107,7 @@ debug=2
 
 ### Example Configuration
 
-Here is an example of filter configuration where the maximum number of returned\
+Here is an example of filter configuration where the maximum number of returned
 rows is 10000 and maximum allowed resultset size is 256KB
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-named-server-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-named-server-filter.md
@@ -2,25 +2,25 @@
 
 ### Overview
 
-The **namedserverfilter** is a MariaDB MaxScale filter module able to route\
-queries to servers based on regular expression (regex) matches. Since it is a\
+The **namedserverfilter** is a MariaDB MaxScale filter module able to route
+queries to servers based on regular expression (regex) matches. Since it is a
 filter instead of a router, the NamedServerFilter only sets routing suggestions.\
-It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the\
-data packets. This filter uses the _PCRE2_ library for regular expression\
+It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the
+data packets. This filter uses the _PCRE2_ library for regular expression
 matching.
 
 ### Configuration
 
-The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of\
-the modes may be used for a given filter instance. The legacy mode is meant for\
-backwards compatibility and allows only one regular expression and one server\
-name in the configuration. In indexed mode, up to 25 regex-server pairs are\
+The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of
+the modes may be used for a given filter instance. The legacy mode is meant for
+backwards compatibility and allows only one regular expression and one server
+name in the configuration. In indexed mode, up to 25 regex-server pairs are
 allowed in the form _match01_ - _target01_, _match02_ - _target02_ and so on.\
-Also, in indexed mode, the server names (targets) may contain a list of names or\
+Also, in indexed mode, the server names (targets) may contain a list of names or
 special tags `->master` or `->slave`.
 
-All parameters except the deprecated `match` and `target` parameters can\
-be modified at runtime. Any modifications to the filter configuration will\
+All parameters except the deprecated `match` and `target` parameters can
+be modified at runtime. Any modifications to the filter configuration will
 only affect sessions created after the change has completed.
 
 Below is a configuration example for the filter in indexed-mode. The legacy mode\
@@ -61,10 +61,10 @@ NamedServerFilter requires at least one _matchXY_ - _targetXY_ pair.
 * Dynamic: Yes
 * Default: None
 
-_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 against which the incoming SQL query is matched. _XY_ must be a number in the range\
-01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is\
-defined, the other must be defined as well. If a query matches the pattern, the filter\
+01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is
+defined, the other must be defined as well. If a query matches the pattern, the filter
 attaches a routing hint defined by the _target_-setting to the query. The _options_-parameter affects how the patterns are compiled.
 
 ```
@@ -80,7 +80,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-[Regular expression options](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+[Regular expression options](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 for `matchXY`.
 
 #### `targetXY`
@@ -99,8 +99,8 @@ accordingly. The target can be one of the following:
 * `->slave` (adds a `HINT_ROUTE_TO_SLAVE` hint)
 * `->all` (adds a `HINT_ROUTE_TO_ALL` hint)
 
-The support for service names was added in MaxScale 6.3.2. Older\
-versions of MaxScale did not accept service names in the `target`\
+The support for service names was added in MaxScale 6.3.2. Older
+versions of MaxScale did not accept service names in the `target`
 parameters.
 
 ```
@@ -114,9 +114,9 @@ target01=MyServer2
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines an IP address or mask which a connecting\
-client's IP address is matched against. Only sessions whose address matches this\
-setting will have this filter active and performing the regex matching. Traffic\
+This optional parameter defines an IP address or mask which a connecting
+client's IP address is matched against. Only sessions whose address matches this
+setting will have this filter active and performing the regex matching. Traffic
 from other client IPs is simply left as is and routed straight through.
 
 ```
@@ -133,7 +133,7 @@ source=192.168.10.%
 
 Note that using `source=%` to match any IP is not allowed.
 
-Since MaxScale 2.3 it's also possible to specify multiple addresses separated\
+Since MaxScale 2.3 it's also possible to specify multiple addresses separated
 by comma. Incoming client connections are subsequently checked against each.
 
 ```
@@ -147,9 +147,9 @@ source=192.168.21.3,192.168.10.%
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines a username the connecting client username is\
-matched against. Only sessions that are connected using this username will have\
-the match and routing hints applied to them. Traffic from other users is simply\
+This optional parameter defines a username the connecting client username is
+matched against. Only sessions that are connected using this username will have
+the match and routing hints applied to them. Traffic from other users is simply
 left as is and routed straight through.
 
 ```
@@ -160,30 +160,30 @@ user=john
 
 The maximum number of accepted _match_ - _target_ pairs is 25.
 
-In the configuration file, the indexed match and target settings may be in any order\
-and may skip numbers. During SQL-query matching, however, the regexes are tested\
-in ascending order: match01, match02, match03 and so on. As soon as a match is\
-found for a given query, the routing hints are written and the packet is\
-forwarded to the next filter or router. Any remaining match regexes are\
-ignored. This means the _match_ - _target_ pairs should be indexed in priority\
-order, or, if priority is not a factor, in order of decreasing match\
+In the configuration file, the indexed match and target settings may be in any order
+and may skip numbers. During SQL-query matching, however, the regexes are tested
+in ascending order: match01, match02, match03 and so on. As soon as a match is
+found for a given query, the routing hints are written and the packet is
+forwarded to the next filter or router. Any remaining match regexes are
+ignored. This means the _match_ - _target_ pairs should be indexed in priority
+order, or, if priority is not a factor, in order of decreasing match
 probability.
 
-Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching\
-the prepared sql against the _match_-parameters. If a match is found, the\
-routing hints are attached to any execution of that prepared statement. Text-\
-mode prepared statements are not supported in this way. To divert them, use\
+Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching
+the prepared sql against the _match_-parameters. If a match is found, the
+routing hints are attached to any execution of that prepared statement. Text-
+mode prepared statements are not supported in this way. To divert them, use
 regular expressions which match the specific "EXECUTE"-query.
 
 ### Examples
 
 #### Example 1 - Route queries targeting a specific table to a server
 
-This will route all queries matching the regular expression `*from *users` to\
+This will route all queries matching the regular expression `*from *users` to
 the server named _server2_. The filter will ignore character case in queries.
 
-A query like `SELECT * FROM users` would be routed to server2 where as a query\
-like `SELECT * FROM accounts` would be routed according to the normal rules of\
+A query like `SELECT * FROM users` would be routed to server2 where as a query
+like `SELECT * FROM accounts` would be routed according to the normal rules of
 the router.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-query-log-all-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-query-log-all-filter.md
@@ -27,13 +27,13 @@ filters=MyLogFilter
 
 ### Log Rotation
 
-The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`\
-command. This will cause the log files to be reopened when the next message is\
+The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`
+command. This will cause the log files to be reopened when the next message is
 written to the file. This applies to both unified and session type logging.
 
 ### Filter Parameters
 
-The QLA filter has one mandatory parameter, `filebase`, and a number of optional\
+The QLA filter has one mandatory parameter, `filebase`, and a number of optional
 parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 
 #### `filebase`
@@ -42,7 +42,7 @@ parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 * Mandatory: Yes
 * Dynamic: No
 
-The basename of the output file created for each session. A session index is\
+The basename of the output file created for each session. A session index is
 added to the filename for each written session file. For unified log files,_.unified_ is appended.
 
 ```
@@ -138,14 +138,14 @@ Type of data to log in the log files.
 | num\_warnings      | Number of warnings in the server reply (v6.2)          |
 | error\_msg         | Error message from the server (if any) (v6.2)          |
 
-The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,\
+The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,
 but can be specified to another unit using _duration\_unit_.
 
 The log entry is written when the last reply from the server is received.\
-Prior to version 6.2 the entry was written when the query was received from\
+Prior to version 6.2 the entry was written when the query was received from
 the client, or if _reply\_time_ was specified, on first reply from the server.
 
-**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_\
+**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_
 is set the error message may contain user defined constants. For example:
 
 ```
@@ -173,7 +173,7 @@ This option is available as of MaxScale version 6.2.
 * Dynamic: Yes
 * Default: `false`
 
-When this option is true the canonical form of the query is logged. In the\
+When this option is true the canonical form of the query is logged. In the
 canonical form all user defined constants are replaced with question marks.\
 This option is available as of MaxScale version 6.2.
 
@@ -200,7 +200,7 @@ Flush log files after every write.
 * Dynamic: Yes
 * Default: `","`
 
-Defines the separator string between elements of\
+Defines the separator string between elements of
 log entries. The value should be enclosed in quotes.
 
 #### `newline_replacement`
@@ -210,19 +210,19 @@ log entries. The value should be enclosed in quotes.
 * Dynamic: Yes
 * Default: `" "`
 
-Default value is `" "` (one space). SQL-queries may include line breaks, which, if\
-printed directly to the log, may break automatic parsing. This parameter defines\
-what should be written in the place of a newline sequence (\r, \n or \r\n). If\
-this is set as the empty string, then newlines are not replaced and printed as\
+Default value is `" "` (one space). SQL-queries may include line breaks, which, if
+printed directly to the log, may break automatic parsing. This parameter defines
+what should be written in the place of a newline sequence (\r, \n or \r\n). If
+this is set as the empty string, then newlines are not replaced and printed as
 is to the output. The value should be enclosed in quotes.
 
 ### Examples
 
 #### Example 1 - Query without primary key
 
-Imagine you have observed an issue with a particular table and you want to\
-determine if there are queries that are accessing that table but not using the\
-primary key of the table. Let's assume the table name is PRODUCTS and the\
+Imagine you have observed an issue with a particular table and you want to
+determine if there are queries that are accessing that table but not using the
+primary key of the table. Let's assume the table name is PRODUCTS and the
 primary key is called PRODUCT\_ID. Add a filter with the following definition:
 
 ```
@@ -242,7 +242,7 @@ password=mypasswd
 filters=ProductsSelectLogger
 ```
 
-The result of using this filter with the service used by the application would\
+The result of using this filter with the service used by the application would
 be a log file of all select queries querying PRODUCTS without using the\
 PRODUCT\_ID primary key in the predicates of the query. Executing `SELECT * FROM PRODUCTS` would log the following into `/var/logs/qla/SelectProducts`:
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-regex-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-regex-filter.md
@@ -2,13 +2,13 @@
 
 ### Overview
 
-The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite\
-query content using regular expression matches and text substitution. The\
+The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite
+query content using regular expression matches and text substitution. The
 regular expressions use the [PCRE2 syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html).
 
-PCRE2 library uses a different syntax than POSIX to refer to capture\
-groups in the replacement string. The main difference is the usage of the dollar\
-character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)\
+PCRE2 library uses a different syntax than POSIX to refer to capture
+groups in the replacement string. The main difference is the usage of the dollar
+character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)
 chapter in the PCRE2 manual.
 
 ### Configuration
@@ -64,7 +64,7 @@ The _options_-parameter affects how the patterns are compiled as [usual](../mari
 * Mandatory: Yes
 * Dynamic: Yes
 
-This is the text that should replace the part of the SQL-query matching the\
+This is the text that should replace the part of the SQL-query matching the
 pattern defined in _match_.
 
 ```
@@ -78,9 +78,9 @@ replace=ENGINE =
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
-the address from which the client connection to MariaDB MaxScale\
-originates. Only sessions that originate from this address will have the match\
+The optional source parameter defines an address that is used to match against
+the address from which the client connection to MariaDB MaxScale
+originates. Only sessions that originate from this address will have the match
 and replacement applied to them.
 
 ```
@@ -94,9 +94,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will have the match and\
+The optional user parameter defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will have the match and
 replacement applied to them.
 
 ```
@@ -110,9 +110,9 @@ user=john
 * Dynamic: Yes
 * Default: None
 
-The optional log\_file parameter defines a log file in which the filter writes\
-all queries that are not matched and matching queries with their replacement\
-queries. All sessions will log to this file so this should only be used for\
+The optional log\_file parameter defines a log file in which the filter writes
+all queries that are not matched and matching queries with their replacement
+queries. All sessions will log to this file so this should only be used for
 diagnostic purposes.
 
 ```
@@ -126,10 +126,10 @@ log_file=/tmp/regexfilter.log
 * Dynamic: Yes
 * Default: None
 
-The optional log\_trace parameter toggles the logging of non-matching and\
+The optional log\_trace parameter toggles the logging of non-matching and
 matching queries with their replacements into the log file on the _info_ level.\
-This is the preferred method of diagnosing the matching of queries since the log\
-level can be changed at runtime. For more details about logging levels and\
+This is the preferred method of diagnosing the matching of queries since the log
+level can be changed at runtime. For more details about logging levels and
 session specific logging, please read the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
 
 ```
@@ -140,10 +140,10 @@ log_trace=true
 
 #### Example 1 - Replace MySQL 5.1 create table syntax with that for later versions
 
-MySQL 5.1 used the parameter TYPE = to set the storage engine that should be\
-used for a table. In later versions this changed to be ENGINE =. Imagine you\
-have an application that you can not change for some reason, but you wish to\
-migrate to a newer version of MySQL. The regexfilter can be used to transform\
+MySQL 5.1 used the parameter TYPE = to set the storage engine that should be
+used for a table. In later versions this changed to be ENGINE =. Imagine you
+have an application that you can not change for some reason, but you wish to
+migrate to a newer version of MySQL. The regexfilter can be used to transform
 the create table statements into the form that could be used by MySQL 5.5
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-tee-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-tee-filter.md
@@ -3,17 +3,17 @@
 ### Overview
 
 The tee filter is a "plumbing" fitting in the MariaDB MaxScale filter toolkit.\
-It can be used in a filter pipeline of a service to make copies of requests from\
+It can be used in a filter pipeline of a service to make copies of requests from
 the client and send the copies to another service within MariaDB MaxScale.
 
-**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a\
-service which uses a tee filter will require a grant for the loopback address,\
+**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a
+service which uses a tee filter will require a grant for the loopback address,
 i.e. `127.0.0.1`.
 
 ### Configuration
 
-The configuration block for the TEE filter requires the minimal filter\
-parameters in its section within the MaxScale configuration file. The service to\
+The configuration block for the TEE filter requires the minimal filter
+parameters in its section within the MaxScale configuration file. The service to
 send the duplicates to must be defined.
 
 ```
@@ -33,7 +33,7 @@ filters=DataMartFilter
 
 ### Filter Parameters
 
-The tee filter requires a mandatory parameter to define the service to replicate\
+The tee filter requires a mandatory parameter to define the service to replicate
 statements to and accepts a number of optional parameters.
 
 #### `target`
@@ -43,8 +43,8 @@ statements to and accepts a number of optional parameters.
 * Dynamic: Yes
 * Default: none
 
-The target where the filter will duplicate all queries. The target can be either\
-a service or a server. The duplicate connection that is created to this target\
+The target where the filter will duplicate all queries. The target can be either
+a service or a server. The duplicate connection that is created to this target
 will be referred to as the "branch target" in this document.
 
 #### `service`
@@ -54,8 +54,8 @@ will be referred to as the "branch target" in this document.
 * Dynamic: Yes
 * Default: none
 
-The service where the filter will duplicate all queries. This parameter is\
-deprecated in favor of the `target` parameter and will be removed in a future\
+The service where the filter will duplicate all queries. This parameter is
+deprecated in favor of the `target` parameter and will be removed in a future
 release. Both `target` and `service` cannot be defined.
 
 #### `match`
@@ -105,7 +105,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
+The optional source parameter defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be replicated.
 
@@ -120,8 +120,8 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a user name that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
+The optional user parameter defines a user name that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
 sessions that are connected using this username are replicated.
 
 ```
@@ -135,63 +135,63 @@ user=john
 * Dynamic: Yes
 * Default: `false`
 
-Enable synchronous routing mode. When configured with `sync=true`, the filter\
-will queue new queries until the response from both the main and the branch\
-target has been received. This means that for `n` executed queries, `n - 1`\
-queries are guaranteed to be synchronized. Adding one extra statement\
-(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL\
+Enable synchronous routing mode. When configured with `sync=true`, the filter
+will queue new queries until the response from both the main and the branch
+target has been received. This means that for `n` executed queries, `n - 1`
+queries are guaranteed to be synchronized. Adding one extra statement
+(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL
 statements have been successfully executed on both targets.
 
-In the synchronous routing mode, a failure of the branch target will cause the\
+In the synchronous routing mode, a failure of the branch target will cause the
 client session to be closed.
 
 ### Limitations
 
-* All statements that are executed on the branch target are done in an\
-  asynchronous manner. This means that when the client receives the response\
-  there is no guarantee that the statement has completed on the branch\
-  target. The `sync` feature provides some synchronization guarantees that can\
+* All statements that are executed on the branch target are done in an
+  asynchronous manner. This means that when the client receives the response
+  there is no guarantee that the statement has completed on the branch
+  target. The `sync` feature provides some synchronization guarantees that can
   be used to verify successful execution on both targets.
-* Any errors on the branch target will cause the connection to it to be\
-  closed. If `target` is a service, it is up to the router to decide whether the\
-  connection is closed. For direct connections to servers, any network errors\
-  cause the connection to be closed. When the connection is closed, no new\
+* Any errors on the branch target will cause the connection to it to be
+  closed. If `target` is a service, it is up to the router to decide whether the
+  connection is closed. For direct connections to servers, any network errors
+  cause the connection to be closed. When the connection is closed, no new
   queries will be routed to the branch target.
 
-With `sync=true`, a failure of the branch target will cause the whole session\
+With `sync=true`, a failure of the branch target will cause the whole session
 to be closed.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md) documentation for
 details about module commands.
 
 The tee filter supports the following module commands.
 
 #### `tee disable [FILTER]`
 
-This command disables a tee filter instance. A disabled tee filter will not send\
+This command disables a tee filter instance. A disabled tee filter will not send
 any queries to the target service.
 
 #### `tee enable [FILTER]`
 
-Enable a disabled tee filter. This resumes the sending of queries to the target\
+Enable a disabled tee filter. This resumes the sending of queries to the target
 service.
 
 ### Examples
 
 #### Example 1 - Replicate all inserts into the orders table
 
-Assume an order processing system that has a table called orders. You also have\
-another database server, the datamart server, that requires all inserts into\
+Assume an order processing system that has a table called orders. You also have
+another database server, the datamart server, that requires all inserts into
 orders to be replicated to it. Deletes and updates are not, however, required.
 
-Set up a service in MariaDB MaxScale, called Orders, to communicate with the\
-order processing system with the tee filter applied to it. Also set up a service\
-to talk to the datamart server, using the DataMart service. The tee filter would\
+Set up a service in MariaDB MaxScale, called Orders, to communicate with the
+order processing system with the tee filter applied to it. Also set up a service
+to talk to the datamart server, using the DataMart service. The tee filter would
 have as its service entry the DataMart service, by adding a match parameter of\
-"insert into orders" would then result in all requests being sent to the order\
-processing system, and insert statements that include the orders table being\
+"insert into orders" would then result in all requests being sent to the order
+processing system, and insert statements that include the orders table being
 additionally sent to the datamart server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-throttle.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-throttle.md
@@ -6,13 +6,13 @@ This filter was added in MariaDB MaxScale 2.3
 
 The throttle filter replaces and extends on the limit\_queries functionality of [the Database Firewall filter](mariadb-maxscale-2106-maxscale-2106-database-firewall-filter.md).
 
-The throttle filter is used to limit the maximum query frequency (QPS - queries\
-per second) of a database session to a configurable value. The main use cases\
-are to prevent a rogue session (client side error) and a DoS attack from\
+The throttle filter is used to limit the maximum query frequency (QPS - queries
+per second) of a database session to a configurable value. The main use cases
+are to prevent a rogue session (client side error) and a DoS attack from
 overloading the system.
 
-The throttling is dynamic. The query frequency is not limited to an absolute\
-value. Depending on the configuration the throttle will allow some amount of\
+The throttling is dynamic. The query frequency is not limited to an absolute
+value. Depending on the configuration the throttle will allow some amount of
 high frequency queries, or especially short bursts with no frequency limitation.
 
 ### Configuration
@@ -33,27 +33,27 @@ filters = Throttle
 ```
 
 This configuration states that the query frequency will be throttled to around\
-500 qps, and that the time limit a query is allowed to stay at the maximum\
-frequency is 60 seconds. All values involving time are configured in\
-milliseconds. With the basic configuration the throttling will be nearly\
-immediate, i.e. a session will only be allowed very short bursts of high\
+500 qps, and that the time limit a query is allowed to stay at the maximum
+frequency is 60 seconds. All values involving time are configured in
+milliseconds. With the basic configuration the throttling will be nearly
+immediate, i.e. a session will only be allowed very short bursts of high
 frequency querying.
 
-When a session has been continuously throttled for `throttling_duration`\
-milliseconds, or 60 seconds in this example, MaxScale will disconnect the\
+When a session has been continuously throttled for `throttling_duration`
+milliseconds, or 60 seconds in this example, MaxScale will disconnect the
 session.
 
 #### Allowing high frequency bursts
 
-The two parameters `max_qps` and `sampling_duration` together define how a\
+The two parameters `max_qps` and `sampling_duration` together define how a
 session is throttled.
 
-Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not\
-an instantaneous measure, but one could say it has a granularity of 10 seconds,\
-we see that over the 10 seconds 10\*400 = 4000 queries are allowed before\
+Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not
+an instantaneous measure, but one could say it has a granularity of 10 seconds,
+we see that over the 10 seconds 10\*400 = 4000 queries are allowed before
 throttling kicks in.
 
-With these values, a fresh session can start off with a speed of 2000 qps, and\
+With these values, a fresh session can start off with a speed of 2000 qps, and
 maintain that speed for 2 seconds before throttling starts.
 
 If the client continues to query at high speed and throttling duration is set to\
@@ -69,8 +69,8 @@ If the client continues to query at high speed and throttling duration is set to
 
 Maximum queries per second.
 
-This is the frequency to which a session will be limited over a given time\
-period. QPS is not measured as an instantaneous value but over a configurable\
+This is the frequency to which a session will be limited over a given time
+period. QPS is not measured as an instantaneous value but over a configurable
 sampling duration (see `sampling_duration`).
 
 **`throttling_duration`**
@@ -79,7 +79,7 @@ sampling duration (see `sampling_duration`).
 * Mandatory: Yes
 * Dynamic: Yes
 
-This defines how long a session is allowed to be throttled before MaxScale\
+This defines how long a session is allowed to be throttled before MaxScale
 disconnects the session.
 
 #### `sampling_duration`
@@ -89,11 +89,11 @@ disconnects the session.
 * Dynamic: Yes
 * Default: 250ms
 
-Sampling duration defines the window of time over which QPS is measured. This\
-parameter directly affects the amount of time that high frequency queries are\
+Sampling duration defines the window of time over which QPS is measured. This
+parameter directly affects the amount of time that high frequency queries are
 allowed before throttling kicks in.
 
-The lower this value is, the more strict throttling becomes. Conversely, the\
+The lower this value is, the more strict throttling becomes. Conversely, the
 longer this time is, the longer bursts of high frequency querying is allowed.
 
 #### `continuous_duration`
@@ -103,8 +103,8 @@ longer this time is, the longer bursts of high frequency querying is allowed.
 * Dynamic: Yes
 * Default: 2s
 
-This value defines what continuous throttling means. Continuous throttling\
-starts as soon as the filter throttles the frequency. Continuous throttling ends\
+This value defines what continuous throttling means. Continuous throttling
+starts as soon as the filter throttles the frequency. Continuous throttling ends
 when no throttling has been performed in the past `continuous_duration` time.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-top-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-top-filter.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-The top filter is a filter module for MariaDB MaxScale that monitors every SQL\
-statement that passes through the filter. It measures the duration of that\
-statement, the time between the statement being sent and the first result being\
-returned. The top N times are kept, along with the SQL text itself and a list\
-sorted on the execution times of the query is written to a file upon closure of\
+The top filter is a filter module for MariaDB MaxScale that monitors every SQL
+statement that passes through the filter. It measures the duration of that
+statement, the time between the statement being sent and the first result being
+returned. The top N times are kept, along with the SQL text itself and a list
+sorted on the execution times of the query is written to a file upon closure of
 the client session.
 
 ### Configuration
@@ -29,7 +29,7 @@ filters=MyLogFilter
 
 #### Filter Parameters
 
-The top filter has one mandatory parameter, `filebase`, and a number of optional\
+The top filter has one mandatory parameter, `filebase`, and a number of optional
 parameters.
 
 **`filebase`**
@@ -38,15 +38,15 @@ parameters.
 * Mandatory: Yes
 * Dynamic: Yes
 
-The basename of the output file created for each session. The session ID is\
+The basename of the output file created for each session. The session ID is
 added to the filename for each file written. This is a mandatory parameter.
 
 ```
 filebase=/tmp/SqlQueryLog
 ```
 
-The filebase may also be set as the filter, the mechanism to set the filebase\
-via the filter option is superseded by the parameter. If both are set the\
+The filebase may also be set as the filter, the mechanism to set the filebase
+via the filter option is superseded by the parameter. If both are set the
 parameter setting will be used and the filter option ignored.
 
 **`count`**
@@ -69,7 +69,7 @@ count=30
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+[Limits](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 ```
@@ -85,7 +85,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+[Limits](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 **`options`**
@@ -96,7 +96,7 @@ the queries logged by the filter.
 * Values: `ignorecase`, `case`, `extended`
 * Default: `case`
 
-[Regular expression options](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+[Regular expression options](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 for `match` and `exclude`.
 
 **`source`**
@@ -106,7 +106,7 @@ for `match` and `exclude`.
 * Dynamic: Yes
 * Default: None
 
-Defines an address that is used to match against\
+Defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be logged.
 
@@ -121,9 +121,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-Defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will result in results being\
+Defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will result in results being
 generated.
 
 ```
@@ -134,8 +134,8 @@ user=john
 
 #### Example 1 - Heavily Contended Table
 
-You have an order system and believe the updates of the PRODUCTS table is\
-causing some performance issues for the rest of your application. You would like\
+You have an order system and believe the updates of the PRODUCTS table is
+causing some performance issues for the rest of your application. You would like
 to know which of the many updates in your application is causing the issue.
 
 Add a filter with the following definition:
@@ -150,12 +150,12 @@ exclude=UPDATE.*PRODUCTS_STOCK.*WHERE
 filebase=/var/logs/top/ProductsUpdate
 ```
 
-Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table\
+Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table
 from being included in the report.
 
 #### Example 2 - One Application Server is Slow
 
-One of your applications servers is slower than the rest, you believe it is\
+One of your applications servers is slower than the rest, you believe it is
 related to database access but you are not sure what is taking the time.
 
 Add a filter with the following definition:
@@ -169,7 +169,7 @@ source=192.168.0.32
 filebase=/var/logs/top/SlowAppServer
 ```
 
-In order to produce a comparison with an unaffected application server you can\
+In order to produce a comparison with an unaffected application server you can
 also add a second filter as a control.
 
 ```
@@ -194,14 +194,14 @@ password=mypasswd
 filters=SlowAppServer | ControlAppServer
 ```
 
-You will then have two sets of logs files written, one which profiles the top 20\
-queries of the slow application server and another that gives you the top 20\
-queries of your control application server. These two sets of files can then be\
+You will then have two sets of logs files written, one which profiles the top 20
+queries of the slow application server and another that gives you the top 20
+queries of your control application server. These two sets of files can then be
 compared to determine what if anything is different between the two.
 
 ### Output Report
 
-The following is an example report for a number of fictitious queries executed\
+The following is an example report for a number of fictitious queries executed
 against the employees example database available for MySQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-transaction-performance-monitoring-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-transaction-performance-monitoring-filter.md
@@ -1,21 +1,21 @@
 # MaxScale 21.06 Transaction Performance Monitoring Filter
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Overview
 
-The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale\
+The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale
 that monitors every SQL statement that passes through the filter.\
 The filter groups a series of SQL statements into a transaction by detecting\
-'commit' or 'rollback' statements. It logs all committed transactions with necessary\
-information, such as timestamp, client, SQL statements, latency, etc., which\
+'commit' or 'rollback' statements. It logs all committed transactions with necessary
+information, such as timestamp, client, SQL statements, latency, etc., which
 can be used later for transaction performance analysis.
 
 ### Configuration
 
-The configuration block for the TPM filter requires the minimal filter\
+The configuration block for the TPM filter requires the minimal filter
 options in it's section within the maxscale.cnf file, stored in /etc/maxscale.cnf.
 
 ```
@@ -51,9 +51,9 @@ filename=/tmp/SqlQueryLog
 
 #### Source
 
-The optional `source` parameter defines an address that is used\
-to match against the address from which the client connection\
-to MaxScale originates. Only sessions that originate from this\
+The optional `source` parameter defines an address that is used
+to match against the address from which the client connection
+to MaxScale originates. Only sessions that originate from this
 address will be logged.
 
 ```
@@ -62,9 +62,9 @@ source=127.0.0.1
 
 #### User
 
-The optional `user` parameter defines a user name that is used\
+The optional `user` parameter defines a user name that is used
 to match against the user from which the client connection to\
-MaxScale originates. Only sessions that are connected using\
+MaxScale originates. Only sessions that are connected using
 this username are logged.
 
 ```
@@ -73,7 +73,7 @@ user=john
 
 #### Delimiter
 
-The optional `delimiter` parameter defines a delimiter that is used to\
+The optional `delimiter` parameter defines a delimiter that is used to
 distinguish columns in the log. The default delimiter is **`:::`**.
 
 ```
@@ -82,7 +82,7 @@ delimiter=:::
 
 #### Query\_delimiter
 
-The optional `query_delimiter` defines a delimiter that is used to\
+The optional `query_delimiter` defines a delimiter that is used to
 distinguish different SQL statements in a transaction.\
 The default query delimiter is **`@@@`**.
 
@@ -92,9 +92,9 @@ query_delimiter=@@@
 
 #### Named\_pipe
 
-**`named_pipe`** is the path to a named pipe, which TPM filter uses to\
+**`named_pipe`** is the path to a named pipe, which TPM filter uses to
 communicate with 3rd-party applications (e.g., [DBSeer](https://dbseer.org)).\
-Logging is enabled when the router receives the character '1' and logging is\
+Logging is enabled when the router receives the character '1' and logging is
 disabled when the router receives the character '0' from this named pipe.\
 The default named pipe is **`/tmp/tpmfilter`** and logging is **disabled** by default.
 
@@ -124,7 +124,7 @@ For each transaction, the TPM filter prints its log in the following format:
 
 #### Example 1 - Log Transactions for Performance Analysis
 
-You want to log every transaction with its SQL statements and latency\
+You want to log every transaction with its SQL statements and latency
 for future transaction performance analysis.
 
 Add a filter with the following definition:
@@ -147,7 +147,7 @@ password=mypasswd
 filters=PerformanceLogger
 ```
 
-After the filter reads the character '1' from its named pipe, the following\
+After the filter reads the character '1' from its named pipe, the following
 is an example log that is generated from the above TPM filter with the above configuration:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-building-mariadb-maxscale-from-source-code.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-building-mariadb-maxscale-from-source-code.md
@@ -1,6 +1,6 @@
 # Building MariaDB MaxScale from Source Code
 
-MariaDB MaxScale can be built on any system that meets the requirements. The main\
+MariaDB MaxScale can be built on any system that meets the requirements. The main
 requirements are as follows:
 
 * CMake version 3.16 or later (Packaging requires CMake 3.25.1 or later)
@@ -17,7 +17,7 @@ requirements are as follows:
 * libmicrohttpd
 * Node.js 14 or newer for building MaxCtrl and the GUI (webpack), Node.js 10 or newer for running MaxCtrl
 
-This is the minimum set of requirements that must be met to build the MaxScale\
+This is the minimum set of requirements that must be met to build the MaxScale
 core package. Some modules in MaxScale require optional extra dependencies.
 
 * libuuid (binlogrouter)
@@ -28,9 +28,9 @@ core package. Some modules in MaxScale require optional extra dependencies.
 * memcached (storage\_memcached for the cache filter)
 * hiredis (storage\_redis for the cache filter)
 
-Some of these dependencies are not available on all operating systems and are\
-downloaded automatically during the build step. To skip the building of modules\
-that need automatic downloading of the dependencies, use `-DBUNDLE=N` when\
+Some of these dependencies are not available on all operating systems and are
+downloaded automatically during the build step. To skip the building of modules
+that need automatic downloading of the dependencies, use `-DBUNDLE=N` when
 configuring CMake.
 
 ### Quickstart
@@ -56,7 +56,7 @@ For a definitive list of packages, consult the [install\_build\_deps.sh](https:/
 
 The tests and other parts of the build can be controlled via CMake arguments.
 
-Here is a small table with the names of the most common parameters and what\
+Here is a small table with the names of the most common parameters and what
 they control. These should all be given as parameters to the -D switch in _NAME_=_VALUE_ format (e.g. `-DBUILD_TESTS=Y`).
 
 | Argument Name          | Explanation                                                                                                                                                                |
@@ -68,25 +68,25 @@ they control. These should all be given as parameters to the -D switch in _NAME_
 | TARGET\_COMPONENT      | Which component to install, default is the 'core' package. Other targets are 'experimental', which installs experimental packages and 'all' which installs all components. |
 | TARBALL                | Build tar.gz packages, requires PACKAGE=Y                                                                                                                                  |
 
-**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a\
+**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a
 list of the CMake variables.
 
 ### Running unit tests
 
-To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,\
+To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,
 compile and then run the `make test` command.
 
 ## Building MariaDB MaxScale packages
 
-If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation\
-and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your\
+If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation
+and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your
 system.
 
-To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create\
+To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create
 a _maxscale-x.y.z.tar.gz_ file where _x.y.z_ is the version number.
 
-Some Debian and Ubuntu systems suffer from a bug where `make package` fails\
-with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to\
+Some Debian and Ubuntu systems suffer from a bug where `make package` fails
+with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to
 the LD\_LIBRARY\_PATH environment variable.
 
 ```
@@ -96,14 +96,14 @@ LD_LIBRARY_PATH=$PWD/server/core/ make package
 
 ### Installing optional components
 
-The MaxScale build system is split into multiple components. The main component\
-is the `core` MaxScale package which contains MaxScale and all the modules. This\
-is the default component that is build, installed and packaged. There is also\
-the `experimental` component that contains all experimental modules which are\
-not considered as part of the core MaxScale package and are either alpha or beta\
+The MaxScale build system is split into multiple components. The main component
+is the `core` MaxScale package which contains MaxScale and all the modules. This
+is the default component that is build, installed and packaged. There is also
+the `experimental` component that contains all experimental modules which are
+not considered as part of the core MaxScale package and are either alpha or beta
 quality modules.
 
-To build the experimental modules along with the MaxScale core components,\
+To build the experimental modules along with the MaxScale core components,
 invoke CMake with `-DTARGET_COMPONENT=core,experimental`.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-installing-mariadb-maxscale-using-a-tarball.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-installing-mariadb-maxscale-using-a-tarball.md
@@ -1,6 +1,6 @@
 # Installing MariaDB MaxScale using a tarball
 
-MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`\
+MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`
 identifies the operating system, e.g. `maxscale-2.5.6.centos.7.tar.gz`.
 
 In order to use the tarball, the following libraries are required:
@@ -12,12 +12,12 @@ In order to use the tarball, the following libraries are required:
 * libatomic
 
 The tarball has been built with the assumption that it will be installed in `/usr/local`.\
-However, it is possible to install it in any directory, but in that case MariaDB MaxScale\
+However, it is possible to install it in any directory, but in that case MariaDB MaxScale
 must be invoked with a flag.
 
 ### Installing as root in `/usr/local`
 
-If you have root access to the system you probably want to install MariaDB MaxScale under\
+If you have root access to the system you probably want to install MariaDB MaxScale under
 the user and group `maxscale`.
 
 The required steps are as follows:
@@ -32,14 +32,14 @@ $ cd maxscale
 $ sudo chown -R maxscale var
 ```
 
-Creating the symbolic link is necessary, since MariaDB MaxScale has been built\
+Creating the symbolic link is necessary, since MariaDB MaxScale has been built
 with the assumption that the plugin directory is `/usr/local/maxscale/lib/maxscale`.
 
 The symbolic link also makes it easy to switch between different versions of\
 MariaDB MaxScale that have been installed side by side in `/usr/local`;\
 just make the symbolic link point to another installation.
 
-In addition, the first time you install MariaDB MaxScale from a tarball\
+In addition, the first time you install MariaDB MaxScale from a tarball
 you need to create the following directories:
 
 ```
@@ -68,14 +68,14 @@ When the configuration file has been created, MariaDB MaxScale can be started.
 $ sudo bin/maxscale --user=maxscale -d
 ```
 
-The `-d` flag causes maxscale _not_ to turn itself into a daemon,\
+The `-d` flag causes maxscale _not_ to turn itself into a daemon,
 which is advisable the first time MariaDB MaxScale is started, as it makes it easier to spot problems.
 
 If you want to place the configuration file somewhere else but in `/etc`\
 you can invoke MariaDB MaxScale with the `--config` flag,\
 for instance, `--config=/usr/local/maxscale/etc/maxscale.cnf`.
 
-Note also that if you want to keep _everything_ under `/usr/local/maxscale`\
+Note also that if you want to keep _everything_ under `/usr/local/maxscale`
 you can invoke MariaDB MaxScale using the flag `--basedir`.
 
 ```
@@ -103,12 +103,12 @@ $ cd maxscale-x.y.z.OS
 $ bin/maxscale -d --basedir=.
 ```
 
-With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`\
-directories are found. Unless it is specified, MariaDB MaxScale assumes\
-the `lib` directory is found in `/usr/local/maxscale`,\
+With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`
+directories are found. Unless it is specified, MariaDB MaxScale assumes
+the `lib` directory is found in `/usr/local/maxscale`,
 and the `var` and `etc` directories in `/`.
 
-It is also possible to specify the directories and the location of\
+It is also possible to specify the directories and the location of
 the configuration file individually. Invoke MaxScale like
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-This document describes how to configure MariaDB MaxScale and presents some\
-possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,\
-and consists of an event processing core with various support functions and\
+This document describes how to configure MariaDB MaxScale and presents some
+possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,
+and consists of an event processing core with various support functions and
 plugin modules that tailor the behavior of the program.
 
 ## Concepts
@@ -24,9 +24,9 @@ plugin modules that tailor the behavior of the program.
 
 #### Server
 
-A server represents an individual database server to which a client can be\
-connected via MariaDB MaxScale. The status of a server varies during the lifetime\
-of the server and typically the status is updated by some monitor. However, it\
+A server represents an individual database server to which a client can be
+connected via MariaDB MaxScale. The status of a server varies during the lifetime
+of the server and typically the status is updated by some monitor. However, it
 is also possible to update the status of a server manually.
 
 | Status                   | Description                                                                                                                                                                                                                                                                                                               |
@@ -45,58 +45,58 @@ For more information on how to manually set these states via MaxCtrl, read the [
 
 #### Monitor
 
-A monitor module is capable of monitoring the state of a particular kind\
+A monitor module is capable of monitoring the state of a particular kind
 of cluster and making that state available to the routers of MaxScale.
 
-Examples of monitor modules are `mariadbmon` that is capable of monitoring\
-a regular master-slave cluster and in addition of performing both _switchover_\
-and _failover_, `galeramon` that is capable of monitoring a Galera cluster,\
+Examples of monitor modules are `mariadbmon` that is capable of monitoring
+a regular master-slave cluster and in addition of performing both _switchover_
+and _failover_, `galeramon` that is capable of monitoring a Galera cluster,
 and `csmon` that is capable of monitoring a Columnstore cluster.
 
-Monitor modules have sections of their own in the MaxScale configuration\
+Monitor modules have sections of their own in the MaxScale configuration
 file.
 
 #### Filter
 
-A filter module resides in front of routers in the request processing chain\
-of MaxScale. That is, a filter will see a request before it reaches the router\
-and before a response is sent back to the client. This allows filters to\
+A filter module resides in front of routers in the request processing chain
+of MaxScale. That is, a filter will see a request before it reaches the router
+and before a response is sent back to the client. This allows filters to
 reject, handle, alter or log information about a request.
 
-Examples of filters are `dbfwfilter` that is a configurable firewall, `cache`\
-that provides query caching according to rules, `regexfilter` that can rewrite\
-requests according to regular expressions, and `qlafilter` that logs\
+Examples of filters are `dbfwfilter` that is a configurable firewall, `cache`
+that provides query caching according to rules, `regexfilter` that can rewrite
+requests according to regular expressions, and `qlafilter` that logs
 information about requests.
 
-Filters have sections of their own in the MaxScale configuration file that are\
+Filters have sections of their own in the MaxScale configuration file that are
 referred to from _services_.
 
 #### Router
 
-A router module is capable of routing requests to backend servers according to\
-the characteristics of a request and/or the algorithm the router\
+A router module is capable of routing requests to backend servers according to
+the characteristics of a request and/or the algorithm the router
 implements. Examples of routers are `readconnroute` that provides _connection routing_, that is, the server is chosen according to specified rules when the
-session is created and all requests are subsequently routed to that server,\
-and `readwritesplit` that provides _statement routing_, that is, each\
+session is created and all requests are subsequently routed to that server,
+and `readwritesplit` that provides _statement routing_, that is, each
 individual request is routed to the most appropriate server.
 
-Routers do not have sections of their own in the MaxScale configuration file,\
+Routers do not have sections of their own in the MaxScale configuration file,
 but are referred to from _services_.
 
 #### Service
 
-A service abstracts a set of databases and makes them appear as a single one\
-to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular\
-way. If the service uses filters, then all requests will be pre-processed in\
+A service abstracts a set of databases and makes them appear as a single one
+to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular
+way. If the service uses filters, then all requests will be pre-processed in
 some way before they reach the router.
 
 Services have sections of their own in the MaxScale configuration file.
 
 #### Listener
 
-A listener defines a port MaxScale listens on. Connection requests arriving on\
-that port will be forwarded to the service the listener is associated with. A\
-listener may be associated with a single service, but several listeners may be\
+A listener defines a port MaxScale listens on. Connection requests arriving on
+that port will be forwarded to the service the listener is associated with. A
+listener may be associated with a single service, but several listeners may be
 associated with the same service.
 
 Listeners have sections of their own in the MaxScale configuration file.
@@ -108,25 +108,25 @@ The administration of MaxScale can be divided in two parts:
 * Writing the MaxScale configuration file, which is described in the following [section](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#configuration).
 * Performing runtime modifications using [MaxCtrl](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-maxctrl.md)
 
-For detailed information about _MaxCtrl_ please refer to the specific\
+For detailed information about _MaxCtrl_ please refer to the specific
 documentation referred to above. In the following it will only be explained how\
 MaxCtrl relate to each other, as far as user credentials go.
 
-**Note**: By default all runtime configuration changes are saved on disk and\
-loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details\
+**Note**: By default all runtime configuration changes are saved on disk and
+loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details
 on how it works and how to disable it.
 
 MaxCtrl can connect using TCP/IP sockets. When connecting with MaxCtrl using\
-TCP/IP sockets, the user and password must be provided and are checked against a\
+TCP/IP sockets, the user and password must be provided and are checked against a
 separate user credentials database. By default, that database contains the user`admin` whose password is `mariadb`.
 
-Note that if MaxCtrl is invoked without explicitly providing a user and password\
-then it will by default use `admin` and `mariadb`. That means that when the\
+Note that if MaxCtrl is invoked without explicitly providing a user and password
+then it will by default use `admin` and `mariadb`. That means that when the
 default user is removed, the credentials must always be provided.
 
 ### Static Configuration Parameters
 
-The following list of global configuration parameters can **NOT** be changed at\
+The following list of global configuration parameters can **NOT** be changed at
 runtime and can only be defined in a configuration file:
 
 * `admin_auth`
@@ -165,32 +165,32 @@ runtime and can only be defined in a configuration file:
 * `substitute_variables`
 * `threads`
 
-All other parameters that relate to objects can be altered at runtime or can be\
+All other parameters that relate to objects can be altered at runtime or can be
 changed by destroying and recreating the object in question.
 
 ## Configuration
 
-The MariaDB MaxScale configuration is read from a file that MariaDB MaxScale\
+The MariaDB MaxScale configuration is read from a file that MariaDB MaxScale
 will look for in the following places:
 
 1. By default, the file `maxscale.cnf` in the directory `/etc`
 2. The location given with the `--configdir=<path>` command line argument.
 
-MariaDB MaxScale will further look for a directory with the same name as the\
-configuration file, followed by `.d` (for instance `/etc/maxscale.cnf.d`) and\
-recursively read all files, having a `.cnf` suffix, it finds in the directory\
+MariaDB MaxScale will further look for a directory with the same name as the
+configuration file, followed by `.d` (for instance `/etc/maxscale.cnf.d`) and
+recursively read all files, having a `.cnf` suffix, it finds in the directory
 hierarchy. All other files will be ignored.
 
-There are no restrictions on how different configuration sections are arranged,\
-but the strong suggestion is to place global settings into the configuration\
-file MariaDB MaxScale is invoked with, and then, if deemed necessary, create\
+There are no restrictions on how different configuration sections are arranged,
+but the strong suggestion is to place global settings into the configuration
+file MariaDB MaxScale is invoked with, and then, if deemed necessary, create
 separate configuration files for _servers_, _filters_, etc.
 
-The configuration file itself is based on the [.ini](https://en.wikipedia.org/wiki/INI_file) file format and consists of\
-various sections that are used to build the configuration; these sections define\
+The configuration file itself is based on the [.ini](https://en.wikipedia.org/wiki/INI_file) file format and consists of
+various sections that are used to build the configuration; these sections define
 services, servers, listeners, monitors and global settings.
 
-Comments are defined by prefixing a row with a hash (`#`). Trailing comments are\
+Comments are defined by prefixing a row with a hash (`#`). Trailing comments are
 not supported.
 
 ```
@@ -198,11 +198,11 @@ not supported.
 some_parameter=123
 ```
 
-**Note:** Multi-line parameters have been deprecated in MaxScale 6.0 due to\
-the unintuitive way they worked when the same parameter was declared multiple\
+**Note:** Multi-line parameters have been deprecated in MaxScale 6.0 due to
+the unintuitive way they worked when the same parameter was declared multiple
 times.
 
-Parameters, which expect a comma-separated list of values can be defined on\
+Parameters, which expect a comma-separated list of values can be defined on
 multiple lines. The following is an example of a multi-line definition.
 
 ```
@@ -214,49 +214,49 @@ servers=server1,
         server3
 ```
 
-The values of the parameter that are not on the first line need to have at least\
-one whitespace character before them in order for them to be recognized as a\
+The values of the parameter that are not on the first line need to have at least
+one whitespace character before them in order for them to be recognized as a
 part of the multi-line parameter.
 
 ### Names
 
 Section names may not contain whitespace and must not start with the characters`@@`, but otherwise there are no restrictions.
 
-As the object names are used to form URLs in the MaxScale REST API, they must be\
+As the object names are used to form URLs in the MaxScale REST API, they must be
 safe for use in URLs. This means that only alphanumeric characters (i.e. `a-zA-Z` and `0-9`) and the special characters `_.~-` can be used.
 
 ### Dynamic Configuration
 
 By default all changes done at runtime via the MaxScale GUI, MaxCtrl or the REST\
-API will be saved on disk, inside the [persistdir](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#persistdir) directory. The\
-changes done at runtime will override the configuration found in the static\
+API will be saved on disk, inside the [persistdir](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#persistdir) directory. The
+changes done at runtime will override the configuration found in the static
 configuration files for that particular object.
 
-This means that if an object that is found in `/etc/maxscale.cnf` is modified at\
-runtime, all future changes to it must also be done at runtime. Any\
-modifications done to `/etc/maxscale.cnf` after a runtime change has been made\
+This means that if an object that is found in `/etc/maxscale.cnf` is modified at
+runtime, all future changes to it must also be done at runtime. Any
+modifications done to `/etc/maxscale.cnf` after a runtime change has been made
 are ignored for that object.
 
-To prevent the saving of runtime changes and to make all runtime changes\
-volatile, add [load\_persisted\_configs=false](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under\
-the `[maxscale]` section. This will make MaxScale behave like the MariaDB server\
-does: any changes done with `SET GLOBAL` statements are lost if the process is\
+To prevent the saving of runtime changes and to make all runtime changes
+volatile, add [load\_persisted\_configs=false](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under
+the `[maxscale]` section. This will make MaxScale behave like the MariaDB server
+does: any changes done with `SET GLOBAL` statements are lost if the process is
 restarted.
 
 ### Special Parameter Types
 
 #### Booleans
 
-Boolean type parameters interpret the values `true`, `yes`, `on` and `1` as\_true\_ values and `false`, `no`, `off` and `0` as _false_ values. The REST API\
+Boolean type parameters interpret the values `true`, `yes`, `on` and `1` as\_true\_ values and `false`, `no`, `off` and `0` as _false_ values. The REST API
 only accepts JSON boolean values for boolean type parameters.
 
 #### Sizes
 
-Where _specifically noted_, a number denoting a size can be suffixed by a subset\
-of the IEC binary prefixes or the SI prefixes. In the former case the number\
-will be interpreted as a certain multiple of 1024 and in the latter case as a\
-certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`\
-and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,\
+Where _specifically noted_, a number denoting a size can be suffixed by a subset
+of the IEC binary prefixes or the SI prefixes. In the former case the number
+will be interpreted as a certain multiple of 1024 and in the latter case as a
+certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`
+and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,
 the matching is case insensitive.
 
 For instance, the following entries
@@ -281,8 +281,8 @@ max_size=1T
 
 #### Durations
 
-A number denoting a duration can be suffixed by one of the case-insensitive\
-suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,\
+A number denoting a duration can be suffixed by one of the case-insensitive
+suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,
 minutes, seconds and milliseconds, respectively.
 
 For instance, the following entries
@@ -297,79 +297,79 @@ soft_ttl=3600000ms
 
 are equivalent.
 
-Note that if an explicit unit is not specified, then it is specific to the\
-configuration parameter whether the duration is interpreted as seconds or\
+Note that if an explicit unit is not specified, then it is specific to the
+configuration parameter whether the duration is interpreted as seconds or
 milliseconds.
 
 _Not_ providing an explicit unit has been deprecated in MaxScale 2.4.
 
 #### Regular Expressions
 
-Many modules have settings which accept a regular expression. In most cases, these\
+Many modules have settings which accept a regular expression. In most cases, these
 settings are named either _match_ or _exclude_, and are used to filter users or queries.\
-MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching\
+MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching
 regular expressions.
 
-When writing a regular expression (regex) type parameter to a MaxScale configuration file,\
-the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This\
-clarifies where the pattern begins and ends, even if it includes whitespace. Without\
-slashes the configuration loader trims the pattern from the ends. The slashes are removed\
-before compiling the pattern. For backwards compatibility, the slashes are not yet\
-mandatory. Omitting them is, however, deprecated and will be rejected in a future release\
-of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_\
-accept parameters in this type of regular expression form. Some other modules may not\
+When writing a regular expression (regex) type parameter to a MaxScale configuration file,
+the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This
+clarifies where the pattern begins and ends, even if it includes whitespace. Without
+slashes the configuration loader trims the pattern from the ends. The slashes are removed
+before compiling the pattern. For backwards compatibility, the slashes are not yet
+mandatory. Omitting them is, however, deprecated and will be rejected in a future release
+of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_
+accept parameters in this type of regular expression form. Some other modules may not
 handle the slashes yet correctly.
 
-PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses\
-regular expressions simply, only checking whether the pattern and subject match at some\
-point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to\
-accept any query with the text "SELECT" somewhere within. To force the pattern to only\
+PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses
+regular expressions simply, only checking whether the pattern and subject match at some
+point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to
+accept any query with the text "SELECT" somewhere within. To force the pattern to only
 match at the beginning of the query, set `match=/^SELECT/`. To only match the end, set`match=/SELECT$/`.
 
-Modules which accept regular expression parameters also often accept options which affect\
-how the patterns are compiled. Typically, this setting is called _options_ and accepts\
+Modules which accept regular expression parameters also often accept options which affect
+how the patterns are compiled. Typically, this setting is called _options_ and accepts
 values such as `ignorecase`, `case` and `extended`.
 
-* `ignorecase`: Causes the regular expression matcher to ignore letter case, and\
+* `ignorecase`: Causes the regular expression matcher to ignore letter case, and
   is often on by default. When enabled, `/SELECT/` would match both `SELECT` and`select`.
-* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this\
+* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this
   is not the same as the extended regular expression syntax that for example`grep -E` uses.
-* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not\
+* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not
   match `select`.
 
-These settings can also be defined in the pattern itself, so they can be\
-used even in modules without pattern compilation settings. The pattern\
-settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)\
+These settings can also be defined in the pattern itself, so they can be
+used even in modules without pattern compilation settings. The pattern
+settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)
 for more information.
 
 **Standard regular expression settings for filters**
 
-Many filters use the settings _match_, _exclude_ and _options_. Since these settings are\
-used in a similar way across these filters, the settings are explained here. The\
-documentation of the filters link here and describe any exceptions to this\
+Many filters use the settings _match_, _exclude_ and _options_. Since these settings are
+used in a similar way across these filters, the settings are explained here. The
+documentation of the filters link here and describe any exceptions to this
 generalized explanation.
 
-These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the\
+These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the
 patterns are compiled. _options_ works as explained above, accepting the values`ignorecase`, `case` and `extended`, with `ignorecase` being the default.
 
-The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is\
+The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is
 not defined, all queries are considered to match.
 
 If _exclude_ is defined, the filter only acts on queries not matching that pattern. If\_exclude\_ is not defined, nothing is excluded.
 
 If both are defined, the query needs to match _match_ but not match _exclude_.
 
-Even if a filter does not act on a query, the query is not lost. The query is simply\
+Even if a filter does not act on a query, the query is not lost. The query is simply
 passed on to the next module in the processing chain as if the filter was not there.
 
 #### Enumerations
 
-Enumeration type parameters have a pre-defined set of accepted values. For types\
-declared as `enum`, only one value is accepted. For `enum_mask` types, multiple\
+Enumeration type parameters have a pre-defined set of accepted values. For types
+declared as `enum`, only one value is accepted. For `enum_mask` types, multiple
 values can be defined by separating them with commas. All enumeration values in\
 MaxScale are case-sensitive.
 
-For example the `router_options` parameter in the `readconnroute` router is a\
+For example the `router_options` parameter in the `readconnroute` router is a
 mask type enumeration:
 
 ```
@@ -378,8 +378,8 @@ router_options=master,slave
 
 ### Global Settings
 
-The global settings, in a section named `[MaxScale]`, allow various parameters\
-that affect MariaDB MaxScale as a whole to be tuned. This section must be\
+The global settings, in a section named `[MaxScale]`, allow various parameters
+that affect MariaDB MaxScale as a whole to be tuned. This section must be
 defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 
 #### `threads`
@@ -389,13 +389,13 @@ defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 * Dynamic: No
 * Default: `auto`
 
-This parameter controls the number of worker threads that are handling the\
-events coming from the kernel. The default is `auto` which uses as many threads\
-as there are CPU cores. MaxScale versions older than 6 used one thread by\
+This parameter controls the number of worker threads that are handling the
+events coming from the kernel. The default is `auto` which uses as many threads
+as there are CPU cores. MaxScale versions older than 6 used one thread by
 default.
 
-You can explicitly enable automatic configuration of this value by setting the\
-value to `auto`. This way MariaDB MaxScale will detect the number of available\
+You can explicitly enable automatic configuration of this value by setting the
+value to `auto`. This way MariaDB MaxScale will detect the number of available
 processors and set the amount of threads to be equal to that number.
 
 The maximum value for threads is 100.
@@ -409,7 +409,7 @@ threads=auto
 ```
 
 Additional threads will be created to execute other internal services within\
-MariaDB MaxScale. This setting is used to configure the number of threads that\
+MariaDB MaxScale. This setting is used to configure the number of threads that
 will be used to manage the user connections.
 
 #### `rebalance_period`
@@ -419,22 +419,22 @@ will be used to manage the user connections.
 * Dynamic: Yes
 * Default: `0s`
 
-This duration parameter controls how often the load of the worker threads\
-should be checked. The default value is 0, which means that no checks and\
+This duration parameter controls how often the load of the worker threads
+should be checked. The default value is 0, which means that no checks and
 no rebalancing will be performed.
 
 ```
 rebalance_period=10s
 ```
 
-Note that the value of `rebalance_period` should not be smaller than the\
+Note that the value of `rebalance_period` should not be smaller than the
 value of `rebalance_window` whose default value is 10.
 
-**NOTE** The rebalancing functionality is currently disabled and an attempt\
+**NOTE** The rebalancing functionality is currently disabled and an attempt
 to enable it will be ignored.
 
-If the value of `rebalance_period` is significantly shorter than that\
-of `rebalance_window`, it may lead to oscillation where work is constantly\
+If the value of `rebalance_period` is significantly shorter than that
+of `rebalance_window`, it may lead to oscillation where work is constantly
 moved from one thread to another.
 
 #### `rebalance_threshold`
@@ -444,21 +444,21 @@ moved from one thread to another.
 * Dynamic: Yes
 * Default: `20`
 
-This integer parameter controls at which point MaxScale should start\
+This integer parameter controls at which point MaxScale should start
 moving work from one worker thread to another.
 
 If the difference in load between the thread with the maximum load and\
 the thread with the minimum load is larger than the value of this parameter,\
 then work will be moved from the former to the latter.
 
-Although the load of a thread can vary between 0 and 100, the value of this\
+Although the load of a thread can vary between 0 and 100, the value of this
 parameter must be between 5 and 100.
 
 ```
 rebalance_threshold=15
 ```
 
-Note that rebalancing will not be performed unless `rebalance_period`\
+Note that rebalancing will not be performed unless `rebalance_period`
 has been specified.
 
 #### `rebalance_window`
@@ -468,11 +468,11 @@ has been specified.
 * Dynamic: Yes
 * Default: `10`
 
-This integer parameter controls how many seconds of load should be\
-taken into account when deciding whether work should be moved from\
+This integer parameter controls how many seconds of load should be
+taken into account when deciding whether work should be moved from
 one thread to another.
 
-The default value is 10, which means that the load during the last 10\
+The default value is 10, which means that the load during the last 10
 seconds is considered when deciding whether work should be moved.
 
 The minimum value is 1 and the maximum 60.
@@ -484,8 +484,8 @@ The minimum value is 1 and the maximum 60.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether reverse domain name lookups are made to convert\
-client IP addresses to hostnames. If enabled, client IP addresses will not be\
+This parameter controls whether reverse domain name lookups are made to convert
+client IP addresses to hostnames. If enabled, client IP addresses will not be
 resolved to hostnames during authentication or for the REST API even if requested.
 
 If you have database users that use a hostname in the host part of the user\
@@ -501,8 +501,8 @@ an IP address.
 * Dynamic: Yes
 * Default: `10s`
 
-Duration, default 10s. This setting defines the connection timeout when\
-attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same\
+Duration, default 10s. This setting defines the connection timeout when
+attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same
 value is also used for read and write timeouts. Increasing this value causes\
 MaxScale to wait longer for a response from a server before user fetching fails.\
 Other servers may then be attempted.
@@ -511,10 +511,10 @@ Other servers may then be attempted.
 auth_connect_timeout=10s
 ```
 
-The value is given as [a duration](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,\
-the value is interpreted as seconds. In subsequent versions a value without a\
-unit may be rejected. Since the granularity of the timeout is seconds, a timeout\
-specified in milliseconds will be rejected even if the given value is longer\
+The value is given as [a duration](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,
+the value is interpreted as seconds. In subsequent versions a value without a
+unit may be rejected. Since the granularity of the timeout is seconds, a timeout
+specified in milliseconds will be rejected even if the given value is longer
 than a second.
 
 #### `auth_read_timeout`
@@ -532,14 +532,14 @@ Deprecated and ignored as of MaxScale 2.5.0. See _auth\_connect\_timeout_ above.
 * Dynamic: No
 * Default: `1`
 
-The number of times an interrupted internal query will be retried. The default\
-is to retry the query once. This feature was added in MaxScale 2.1.10 and was\
+The number of times an interrupted internal query will be retried. The default
+is to retry the query once. This feature was added in MaxScale 2.1.10 and was
 disabled by default until MaxScale 2.3.0.
 
-An interrupted query is any query that is interrupted by a network\
-error. Connection timeouts are included in network errors and thus is it\
-advisable to make sure that the value of `query_retry_timeout` is set to an\
-adequate value. Internal queries are only used to retrieve authentication data\
+An interrupted query is any query that is interrupted by a network
+error. Connection timeouts are included in network errors and thus is it
+advisable to make sure that the value of `query_retry_timeout` is set to an
+adequate value. Internal queries are only used to retrieve authentication data
 and monitor the servers.
 
 #### `query_retry_timeout`
@@ -549,16 +549,16 @@ and monitor the servers.
 * Dynamic: Yes
 * Default: `10s`
 
-The total timeout in seconds for any retried queries. The default value is 5\
+The total timeout in seconds for any retried queries. The default value is 5
 seconds.
 
-An interrupted query is retried for either the configured amount of attempts or\
+An interrupted query is retried for either the configured amount of attempts or
 until the configured timeout is reached.
 
-The value is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `passive`
@@ -568,11 +568,11 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `false`
 
-Controls whether MaxScale is a passive node in a cluster of multiple MaxScale\
+Controls whether MaxScale is a passive node in a cluster of multiple MaxScale
 instances.
 
-This parameter is intended to be used with multiple MaxScale instances that use\
-failover functionality to manipulate the cluster in some form. Passive nodes\
+This parameter is intended to be used with multiple MaxScale instances that use
+failover functionality to manipulate the cluster in some form. Passive nodes
 only observe the clusters being monitored and take no direct actions.
 
 The following functionality is disabled when passive mode is enabled:
@@ -581,8 +581,8 @@ The following functionality is disabled when passive mode is enabled:
 * Automatic rejoin in the `mariadbmon` module
 * Launching of monitor scripts
 
-**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and\
-route any traffic sent to it. The **only** operations affected by the passive\
+**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and
+route any traffic sent to it. The **only** operations affected by the passive
 mode are the ones listed above.
 
 #### `ms_timestamp`
@@ -592,7 +592,7 @@ mode are the ones listed above.
 * Dynamic: Yes
 * Default: `false`
 
-Enable or disable the high precision timestamps in logfiles. Enabling this adds\
+Enable or disable the high precision timestamps in logfiles. Enabling this adds
 millisecond precision to all logfile timestamps.
 
 #### `skip_permission_checks`
@@ -602,13 +602,13 @@ millisecond precision to all logfile timestamps.
 * Dynamic: Yes
 * Default: `false`
 
-Skip service and monitor user permission checks. This is useful when you know\
+Skip service and monitor user permission checks. This is useful when you know
 the permissions are OK and you want to speed up the startup process.
 
-It is recommended to not disable the permission checks so that any missing\
-privileges are detected when maxscale is starting up. If you are experiencing a\
-slow startup of MaxScale due to large amounts of connection timeouts when\
-permissions are checked, disabling the permission checks could speed up the\
+It is recommended to not disable the permission checks so that any missing
+privileges are detected when maxscale is starting up. If you are experiencing a
+slow startup of MaxScale due to large amounts of connection timeouts when
+permissions are checked, disabling the permission checks could speed up the
 startup process.
 
 ```
@@ -642,8 +642,8 @@ Log messages to MariaDB MaxScale's log file.
 
 Log messages whose syslog priority is _warning_.
 
-MaxScale logs warning level messages whenever a condition is encountered that\
-the user should be notified of but does not require immediate action or it\
+MaxScale logs warning level messages whenever a condition is encountered that
+the user should be notified of but does not require immediate action or it
 indicates a minor problem.
 
 #### `log_notice`
@@ -655,8 +655,8 @@ indicates a minor problem.
 
 Log messages whose syslog priority is _notice_.
 
-These messages contain information that is helpful for the user and they usually\
-do not indicate a problem. These are logged whenever something worth nothing\
+These messages contain information that is helpful for the user and they usually
+do not indicate a problem. These are logged whenever something worth nothing
 happens in either MaxScale or in the servers it monitors.
 
 #### `log_info`
@@ -669,10 +669,10 @@ happens in either MaxScale or in the servers it monitors.
 Log messages whose syslog priority is _info_.
 
 These messages provide detailed information about the internal workings of\
-MariaDB MaxScale. These messages should only be enabled when there is a need to\
-inspect the internal logic of MaxScale. A common use-case is to see why a\
-particular query was handled in a certain way. Almost all modules log some\
-messages on the info level and this can be very helpful when trying to solve\
+MariaDB MaxScale. These messages should only be enabled when there is a need to
+inspect the internal logic of MaxScale. A common use-case is to see why a
+particular query was handled in a certain way. Almost all modules log some
+messages on the info level and this can be very helpful when trying to solve
 routing related problems.
 
 #### `log_debug`
@@ -684,11 +684,11 @@ routing related problems.
 
 Log messages whose syslog priority is _debug_.
 
-These messages are intended for development purposes and are disabled by\
+These messages are intended for development purposes and are disabled by
 default. These are rarely useful outside of debugging core MaxScale issues.
 
-**Note:** If MariaDB MaxScale has been built in release mode, then debug\
-messages are excluded from the build and this setting will not have any\
+**Note:** If MariaDB MaxScale has been built in release mode, then debug
+messages are excluded from the build and this setting will not have any
 effect. If an attempt to enable these is made, a warning is logged.
 
 #### `log_warn_super_user`
@@ -698,10 +698,10 @@ effect. If an attempt to enable these is made, a warning is logged.
 * Dynamic: No
 * Default: `false`
 
-When enabled, a warning is logged whenever a client with SUPER-privilege\
-successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The\
-setting is intended for diagnosing situations where a client interferes with a\
-master server switchover. Super-users bypass the _read\_only_-flag which\
+When enabled, a warning is logged whenever a client with SUPER-privilege
+successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The
+setting is intended for diagnosing situations where a client interferes with a
+master server switchover. Super-users bypass the _read\_only_-flag which
 switchover uses to block writes to the master.
 
 #### `log_augmentation`
@@ -711,9 +711,9 @@ switchover uses to block writes to the master.
 * Dynamic: Yes
 * Default: `0`
 
-Enable or disable the augmentation of messages. If this is enabled, then each\
-logged message is appended with the name of the function where the message was\
-logged. This is primarily for development purposes and hence is disabled by\
+Enable or disable the augmentation of messages. If this is enabled, then each
+logged message is appended with the name of the function where the message was
+logged. This is primarily for development purposes and hence is disabled by
 default.
 
 ```
@@ -731,10 +731,10 @@ To disable the augmentation use the value 0 and to enable it use the value 1.
 * Dynamic: Yes
 * Default: `10, 1000ms, 10000ms`
 
-It is possible that a particular error (or warning) is logged over and over\
-again, if the cause for the error persistently remains. To prevent the log from\
-flooding, it is possible to specify how many times a particular error may be\
-logged within a time period, before the logging of that error is suppressed for\
+It is possible that a particular error (or warning) is logged over and over
+again, if the cause for the error persistently remains. To prevent the log from
+flooding, it is possible to specify how many times a particular error may be
+logged within a time period, before the logging of that error is suppressed for
 a while.
 
 ```
@@ -750,18 +750,18 @@ log_throttling=8, 2s, 15000ms
 In the example above, the logging of a particular error will be suppressed for\
 15 seconds if the error has been logged 8 times in 2 seconds.
 
-The default is `10, 1000ms, 10000ms`, which means that if the same error is\
-logged 10 times in one second, the logging of that error is suppressed for the\
+The default is `10, 1000ms, 10000ms`, which means that if the same error is
+logged 10 times in one second, the logging of that error is suppressed for the
 following 10 seconds.
 
-Whenever an error message that is being throttled is logged within the\
-triggering window (the second argument), the suppression window is\
-extended. This continues until there is a pause in the messages that is longer\
+Whenever an error message that is being throttled is logged within the
+triggering window (the second argument), the suppression window is
+extended. This continues until there is a pause in the messages that is longer
 than the triggering window.
 
-For example, with the default configuration the messages must pause for at least\
-one second in order for the throttling to eventually stop. This mechanism\
-prevents long-lasting error conditions from slowly filling up the log with short\
+For example, with the default configuration the messages must pause for at least
+one second in order for the throttling to eventually stop. This mechanism
+prevents long-lasting error conditions from slowly filling up the log with short
 bursts of messages.
 
 To disable log throttling, add an entry with an empty value
@@ -776,8 +776,8 @@ or one where any of the integers is 0.
 log_throttling=0, 0, 0
 ```
 
-The durations can be specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In\
+The durations can be specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In
 subsequent versions a value without a unit may be rejected.
 
 Note that _notice_, _info_ and _debug_ messages are never throttled.
@@ -789,7 +789,7 @@ Note that _notice_, _info_ and _debug_ messages are never throttled.
 * Dynamic: No
 * Default: `/var/log/maxscale`
 
-Set the directory where the logfiles are stored. The folder needs to be both\
+Set the directory where the logfiles are stored. The folder needs to be both
 readable and writable by the user running MariaDB MaxScale.
 
 ```
@@ -804,10 +804,10 @@ logdir=/var/log/maxscale/
 * Default: `/var/lib/maxscale`
 
 Set the directory where the data files used by MariaDB MaxScale are stored.\
-Modules can write to this directory and for example the binlogrouter uses this\
+Modules can write to this directory and for example the binlogrouter uses this
 folder as the default location for storing binary logs.
 
-This is also the directory where the password encryption key is read from that\
+This is also the directory where the password encryption key is read from that
 is generated by `maxkeys`.
 
 ```
@@ -821,10 +821,10 @@ datadir=/var/lib/maxscale/
 * Dynamic: No
 * Default: `""`
 
-The location where the `.secrets` file is read from. If `secretsdir` is not\
+The location where the `.secrets` file is read from. If `secretsdir` is not
 defined, the file is read from [datadir](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#datadir).
 
-This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6\
+This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6
 and 24.02.2.
 
 #### `libdir`
@@ -834,12 +834,12 @@ and 24.02.2.
 * Dynamic: No
 * Default: OS Dependent
 
-Set the directory where MariaDB MaxScale looks for modules. The library\
-directory is the only directory that MariaDB MaxScale uses when it searches for\
-modules. If you have custom modules for MariaDB MaxScale, make sure you have\
+Set the directory where MariaDB MaxScale looks for modules. The library
+directory is the only directory that MariaDB MaxScale uses when it searches for
+modules. If you have custom modules for MariaDB MaxScale, make sure you have
 them in this folder.
 
-The default value depends on the operating system. For RHEL versions the value\
+The default value depends on the operating system. For RHEL versions the value
 is `/usr/lib64/maxscale/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/`
 
 ```
@@ -855,14 +855,14 @@ libdir=/usr/lib64/maxscale/
 
 Sets the directory where static data assets are loaded.
 
-The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI\
-files have been manually moved somewhere else, this path must be configured to\
+The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI
+files have been manually moved somewhere else, this path must be configured to
 point to the parent directory of the `gui/` subdirectory.
 
-The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path\
-resolves to outside of this directory are not served by the MaxScale GUI: this\
+The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path
+resolves to outside of this directory are not served by the MaxScale GUI: this
 is done to prevent other files from being accessible via the MaxScale REST\
-API. This means that path to the GUI source directory can contain symbolic links\
+API. This means that path to the GUI source directory can contain symbolic links
 but all parts after the `/gui/` directory must reside inside it.
 
 #### `cachedir`
@@ -885,7 +885,7 @@ cachedir=/var/cache/maxscale/
 * Dynamic: No
 * Default: `/var/run/maxscale`
 
-Configure the directory for the PID file for MariaDB MaxScale. This file\
+Configure the directory for the PID file for MariaDB MaxScale. This file
 contains the Process ID for the running MariaDB MaxScale process.
 
 ```
@@ -899,8 +899,8 @@ piddir=/var/run/maxscale/
 * Dynamic: No
 * Default: `/usr/bin`
 
-Configure the directory where the executable files reside. All internal\
-processes which are launched will use this directory to look for executable\
+Configure the directory where the executable files reside. All internal
+processes which are launched will use this directory to look for executable
 files.
 
 ```
@@ -914,13 +914,13 @@ execdir=/usr/bin/
 * Dynamic: No
 * Default: OS Dependent
 
-Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C\
-used in MaxScale can use this directory to load authentication plugins. The\
-versions of the plugins must be binary compatible with the connector version\
+Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C
+used in MaxScale can use this directory to load authentication plugins. The
+versions of the plugins must be binary compatible with the connector version
 that MaxScale was built with.
 
-Starting with version 6.2.0, the plugins are bundled with MaxScale and the\
-default value now points to the bundled plugins. The location where the plugins\
+Starting with version 6.2.0, the plugins are bundled with MaxScale and the
+default value now points to the bundled plugins. The location where the plugins
 are stored depends on the operating system. For RHEL versions the value is`/usr/lib64/maxscale/plugin/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/plugin/`.
 
 Older versions of MaxScale used `/usr/lib/mysql/plugin/` as the default value.
@@ -936,10 +936,10 @@ connector_plugindir=/usr/lib64/maxscale/plugin/
 * Dynamic: No
 * Default: `/var/lib/maxscale/maxscale.cnf.d/`
 
-Configure the directory where persisted configurations are stored. When a new\
-object is created via MaxCtrl, it will be stored in this directory. Do not use\
-this directory for normal configuration files, use _/etc/maxscale.cnf.d/_\
-instead. The user MaxScale is running as must be able to write into this\
+Configure the directory where persisted configurations are stored. When a new
+object is created via MaxCtrl, it will be stored in this directory. Do not use
+this directory for normal configuration files, use _/etc/maxscale.cnf.d/_
+instead. The user MaxScale is running as must be able to write into this
 directory.
 
 ```
@@ -953,16 +953,16 @@ persistdir=/var/lib/maxscale/maxscale.cnf.d/
 * Dynamic: No
 * Default: `/etc/maxscale.modules.d/`
 
-Configure the directory where module configurations are stored. Path arguments\
-are resolved relative to this directory. This directory should be used to store\
+Configure the directory where module configurations are stored. Path arguments
+are resolved relative to this directory. This directory should be used to store
 module specific configurations e.g. dbfwfilter rule files.
 
-Any configuration parameter that is not an absolute path will be interpreted as\
-a relative path. The relative paths use the module configuration directory as\
+Any configuration parameter that is not an absolute path will be interpreted as
+a relative path. The relative paths use the module configuration directory as
 the working directory.
 
-For example, the configuration parameter `file=my_file.txt` would be interpreted\
-as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would\
+For example, the configuration parameter `file=my_file.txt` would be interpreted
+as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would
 be interpreted as `/home/user/my_file.txt`.
 
 ```
@@ -976,7 +976,7 @@ module_configdir=/etc/maxscale.modules.d/
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will\
+Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will
 look for the errmsg.sys file installed with MariaDB MaxScale from this folder.
 
 ```
@@ -990,8 +990,8 @@ language=/var/lib/maxscale/
 * Dynamic: No
 * Default: `qc_sqlite`
 
-The module used by MariaDB MaxScale for query classification. The information\
-provided by this module is used by MariaDB MaxScale when deciding where a\
+The module used by MariaDB MaxScale for query classification. The information
+provided by this module is used by MariaDB MaxScale when deciding where a
 particular statement should be sent. The default query classifier is\_qc\_sqlite\_.
 
 #### `query_classifier_cache_size`
@@ -1002,20 +1002,20 @@ particular statement should be sent. The default query classifier is\_qc\_sqlite
 * Default: System Dependent
 
 Specifies the maximum size of the query classifier cache. The default limit is\
-15% of total system memory starting with MaxScale 2.3.7. In older versions the\
+15% of total system memory starting with MaxScale 2.3.7. In older versions the
 default limit was 40% of total system memory. This feature was added in MaxScale\
 2.3.0.
 
-When the query classifier cache has been enabled, MaxScale will, after a\
-statement has been parsed, store the classification result using the\
+When the query classifier cache has been enabled, MaxScale will, after a
+statement has been parsed, store the classification result using the
 canonicalized version of the statement as the key.
 
-If the classification result for a statement is needed, MaxScale will first\
-canonicalize the statement and check whether the result can be found in the\
-cache. If it can, the statement will not be parsed at all but the cached result\
+If the classification result for a statement is needed, MaxScale will first
+canonicalize the statement and check whether the result can be found in the
+cache. If it can, the statement will not be parsed at all but the cached result
 is used.
 
-The configuration parameter takes one integer that specifies the maximum size of\
+The configuration parameter takes one integer that specifies the maximum size of
 the cache. The size of the cache can be specified as explained [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#sizes).
 
 ```
@@ -1023,17 +1023,17 @@ the cache. The size of the cache can be specified as explained [here](mariadb-ma
 query_classifier_cache_size=1MB
 ```
 
-Note that MaxScale uses a separate cache for each worker thread. To obtain the\
-amount of memory available for each thread, divide the cache size with the value\
-of `threads`. If statements are evicted from the cache (visible in the\
+Note that MaxScale uses a separate cache for each worker thread. To obtain the
+amount of memory available for each thread, divide the cache size with the value
+of `threads`. If statements are evicted from the cache (visible in the
 diagnostic output), consider increasing the cache size.
 
-Note also that limit is not a hard limit, but an approximate one. Namely, although\
-the memory needed for storing the canonicalized statement and the classification\
-result is correctly accounted for, there is additional overhead whose size is not\
+Note also that limit is not a hard limit, but an approximate one. Namely, although
+the memory needed for storing the canonicalized statement and the classification
+result is correctly accounted for, there is additional overhead whose size is not
 exactly known and over which we do not have direct control.
 
-Using `maxctrl show threads` it is possible to check what the actual size of\
+Using `maxctrl show threads` it is possible to check what the actual size of
 the cache is and to see performance statistics.
 
 | Key                | Meaning                                                                                                                 |
@@ -1051,7 +1051,7 @@ the cache is and to see performance statistics.
 * Dynamic: No
 * Default: `""`
 
-Arguments for the query classifier. What arguments are accepted depends on the\
+Arguments for the query classifier. What arguments are accepted depends on the
 particular query classifier being used. The default query classifier -_qc\_sqlite_ - supports the following arguments:
 
 **`log_unrecognized_statements`**
@@ -1059,9 +1059,9 @@ particular query classifier being used. The default query classifier -_qc\_sqlit
 An integer argument taking the following values:
 
 * 0: Nothing is logged. This is the default.
-* 1: Statements that cannot be parsed completely are logged. They may have been\
+* 1: Statements that cannot be parsed completely are logged. They may have been
   partially parsed, or classified based on keyword matching.
-* 2: Statements that cannot even be partially parsed are logged. They may have\
+* 2: Statements that cannot even be partially parsed are logged. They may have
   been classified based on keyword matching.
 * 3: Statements that cannot even be classified by keyword matching are logged.
 
@@ -1070,8 +1070,8 @@ query_classifier=qc_sqlite
 query_classifier_args=log_unrecognized_statements=1
 ```
 
-This will log all statements that cannot be parsed completely. This may be\
-useful if you suspect that MariaDB MaxScale routes statements to the wrong\
+This will log all statements that cannot be parsed completely. This may be
+useful if you suspect that MariaDB MaxScale routes statements to the wrong
 server (e.g. to a slave instead of to a master).
 
 #### `substitute_variables`
@@ -1081,15 +1081,15 @@ server (e.g. to a slave instead of to a master).
 * Dynamic: No
 * Default: `false`
 
-Enable or disable the substitution of environment variables in the MaxScale\
-configuration file. If the substitution of variables is enabled and a\
+Enable or disable the substitution of environment variables in the MaxScale
+configuration file. If the substitution of variables is enabled and a
 configuration line like
 
 ```
 some_parameter=$SOME_VALUE
 ```
 
-is encountered, then `$SOME_VALUE` will be replaced with the actual value\
+is encountered, then `$SOME_VALUE` will be replaced with the actual value
 of the environment variable `SOME_VALUE`. Note: _Variable substitution will be made only if '$' is the first character of the value._ _Everything_ following '$' is interpreted as the name of the environment
 variable.
 
@@ -1099,9 +1099,9 @@ variable.
 substitute_variables=true
 ```
 
-The setting of `substitute_variables` will have an effect on all parameters\
-in the all other sections, irrespective of where the `[maxscale]` section\
-is placed in the configuration file. However, in the `[maxscale]` section,\
+The setting of `substitute_variables` will have an effect on all parameters
+in the all other sections, irrespective of where the `[maxscale]` section
+is placed in the configuration file. However, in the `[maxscale]` section,
 to ensure that substitution will take place, place the`substitute_variables=true` line first.
 
 #### `sql_mode`
@@ -1112,7 +1112,7 @@ to ensure that substitution will take place, place the`substitute_variables=true
 * Values: `default`, `oracle`
 * Default: `default`
 
-Specifies whether the query classifier parser should initially expect _MariaDB_\
+Specifies whether the query classifier parser should initially expect _MariaDB_
 or _PL/SQL_ kind of SQL.
 
 The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`oracle` : The parser expects PL/SQL.
@@ -1121,7 +1121,7 @@ The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`orac
 sql_mode=oracle
 ```
 
-**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume\
+**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume
 that `autocommit` initially is off.
 
 At runtime, MariaDB MaxScale will recognize statements like
@@ -1138,12 +1138,12 @@ set sql_mode=default;
 
 and change mode accordingly.
 
-**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also\
-behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave\
+**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also
+behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave
 as if `autocommit` had been turned on.
 
-Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of\
-the server, so the value of `sql_mode` should reflect the sql mode used\
+Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of
+the server, so the value of `sql_mode` should reflect the sql mode used
 when the server is started.
 
 #### `local_address`
@@ -1155,8 +1155,8 @@ when the server is started.
 
 What specific local address/interface to use when connecting to servers.
 
-This can be used for ensuring that MaxScale uses a particular interface\
-when connecting to servers, in case the computer MaxScale is running on\
+This can be used for ensuring that MaxScale uses a particular interface
+when connecting to servers, in case the computer MaxScale is running on
 has multiple interfaces.
 
 ```
@@ -1170,27 +1170,27 @@ local_address=192.168.1.254
 * Dynamic: Yes
 * Default: `30s`
 
-How often, in seconds, MaxScale at most may refresh the users from the\
+How often, in seconds, MaxScale at most may refresh the users from the
 backend server.
 
-MaxScale will at startup load the users from the backend server, but if\
-the authentication of a user fails, MaxScale assumes it is because a new\
-user has been created and will thus refresh the users. By default, MaxScale\
-will do that at most once per 30 seconds and with this configuration option\
-that can be changed. A value of 0 allows infinite refreshes and a negative\
+MaxScale will at startup load the users from the backend server, but if
+the authentication of a user fails, MaxScale assumes it is because a new
+user has been created and will thus refresh the users. By default, MaxScale
+will do that at most once per 30 seconds and with this configuration option
+that can be changed. A value of 0 allows infinite refreshes and a negative
 value disables the refreshing entirely.
 
 ```
 users_refresh_time=120s
 ```
 
-The value is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds\
+In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds
 but, due to a bug, the default value was 0 which allowed infinite refreshes.
 
 #### `users_refresh_interval`
@@ -1200,12 +1200,12 @@ but, due to a bug, the default value was 0 which allowed infinite refreshes.
 * Dynamic: Yes
 * Default: `0s`
 
-How often, in seconds, MaxScale will automatically refresh the users from the\
+How often, in seconds, MaxScale will automatically refresh the users from the
 backend server.
 
-This configuration is used to periodically refresh the backend users, making sure\
-they are up to date. The default value for this setting is 0, meaning the users\
-are not periodically refreshed. However, they can still be refreshed in case of\
+This configuration is used to periodically refresh the backend users, making sure
+they are up to date. The default value for this setting is 0, meaning the users
+are not periodically refreshed. However, they can still be refreshed in case of
 failed authentication depending on `users_refresh_time`.
 
 ```
@@ -1219,13 +1219,13 @@ users_refresh_interval=2h
 * Dynamic: Yes
 * Default: `0`
 
-How many statements MaxScale should store for each session. This is for\
-debugging purposes, as in case of problems it is often of value to be able\
-to find out exactly what statements were sent before a particular\
+How many statements MaxScale should store for each session. This is for
+debugging purposes, as in case of problems it is often of value to be able
+to find out exactly what statements were sent before a particular
 problem turned up.
 
-**Note:** See also `dump_last_statements` using which the actual dumping\
-of the statements is enabled. Unless both of the parameters are defined,\
+**Note:** See also `dump_last_statements` using which the actual dumping
+of the statements is enabled. Unless both of the parameters are defined,
 the statement dumping mechanism doesn't work.
 
 ```
@@ -1240,10 +1240,10 @@ retain_last_statements=20
 * Values: `on_close`, `on_error`, `never`
 * Default: `never`
 
-With this configuration item it is specified in what circumstances MaxScale\
-should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never\
-logged, with `on_error` they are logged if the client closes the connection\
-improperly, and with `on_close` they are always logged when a client session\
+With this configuration item it is specified in what circumstances MaxScale
+should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never
+logged, with `on_error` they are logged if the client closes the connection
+improperly, and with `on_close` they are always logged when a client session
 is closed.
 
 ```
@@ -1251,7 +1251,7 @@ dump_last_statements=on_error
 ```
 
 Note that you need to specify with `retain_last_statements` how many statements\
-MaxScale should retain for each session. Unless it has been set to another value\
+MaxScale should retain for each session. Unless it has been set to another value
 than `0`, this configuration setting will not have an effect.
 
 #### `session_trace`
@@ -1261,8 +1261,8 @@ than `0`, this configuration setting will not have an effect.
 * Dynamic: Yes
 * Default: `0`
 
-How many log entries are stored in the session specific trace log. This log is\
-written to disk when a session ends abnormally and can be used for debugging\
+How many log entries are stored in the session specific trace log. This log is
+written to disk when a session ends abnormally and can be used for debugging
 purposes. Currently the session trace log is written to the log in the following situations:
 
 * When MaxScale receives a fatal signal and is about to crash.
@@ -1270,8 +1270,8 @@ purposes. Currently the session trace log is written to the log in the following
 * If the session is not closed gracefully (i.e. client doesn't send a COM\_QUIT packet)
 * Whenever readwritesplit receives a response that is was not expecting.
 
-It would be good to enable this if a session is disconnected and the log is not\
-detailed enough. In this case the info log might reveal the true cause of why\
+It would be good to enable this if a session is disconnected and the log is not
+detailed enough. In this case the info log might reveal the true cause of why
 the connection was closed.
 
 ```
@@ -1283,9 +1283,9 @@ Default is `0`.
 The session trace log is also exposed by REST API and is shown with`maxctrl show sessions`.
 
 The order in which the session trace messages are logged into the log changed in\
-MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal\
-log order" of older events coming first and newer events appearing later in the\
-file. Older versions of MaxScale logged the trace dump in the reverse order with\
+MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal
+log order" of older events coming first and newer events appearing later in the
+file. Older versions of MaxScale logged the trace dump in the reverse order with
 the newest messages first and oldest ones last.
 
 #### `session_trace_match`
@@ -1295,17 +1295,17 @@ the newest messages first and oldest ones last.
 * Dynamic: Yes
 * Default: None
 
-If both `session_trace` and `session_trace_match` are defined, and a trace log\
-entry of a session matches the regular expression, the trace log is written to\
+If both `session_trace` and `session_trace_match` are defined, and a trace log
+entry of a session matches the regular expression, the trace log is written to
 disk. The check for the match is done when the session is stopping.
 
-The most effective way to debug MaxScale related issues is to turn on `log_info`\
-and observe the events written into the MaxScale log. The only problem with this\
-approach is that it can cause a severe performance bottleneck and can easily\
-fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged\
+The most effective way to debug MaxScale related issues is to turn on `log_info`
+and observe the events written into the MaxScale log. The only problem with this
+approach is that it can cause a severe performance bottleneck and can easily
+fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged
 can be filtered to only what is needed.
 
-For example, the following configuration would only log the trace log messages\
+For example, the following configuration would only log the trace log messages
 from sessions that execute SQL queries with syntax errors:
 
 ```
@@ -1313,10 +1313,10 @@ session_trace=1000
 session_trace_match=/You have an error in your SQL syntax/
 ```
 
-This could be used to easily identify which applications execute the queries\
-without having to gather the info level log output from all the sessions that\
-connect to MaxScale. For every session that ends up logging a syntax error\
-message, the last 1000 lines of log output done by that session is written into\
+This could be used to easily identify which applications execute the queries
+without having to gather the info level log output from all the sessions that
+connect to MaxScale. For every session that ends up logging a syntax error
+message, the last 1000 lines of log output done by that session is written into
 the MaxScale log.
 
 #### `writeq_high_water`
@@ -1326,19 +1326,19 @@ the MaxScale log.
 * Dynamic: Yes
 * Default: `16Mi`
 
-High water mark for network write buffer. When the size of the outbound network\
-buffer in MaxScale for a single connection exceeds this value, network traffic\
+High water mark for network write buffer. When the size of the outbound network
+buffer in MaxScale for a single connection exceeds this value, network traffic
 throttling for that connection is started. The parameter accepts [size type values](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#sizes). The default value is 16777216 bytes.
 
-More specifically, if the client side write queue is above this value, it will\
-block traffic coming from backend servers. If the backend side write queue is\
+More specifically, if the client side write queue is above this value, it will
+block traffic coming from backend servers. If the backend side write queue is
 above this value, it will block traffic from client.
 
-The buffer that this parameter controls is the buffer internal to MaxScale and\
-is not the kernel TCP send buffer. This means that the total amount of buffered\
+The buffer that this parameter controls is the buffer internal to MaxScale and
+is not the kernel TCP send buffer. This means that the total amount of buffered
 data is determined by both the kernel TCP buffers and the value of`writeq_high_water`.
 
-Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value\
+Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value
 to 0.
 
 #### `writeq_low_water`
@@ -1348,13 +1348,13 @@ to 0.
 * Dynamic: Yes
 * Default: `8Ki`
 
-Low water mark for network write buffer. Once the traffic throttling is enabled,\
-it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#sizes). The\
+Low water mark for network write buffer. Once the traffic throttling is enabled,
+it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#sizes). The
 default value is 8192 bytes.
 
 The value of `writeq_high_water` must always be greater than the value of`writeq_low_water`.
 
-Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value\
+Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value
 to 0.
 
 #### `load_persisted_configs`
@@ -1367,11 +1367,11 @@ to 0.
 Load persisted runtime changes on startup. This parameter was added in MaxScale\
 2.3.6.
 
-All runtime configuration changes are persisted in generated configuration files\
-located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on\
-startup after main configuration files have been read. To make runtime\
-configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores\
-the current runtime state of MaxScale. This makes problem analysis easier if an\
+All runtime configuration changes are persisted in generated configuration files
+located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on
+startup after main configuration files have been read. To make runtime
+configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores
+the current runtime state of MaxScale. This makes problem analysis easier if an
 unexpected outage happens.
 
 #### `max_auth_errors_until_block`
@@ -1381,14 +1381,14 @@ unexpected outage happens.
 * Dynamic: Yes
 * Default: `10`
 
-The maximum number of authentication failures that are tolerated before a host\
-is temporarily blocked. The default value is 10 failures. After a host is\
-blocked, connections from it are rejected for 60 seconds. To disable this\
+The maximum number of authentication failures that are tolerated before a host
+is temporarily blocked. The default value is 10 failures. After a host is
+blocked, connections from it are rejected for 60 seconds. To disable this
 feature, set the value to 0.
 
-Note that the configured value is not a hard limit. The number of tolerated\
-failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the\
-configured value of this parameter and `threads` is the number of configured\
+Note that the configured value is not a hard limit. The number of tolerated
+failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the
+configured value of this parameter and `threads` is the number of configured
 threads.
 
 #### `debug`
@@ -1398,16 +1398,16 @@ threads.
 * Dynamic: No
 * Default: `""`
 
-Define debug options from the --debug command line option. Either the command\
-line option or the parameter should be used, not both. The debug options are\
+Define debug options from the --debug command line option. Either the command
+line option or the parameter should be used, not both. The debug options are
 only for testing purposes and are not to be used in production.
 
 #### REST API Configuration
 
-The MaxScale REST API is an HTTP interface that provides JSON format data\
+The MaxScale REST API is an HTTP interface that provides JSON format data
 intended to be consumed by monitoring applications and visualization tools.
 
-The following options must be defined under the `[maxscale]` section in the\
+The following options must be defined under the `[maxscale]` section in the
 configuration file.
 
 #### `admin_host`
@@ -1436,8 +1436,8 @@ The port where the REST API listens on. The default value is port 8989.
 * Dynamic: No
 * Default: `true`
 
-Enable REST API authentication using HTTP Basic Access\
-authentication. This is not a secure method of authentication without HTTPS but\
+Enable REST API authentication using HTTP Basic Access
+authentication. This is not a secure method of authentication without HTTPS but
 it does add a small layer of security.
 
 For more information, read the [REST API documentation](../mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-rest-api.md).
@@ -1451,7 +1451,7 @@ For more information, read the [REST API documentation](../mariadb-maxscale-21-0
 
 The path to the TLS private key in PEM format for the admin interface.
 
-If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin\
+If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin
 interface will use encrypted HTTPS instead of plain HTTP.
 
 #### `admin_ssl_cert`
@@ -1461,7 +1461,7 @@ interface will use encrypted HTTPS instead of plain HTTP.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS public certificate in PEM format. See `admin_ssl_key`\
+The path to the TLS public certificate in PEM format. See `admin_ssl_key`
 documentation for more details.
 
 #### `admin_ssl_ca_cert`
@@ -1471,8 +1471,8 @@ documentation for more details.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS CA certificate in PEM format. If defined, the client\
-certificate, if provided, will be validated against it. This parameter is\
+The path to the TLS CA certificate in PEM format. If defined, the client
+certificate, if provided, will be validated against it. This parameter is
 optional starting with MaxScale 2.3.19.
 
 #### `admin_ssl_version`
@@ -1483,7 +1483,7 @@ optional starting with MaxScale 2.3.19.
 * Values: `MAX`, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`, `TLSv10`, `TLSv11`, `TLSv12`, `TLSv13`
 * Default: `MAX`
 
-This parameter controls the enabled TLS versions in the REST API. Accepted\
+This parameter controls the enabled TLS versions in the REST API. Accepted
 values are:
 
 * `TLSv10`
@@ -1492,7 +1492,7 @@ values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -1500,19 +1500,19 @@ releases accept also the following alias values:
 * `TLSv1.2`
 * `TLSv1.3` (not supported on OpenSSL 1.0)
 
-The default value is `MAX` which negotiates the highest level of encryption that\
-both the client and server support. The list of supported TLS versions depends\
+The default value is `MAX` which negotiates the highest level of encryption that
+both the client and server support. The list of supported TLS versions depends
 on the operating system and what TLS versions the GnuTLS library supports.
 
 For example, to enable only TLSv1.1 and TLSv1.3, use`admin_ssl_version=TLSv1.1,TLSv1.3`.
 
 This parameter was added in MaxScale 2.5.7.
 
-Older versions of MaxScale interpreted `admin_ssl_version` as the minimum\
+Older versions of MaxScale interpreted `admin_ssl_version` as the minimum
 allowed TLS version. In those versions, `admin_ssl_version=TLSv1.2` allowed both\
-TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2\
-and all newer versions, the value is a enumeration of accepted TLS protocol\
-versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To\
+TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2
+and all newer versions, the value is a enumeration of accepted TLS protocol
+versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To
 retain the old behavior, specify all the accepted values with`admin_ssl_version=TLSv1.2,TLSv1.3`
 
 #### `admin_enabled`
@@ -1522,7 +1522,7 @@ retain the old behavior, specify all the accepted values with`admin_ssl_version=
 * Dynamic: No
 * Default: `true`
 
-Enable or disable the admin interface. This allows the admin interface to\
+Enable or disable the admin interface. This allows the admin interface to
 be completely disabled to prevent access to it.
 
 #### `admin_gui`
@@ -1535,9 +1535,9 @@ be completely disabled to prevent access to it.
 Enable or disable the admin graphical user interface.
 
 MaxScale provides a GUI for administrative operations via the REST API. When the\
-GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will\
-serve the GUI. When disabled, the REST API will respond with a 200 OK to the\
-request. By disabling the GUI, the root resource can be used as a low overhead\
+GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will
+serve the GUI. When disabled, the REST API will respond with a 200 OK to the
+request. By disabling the GUI, the root resource can be used as a low overhead
 health check.
 
 #### `admin_secure_gui`
@@ -1549,10 +1549,10 @@ health check.
 
 Whether to serve the GUI only over secure HTTPS connections.
 
-To be secure by default, the GUI is only served over HTTPS connections as\
+To be secure by default, the GUI is only served over HTTPS connections as
 it uses a token authentication scheme. This also controls whether the`/auth` endpoint requires an encrypted connection.
 
-To allow use of the GUI without having to configure TLS certificates for\
+To allow use of the GUI without having to configure TLS certificates for
 the MaxScale REST API, set this parameter to false.
 
 #### `admin_log_auth_failures`
@@ -1571,17 +1571,17 @@ Log authentication failures for the admin interface.
 * Dynamic: No
 * Default: `""`
 
-Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings\
-accept a PAM service name which is used during authentication if normal authentication\
+Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings
+accept a PAM service name which is used during authentication if normal authentication
 fails. `admin_pam_readwrite_service` should accept users who can do any\
-MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only\
-do read operations. Because REST-API does not support back and forth communication between\
-the client and MaxScale, the PAM services must be simple. They should only ask for the\
+MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only
+do read operations. Because REST-API does not support back and forth communication between
+the client and MaxScale, the PAM services must be simple. They should only ask for the
 password and nothing else.
 
-If only `admin_pam_readwrite_service` is configured, both read and write operations can be\
-authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read\
-operations can be authenticated by PAM. If both are set, the service used is determined by\
+If only `admin_pam_readwrite_service` is configured, both read and write operations can be
+authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read
+operations can be authenticated by PAM. If both are set, the service used is determined by
 the requested operation. Leave or set both empty to disable PAM for REST-API.
 
 #### `config_sync_cluster`
@@ -1591,10 +1591,10 @@ the requested operation. Leave or set both empty to disable PAM for REST-API.
 * Dynamic: Yes
 * Default: None
 
-This parameter controls which cluster (i.e. monitor) is used to synchronize\
+This parameter controls which cluster (i.e. monitor) is used to synchronize
 configuration changes between MaxScale instances. The first server labeled`Master` will be used for the synchronization.
 
-By default configuration synchronization is not enabled and it must be\
+By default configuration synchronization is not enabled and it must be
 explicitly enabled by defining a monitor name for `config_sync_cluster`.
 
 When `config_sync_cluster` is defined, `config_sync_user` and`config_sync_password` must also be defined.
@@ -1609,8 +1609,8 @@ Synchronization](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configurat
 * Dynamic: Yes
 * Default: None
 
-The username for the account that is used to synchronize configuration changes\
-across MaxScale instances. Both this parameter and `config_sync_password` are\
+The username for the account that is used to synchronize configuration changes
+across MaxScale instances. Both this parameter and `config_sync_password` are
 required if `config_sync_cluster` is configured.
 
 This account must have the following grants:
@@ -1619,7 +1619,7 @@ This account must have the following grants:
 GRANT SELECT, INSERT, UPDATE, CREATE ON `mysql`.`maxscale_config`
 ```
 
-The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`\
+The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`
 grant is not needed by the user configured in `config_sync_user`. The following\
 SQL is used to create the table.
 
@@ -1633,7 +1633,7 @@ CREATE TABLE IF NOT EXISTS mysql.maxscale_config(
 ) ENGINE=InnoDB;
 ```
 
-If the database where the table is created is changed with `config_sync_db`, the\
+If the database where the table is created is changed with `config_sync_db`, the
 grants must be adjusted to target that database instead.
 
 #### `config_sync_password`
@@ -1643,8 +1643,8 @@ grants must be adjusted to target that database instead.
 * Dynamic: Yes
 * Default: None
 
-The password for `config_sync_user`. Both this parameter and `config_sync_user`\
-are required if `config_sync_cluster` is configured. This password can\
+The password for `config_sync_user`. Both this parameter and `config_sync_user`
+are required if `config_sync_cluster` is configured. This password can
 optionally be encrypted using `maxpasswd`.
 
 #### `config_sync_db`
@@ -1654,13 +1654,13 @@ optionally be encrypted using `maxpasswd`.
 * Dynamic: No
 * Default: `mysql`
 
-The database where the `maxscale_config` table is created. By default the table\
-is created in the `mysql` database. This parameter was added in MaxScale\
+The database where the `maxscale_config` table is created. By default the table
+is created in the `mysql` database. This parameter was added in MaxScale
 versions 6.4.6 and 22.08.5.
 
-As tables in the `mysql` database cannot have triggers on them, the database\
+As tables in the `mysql` database cannot have triggers on them, the database
 must be changed to a user-created one in order to create triggers on the table.\
-An example use-case for triggers on this table is to track all configuration\
+An example use-case for triggers on this table is to track all configuration
 changes done to MaxScale by inserting them into a separate table.
 
 #### `config_sync_interval`
@@ -1672,9 +1672,9 @@ changes done to MaxScale by inserting them into a separate table.
 
 How often to synchronize the configuration with the cluster.
 
-As the synchronization involves selecting the configuration version from the\
-database, this value should not be set to an unreasonably low value. The default\
-value of 5 second should provide a good compromise between responsiveness and\
+As the synchronization involves selecting the configuration version from the
+database, this value should not be set to an unreasonably low value. The default
+value of 5 second should provide a good compromise between responsiveness and
 how much load it places on the database.
 
 #### `config_sync_timeout`
@@ -1684,22 +1684,22 @@ how much load it places on the database.
 * Dynamic: Yes
 * Default: `10s`
 
-Timeout for all SQL operations done during the configuration synchronization. If\
-an operation exceeds this timeout, the configuration change is treated as failed\
+Timeout for all SQL operations done during the configuration synchronization. If
+an operation exceeds this timeout, the configuration change is treated as failed
 and an error is reported to the client that did the change.
 
 ### Events
 
-MaxScale logs warnings and errors for various reasons and often it is self-\
-evident and generally applicable whether some occurrence should warrant a\
+MaxScale logs warnings and errors for various reasons and often it is self-
+evident and generally applicable whether some occurrence should warrant a
 warning or an error, or perhaps just an info-level message.
 
-However, there are events whose seriousness is not self-evident. For\
-instance, in some environments an authentication failure may simply indicate\
-that someone has made a typo, while in some other environment that can only\
+However, there are events whose seriousness is not self-evident. For
+instance, in some environments an authentication failure may simply indicate
+that someone has made a typo, while in some other environment that can only
 happen in case there has been a security breech.
 
-To handle events like these, MaxScale defines _events_ whose logging\
+To handle events like these, MaxScale defines _events_ whose logging
 facility and level can be controlled by the administrator. Given an event`X`, its facility and level are controlled in the following manner:
 
 ```
@@ -1707,21 +1707,21 @@ event.X.facility=LOG_LOCAL0
 event.X.level=LOG_ERR
 ```
 
-The above means that if event _X_ occurs, then that is logged using the\
+The above means that if event _X_ occurs, then that is logged using the
 facility `LOG_LOCAL0` and the level `LOG_ERR`.
 
-The valid values of facility`are the facility values reported by`man\
+The valid values of facility`are the facility values reported by`man
 syslog`, e.g.`LOG\_AUTH`,`LOG\_LOCAL0`and`LOG\_USER`. Likewise, the valid values for`level`are the ones also reported by`man syslog`, e.g.`LOG\_WARNING`,`LOG\_ERR`and`LOG\_CRIT\`.
 
-Note that MaxScale does not act upon the level, that is, even if the level\
-of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut\
+Note that MaxScale does not act upon the level, that is, even if the level
+of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut
 down if that event occurs.
 
 The default facility is `LOG_USER` and the default level is `LOG_WARNING`.
 
-Note that you may also have to configure `rsyslog` to ensure that the\
-event can be logged to the intended log file. For instance, if the facility\
-is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line\
+Note that you may also have to configure `rsyslog` to ensure that the
+event can be logged to the intended log file. For instance, if the facility
+is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line
 like
 
 ```
@@ -1743,22 +1743,22 @@ event.authentication_failure.level=LOG_CRIT
 
 ### Service
 
-A service represents the database service that MariaDB MaxScale offers to the\
-clients. In general a service consists of a set of backend database servers and\
-a routing algorithm that determines how MariaDB MaxScale decides to send\
+A service represents the database service that MariaDB MaxScale offers to the
+clients. In general a service consists of a set of backend database servers and
+a routing algorithm that determines how MariaDB MaxScale decides to send
 statements or route connections to those backend servers.
 
-A service may be considered as a virtual database server that MariaDB MaxScale\
+A service may be considered as a virtual database server that MariaDB MaxScale
 makes available to its clients.
 
 Several different services may be defined using the same set of backend servers.\
-For example a connection based routing service might be used by clients that\
-already performed internal read/write splitting, whilst a different statement\
-based router may be used by clients that are not written with this functionality\
-in place. Both sets of applications could access the same data in the same\
+For example a connection based routing service might be used by clients that
+already performed internal read/write splitting, whilst a different statement
+based router may be used by clients that are not written with this functionality
+in place. Both sets of applications could access the same data in the same
 databases.
 
-A service is identified by a service name, which is the name of the\
+A service is identified by a service name, which is the name of the
 configuration file section and a type parameter of service.
 
 ```
@@ -1766,9 +1766,9 @@ configuration file section and a type parameter of service.
 type=service
 ```
 
-In order for MariaDB MaxScale to forward any requests it must have at least one\
-service defined within the configuration file. The definition of a service alone\
-is not enough to allow MariaDB MaxScale to forward requests however, the service\
+In order for MariaDB MaxScale to forward any requests it must have at least one
+service defined within the configuration file. The definition of a service alone
+is not enough to allow MariaDB MaxScale to forward requests however, the service
 is merely present to link together the other configuration elements.
 
 #### `router`
@@ -1777,15 +1777,15 @@ is merely present to link together the other configuration elements.
 * Mandatory: Yes
 * Dynamic: No
 
-The router parameter of a service defines the name of the router module that\
+The router parameter of a service defines the name of the router module that
 will be used to implement the routing algorithm between the client of MariaDB\
-MaxScale and the backend databases. Additionally routers may also be passed a\
-comma separated list of options that are used to control the behavior of the\
-routing algorithm. The two parameters that control the routing choice are router\
-and router\_options. The router options are specific to a particular router and\
-are used to modify the behavior of the router. The read connection router can be\
-passed options of master, slave or synced, an example of configuring a service\
-to use this router and limiting the choice of servers to those in slave state\
+MaxScale and the backend databases. Additionally routers may also be passed a
+comma separated list of options that are used to control the behavior of the
+routing algorithm. The two parameters that control the routing choice are router
+and router\_options. The router options are specific to a particular router and
+are used to modify the behavior of the router. The read connection router can be
+passed options of master, slave or synced, an example of configuring a service
+to use this router and limiting the choice of servers to those in slave state
 would be as follows.
 
 ```
@@ -1793,7 +1793,7 @@ router=readconnroute
 router_options=slave
 ```
 
-To change the router to connect on to servers in the master state as well as\
+To change the router to connect on to servers in the master state as well as
 slave servers, the router options can be modified to include the master state.
 
 ```
@@ -1801,7 +1801,7 @@ router=readconnroute
 router_options=master,slave
 ```
 
-A more complete description of router options and what is available for a given\
+A more complete description of router options and what is available for a given
 router is included with the documentation of the router itself.
 
 #### `filters`
@@ -1811,17 +1811,17 @@ router is included with the documentation of the router itself.
 * Dynamic: Yes
 * Default: None
 
-The filters option allow a set of filters to be defined for a service; requests\
-from the client are passed through these filters before being sent to the router\
-for dispatch to the backend server. The filters parameter takes one or more\
-filter names, as defined within the filter definition section of the\
+The filters option allow a set of filters to be defined for a service; requests
+from the client are passed through these filters before being sent to the router
+for dispatch to the backend server. The filters parameter takes one or more
+filter names, as defined within the filter definition section of the
 configuration file. Multiple filters are separated using the | character.
 
 ```
 filters=counter | QLA
 ```
 
-The requests pass through the filters from left to right in the order defined in\
+The requests pass through the filters from left to right in the order defined in
 the configuration parameter.
 
 #### `targets`
@@ -1831,7 +1831,7 @@ the configuration parameter.
 * Dynamic: Yes
 * Default: None
 
-The `targets` parameter is a comma separated list of server and/or service names\
+The `targets` parameter is a comma separated list of server and/or service names
 that comprise the routing targets of the service. This parameter was added in\
 MaxScale 2.5.0.
 
@@ -1839,9 +1839,9 @@ MaxScale 2.5.0.
 targets=My-Service,server2
 ```
 
-This parameter allows nested service configurations to be defined without having\
-to configure listeners for all services. For example, one use-case is to use\
-multiple readwritesplit services behind a schemarouter service to have both the\
+This parameter allows nested service configurations to be defined without having
+to configure listeners for all services. For example, one use-case is to use
+multiple readwritesplit services behind a schemarouter service to have both the
 sharding of schemarouter with the high-availability of readwritesplit.
 
 **NOTE:** The `targets` parameter is mutually exclusive with the `cluster` and`servers` parameters.
@@ -1853,8 +1853,8 @@ sharding of schemarouter with the high-availability of readwritesplit.
 * Dynamic: Yes
 * Default: None
 
-The servers parameter in a service definition provides a comma separated list of\
-the backend servers that comprise the service. The server names are those used\
+The servers parameter in a service definition provides a comma separated list of
+the backend servers that comprise the service. The server names are those used
 in the name section of a block with a type parameter of server (see below).
 
 ```
@@ -1870,7 +1870,7 @@ servers=server1,server2,server3
 * Dynamic: Yes
 * Default: None
 
-The servers the service uses are defined by the monitor specified as value\
+The servers the service uses are defined by the monitor specified as value
 of this configuration parameter.
 
 ```
@@ -1885,7 +1885,7 @@ cluster=TheMonitor
 * Mandatory: Yes
 * Dynamic: Yes
 
-This setting defines the _user_ the service uses to fetch user account\
+This setting defines the _user_ the service uses to fetch user account
 information from backends. A _password_ is specified using [password](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#password).
 
 ```
@@ -1893,8 +1893,8 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
 #### `password`
@@ -1903,9 +1903,9 @@ regarding user account management and client authentication.
 * Mandatory: Yes
 * Dynamic: Yes
 
-This settings defines the _password_ the service uses to fetch user account\
-information from backends. The _password_ may be either a plain text password or\
-an [encrypted password](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified\
+This settings defines the _password_ the service uses to fetch user account
+information from backends. The _password_ may be either a plain text password or
+an [encrypted password](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified
 using [user](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#user).
 
 ```
@@ -1913,8 +1913,8 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
 #### `enable_root_user`
@@ -1938,7 +1938,7 @@ Deprecated and ignored.
 * Dynamic: No
 * Default: None
 
-This parameter sets a custom version string that is sent in the MySQL Handshake\
+This parameter sets a custom version string that is sent in the MySQL Handshake
 from MariaDB MaxScale to clients.
 
 Example:
@@ -1947,13 +1947,13 @@ Example:
 version_string=10.11.2-MariaDB-RWsplit
 ```
 
-If not set, MaxScale will attempt to use a version string from the\
-backend databases by selecting the version string of the database with\
+If not set, MaxScale will attempt to use a version string from the
+backend databases by selecting the version string of the database with
 the lowest version number. If the selected version is from the MariaDB\
 10 series, a `5.5.5-` prefix will be added to it similarly to how the\
 MariaDB 10 series versions added it.
 
-If MaxScale has not been able to connect to a single database and the\
+If MaxScale has not been able to connect to a single database and the
 versions are unknown, the default value of `5.5.5-10.4.32 <MaxScale version>-maxscale` is used where `<MaxScale version>` is the version of\
 MaxScale.
 
@@ -1964,11 +1964,11 @@ MaxScale.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether only a single server or all of the servers are\
+This parameter controls whether only a single server or all of the servers are
 used when loading the users from the backend servers.
 
-By default MaxScale uses the first server labeled as `Master` as the source of\
-the authentication data. When this option is enabled, the authentication data is\
+By default MaxScale uses the first server labeled as `Master` as the source of
+the authentication data. When this option is enabled, the authentication data is
 loaded from all the servers and combined into one big data set.
 
 #### `strip_db_esc`
@@ -1983,12 +1983,12 @@ names when loading user grants from a backend server. When enabled, a grant\
 such as `grant select on` test\_`.* to 'user'@'%';` is read as `grant select on` test\_`.* to 'user'@'%';`
 
 This setting has no effect on database-level grants fetched from a MariaDB\
-Server. The database names of a MariaDB Server are compared using the LIKE\
-operator to properly handle wildcards and escaped wildcards. This setting may\
-affect database names in table and column level grants, although these typically\
+Server. The database names of a MariaDB Server are compared using the LIKE
+operator to properly handle wildcards and escaped wildcards. This setting may
+affect database names in table and column level grants, although these typically
 do not contain backlashes.
 
-Some visual database management tools automatically escape some characters and\
+Some visual database management tools automatically escape some characters and
 this might cause conflicts when MaxScale tries to authenticate users.
 
 #### `log_auth_warnings`
@@ -1998,8 +1998,8 @@ this might cause conflicts when MaxScale tries to authenticate users.
 * Dynamic: Yes
 * Default: `true`
 
-Enable or disable the logging of authentication failures and warnings. If\
-enabled, messages about failed authentication attempts will be logged with\
+Enable or disable the logging of authentication failures and warnings. If
+enabled, messages about failed authentication attempts will be logged with
 details about who tried to connect to MariaDB MaxScale and from where.
 
 #### `log_warning`
@@ -2009,10 +2009,10 @@ details about who tried to connect to MariaDB MaxScale and from where.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log warning messages even if the global\
+When enabled, this allows a service to log warning messages even if the global
 log level configuration disables them.
 
-Note that disabling the service level logging does not override the global\
+Note that disabling the service level logging does not override the global
 logging configuration: with `log_warning=false` in the service and`log_warning=true` globally, warnings will still be logged for all services.
 
 #### `log_notice`
@@ -2022,7 +2022,7 @@ logging configuration: with `log_warning=false` in the service and`log_warning=t
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log notice messages even if the global\
+When enabled, this allows a service to log notice messages even if the global
 log level configuration disables them.
 
 #### `log_info`
@@ -2032,7 +2032,7 @@ log level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log info messages even if the global log\
+When enabled, this allows a service to log info messages even if the global log
 level configuration disables them.
 
 #### `log_debug`
@@ -2042,10 +2042,10 @@ level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log debug messages even if the global log\
+When enabled, this allows a service to log debug messages even if the global log
 level configuration disables them.
 
-Debug messages are only enabled for debug builds. Enabling `log_debug` in a\
+Debug messages are only enabled for debug builds. Enabling `log_debug` in a
 release build does nothing.
 
 #### `connection_timeout`
@@ -2056,35 +2056,35 @@ release build does nothing.
 * Default: `0s`
 
 The connection\_timeout parameter is used to disconnect sessions to MariaDB\
-MaxScale that have been idle for too long. The session timeouts are disabled by\
-default. To enable them, define the timeout in seconds in the service's\
-configuration section. A value of zero is interpreted as no timeout, the same\
+MaxScale that have been idle for too long. The session timeouts are disabled by
+default. To enable them, define the timeout in seconds in the service's
+configuration section. A value of zero is interpreted as no timeout, the same
 as if the parameter is not defined.
 
-The value is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `connection_timeout` for those is not used.
 
-The value of `connection_timeout` should be lower than the lowest `wait_timeout`\
-value on the backend servers. This way idle clients are disconnected by MaxScale\
-before the backend servers have to close them. Any client-side idle timeouts\
-(e.g. maximum lifetime for connection pools) should be lower than both`connection_timeout` and `wait_timeout`. This way the client application will\
-end up closing the connection itself which most of the time results in better\
+The value of `connection_timeout` should be lower than the lowest `wait_timeout`
+value on the backend servers. This way idle clients are disconnected by MaxScale
+before the backend servers have to close them. Any client-side idle timeouts
+(e.g. maximum lifetime for connection pools) should be lower than both`connection_timeout` and `wait_timeout`. This way the client application will
+end up closing the connection itself which most of the time results in better
 and more helpful error messages.
 
-**Warning:** If a connection is idle for longer than the configured connection\
+**Warning:** If a connection is idle for longer than the configured connection
 timeout, it will be forcefully disconnected and a warning will be logged in the\
 MaxScale log file.
 
-In MaxScale versions 6.2.0 and older, if long-running operations (e.g. `ALTER TABLE`) were performed, MaxScale would close the connections if they look longer\
+In MaxScale versions 6.2.0 and older, if long-running operations (e.g. `ALTER TABLE`) were performed, MaxScale would close the connections if they look longer
 than `connection_timeout` seconds to execute\
-([MXS-3893](https://jira.mariadb.org/browse/MXS-3893)). In MaxScale 6.2.1 this\
+([MXS-3893](https://jira.mariadb.org/browse/MXS-3893)). In MaxScale 6.2.1 this
 has been fixed and the active operations are now correctly tracked.
 
 Example:
@@ -2101,13 +2101,13 @@ connection_timeout=300s
 * Dynamic: Yes
 * Default: `0`
 
-The maximum number of simultaneous connections MaxScale should permit to this\
-service. If the parameter is zero or is omitted, there is no limit. Any attempt\
-to make more connections after the limit is reached will result in a "Too many\
+The maximum number of simultaneous connections MaxScale should permit to this
+service. If the parameter is zero or is omitted, there is no limit. Any attempt
+to make more connections after the limit is reached will result in a "Too many
 connections" error being returned.
 
-**Warning**: In MaxScale 2.5, it is possible that the number of concurrent\
-connections temporarily exceeds the value of `max_connections`. This has been\
+**Warning**: In MaxScale 2.5, it is possible that the number of concurrent
+connections temporarily exceeds the value of `max_connections`. This has been
 fixed in MaxScale 6.
 
 Example:
@@ -2125,19 +2125,19 @@ max_connections=100
 * Default: `false`
 
 Enable transaction state tracking by offloading it to the backend servers.\
-Getting the transaction state from the server will be more accurate for stored\
-procedures or multi-statement SQL that modifies the transaction state\
+Getting the transaction state from the server will be more accurate for stored
+procedures or multi-statement SQL that modifies the transaction state
 non-atomically.
 
-In general, it is better to avoid using this type of SQL as tracking the\
-transaction state via the server responses is not compatible with features such\
-as `transaction_replay` in readwritesplit. `session_track_trx_state` should only\
-be enabled if the default transaction tracking done by MaxScale does not produce\
+In general, it is better to avoid using this type of SQL as tracking the
+transaction state via the server responses is not compatible with features such
+as `transaction_replay` in readwritesplit. `session_track_trx_state` should only
+be enabled if the default transaction tracking done by MaxScale does not produce
 the desired outcome.
 
-This is only supported by MariaDB versions 10.3 or newer. The following must be\
-configured in the MariaDB server in order for this feature to work. Not\
-configuring the MariaDB server with it can result in the transaction state being\
+This is only supported by MariaDB versions 10.3 or newer. The following must be
+configured in the MariaDB server in order for this feature to work. Not
+configuring the MariaDB server with it can result in the transaction state being
 wrong in MaxScale which can result in data inconsistency.
 
 ```
@@ -2154,12 +2154,12 @@ session_track_transaction_info = CHARACTERISTICS
 
 How many statements MaxScale should store for each session of this service.\
 This overrides the value of the global setting with the same name. If`retain_last_statements` has been specified in the global section of the\
-MaxScale configuration file, then if it has _not_ been explicitly specified\
-for the service, the global value holds, otherwise the service specific\
-value rules. That is, it is possible to enable the setting globally and\
+MaxScale configuration file, then if it has _not_ been explicitly specified
+for the service, the global value holds, otherwise the service specific
+value rules. That is, it is possible to enable the setting globally and
 turn it off for a specific service, or just enable it for specific services.
 
-The value of this parameter can be changed at runtime using `maxctrl` and the\
+The value of this parameter can be changed at runtime using `maxctrl` and the
 new value will take effect for sessions created thereafter.
 
 ```
@@ -2173,38 +2173,38 @@ maxctrl alter service MyService retain_last_statements 5
 * Dynamic: Yes
 * Default: `300s`
 
-Keep idle connections alive by sending pings to backend servers. This feature\
-was introduced in MaxScale 2.5.0 where it was changed from a\
-readwritesplit-specific feature to a generic service feature. The default value\
+Keep idle connections alive by sending pings to backend servers. This feature
+was introduced in MaxScale 2.5.0 where it was changed from a
+readwritesplit-specific feature to a generic service feature. The default value
 for this parameter is 300 seconds. To disable this feature, set the value to 0.
 
-The keepalive interval is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no\
+The keepalive interval is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no
 explicit unit is provided, the value is interpreted as seconds in MaxScale\
-2.5. In subsequent versions a value without a unit may be rejected. Note that\
-since the granularity of the keepalive is seconds, a keepalive specified in\
+2.5. In subsequent versions a value without a unit may be rejected. Note that
+since the granularity of the keepalive is seconds, a keepalive specified in
 milliseconds will be rejected, even if the duration is longer than a second.
 
-The parameter value is the interval in seconds between each keepalive ping. A\
-keepalive ping will be sent to a backend server if the connection has been idle\
+The parameter value is the interval in seconds between each keepalive ping. A
+keepalive ping will be sent to a backend server if the connection has been idle
 for longer than the configured keepalive interval.
 
-Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client\
-has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings\
+Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client
+has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings
 regardless of the client state.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `connection_keepalive` for those is not used.
 
-If the value of `connection_keepalive` is changed at runtime, the change in the\
+If the value of `connection_keepalive` is changed at runtime, the change in the
 value takes effect immediately.
 
-As the connection keepalive pings must be done only when there's no ongoing\
-query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that\
-rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the\
+As the connection keepalive pings must be done only when there's no ongoing
+query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that
+rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the
 performance will be the same with or without `connection_keepalive`.
 
-If you want to avoid the performance cost and you don't need the connection\
+If you want to avoid the performance cost and you don't need the connection
 keepalive feature, you can disable it with `connection_keepalive=0s`.
 
 #### `force_connection_keepalive`
@@ -2214,16 +2214,16 @@ keepalive feature, you can disable it with `connection_keepalive=0s`.
 * Dynamic: Yes
 * Default: `false`
 
-By default, connection keepalive pings are only sent if the client is either\
-executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are\
-unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can\
-be used to emulate the pre-2.5.21 behavior if long-lived application connections\
+By default, connection keepalive pings are only sent if the client is either
+executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are
+unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can
+be used to emulate the pre-2.5.21 behavior if long-lived application connections
 rely on the old unconditional keepalive pings.
 
 _Note:_ if `force_connection_keepalive` is enabled and `connection_keepalive` in\
-MaxScale is set to a lower value than the `wait_timeout` on the database, the\
-client idle timeouts that `wait_timeout` control are no longer effective. This\
-happens because MaxScale unconditionally sends the pings which make the client\
+MaxScale is set to a lower value than the `wait_timeout` on the database, the
+client idle timeouts that `wait_timeout` control are no longer effective. This
+happens because MaxScale unconditionally sends the pings which make the client
 behave like it is not idle and thus the connections will never be killed due to`wait_timeout`.
 
 #### `net_write_timeout`
@@ -2233,17 +2233,17 @@ behave like it is not idle and thus the connections will never be killed due to`
 * Dynamic: Yes
 * Default: `0s`
 
-This parameter controls how long a network write to the client can stay\
+This parameter controls how long a network write to the client can stay
 buffered. This feature is disabled by default.
 
-When `net_write_timeout` is configured and data is buffered on the client\
-network connection, if the time since the last successful network write exceeds\
+When `net_write_timeout` is configured and data is buffered on the client
+network connection, if the time since the last successful network write exceeds
 the configured limit, the client connection will be disconnected.
 
-The value is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `max_sescmd_history`
@@ -2253,45 +2253,45 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `50`
 
-`max_sescmd_history` sets a limit on how many distinct session commands are\
-stored in the session command history. When the history limit is exceeded, the\
-history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server\
+`max_sescmd_history` sets a limit on how many distinct session commands are
+stored in the session command history. When the history limit is exceeded, the
+history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server
 reconnections are no longer possible.
 
-The required history size can be estimated by counting the total number of\
-session state modifying commands (e.g `SET NAMES`) that are used by a\
-client. Note that connectors usually add some commands that aren't visible to\
-the application developer which means a safety margin should be added. A good\
-rule of thumb is to count the expected number of statements and double that\
-number. The default value of 50 is a value that'll work for most applications\
+The required history size can be estimated by counting the total number of
+session state modifying commands (e.g `SET NAMES`) that are used by a
+client. Note that connectors usually add some commands that aren't visible to
+the application developer which means a safety margin should be added. A good
+rule of thumb is to count the expected number of statements and double that
+number. The default value of 50 is a value that'll work for most applications
 that do not rely heavily on user variables.
 
-Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4\
-and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol\
-prepared statements opened by the client are also kept open by MaxScale and are\
+Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4
+and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol
+prepared statements opened by the client are also kept open by MaxScale and are
 restored whenever a reconnection to a server happens. The limits imposed by`max_sescmd_history` apply to other text protocol commands e.g. `SET NAMES`.\
-Note that text protocol prepared statements count as text protocol commands and\
-are thus potentially pruned when history pruning happens. If an application uses\
+Note that text protocol prepared statements count as text protocol commands and
+are thus potentially pruned when history pruning happens. If an application uses
 a lot of `PREPARE stmt FROM <sql>` commands, it is recommended that the value of`max_sescmd_history` is increased accordingly.
 
-In older versions of MaxScale, binary protocol prepared statements were limited\
-by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this\
-caused problems when the binary protocol prepared statement were pruned while\
-they were still open from the client's point of view. In older versions, the\
-recommended value of `max_sescmd_history` is the number of state modifying\
-commands plus the maximum number of open prepared statements that any application\
+In older versions of MaxScale, binary protocol prepared statements were limited
+by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this
+caused problems when the binary protocol prepared statement were pruned while
+they were still open from the client's point of view. In older versions, the
+recommended value of `max_sescmd_history` is the number of state modifying
+commands plus the maximum number of open prepared statements that any application
 may use.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
-In addition to limiting the number of commands to store, it also acts as a hard\
-limit on the number of packets that may be queued up on a backend before it is\
-closed. Packets are queued while the TCP socket is being opened and when\
-prepared statements are being prepared. In certain rare cases, a slow server may\
-fall behind and not catch up to the rest of the cluster and a backlog of packets\
-forms. In these cases, if more than `max_sescmd_history` packets are queued, the\
+In addition to limiting the number of commands to store, it also acts as a hard
+limit on the number of packets that may be queued up on a backend before it is
+closed. Packets are queued while the TCP socket is being opened and when
+prepared statements are being prepared. In certain rare cases, a slow server may
+fall behind and not catch up to the rest of the cluster and a backlog of packets
+forms. In these cases, if more than `max_sescmd_history` packets are queued, the
 connection to the server is closed.
 
 #### `prune_sescmd_history`
@@ -2301,37 +2301,37 @@ connection to the server is closed.
 * Dynamic: Yes
 * Default: `true`
 
-This option enables pruning of the session command history when it exceeds the\
-value configured in `max_sescmd_history`. When this option is enabled, only a\
-set number of statements are stored in the history. This limits the per-session\
+This option enables pruning of the session command history when it exceeds the
+value configured in `max_sescmd_history`. When this option is enabled, only a
+set number of statements are stored in the history. This limits the per-session
 memory use while still allowing safe reconnections.
 
-This parameter is intended to be used with pooled connections that remain in use\
-for a very long time. Most connection pool implementations do not reset the\
-session state and instead re-initialize it with new values. This causes the\
-session command history to grow at roughly a constant rate for the lifetime of\
+This parameter is intended to be used with pooled connections that remain in use
+for a very long time. Most connection pool implementations do not reset the
+session state and instead re-initialize it with new values. This causes the
+session command history to grow at roughly a constant rate for the lifetime of
 the pooled connection.
 
-Each client-side session that uses a pooled connection only executes a finite\
-amount of session commands. By retaining a shorter history that encompasses all\
-session commands the individual clients execute, the session state of a pooled\
+Each client-side session that uses a pooled connection only executes a finite
+amount of session commands. By retaining a shorter history that encompasses all
+session commands the individual clients execute, the session state of a pooled
 connection can be accurately recreated on another server.
 
-When the session command history pruning is enabled, there is a theoretical\
-possibility that upon server reconnection the session states of the connections\
-are inconsistent. This can only happen if the length of the stored history is\
-shorter than the list of relevant statements that affect the session state. In\
-practice the default value of 50 session commands is a fairly reasonable value\
+When the session command history pruning is enabled, there is a theoretical
+possibility that upon server reconnection the session states of the connections
+are inconsistent. This can only happen if the length of the stored history is
+shorter than the list of relevant statements that affect the session state. In
+practice the default value of 50 session commands is a fairly reasonable value
 and the risk of inconsistent session state is relatively low.
 
-In case the default history length is too short for safe pruning, set the value\
-of `max_sescmd_history` to the total number of commands that affect the session\
-state plus a safety margin of 10. The safety margin reserves some extra space\
-for new commands that might be executed due to changes in the client side\
+In case the default history length is too short for safe pruning, set the value
+of `max_sescmd_history` to the total number of commands that affect the session
+state plus a safety margin of 10. The safety margin reserves some extra space
+for new commands that might be executed due to changes in the client side
 application.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `disable_sescmd_history`
@@ -2341,17 +2341,17 @@ history. Currently only `readwritesplit` and `schemarouter` support it.
 * Dynamic: Yes
 * Default: `false`
 
-This option disables the session command history. This way no history is stored\
-and if a slave server fails, the router will not try to replace the failed\
-slave. Disabling session command history will allow long-lived connections\
+This option disables the session command history. This way no history is stored
+and if a slave server fails, the router will not try to replace the failed
+slave. Disabling session command history will allow long-lived connections
 without causing a constant growth in the memory consumption.
 
-This parameter should only be used when either the memory footprint must be as\
-small as possible or when the pruning of the session command history is not\
+This parameter should only be used when either the memory footprint must be as
+small as possible or when the pruning of the session command history is not
 acceptable.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `user_accounts_file`
@@ -2368,25 +2368,25 @@ Default value is empty, which disables the feature.
 user_accounts_file=/home/root/users.json
 ```
 
-In addition to querying the backends, MaxScale can read users from a file. This\
-feature is useful when backends have limitations on the type of users that can\
-be created, or if MaxScale needs to allow users to log in even\
-when backends are down (e.g. binlog router). The users read from the file are\
-only present on MaxScale, so logging into backends can still fail. The format of\
-the file is protocol-specific. The following only applies to MariaDB-protocol,\
+In addition to querying the backends, MaxScale can read users from a file. This
+feature is useful when backends have limitations on the type of users that can
+be created, or if MaxScale needs to allow users to log in even
+when backends are down (e.g. binlog router). The users read from the file are
+only present on MaxScale, so logging into backends can still fail. The format of
+the file is protocol-specific. The following only applies to MariaDB-protocol,
 which is also the only protocol supporting this feature.
 
-The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which\
-contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at\
-least the string fields _user_ and _host_, which define the user account to add\
+The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which
+contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at
+least the string fields _user_ and _host_, which define the user account to add
 or modify.
 
-The elements in the _user_-array may contain the following additional fields. If\
+The elements in the _user_-array may contain the following additional fields. If
 a field is not defined, it is assumed either empty (string) or false (boolean).
 
 * password: String. Password hash, similar to the equivalent column on server.
 * plugin: String. Authentication plugin used by client, similar to server.
-* authentication\_string: String. Additional authentication info, similar to\
+* authentication\_string: String. Additional authentication info, similar to
   server.
 * default\_role: String. Default role of user, similar to server.
 * super\_priv: Boolean. True if user has SUPER grant.
@@ -2396,17 +2396,17 @@ a field is not defined, it is assumed either empty (string) or false (boolean).
 
 The elements in the _db_-array must contain the following additional field:
 
-* db: String. Database which the user can access. Can contain % and \_\
+* db: String. Database which the user can access. Can contain % and \_
   wildcards.
 
-The elements in the _roles\_mapping_-array must contain the following additional\
+The elements in the _roles\_mapping_-array must contain the following additional
 field:
 
 * role: String. Role the user can access.
 
 When users are read from both servers and the file, the server takes priority.\
 That is, if user `'joe'@'%'` is defined on both, the file-version is discarded.\
-The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant\
+The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant
 and role lists.
 
 An example users file is below.
@@ -2465,9 +2465,9 @@ Defines when _user\_accounts\_file_ is read. The value is an enum, either\
 read from a server. The file contents are then added to the server-based data.\
 If reading from server fails (e.g. servers are down), the file is ignored.
 
-"file\_only\_always" means that users are not read from the servers at all and the\
-file contents is all that matters. The state of the servers is ignored. This\
-mode can be useful with the binlog router, as it allows clients to log in and\
+"file\_only\_always" means that users are not read from the servers at all and the
+file contents is all that matters. The state of the servers is ignored. This
+mode can be useful with the binlog router, as it allows clients to log in and
 fetch binary logs from MaxScale even when backend servers are down.
 
 ```
@@ -2481,36 +2481,36 @@ user_accounts_file_usage=file_only_always
 * Dynamic: Yes
 * Default: `-1s`
 
-Normally, MaxScale only pools backend connections when\
-a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections\
+Normally, MaxScale only pools backend connections when
+a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections
 instead of creating new connections to backends. If connection sharing is enabled,\
-MaxScale can pool backend connections also from running sessions, and\
-re-attach a pooled connection when a session is doing a query. This effectively\
+MaxScale can pool backend connections also from running sessions, and
+re-attach a pooled connection when a session is doing a query. This effectively
 allows multiple sessions to share backend connections.
 
-_idle\_session\_pool\_time_ defines the amount of time a session must be idle\
-before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value is by default given in\
+_idle\_session\_pool\_time_ defines the amount of time a session must be idle
+before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value is by default given in
 seconds, but can also be given in milliseconds.
 
-This feature has a significant drawback: when a backend connection is reused, it\
-needs to be restored to the correct state. This means reauthenticating and\
-replaying session commands. This can add a significant delay before the\
-connection is actually ready for a query. If the session command history size\
-exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for\
+This feature has a significant drawback: when a backend connection is reused, it
+needs to be restored to the correct state. This means reauthenticating and
+replaying session commands. This can add a significant delay before the
+connection is actually ready for a query. If the session command history size
+exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for
 the session.
 
-This feature should only be used when limiting the backend connection count is\
-a priority, even at the cost of query delay and throughput. This feature only\
+This feature should only be used when limiting the backend connection count is
+a priority, even at the cost of query delay and throughput. This feature only
 works when the following server settings are also set in MaxScale configuration:
 
 1. [max\_routing\_connections](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#max_routing_connections)
 2. [persistpoolmax](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#persistpoolmax)
 3. [persistmaxtime](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#persistmaxtime)
 
-Since reusing a backend connection is an expensive operation, MaxScale only\
-pools connections when another session requires them. _idle\_session\_pool\_time_\
-thus effectively limits the frequency at which a connection can be moved from\
-one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to\
+Since reusing a backend connection is an expensive operation, MaxScale only
+pools connections when another session requires them. _idle\_session\_pool\_time_
+thus effectively limits the frequency at which a connection can be moved from
+one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to
 move connections as soon as possible.
 
 ```
@@ -2522,57 +2522,57 @@ See below for more information on configuring connection sharing.
 **Details, limitations and suggestions for connection sharing**
 
 As noted above, when a connection is pooled and reused its state is lost.\
-Although session variables and prepared statements are restored by replaying\
+Although session variables and prepared statements are restored by replaying
 session commands, some state information cannot be transferred.
 
-The most common such state is a transaction. When a transaction is on,\
+The most common such state is a transaction. When a transaction is on,
 connection sharing is disabled for that session until the transaction completes.\
-Other similar situations may not be properly detected, and it's the\
-responsibility of the user to avoid introducing such state to the session when\
+Other similar situations may not be properly detected, and it's the
+responsibility of the user to avoid introducing such state to the session when
 using connection sharing. This means that the following should not be used:
 
-* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that\
+* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that
   introduces state into the connection.
-* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector\
+* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector
   must be used instead of the variable.
 * Stored procedures that cause session level side-effects.
 
-Several settings affect connection sharing and its effectiveness. Reusing a\
-connection is an expensive operation so its frequency should be minimized. The\
+Several settings affect connection sharing and its effectiveness. Reusing a
+connection is an expensive operation so its frequency should be minimized. The
 important configuration settings in addition to _idle\_session\_pool\_time_ are\
 MaxScale server settings [persistpoolmax](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#persistpoolmax),[persistmaxtime](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#persistmaxtime) and [max\_routing\_connections](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#max_routing_connections).\
-The service settings [max\_sescmd\_history](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These\
+The service settings [max\_sescmd\_history](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These
 settings should be tuned according to the use case.
 
-_persistpoolmax_ limits how many connections can be kept in a pool for a given\
-server. If the pool is full, no more connections are detached from sessions even\
-if they are idle and required. The pool size should be large enough to contain\
+_persistpoolmax_ limits how many connections can be kept in a pool for a given
+server. If the pool is full, no more connections are detached from sessions even
+if they are idle and required. The pool size should be large enough to contain
 any connections being transferred between sessions, but not be greater than _max\_routing\_connections_. Using the value of _max\_routing\_connections_ is a
 reasonable starting point.
 
-_persistmaxtime_ limits the time a connection may stay in the pool. This should\
-be high enough so that pooled connections are not unnecessarily closed. Cleaning\
+_persistmaxtime_ limits the time a connection may stay in the pool. This should
+be high enough so that pooled connections are not unnecessarily closed. Cleaning
 up clearly unneeded connections from the pool may be useful when _max\_routing\_connections_ is restrictively tuned. Because each MaxScale routing
-thread has its own connection pool, one thread can monopolize access to a\
-server. For example, if the pool of thread 1 has 100 connections to _ServerA_\
-with `max_routing_connections=100`, other threads can no longer connect to the\
-server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as\
-it would cause unneeded connections in the pool to be closed faster. Such\
-connection slots then become available to other routing threads. Reducing the\
-number of [routing threads](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool\
-fragmentation. This may reduce overall throughput, though. When using connection\
+thread has its own connection pool, one thread can monopolize access to a
+server. For example, if the pool of thread 1 has 100 connections to _ServerA_
+with `max_routing_connections=100`, other threads can no longer connect to the
+server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as
+it would cause unneeded connections in the pool to be closed faster. Such
+connection slots then become available to other routing threads. Reducing the
+number of [routing threads](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool
+fragmentation. This may reduce overall throughput, though. When using connection
 sharing, backend connections are only in the pool momentarily. Consequently,_persistmaxtime_ can be set quite low, e.g. 10s.
 
-If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is\
-disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find\
-a backend connection. This can be avoided with _prune\_sescmd\_history_. However,\
-pruning means that old session commands will not be replayed when a pooled\
-connection is reused. If the pruned commands are important\
+If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is
+disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find
+a backend connection. This can be avoided with _prune\_sescmd\_history_. However,
+pruning means that old session commands will not be replayed when a pooled
+connection is reused. If the pruned commands are important
 (e.g. statement preparations), the session may fail later on.
 
 If the number of clients actively running queries is greater than _max\_routing\_connections_, query throughput will suffer as clients will need to
-take turns. In this situation, it's imperative to minimize the number of\
-backend connections a single session uses. The settings to achieve this depend\
+take turns. In this situation, it's imperative to minimize the number of
+backend connections a single session uses. The settings to achieve this depend
 on the router. For ReadWriteSplit the following should be used:
 
 ```
@@ -2581,12 +2581,12 @@ lazy_connect=1
 transaction_replay=true
 ```
 
-The above settings mean that MaxScale can process roughly\
-(_number of slave servers_ X _max\_routing\_connections_) read queries\
-simultaneously. Write queries will still need to take turns as there is only one\
+The above settings mean that MaxScale can process roughly
+(_number of slave servers_ X _max\_routing\_connections_) read queries
+simultaneously. Write queries will still need to take turns as there is only one
 master server.
 
-The following configuration snippet shows example server and service\
+The following configuration snippet shows example server and service
 configurations for connection sharing with ReadWriteSplit.
 
 ```
@@ -2613,11 +2613,11 @@ lazy_connect=1
 * Dynamic: Yes
 * Default: `60s`
 
-When connection sharing (as described above) is on, clients\
-may have to wait for their turn to use a backend connection. If too much time\
-passes without a connection becoming available, MaxScale returns an error to\
-the client, usually also ending the session. _multiplex\_timeout_ sets this\
-timeout. Increase it if queries are failing with "Timed out when waiting for a\
+When connection sharing (as described above) is on, clients
+may have to wait for their turn to use a backend connection. If too much time
+passes without a connection becoming available, MaxScale returns an error to
+the client, usually also ending the session. _multiplex\_timeout_ sets this
+timeout. Increase it if queries are failing with "Timed out when waiting for a
 connection". Decrease it if failing early is preferable to stalling.
 
 ```
@@ -2626,10 +2626,10 @@ multiplex_timeout=33s
 
 ### Server
 
-Server sections define the backend database servers MaxScale uses. A server is\
-identified by its section name in the configuration file. The only mandatory\
-parameter of a server is _type_, but _address_ and _port_ are also usually\
-defined. A server may be a member of one or more services. A server may only be\
+Server sections define the backend database servers MaxScale uses. A server is
+identified by its section name in the configuration file. The only mandatory
+parameter of a server is _type_, but _address_ and _port_ are also usually
+defined. A server may be a member of one or more services. A server may only be
 monitored by at most one monitor.
 
 ```
@@ -2646,7 +2646,7 @@ port=3000
 * Dynamic: Yes
 * Default: `""`
 
-The IP-address or hostname of the machine running the database server. MaxScale\
+The IP-address or hostname of the machine running the database server. MaxScale
 uses this address to connect to the server.
 
 Either _address_ or _socket_ must be defined, but not both.
@@ -2658,7 +2658,7 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: `3306`
 
-The port the backend server listens on for incoming connections. MaxScale uses\
+The port the backend server listens on for incoming connections. MaxScale uses
 this port to connect to the server.
 
 #### `socket`
@@ -2668,7 +2668,7 @@ this port to connect to the server.
 * Dynamic: Yes
 * Default: `""`
 
-The absolute path to a UNIX domain socket the MariaDB server is listening\
+The absolute path to a UNIX domain socket the MariaDB server is listening
 on.
 
 Either _address_ or _socket_ must be defined, but not both.
@@ -2680,9 +2680,9 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitorpasswd](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -2697,9 +2697,9 @@ monitorpw=mymonitorpasswd
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitoruser](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitoruser](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -2707,7 +2707,7 @@ monitoruser=mymonitoruser
 monitorpw=mymonitorpasswd
 ```
 
-`monitorpw` may be either a plain text password or an encrypted password. See\
+`monitorpw` may be either a plain text password or an encrypted password. See
 the section [encrypting passwords](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#encrypting-passwords) for more information.
 
 #### `extra_port`
@@ -2717,19 +2717,19 @@ the section [encrypting passwords](mariadb-maxscale-2106-maxscale-2106-mariadb-m
 * Dynamic: Yes
 * Default: `0`
 
-An alternative port used for administrative connections to the server. If this\
-setting is defined, MaxScale uses it for monitoring the server and to fetch user\
+An alternative port used for administrative connections to the server. If this
+setting is defined, MaxScale uses it for monitoring the server and to fetch user
 accounts. Client sessions will still use the normal port.
 
-Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on\
-the backend server has been reached. Extra-port connections have their own\
-connection limit, which is one by default. This needs to be increased to allow\
+Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on
+the backend server has been reached. Extra-port connections have their own
+connection limit, which is one by default. This needs to be increased to allow
 both monitor and user account manager to connect.
 
-If the connection to the extra-port fails due to connection number limit or if\
+If the connection to the extra-port fails due to connection number limit or if
 the port is not open on the server, normal port is used.
 
-For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)\
+For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)
 and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables#extra_max_connections).
 
 #### `persistpoolmax`
@@ -2740,15 +2740,15 @@ and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-
 * Default: `0`
 
 Sets the size of the server connection pool. Disabled by default. When enabled,\
-MaxScale places unused connections to the server to a pool and reuses them\
-later. Connections typically become unused when a session closes. If the size of\
+MaxScale places unused connections to the server to a pool and reuses them
+later. Connections typically become unused when a session closes. If the size of
 the pool reaches _persistpoolmax_, unused connections are closed instead.
 
-Every routing thread has its own pool. As of version 6.3.0, MaxScale will round\
+Every routing thread has its own pool. As of version 6.3.0, MaxScale will round
 up _persistpoolmax_ so that every thread has an equal size pool.
 
-When a MariaDB-protocol connection is taken from the pool to be used in a new\
-session, the state of the connection is dependent on the router. ReadWriteSplit\
+When a MariaDB-protocol connection is taken from the pool to be used in a new
+session, the state of the connection is dependent on the router. ReadWriteSplit
 restores the connection to match the session state. Other routers do not.
 
 #### `persistmaxtime`
@@ -2758,15 +2758,15 @@ restores the connection to match the session state. Other routers do not.
 * Dynamic: Yes
 * Default: `0s`
 
-The `persistmaxtime` parameter defaults to zero but can be set to a duration as\
-documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is\
-interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a\
-unit may be rejected. Note that since the granularity of the parameter is\
-seconds, a value specified in milliseconds will be rejected, even if the\
+The `persistmaxtime` parameter defaults to zero but can be set to a duration as
+documented [here](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is
+interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a
+unit may be rejected. Note that since the granularity of the parameter is
+seconds, a value specified in milliseconds will be rejected, even if the
 duration is longer than a second.
 
-A DCB placed in the persistent pool for a server will only be reused if the\
-elapsed time since it joined the pool is less than the given value. Otherwise,\
+A DCB placed in the persistent pool for a server will only be reused if the
+elapsed time since it joined the pool is less than the given value. Otherwise,
 the DCB will be discarded and the connection closed.
 
 #### `max_routing_connections`
@@ -2776,18 +2776,18 @@ the DCB will be discarded and the connection closed.
 * Dynamic: Yes
 * Default: `0`
 
-Maximum number of routing connections to this server. Connections held in a pool\
-also count towards this maximum. Does not limit monitor connections or user\
+Maximum number of routing connections to this server. Connections held in a pool
+also count towards this maximum. Does not limit monitor connections or user
 account fetching. A value of 0 (default) means no limit.
 
-Since every client session can generate a connection to a server, the server may\
-run out of memory when the number of clients is high enough. This setting limits\
-server memory use caused by MaxScale. The effect depends on if the service\
-setting [idle\_session\_pool\_time](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection\
+Since every client session can generate a connection to a server, the server may
+run out of memory when the number of clients is high enough. This setting limits
+server memory use caused by MaxScale. The effect depends on if the service
+setting [idle\_session\_pool\_time](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection
 sharing, is enabled or not.
 
 If connection sharing is not on, _max\_routing\_connections_ simply sets a limit.\
-Any sessions attempting to exceed this limit will fail to connect to the\
+Any sessions attempting to exceed this limit will fail to connect to the
 backend. The client can still connect to MaxScale, but queries will fail.
 
 If connection sharing is on, sessions exceeding the limit will be put on hold\
@@ -2805,32 +2805,32 @@ max_routing_connections=1234
 * Dynamic: Yes
 * Default: `false`
 
-If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-header when connecting client sessions to the server. The header contains the\
-original client IP address and port, as seen by MaxScale. The server will then\
-read the header and perform authentication as if the connection originated from\
-this address instead of MaxScale's IP address. With this feature, the user\
-accounts on the backend server can be simplified to only contain the actual\
+If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+header when connecting client sessions to the server. The header contains the
+original client IP address and port, as seen by MaxScale. The server will then
+read the header and perform authentication as if the connection originated from
+this address instead of MaxScale's IP address. With this feature, the user
+accounts on the backend server can be simplified to only contain the actual
 client hosts and not the MaxScale host.
 
-PROXY protocol will be supported by MariaDB 10.3, which this feature has been\
-tested with. To use it, enable the PROXY protocol in MaxScale for every\
-compatible server and configure the MariaDB servers themselves to accept the\
-protocol headers from MaxScale's IP address. On the server side, the protocol\
-should be enabled only for trusted IPs, as it allows the sender to spoof the\
-connection origin. If a proxy header is sent to a server not expecting it, the\
-connection will fail. Usually PROXY protocol should be enabled for every\
+PROXY protocol will be supported by MariaDB 10.3, which this feature has been
+tested with. To use it, enable the PROXY protocol in MaxScale for every
+compatible server and configure the MariaDB servers themselves to accept the
+protocol headers from MaxScale's IP address. On the server side, the protocol
+should be enabled only for trusted IPs, as it allows the sender to spoof the
+connection origin. If a proxy header is sent to a server not expecting it, the
+connection will fail. Usually PROXY protocol should be enabled for every
 server in a cluster, as they typically have similar grants.
 
-Other SQL-servers may support PROXY protocol as well, but the implementation may\
-be highly restricting. Strict adherence to the protocol requires that the\
-backend server does not allow mixing of un-proxied and proxied connections from\
-a given IP. MaxScale requires normal connections to backends for monitoring and\
-authentication data queries, which would be blocked. To bypass this restriction,\
-the server monitor needs to be disabled and the service listener needs to be\
+Other SQL-servers may support PROXY protocol as well, but the implementation may
+be highly restricting. Strict adherence to the protocol requires that the
+backend server does not allow mixing of un-proxied and proxied connections from
+a given IP. MaxScale requires normal connections to backends for monitoring and
+authentication data queries, which would be blocked. To bypass this restriction,
+the server monitor needs to be disabled and the service listener needs to be
 configured to disregard authentication errors (`skip_authentication=true`).\
-Server states also need to be set manually in MaxCtrl. These steps are _not_\
-required for MariaDB 10.3, since its implementation is more flexible and allows\
+Server states also need to be set manually in MaxCtrl. These steps are _not_
+required for MariaDB 10.3, since its implementation is more flexible and allows
 both PROXY-headered and headerless connections from a proxy-enabled IP.
 
 #### `disk_space_threshold`
@@ -2840,30 +2840,30 @@ both PROXY-headered and headerless connections from a proxy-enabled IP.
 * Dynamic: No
 * Default: None
 
-This parameter specifies how full a disk may be, before MaxScale should start\
-logging warnings or take other actions (e.g. perform a switchover). This\
+This parameter specifies how full a disk may be, before MaxScale should start
+logging warnings or take other actions (e.g. perform a switchover). This
 functionality will only work with MariaDB server versions 10.1.32, 10.2.14 and\
 10.3.6 onwards, if the `DISKS` _information schema plugin_ has been installed.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-A limit is specified as a path followed by a colon and a percentage specifying\
+A limit is specified as a path followed by a colon and a percentage specifying
 how full the corresponding disk may be, before action is taken. E.g. an entry like
 
 ```
 /data:80
 ```
 
-specifies that the disk that has been mounted on `/data` may be used until 80%\
-of the total space has been consumed. Multiple entries can be specified by\
-separating them by a comma. If the path is specified using `*`, then the limit\
-applies to all disks. However, the value of `*` is only applied if there is not\
+specifies that the disk that has been mounted on `/data` may be used until 80%
+of the total space has been consumed. Multiple entries can be specified by
+separating them by a comma. If the path is specified using `*`, then the limit
+applies to all disks. However, the value of `*` is only applied if there is not
 an exact match.
 
-Note that if a particular disk has been mounted on several paths, only one path\
-need to be specified. If several are specified, then the one with the smallest\
+Note that if a particular disk has been mounted on several paths, only one path
+need to be specified. If several are specified, then the one with the smallest
 percentage will be applied.
 
 Examples:
@@ -2875,7 +2875,7 @@ disk_space_threshold=/data1:80,/data2:60,*:90
 ```
 
 The last line means that the disk mounted at `/data1` may be used up to\
-80%, the disk mounted at `/data2` may be used up to 60% and all other disks\
+80%, the disk mounted at `/data2` may be used up to 60% and all other disks
 mounted at any paths may be used up until 90% of maximum capacity, before\
 MaxScale starts to warn to take action.
 
@@ -2892,7 +2892,7 @@ Note that the path to be used, is one of the paths returned by:
 ...
 ```
 
-There is no default value, but this parameter must be explicitly specified\
+There is no default value, but this parameter must be explicitly specified
 if the disk space situation should be monitored.
 
 #### `rank`
@@ -2903,20 +2903,20 @@ if the disk space situation should be monitored.
 * Values: `primary`, `secondary`
 * Default: `primary`
 
-This parameter controls the order in which servers are used. Valid values for\
+This parameter controls the order in which servers are used. Valid values for
 this parameter are `primary` and `secondary`. The default value is`primary`.
 
-This behavior depends on the router implementation but the general rule of thumb\
+This behavior depends on the router implementation but the general rule of thumb
 is that primary servers will be used before secondary servers.
 
-Readconnroute will always use primary servers before secondary servers as long\
+Readconnroute will always use primary servers before secondary servers as long
 as they match the configured server type.
 
-Readwritesplit will pick servers that have the same rank as the current\
-master. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-readwritesplit.md)\
+Readwritesplit will pick servers that have the same rank as the current
+master. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-readwritesplit.md)
 for a detailed description of the behavior.
 
-The following example server configuration demonstrates how `rank` can be used\
+The following example server configuration demonstrates how `rank` can be used
 to exclude `DR-site` servers from routing.
 
 ```
@@ -2941,7 +2941,7 @@ address=192.168.0.22
 rank=secondary
 ```
 
-The `main-site-master` and `main-site-slave` servers will be used as long as\
+The `main-site-master` and `main-site-slave` servers will be used as long as
 they are available. When they are no longer available, the `DR-site-master` and`DR-site-slave` will be used.
 
 #### `priority`
@@ -2951,31 +2951,31 @@ they are available. When they are no longer available, the `DR-site-master` and`
 * Dynamic: Yes
 * Default: 0
 
-Server priority. Currently only used by galeramon to choose the order in which\
-nodes are selected as the current master server. Refer to the [Server Priorities](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-galera-monitor.md)\
+Server priority. Currently only used by galeramon to choose the order in which
+nodes are selected as the current master server. Refer to the [Server Priorities](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-galera-monitor.md)
 section of the galeramon documentation for more information on how to use it.
 
-Starting with MaxScale 2.5.21, this parameter also accepts negative values. In\
+Starting with MaxScale 2.5.21, this parameter also accepts negative values. In
 older versions, the parameter only accepted non-negative values.
 
 ### Monitor
 
-Monitor sections are used to define the monitoring module that watches a set of\
+Monitor sections are used to define the monitoring module that watches a set of
 servers. Each server can only be monitored by one monitor.
 
 Common monitor parameters [can be found here](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md).
 
 ### Listener
 
-A listener defines a port MaxScale listens on for incoming connections. Accepted\
-connections are linked with a MaxScale service. Multiple listeners can feed the\
-same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface\
+A listener defines a port MaxScale listens on for incoming connections. Accepted
+connections are linked with a MaxScale service. Multiple listeners can feed the
+same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface
 only. _socket_ is also optional and is used for Unix socket connections.
 
-The network socket where the listener listens may have a backlog of\
+The network socket where the listener listens may have a backlog of
 connections. The size of this backlog is controlled by the\_net.ipv4.tcp\_max\_syn\_backlog\_ and _net.core.somaxconn_ kernel parameters.
 
-Increasing the size of the backlog by modifying the kernel parameters helps with\
+Increasing the size of the backlog by modifying the kernel parameters helps with
 sudden connection spikes and rejected connections. For more information see [listen(2)](https://man7.org/linux/man-pages/man2/listen.2.html).
 
 ```
@@ -2991,7 +2991,7 @@ port=3006
 * Mandatory: Yes
 * Dynamic: No
 
-The service to which the listener is associated. This is the name of a service\
+The service to which the listener is associated. This is the name of a service
 that is defined elsewhere in the configuration file.
 
 #### `protocol`
@@ -3004,11 +3004,11 @@ that is defined elsewhere in the configuration file.
 The name of the protocol module used for communication between the client and\
 MaxScale. The same protocol is also used for backend communication.
 
-Usually this does not need to be defined as the default protocol is the MariaDB\
+Usually this does not need to be defined as the default protocol is the MariaDB
 network protocol that is used by SQL connections.
 
-For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL\
-protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md) module\
+For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL
+protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md) module
 documentation.
 
 #### `address`
@@ -3018,8 +3018,8 @@ documentation.
 * Dynamic: No
 * Default: `"::"`
 
-This sets the address the listening socket is bound to. The address may be\
-specified as an IP address in 'dot notation' or as a hostname. If left undefined\
+This sets the address the listening socket is bound to. The address may be
+specified as an IP address in 'dot notation' or as a hostname. If left undefined
 the listener will bind to all network interfaces.
 
 #### `port`
@@ -3029,7 +3029,7 @@ the listener will bind to all network interfaces.
 * Dynamic: No
 * Default: `0`
 
-The port the listener listens on. If left undefined a default port for the\
+The port the listener listens on. If left undefined a default port for the
 protocol is used.
 
 #### `socket`
@@ -3039,10 +3039,10 @@ protocol is used.
 * Dynamic: No
 * Default: `""`
 
-If defined, the listener uses Unix domain sockets to listen for incoming\
+If defined, the listener uses Unix domain sockets to listen for incoming
 connections. The parameter value is the name of the socket to use.
 
-If you want to use both network ports and UNIX domain sockets with a service,\
+If you want to use both network ports and UNIX domain sockets with a service,
 define two separate listeners that connect to the same service.
 
 #### `authenticator`
@@ -3052,8 +3052,8 @@ define two separate listeners that connect to the same service.
 * Dynamic: No
 * Default: `""`
 
-The authenticator module to use. Each protocol module defines a default\
-authentication module, which is used if the setting is left undefined._MariaDBClient_-protocol supports multiple authenticators and they can be used\
+The authenticator module to use. Each protocol module defines a default
+authentication module, which is used if the setting is left undefined._MariaDBClient_-protocol supports multiple authenticators and they can be used
 simultaneously by giving a comma-separated list e.g.`authenticator=PAMAuth,mariadbauth,gssapiauth`
 
 #### `authenticator_options`
@@ -3063,8 +3063,8 @@ simultaneously by giving a comma-separated list e.g.`authenticator=PAMAuth,maria
 * Dynamic: No
 * Default: `""`
 
-This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of\
-this parameter should be a comma-separated list of key-value pairs. See\
+This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of
+this parameter should be a comma-separated list of key-value pairs. See
 authenticator specific documentation for more details.
 
 #### `sql_mode`
@@ -3085,10 +3085,10 @@ If both are used this setting will override the global setting for this listener
 * Dynamic: Yes
 * Default: `""`
 
-Path to a text file with sql queries. Any sessions created from the listener\
-will send the contents of the file to backends after authentication. Each\
-non-empty line in the file is interpreted as a query. Each query must succeed\
-for the backend connection to be usable for client queries. The queries should\
+Path to a text file with sql queries. Any sessions created from the listener
+will send the contents of the file to backends after authentication. Each
+non-empty line in the file is interpreted as a query. Each query must succeed
+for the backend connection to be usable for client queries. The queries should
 not return any data.
 
 ```
@@ -3109,28 +3109,28 @@ set @myvar2 = 4;
 * Dynamic: Yes
 * Default: `""`
 
-Path to a json-text file with user and group mapping, as well as server\
-credentials. Only affects MariaDB-protocol based listeners. Default value is\
+Path to a json-text file with user and group mapping, as well as server
+credentials. Only affects MariaDB-protocol based listeners. Default value is
 empty, which disables the feature.
 
 ```
 user_mapping_file=/home/root/mapping.json
 ```
 
-Should not be used together with [PAM Authenticator](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-pam-authenticator.md)\
-settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite\
-the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on\
+Should not be used together with [PAM Authenticator](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-pam-authenticator.md)
+settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite
+the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on
 backends and map them to backend users.
 
 This file functions very similar to [PAM-based mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
-Both user-to-user and group-to-user mappings can be defined. Also, the password\
-and authentication plugin for the mapped users can be added. The file is only\
-read during listener creation (typically MaxScale start) or when a listener is\
-modified during runtime. When a client logs into MaxScale, their username is\
+Both user-to-user and group-to-user mappings can be defined. Also, the password
+and authentication plugin for the mapped users can be added. The file is only
+read during listener creation (typically MaxScale start) or when a listener is
+modified during runtime. When a client logs into MaxScale, their username is
 searched from the mapping data. If the name matches either a name mapping or a\
-Linux group mapping, the username is replaced by the mapped name. The mapped\
-name is then used when logging into backends. If the file also contains\
-credentials for the mapped user, then those are used. Otherwise, MaxScale tries\
+Linux group mapping, the username is replaced by the mapped name. The mapped
+name is then used when logging into backends. If the file also contains
+credentials for the mapped user, then those are used. Otherwise, MaxScale tries
 to log in with an empty password and default MariaDB authentication.
 
 Three arrays are read from the file: _user\_map_, _group\_map_ and\_server\_credentials\_, none of which are mandatory.
@@ -3145,25 +3145,25 @@ Each array element in the _group\_map_-array must define the following fields:
 * original\_group: String. Incoming client Linux group.
 * mapped\_user: String. Username the client is mapped to.
 
-Each array element in the _server\_credentials_-array can define the following\
+Each array element in the _server\_credentials_-array can define the following
 fields:
 
 * mapped\_user: String. The mapped username this password is for.
-* password: String. Backend server password. Can be encrypted with\
+* password: String. Backend server password. Can be encrypted with
   maxpasswd.
-* plugin: String, optional. Authentication plugin to use. Must be enabled on\
-  the listener. Defaults to empty, which results in standard MariaDB\
+* plugin: String, optional. Authentication plugin to use. Must be enabled on
+  the listener. Defaults to empty, which results in standard MariaDB
   authentication.
 
-When a client successfully logs into MaxScale, MaxScale first searches for\
-name-based mapping. The incoming client does not need to be a Linux user for\
-name-based mapping to take place. If the name is not found, MaxScale checks if\
-the client is a Linux user with a group membership matching an element in the\
-group mapping array. If the client is a member of more than 100 groups, this\
+When a client successfully logs into MaxScale, MaxScale first searches for
+name-based mapping. The incoming client does not need to be a Linux user for
+name-based mapping to take place. If the name is not found, MaxScale checks if
+the client is a Linux user with a group membership matching an element in the
+group mapping array. If the client is a member of more than 100 groups, this
 check may fail.
 
-If a mapping is found, MaxScale searches the credentials array for a matching\
-username, and uses the password and plugin listed. The plugin need not be the\
+If a mapping is found, MaxScale searches the credentials array for a matching
+username, and uses the password and plugin listed. The plugin need not be the
 same as the one the original user used. Currently, "mysql\_native\_password" and\
 "pam" are supported as mapped plugins.
 
@@ -3204,18 +3204,18 @@ An example mapping file is below.
 
 ## Available Protocols
 
-The protocols supported by MariaDB MaxScale are implemented as external modules\
+The protocols supported by MariaDB MaxScale are implemented as external modules
 that are loaded dynamically into the MariaDB MaxScale core. They allow MariaDB\
-MaxScale to communicate in various protocols both on the client side and the\
-backend side. Each of the protocols can be either a client protocol or a backend\
-protocol. Client protocols are used for client-MariaDB MaxScale communication\
+MaxScale to communicate in various protocols both on the client side and the
+backend side. Each of the protocols can be either a client protocol or a backend
+protocol. Client protocols are used for client-MariaDB MaxScale communication
 and backend protocols are for MariaDB MaxScale-database communication.
 
 ### `MariaDBClient`
 
-This is the implementation of the MySQL-protocol. When defined for a listener,\
+This is the implementation of the MySQL-protocol. When defined for a listener,
 the listener will accept MySQL-connections from clients, assign them to a\
-MaxScale service and route the queries from the client to backend servers. Any\
+MaxScale service and route the queries from the client to backend servers. Any
 backends used by the service should be MariaDB/MySQL-servers or compatible.
 
 ### `CDC`
@@ -3224,42 +3224,42 @@ See [Change Data Capture Protocol](../mariadb-maxscale-21-06-protocols/mariadb-m
 
 ## TLS/SSL encryption
 
-This section describes configuration parameters for both servers and listeners\
-that control the TLS/SSL encryption method and the various certificate files\
+This section describes configuration parameters for both servers and listeners
+that control the TLS/SSL encryption method and the various certificate files
 involved in it.
 
 To enable TLS/SSL for a listener, you must set the `ssl` parameter to`true` and provide at least the `ssl_cert` and `ssl_key` parameters.
 
-To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification\
+To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification
 enabled, the `ssl_cert` and `ssl_key` parameters must also be defined.
 
 Custom CA certificates can be defined with the `ssl_ca_cert` parameter.
 
-After this, MaxScale connections between the server and/or the client will be\
-encrypted. Note that the database must also be configured to use TLS/SSL\
+After this, MaxScale connections between the server and/or the client will be
+encrypted. Note that the database must also be configured to use TLS/SSL
 connections if backend connection encryption is used.
 
-**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on\
+**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on
 the same port.
 
-If TLS encryption is enabled for a listener, any unencrypted connections to it\
-will be rejected. MaxScale does this to improve security by preventing\
+If TLS encryption is enabled for a listener, any unencrypted connections to it
+will be rejected. MaxScale does this to improve security by preventing
 accidental creation of unencrypted connections.
 
-The separation of secure and insecure connections differs from the MariaDB\
+The separation of secure and insecure connections differs from the MariaDB
 server which allows both secure and insecure connections on the same port. As\
-MaxScale is the gateway through which all connections go, in order to guarantee\
-a more secure system MaxScale enforces a stricter security policy than what the\
+MaxScale is the gateway through which all connections go, in order to guarantee
+a more secure system MaxScale enforces a stricter security policy than what the
 server does.
 
-TLS encryption must be enabled for listeners when they are created. For servers,\
+TLS encryption must be enabled for listeners when they are created. For servers,
 the TLS can be enabled after creation but it cannot be disabled or altered.
 
 Starting with MaxScale 2.5.20, if the TLS certificate given to MaxScale has the\
-X509v3 extended key usage information, MaxScale will check it and refuse to use\
-a certificate with the wrong usage. This means that a certificate with only\
-clientAuth can only be used with servers and a certificate with only serverAuth\
-can only be used with listeners. In order to use the same certificate for both\
+X509v3 extended key usage information, MaxScale will check it and refuse to use
+a certificate with the wrong usage. This means that a certificate with only
+clientAuth can only be used with servers and a certificate with only serverAuth
+can only be used with listeners. In order to use the same certificate for both
 listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 #### `ssl`
@@ -3271,12 +3271,12 @@ listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 This enables SSL connections when set to true. The legacy values `required` and`disabled` were removed in MaxScale 6.0.
 
-If enabled, the certificate files mentioned above must also be\
+If enabled, the certificate files mentioned above must also be
 supplied. MaxScale connections to will then be encrypted with TLS/SSL.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require\
-ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created\
+24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require
+ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created
 with `REQUIRE SSL` or `REQUIRE X509`.
 
 #### `ssl_key`
@@ -3286,8 +3286,8 @@ with `REQUIRE SSL` or `REQUIRE X509`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client private key MaxScale should use. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client private key MaxScale should use. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_cert`
@@ -3297,9 +3297,9 @@ parameter for listeners but an optional parameter for servers.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client certificate MaxScale should use with the server. The\
-certificate must match the key defined in `ssl_key`. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client certificate MaxScale should use with the server. The
+certificate must match the key defined in `ssl_key`. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_ca_cert`
@@ -3309,10 +3309,10 @@ parameter for listeners but an optional parameter for servers.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the Certificate Authority (CA) certificate for the CA that signed the\
-certificate referred to in the previous parameter. It will be used to verify\
-that the certificate is valid. This is a required parameter for both listeners\
+A string giving a file path that identifies an existing readable file. The file
+must be the Certificate Authority (CA) certificate for the CA that signed the
+certificate referred to in the previous parameter. It will be used to verify
+that the certificate is valid. This is a required parameter for both listeners
 and servers. The CA certificate can consist of a certificate chain.
 
 #### `ssl_version`
@@ -3331,7 +3331,7 @@ This parameter controls the allowed TLS version. Accepted values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -3343,18 +3343,18 @@ The default setting (MAX) allows all supported versions. MaxScale supports\
 TLSv1.0, TLSv1.1, TLSv1.2 and TLSv1.3 depending on the OpenSSL library version.\
 TLSv1.0 and TLSv1.1 are considered deprecated and should not be used, so setting`ssl_version=TLSv1.2,TLSv1.3` or `ssl_version=TLSv1.3` is recommended.
 
-In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this\
-setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would\
+In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this
+setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would
 only enable TLSv12. The interpretation changed in MaxScale versions 6.4.14,\
-22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while\
-allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`\
+22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while
+allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`
 enabled both TLSv1.2 and TLSv1.3.
 
 The interpretation changed again in MaxScale versions 6.4.16, 22.08.13,\
-23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an\
-enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior\
-from the previous releases where the newer versions were automatically enabled,\
-the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)\
+23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an
+enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior
+from the previous releases where the newer versions were automatically enabled,
+the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)
 parameter works.
 
 #### `ssl_cipher`
@@ -3364,8 +3364,8 @@ parameter works.
 * Dynamic: Yes
 * Default: `""`
 
-Set the list of TLS ciphers. By default, no explicit ciphers are defined and the\
-system defaults are used. Note that this parameter does not modify TLSv1.3\
+Set the list of TLS ciphers. By default, no explicit ciphers are defined and the
+system defaults are used. Note that this parameter does not modify TLSv1.3
 ciphers.
 
 #### `ssl_cert_verify_depth`
@@ -3375,8 +3375,8 @@ ciphers.
 * Dynamic: Yes
 * Default: `9`
 
-The maximum length of the certificate authority chain that will be accepted. The\
-default value is 9, same as the OpenSSL default. The configured value must be\
+The maximum length of the certificate authority chain that will be accepted. The
+default value is 9, same as the OpenSSL default. The configured value must be
 larger than 0.
 
 #### `ssl_verify_peer_certificate`
@@ -3386,11 +3386,11 @@ larger than 0.
 * Dynamic: Yes
 * Default: `false`
 
-Peer certificate verification. This functionality is disabled by default. In\
+Peer certificate verification. This functionality is disabled by default. In
 versions prior to 2.3.17 the feature was enabled by default.
 
-When this feature is enabled, the peer must send a certificate. The certificate\
-sent by the peer is verified against the configured Certificate Authority to\
+When this feature is enabled, the peer must send a certificate. The certificate
+sent by the peer is verified against the configured Certificate Authority to
 make sure the peer is who they claim to be. For listeners, this behaves as if`REQUIRE X509` was defined for all users. For servers, this behaves like the`--ssl-verify-server-cert` command line option for the `mysql` client.
 
 #### `ssl_verify_peer_host`
@@ -3402,10 +3402,10 @@ make sure the peer is who they claim to be. For listeners, this behaves as if`RE
 
 Peer host verification.
 
-When this feature is enabled, the peer hostname or IP is verified against the\
-certificate that is sent by the peer. If the IP address or the hostname does not\
-match the one in the certificate returned by the peer, the connection will be\
-closed. If the peer does not provide a certificate, the host verification is not\
+When this feature is enabled, the peer hostname or IP is verified against the
+certificate that is sent by the peer. If the IP address or the hostname does not
+match the one in the certificate returned by the peer, the connection will be
+closed. If the peer does not provide a certificate, the host verification is not
 done. To require peer certificates, use `ssl_verify_peer_certificate`.
 
 #### `ssl_crl`
@@ -3415,8 +3415,8 @@ done. To require peer certificates, use `ssl_verify_peer_certificate`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be a Certificate Revocation List in the PEM format that defines the revoked\
+A string giving a file path that identifies an existing readable file. The file
+must be a Certificate Revocation List in the PEM format that defines the revoked
 certificates. This parameter is only accepted by listeners.
 
 **Example SSL enabled server configuration**
@@ -3432,7 +3432,7 @@ ssl_key=/usr/local/mariadb/maxscale/ssl/key.max-client.pem
 ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
-This example configuration requires all connections to this server to be\
+This example configuration requires all connections to this server to be
 encrypted with SSL. The paths to the certificate files and the Certificate\
 Authority file are also provided.
 
@@ -3450,18 +3450,18 @@ ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
 This example configuration requires all connections to be encrypted with\
-SSL. The paths to the certificate files and the Certificate Authority file are\
+SSL. The paths to the certificate files and the Certificate Authority file are
 also provided.
 
 ## Module Types
 
 ### Routing Modules
 
-The main task of MariaDB MaxScale is to accept database connections from client\
-applications and route the connections or the statements sent over those\
+The main task of MariaDB MaxScale is to accept database connections from client
+applications and route the connections or the statements sent over those
 connections to the various services supported by MariaDB MaxScale.
 
-Currently a number of routing modules are available, these are designed for a\
+Currently a number of routing modules are available, these are designed for a
 range of different needs.
 
 Connection based load balancing:
@@ -3482,18 +3482,18 @@ Binary log server:
 
 ### Monitor Modules
 
-Monitor modules are used by MariaDB MaxScale to internally monitor the state of\
-the backend databases in order to set the server flags for each of those\
-servers. The router modules then use these flags to determine if the particular\
-server is a suitable destination for routing connections for particular query\
+Monitor modules are used by MariaDB MaxScale to internally monitor the state of
+the backend databases in order to set the server flags for each of those
+servers. The router modules then use these flags to determine if the particular
+server is a suitable destination for routing connections for particular query
 classifications. The monitors are run within separate threads of MariaDB\
 MaxScale and do not affect MariaDB MaxScale's routing performance.
 
 * [MariaDB Monitor](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md)
 * [Galera Monitor](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-galera-monitor.md)
 
-The use of monitors in MaxScale is not absolutely mandatory: it is possible to\
-run MariaDB MaxScale without a monitor module. In this case an external\
+The use of monitors in MaxScale is not absolutely mandatory: it is possible to
+run MariaDB MaxScale without a monitor module. In this case an external
 monitoring system must the status of each server via MaxCtrl or the REST\
 API. **Only do this if you know what you are doing.**
 
@@ -3527,10 +3527,10 @@ flowchart LR
 _A client's query passes through the router session's QLA and Regex filters on its way to the backend server, with QLA also logging the query._
 
 Filters provide a means to manipulate or process requests as they pass through\
-MariaDB MaxScale between the client side protocol and the query router. A full\
+MariaDB MaxScale between the client side protocol and the query router. A full
 explanation of each filter's functionality can be found in its documentation.
 
-The [Filter Tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-filters.md) document shows how you\
+The [Filter Tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-filters.md) document shows how you
 can add a filter to a service and combine multiple filters in one service.
 
 * [Query Log All (QLA) Filter](../mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-query-log-all-filter.md)
@@ -3544,8 +3544,8 @@ can add a filter to a service and combine multiple filters in one service.
 
 Passwords stored in the maxscale.cnf file may optionally be encrypted for added security.\
 This is done by creation of an encryption key on installation of MariaDB MaxScale.\
-Encryption keys may be created manually by executing the maxkeys utility with the argument\
-of the filename to store the key. The default location MariaDB MaxScale stores\
+Encryption keys may be created manually by executing the maxkeys utility with the argument
+of the filename to store the key. The default location MariaDB MaxScale stores
 the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES CBC encryption.
 
 ```
@@ -3553,16 +3553,16 @@ the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES C
 maxkeys /var/lib/maxscale/
 ```
 
-Changing the encryption key for MariaDB MaxScale will invalidate any currently\
+Changing the encryption key for MariaDB MaxScale will invalidate any currently
 encrypted keys stored in the maxscale.cnf file.
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
 ### Creating Encrypted Passwords
 
-Encrypted passwords are created by executing the maxpasswd command with the location\
+Encrypted passwords are created by executing the maxpasswd command with the location
 of the .secrets file and the password you require to encrypt as an argument.
 
 ```
@@ -3571,9 +3571,9 @@ maxpasswd /var/lib/maxscale/ MaxScalePw001
 61DD955512C39A4A8BC4BB1E5F116705
 ```
 
-The output of the maxpasswd command is a hexadecimal string, this should be inserted\
+The output of the maxpasswd command is a hexadecimal string, this should be inserted
 into the maxscale.cnf file in place of the ordinary, plain text, password.\
-MariaDB MaxScale will determine this as an encrypted password and automatically decrypt\
+MariaDB MaxScale will determine this as an encrypted password and automatically decrypt
 it before sending it the database server.
 
 ```
@@ -3587,7 +3587,7 @@ password=61DD955512C39A4A8BC4BB1E5F116705
 
 ## Runtime Configuration Changes
 
-Read the following documents for different methods of altering the MaxScale\
+Read the following documents for different methods of altering the MaxScale
 configuration at runtime.
 
 * MaxCtrl
@@ -3598,88 +3598,88 @@ configuration at runtime.
 * [alter](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-maxctrl.md)
 * [REST API](../mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-rest-api.md) documentation
 
-All changes to the configuration done via MaxCtrl are persisted as individual\
-configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these\
-files will override any configurations found in the main configuration file or\
+All changes to the configuration done via MaxCtrl are persisted as individual
+configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these
+files will override any configurations found in the main configuration file or
 any auxiliary configuration files.
 
-Refer to the [Dynamic Configuration](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more\
+Refer to the [Dynamic Configuration](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more
 details on how this mechanism works and how to disable it.
 
 ### Configuration Synchronization
 
-The configuration synchronization mechanism is intended for synchronizing\
-configuration changes done on one MaxScale to all other MaxScales. This is done\
+The configuration synchronization mechanism is intended for synchronizing
+configuration changes done on one MaxScale to all other MaxScales. This is done
 by propagating the changes via the database cluster used by Maxscale.
 
-When configuring configuration synchronization for the first time, the same\
-static configuration files should be used on all MaxScale instances that use the\
+When configuring configuration synchronization for the first time, the same
+static configuration files should be used on all MaxScale instances that use the
 same cluster: the value of `config_sync_cluster` must be the same on all\
-MaxScale instances and the cluster (i.e. the monitor) pointed by it and its\
+MaxScale instances and the cluster (i.e. the monitor) pointed by it and its
 servers must be the same in every configuration.
 
-Whenever the MaxScale configuration is modified at runtime, the latest\
-configuration is stored in the database cluster in the `mysql.maxscale_config`\
-table. The table is created when the first modification to the configuration is\
+Whenever the MaxScale configuration is modified at runtime, the latest
+configuration is stored in the database cluster in the `mysql.maxscale_config`
+table. The table is created when the first modification to the configuration is
 done. A local copy of the configuration is stored in the data directory to allow\
-MaxScale to function even if a connection to the cluster cannot be made. By\
+MaxScale to function even if a connection to the cluster cannot be made. By
 default this file is stored at `/var/lib/maxscale/maxscale-config.json`.
 
-Whenever MaxScale starts up, it checks if a local version of this configuration\
-exists. If it does and it is a valid cached configuration, the static\
-configuration file as well as any other generated configuration files are\
-ignored. The exception is the `[maxscale]` section of the main static\
+Whenever MaxScale starts up, it checks if a local version of this configuration
+exists. If it does and it is a valid cached configuration, the static
+configuration file as well as any other generated configuration files are
+ignored. The exception is the `[maxscale]` section of the main static
 configuration file which is always read.
 
-Each configuration has a version number with the initial configuration being\
-version 0. Each time the configuration is modified, the version number is\
-incremented. This version number is used to detect when MaxScale needs to update\
+Each configuration has a version number with the initial configuration being
+version 0. Each time the configuration is modified, the version number is
+incremented. This version number is used to detect when MaxScale needs to update
 its configuration.
 
 #### Error Handling in Configuration Synchronization
 
-When doing a configuration change on the local MaxScale, if the configuration\
-change completes on MaxScale but fails to be committed to the database, MaxScale\
+When doing a configuration change on the local MaxScale, if the configuration
+change completes on MaxScale but fails to be committed to the database, MaxScale
 will attempt to revert the local configuration change. If this attempt fails,\
 MaxScale will discard the cached configuration and abort the process.
 
-When synchronizing with the cluster, if MaxScale fails to apply a configuration\
-retrieved from the cluster, it attempts to revert the configuration to the\
-previous version. If successful, the failed configuration update is ignored. If\
-the configuration update that fails cannot be reverted, the MaxScale\
-configuration will be in an indeterminate state. When this happens, MaxScale\
+When synchronizing with the cluster, if MaxScale fails to apply a configuration
+retrieved from the cluster, it attempts to revert the configuration to the
+previous version. If successful, the failed configuration update is ignored. If
+the configuration update that fails cannot be reverted, the MaxScale
+configuration will be in an indeterminate state. When this happens, MaxScale
 will discard the cached configuration and abort the process.
 
-When loading a locally cached configuration during startup, if any errors are\
-found in the cached configuration, it is discarded and the MaxScale process will\
-attempt to restart by exiting with code 75 from the main process. If MaxScale is\
+When loading a locally cached configuration during startup, if any errors are
+found in the cached configuration, it is discarded and the MaxScale process will
+attempt to restart by exiting with code 75 from the main process. If MaxScale is
 being used as a SystemD service, this will automatically trigger a restart of\
 MaxScale and no further actions are needed.
 
-The most common reason for a failed configuration update is missing files. For\
-example, if a configuration update adds encrypted connections to a server and\
-the TLS certificates it uses were not copied over to all MaxScale nodes before\
-the change was done, the operation will fail on all nodes that do not have these\
+The most common reason for a failed configuration update is missing files. For
+example, if a configuration update adds encrypted connections to a server and
+the TLS certificates it uses were not copied over to all MaxScale nodes before
+the change was done, the operation will fail on all nodes that do not have these
 files.
 
-If the synchronization of the configuration change fails at the step when the\
-database transaction is being committed, the new configuration can be\
-momentarily visible to the local MaxScale. This means the changes are not\
-guaranteed to be atomic on the local MaxScale but are atomic from the cluster's\
+If the synchronization of the configuration change fails at the step when the
+database transaction is being committed, the new configuration can be
+momentarily visible to the local MaxScale. This means the changes are not
+guaranteed to be atomic on the local MaxScale but are atomic from the cluster's
 point of view.
 
 #### Synchronization of Encrypted Passwords
 
-Starting with MaxScale 6.4.9, any passwords that are transmitted by the\
-configuration synchronization are encrypted if password encryption has been\
-enabled in MaxScale. This means that all MaxScale nodes in the same\
-configuration cluster must be configured to use password encryption and they\
+Starting with MaxScale 6.4.9, any passwords that are transmitted by the
+configuration synchronization are encrypted if password encryption has been
+enabled in MaxScale. This means that all MaxScale nodes in the same
+configuration cluster must be configured to use password encryption and they
 need to all use the same encryption keys that were created with `maxkeys`.
 
 #### Managing Configuration Synchronization
 
-The output of `maxctrl show maxscale` contains the `Config Sync` field with\
-information about the current configuration state of the local Maxscale as well\
+The output of `maxctrl show maxscale` contains the `Config Sync` field with
+information about the current configuration state of the local Maxscale as well
 as the state of any other nodes using this cluster.
 
 ```
@@ -3697,17 +3697,17 @@ as the state of any other nodes using this cluster.
 ├──────────────┼─────────────────────────────────────────────────────────────┤
 ```
 
-The `version` field is the logical configuration version and the `origin` is the\
-node that originates the latest configuration change. The `checksum` field is\
+The `version` field is the logical configuration version and the `origin` is the
+node that originates the latest configuration change. The `checksum` field is
 the checksum of the logical configuration and can be used to compare whether two\
-Maxscale instances are in the same configuration state. The `nodes` field\
-contains the status of each MaxScale instance mapped to the hostname of the\
-server. This field is updated whenever MaxScale reads the configuration from the\
-cluster and can thus be used to detect which MaxScales have updated their\
+Maxscale instances are in the same configuration state. The `nodes` field
+contains the status of each MaxScale instance mapped to the hostname of the
+server. This field is updated whenever MaxScale reads the configuration from the
+cluster and can thus be used to detect which MaxScales have updated their
 configuration.
 
-The `mysql.maxscale_config` table where the configuration changes are stored\
-must not be modified manually. The only case when the table should be modified\
+The `mysql.maxscale_config` table where the configuration changes are stored
+must not be modified manually. The only case when the table should be modified
 is when resetting the configuration synchronization.
 
 To reset the configuration synchronization:
@@ -3717,56 +3717,56 @@ To reset the configuration synchronization:
 3. Drop the `mysql.maxscale_config` table
 4. Start all MaxScale instances
 
-To disable configuration synchronization, remove `config_sync_cluster` from the\
-configuration file or set it to an empty string: `config_sync_cluster=""`. This\
+To disable configuration synchronization, remove `config_sync_cluster` from the
+configuration file or set it to an empty string: `config_sync_cluster=""`. This
 can be done at runtime with MaxCtrl by passing an empty string to`config_sync_cluster`:
 
 ```
 maxctrl alter maxscale config_sync_cluster ""
 ```
 
-If MaxScale cannot create a connection to the database cluster, configuration\
-changes are not possible until communication with the database is possible. To\
-override this behavior and force the changes to be done, use the `--skip-sync`\
-option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any\
-updates done with `--skip-sync` will overwritten by changes coming from the\
+If MaxScale cannot create a connection to the database cluster, configuration
+changes are not possible until communication with the database is possible. To
+override this behavior and force the changes to be done, use the `--skip-sync`
+option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any
+updates done with `--skip-sync` will overwritten by changes coming from the
 cluster.
 
 #### Limitations in Configuration Synchronization
 
-* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) The synchronization\
-  only affects the MaxScale configuration. The state of objects or any external\
+* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) The synchronization
+  only affects the MaxScale configuration. The state of objects or any external
   files (e.g. TLS certificates) are not synchronized by this mechanism.
-* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`\
-  option will not export the cluster configuration and instead exports only the\
-  static configuration files. To start a new MaxScale based off of a clustered\
-  configuration, copy the static configuration files as well as the JSON\
-  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale\
+* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`
+  option will not export the cluster configuration and instead exports only the
+  static configuration files. To start a new MaxScale based off of a clustered
+  configuration, copy the static configuration files as well as the JSON
+  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale
   instance.
 
 ### Backing Up Configuration Changes
 
-The combination of configuration files can be done either manually\
-(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line\
+The combination of configuration files can be done either manually
+(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line
 option. See `maxscale --help` for more information about how to use the`--export-config` flag.
 
-For example, to export the current runtime configuration, run the following\
+For example, to export the current runtime configuration, run the following
 command.
 
 ```
 maxscale --export-config=/tmp/maxscale.cnf.combined
 ```
 
-This will create the `/tmp/maxscale.cnf.combined` file and write the current\
-configuration into the it. This allows new MaxScale instances to be easily set\
-up without requiring copying of all runtime configuration files. The user\
-executing the command must be able to read all MaxScale configuration files as\
+This will create the `/tmp/maxscale.cnf.combined` file and write the current
+configuration into the it. This allows new MaxScale instances to be easily set
+up without requiring copying of all runtime configuration files. The user
+executing the command must be able to read all MaxScale configuration files as
 well as create and write the provided filename.
 
 ## Error Reporting
 
-MariaDB MaxScale is designed to be executed as a service, therefore all error\
-reports, including configuration errors, are written to the MariaDB MaxScale\
+MariaDB MaxScale is designed to be executed as a service, therefore all error
+reports, including configuration errors, are written to the MariaDB MaxScale
 error log file. By default, MariaDB MaxScale will log to a file in`/var/log/maxscale` and the system log.
 
 ## Limitations
@@ -3775,36 +3775,36 @@ The current limitations of MaxScale are listed in the [Limitations](../mariadb-m
 
 ## Performance Optimization
 
-* Tune `query_classifier_cache_size` to allow maximal use of the query\
-  classifier cache. Increase the value and/or system memory until the set of\
-  unique SQL patterns fits into memory. By default at most 15% of the system\
-  memory is used for this cache. To detect if the SQL statements fit into\
-  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to\
-  see how many evictions take place. If it keeps increasing, increase the size\
-  of the query classifier cache. Using the query classifier cache with a CPU\
-  bound workload gives a roughly 20% improvement in performance compared to when\
+* Tune `query_classifier_cache_size` to allow maximal use of the query
+  classifier cache. Increase the value and/or system memory until the set of
+  unique SQL patterns fits into memory. By default at most 15% of the system
+  memory is used for this cache. To detect if the SQL statements fit into
+  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to
+  see how many evictions take place. If it keeps increasing, increase the size
+  of the query classifier cache. Using the query classifier cache with a CPU
+  bound workload gives a roughly 20% improvement in performance compared to when
   it is turned off.
-* A faster CPU with more CPU cores is better. This is true for most applications\
+* A faster CPU with more CPU cores is better. This is true for most applications
   but especially for MaxScale as it is mostly limited by the speed of the\
   CPU. Using `threads=auto` is recommended (the default starting with MaxScale\
   6\).
-* Network throughput between the client, MaxScale and the database nodes governs\
-  how much traffic can be handled. The client-to-MaxScale network is likely to\
-  be saturated first: having multiple MaxScales in front of the cluster is an\
+* Network throughput between the client, MaxScale and the database nodes governs
+  how much traffic can be handled. The client-to-MaxScale network is likely to
+  be saturated first: having multiple MaxScales in front of the cluster is an
   easy way of solving this problem.
-* Certain MaxScale modules store data on disk. A faster disk improves their\
-  performance but depending on the module, this might not be a big enough of a\
-  problem to worry about. Filters like the `qlafilter` that write information to\
+* Certain MaxScale modules store data on disk. A faster disk improves their
+  performance but depending on the module, this might not be a big enough of a
+  problem to worry about. Filters like the `qlafilter` that write information to
   disk for every SQL query can cause performance bottlenecks.
 
 ## Troubleshooting
 
-For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)\
+For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 article on the MariaDB documentation.
 
 ### Systemd Watchdog
 
-If MaxScale is running as a systemd service, the systemd Watchdog will be\
+If MaxScale is running as a systemd service, the systemd Watchdog will be
 enabled by default. To configure it, change the `WatchdogSec` option in the\
 Service section of the maxscale systemd configuration file located in`/lib/systemd/system/maxscale.service`:
 
@@ -3812,8 +3812,8 @@ Service section of the maxscale systemd configuration file located in`/lib/syste
 WatchdogSec=30s
 ```
 
-It is not recommended to use a watchdog timeout less than 30 seconds. When\
-enabled MaxScale will check that all threads are running and notify systemd\
+It is not recommended to use a watchdog timeout less than 30 seconds. When
+enabled MaxScale will check that all threads are running and notify systemd
 with a "keep-alive ping".
 
 Systemd reference: [systemd.service.html](https://www.freedesktop.org/software/systemd/man/systemd.service.html)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-installation-guide.md
@@ -1,14 +1,14 @@
 # MariaDB MaxScale Installation Guide
 
-We recommend to install MaxScale on a separate server, to ensure that there\
-can be no competition of resources between MaxScale and a MariaDB Server that\
+We recommend to install MaxScale on a separate server, to ensure that there
+can be no competition of resources between MaxScale and a MariaDB Server that
 it manages.
 
 ### Install MariaDB MaxScale From MariaDB Repositories
 
-The recommended approach is to use [the MariaDB package\
-repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
-to install MaxScale. After enabling the repository by following the\
+The recommended approach is to use [the MariaDB package
+repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
+to install MaxScale. After enabling the repository by following the
 instructions, MaxScale can be installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install maxscale`.
@@ -17,9 +17,9 @@ instructions, MaxScale can be installed with the following commands.
 
 ### Install MariaDB MaxScale From a RPM/DEB Package
 
-Download the correct MaxScale package for your CPU architecture and operating\
-system from [the MariaDB Downloads\
-page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be\
+Download the correct MaxScale package for your CPU architecture and operating
+system from [the MariaDB Downloads
+page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be
 installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install /path/to/maxscale-*.rpm`
@@ -29,7 +29,7 @@ installed with the following commands.
 ### Install MariaDB MaxScale Using a Tarball
 
 MaxScale can also be installed using a tarball.\
-That may be required if you are using a Linux distribution for which there\
+That may be required if you are using a Linux distribution for which there
 exist no installation package or if you want to install many different\
 MaxScale versions side by side. For instructions on how to do that, please refer to [Install MariaDB MaxScale using a Tarball](mariadb-maxscale-2106-maxscale-2106-installing-mariadb-maxscale-using-a-tarball.md).
 
@@ -42,20 +42,20 @@ To do this, refer to the separate document [Building MariaDB MaxScale from Sourc
 
 #### Memory allocation behavior
 
-MaxScale assumes that memory allocations always succeed and in general does\
-not check for memory allocation failures. This assumption is compatible with\
-the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)\
+MaxScale assumes that memory allocations always succeed and in general does
+not check for memory allocation failures. This assumption is compatible with
+the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)
 having the value `0`, which is also the default on most systems.
 
-With `vm.overcommit_memory` being `0`, memory _allocations_ made by an\
-application never fail, but instead the application may be killed by the\
-so-called OOM (out-of-memory) killer if, by the time the application\
-actually attempts to _use_ the allocated memory, there is not available\
+With `vm.overcommit_memory` being `0`, memory _allocations_ made by an
+application never fail, but instead the application may be killed by the
+so-called OOM (out-of-memory) killer if, by the time the application
+actually attempts to _use_ the allocated memory, there is not available
 free memory on the system.
 
-If the value is `2`, then a memory allocation made by an application may\
-fail and unless the application is prepared for that possibility, it will\
-likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory\
+If the value is `2`, then a memory allocation made by an application may
+fail and unless the application is prepared for that possibility, it will
+likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory
 allocation failures, it will crash in this situation.
 
 The current value of `vm.overcommit_memory` can be checked with
@@ -72,36 +72,36 @@ cat /proc/sys/vm/overcommit_memory
 
 ### Configuring MariaDB MaxScale
 
-[The MaxScale Tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-setting-up-mariadb-maxscale.md) covers the first\
-steps in configuring your MariaDB MaxScale installation. Follow this tutorial\
+[The MaxScale Tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-setting-up-mariadb-maxscale.md) covers the first
+steps in configuring your MariaDB MaxScale installation. Follow this tutorial
 to learn how to configure and start using MaxScale.
 
-For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) and the module specific documents\
+For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) and the module specific documents
 listed in the [Documentation Contents](../mariadb-maxscale-2106-maxscale-2106-contents.md).
 
 ### Encrypting Passwords
 
-Read the [Encrypting Passwords](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
-section of the configuration guide to set up password encryption for the\
+Read the [Encrypting Passwords](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
+section of the configuration guide to set up password encryption for the
 configuration file.
 
 ### Administration Of MariaDB MaxScale
 
 There are various administration tasks that may be done with MariaDB MaxScale.\
-A command line tools is available, [maxctrl](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-maxctrl.md), that will\
+A command line tools is available, [maxctrl](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-maxctrl.md), that will
 interact with a running MariaDB MaxScale and allow the status of MariaDB\
-MaxScale to be monitored and give some control of the MariaDB MaxScale\
+MaxScale to be monitored and give some control of the MariaDB MaxScale
 functionality.
 
-[The administration tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-administration-tutorial.md)\
+[The administration tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-administration-tutorial.md)
 covers the common administration tasks that need to be done with MariaDB MaxScale.
 
 ### Copying or Backing Up MaxScale
 
-The main configuration file for MaxScale is in `/etc/maxscale.cnf` and\
+The main configuration file for MaxScale is in `/etc/maxscale.cnf` and
 additional user-created configuration files are in`/etc/maxscale.cnf.d/`. Objects created or modified at runtime are stored in`/var/lib/maxscale/maxscale.cnf.d/`. Some modules also store internal data in`/var/lib/maxscale/` named after the module or the configuration object.
 
-The simplest way to back up the configuration and runtime data of a MaxScale\
+The simplest way to back up the configuration and runtime data of a MaxScale
 installation is to create an archive from the following files and directories:
 
 * `/etc/maxscale.cnf`
@@ -114,7 +114,7 @@ This can be done with the following command:
 tar -caf maxscale-backup.tar.gz /etc/maxscale.cnf /etc/maxscale.cnf.d/ /var/lib/maxscale/
 ```
 
-If MaxScale is configured to store data in custom locations, these should be\
+If MaxScale is configured to store data in custom locations, these should be
 included in the backup as well.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-maxgui-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-maxgui-guide.md
@@ -6,28 +6,28 @@ _MaxGUI_ is a browser-based interface for MaxScale REST-API and query execution.
 
 ## Enabling MaxGUI
 
-To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale\
+To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale
 configuration file. Once enabled, MaxGUI will be available on port 8989:`http://127.0.0.1:8989/`
 
 ### Securing the GUI
 
 To make MaxGUI secure, set `admin_secure_gui=true` and configure both the`admin_ssl_key` and `admin_ssl_cert` parameters.
 
-Check the [Configuration Guide](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) for the parameter\
-documentation and read the _Configuration and Hardening_ section of the [REST API tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-rest-api-tutorial.md) for instructions on\
+Check the [Configuration Guide](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) for the parameter
+documentation and read the _Configuration and Hardening_ section of the [REST API tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-rest-api-tutorial.md) for instructions on
 how to harden your MaxScale installation for production use.
 
 ## Authentication
 
-MaxGUI cannot be used without providing credentials. MaxGUI uses\
+MaxGUI cannot be used without providing credentials. MaxGUI uses
 the same credentials as `maxctrl`, so by default, the username is`admin` and the password is `mariadb`.
 
-MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the\
+MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the
 authentication method for persisting the user's session.\
 If the _Remember me_ checkbox is ticked, the session will persist for\
 24 hours, otherwise, as soon as MaxGUI is closed, the session will expire.
 
-To log out, simply click the username section in the top right corner of\
+To log out, simply click the username section in the top right corner of
 the page header to access the logout menu.
 
 ## Features
@@ -36,17 +36,17 @@ the page header to access the logout menu.
 
 The dashboard shows three graphs:
 
-* Sessions graph illustrates the total number of current sessions\
+* Sessions graph illustrates the total number of current sessions
   updating every 10 seconds.
-* Connections graph shows servers current connections\
+* Connections graph shows servers current connections
   updating every 10 seconds.
-* Load graph shows the last second load of thread,\
+* Load graph shows the last second load of thread,
   which is updated every second.
 
-Under the graphs section, there is tab navigation to switch\
-table view which contains overview information of the\
-following resources: all servers grouped by monitor, current sessions\
-and all services. The information of these resources are\
+Under the graphs section, there is tab navigation to switch
+table view which contains overview information of the
+following resources: all servers grouped by monitor, current sessions
+and all services. The information of these resources are
 updated every 10 seconds.
 
 ### Detail page
@@ -54,15 +54,15 @@ updated every 10 seconds.
 The monitor, server, and services resources have their own details page.\
 It can be accessed by clicking the resource name on the dashboard page.
 
-On the details page, resource parameters as well as relationships\
+On the details page, resource parameters as well as relationships
 can be modified in the resource's parameters section.
 
-Deletion of a resource or other actions can be done by clicking the\
+Deletion of a resource or other actions can be done by clicking the
 setting icon located next to the resource name.\
-For instance, clicking the setting icon on the Monitor detail page will\
+For instance, clicking the setting icon on the Monitor detail page will
 popup three icons allowing a monitor to be started, stopped, and deleted.
 
-For Servers, the monitor relationship can be modified by hovering\
+For Servers, the monitor relationship can be modified by hovering
 over the rectangular _Monitor_ block section at the top of the page.
 
 ### SQL editor page
@@ -75,68 +75,68 @@ The query layout editor interface comprises the following sections:
 
 #### Worksheet tab bar
 
-Located at the top of the page, users can create multiple connections\
+Located at the top of the page, users can create multiple connections
 to perform parallel querying.\
-On the right side, there are buttons to save query to favorite,\
-open Query configuration dialog, and set the\
+On the right side, there are buttons to save query to favorite,
+open Query configuration dialog, and set the
 page to full-screen mode.
 
 #### Taskbar
 
-Located below the worksheet tab bar, this contains resource quick action\
+Located below the worksheet tab bar, this contains resource quick action
 buttons on the left side and query action buttons on the right side. _Resource quick action buttons are used to manage active connections and active database._ Query action buttons are used to run SQL statements, visualize
 query result in graphs, and configure query settings.
 
 #### Schema sidebar
 
 List databases, tables and columns of the server.\
-The list is fetched when needed and provided with\
-dedicated options which can be accessed by clicking the more\
+The list is fetched when needed and provided with
+dedicated options which can be accessed by clicking the more
 options (...) icon.\
-For example, for table, it has options to _Preview Data_\
-and _View Details_ which internally executes `SELECT * FROM database.table_name`\
+For example, for table, it has options to _Preview Data_
+and _View Details_ which internally executes `SELECT * FROM database.table_name`
 and `DESCRIBE database.table_name`, respectively.
 
 #### SQL editor
 
-* Writing SQL statements and executing all statements\
-  or selected statements by using shortcut keys. In general, the editor\
+* Writing SQL statements and executing all statements
+  or selected statements by using shortcut keys. In general, the editor
   provides some of the most famous editor features of Visual Studio Code
-* All the command palette can be shown by pressing F1 or right-click\
+* All the command palette can be shown by pressing F1 or right-click
   on the editor to open the context menu and choose Command Palette
 
 #### Query result
 
-Located at the bottom of the page, the result section is comprised of three\
+Located at the bottom of the page, the result section is comprised of three
 tabs which are _Results_, _Data Preview_ and _History/Favorite_. The Results tab shows the query results of the SQL statements from the SQL editor. The _Data Preview_ contains two sub-tabs _DATA_ and _DETAILS_ showing
 the results of _Preview Data_ and _View Details_, respectively.
 
 * The _History/Favorite_ shows query history and favorite queries
 
-Result tables can be filtered, sorted (only when total rows <= 10000), exported,\
+Result tables can be filtered, sorted (only when total rows <= 10000), exported,
 and grouped. The result can be exported as `json`, `csv` with a custom delimiter.
 
-The table result can be converted to the vertical mode by clicking the _transform_ icon\
-on the right corner above the table. In addition, table columns visibility can be\
+The table result can be converted to the vertical mode by clicking the _transform_ icon
+on the right corner above the table. In addition, table columns visibility can be
 toggled and resized.
 
 #### Query result visualization
 
-Query result can be visualized into line, scatter, vertical bar, and horizontal\
-bar graphs. In order to see the graph, simply click the _graph_ icon next to\
+Query result can be visualized into line, scatter, vertical bar, and horizontal
+bar graphs. In order to see the graph, simply click the _graph_ icon next to
 the _gear_ icon in the task bar, then fill in the inputs.
 
-The graph can be resized by clicking the border of the pane and exported as `jpeg`\
+The graph can be resized by clicking the border of the pane and exported as `jpeg`
 format with same ratio.
 
 #### DDL Editor
 
-This editor helps to alter table easily which can be accessed by right-clicking the table\
+This editor helps to alter table easily which can be accessed by right-clicking the table
 on [the schema sidebar](mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-maxgui-guide.md#schema-sidebar) and choose _Alter Table_.
 
 #### Current limitations
 
-A connection is bound to a worksheet, so sessions querying of a connection is\
+A connection is bound to a worksheet, so sessions querying of a connection is
 not yet supported.\
 The hard limit rows of each result are set to 10000 rows which means\
 MaxScale returns 10000 rows regardless value of the LIMIT clause. In addition,`LIMIT` is not automatically injected into statements written in the SQL editor.
@@ -147,21 +147,21 @@ To access logs viewer, choose _Logs Archive_ in the sidebar navigation.
 
 ### Resource creation
 
-A resource can be created by clicking the _+ Create New_ button at\
+A resource can be created by clicking the _+ Create New_ button at
 the top right corner of the dashboard or the detail page.
 
-_Note_: Resources that depend on a module can be created only if that\
+_Note_: Resources that depend on a module can be created only if that
 module has been loaded by MaxScale.
 
 ### Viewing and modifying Maxscale parameters
 
-MaxScale parameters can be viewed and modified at runtime on the Settings\
-page, which can be accessed by clicking the gear icon in the sidebar\
+MaxScale parameters can be viewed and modified at runtime on the Settings
+page, which can be accessed by clicking the gear icon in the sidebar
 navigation.
 
 ### Global search
 
-The global search input located next to the _+ Create New_ button can be\
+The global search input located next to the _+ Create New_ button can be
 used for searching for keywords in tables.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-change-data-capture-cdc-protocol.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-change-data-capture-cdc-protocol.md
@@ -1,10 +1,10 @@
 # MaxScale 21.06 Change Data Capture (CDC) Protocol
 
-CDC is a new protocol that allows compatible clients to authenticate and\
-register for Change Data Capture events. The new protocol must be use in\
+CDC is a new protocol that allows compatible clients to authenticate and
+register for Change Data Capture events. The new protocol must be use in
 conjunction with AVRO router which currently converts MariaDB binlog events into\
-AVRO records. Change Data Capture protocol is used by clients in order to\
-interact with stored AVRO file and also allows registered clients to be notified\
+AVRO records. Change Data Capture protocol is used by clients in order to
+interact with stored AVRO file and also allows registered clients to be notified
 with the new events coming from MariaDB 10.0/10.1 database.
 
 ### Creating Users
@@ -47,12 +47,12 @@ In the future, optional flags could be implemented.
 
 #### Authentication
 
-The authentication starts when the client sends the hexadecimal representation\
+The authentication starts when the client sends the hexadecimal representation
 of the username concatenated with a colon (`:`) and the SHA1 of the password.
 
 `bin2hex(username + ':' + SHA1(password))`
 
-For example the user _foobar_ with a password of _foopasswd_ should send the\
+For example the user _foobar_ with a password of _foopasswd_ should send the
 following hexadecimal string
 
 ```
@@ -83,9 +83,9 @@ Server returns `OK` on success and `ERR` on failure.
 
 `REQUEST-DATA DATABASE.TABLE[.VERSION] [GTID]`
 
-This command fetches data from specified table in a database and returns the\
-output in the requested format (AVRO or JSON). Data records are sent to clients\
-and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new\
+This command fetches data from specified table in a database and returns the
+output in the requested format (AVRO or JSON). Data records are sent to clients
+and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new
 schema and data will be sent as well.
 
 The data will be streamed until the client closes the connection.
@@ -102,7 +102,7 @@ REQUEST-DATA db2.table4 0-11-345
 
 ### Example Client
 
-MaxScale includes an example CDC client application written in Python 3. You can\
+MaxScale includes an example CDC client application written in Python 3. You can
 find the source code for it [in the MaxScale repository](https://github.com/mariadb-corporation/MaxScale/tree/2.0/server/modules/protocol/examples/cdc.py).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-change-data-capture-cdc-users.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-change-data-capture-cdc-users.md
@@ -1,12 +1,12 @@
 # MaxScale 21.06 Change Data Capture (CDC) users
 
-Change Data Capture (CDC) is a new MaxScale protocol that allows compatible\
-clients to authenticate and register for Change Data Capture events. The new\
+Change Data Capture (CDC) is a new MaxScale protocol that allows compatible
+clients to authenticate and register for Change Data Capture events. The new
 protocol must be use in conjunction with AVRO router which currently converts\
-MariaDB binlog events into AVRO records. Clients connect to CDC listener and\
+MariaDB binlog events into AVRO records. Clients connect to CDC listener and
 authenticate using credentials provided in a format described in the [CDC Protocol documentation](mariadb-maxscale-2106-maxscale-2106-change-data-capture-cdc-protocol.md).
 
-**Note**: If no users are found in that file or if it doesn't exist, the only\
+**Note**: If no users are found in that file or if it doesn't exist, the only
 available user will be the _service user_:
 
 ```
@@ -26,7 +26,7 @@ Starting with MaxScale 2.1, users can also be created through maxctrl:
 maxctrl call command cdc add_user <service> <name> <password>
 ```
 
-The should be the service name where the user is created. Older\
+The should be the service name where the user is created. Older
 versions of MaxScale should use the _cdc\_users.py_ script.
 
 ```
@@ -39,7 +39,7 @@ The output of this command should be appended to the _cdcusers_ file at`/var/lib
 bash$ cdc_users.py user1 pass1 >> /var/lib/maxscale/avro-service/cdcusers
 ```
 
-Users can be deleted by removing the related rows in 'cdcusers' file. For\
+Users can be deleted by removing the related rows in 'cdcusers' file. For
 more details on the format of the _cdcusers_ file, read the [CDC Protocol documentation](mariadb-maxscale-2106-maxscale-2106-change-data-capture-cdc-protocol.md).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-mariadb-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-mariadb-protocol-module.md
@@ -2,7 +2,7 @@
 
 The `mariadbprotocol` module implements the MariaDB client-server protocol.
 
-The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all\
+The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all
 aliases to `mariadbprotocol`.
 
 * [MariaDB Protocol Module](mariadb-maxscale-2106-maxscale-2106-mariadb-protocol-module.md#mariadb-protocol-module)
@@ -11,7 +11,7 @@ aliases to `mariadbprotocol`.
 
 ### Configuration
 
-Protocol level parameters are defined in the listeners. They must be defined\
+Protocol level parameters are defined in the listeners. They must be defined
 using the scoped parameter syntax where the protocol name is used as the prefix.
 
 ```
@@ -32,8 +32,8 @@ For the MariaDB protocol module, the prefix is always `mariadbprotocol`.
 * Dynamic: Yes
 * Default: true
 
-Whether the use of the replication protocol is allowed through this listener. If\
-disabled with `mariadbprotocol.allow_replication=false`, all attempts to start\
+Whether the use of the replication protocol is allowed through this listener. If
+disabled with `mariadbprotocol.allow_replication=false`, all attempts to start
 replication will be rejected with a ER\_FEATURE\_DISABLED error (error number\
 1289\).
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md
@@ -1,20 +1,20 @@
 # MaxScale 21.06 NoSQL Protocol Module
 
-The `nosqlprotocol` module allows a MariaDB server or cluster to be\
+The `nosqlprotocol` module allows a MariaDB server or cluster to be
 used as the backend of an application using a MongoDB® client library.\
 Internally, all documents are stored in a table containing two columns;\
 an `id` column for the object id and a `doc` column for the document itself.
 
-When the MongoDB® client application issues MongoDB protocol _commands_,\
-either directly or indirectly via the client library, they are transparently\
+When the MongoDB® client application issues MongoDB protocol _commands_,
+either directly or indirectly via the client library, they are transparently
 converted into the equivalent SQL and executed against the MariaDB backend.\
-The MariaDB responses are then in turn converted into the format expected by\
+The MariaDB responses are then in turn converted into the format expected by
 the MongoDB® client library and application.
 
 ## Configuring
 
-There are a number of [parameters](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#parameters) with which the behavior\
-of _nosqlprotocol_ can be adjusted. A minimal configuration looks\
+There are a number of [parameters](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#parameters) with which the behavior
+of _nosqlprotocol_ can be adjusted. A minimal configuration looks
 like:
 
 ```
@@ -31,13 +31,13 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-`nosqlprotocol.user` and `nosqlprotocol.password` specify the\
-credentials that will be used when accessing the backend database or\
+`nosqlprotocol.user` and `nosqlprotocol.password` specify the
+credentials that will be used when accessing the backend database or
 cluster. Note that the same credentials will be used for _all_ connecting\
 MongoDB® clients.
 
-Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which\
-the client requests will be sent. _Nosqlprotocol_ places no limitations\
+Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which
+the client requests will be sent. _Nosqlprotocol_ places no limitations
 on what filters, routers or backends can be used.
 
 To configure the same listener with MaxCtrl, the parameters must be passed in a\
@@ -47,7 +47,7 @@ JSON object in the following manner:
 maxctrl create listener TheService MongoDB-Listener --protocol=nosqlprotocol 'nosqlprotocol={"user":"the_user", "password": "the_password"}'
 ```
 
-All the parameters that the nosqlprotocol module takes must be passed in the\
+All the parameters that the nosqlprotocol module takes must be passed in the
 same JSON object.
 
 A complete example can be found at the [end](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#example) of this document.
@@ -57,18 +57,18 @@ A complete example can be found at the [end](mariadb-maxscale-2106-maxscale-2106
 Nosqlprotocol supports _SCRAM_ _authentication_ as implemented by MongoDB®.\
 The mechanisms `SCRAM-SHA-1` and `SCRAM-SHA-256` are both supported.
 
-If nosqlprotocol has been setup so that no authentication is required, then\
-when connecting only the host and port should be provided, but neither a\
+If nosqlprotocol has been setup so that no authentication is required, then
+when connecting only the host and port should be provided, but neither a
 username nor a password.
 
-For instance, if the _MongoDB Node.JS Driver_ is used, then the connection\
+For instance, if the _MongoDB Node.JS Driver_ is used, then the connection
 string should look like:
 
 ```
 const uri = "mongodb://127.0.0.1:17017"
 ```
 
-Similarly, if the _Mongo Shell_ is used, only the host and port should\
+Similarly, if the _Mongo Shell_ is used, only the host and port should
 be provided:
 
 ```
@@ -80,26 +80,26 @@ MongoDB shell version v4.4.1
 
 ### NoSQL and MariaDB Users
 
-A MariaDB user consists of a name and a host part. A user `'user'@'%'`\
-and a user `'user'@'127.0.0.1'` are completely different. The host part\
-specifies where a user may connect from, with `%` being a wildcard that\
-matches all hosts. What data a user is allowed to access and modify is\
+A MariaDB user consists of a name and a host part. A user `'user'@'%'`
+and a user `'user'@'127.0.0.1'` are completely different. The host part
+specifies where a user may connect from, with `%` being a wildcard that
+matches all hosts. What data a user is allowed to access and modify is
 specified by what _privileges_ are granted to the user.
 
-A NoSQL user is somewhat different. It is created in the context of a\
-particular database, so there may be a user `userx` in the database `dbA`\
-and different user with the same name `userx` in the database `dbB`. What\
-hosts a user may connect from can be restricted, but that is a property of\
-the user and not an implicit part of it. What data a user is allowed to\
-access and modify is specified by the _roles_ that have been assigned to\
+A NoSQL user is somewhat different. It is created in the context of a
+particular database, so there may be a user `userx` in the database `dbA`
+and different user with the same name `userx` in the database `dbB`. What
+hosts a user may connect from can be restricted, but that is a property of
+the user and not an implicit part of it. What data a user is allowed to
+access and modify is specified by the _roles_ that have been assigned to
 the user.
 
-From the above it should be clear that there is not a 1-to-1\
-correspondence between the concept of a user in NoSQL and the concept\
+From the above it should be clear that there is not a 1-to-1
+correspondence between the concept of a user in NoSQL and the concept
 of a user in MariaDB, but that some additional conventions are needed.
 
-To make it possible to have different NoSQL users with the same name,\
-the database in whose context the user is created is prepended to the\
+To make it possible to have different NoSQL users with the same name,
+the database in whose context the user is created is prepended to the
 user name, separated with a dot, when the MariaDB user is created.
 
 This is perhaps easiest to illustrate using an example:
@@ -115,7 +115,7 @@ MariaDB [(none)]> select user, host from mysql.user;
 2 rows in set (0.001 sec)
 ```
 
-Currently there are two user accounts defined. Even though there is\
+Currently there are two user accounts defined. Even though there is
 a user `bob`, creating a NoSQL user `bob` succeeds.
 
 ```
@@ -139,20 +139,20 @@ MariaDB [(none)]> select user, host from mysql.user;
 3 rows in set (0.001 sec)
 ```
 
-The MariaDB user corresponding to the NoSQL user `bob`, created in the\
+The MariaDB user corresponding to the NoSQL user `bob`, created in the
 context of the database `test`, has `test` as a prefix.
 
 #### The `mariadb` database
 
-The fact that NoSQL users have the database embedded in the MariaDB\
-name may be inconvenient if the same data is accessed both as NoSQL\
-via nosqlprotocol and as SQL directly from MariaDB. It also makes\
+The fact that NoSQL users have the database embedded in the MariaDB
+name may be inconvenient if the same data is accessed both as NoSQL
+via nosqlprotocol and as SQL directly from MariaDB. It also makes
 it impossible to use an existing MariaDB account from NoSQL.
 
-To provide a solution for this problem, the database `mariadb` is treated\
-in a specific fashion. A user created in the context of the `mariadb`\
+To provide a solution for this problem, the database `mariadb` is treated
+in a specific fashion. A user created in the context of the `mariadb`
 database is created in the MariaDB server without the database prefix.\
-If we now try to create a user `bob` in the `mariadb` database it will fail,\
+If we now try to create a user `bob` in the `mariadb` database it will fail,
 because the user `'bob'@'%'` exists already.
 
 ```
@@ -195,7 +195,7 @@ we will see that `alice` was created without a database prefix.
 
 When creating a user nosqlprotocol accepts all roles as predefined by\
 MongoDB®, but not all of them are translated into GRANT privileges.\
-The following table shows what privilege(s) a particular role is\
+The following table shows what privilege(s) a particular role is
 converted to.
 
 | Role      | Privilege                                     |
@@ -212,21 +212,21 @@ The following roles are shorthands for several other roles.
 | dbOwner | dbAdmin, readWrite, userAdmin |
 | root    | dbAdmin, readWrite, userAdmin |
 
-`dbOwner` differs from `root` in that the privileges of the former\
-apply only to a particular database, while the privileges of the\
-latter apply to _all_ databases. However, the role `root` can\
+`dbOwner` differs from `root` in that the privileges of the former
+apply only to a particular database, while the privileges of the
+latter apply to _all_ databases. However, the role `root` can
 only be assigned to a user in the `admin` database.
 
-In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in\
-the `admin` database. If so, then the privilege is granted on `*.*`,\
+In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in
+the `admin` database. If so, then the privilege is granted on `*.*`,
 otherwise on `<db>.*`.
 
-If the `root` role is assigned to a user in the `admin` database,\
+If the `root` role is assigned to a user in the `admin` database,
 then the privileges are granted on `*.*`, otherwise on `<db>.*`.
 
-Other pre-defined roles are recognized and stored in the local\
-nosqlprotocol account database, but they do not affect what privileges\
-are granted to the MariaDB user. Currently user-defined roles are\
+Other pre-defined roles are recognized and stored in the local
+nosqlprotocol account database, but they do not affect what privileges
+are granted to the MariaDB user. Currently user-defined roles are
 not supported.
 
 ### Client Authentication
@@ -239,11 +239,11 @@ Authenticationwise nosqlprotocol can be used in three different ways:
 
 #### Anonymously
 
-If there is an anonymous user on the MariaDB server and if nosqlprotocol\
-is configured without a user/password, then all nosqlprotocol clients will\
+If there is an anonymous user on the MariaDB server and if nosqlprotocol
+is configured without a user/password, then all nosqlprotocol clients will
 access the MariaDB server as anonymous users.
 
-Note that the anonymous MariaDB user is only intended for testing and\
+Note that the anonymous MariaDB user is only intended for testing and
 should in general not be used, but deleted.
 
 #### Shared Credentials
@@ -257,18 +257,18 @@ nosqlprotocol.password=thepassword
 ```
 
 then each MongoDB® client will use those credentials when accessing the\
-MariaDB server. Note that from the perspective of the MariaDB server, it\
+MariaDB server. Note that from the perspective of the MariaDB server, it
 is not possible to distinguish between different MongoDB® clients.
 
 #### Unique Credentials
 
-If nosqlprotocol authentication has been taken into use and a MongoDB®\
-client authenticates, either when connecting or later, then the credentials\
+If nosqlprotocol authentication has been taken into use and a MongoDB®
+client authenticates, either when connecting or later, then the credentials
 of MongoDB® client will be used when accessing the MariaDB server.
 
-Note that even if nosqlprotocol authentication has been enabled, authentication\
-is not required, and if the MongoDB® client has not authenticated itself, the\
-credentials specified with `nosqlprotocol.[user|password]` (or the anonymous\
+Note that even if nosqlprotocol authentication has been enabled, authentication
+is not required, and if the MongoDB® client has not authenticated itself, the
+credentials specified with `nosqlprotocol.[user|password]` (or the anonymous
 user) will be used when accessing the MariaDB server.
 
 #### Enforce Authentication
@@ -279,14 +279,14 @@ To enforce authentication, specify
 nosqlprotocol.authentication_required=true
 ```
 
-in the configuration. If authentication is required, then any command\
-that requires access to the MariaDB server will fail, unless the client\
+in the configuration. If authentication is required, then any command
+that requires access to the MariaDB server will fail, unless the client
 has authenticated.
 
 ### Authorization
 
-By default nosqlprotocol does no authorization. However, a nosqlprotocol\
-client is _always_ subject to the authorization performed by the MariaDB\
+By default nosqlprotocol does no authorization. However, a nosqlprotocol
+client is _always_ subject to the authorization performed by the MariaDB
 server.
 
 When nosqlprotocol authorization is enabled by adding
@@ -295,8 +295,8 @@ When nosqlprotocol authorization is enabled by adding
 nosqlprotocol.authorization_enabled=true
 ```
 
-to the configuration file, some commands will be subject to authorization,\
-by nosqlprotocol. The following table lists the commands and what role they\
+to the configuration file, some commands will be subject to authorization,
+by nosqlprotocol. The following table lists the commands and what role they
 require.
 
 | Command                                                                                                 | Role      |
@@ -311,21 +311,21 @@ require.
 | [updateUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#updateUser)                   | userAdmin |
 | [usersInfo](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#usersInfo)                     | userAdmin |
 
-It is important to note that even if nosqlprotocol authorization\
-is enabled, the MariaDB server has the final word. That is, even if the\
-roles of a user would be sufficient for a particular operation, if the\
-granted privileges are not, the operation will not succeed. There may\
-be a mismatch between roles and grants, for instance, if the wrong roles\
-were specified when the user was added, or if the grants have been\
+It is important to note that even if nosqlprotocol authorization
+is enabled, the MariaDB server has the final word. That is, even if the
+roles of a user would be sufficient for a particular operation, if the
+granted privileges are not, the operation will not succeed. There may
+be a mismatch between roles and grants, for instance, if the wrong roles
+were specified when the user was added, or if the grants have been
 altered directly and not via nosqlprotocol.
 
 ### Bootstrapping the Authentication/Authorization
 
-In order to enable authorization you need to have NoSQL users and\
-those can be created with [createUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#createUser) or added\
+In order to enable authorization you need to have NoSQL users and
+those can be created with [createUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#createUser) or added
 with [mxsAddUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#addUser).
 
-If you want to _create_ a user, then you first need to configure\
+If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
 
 ```
@@ -333,7 +333,7 @@ nosqlprotocol.user = user_with_privileges_for_creating_a_user
 nosqlprotocol.password = the_users_password
 ```
 
-At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that\
+At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that
 as those are their default values, they do not have to be specified.
 
 Start MaxScale and connect to it with the MongoDB® command line client
@@ -353,8 +353,8 @@ switched to db admin
 { "ok" : 1 }
 ```
 
-Alternatively you can add an existing user. Note that it should be\
-added to the `mariadb` database, unless it was created with the\
+Alternatively you can add an existing user. Note that it should be
+added to the `mariadb` database, unless it was created with the
 convention of having the database as a prefix, e.g. `db.bob`.
 
 ```
@@ -373,12 +373,12 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but\
-as they will be ignored with `nosqlprotocol.authentication_required=true`\
+The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but
+as they will be ignored with `nosqlprotocol.authentication_required=true`
 being present, it is not mandatory.
 
-If you now try to create a user when not having been authenticated or\
-when authenticated as a user without the `userAdmin` role, the result\
+If you now try to create a user when not having been authenticated or
+when authenticated as a user without the `userAdmin` role, the result
 will be:
 
 ```
@@ -393,40 +393,40 @@ switched to db test
 }
 ```
 
-**NOTE** When a client authenticates, the password will not be\
-transferred in cleartext over the network, so, even without SSL,\
-it is not possible to gain access to a password by monitoring the\
+**NOTE** When a client authenticates, the password will not be
+transferred in cleartext over the network, so, even without SSL,
+it is not possible to gain access to a password by monitoring the
 network traffic.
 
-However, when a user is created or added (or the password is changed),\
-the password will be transferred in _cleartext_. To prevent eavesdropping,\
+However, when a user is created or added (or the password is changed),
+the password will be transferred in _cleartext_. To prevent eavesdropping,
 create/add users when connecting over a domain socket, or use [TLS/SSL](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#tlsssl)
 
 #### TLS/SSL
 
-Since `nosqlprotocol` is a regular protocol module used in a listener,\
-the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#tlsssl-encryption)\
+Since `nosqlprotocol` is a regular protocol module used in a listener,
+the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md#tlsssl-encryption)
 for details.
 
 ### Local Account Database
 
-So as to be able to log in on behalf of clients, nosqlprotocol\
-must know their password. As the password is not transferred\
-to nosqlprotocol during the authentication in a way that could\
-be used when logging into MariaDB, the password must be stored\
-locally when the user is created with [createUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#createUser)\
+So as to be able to log in on behalf of clients, nosqlprotocol
+must know their password. As the password is not transferred
+to nosqlprotocol during the authentication in a way that could
+be used when logging into MariaDB, the password must be stored
+locally when the user is created with [createUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#createUser)
 or added with [mxsAddUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsAddUser).
 
-Note that the password is not stored in cleartext but as three\
-different hashes; hashed with sha1 for use with MariaDB, salted\
-and hashed with sha1 for use with the `SCRAM-SHA-1` authentication\
-mechanism (if that is enabled for the user) and salted and hashed\
-with sha256 for use with the `SCRAM-SHA-256` authentication mechanism\
+Note that the password is not stored in cleartext but as three
+different hashes; hashed with sha1 for use with MariaDB, salted
+and hashed with sha1 for use with the `SCRAM-SHA-1` authentication
+mechanism (if that is enabled for the user) and salted and hashed
+with sha256 for use with the `SCRAM-SHA-256` authentication mechanism
 (if that is enabled for the user).
 
-The account information of nosqlprotocol is stored in an [sqlite3](https://sqlite.org/index.html) database whose name is`<libdir>/nosqlprotocol/<listener-name>-v1.db`, where`<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the\
-listener section in the MaxScale configuration file, and `-v1`\
-a suffix for making schema evolution easier, should there be\
+The account information of nosqlprotocol is stored in an [sqlite3](https://sqlite.org/index.html) database whose name is`<libdir>/nosqlprotocol/<listener-name>-v1.db`, where`<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the
+listener section in the MaxScale configuration file, and `-v1`
+a suffix for making schema evolution easier, should there be
 a need for that.
 
 For instance, given a configuration like
@@ -441,51 +441,51 @@ protocol=nosqlprotocol
 
 the account information will be stored in the file`<libdir>/nosqlprotocol/NoSQL-Listener-v1.db`.
 
-Note that since the database name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the database name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
-To retain the accounts, the database file should also be\
+To retain the accounts, the database file should also be
 renamed.
 
-At first startup, the `nosqlprotocol` directory and\
-the file `NoSQL-Listener-v1.db` will be created. They will\
-be created with file permissions that only allow MaxScale\
-access. At subsequent startups the permissions will be checked\
-and MaxScale will refuse to start if the permissions allow\
+At first startup, the `nosqlprotocol` directory and
+the file `NoSQL-Listener-v1.db` will be created. They will
+be created with file permissions that only allow MaxScale
+access. At subsequent startups the permissions will be checked
+and MaxScale will refuse to start if the permissions allow
 access to others.
 
 **We strongly recommend that no manual modifications are made**\
 **to the database.**
 
-Note that we make **no** guarantees that the way in which the\
-account information is stored by nosqlprotocol will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the way in which the
+account information is stored by nosqlprotocol will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ## Wire Protocol
 
-_Nosqlprotocol_ fully supports wire protocol version 6 and only provides\
-rudimentary support for earlier wire protocol versions, but reports at\
-startup that it would support versions 0 to 6. The reason is that some\
-client libraries are buggy and use an old wire protocol version if the\
-server claims to support only version 6. Consequently, one should use a\
+_Nosqlprotocol_ fully supports wire protocol version 6 and only provides
+rudimentary support for earlier wire protocol versions, but reports at
+startup that it would support versions 0 to 6. The reason is that some
+client libraries are buggy and use an old wire protocol version if the
+server claims to support only version 6. Consequently, one should use a
 client library version that at least supports wire protocol version 6.
 
 ## Client Library
 
-As the goal of _nosqlprotocol_ is to implement, to the extent that it\
-is feasible, the wire protocol and the database commands the way MongoDB®\
+As the goal of _nosqlprotocol_ is to implement, to the extent that it
+is feasible, the wire protocol and the database commands the way MongoDB®
 implements them, it should be possible to use any language specific driver.
 
-However, during the development of _nosqlprotocol_, the _only_ client library\
+However, during the development of _nosqlprotocol_, the _only_ client library
 that has been verified to work is version 3.6 of _MongoDB Node.JS Driver_.
 
 ## Parameters
 
-Using the following parameters, the behavior of _nosqlprotocol_ can be\
+Using the following parameters, the behavior of _nosqlprotocol_ can be
 adjusted. As they are not generic listener parameters, but specific to _nosqlprotocol_ they must be qualified with the `nosqlprotocol`-prefix.
 
 For instance:
@@ -507,7 +507,7 @@ nosqlprotocol.on_unknown_command=return_error
 * Mandatory: No
 * Default: `""`
 
-Specifies the _user_ to be used when connecting to the backend, if the MongoDB®\
+Specifies the _user_ to be used when connecting to the backend, if the MongoDB®
 client is not authenticated.
 
 ### `password`
@@ -516,8 +516,8 @@ client is not authenticated.
 * Mandatory: No
 * Default: `""`
 
-Specifies the _password_ to be used when connecting to the backend, is the MongoDB®\
-client is not authenticated. Note that the same _user_/_password_ combination will be\
+Specifies the _password_ to be used when connecting to the backend, is the MongoDB®
+client is not authenticated. Note that the same _user_/_password_ combination will be
 used for all unauthenticated MongoDB® clients connecting to the same listener port.
 
 ### `authentication_required`
@@ -526,11 +526,11 @@ used for all unauthenticated MongoDB® clients connecting to the same listener p
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the client always must authenticate. If authentication is required,\
-it does not matter whether `user` and `password` have been specified, the client must\
+Specifies whether the client always must authenticate. If authentication is required,
+it does not matter whether `user` and `password` have been specified, the client must
 authenticate.
 
-Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsAddUser),\
+Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsAddUser),
 with authentication being optional and authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -542,9 +542,9 @@ MariaDB server.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether nosqlprotocol itself should perform authorization in the context\
-of the commands [mxsAddUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users\
-have been created with [createUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsAddUser)\
+Specifies whether nosqlprotocol itself should perform authorization in the context
+of the commands [mxsAddUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users
+have been created with [createUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#mxsAddUser)
 with authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -557,8 +557,8 @@ MariaDB server.
 * Default: `"%"`
 
 Specifies the _host_ to be used when a MariaDB user is created via nosqlprotocol.\
-By default all users are created as `...@'%'`, which means that it is possible to\
-connect to the MariaDB server from any host using the credentials of the created\
+By default all users are created as `...@'%'`, which means that it is possible to
+connect to the MariaDB server from any host using the credentials of the created
 user. For tighter security, the IP-address of the MaxScale host can be specified.
 
 NOTE: This value does **not** specify from which host it is allowed to connect to\
@@ -584,8 +584,8 @@ Enumeration values:
 * Mandatory: No
 * Default: `false`
 
-Specifies whether an unknown command should be logged. This is primarily\
-for debugging purposes, to find out whether a client uses a command that\
+Specifies whether an unknown command should be logged. This is primarily
+for debugging purposes, to find out whether a client uses a command that
 currently is not supported.
 
 ### `auto_create_databases`
@@ -607,7 +607,7 @@ Note that setting this parameter to `true`, without also setting`auto_create_tab
 Specifies whether tables should automatically be created, as needed.
 
 Note that this applies only if the relevant database already exists.\
-If a database should also be created if needed, then `auto_create_databases`\
+If a database should also be created if needed, then `auto_create_databases`
 must also be set to `true`.
 
 ### `id_length`
@@ -628,16 +628,16 @@ Specifies the length of the id column in tables that are automatically created.
 
 Enumeration values:
 
-* `default`: Each document is inserted using a separate `INSERT`, either in a\
-  multi-statement or in a compound statement. Whether an error causes the remaining\
-  insertions to be aborted, depends on the value of `ordered` specified in the\
+* `default`: Each document is inserted using a separate `INSERT`, either in a
+  multi-statement or in a compound statement. Whether an error causes the remaining
+  insertions to be aborted, depends on the value of `ordered` specified in the
   insert command.
-* `atomic`: If the value of `ordered` in the insert command is `true`\
-  (the default) then all documents are inserted using a single `INSERT` statement,\
-  that is, either all insertions succeed or none will. If `ordered` is false, then\
+* `atomic`: If the value of `ordered` in the insert command is `true`
+  (the default) then all documents are inserted using a single `INSERT` statement,
+  that is, either all insertions succeed or none will. If `ordered` is false, then
   the behavior is as in the `default` case.
 
-What combination of `ordered_insert_behavior` and `ordered` (in the insert command\
+What combination of `ordered_insert_behavior` and `ordered` (in the insert command
 document) is used, has an impact on the performance. Please see the discussion at [insert](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#insert).
 
 ### `cursor_timeout`
@@ -646,7 +646,7 @@ document) is used, has an impact on the performance. Please see the discussion a
 * Mandatory: No
 * Default: `60s`
 
-Specifies how long a cursor can be idle, that is, not accessed, before it is\
+Specifies how long a cursor can be idle, that is, not accessed, before it is
 automatically closed.
 
 ### `debug`
@@ -671,21 +671,21 @@ So, specify
 nosqlprotocol.debug=in,out,back
 ```
 
-to have the incoming command, the corresponding SQL sent to the backend\
+to have the incoming command, the corresponding SQL sent to the backend
 and the resulting response sent to the client logged.
 
 ## Databases and Tables
 
 By default, _nosqlprotocol_ automatically creates databases as needed.\
-The default behavior can be changed by setting `auto_create_databases` to\
+The default behavior can be changed by setting `auto_create_databases` to
 false. In that case, databases must manually be created.
 
 Each MongoDB® _collection_ corresponds to a MariaDB table with the same name.\
-However, it is always possible to access a collection irrespective of whether\
+However, it is always possible to access a collection irrespective of whether
 the corresponding table exists or not; it will simply appear to be empty.
 
-Inserting documents into a collection, whose corresponding table does not\
-exist, succeeds, provided `auto_create_tables` is `true`, as the table will\
+Inserting documents into a collection, whose corresponding table does not
+exist, succeeds, provided `auto_create_tables` is `true`, as the table will
 in that case be created.
 
 When _nosqlprotocol_ creates a table, it uses a statement like
@@ -696,19 +696,19 @@ CREATE TABLE name (id VARCHAR(35) AS (JSON_COMPACT(JSON_EXTRACT(doc, "$._id"))) 
                    CONSTRAINT id_not_null CHECK(id IS NOT NULL));
 ```
 
-where the length of the `VARCHAR` is specified by the value of `id_length`,\
+where the length of the `VARCHAR` is specified by the value of `id_length`,
 whose default and minimum is 35.
 
-_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain\
+_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain
 a similar constraint.
 
-Note that _nosqlprotocol_ does not in any way verify that the table\
-corresponding to a collection being accessed or modified does indeed\
-have the expected columns `id` and `doc` of the expected types, but it\
-simply uses the table, which will fail if the layout is not the expected\
+Note that _nosqlprotocol_ does not in any way verify that the table
+corresponding to a collection being accessed or modified does indeed
+have the expected columns `id` and `doc` of the expected types, but it
+simply uses the table, which will fail if the layout is not the expected
 one.
 
-To reduce the risk for confusion, the recommendation is to use a specific\
+To reduce the risk for confusion, the recommendation is to use a specific
 database for tables that contain documents.
 
 ## Operators
@@ -744,7 +744,7 @@ The following operators are currently supported.
 
 **`$type`**
 
-When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset\
+When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset
 of types can be used in `$type` queries:
 
 | Type           | Number | Alias    | MariaDB Type |
@@ -791,10 +791,10 @@ As arguments, only the operators `$eq` and `$ne` are supported.
 
 ## Database Commands
 
-The following commands are supported. At each command is specified\
+The following commands are supported. At each command is specified
 what fields are relevant for the command.
 
-**All** non-listed fields are ignored; their presence or absence have no\
+**All** non-listed fields are ignored; their presence or absence have no
 impact, unless otherwise explicitly specified.
 
 ### Aggregation Commands
@@ -865,7 +865,7 @@ The `projection` parameter takes a document of the following form:
 { <field1>: <value>, <field2>: <value> ... }
 ```
 
-If a `projection` document is not provided or if it is empty, the entire document\
+If a `projection` document is not provided or if it is empty, the entire document
 will be returned.
 
 | Projection     | Description                         |
@@ -879,23 +879,23 @@ For fields in an embedded documents, the field can be specified using:
 
 * dot notation; e.g. `"field.nestedfield": <value>`
 
-In particular, specifying fields in embedded documents using nested form\
+In particular, specifying fields in embedded documents using nested form
 is not supported.
 
 **`_id` Field Projection**
 
-The `_id` field is included in the returned documents by default unless you\
+The `_id` field is included in the returned documents by default unless you
 explicitly specify `_id: 0` in the projection to suppress the field.
 
 **Inclusion or Exclusion**
 
-A `projection` cannot contain both include and exclude specifications,\
+A `projection` cannot contain both include and exclude specifications,
 with the exception of the `_id` field:
 
 * In projections that explicitly include fields, the `_id` field is the only field that can be explicitly excluded.
 * In projections that explicitly excludes fields, the `_id` field is the only field that can be explicitly include; however, the `_id` field is included by default.
 
-_NOTE_ Currently `_id` is the only field that can be excluded, and _only_\
+_NOTE_ Currently `_id` is the only field that can be excluded, and _only_
 if other fields are explicitly included._NOTE_ Currently exclusion of other fields but `_id` is not supported.
 
 **Filtering by `_id`**
@@ -924,7 +924,7 @@ and in the latter
 ... WHERE (JSON_EXTRACT(doc, '$._id') = 4711)
 ```
 
-That is, in the former case the _indexed_ column `id` will be used, in the\
+That is, in the former case the _indexed_ column `id` will be used, in the
 latter it will not.
 
 #### findAndModify
@@ -964,9 +964,9 @@ The following fields are relevant.
 
 #### insert
 
-The `insert` command inserts one or more documents into the table whose\
-name is the same as that of the collection. If the option `auto_create_tables`\
-is `true`, then the table is created if it does not already exist. If the\
+The `insert` command inserts one or more documents into the table whose
+name is the same as that of the collection. If the option `auto_create_tables`
+is `true`, then the table is created if it does not already exist. If the
 value is `false`, then the insert will fail unless the table already exists.
 
 The following fields are relevant.
@@ -983,9 +983,9 @@ The impact of `ordered` is dependent upon the value of `ordered_insert_behavior`
 
 **`default`**
 
-In this case `ordered` has the same impact as in MongoDB®. That is, if the value\
-is `true`, then when an insert of a document fails, return without inserting any\
-remaining documents listed in the inserts array. If `false`, then when an insert\
+In this case `ordered` has the same impact as in MongoDB®. That is, if the value
+is `true`, then when an insert of a document fails, return without inserting any
+remaining documents listed in the inserts array. If `false`, then when an insert
 of a document fails, continue to insert the remaining documents.
 
 **`atomic`**
@@ -997,7 +997,7 @@ then the behavior is identical with that of `default`.
 
 **Performance**
 
-What combination of `ordered_insert_behavior` and `ordered` is used, has an\
+What combination of `ordered_insert_behavior` and `ordered` is used, has an
 impact on the performance.
 
 | ordered\_insert\_behavior | ordered = true                                                                                                                        | ordered = false                                                                                                                        |
@@ -1005,8 +1005,8 @@ impact on the performance.
 | default                   | All documents are inserted within a compound statement, in a transaction containing as many INSERT statements as there are documents. | All documents are inserted in a single multi-statement transaction containing as many INSERT IGNORE statements as there are documents. |
 | atomic                    | All documents are inserted using a single INSERT statement.                                                                           | Same as above                                                                                                                          |
 
-Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,\
-being roughly twice as slow. The performance of 'default + true' is halfway between\
+Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,
+being roughly twice as slow. The performance of 'default + true' is halfway between
 the two.
 
 #### resetError
@@ -1039,10 +1039,10 @@ Each document contains the following fields:
 | u     | document | The modifications to apply. See behavior below for details.                                                                                                        |
 | multi | boolean  | Optional. If true, updates all documents that meet the query criteria. If false limit the update to one document that meets the query criteria. Defaults to false. |
 
-Note that currently it is possible to set `multi` to `true` in conjunction\
+Note that currently it is possible to set `multi` to `true` in conjunction
 with a _replacement-style_ update, even though MongoDB® rejects that.
 
-All other fields are ignored, with the exception of `upsert` that if present\
+All other fields are ignored, with the exception of `upsert` that if present
 with the value of `true` will cause the command to fail.
 
 **Behavior**
@@ -1068,7 +1068,7 @@ In this case, the update command updates only the corresponding fields in the do
 
 **Update with a Replacement Document**
 
-The update statement field `u` field can accept a _replacement document_,\
+The update statement field `u` field can accept a _replacement document_,
 i.e. the document contains only `field:value` expressions. For example:
 
 ```
@@ -1083,12 +1083,12 @@ updates: [
 ```
 
 In this case, the update command replaces the matching document with the update document.\
-The update command can only replace a single matching document; i.e. the multi field\
+The update command can only replace a single matching document; i.e. the multi field
 cannot be true.
 
-**Note** If the replacement document contains an `_id` field, it will be ignored and the\
-document id will remain non-changed while the document otherwise is replaced. This is\
-different from MongoDB® where the presence of the `_id` field in the replacement document\
+**Note** If the replacement document contains an `_id` field, it will be ignored and the
+document id will remain non-changed while the document otherwise is replaced. This is
+different from MongoDB® where the presence of the `_id` field in the replacement document
 causes an error, if the value is not the same as it is in the document being replaced.
 
 ### Authentication Commands
@@ -1103,7 +1103,7 @@ The following fields are relevant.
 
 If you are not logged in and using authentication, `logout` has no effect.
 
-Note that in order to be logged out, the logging out must be done while\
+Note that in order to be logged out, the logging out must be done while
 using the same database that was used when you logged on.
 
 Always returns
@@ -1116,7 +1116,7 @@ Always returns
 
 #### createUser
 
-Creates a new MariaDB user and adds an entry to the local nosqlprotocol\
+Creates a new MariaDB user and adds an entry to the local nosqlprotocol
 account database.
 
 The following fields are relevant.
@@ -1130,8 +1130,8 @@ The following fields are relevant.
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is\
-the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the\
+The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is
+the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the
 following command
 
 ```
@@ -1141,19 +1141,19 @@ following command
 
 the MariaDB user `'myDatabase.user1'@'%'` will be created.
 
-The elements of the `roles` array are converted into privileges\
+The elements of the `roles` array are converted into privileges
 as explained in [here](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#roles_and_privileges).
 
 In practice the creation is performed as follows:_First the MariaDB user is created._ Then the privileges are granted.
 
 * Finally the local nosqlprotocol account database is updated.
 
-If the granting of privileges fails, an attempt will be made to\
+If the granting of privileges fails, an attempt will be made to
 drop the user.
 
 #### dropAllUsersFromDatabase
 
-Drops all users from the local nosqlprotocol account database and\
+Drops all users from the local nosqlprotocol account database and
 the corresponding MariaDB users.
 
 The following fields are relevant.
@@ -1175,13 +1175,13 @@ The following fields are relevant.
 | -------- | ------ | ----------------------------------- |
 | dropUser | string | The name of the user to be dropped. |
 
-The user will first be dropped from the MariaDB server and if\
+The user will first be dropped from the MariaDB server and if
 that succeeds also from the local nosqlprotocol account database.
 
 #### grantRolesToUser
 
-This command _adds_ more roles to a NoSQL user, which may imply\
-that additional privileges are granted to the corresponding MariaDB\
+This command _adds_ more roles to a NoSQL user, which may imply
+that additional privileges are granted to the corresponding MariaDB
 user.
 
 | Field            | Type   | Description                                    |
@@ -1190,12 +1190,12 @@ user.
 | roles            | array  | An array of additional roles.                  |
 
 Note that roles assigned to different databases will result in separate\
-GRANT statements, which means that it is possible that some succeed and\
+GRANT statements, which means that it is possible that some succeed and
 others do not.
 
 #### revokeRolesFromUser
 
-This command \_removes roles from an NoSQL user, which may imply\
+This command \_removes roles from an NoSQL user, which may imply
 that privileges are revoked from the corresponding MariaDB user.
 
 | Field               | Type   | Description                                |
@@ -1203,8 +1203,8 @@ that privileges are revoked from the corresponding MariaDB user.
 | revokeRolesFromUser | string | The name of the user to remove roles from. |
 | roles               | array  | An array of roles to remove.               |
 
-Note that roles to be removed from different databases will result in\
-separate REVOKE statements, which means that it is possible that some\
+Note that roles to be removed from different databases will result in
+separate REVOKE statements, which means that it is possible that some
 succeed and others do not.
 
 #### updateUser
@@ -1219,8 +1219,8 @@ This command updates the information about a particular user.
 | roles      | array    | Optional. The roles granted to the user. Note that the existing ones are replaced and not amended with these roles.                                                                                                                                                |
 | mechanisms | array    | Optional. The specific SCRAM mechanisms for user credentials. Note that if a new pwd is provided, then the array can contain all supported SCRAM mechanisms. If a new pwd is not provided, then the array must be a subset of the existing mechanisms of the user. |
 
-Changes to `customData` or `mechanisism` are made only to the local\
-nosqlprotocol database, but changes to `pwd` or `roles` require\
+Changes to `customData` or `mechanisism` are made only to the local
+nosqlprotocol database, but changes to `pwd` or `roles` require
 the MariaDB server to be updated.
 
 ### Replication Commands
@@ -1282,8 +1282,8 @@ The following fields are relevant.
 | capped | boolean | Optional. If specified, the value must be false as capped collections are not supported. |
 | viewOn | string  | Optional. If specified, the command will fail as views are not supported.                |
 
-Currently, _capped collections_ and _views_ are not supported. Consequently,\
-specifying that the collection should be capped or that it should be a\
+Currently, _capped collections_ and _views_ are not supported. Consequently,
+specifying that the collection should be capped or that it should be a
 view on another collection, will cause the command to fail.
 
 #### createIndexes
@@ -1294,9 +1294,9 @@ The following fields are relevant.
 | ------------- | ------ | ------------------------------------------- |
 | createIndexes | string | The collection for which to create indexes. |
 
-**NOTE** Currently it is not possible to create indexes, but the command\
-will nonetheless return success, provide the index specification passes\
-some rudimentary sanity checks. Note also that the collection will be\
+**NOTE** Currently it is not possible to create indexes, but the command
+will nonetheless return success, provide the index specification passes
+some rudimentary sanity checks. Note also that the collection will be
 created if it does not exist.
 
 #### drop
@@ -1323,9 +1323,9 @@ The following fields are relevant.
 | ----------- | ---- | ----------- |
 | dropIndexes | any  | Ignored.    |
 
-**NOTE** Currently it is not possible to create indexes and thus there\
-will never be any indexes that could be dropped. However, provided the\
-specified collection exists, dropping indexes will always succeed except\
+**NOTE** Currently it is not possible to create indexes and thus there
+will never be any indexes that could be dropped. However, provided the
+specified collection exists, dropping indexes will always succeed except
 for an attempt to drop the built-in `_id_` index.
 
 #### fsync
@@ -1366,8 +1366,8 @@ The following fields are relevant.
 | filter          | document | The field name is honored, other fields are not but cause warnings to be logged.                                                                 |
 | nameOnly        | boolean  | Optional. A flag to indicate whether the command should return just the collection names and type or return both the name and other information. |
 
-Note that the command lists all collections (that is, tables) that are found\
-in the current database. The listed collections may or may not be suitable\
+Note that the command lists all collections (that is, tables) that are found
+in the current database. The listed collections may or may not be suitable
 for being accessed using _nosqlprotocol_.
 
 #### listDatabases
@@ -1387,9 +1387,9 @@ The following fields are relevant.
 | ----------- | ------ | --------------------------- |
 | listIndexes | string | The name of the collection. |
 
-**NOTE** As it currently is not possible to actually create indexes,\
-although an attempt to do so using `createIndexes` will succeed, the\
-result will always only contain information about the built-in\
+**NOTE** As it currently is not possible to actually create indexes,
+although an attempt to do so using `createIndexes` will succeed, the
+result will always only contain information about the built-in
 index `_id_`.
 
 #### renameCollection
@@ -1497,8 +1497,8 @@ The following fields are relevant.
 | -------- | ------ | --------------------------------------- |
 | validate | string | The name of the collection to validate. |
 
-The command does not actually perform any validation but for checking\
-that the collection exists. The response will contain in `nrecords`\
+The command does not actually perform any validation but for checking
+that the collection exists. The response will contain in `nrecords`
 the current number of documents/rows it contains.
 
 #### whatsmyuri
@@ -1535,11 +1535,11 @@ The following document will always be returned:
 
 **mxsAddUser**
 
-The `mxsAddUser` command adds an _existing_ MariaDB user to the local\
+The `mxsAddUser` command adds an _existing_ MariaDB user to the local
 nosqlprotocol account database. Use [createUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#createUser) if the\
 MariaDB user should be created as well.
 
-Note that the `mxsAddUser` command does not check that the user exists\
+Note that the `mxsAddUser` command does not check that the user exists
 or that the specified roles are compatible with the grants of the user.
 
 **Syntax**
@@ -1575,17 +1575,17 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The value of `mxsAddUser` should be the name (without the host part) of\
-an existing user in the MariaDB server and the value of `pwd` should be\
+The value of `mxsAddUser` should be the name (without the host part) of
+an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the addition of the user succeeds, the command returns a document\
+If the addition of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -1611,7 +1611,7 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsCreateDatabase**
 
-The 'mxsCreateDatabase' command creates a new database and must be run\
+The 'mxsCreateDatabase' command creates a new database and must be run
 against the `admin` database.
 
 **Syntax**
@@ -1636,7 +1636,7 @@ The command takes the following fields:
 
 **Returns**
 
-If database creation succeeds, the command returns a document with the\
+If database creation succeeds, the command returns a document with the
 single field `ok` whose value is `1`.
 
 ```
@@ -1687,7 +1687,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains diagnostics of the command\
+The command returns a document that contains diagnostics of the command
 provided as argument. For example:
 
 ```
@@ -1712,19 +1712,19 @@ provided as argument. For example:
 }
 ```
 
-`kind` specifies of what kind the command is; an _immediate_ command is one for\
-which MaxScale autonomously can generate the response, a _single_ command is one\
-where the command will cause a single SQL statement to be sent to the backend, and\
-a _multi_ command is one where potentially multiple SQL statements will be sent to\
+`kind` specifies of what kind the command is; an _immediate_ command is one for
+which MaxScale autonomously can generate the response, a _single_ command is one
+where the command will cause a single SQL statement to be sent to the backend, and
+a _multi_ command is one where potentially multiple SQL statements will be sent to
 the backend.
 
-If the command is _immediate_ then there will be a field `response` containing\
-the actual response of the command, if the command is _single_ then there will be\
-a field `sql` containing the actual statement that would have been sent to the backend,\
-and if the command is _multi_ then there will be a field `sql` containing an array\
+If the command is _immediate_ then there will be a field `response` containing
+the actual response of the command, if the command is _single_ then there will be
+a field `sql` containing the actual statement that would have been sent to the backend,
+and if the command is _multi_ then there will be a field `sql` containing an array
 of statements that would have been sent to the backend.
 
-If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that\
+If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that
 the value of `ok` will always be 1.
 
 #### mxsGetConfig
@@ -1733,7 +1733,7 @@ the value of `ok` will always be 1.
 
 **mxsGetConfig**
 
-The `mxsGetConfig` command returns the current configuration of the session\
+The `mxsGetConfig` command returns the current configuration of the session
 and must be run against the 'admin' database.
 
 **Syntax**
@@ -1757,7 +1757,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the current configuration of\
+The command returns a document that contains the current configuration of
 the session. For example:
 
 ```
@@ -1779,8 +1779,8 @@ the session. For example:
 
 **mxsRemoveUser**
 
-The `mxsRemoveUser` removes a user from the local nosqlprotocol account\
-database. Use [dropUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped\
+The `mxsRemoveUser` removes a user from the local nosqlprotocol account
+database. Use [dropUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped
 as well.
 
 **Syntax**
@@ -1805,7 +1805,7 @@ The command has the following fields:
 
 **Returns**
 
-If the removal of the user succeeds, the command returns a document\
+If the removal of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -1831,10 +1831,10 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsSetConfig**
 
-The `mxsSetConfig` command changes the configuration of the session\
+The `mxsSetConfig` command changes the configuration of the session
 and must be run against the 'admin' database.
 
-Note that the changes only affect the current session and are **not**\
+Note that the changes only affect the current session and are **not**
 persisted.
 
 **Syntax**
@@ -1866,7 +1866,7 @@ The document takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the changed configuration of\
+The command returns a document that contains the changed configuration of
 the session. For example:
 
 ```
@@ -1898,12 +1898,12 @@ the session. For example:
 
 **mxsUpdateUser**
 
-The `mxsUpdateUser` command updates a user in the local nosqlprotocol\
-account database. Use [updateUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#updateUser) to update MariaDB user\
+The `mxsUpdateUser` command updates a user in the local nosqlprotocol
+account database. Use [updateUser](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#updateUser) to update MariaDB user
 as well.
 
-Note that the `mxsUpdateUser` command does not check that the changed\
-data is compatible e.g. with the grants of the corresponding MariaDB\
+Note that the `mxsUpdateUser` command does not check that the changed
+data is compatible e.g. with the grants of the corresponding MariaDB
 user.
 
 **Syntax**
@@ -1939,13 +1939,13 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. If a new password is not provided, the specified mechanisms must be a subset of the current mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2106-maxscale-2106-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the updating of the user succeeds, the command returns a document\
+If the updating of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -1967,27 +1967,27 @@ If there is a failure of some kind, the command returns an error document
 
 ## Object Id
 
-When a document is created, an id of type `ObjectId` will be autogenerated by\
-the MongoDB® client library. If the id is provided explicitly, by assigning a\
-value to the `_id` field, the value must be an `ObjectId`, a string or an\
+When a document is created, an id of type `ObjectId` will be autogenerated by
+the MongoDB® client library. If the id is provided explicitly, by assigning a
+value to the `_id` field, the value must be an `ObjectId`, a string or an
 integer.
 
 ## Compatibility
 
-Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)\
+Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)
 test-suite pass.
 
 ## Example
 
-The following is a minimal setup for getting _nosqlprotocol_ up and\
-running. It is assumed the reader knows how to configure MaxScale for\
+The following is a minimal setup for getting _nosqlprotocol_ up and
+running. It is assumed the reader knows how to configure MaxScale for
 normal use. If not, please start with the [MaxScale tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-setting-up-mariadb-maxscale.md).\
-Note that as _nosqlprotocol_ is the first component in the MaxScale\
+Note that as _nosqlprotocol_ is the first component in the MaxScale
 routing chain, it can be used with all routers and filters.
 
 ### Configuring MaxScale
 
-In the following it is assumed that MaxScale already has been configured\
+In the following it is assumed that MaxScale already has been configured
 for normal use and that there exists a _service_ `[TheService]`.
 
 ```
@@ -2004,10 +2004,10 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-The values `the_user` and `the_password` must be replaced with the\
+The values `the_user` and `the_password` must be replaced with the
 actual credentials to be used for every MongoDB® client that connects.
 
-If MaxScale is now started, the following entry should appear in the\
+If MaxScale is now started, the following entry should appear in the
 log file.
 
 ```
@@ -2018,8 +2018,8 @@ log file.
 
 The mongo Shell is a powerful tool with which to access and manipulate a\
 MongoDB database. It is part of the MongoDB® package. Having the native\
-MongoDB database installed is convenient, as it makes it easy to ascertain\
-whether a problem is due to _nosqlprotocol_ not fully implementing something\
+MongoDB database installed is convenient, as it makes it easy to ascertain
+whether a problem is due to _nosqlprotocol_ not fully implementing something
 or due to the API not being used in the correct fashion.
 
 With the _mongo shell_, all that is needed is to invoke it with the port\_nosqlprotocol\_ is listening on:
@@ -2036,7 +2036,7 @@ MongoDB server version: 4.4.1
 >
 ```
 
-If the shell prompt appears, then a connection was successfully\
+If the shell prompt appears, then a connection was successfully
 established and the shell can be used.
 
 ```
@@ -2044,13 +2044,13 @@ established and the shell can be used.
 { "n" : 1, "ok" : 1 }
 ```
 
-The `db` variable is implicitly available, and refers by default to\
+The `db` variable is implicitly available, and refers by default to
 the `test` database.
 
 The command inserted a document into the collection called `collection`.\
-The table corresponding to that collection is created implicitly because\
-the default value of `auto_create_tables` is `true`. Here, the object id\
-is specified explicitly, but there is no need for that, as one will be\
+The table corresponding to that collection is created implicitly because
+the default value of `auto_create_tables` is `true`. Here, the object id
+is specified explicitly, but there is no need for that, as one will be
 created if needed.
 
 To check whether the documents was inserted into the collection, the`find` command can be issued:
@@ -2085,18 +2085,18 @@ MariaDB [(none)]> select * from test.collection;
 +------+------------------------------------+
 ```
 
-The collection `collection` is represented by a table `collection` with\
-the two columns `id` and `doc`. `id` is a virtual column whose content is\
+The collection `collection` is represented by a table `collection` with
+the two columns `id` and `doc`. `id` is a virtual column whose content is
 the value of the `_id` field of the document in the `doc` column.
 
-All MongoDB® commands that _mongdbprotocol_ support (but for the ones that\
-do not require database access), basically access or manipulate the\
+All MongoDB® commands that _mongdbprotocol_ support (but for the ones that
+do not require database access), basically access or manipulate the
 content in the `doc` column using the [JSON functions](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements-and-structure/sql-statements/built-in-functions/special-functions/json-functions) of MariaDB.
 
-From within the mongo shell itself it is easy to find out just what SQL\
+From within the mongo shell itself it is easy to find out just what SQL
 a particular MongoDB command is translated into.
 
-For instance, the SQL that the insert command with which the document was\
+For instance, the SQL that the insert command with which the document was
 added can be found out like:
 
 ```
@@ -2121,18 +2121,18 @@ Similarly, the SQL of the `find` command can be find out like:
 }
 ```
 
-The returned SQL can be directly pasted at the `mysql` prompt, which is\
+The returned SQL can be directly pasted at the `mysql` prompt, which is
 quite convenient in case the MongoDB® command does not behave as expected.
 
 ### MongoDB® Node.JS Driver
 
-As all client libraries implement and depend on the MongoDB® wire protocol,\
-all client libraries should work with _nosqlprotocol_. However, the\
-only client library that has been used and that has been verified to work\
+As all client libraries implement and depend on the MongoDB® wire protocol,
+all client libraries should work with _nosqlprotocol_. However, the
+only client library that has been used and that has been verified to work
 is version 3.6 of the _MongoDB Node.JS Driver_.
 
-In principle, the only thing that needs to be altered in an existing\
-program using the library is to change the uri string that typically\
+In principle, the only thing that needs to be altered in an existing
+program using the library is to change the uri string that typically
 is something like
 
 ```
@@ -2147,8 +2147,8 @@ const uri = "mongodb://<maxscale-ip>:17017";
 
 with the assumption that the default _nosqlprotocol_ port is used.
 
-In practice, additional modifications may be needed since _nosqlprotocol_\
-does not implement all commands and does not in all cases implement the\
+In practice, additional modifications may be needed since _nosqlprotocol_
+does not implement all commands and does not in all cases implement the
 full functionality of the commands that it supports.
 
 #### Inserting a Document

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-maxctrl.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-maxctrl.md
@@ -1,13 +1,13 @@
 # MaxScale 21.06 MaxCtrl
 
-MaxCtrl is a command line administrative client for MaxScale which uses\
-the MaxScale REST API for communication. It has replaced the legacy MaxAdmin\
+MaxCtrl is a command line administrative client for MaxScale which uses
+the MaxScale REST API for communication. It has replaced the legacy MaxAdmin
 command line client that is no longer supported or included.
 
-By default, the MaxScale REST API listens on port 8989 on the local host. The\
+By default, the MaxScale REST API listens on port 8989 on the local host. The
 default credentials for the REST API are `admin:mariadb`. The users used by the\
-REST API are the same that are used by the MaxAdmin network interface. This\
-means that any users created for the MaxAdmin network interface should work with\
+REST API are the same that are used by the MaxAdmin network interface. This
+means that any users created for the MaxAdmin network interface should work with
 the MaxScale REST API and MaxCtrl.
 
 For more information about the MaxScale REST API, refer to the [REST API documentation](../mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-rest-api.md) and the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
@@ -18,10 +18,10 @@ For more information about the MaxScale REST API, refer to the [REST API documen
 
 ## .maxctrl.cnf
 
-If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the\
-section `[maxctrl]` as defaults for command line arguments. For instance,\
-to avoid having to specify the user and password on the command line,\
-create the file `.maxctrl.cnf` in your home directory, with the following\
+If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the
+section `[maxctrl]` as defaults for command line arguments. For instance,
+to avoid having to specify the user and password on the command line,
+create the file `.maxctrl.cnf` in your home directory, with the following
 content:
 
 ```
@@ -30,11 +30,11 @@ u = my-name
 p = my-password
 ```
 
-Note that all access rights to the file must be removed from everybody else\
-but the owner. MaxCtrl refuses to use the file unless the rights have been\
+Note that all access rights to the file must be removed from everybody else
+but the owner. MaxCtrl refuses to use the file unless the rights have been
 removed.
 
-Another file from which to read the defaults can be specified with the `-c`\
+Another file from which to read the defaults can be specified with the `-c`
 flag.
 
 ## Commands

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md
@@ -1,16 +1,16 @@
 # MaxScale 21.06 Module commands
 
-Introduced in MaxScale 2.1, the module commands are special, module-specific\
+Introduced in MaxScale 2.1, the module commands are special, module-specific
 commands. They allow the modules to expand beyond the capabilities of the module\
 API. Currently, only MaxCtrl implements an interface to the module commands.
 
-All registered module commands can be shown with `maxctrl list commands` and\
+All registered module commands can be shown with `maxctrl list commands` and
 they can be executed with `maxctrl call command <module> <name> ARGS...` whereis the name of the module and is the name of the command._ARGS_ is a command specific list of arguments.
 
 ### Developer reference
 
-The module command API is defined in the _modulecmd.h_ header. It consists of\
-various functions to register and call module commands. Read the function\
+The module command API is defined in the _modulecmd.h_ header. It consists of
+various functions to register and call module commands. Read the function
 documentation in the header for more details.
 
 The following example registers the module command _my\_command_ for module _my\_module_.
@@ -50,11 +50,11 @@ int main(int argc, char **argv)
 }
 ```
 
-The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of\
-arguments the command expects. The first argument is a boolean and the second\
+The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of
+arguments the command expects. The first argument is a boolean and the second
 argument is an optional string.
 
-Arguments are passed to the parsing function as an array of void pointers. They\
+Arguments are passed to the parsing function as an array of void pointers. They
 are interpreted as the types the command expects.
 
 When the module command is executed, the _argv_ parameter for the _my\_simple\_cmd_ contains the parsed arguments received from the caller of the

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-admin-user-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-admin-user-resource.md
@@ -11,7 +11,7 @@ MaxScale's configuration.
 GET /v1/users/inet/:name
 ```
 
-Get a single network user. The _:name_ in the URI must be a valid network\
+Get a single network user. The _:name_ in the URI must be a valid network
 user name.
 
 **Response**
@@ -122,7 +122,7 @@ Get all administrative users.
 POST /v1/users/inet
 ```
 
-Create a new network user. The request body must define at least the\
+Create a new network user. The request body must define at least the
 following fields.
 
 * `data.id`
@@ -134,11 +134,11 @@ following fields.
 * `data.attributes.account`
 * Set to `admin` for administrative users and `basic` to read-only users
 
-Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic\
-account performs one of the aforementioned request, the REST API will respond\
+Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic
+account performs one of the aforementioned request, the REST API will respond
 with a `401 Unauthorized` error.
 
-Here is an example request body defining the network user _my-user_ with the\
+Here is an example request body defining the network user _my-user_ with the
 password _my-password_ that is allowed to execute only read-only operations.
 
 ```
@@ -166,7 +166,7 @@ Status: 204 No Content
 POST /v1/users/unix
 ```
 
-This enables an existing UNIX account on the system for administrative\
+This enables an existing UNIX account on the system for administrative
 operations. The request body must define at least the following fields.
 
 * `data.id`
@@ -230,8 +230,8 @@ Status: 204 No Content
 PATCH /v1/users/inet/:name
 ```
 
-Update network user. Currently, only the password can be updated. This\
-means that the request body must define the `data.attributes.password`\
+Update network user. Currently, only the password can be updated. This
+means that the request body must define the `data.attributes.password`
 field.
 
 Here is an example request body that updates the password.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-filter-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-filter-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 21.06 Filter Resource
 
-A filter resource represents an instance of a filter inside MaxScale. Multiple\
+A filter resource represents an instance of a filter inside MaxScale. Multiple
 services can use the same filter and a single service can use multiple filters.
 
 ### Resource Operations
@@ -178,7 +178,7 @@ GET /v1/filters
 POST /v1/filters
 ```
 
-Create a new filter. The posted object must define at\
+Create a new filter. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -190,8 +190,8 @@ least the following fields.
 
 All of the filter parameters should be defined at creation time in the`data.attributes.parameters` object.
 
-As the service to filter relationship is ordered (filters are applied in the\
-order they are listed), filter to service relationships cannot be defined at\
+As the service to filter relationship is ordered (filters are applied in the
+order they are listed), filter to service relationships cannot be defined at
 creation time.
 
 The following example defines a request body which creates a new filter.
@@ -223,8 +223,8 @@ Filter is created:
 PATCH /v1/filters/:name
 ```
 
-Filter parameters can be updated at runtime if the module supports it. Refer to\
-the individual module documentation for more details on whether it supports\
+Filter parameters can be updated at runtime if the module supports it. Refer to
+the individual module documentation for more details on whether it supports
 runtime configuration and which parameters can be updated.
 
 The following example modifies a filter by changing the `match` parameter to`.*users.*`.
@@ -256,10 +256,10 @@ DELETE /v1/filters/:filter
 The _:filter_ in the URI must map to the name of the filter to be destroyed.
 
 A filter can only be destroyed if no service uses it. This means that the`data.relationships` object for the filter must be empty. Note that the service\
-→ filter relationship cannot be modified from the filters resource and must be\
+→ filter relationship cannot be modified from the filters resource and must be
 done via the services resource.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the filter by first removing it from all services that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-listener-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-listener-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 21.06 Listener Resource
 
-A listener resource represents a listener of a service in MaxScale. All\
+A listener resource represents a listener of a service in MaxScale. All
 listeners point to a service in MaxScale.
 
 ### Resource Operations
@@ -205,10 +205,10 @@ Creates a new listener. The request body must define the following fields.
 * `data.type`
 * Type of the object, must be `listeners`
 * `data.attributes.parameters.port` OR `data.attributes.parameters.socket`
-* The TCP port or UNIX Domain Socket the listener listens on. Only one of the\
+* The TCP port or UNIX Domain Socket the listener listens on. Only one of the
   fields can be defined.
 * `data.relationships.services.data`
-* The service relationships data, must define a JSON object with an `id` value\
+* The service relationships data, must define a JSON object with an `id` value
   that defines the service to use and a `type` value set to `services`.
 
 The following is the minimal required JSON object for defining a new listener.
@@ -234,7 +234,7 @@ The following is the minimal required JSON object for defining a new listener.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) for\
+Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) for
 a full list of listener parameters.
 
 **Response**
@@ -249,15 +249,15 @@ Listener is created:
 PATCH /v1/listeners/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the listener.
 
 All parameters marked as modifiable at runtime can be modified. Currently, all\
-TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters\
+TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters
 can be modified at runtime.
 
-Parameters that affect the network address or the port the listener listens on\
-cannot be modified at runtime. To modify these parameters, recreate the\
+Parameters that affect the network address or the port the listener listens on
+cannot be modified at runtime. To modify these parameters, recreate the
 listener.
 
 **Response**
@@ -272,7 +272,7 @@ Listener is modified:
 DELETE /v1/listeners/:name
 ```
 
-The _:name_ must be a valid listener name. When a listener is destroyed, the\
+The _:name_ must be a valid listener name. When a listener is destroyed, the
 network port it listens on is available for reuse.
 
 **Response**
@@ -291,7 +291,7 @@ Listener cannot be deleted:
 PUT /v1/listeners/:name/stop
 ```
 
-Stops a started listener. When a listener is stopped, new connections are no\
+Stops a started listener. When a listener is stopped, new connections are no
 longer accepted and are queued until the listener is started again.
 
 **Parameters**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-maxscale-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-maxscale-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 21.06 MaxScale Resource
 
-The MaxScale resource represents a MaxScale instance and it is the core on top\
+The MaxScale resource represents a MaxScale instance and it is the core on top
 of which the modules build upon.
 
 ### Resource Operations
@@ -11,7 +11,7 @@ of which the modules build upon.
 GET /v1/maxscale
 ```
 
-Retrieve global information about a MaxScale instance. This includes various\
+Retrieve global information about a MaxScale instance. This includes various
 file locations, configuration options and version information.
 
 **Response**
@@ -116,8 +116,8 @@ file locations, configuration options and version information.
 PATCH /v1/maxscale
 ```
 
-Update MaxScale parameters. The request body must define updated values for the`data.attributes.parameters` object. The parameters that can be modified are\
-listed in the `/v1/maxscale/modules/maxscale` endpoint and have the `modifiable`\
+Update MaxScale parameters. The request body must define updated values for the`data.attributes.parameters` object. The parameters that can be modified are
+listed in the `/v1/maxscale/modules/maxscale` endpoint and have the `modifiable`
 value set to `true`.
 
 **Response**
@@ -136,8 +136,8 @@ Invalid JSON body:
 GET /v1/maxscale/threads/:id
 ```
 
-Get the information and statistics of a particular thread. The _:id_ in\
-the URI must map to a valid thread number between 0 and the configured\
+Get the information and statistics of a particular thread. The _:id_ in
+the URI must map to a valid thread number between 0 and the configured
 value of `threads`.
 
 **Response**
@@ -486,15 +486,15 @@ Get the information for all threads. Returns a collection of threads resources.
 GET /v1/maxscale/logs
 ```
 
-Get information about the current state of logging, enabled log files and the\
+Get information about the current state of logging, enabled log files and the
 location where the log files are stored.
 
-**Note:** The parameters in this endpoint are a subset of the parameters in the`/v1/maxscale` endpoint. Because of this, the parameters in this endpoint are\
+**Note:** The parameters in this endpoint are a subset of the parameters in the`/v1/maxscale` endpoint. Because of this, the parameters in this endpoint are
 deprecated as of MaxScale 6.0.
 
-**Note:** In MaxScale 2.5 the `log_throttling` and `ms_timestamp` parameters\
-were incorrectly named as `throttling` and `highprecision`. In MaxScale 6,\
-the parameter names are now correct which means the parameters declared here\
+**Note:** In MaxScale 2.5 the `log_throttling` and `ms_timestamp` parameters
+were incorrectly named as `throttling` and `highprecision`. In MaxScale 6,
+the parameter names are now correct which means the parameters declared here
 aren't fully backwards compatible.
 
 **Response**
@@ -544,11 +544,11 @@ GET /v1/maxscale/logs/data
 
 Get the contents of the MaxScale logs. This endpoint was added in MaxScale 6.
 
-To navigate the log, use the `prev` link to move backwards to older log\
+To navigate the log, use the `prev` link to move backwards to older log
 entries. The latest log entries can be read with the `last` link.
 
-The entries are sorted in ascending order by the time they were logged. This\
-means that with the default parameters, the latest logged event is the last\
+The entries are sorted in ascending order by the time they were logged. This
+means that with the default parameters, the latest logged event is the last
 element in the returned array.
 
 **Parameters**
@@ -556,19 +556,19 @@ element in the returned array.
 This endpoint supports the following parameters:
 
 * `page[size]`
-* Set number of rows of data to read. By default, 50 rows of data are read\
+* Set number of rows of data to read. By default, 50 rows of data are read
   from the log.
 * `page[cursor]`
-* Set position from where the log data is retrieved. The default position to\
+* Set position from where the log data is retrieved. The default position to
   retrieve the log data is the end of the log.\
-  This value should not be modified by the user and the values returned in the`links` object should be used instead. This way the navigation will provide\
+  This value should not be modified by the user and the values returned in the`links` object should be used instead. This way the navigation will provide
   a consistent view of the log that does not overlap.\
-  Optionally, the `id` values in the returned data can be used as the values\
+  Optionally, the `id` values in the returned data can be used as the values
   for this parameter to read data from a known point in the file.
 * `priority`
-* Include messages only from these log levels. The default is to include all\
+* Include messages only from these log levels. The default is to include all
   messages.\
-  The value given should be a comma-separated list of log priorities. The\
+  The value given should be a comma-separated list of log priorities. The
   priorities are `alert`, `error`, `warning`, `notice`, `info` and`debug`. Note that the `debug` log level is only used in debug builds of\
   MaxScale.
 
@@ -621,10 +621,10 @@ GET /v1/maxscale/logs/stream
 
 Stream the contents of the MaxScale logs. This endpoint was added in MaxScale 6.
 
-This endpoint opens a [WebSocket](https://tools.ietf.org/html/rfc6455)\
-connection and streams the contents of the log to it. Each WebSocket message\
-will contain the JSON representation of the log message. The JSON is formatted\
-in the same way as the values in the `log` array of the `/v1/maxscale/logs/data`\
+This endpoint opens a [WebSocket](https://tools.ietf.org/html/rfc6455)
+connection and streams the contents of the log to it. Each WebSocket message
+will contain the JSON representation of the log message. The JSON is formatted
+in the same way as the values in the `log` array of the `/v1/maxscale/logs/data`
 endpoint:
 
 ```
@@ -638,12 +638,12 @@ endpoint:
 
 #### Limitations
 
-* If the client writes any data to the open socket, it will be treated as\
+* If the client writes any data to the open socket, it will be treated as
   an error and the stream is closed.
-* The WebSocket ping and close commands are not yet supported and will be\
+* The WebSocket ping and close commands are not yet supported and will be
   treated as errors.
-* When `maxlog` is used as source of log data, any log messages logged after log\
-  rotation will not be sent if the file was moved or truncated. To fetch new\
+* When `maxlog` is used as source of log data, any log messages logged after log
+  rotation will not be sent if the file was moved or truncated. To fetch new
   events after log rotation, reopen the WebSocket connection.
 
 **Parameters**
@@ -651,14 +651,14 @@ endpoint:
 This endpoint supports the following parameters:
 
 * `page[cursor]`
-* Set position from where the log data is retrieved. The default position to\
+* Set position from where the log data is retrieved. The default position to
   retrieve the log data is the end of the log.\
-  To stream data from a known point, first read the data via the`/v1/maxscale/logs/data` endpoint and then use the `id` value of the newest\
+  To stream data from a known point, first read the data via the`/v1/maxscale/logs/data` endpoint and then use the `id` value of the newest
   log message (i.e. the first value in the `log` array) to start the stream.
 * `priority`
-* Include messages only from these log levels. The default is to include all\
+* Include messages only from these log levels. The default is to include all
   messages.\
-  The value given should be a comma-separated list of log priorities. The\
+  The value given should be a comma-separated list of log priorities. The
   priorities are `alert`, `error`, `warning`, `notice`, `info` and`debug`. Note that the `debug` log level is only used in debug builds of\
   MaxScale.
 
@@ -674,7 +674,7 @@ Client didn't request a WebSocket upgrade:
 
 ### Update logging parameters
 
-**Note:** The modification of logging parameters via this endpoint has\
+**Note:** The modification of logging parameters via this endpoint has
 deprecated in MaxScale 6.0. The parameters should be modified with the`/v1/maxscale` endpoint instead.
 
 Any PATCH requests done to this endpoint will be redirected to the`/v1/maxscale` endpoint. Due to the misspelling of the `ms_timestamp` and`log_throttling` parameters, this is not fully backwards compatible.
@@ -701,7 +701,7 @@ Invalid JSON body:
 POST /v1/maxscale/logs/flush
 ```
 
-Flushes any pending messages to disk and reopens the log files. The body of the\
+Flushes any pending messages to disk and reopens the log files. The body of the
 message is ignored.
 
 **Response**
@@ -735,16 +735,16 @@ Retrieve all pending tasks that are queued for execution.
 GET /v1/maxscale/modules/:name
 ```
 
-Retrieve information about a loaded module. The _:name_ must be the name of a\
+Retrieve information about a loaded module. The _:name_ must be the name of a
 valid loaded module or either `maxscale` or `servers`.
 
-The `maxscale` module will display the global configuration options\
+The `maxscale` module will display the global configuration options
 (i.e. everything under the `[maxscale]` section) as a module.
 
-The `servers` module displays the server object type and the configuration\
+The `servers` module displays the server object type and the configuration
 parameters it accepts as a module.
 
-Any parameter with the `modifiable` value set to `true` can be modified\
+Any parameter with the `modifiable` value set to `true` can be modified
 at runtime using a PATCH command on the corresponding object endpoint.
 
 **Response**
@@ -1246,8 +1246,8 @@ GET /v1/maxscale/modules
 
 Retrieve information about all loaded modules.
 
-This endpoint supports the `load=all` parameter. When defined, all modules\
-located in the MaxScale module directory (`libdir`) will be loaded. This allows\
+This endpoint supports the `load=all` parameter. When defined, all modules
+located in the MaxScale module directory (`libdir`) will be loaded. This allows
 one to see the parameters of a module before the object is created.
 
 **Response**
@@ -3723,16 +3723,16 @@ For commands that can modify data:
 POST /v1/maxscale/modules/:module/:command
 ```
 
-Modules can expose commands that can be called via the REST API. The module\
-resource lists all commands in the `data.attributes.commands` list. Each value\
-is a command sub-resource identified by its `id` field and the HTTP method the\
+Modules can expose commands that can be called via the REST API. The module
+resource lists all commands in the `data.attributes.commands` list. Each value
+is a command sub-resource identified by its `id` field and the HTTP method the
 command uses is defined by the `attributes.method` field.
 
-The _:module_ in the URI must be a valid name of a loaded module and _:command_\
-must be a valid command identifier that is exposed by that module. All\
+The _:module_ in the URI must be a valid name of a loaded module and _:command_
+must be a valid command identifier that is exposed by that module. All
 parameters to the module commands are passed as HTTP request parameters.
 
-Here is an example POST requests to the dbfwfilter module command _reload_ with\
+Here is an example POST requests to the dbfwfilter module command _reload_ with
 two parameters, the name of the filter instance and the path to a file:
 
 ```
@@ -3760,8 +3760,8 @@ Command with output:
 }
 ```
 
-The contents of the `meta` field will contain the output of the module\
-command. This output depends on the command that is being executed. It can\
+The contents of the `meta` field will contain the output of the module
+command. This output depends on the command that is being executed. It can
 contain any valid JSON value.
 
 Command with no output:

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-monitor-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-monitor-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 21.06 Monitor Resource
 
-A monitor resource represents a monitor inside MaxScale that monitors one or\
+A monitor resource represents a monitor inside MaxScale that monitors one or
 more servers.
 
 ### Resource Operations
@@ -323,7 +323,7 @@ Get all monitors.
 POST /v1/monitors
 ```
 
-Create a new monitor. The request body must define at least the following\
+Create a new monitor. The request body must define at least the following
 fields.
 
 * `data.id`
@@ -339,8 +339,8 @@ fields.
 
 All monitor parameters can be defined at creation time.
 
-The following example defines a request body which creates a new monitor and\
-assigns two servers to be monitored by it. It also defines a custom value for\
+The following example defines a request body which creates a new monitor and
+assigns two servers to be monitored by it. It also defines a custom value for
 the _monitor\_interval_ parameter.
 
 ```
@@ -386,7 +386,7 @@ Monitor is created:
 PATCH /v1/monitors/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 monitor.
 
 #### Modifiable Fields
@@ -401,8 +401,8 @@ The following standard server parameter can be modified.
 * [backend\_read\_timeout](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md)
 * [backend\_connect\_attempts](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md)
 
-In addition to these standard parameters, the monitor specific parameters can\
-also be modified. Refer to the monitor module documentation for details on these\
+In addition to these standard parameters, the monitor specific parameters can
+also be modified. Refer to the monitor module documentation for details on these
 parameters.
 
 **Response**
@@ -421,12 +421,12 @@ Invalid request body:
 PATCH /v1/monitors/:name/relationships/servers
 ```
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the monitor.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 server relationship for a monitor.
 
 ```
@@ -465,10 +465,10 @@ Invalid JSON body:
 DELETE /v1/monitors/:name
 ```
 
-Destroy a created monitor. The monitor must not have relationships to any\
+Destroy a created monitor. The monitor must not have relationships to any
 servers in order to be destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the monitor by first unlinking it from all servers that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-rest-api.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-rest-api.md
@@ -4,28 +4,28 @@ This document describes the version 1 of the MaxScale REST API.
 
 ### Note About Syntax
 
-Although JSON does not define a syntax for comments, some of the JSON examples\
-have C-style inline comments in them. These comments use `//` to mark the start\
+Although JSON does not define a syntax for comments, some of the JSON examples
+have C-style inline comments in them. These comments use `//` to mark the start
 of the comment and extend to the end of the current line.
 
 ### Configuration
 
-Read the [REST API](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+Read the [REST API](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 section of the configuration guide for more details on how to configure the REST API.
 
 ### Authentication
 
-The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)\
-authentication with the MaxScale administrative interface users. The default\
+The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)
+authentication with the MaxScale administrative interface users. The default
 user is `admin:mariadb`.
 
-It is highly recommended to enable HTTPS on the MaxScale REST API to make the\
-communication between the client and MaxScale secure. Without it, the passwords\
-can be intercepted from the network traffic. Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) for more\
+It is highly recommended to enable HTTPS on the MaxScale REST API to make the
+communication between the client and MaxScale secure. Without it, the passwords
+can be intercepted from the network traffic. Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) for more
 details on how to enable HTTPS for the MaxScale REST API.
 
-For more details on how administrative interface users are created and managed,\
-refer to the [MaxCtrl](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-maxctrl.md) documentation as well as the\
+For more details on how administrative interface users are created and managed,
+refer to the [MaxCtrl](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-maxctrl.md) documentation as well as the
 documentation of the [users](mariadb-maxscale-2106-maxscale-2106-admin-user-resource.md) resource.
 
 #### JSON Web Tokens
@@ -36,7 +36,7 @@ MaxScale supports authentication via [JSON Web Tokens](https://tools.ietf.org/ht
 GET /v1/auth
 ```
 
-The `/v1/auth` endpoint can be used to generate new tokens which are returned in\
+The `/v1/auth` endpoint can be used to generate new tokens which are returned in
 the following form.
 
 ```
@@ -47,12 +47,12 @@ the following form.
 }
 ```
 
-Note that by default the `/auth` endpoint requires the connection to be\
-encrypted (HTTPS) and attempts to use it without encryption will be treated as\
+Note that by default the `/auth` endpoint requires the connection to be
+encrypted (HTTPS) and attempts to use it without encryption will be treated as
 an error. To allow use of the `/auth` endpoint without encryption, use`admin_secure_gui=false`.
 
-If the token is used to authenticate users in a web browser, the token can be\
-optionally stored in cookies. This can be enabled with the `persist=yes`\
+If the token is used to authenticate users in a web browser, the token can be
+optionally stored in cookies. This can be enabled with the `persist=yes`
 parameter in the request:
 
 ```
@@ -60,23 +60,23 @@ GET /v1/auth?persist=yes
 ```
 
 When the token is stored in the cookies, it will be split into two parts: the\
-JWT body will be stored in a cookie named `token_body` and the JWT signature is\
-stored in `token_sig`. The JWT signature will be stored with `SameSite=Strict`\
-and `HttpOnly` cookie options which means the JavaScript context of the browser\
+JWT body will be stored in a cookie named `token_body` and the JWT signature is
+stored in `token_sig`. The JWT signature will be stored with `SameSite=Strict`
+and `HttpOnly` cookie options which means the JavaScript context of the browser
 will not have access to it. This is done to prevent CSRF attacks.
 
-By default, the generated tokens are valid for 8 hours. The token validity\
+By default, the generated tokens are valid for 8 hours. The token validity
 period can be set with the `max-age` request parameter:
 
 ```
 GET /v1/auth?max-age=28800
 ```
 
-When `max-age` is combined with `persist`, the `Max-Age` cookie option is\
+When `max-age` is combined with `persist`, the `Max-Age` cookie option is
 also set to the same value.
 
-To use the token for authentication, the generated token must be presented in\
-the Authorization header with the Bearer authentication scheme. For example, the\
+To use the token for authentication, the generated token must be presented in
+the Authorization header with the Bearer authentication scheme. For example, the
 token above would be used in the following manner:
 
 ```
@@ -87,26 +87,26 @@ If MaxScale is restarted, all generated tokens are invalidated.
 
 **`/auth` Request Parameters**
 
-The `/auth` endpoint supports the following request parameters that must be\
+The `/auth` endpoint supports the following request parameters that must be
 given in the HTTP query string.
 
 * `max-age`
-* Sets the token maximum age in seconds. The default is `max-age=28800`. Only\
-  positive values are accepted and if a non-positive or a non-integer value is\
+* Sets the token maximum age in seconds. The default is `max-age=28800`. Only
+  positive values are accepted and if a non-positive or a non-integer value is
   found, the parameter is ignored.
 * `persist`
 * Store the generated token in cookies instead of returning it as the response body.\
   This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in two cookies, `token_body` and`token_sig`, and the response is 204 No Content instead of 200 OK.\
-  The `token_body` cookie contains the JWT header and claims sections\
+  The `token_body` cookie contains the JWT header and claims sections
   (i.e. the token body before the second period). This can be accessed by\
   JavaScript.\
-  The `token_sig` part contains the rest of the token. The cookie is stored as\
-  a HttpOnly cookie which prevents access to from JavaScript. This is done to\
+  The `token_sig` part contains the rest of the token. The cookie is stored as
+  a HttpOnly cookie which prevents access to from JavaScript. This is done to
   mitigate any attacks that might leak the token.
 
 ### Resources
 
-The MaxScale REST API provides the following resources. All resources conform to\
+The MaxScale REST API provides the following resources. All resources conform to
 the [JSON API](https://jsonapi.org/format/) specification.
 
 * [maxscale](mariadb-maxscale-2106-maxscale-2106-maxscale-resource.md)
@@ -119,45 +119,45 @@ the [JSON API](https://jsonapi.org/format/) specification.
 * [users](mariadb-maxscale-2106-maxscale-2106-admin-user-resource.md)
 * [sql](mariadb-maxscale-2106-maxscale-2106-sql-resource.md)
 
-In addition to the named resources, the REST API will respond with a HTTP 200 OK\
-response to GET requests on the root resource (`/`) as well as the namespace\
-root resource (`/v1/`). These can be used for HTTP health checks to determine\
+In addition to the named resources, the REST API will respond with a HTTP 200 OK
+response to GET requests on the root resource (`/`) as well as the namespace
+root resource (`/v1/`). These can be used for HTTP health checks to determine
 whether MaxScale is running.
 
 ### API Versioning
 
 All of the current resources are in the `/v1/` namespace of the MaxScale REST\
-API. Further additions to the namespace can be added that do not break backwards\
+API. Further additions to the namespace can be added that do not break backwards
 compatibility of any existing resources. What this means in practice is that:
 
 * No resources or URLs will be removed
 * The API will be JSON API compliant
 
-Note that this means that the contents of individual resources can change. New\
-fields can be added, old ones can be removed and the meaning of existing fields\
-can change. The aim is to be as backwards compatible as reasonably possible\
+Note that this means that the contents of individual resources can change. New
+fields can be added, old ones can be removed and the meaning of existing fields
+can change. The aim is to be as backwards compatible as reasonably possible
 without sacrificing the clarity and functionality of the API.
 
-Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the\
+Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the
 prefix is not used, the latest API version is used.
 
 #### Resource Relationships
 
-All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other\
+All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other
 objects. This closely resembles the JSON API definition of links.
 
-In the _relationships_ objects, all resources have a _self_ link that points to\
-the resource itself. This allows easy access to the objects pointed by the\
+In the _relationships_ objects, all resources have a _self_ link that points to
+the resource itself. This allows easy access to the objects pointed by the
 relationships as the reply URL is included in the response itself.
 
-To create a relationship between two objects, define it in the initial POST\
-request. To modify the relationships of existing objects, perform a PATCH\
-request with the new definition of the relevant relationship. To completely\
-remove all relationships from an object, the `data` field of the corresponding\
+To create a relationship between two objects, define it in the initial POST
+request. To modify the relationships of existing objects, perform a PATCH
+request with the new definition of the relevant relationship. To completely
+remove all relationships from an object, the `data` field of the corresponding
 relationship object must be set to an empty array.
 
-The following lists the resources and the types of links each resource can have\
-in addition to the _self_ link. Examples of these relationships can be seen in\
+The following lists the resources and the types of links each resource can have
+in addition to the _self_ link. Examples of these relationships can be seen in
 the resource documentation.
 
 * `services` - Service resource
@@ -167,7 +167,7 @@ the resource documentation.
   List of services used by the service
 * `filters`\
   List of filters used by the service\
-  NOTE: This is an ordered relationship where the order of the filters\
+  NOTE: This is an ordered relationship where the order of the filters
   defines the order in which they process queries.
 * `listeners`\
   List of listeners used by the service
@@ -189,83 +189,83 @@ the resource documentation.
 
 ### Common Request Parameters
 
-All the resources that return JSON content also support the following\
+All the resources that return JSON content also support the following
 parameters. Parameters are given in the HTTP query string:`https://localhost:8989/v1/servers?pretty=true&fields[servers]=state`.
 
 * `pretty`
 * Pretty-print output.\
-  If this parameter is set to `true` then the returned objects are formatted\
-  in a more human readable format. If the parameter is set to `false` then the\
-  returned objects are formatted in a compact format. All resources support\
+  If this parameter is set to `true` then the returned objects are formatted
+  in a more human readable format. If the parameter is set to `false` then the
+  returned objects are formatted in a compact format. All resources support
   this parameter. The default value for this parameter is `true`.
 * `fields[TYPE]=field1,field2...`
 * Return a [Sparse Fieldset](https://jsonapi.org/format/#fetching-sparse-fieldsets)\
-  This parameter controls which fields are returned in the REST API\
-  response. The `TYPE` value in the `fields` parameter must be the resource\
-  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated\
-  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which\
-  fields of the object to return. Only fields in objects in the `attributes`\
-  and `relationships` objects are inspected. This means that if the path\
-  marked by the JSON Pointer contains an array in it, it will not advance past\
+  This parameter controls which fields are returned in the REST API
+  response. The `TYPE` value in the `fields` parameter must be the resource
+  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated
+  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which
+  fields of the object to return. Only fields in objects in the `attributes`
+  and `relationships` objects are inspected. This means that if the path
+  marked by the JSON Pointer contains an array in it, it will not advance past
   this array.\
-  For example, to return only the server state output from the `/servers`\
-  endpoint, the `fields[servers]=state` parameter can be used. This would\
-  return only the `data.attributes.state` part of the resource. To return the\
-  nested value `data.attributes.statistics.connections`, the corresponding\
+  For example, to return only the server state output from the `/servers`
+  endpoint, the `fields[servers]=state` parameter can be used. This would
+  return only the `data.attributes.state` part of the resource. To return the
+  nested value `data.attributes.statistics.connections`, the corresponding
   parameter would be `fields[servers]=statistics/connections`.
 * `filter=json_ptr=json_value`
 * Filter the output of the result\
-  This parameter controls which rows are returned in a REST API response that\
-  returns an array in the `data` member (i.e. a request to a resource\
+  This parameter controls which rows are returned in a REST API response that
+  returns an array in the `data` member (i.e. a request to a resource
   collection). Requests to individual resources are not filtered.\
   The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and a valid\
-  JSON type as the value. The comparison is done for each individual object in\
-  the `data` array of the result. For example, if the object stored in`data[0]` has a value pointed by the given JSON pointer and that value\
+  JSON type as the value. The comparison is done for each individual object in
+  the `data` array of the result. For example, if the object stored in`data[0]` has a value pointed by the given JSON pointer and that value
   compares equal to the given value, the array row is kept in the result.\
-  A practical use for this parameter is to return only sessions for a\
-  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can\
-  be used. Note the double quotes around the `"RW-Split-Router"`, they are\
+  A practical use for this parameter is to return only sessions for a
+  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
+  be used. Note the double quotes around the `"RW-Split-Router"`, they are
   required to correctly convert strings into JSON values.
 * `page[size]`
-* The number of elements that are returned for resource collections. By\
-  default all elements in the resource collection are returned. The value must\
-  be a valid positive integer, otherwise the parameter is ignored. If\
-  pagination is used, the `links` object will have pagination links to the\
+* The number of elements that are returned for resource collections. By
+  default all elements in the resource collection are returned. The value must
+  be a valid positive integer, otherwise the parameter is ignored. If
+  pagination is used, the `links` object will have pagination links to the
   next page if more elements are available.
 * `page[number]`
-* How many pages of results to skip. The first page of results starts from 0\
-  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This\
-  should be considered pseudo-pagination as the results are not guaranteed to\
+* How many pages of results to skip. The first page of results starts from 0
+  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This
+  should be considered pseudo-pagination as the results are not guaranteed to
   be consistent between requests.
 * `sync`
 * Control configuration synchronization.\
-  If this parameter is set to `false` then the configuration synchronization\
-  is disabled for this request. This can be used to perform configuration\
-  changes when MaxScale is unable to reach the cluster used to synchronize the\
-  configuration. The modifications to the local configuration will be\
-  overwritten when the next modification to the cluster's configuration is\
+  If this parameter is set to `false` then the configuration synchronization
+  is disabled for this request. This can be used to perform configuration
+  changes when MaxScale is unable to reach the cluster used to synchronize the
+  configuration. The modifications to the local configuration will be
+  overwritten when the next modification to the cluster's configuration is
   done which means this should only be used to perform temporary fixes.
 
 ### HTTP Headers
 
 #### Request Headers
 
-REST makes use of the HTTP protocols in its aim to provide a natural way to\
-understand the workings of an API. The following request headers are understood\
+REST makes use of the HTTP protocols in its aim to provide a natural way to
+understand the workings of an API. The following request headers are understood
 by this API.
 
 **Authorization**
 
 Credentials for authentication. This header should consist of a HTTP Basic\
-Access authentication type payload which is the base64 encoded value of the\
+Access authentication type payload which is the base64 encoded value of the
 username and password joined by a colon e.g. `Base64("maxuser:maxpwd")`.
 
 **Content-Type**
 
-All PUT and POST requests must use the `Content-Type: application/json` media\
-type and the request body must be a complete and valid JSON representation of a\
-resource. All PATCH requests must use the `Content-Type: application/json` media\
-type and the request body must be a JSON document containing a partial\
+All PUT and POST requests must use the `Content-Type: application/json` media
+type and the request body must be a complete and valid JSON representation of a
+resource. All PATCH requests must use the `Content-Type: application/json` media
+type and the request body must be a JSON document containing a partial
 definition of the modified resource.
 
 **Host**
@@ -274,59 +274,59 @@ The address and port of the server.
 
 **If-Match**
 
-The request is performed only if the provided ETag value matches the one on the\
-server. This field should be used with PATCH requests to prevent concurrent\
+The request is performed only if the provided ETag value matches the one on the
+server. This field should be used with PATCH requests to prevent concurrent
 updates to the same resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Modified-Since**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **If-None-Match**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Unmodified-Since**
 
-The request is performed only if the requested resource has not been modified\
+The request is performed only if the requested resource has not been modified
 since the provided date.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **X-HTTP-Method-Override**
 
-Some clients only support GET and PUT requests. By providing the string value of\
-the intended method in the `X-HTTP-Method-Override` header, a client can, for\
-example, perform a POST, PATCH or DELETE request with the PUT method\
+Some clients only support GET and PUT requests. By providing the string value of
+the intended method in the `X-HTTP-Method-Override` header, a client can, for
+example, perform a POST, PATCH or DELETE request with the PUT method
 (e.g. `X-HTTP-Method-Override: PATCH`).
 
-If this header is defined in the request, the current method of the request is\
-replaced with the one in the header. The HTTP method must be in uppercase and it\
+If this header is defined in the request, the current method of the request is
+replaced with the one in the header. The HTTP method must be in uppercase and it
 must be one of the methods that the requested resource supports.
 
 #### Response Headers
 
 **Allow**
 
-All resources return the Allow header with the supported HTTP methods. For\
-example the resource `/services` will always return the `Accept: GET, PATCH, PUT`\
+All resources return the Allow header with the supported HTTP methods. For
+example the resource `/services` will always return the `Accept: GET, PATCH, PUT`
 header.
 
 **Accept-Patch**
 
-All PATCH capable resources return the `Accept-Patch: application/json-patch`\
+All PATCH capable resources return the `Accept-Patch: application/json-patch`
 header.
 
 **Date**
@@ -336,12 +336,12 @@ English and it uses the server's local timezone.
 
 **ETag**
 
-An identifier for a specific version of a resource. The value of this header\
-changes whenever a resource is modified via the REST API. It will not change if\
-an internal MaxScale event (e.g. server changing state or statistics being\
+An identifier for a specific version of a resource. The value of this header
+changes whenever a resource is modified via the REST API. It will not change if
+an internal MaxScale event (e.g. server changing state or statistics being
 updated) causes a change.
 
-When the client sends the `If-Match` or `If-None-Match` header, the provided\
+When the client sends the `If-Match` or `If-None-Match` header, the provided
 value should be the value of the `ETag` header of an earlier GET.
 
 **Last-Modified**
@@ -350,29 +350,29 @@ The date when the resource was last modified in "HTTP-date" format.
 
 **Location**
 
-If an out of date resource location is requested, a HTTP return code of 3XX with\
-the `Location` header is returned. The value of the header contains the new\
+If an out of date resource location is requested, a HTTP return code of 3XX with
+the `Location` header is returned. The value of the header contains the new
 location of the requested resource as a relative URI.
 
 **WWW-Authenticate**
 
-The requested authentication method. For example, `WWW-Authenticate: Basic`\
+The requested authentication method. For example, `WWW-Authenticate: Basic`
 would require basic HTTP authentication.
 
 **Mxs-Warning**
 
-This header is used for sending generic warnings to clients about actions that\
-were successful and valid but could cause problems in the future. Currently\
-these are used to indicate when a configuration change was made to a static\
-object and an overriding configuration is created or when a static object is\
+This header is used for sending generic warnings to clients about actions that
+were successful and valid but could cause problems in the future. Currently
+these are used to indicate when a configuration change was made to a static
+object and an overriding configuration is created or when a static object is
 being deleted at runtime.
 
-The content of the header is the human-readable warning that should be displayed\
+The content of the header is the human-readable warning that should be displayed
 to a user.
 
 ### Response Codes
 
-Every HTTP response starts with a line with a return code which indicates the\
+Every HTTP response starts with a line with a return code which indicates the
 outcome of the request. The API uses some of the standard HTTP values:
 
 #### 2xx Success
@@ -382,37 +382,37 @@ outcome of the request. The API uses some of the standard HTTP values:
 * 201 Created
 * A new resource was created.
 * 202 Accepted
-* The request has been accepted for processing, but the processing has not\
+* The request has been accepted for processing, but the processing has not
   been completed.
 * 204 No Content
 * Successful HTTP requests, response has no body.
 
 #### 3xx Redirection
 
-This class of status code indicates the client must take additional action to\
+This class of status code indicates the client must take additional action to
 complete the request.
 
 * 301 Moved Permanently
 * This and all future requests should be directed to the given URI.
 * 302 Found
-* The response to the request can be found under another URI using the same\
+* The response to the request can be found under another URI using the same
   method as in the original request.
 * 303 See Other
-* The response to the request can be found under another URI using a GET\
+* The response to the request can be found under another URI using a GET
   method.
 * 304 Not Modified
-* Indicates that the resource has not been modified since the version\
+* Indicates that the resource has not been modified since the version
   specified by the request headers If-Modified-Since or If-None-Match.
 * 307 Temporary Redirect
-* The request should be repeated with another URI but future requests should\
+* The request should be repeated with another URI but future requests should
   use the original URI.
 * 308 Permanent Redirect
 * The request and all future requests should be repeated using another URI.
 
 #### 4xx Client Error
 
-The 4xx class of status code is when the client seems to have erred. Except when\
-responding to a HEAD request, the body of the response _MAY_ contains a JSON\
+The 4xx class of status code is when the client seems to have erred. Except when
+responding to a HEAD request, the body of the response _MAY_ contains a JSON
 representation of the error.
 
 ```
@@ -423,7 +423,7 @@ representation of the error.
 }
 ```
 
-The _error_ field contains a short error description and the _description_ field\
+The _error_ field contains a short error description and the _description_ field
 contains a more detailed version of the error message.
 
 * 400 Bad Request
@@ -431,41 +431,41 @@ contains a more detailed version of the error message.
 * 401 Unauthorized
 * Authentication is required. The response includes a WWW-Authenticate header.
 * 403 Forbidden
-* The request was a valid request, but the client does not have the necessary\
+* The request was a valid request, but the client does not have the necessary
   permissions for the resource.
 * 404 Not Found
 * The requested resource could not be found.
 * 405 Method Not Allowed
 * A request method is not supported for the requested resource.
 * 406 Not Acceptable
-* The requested resource is capable of generating only content not acceptable\
+* The requested resource is capable of generating only content not acceptable
   according to the Accept headers sent in the request.
 * 409 Conflict
-* Indicates that the request could not be processed because of conflict in the\
+* Indicates that the request could not be processed because of conflict in the
   request, such as an edit conflict be tween multiple simultaneous updates.
 * 411 Length Required
-* The request did not specify the length of its content, which is required by\
+* The request did not specify the length of its content, which is required by
   the requested resource.
 * 412 Precondition Failed
-* The server does not meet one of the preconditions that the requester put on\
+* The server does not meet one of the preconditions that the requester put on
   the request.
 * 413 Payload Too Large
 * The request is larger than the server is willing or able to process.
 * 414 URI Too Long
 * The URI provided was too long for the server to process.
 * 415 Unsupported Media Type
-* The request entity has a media type which the server or resource does not\
+* The request entity has a media type which the server or resource does not
   support.
 * 422 Unprocessable Entity
-* The request was well-formed but was unable to be followed due to semantic\
+* The request was well-formed but was unable to be followed due to semantic
   errors.
 * 423 Locked
 * The resource that is being accessed is locked.
 * 428 Precondition Required
-* The origin server requires the request to be conditional. This error code is\
+* The origin server requires the request to be conditional. This error code is
   returned when none of the `Modified-Since` or `Match` type headers are used.
 * 431 Request Header Fields Too Large
-* The server is unwilling to process the request because either an individual\
+* The server is unwilling to process the request because either an individual
   header field, or all the header fields collectively, are too large.
 
 #### 5xx Server Error
@@ -473,30 +473,30 @@ contains a more detailed version of the error message.
 The server failed to fulfill an apparently valid request.
 
 * 500 Internal Server Error
-* A generic error message, given when an unexpected condition was encountered\
+* A generic error message, given when an unexpected condition was encountered
   and no more specific message is suitable.
 * 501 Not Implemented
-* The server either does not recognize the request method, or it lacks the\
+* The server either does not recognize the request method, or it lacks the
   ability to fulfill the request.
 * 502 Bad Gateway
-* The server was acting as a gateway or proxy and received an invalid response\
+* The server was acting as a gateway or proxy and received an invalid response
   from the upstream server.
 * 503 Service Unavailable
-* The server is currently unavailable (because it is overloaded or down for\
+* The server is currently unavailable (because it is overloaded or down for
   maintenance). Generally, this is a temporary state.
 * 504 Gateway Timeout
-* The server was acting as a gateway or proxy and did not receive a timely\
+* The server was acting as a gateway or proxy and did not receive a timely
   response from the upstream server.
 * 505 HTTP Version Not Supported
 * The server does not support the HTTP protocol version used in the request.
 * 506 Variant Also Negotiates
-* Transparent content negotiation for the request results in a circular\
+* Transparent content negotiation for the request results in a circular
   reference.
 * 507 Insufficient Storage
-* The server is unable to store the representation needed to complete the\
+* The server is unable to store the representation needed to complete the
   request.
 * 508 Loop Detected
-* The server detected an infinite loop while processing the request (sent in\
+* The server detected an infinite loop while processing the request (sent in
   lieu of 208 Already Reported).
 * 510 Not Extended
 * Further extensions to the request are required for the server to fulfil it.
@@ -507,23 +507,23 @@ The following response headers are not currently in use. Future versions of the\
 API could return them.
 
 * 206 Partial Content
-* The server is delivering only part of the resource (byte serving) due to a\
+* The server is delivering only part of the resource (byte serving) due to a
   range header sent by the client.
 * 300 Multiple Choices
-* Indicates multiple options for the resource from which the client may choose\
+* Indicates multiple options for the resource from which the client may choose
   (via agent-driven content negotiation).
 * 407 Proxy Authentication Required
 * The client must first authenticate itself with the proxy.
 * 408 Request Timeout
-* The server timed out waiting for the request. According to HTTP\
-  specifications: "The client did not produce a request within the time that\
-  the server was prepared to wait. The client MAY repeat the request without\
+* The server timed out waiting for the request. According to HTTP
+  specifications: "The client did not produce a request within the time that
+  the server was prepared to wait. The client MAY repeat the request without
   modifications at any later time."
 * 410 Gone
-* Indicates that the resource requested is no longer available and will not be\
+* Indicates that the resource requested is no longer available and will not be
   available again.
 * 416 Range Not Satisfiable
-* The client has asked for a portion of the file (byte serving), but the\
+* The client has asked for a portion of the file (byte serving), but the
   server cannot supply that portion.
 * 417 Expectation Failed
 * The server cannot meet the requirements of the Expect request-header field.
@@ -532,10 +532,10 @@ API could return them.
 * 424 Failed Dependency
 * The request failed due to failure of a previous request.
 * 426 Upgrade Required
-* The client should switch to a different protocol such as TLS/1.0, given in\
+* The client should switch to a different protocol such as TLS/1.0, given in
   the Upgrade header field.
 * 429 Too Many Requests
-* The user has sent too many requests in a given amount of time. Intended for\
+* The user has sent too many requests in a given amount of time. Intended for
   use with rate-limiting schemes.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-server-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-server-resource.md
@@ -757,7 +757,7 @@ Response contains a resource collection with all servers.
 POST /v1/servers
 ```
 
-Create a new server by defining the resource. The posted object must define at\
+Create a new server by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -765,10 +765,10 @@ least the following fields.
 * `data.type`
 * Type of the object, must be `servers`
 * `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-* The [address](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) or [socket](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) to use. Only\
+* The [address](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) or [socket](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) to use. Only
   one of the fields can be defined.
 * `data.attributes.parameters.port`
-* The [port](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) to use. Needs\
+* The [port](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) to use. Needs
   to be defined if the `address` field is defined.
 
 The following is the minimal required JSON object for defining a new server.
@@ -788,7 +788,7 @@ The following is the minimal required JSON object for defining a new server.
 }
 ```
 
-The relationships of a server can also be defined at creation time. This allows\
+The relationships of a server can also be defined at creation time. This allows
 new servers to be created and immediately taken into use.
 
 ```
@@ -828,7 +828,7 @@ new servers to be created and immediately taken into use.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 for a full list of server parameters.
 
 **Response**
@@ -847,19 +847,19 @@ Invalid JSON body:
 PATCH /v1/servers/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 server.
 
 #### Modifiable Fields
 
-In addition to the server [parameters](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md), the _services_\
-and _monitors_ fields of the _relationships_ object can be modified. Removal,\
-addition and modification of the links will change which service and monitors\
+In addition to the server [parameters](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md), the _services_
+and _monitors_ fields of the _relationships_ object can be modified. Removal,
+addition and modification of the links will change which service and monitors
 use this server.
 
 For example, removing the first value in the _services_ list in the_relationships_ object from the following JSON document will remove the_server1_ from the service _RW-Split-Router_.
 
-Removing a service from a server is analogous to removing the server from the\
+Removing a service from a server is analogous to removing the server from the
 service. Both unlink the two objects from each other.
 
 Request for `PATCH /v1/servers/server1` that modifies the address of the server:
@@ -897,9 +897,9 @@ Request for `PATCH /v1/servers/server1` that modifies the server relationships:
 }
 ```
 
-If parts of the resource are not defined (e.g. the `attributes` field in the\
-above example), those parts of the resource are not modified. All parts that are\
-defined are interpreted as the new definition of those part of the resource. In\
+If parts of the resource are not defined (e.g. the `attributes` field in the
+above example), those parts of the resource are not modified. All parts that are
+defined are interpreted as the new definition of those part of the resource. In
 the above example, the `relationships` of the resource are completely redefined.
 
 **Response**
@@ -918,15 +918,15 @@ Invalid JSON body:
 PATCH /v1/servers/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _services_, for service\
+The _:type_ in the URI must be either _services_, for service
 relationships, or _monitors_, for monitor relationships.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the particular type from the server.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 service relationship for a server.
 
 ```
@@ -965,11 +965,11 @@ Invalid JSON body:
 DELETE /v1/servers/:name
 ```
 
-A server can only be deleted if it is not used by any services or\
+A server can only be deleted if it is not used by any services or
 monitors.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the server by first unlinking it from all services and monitors that use\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the server by first unlinking it from all services and monitors that use
 it.
 
 **Response**
@@ -988,7 +988,7 @@ Server is in use:
 PUT /v1/servers/:name/set
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the following values.
 
 | Value       | State Description                |
@@ -1000,19 +1000,19 @@ request. The value of `state` must be one of the following values.
 | synced      | Server is a Galera node          |
 | drain       | Server is drained of connections |
 
-For example, to set the server _db-server-1_ into maintenance mode, a request to\
+For example, to set the server _db-server-1_ into maintenance mode, a request to
 the following URL must be made:
 
 ```
 PUT /v1/servers/db-server-1/set?state=maintenance
 ```
 
-This endpoint also supports the `force=yes` parameter that will cause all\
-connections to the server to be closed if `state=maintenance` is also set. By\
-default setting a server into maintenance mode will cause connections to be\
+This endpoint also supports the `force=yes` parameter that will cause all
+connections to the server to be closed if `state=maintenance` is also set. By
+default setting a server into maintenance mode will cause connections to be
 closed only after the next request is sent.
 
-The following example forcefully closes all connections to server _db-server-1_\
+The following example forcefully closes all connections to server _db-server-1_
 and sets it into maintenance mode:
 
 ```
@@ -1035,7 +1035,7 @@ Missing or invalid parameter:
 PUT /v1/servers/:name/clear
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the values defined in the_set_ endpoint documentation.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-service-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-service-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 21.06 Service Resource
 
-A service resource represents a service inside MaxScale. A service is a\
+A service resource represents a service inside MaxScale. A service is a
 collection of network listeners, filters, a router and a set of backend servers.
 
 ### Resource Operations
@@ -718,7 +718,7 @@ Get all services.
 POST /v1/services
 ```
 
-Create a new service by defining the resource. The posted object must define at\
+Create a new service by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -732,24 +732,24 @@ least the following fields.
 * `data.attributes.parameters.password`
 * The [password](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) to use
 
-The `data.attributes.parameters` object is used to define router and service\
-parameters. All configuration parameters that can be defined in the\
-configuration file can also be added to the parameters object. The exceptions to\
-this are the `type`, `router`, `servers` and `filters` parameters which must not\
+The `data.attributes.parameters` object is used to define router and service
+parameters. All configuration parameters that can be defined in the
+configuration file can also be added to the parameters object. The exceptions to
+this are the `type`, `router`, `servers` and `filters` parameters which must not
 be defined.
 
-As with other REST API resources, the `data.relationships` field defines the\
-relationships of the service to other resources. Services can have two types of\
+As with other REST API resources, the `data.relationships` field defines the
+relationships of the service to other resources. Services can have two types of
 relationships: `servers` and `filters` relationships.
 
-If the request body defines a valid `relationships` object, the service is\
-linked to those resources. For servers, this is equivalent to adding the list of\
-server names into the [servers](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) parameter. For\
-filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) parameter in the\
-order they appear. For other services, this is equivalent to adding the list of\
+If the request body defines a valid `relationships` object, the service is
+linked to those resources. For servers, this is equivalent to adding the list of
+server names into the [servers](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) parameter. For
+filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) parameter in the
+order they appear. For other services, this is equivalent to adding the list of
 server names into the [targets](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) parameter.
 
-The following example defines a new service with both a server and a filter\
+The following example defines a new service with both a server and a filter
 relationship.
 
 ```
@@ -798,21 +798,21 @@ Service is created:
 DELETE /v1/services/:name
 ```
 
-A service can only be destroyed if the service uses no servers or filters and\
-all the listeners pointing to the service have been destroyed. This means that\
-the `data.relationships` must be an empty object and `data.attributes.listeners`\
+A service can only be destroyed if the service uses no servers or filters and
+all the listeners pointing to the service have been destroyed. This means that
+the `data.relationships` must be an empty object and `data.attributes.listeners`
 must be an empty array in order for the service to qualify for destruction.
 
-If there are open client connections that use the service when it is destroyed,\
-they are allowed to gracefully close before the service is destroyed. This means\
-that the destruction of a service can be acknowledged via the REST API before\
+If there are open client connections that use the service when it is destroyed,
+they are allowed to gracefully close before the service is destroyed. This means
+that the destruction of a service can be acknowledged via the REST API before
 the destruction process has fully completed.
 
-To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2106-maxscale-2106-session-resource.md) resource should be used. If a session for\
+To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2106-maxscale-2106-session-resource.md) resource should be used. If a session for
 the service is still open, it has not yet been destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the service by first unlinking it from all servers and filters that it\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the service by first unlinking it from all servers and filters that it
 uses.
 
 **Response**
@@ -827,15 +827,15 @@ Service is destroyed:
 PATCH /v1/services/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the service.
 
-All standard service parameters can be modified. Refer to the [service](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) documentation on\
+All standard service parameters can be modified. Refer to the [service](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) documentation on
 the details of these parameters.
 
-In addition to the standard service parameters, router parameters can be updated\
-at runtime if the router module supports it. Refer to the individual router\
-documentation for more details on whether the router supports it and which\
+In addition to the standard service parameters, router parameters can be updated
+at runtime if the router module supports it. Refer to the individual router
+documentation for more details on whether the router supports it and which
 parameters can be updated at runtime.
 
 The following example modifies a service by changing the `user` parameter to `admin`.
@@ -864,22 +864,22 @@ Service is modified:
 PATCH /v1/services/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _servers_, _services_ or _filters_,\
+The _:type_ in the URI must be either _servers_, _services_ or _filters_,
 depending on which relationship is being modified.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of this type for the service.
 
-_Note:_ The order of the values in the `filters` relationship will define the\
-order the filters are set up in. The order in which the filters appear in the\
-array will be the order in which the filters are applied to each query. Refer\
-to the [filters](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) parameter\
+_Note:_ The order of the values in the `filters` relationship will define the
+order the filters are set up in. The order in which the filters appear in the
+array will be the order in which the filters are applied to each query. Refer
+to the [filters](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) parameter
 for more details.
 
-The following is an example request and request body that defines a single\
-server relationship for a service that is equivalent to a `servers=my-server`\
+The following is an example request and request body that defines a single
+server relationship for a service that is equivalent to a `servers=my-server`
 parameter.
 
 ```
@@ -975,7 +975,7 @@ This endpoint is deprecated, use the [this](mariadb-maxscale-2106-maxscale-2106-
 GET /v1/services/:name/listeners/:listener
 ```
 
-This endpoint is deprecated, use the [this](mariadb-maxscale-2106-maxscale-2106-listener-resource.md)\
+This endpoint is deprecated, use the [this](mariadb-maxscale-2106-maxscale-2106-listener-resource.md)
 listeners endpoint instead.
 
 #### Create a new listener

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-session-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-session-resource.md
@@ -1,7 +1,7 @@
 # MaxScale 21.06 Session Resource
 
-A session is an abstraction of a client connection, any number of related backend\
-connections, a router module session and possibly filter module sessions. Each\
+A session is an abstraction of a client connection, any number of related backend
+connections, a router module session and possibly filter module sessions. Each
 session is created on a service and each service can have multiple sessions.
 
 ### Resource Operations
@@ -12,11 +12,11 @@ session is created on a service and each service can have multiple sessions.
 GET /v1/sessions/:id
 ```
 
-Get a single session. _:id_ must be a valid session ID. The session ID is the\
+Get a single session. _:id_ must be a valid session ID. The session ID is the
 same that is exposed to the client as the connection ID.
 
-This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to\
-perform reverse DNS on the client IP address. As this requires communicating with\
+This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to
+perform reverse DNS on the client IP address. As this requires communicating with
 an external server, the operation may be expensive.
 
 **Response**
@@ -163,10 +163,10 @@ Get all sessions.
 PATCH /v1/sessions/:id
 ```
 
-The request body must be a JSON object which represents the new configuration of\
+The request body must be a JSON object which represents the new configuration of
 the session. The `:id` must be a valid session ID that is active.
 
-The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean\
+The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean
 parameters control whether the associated logging level is enabled:
 
 ```
@@ -181,11 +181,11 @@ parameters control whether the associated logging level is enabled:
 }
 ```
 
-The filters that a session uses can be updated by re-defining the filter\
-relationship of the session. This causes new filter sessions to be opened\
-immediately. The old filter session are closed and replaced with the new filter\
-session the next time the session is idle. The order in which the filters are\
-defined in the request body is the order in which the filters are installed,\
+The filters that a session uses can be updated by re-defining the filter
+relationship of the session. This causes new filter sessions to be opened
+immediately. The old filter session are closed and replaced with the new filter
+session the next time the session is idle. The order in which the filters are
+defined in the request body is the order in which the filters are installed,
 similar to how the filter relationship for services behaves.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-sql-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-sql-resource.md
@@ -7,31 +7,31 @@ The SQL resource represents a database connection.
 The following endpoints provide a simple REST API interface for executing\
 SQL queries on servers and services in MaxScale.
 
-This document uses the `:id` value in the URL to represent a connection ID and\
-the `:query_id` to represent a query ID. These values do not need to be manually\
+This document uses the `:id` value in the URL to represent a connection ID and
+the `:query_id` to represent a query ID. These values do not need to be manually
 added as the relevant links are returned in the request body of each endpoint.
 
-The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A\
-connection token can be acquired with a `POST /v1/sql` request and can be used\
-with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in\
+The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A
+connection token can be acquired with a `POST /v1/sql` request and can be used
+with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in
 the `token` parameter of the request:
 
 ```
 POST /v1/sql/query?token=eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhZG1pbiIsImV4cCI6MTU4MzI1NDE1MSwiaWF0IjoxNTgzMjI1MzUxLCJpc3MiOiJtYXhzY2FsZSJ9.B1BqhjjKaCWKe3gVXLszpOPfeu8cLiwSb4CMIJAoyqw
 ```
 
-In addition to request parameters, the token can be stored in cookies in which\
-case they are automatically used by the REST API. For more information about\
+In addition to request parameters, the token can be stored in cookies in which
+case they are automatically used by the REST API. For more information about
 token storage in cookies, see the documentation for `POST /v1/sql`.
 
 ### Request Parameters
 
-All of the endpoints that operate on a single connection support the following\
-request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an\
+All of the endpoints that operate on a single connection support the following
+request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an
 exception as they ignore the current connection token.
 
 * `token`
-* The connection token to use for the request. If provided, the value is\
+* The connection token to use for the request. If provided, the value is
   unconditionally used even if a cookie with a valid token exists.
 
 #### Get one SQL connection
@@ -112,7 +112,7 @@ POST /v1/sql
 The request body must be a JSON object consisting of the following fields:
 
 * `target`
-* The object in MaxScale to connect to. This is a mandatory value and the\
+* The object in MaxScale to connect to. This is a mandatory value and the
   given value must be the name of a valid server, service or listener in\
   MaxScale.
 * `user`
@@ -120,11 +120,11 @@ The request body must be a JSON object consisting of the following fields:
 * `password`
 * The password for the user. This is a mandatory value.
 * `db`
-* The default database for the connection. By default the connection will have\
+* The default database for the connection. By default the connection will have
   no default database.
 * `timeout`
-* Connection timeout in seconds. The default connection timeout is 10\
-  seconds. This controls how long the SQL connection creation can take before\
+* Connection timeout in seconds. The default connection timeout is 10
+  seconds. This controls how long the SQL connection creation can take before
   an error is returned.
 
 Here is an example request body:
@@ -139,16 +139,16 @@ Here is an example request body:
 }
 ```
 
-The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token\
-is stored in cookies instead of the metadata object and the response body will\
+The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token
+is stored in cookies instead of the metadata object and the response body will
 not contain the token.
 
-The location of the newly created connection will be stored at `links.self` in\
+The location of the newly created connection will be stored at `links.self` in
 the response body as well as in the `Location` header.
 
-The token must be given to all subsequent requests that use the connection. It\
-must be either given in the `token` parameter of a request or it must be stored\
-in the cookies. If both a `token` parameter and a cookie exist at the same time,\
+The token must be given to all subsequent requests that use the connection. It
+must be either given in the `token` parameter of a request or it must be stored
+in the cookies. If both a `token` parameter and a cookie exist at the same time,
 the `token` parameter will be used instead of the cookie.
 
 **Request Parameters**
@@ -157,16 +157,16 @@ This endpoint supports the following request parameters.
 
 * `persist`
 * Store the connection token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in two cookies,`conn_id_body_<id>` and `conn_id_sig_<id>` where the `<id>` part is replaced\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in two cookies,`conn_id_body_<id>` and `conn_id_sig_<id>` where the `<id>` part is replaced
   by the ID of the connection.\
-  The `conn_id_body_<id>` cookie contains the JWT header and claims sections\
-  and contains the connection ID in the `aud` value. This can be used to\
-  retrieve the connection ID from the cookies if the browser session is\
+  The `conn_id_body_<id>` cookie contains the JWT header and claims sections
+  and contains the connection ID in the `aud` value. This can be used to
+  retrieve the connection ID from the cookies if the browser session is
   closed.
 * `max-age`
-* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or\
-  a non-integer value is found, the parameter is ignored. Once the token age\
-  exceeds the configured maximum value, the token can no longer be used and a\
+* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or
+  a non-integer value is found, the parameter is ignored. Once the token age
+  exceeds the configured maximum value, the token can no longer be used and a
   new connection must be created.
 
 **Response**
@@ -221,12 +221,12 @@ Missing or invalid connection token:
 POST /v1/sql/:id/reconnect
 ```
 
-Reconnects an existing connection. This can also be used if the connection to\
+Reconnects an existing connection. This can also be used if the connection to
 the backend server was lost due to a network error.
 
 The connection will use the same credentials that were passed to the `POST /v1/sql` endpoint. The new connection will still have the same ID in the REST\
-API but will be treated as a new connection by the database. A reconnection\
-re-initializes the connection and resets the session state. Reconnections cannot\
+API but will be treated as a new connection by the database. A reconnection
+re-initializes the connection and resets the session state. Reconnections cannot
 take place while a transaction is open.
 
 **Response**
@@ -249,7 +249,7 @@ Missing or invalid connection token:
 POST /v1/sql/:id/queries
 ```
 
-The request body must be a JSON object with the value of the `sql` field set to\
+The request body must be a JSON object with the value of the `sql` field set to
 the SQL to be executed:
 
 ```
@@ -262,22 +262,22 @@ the SQL to be executed:
 The request body must be a JSON object consisting of the following fields:
 
 * `sql`
-* The SQL to be executed. If the SQL contain multiple statements, multiple\
+* The SQL to be executed. If the SQL contain multiple statements, multiple
   results are returned in the response body.
 * `max_rows`
-* The maximum number of rows returned in the response. By default this is 1000\
-  rows. Setting the value to 0 means no limit. Any extra rows in the result\
+* The maximum number of rows returned in the response. By default this is 1000
+  rows. Setting the value to 0 means no limit. Any extra rows in the result
   will be discarded.
 
-By default, the complete result is returned in the response body. If the SQL\
-query returns more than one result, the `results` array will contain all the\
+By default, the complete result is returned in the response body. If the SQL
+query returns more than one result, the `results` array will contain all the
 results.
 
-The `results` array can have three types of objects: resultsets, errors, and OK\
+The `results` array can have three types of objects: resultsets, errors, and OK
 responses.
 
-* A resultset consists of the `data` field with the result data stored as a two\
-  dimensional array. The names of the fields are stored in an array in the`fields` field. These types of results will be returned for any operation that\
+* A resultset consists of the `data` field with the result data stored as a two
+  dimensional array. The names of the fields are stored in an array in the`fields` field. These types of results will be returned for any operation that
   returns rows (i.e. `SELECT` statements)
 
 ```
@@ -313,7 +313,7 @@ responses.
 }
 ```
 
-* An error consists of an object with the `errno` field set to the MariaDB error\
+* An error consists of an object with the `errno` field set to the MariaDB error
   code, the `message` field set to the human-readable error message and the`sqlstate` field set to the current SQLSTATE of the connection.
 
 ```
@@ -338,9 +338,9 @@ responses.
 }
 ```
 
-* An OK response is returned for any result that completes successfully but not\
-  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`\
-  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field\
+* An OK response is returned for any result that completes successfully but not
+  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`
+  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field
   contains the number of warnings raised by the operation.
 
 ```
@@ -365,9 +365,9 @@ responses.
 }
 ```
 
-It is also possible for the fields of the error response to be present in the\
-resultset response if the result ended with an error but still generated some\
-data. Usually this happens when query execution is interrupted but a partial\
+It is also possible for the fields of the error response to be present in the
+resultset response if the result ended with an error but still generated some
+data. Usually this happens when query execution is interrupted but a partial
 result was generated by the server.
 
 **Response**
@@ -406,7 +406,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-avrorouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-avrorouter.md
@@ -1,13 +1,13 @@
 # MaxScale 21.06 Avrorouter
 
-The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes\
+The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes
 binary logs from a local directory and transforms them into a set of Avro files.\
 These files can then be queried by clients for various purposes.
 
 This router is intended to be used in tandem with the [Binlog Server](mariadb-maxscale-2106-maxscale-2106-binlogrouter.md).\
 The Binlog Server can connect to a master server and request binlog records.\
-These records can then consumed by the avrorouter directly from the binlog cache\
-of the Binlog Server. This allows MariaDB MaxScale to automatically transform\
+These records can then consumed by the avrorouter directly from the binlog cache
+of the Binlog Server. This allows MariaDB MaxScale to automatically transform
 binlog events on the master to local Avro format files.
 
 ```mermaid
@@ -64,25 +64,25 @@ flowchart LR
 ```
 _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog events are converted to Avro-formatted change data and streamed to CDC clients, Kafka, and Hadoop._
 
-The avrorouter can also consume binary logs straight from the master. This will\
-remove the need to configure the Binlog Server but it will increase the disk space\
+The avrorouter can also consume binary logs straight from the master. This will
+remove the need to configure the Binlog Server but it will increase the disk space
 requirement on the master server by at least a factor of two.
 
-The converted Avro files can be requested with the CDC protocol. This protocol\
-should be used to communicate with the avrorouter and currently it is the only\
-supported protocol. The clients can request either Avro or JSON format data\
+The converted Avro files can be requested with the CDC protocol. This protocol
+should be used to communicate with the avrorouter and currently it is the only
+supported protocol. The clients can request either Avro or JSON format data
 streams from a database table.
 
 ### Direct Replication Mode
 
-MaxScale 2.4.0 added a direct replication mode that connects the avrorouter\
-directly to a MariaDB server. This mode is an improvement over the binlogrouter\
-based replication as it provides a more space-efficient and faster conversion\
-process. This is the recommended method of using the avrorouter as it is faster,\
+MaxScale 2.4.0 added a direct replication mode that connects the avrorouter
+directly to a MariaDB server. This mode is an improvement over the binlogrouter
+based replication as it provides a more space-efficient and faster conversion
+process. This is the recommended method of using the avrorouter as it is faster,
 more efficient and less prone to errors caused by missing DDL events.
 
-To enable the direct replication mode, add either the `servers` or the `cluster`\
-parameter to the avrorouter service. The avrorouter will then use one of the\
+To enable the direct replication mode, add either the `servers` or the `cluster`
+parameter to the avrorouter service. The avrorouter will then use one of the
 servers as the replication source.
 
 Here is a minimal avrorouter direct replication configuration:
@@ -110,12 +110,12 @@ protocol=CDC
 port=4001
 ```
 
-In direct replication mode, the avrorouter stores the latest replicated GTID in\
-the `last_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove\
+In direct replication mode, the avrorouter stores the latest replicated GTID in
+the `last_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove
 the file.
 
-Additionally, the avrorouter will attempt to automatically create any missing\
-schema files for tables that have data events for them but the DDL for those\
+Additionally, the avrorouter will attempt to automatically create any missing
+schema files for tables that have data events for them but the DDL for those
 tables is not contained in the binlogs.
 
 ### Configuration
@@ -131,13 +131,13 @@ For information about common service parameters, refer to the [Configuration Gui
 * Dynamic: No
 * Default: `""`
 
-The GTID where avrorouter starts the replication from in direct replication\
-mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where\
-the first number is the replication domain, the second the server\_id value of\
+The GTID where avrorouter starts the replication from in direct replication
+mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where
+the first number is the replication domain, the second the server\_id value of
 the server and the last is the GTID sequence number.
 
-This parameter has no effect in the traditional mode. If this parameter is\
-defined, the replication will start from the implicit GTID that the master first\
+This parameter has no effect in the traditional mode. If this parameter is
+defined, the replication will start from the implicit GTID that the master first
 serves.
 
 **`server_id`**
@@ -147,7 +147,7 @@ serves.
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
 used when replicating from the master in direct replication mode.
 
 **`codec`**
@@ -161,7 +161,7 @@ used when replicating from the master in direct replication mode.
 The compression codec to use. By default, the avrorouter does not use compression.
 
 This parameter takes one of the following two values; _null_ or\_deflate\_. These are the mandatory compression algorithms required by the\
-Avro specification. For more information about the compression types,\
+Avro specification. For more information about the compression types,
 refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specification/#required-codecs).
 
 **`match` and `exclude`**
@@ -171,13 +171,13 @@ refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specificat
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+These [regular expression settings](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 filter events for processing depending on table names. Avrorouter does not support the\_options\_-parameter for regular expressions.
 
-To prevent excessive matching of similarly named tables, surround each table\
-name with the `^` and `$` tokens. For example, to match the `test.clients` table\
-but not `test.clients_old` table use `match=^test[.]clients$`. For multiple\
-tables, surround each table in parentheses and add a pipe character between\
+To prevent excessive matching of similarly named tables, surround each table
+name with the `^` and `$` tokens. For example, to match the `test.clients` table
+but not `test.clients_old` table use `match=^test[.]clients$`. For multiple
+tables, surround each table in parentheses and add a pipe character between
 them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 
 **`binlogdir`**
@@ -187,8 +187,8 @@ them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location of the binary log files. This is the first mandatory parameter\
-and it defines where the module will read binlog files from. Read access to\
+The location of the binary log files. This is the first mandatory parameter
+and it defines where the module will read binlog files from. Read access to
 this directory is required.
 
 **`avrodir`**
@@ -198,14 +198,14 @@ this directory is required.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location where the Avro files are stored. This is the second mandatory\
-parameter and it governs where the converted files are stored. This directory\
-will be used to store the Avro files, plain-text Avro schemas and other files\
-needed by the avrorouter. The user running MariaDB MaxScale will need both read and\
+The location where the Avro files are stored. This is the second mandatory
+parameter and it governs where the converted files are stored. This directory
+will be used to store the Avro files, plain-text Avro schemas and other files
+needed by the avrorouter. The user running MariaDB MaxScale will need both read and
 write access to this directory.
 
-The avrorouter will also use the _avrodir_ to store various internal\
-files. These files are named _avro.index_ and _avro-conversion.ini_. By default,\
+The avrorouter will also use the _avrodir_ to store various internal
+files. These files are named _avro.index_ and _avro-conversion.ini_. By default,
 the default data directory, _/var/lib/maxscale/_, is used. Before version 2.1 of\
 MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 
@@ -216,7 +216,7 @@ MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 * Dynamic: No
 * Default: `mysql-bin`
 
-The base name of the binlog files. The binlog files are assumed to follow the\
+The base name of the binlog files. The binlog files are assumed to follow the
 naming schema _._ where is the binlog number and is the value of this router option.
 
 For example, with the following parameters:
@@ -236,11 +236,11 @@ The first binlog file the avrorouter would look for is `/var/lib/mysql/binlogs/m
 * Default: `1`
 
 The starting index number of the binlog file. The default value is 1.\
-For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_\
+For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_
 the index would be 5.
 
-If you need to start from a binlog file other than 1, you need to set the value\
-of this option to the correct index. The avrorouter will always start from the\
+If you need to start from a binlog file other than 1, you need to set the value
+of this option to the correct index. The avrorouter will always start from the
 beginning of the binary log file.
 
 #### `cooperative_replication`
@@ -250,39 +250,39 @@ beginning of the binary log file.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
-cluster. This is a boolean parameter and is disabled by default. It was\
+Controls whether multiple instances cooperatively replicate from the same
+cluster. This is a boolean parameter and is disabled by default. It was
 added in MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`),\
-the replication is only active if the monitor owns the cluster it is\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`),
+the replication is only active if the monitor owns the cluster it is
 monitoring.
 
-With this feature, multiple MaxScale instances can replicate from the same set\
-of servers and only one of them actively processes the replication stream. This\
-allows the avrorouter instances to be made highly-available without having to\
+With this feature, multiple MaxScale instances can replicate from the same set
+of servers and only one of them actively processes the replication stream. This
+allows the avrorouter instances to be made highly-available without having to
 have them all process the events at the same time.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID processed by that\
-instance. This means that if the instance hasn't replicated events that have\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID processed by that
+instance. This means that if the instance hasn't replicated events that have
 been purged from the binary logs, the replication cannot continue.
 
 **Avro File Related Parameters**
 
 These options control how large the Avro file data blocks can get.\
-Increasing or lowering the block size could have a positive effect\
-depending on your use case. For more information about the Avro file\
+Increasing or lowering the block size could have a positive effect
+depending on your use case. For more information about the Avro file
 format and how it organizes data, refer to the [Avro documentation](https://avro.apache.org/docs/current/).
 
-The avrorouter will flush a block and start a new one when either `group_trx`\
-transactions or `group_rows` row events have been processed. Changing these\
-options will also allow more frequent updates to stored data but this\
+The avrorouter will flush a block and start a new one when either `group_trx`
+transactions or `group_rows` row events have been processed. Changing these
+options will also allow more frequent updates to stored data but this
 will cause a small increase in file size and search times.
 
-It is highly recommended to keep the block sizes relatively large to allow\
-larger chunks of memory to be flushed to disk at one time. This will make\
+It is highly recommended to keep the block sizes relatively large to allow
+larger chunks of memory to be flushed to disk at one time. This will make
 the conversion process noticeably faster.
 
 **`group_trx`**
@@ -292,7 +292,7 @@ the conversion process noticeably faster.
 * Dynamic: No
 * Default: `1`
 
-Controls the number of transactions that are grouped into a single Avro\
+Controls the number of transactions that are grouped into a single Avro
 data block.
 
 **`group_rows`**
@@ -302,7 +302,7 @@ data block.
 * Dynamic: No
 * Default: `1000`
 
-Controls the number of row events that are grouped into a single Avro\
+Controls the number of row events that are grouped into a single Avro
 data block.
 
 **`block_size`**
@@ -312,10 +312,10 @@ data block.
 * Dynamic: Yes
 * Default: `16KiB`
 
-The Avro data block size in bytes. The default is 16 kilobytes. Increase this\
-value if individual events in the binary logs are very large. The value is a\
+The Avro data block size in bytes. The default is 16 kilobytes. Increase this
+value if individual events in the binary logs are very large. The value is a
 size type parameter which means that it can also be defined with an SI suffix.\
-Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 for more details about size type parameters and how to use them.
 
 **Example configuration**
@@ -338,94 +338,94 @@ avrodir=/var/lib/maxscale
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-module-commands.md) documentation for
 details about module commands.
 
 The avrorouter supports the following module commands.
 
 #### `avrorouter::convert SERVICE {start | stop}`
 
-Start or stop the binary log to Avro conversion. The first parameter is the name\
-of the service to stop and the second parameter tells whether to start the\
+Start or stop the binary log to Avro conversion. The first parameter is the name
+of the service to stop and the second parameter tells whether to start the
 conversion process or to stop it.
 
 #### `avrorouter::purge SERVICE`
 
 This command will delete all files created by the avrorouter. This includes all\
-.avsc schema files and .avro data files as well as the internal state tracking\
+.avsc schema files and .avro data files as well as the internal state tracking
 files. Use this to completely reset the conversion process.
 
-**Note:** Once the command has completed, MaxScale must be restarted to restart\
+**Note:** Once the command has completed, MaxScale must be restarted to restart
 the conversion process. Issuing a `convert start` command **will not work**.
 
-**WARNING:** You will lose any and all converted data when this command is\
+**WARNING:** You will lose any and all converted data when this command is
 executed.
 
 ### Files Created by the Avrorouter
 
-The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store\
-the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains\
-the last converted position and GTID in the binlogs. If you need to reset the\
+The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store
+the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains
+the last converted position and GTID in the binlogs. If you need to reset the
 conversion process, delete these two files and restart MaxScale.
 
 ### Resetting the Conversion Process
 
-To reset the binlog conversion process, issue the `purge` module command by\
-executing it via MaxCtrl and stop MaxScale. If manually created schema files\
+To reset the binlog conversion process, issue the `purge` module command by
+executing it via MaxCtrl and stop MaxScale. If manually created schema files
 were used, they need to be recreated once MaxScale is stopped. After stopping\
-MaxScale and optionally creating the schema files, the conversion process can be\
+MaxScale and optionally creating the schema files, the conversion process can be
 started by starting MaxScale.
 
 ### Stopping the Avrorouter
 
-The safest way to stop the avrorouter when used with the binlogrouter is to\
+The safest way to stop the avrorouter when used with the binlogrouter is to
 follow the following steps:
 
 * Issue `STOP SLAVE` on the binlogrouter
 * Wait for the avrorouter to process all files
 * Stop MaxScale with `systemctl stop maxscale`
 
-This guarantees that the conversion process halts at a known good position in\
+This guarantees that the conversion process halts at a known good position in
 the latest binlog file.
 
 ### Example Client
 
 The avrorouter comes with an example client program, _cdc.py_, written in Python 3.\
-This client can connect to a MaxScale configured with the CDC protocol and the\
+This client can connect to a MaxScale configured with the CDC protocol and the
 avrorouter.
 
-Before using this client, you will need to install the Python 3 interpreter and\
-add users to the service with the _cdc\_users.py_ script. Fore more details about\
-the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-change-data-capture-cdc-protocol.md)\
+Before using this client, you will need to install the Python 3 interpreter and
+add users to the service with the _cdc\_users.py_ script. Fore more details about
+the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-change-data-capture-cdc-protocol.md)
 and [CDC Users](../mariadb-maxscale-21-06-protocols/mariadb-maxscale-2106-maxscale-2106-change-data-capture-cdc-users.md) documentation.
 
-Read the output of `cdc.py --help` for a full list of supported options\
+Read the output of `cdc.py --help` for a full list of supported options
 and a short usage description of the client program.
 
 ### Avro Schema Generator
 
-The avrorouter needs to have access to the CREATE TABLE statement for all tables\
-for which there are data events in the binary logs. If the CREATE TABLE\
-statements for the tables aren't present in the current binary logs, the schema\
+The avrorouter needs to have access to the CREATE TABLE statement for all tables
+for which there are data events in the binary logs. If the CREATE TABLE
+statements for the tables aren't present in the current binary logs, the schema
 files must be created.
 
-In the direct replication mode, avrorouter will automatically create the missing\
-schema files by connecting to the database and executing a `SHOW CREATE TABLE`\
-statement. If a connection cannot be made or the service user lacks the\
-permission, an error will be logged and the data events for that table will not\
+In the direct replication mode, avrorouter will automatically create the missing
+schema files by connecting to the database and executing a `SHOW CREATE TABLE`
+statement. If a connection cannot be made or the service user lacks the
+permission, an error will be logged and the data events for that table will not
 be processed.
 
-For the legacy binlog mode, the files must be generated with a schema file\
+For the legacy binlog mode, the files must be generated with a schema file
 generator. There are currently two methods to generate the .avsc schema files.
 
 #### Simple Schema Generator
 
-The `cdc_one_schema.py` generates a schema file for a single table by reading a\
-tab separated list of field and type names from the standard input. This is the\
-recommended schema generation tool as it does not directly communicate with the\
+The `cdc_one_schema.py` generates a schema file for a single table by reading a
+tab separated list of field and type names from the standard input. This is the
+recommended schema generation tool as it does not directly communicate with the
 database thus making it more flexible.
 
-The only requirement to run the script is that a Python interpreter is\
+The only requirement to run the script is that a Python interpreter is
 installed.
 
 To use this script, pipe the output of the `mysql` command line into the`cdc_one_schema.py` script:
@@ -434,15 +434,15 @@ To use this script, pipe the output of the `mysql` command line into the`cdc_one
 mysql -ss -u <user> -p -h <host> -P <port> -e 'DESCRIBE `<database>`.`<table>`'|./cdc_one_schema.py <database> <table>
 ```
 
-Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with\
-appropriate values and run the command. Note that the `-ss` parameter is\
-mandatory as that will generate the tab separated output instead of the default\
+Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with
+appropriate values and run the command. Note that the `-ss` parameter is
+mandatory as that will generate the tab separated output instead of the default
 pretty-printed output.
 
-An .avsc file named after the database and table name will be generated in the\
+An .avsc file named after the database and table name will be generated in the
 current working directory. Copy this file to the location pointed by the`avrodir` parameter of the avrorouter.
 
-Alternatively, you can also copy the output of the `mysql` command to a file and\
+Alternatively, you can also copy the output of the `mysql` command to a file and
 feed it into the script if you cannot execute the SQL command directly:
 
 ```
@@ -465,31 +465,31 @@ usage: cdc_schema.py [--help] [-h HOST] [-P PORT] [-u USER] [-p PASSWORD] DATABA
 The _cdc\_schema.py_ executable is installed as a part of MaxScale. This is a\
 Python 3 script that generates Avro schema files from an existing database.
 
-The script will generate the .avsc schema files into the current directory. Run\
-the script for all required databases copy the generated .avsc files to the\
+The script will generate the .avsc schema files into the current directory. Run
+the script for all required databases copy the generated .avsc files to the
 directory where the avrorouter stores the .avro files (the value of `avrodir`).
 
 #### Go Schema Generator
 
-The _cdc\_schema.go_ example Go program is provided with MaxScale. This file\
-can be used to create Avro schemas for the avrorouter by connecting to a\
-database and reading the table definitions. You can find the file in MaxScale's\
+The _cdc\_schema.go_ example Go program is provided with MaxScale. This file
+can be used to create Avro schemas for the avrorouter by connecting to a
+database and reading the table definitions. You can find the file in MaxScale's
 share directory in `/usr/share/maxscale/`.
 
-You'll need to install the Go compiler and run `go get` to resolve Go\
-dependencies before you can use the _cdc\_schema_ program. After resolving the\
-dependencies you can run the program with `go run cdc_schema.go`. The program\
-will create .avsc files in the current directory. These files should be moved\
-to the location pointed by the _avrodir_ option of the avrorouter if they are\
+You'll need to install the Go compiler and run `go get` to resolve Go
+dependencies before you can use the _cdc\_schema_ program. After resolving the
+dependencies you can run the program with `go run cdc_schema.go`. The program
+will create .avsc files in the current directory. These files should be moved
+to the location pointed by the _avrodir_ option of the avrorouter if they are
 to be used by the router itself.
 
-Read the output of `go run cdc_schema.go -help` for more information on how\
+Read the output of `go run cdc_schema.go -help` for more information on how
 to run the program.
 
 ### Examples
 
-The [Avrorouter Tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-avrorouter-tutorial.md) shows you how\
-the Avrorouter works with the Binlog Server to convert binlogs from a master server\
+The [Avrorouter Tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-avrorouter-tutorial.md) shows you how
+the Avrorouter works with the Binlog Server to convert binlogs from a master server
 into easy to process Avro data.
 
 Here is a simple configuration example which reads binary logs locally from`/var/lib/mysql/` and stores them as Avro files in `/var/lib/maxscale/avro/`.\
@@ -519,7 +519,7 @@ Python script. It queries the table _test.mytable_ for all change records.
 cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytable
 ```
 
-You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change\
+You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change
 records to a Kafka broker.
 
 ```
@@ -527,28 +527,28 @@ cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytab
 cdc_kafka_producer.py --kafka-broker 127.0.0.1:9092 --kafka-topic test.mytable
 ```
 
-For more information on how to use these scripts, see the output of `cdc.py -h`\
+For more information on how to use these scripts, see the output of `cdc.py -h`
 and `cdc_kafka_producer.py -h`.
 
 ### Building Avrorouter
 
-To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development\
+To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development
 headers. When configuring MaxScale with CMake, you will need to add`-DBUILD_CDC=Y` to build the CDC module set.
 
-The Avro C library needs to be build with position independent code enabled. You\
-can do this by adding the following flags to the CMake invocation when\
+The Avro C library needs to be build with position independent code enabled. You
+can do this by adding the following flags to the CMake invocation when
 configuring the Avro C library.
 
 ```
 -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC
 ```
 
-For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-building-mariadb-maxscale-from-source-code.md)\
+For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-building-mariadb-maxscale-from-source-code.md)
 document.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for an avrorouter service contains the following\
+The `router_diagnostics` output for an avrorouter service contains the following
 fields.
 
 * `infofile`: File where the avrorouter stores the conversion process state.
@@ -568,8 +568,8 @@ The avrorouter does not support the following data types, conversions or SQL sta
 * Fields CAST from integer types to string types
 * [CREATE TABLE ... AS SELECT statements](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/tables/create-table)
 
-The avrorouter does not do any crash recovery. This means that the avro files\
-need to be removed or truncated to valid block lengths before starting the\
+The avrorouter does not do any crash recovery. This means that the avro files
+need to be removed or truncated to valid block lengths before starting the
 avrorouter.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-binlogrouter-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-binlogrouter-24.md
@@ -1,63 +1,63 @@
 # MaxScale 21.06 Binlogrouter 2.4
 
 **NOTE** This is the documentation for the binlogrouter in\
-MaxScale 2.4 and is only provided for reference. The documentation\
+MaxScale 2.4 and is only provided for reference. The documentation
 for the binlogrouter in MaxScale 2.5 is provided [here](mariadb-maxscale-2106-maxscale-2106-binlogrouter.md).
 
 ### Introduction
 
 The binlogrouter is a replication protocol proxy module for MariaDB\
-MaxScale. This module allows MariaDB MaxScale to connect to a master server and\
-retrieve binary logs while slave servers can connect to MariaDB MaxScale like\
-they would connect to a normal master server. If the master server goes down,\
-the slave servers can still connect to MariaDB MaxScale and read binary\
-logs. You can switch to a new master server without the slaves noticing that the\
-actual master server has changed. This allows for a more highly available\
+MaxScale. This module allows MariaDB MaxScale to connect to a master server and
+retrieve binary logs while slave servers can connect to MariaDB MaxScale like
+they would connect to a normal master server. If the master server goes down,
+the slave servers can still connect to MariaDB MaxScale and read binary
+logs. You can switch to a new master server without the slaves noticing that the
+actual master server has changed. This allows for a more highly available
 replication setup where replication is high-priority.
 
 ### Configuration
 
 #### Mandatory Router Parameters
 
-The binlogrouter requires the `user` and `password` parameters. These should be\
+The binlogrouter requires the `user` and `password` parameters. These should be
 configured according to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
 
-In addition to these two parameters, the `server_id` and `binlogdir` parameters\
+In addition to these two parameters, the `server_id` and `binlogdir` parameters
 needs to be defined.
 
 #### Router Parameters
 
 The binlogrouter accepts the following parameters.
 
-**Note:** Earlier versions of MaxScale supported the configuration of the\
-binlogrouter only via `router_options` (a the comma-separated list of key-value\
-pairs). As of MaxScale 2.1, all of the router options should be defined as\
-parameters. The values defined in `router_options` will have priority over the\
-parameters to support legacy configurations. The use of `router_options` is\
+**Note:** Earlier versions of MaxScale supported the configuration of the
+binlogrouter only via `router_options` (a the comma-separated list of key-value
+pairs). As of MaxScale 2.1, all of the router options should be defined as
+parameters. The values defined in `router_options` will have priority over the
+parameters to support legacy configurations. The use of `router_options` is
 deprecated.
 
 **`binlogdir`**
 
-This parameter controls the location where MariaDB MaxScale stores the binary log\
+This parameter controls the location where MariaDB MaxScale stores the binary log
 files. This is a mandatory parameter.
 
-The _binlogdir_ also contains the _cache_ subdirectory which stores data\
-retrieved from the master during the slave registration phase. The\
-master.ini file also resides in the _binlogdir_. This file keeps track of\
+The _binlogdir_ also contains the _cache_ subdirectory which stores data
+retrieved from the master during the slave registration phase. The
+master.ini file also resides in the _binlogdir_. This file keeps track of
 the current master configuration and it is updated when a `CHANGE MASTER TO` query is executed.
 
-From 2.1 onwards, the 'cache' directory is stored in the same location as other\
-user credential caches. This means that with the default options, the user\
+From 2.1 onwards, the 'cache' directory is stored in the same location as other
+user credential caches. This means that with the default options, the user
 credential cache is stored in`/var/cache/maxscale/<Service Name>/<Listener Name>/cache/`.
 
-Read the [MySQL Authenticator](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-mariadbmysql-authenticator.md)\
-documentation for instructions on how to define a custom location for the user\
+Read the [MySQL Authenticator](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-mariadbmysql-authenticator.md)
+documentation for instructions on how to define a custom location for the user
 cache.
 
 **`server_id`**
 
-MariaDB MaxScale must have a unique _server\_id_. This parameter configures\
-the value of the _server\_id_ that MariaDB MaxScale will use when\
+MariaDB MaxScale must have a unique _server\_id_. This parameter configures
+the value of the _server\_id_ that MariaDB MaxScale will use when
 connecting to the master. This is a mandatory parameter.
 
 Older versions of MaxScale allowed the ID to be specified using `server-id`.\
@@ -65,11 +65,11 @@ This has been deprecated and will be removed in a future release of MariaDB MaxS
 
 **`master_id`**
 
-The _server\_id_ value that MariaDB MaxScale should use to report to the slaves\
+The _server\_id_ value that MariaDB MaxScale should use to report to the slaves
 that connect to MariaDB MaxScale.
 
-This may either be the same as the server id of the real master or can be\
-chosen to be different if the slaves need to be aware of the proxy\
+This may either be the same as the server id of the real master or can be
+chosen to be different if the slaves need to be aware of the proxy
 layer. The real master server ID will be used if the option is not set.
 
 Older versions of MaxScale allowed the ID to be specified using `master-id`.\
@@ -77,52 +77,52 @@ This has been deprecated and will be removed in a future release of MariaDB MaxS
 
 **`uuid`**
 
-This is used to set the unique UUID that the binlog router uses when it connects\
+This is used to set the unique UUID that the binlog router uses when it connects
 to the master server. By default the UUID will be generated.
 
 **`master_uuid`**
 
-It is a requirement of replication that each server has a unique UUID value. If\
-this option is not set, binlogrouter will identify itself to the slaves using\
+It is a requirement of replication that each server has a unique UUID value. If
+this option is not set, binlogrouter will identify itself to the slaves using
 the UUID of the real master.
 
 **`master_version`**
 
-By default, the router will identify itself to the slaves using the server\
-version of the real master. This option allows the router to use a custom\
+By default, the router will identify itself to the slaves using the server
+version of the real master. This option allows the router to use a custom
 version string.
 
 **`master_hostname`**
 
-By default, the router will identify itself to the slaves using the hostname of\
+By default, the router will identify itself to the slaves using the hostname of
 the real master. This option allows the router to use a custom hostname.
 
 **`slave_hostname`**
 
-Since MaxScale 2.1.6 the router can optionally identify itself to the master\
-using a custom hostname. The specified hostname can be seen in the master via`SHOW SLAVE HOSTS` command. The default is not to send any hostname string\
+Since MaxScale 2.1.6 the router can optionally identify itself to the master
+using a custom hostname. The specified hostname can be seen in the master via`SHOW SLAVE HOSTS` command. The default is not to send any hostname string
 during registration.
 
 **`user`**
 
-_Note:_ This is option can only be given to the `router_options` parameter. Use\
+_Note:_ This is option can only be given to the `router_options` parameter. Use
 the `user` parameter of the service instead.
 
-This is the user name that MariaDB MaxScale uses when it connects to the\
-master. This user name must have the rights required for replication as with any\
-other user that a slave uses for replication purposes. If the user parameter is\
-not given in the router options then the same user as is used to retrieve the\
-credential information will be used for the replication connection, i.e. the\
+This is the user name that MariaDB MaxScale uses when it connects to the
+master. This user name must have the rights required for replication as with any
+other user that a slave uses for replication purposes. If the user parameter is
+not given in the router options then the same user as is used to retrieve the
+credential information will be used for the replication connection, i.e. the
 user in the service entry.
 
 This user is the only one available for MySQL connection to MaxScale Binlog\
 Server for administration when master connection is not done yet.
 
-In MaxScale 2.1, the service user injection is done by the MySQLAuth\
-authenticator module. Read the [MySQL Authenticator](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-mariadbmysql-authenticator.md)\
+In MaxScale 2.1, the service user injection is done by the MySQLAuth
+authenticator module. Read the [MySQL Authenticator](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-mariadbmysql-authenticator.md)
 documentation for more details.
 
-The user that is used for replication must be granted replication privileges on\
+The user that is used for replication must be granted replication privileges on
 the database server.
 
 ```
@@ -132,47 +132,47 @@ GRANT REPLICATION SLAVE ON *.* TO 'repl'@'maxscalehost';
 
 **`password`**
 
-_Note:_ This is option can only be given to the `router_options` parameter. Use\
+_Note:_ This is option can only be given to the `router_options` parameter. Use
 the `password` parameter of the service instead.
 
-The password for the user. If the password is not explicitly given then the\
-password in the service entry will be used. For compatibility with other\
-username and password definitions within the MariaDB MaxScale configuration file\
+The password for the user. If the password is not explicitly given then the
+password in the service entry will be used. For compatibility with other
+username and password definitions within the MariaDB MaxScale configuration file
 it is also possible to use the parameter `passwd`.
 
 **`heartbeat`**
 
-This defines the value of the heartbeat interval for the connection\
-to the master. The duration can be specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit\
-unit is provided, the value is interpreted as seconds in MaxScale 2.4. In\
-subsequent versions a value without a unit may be rejected. Note that since\
-the granularity of the parameter is seconds, a value specified in milliseconds\
+This defines the value of the heartbeat interval for the connection
+to the master. The duration can be specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit
+unit is provided, the value is interpreted as seconds in MaxScale 2.4. In
+subsequent versions a value without a unit may be rejected. Note that since
+the granularity of the parameter is seconds, a value specified in milliseconds
 will be rejected, even if the duration is longer than a second.\
 The default value for the heartbeat period is every 5 minutes.
 
-MariaDB MaxScale requests the master to ensure that a binlog event is sent at\
-least every heartbeat period. If there are no real binlog events to send the\
-master will sent a special heartbeat event. The current interval value is\
+MariaDB MaxScale requests the master to ensure that a binlog event is sent at
+least every heartbeat period. If there are no real binlog events to send the
+master will sent a special heartbeat event. The current interval value is
 reported in the diagnostic output.
 
 **`burstsize`**
 
-This parameter is used to define the maximum amount of data that will be sent to\
-a slave by MariaDB MaxScale when that slave is lagging behind the master. The\
+This parameter is used to define the maximum amount of data that will be sent to
+a slave by MariaDB MaxScale when that slave is lagging behind the master. The
 default value is `1M`.
 
-The burst size can be provided as specified [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md), except that IEC binary\
-prefixes can be used as suffixes only from MaxScale 2.1 onwards. MaxScale 2.0\
+The burst size can be provided as specified [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md), except that IEC binary
+prefixes can be used as suffixes only from MaxScale 2.1 onwards. MaxScale 2.0
 and earlier only support `burstsize` defined in bytes.
 
-In this situation the slave is said to be in "catchup mode", this parameter is\
-designed to both prevent flooding of that slave and also to prevent threads\
-within MariaDB MaxScale spending disproportionate amounts of time with slaves\
+In this situation the slave is said to be in "catchup mode", this parameter is
+designed to both prevent flooding of that slave and also to prevent threads
+within MariaDB MaxScale spending disproportionate amounts of time with slaves
 that are lagging behind the master.
 
 **`mariadb10-compatibility`**
 
-This parameter allows binlogrouter to replicate from a MariaDB 10.0 master\
+This parameter allows binlogrouter to replicate from a MariaDB 10.0 master
 server: this parameter is enabled by default since MaxScale 2.2.0.\
 In earlier versions the parameter was disabled by default.
 
@@ -181,7 +181,7 @@ In earlier versions the parameter was disabled by default.
 mariadb10-compatibility=1
 ```
 
-Additionally, since MaxScale 2.2.1, MariaDB 10.x slave servers\
+Additionally, since MaxScale 2.2.1, MariaDB 10.x slave servers
 can connect to binlog server using GTID value instead of binlog name and position.
 
 Example of a MariaDB 10.x slave connection to MaxScale
@@ -198,51 +198,51 @@ MariaDB> START SLAVE;
 **Note:**
 
 * Slave servers can connect either with file and pos or GTID.
-* MaxScale saves all the incoming MariaDB GTIDs (DDLs and DMLs)\
+* MaxScale saves all the incoming MariaDB GTIDs (DDLs and DMLs)
   in a sqlite3 database located in binlogdir (`gtid_maps.db`).\
-  When a slave server connects with a GTID request a lookup is made for\
+  When a slave server connects with a GTID request a lookup is made for
   the value match and following binlog events will be sent.
 
 **`transaction_safety`**
 
-This parameter is used to enable/disable incomplete transactions detection in\
+This parameter is used to enable/disable incomplete transactions detection in
 binlog router. The default value is _off_.
 
-When MariaDB MaxScale starts an error message may appear if current binlog file\
-is corrupted or an incomplete transaction is found. During normal operations\
-binlog events are not distributed to the slaves until a COMMIT is seen. Set\
+When MariaDB MaxScale starts an error message may appear if current binlog file
+is corrupted or an incomplete transaction is found. During normal operations
+binlog events are not distributed to the slaves until a COMMIT is seen. Set
 transaction\_safety=on to enable detection of incomplete transactions.
 
 **`send_slave_heartbeat`**
 
-This defines whether MariaDB MaxScale sends the heartbeat packet to the slave\
-when there are no real binlog events to send. This parameter takes a boolean\
-value and the default value is false. This means that no heartbeat events are\
+This defines whether MariaDB MaxScale sends the heartbeat packet to the slave
+when there are no real binlog events to send. This parameter takes a boolean
+value and the default value is false. This means that no heartbeat events are
 sent to slave servers.
 
-If value is set to true the interval value (requested by the slave during\
-registration) is reported in the diagnostic output and the packet is send after\
+If value is set to true the interval value (requested by the slave during
+registration) is reported in the diagnostic output and the packet is send after
 the time interval without any event to send.
 
 **`semisync`**
 
-This parameter controls whether binlog server could ask Master server to start\
-the Semi-Synchronous replication. This parameter takes a boolean value and the\
+This parameter controls whether binlog server could ask Master server to start
+the Semi-Synchronous replication. This parameter takes a boolean value and the
 default value is false.
 
-In order to get semi-sync working, the Master server must have the_rpl\_semi\_sync\_master_ plugin installed. The availability of the plugin and the\
+In order to get semi-sync working, the Master server must have the_rpl\_semi\_sync\_master_ plugin installed. The availability of the plugin and the
 value of the GLOBAL VARIABLE _rpl\_semi\_sync\_master\_enabled_ are checked in the\
-Master registration phase: if the plugin is installed in the Master database,\
+Master registration phase: if the plugin is installed in the Master database,
 the binlog server subsequently requests the semi-sync option.
 
 **Note:**
 
-* the network replication stream from Master has two additional bytes before\
+* the network replication stream from Master has two additional bytes before
   each binlog event.
 * the Semi-Sync protocol requires an acknowledge packet to be sent back to\
   Master only when requested: the semi-sync flag will have value of 1.\
   This flag is set only if _rpl\_semi\_sync\_master\_enabled=1_ is set in the\
-  Master, otherwise it will always have value of 0 and no ack packet is sent\
+  Master, otherwise it will always have value of 0 and no ack packet is sent
   back.
 
 Please note that semi-sync replication is only related to binlog server to\
@@ -250,32 +250,32 @@ Master communication.
 
 **`ssl_cert_verification_depth`**
 
-This parameter sets the maximum length of the certificate authority chain that\
-will be accepted. Legal values are positive integers. This applies to SSL\
-connection to master server that could be activated either by writing options in\
-master.ini or later via a _CHANGE MASTER TO_ command. This parameter cannot be\
+This parameter sets the maximum length of the certificate authority chain that
+will be accepted. Legal values are positive integers. This applies to SSL
+connection to master server that could be activated either by writing options in
+master.ini or later via a _CHANGE MASTER TO_ command. This parameter cannot be
 modified at runtime. The default verification depth is 9.
 
 **`encrypt_binlog`**
 
 Whether to encrypt binlog files: the default is _off_.
 
-When set to _on_ the binlog files will be encrypted using specified AES algorithm\
+When set to _on_ the binlog files will be encrypted using specified AES algorithm
 and the KEY in the specified key file.
 
-**Note:** binlog encryption must be used while replicating from a MariaDB 10.1\
-server and serving data to MariaDB 10.x slaves. In order to use binlog\
-encryption the master server MariaDB 10.1 must have encryption active\
-(encrypt-binlog=1 in my.cnf). This is required because both master and maxscale\
-must store encrypted data for a working scenario for Secure\
+**Note:** binlog encryption must be used while replicating from a MariaDB 10.1
+server and serving data to MariaDB 10.x slaves. In order to use binlog
+encryption the master server MariaDB 10.1 must have encryption active
+(encrypt-binlog=1 in my.cnf). This is required because both master and maxscale
+must store encrypted data for a working scenario for Secure
 data-at-rest. Additionally, as long as Master server doesn't send the\
-StartEncryption event (which contains encryption setup information for the\
-binlog file), there is a position gap between end of FormatDescription event pos\
-and next event start pos. The StartEncryption event size is 36 or 40 (depending\
+StartEncryption event (which contains encryption setup information for the
+binlog file), there is a position gap between end of FormatDescription event pos
+and next event start pos. The StartEncryption event size is 36 or 40 (depending
 on CRC32 being used), so the gap has that size.
 
-MaxScale binlog server adds its own StartEncryption to binlog files consequently\
-the binlog events positions in binlog file are the same as in the master binlog\
+MaxScale binlog server adds its own StartEncryption to binlog files consequently
+the binlog events positions in binlog file are the same as in the master binlog
 file and there is no position mismatch.
 
 **`encryption_algorithm`**
@@ -290,11 +290,11 @@ The specified key file must contains lines with following format:
 
 Id is the scheme identifier, which must have the value 1 for binlog encryption\
 , the ';' is a separator and HEX(KEY) contains the hex representation of the KEY.\
-The KEY must have exact 16, 24 or 32 bytes size and the selected algorithm\
+The KEY must have exact 16, 24 or 32 bytes size and the selected algorithm
 (aes\_ctr or aes\_cbc) with 128, 192 or 256 ciphers will be used.
 
-**Note:** the key file has the same format as MariaDB 10.1 server so it's\
-possible to use an existing key file (not encrypted) which could contain several`scheme;key` values: only key id with value 1 will be parsed, and if not found\
+**Note:** the key file has the same format as MariaDB 10.1 server so it's
+possible to use an existing key file (not encrypted) which could contain several`scheme;key` values: only key id with value 1 will be parsed, and if not found
 an error will be reported.
 
 Example key file with multiple keys:
@@ -312,11 +312,11 @@ Example key file with multiple keys:
 
 **`mariadb10_master_gtid`**
 
-This option allows MaxScale binlog router to register with MariaDB 10.X master\
-using GTID instead of _binlog\_file_ name and _position_ in CHANGE MASTER TO\
+This option allows MaxScale binlog router to register with MariaDB 10.X master
+using GTID instead of _binlog\_file_ name and _position_ in CHANGE MASTER TO
 admin command. This feature is disabled by default.
 
-The user can set a known GTID or an empty value (in this case the Master server\
+The user can set a known GTID or an empty value (in this case the Master server
 will send events from it's first available binlog file).
 
 Example of MaxScale connection to a MariaDB 10.X Master
@@ -334,41 +334,41 @@ MariaDB> START SLAVE;
 If using GTID request then it's no longer possible to use MASTER\_LOG\_FILE and\
 MASTER\_LOG\_POS in `CHANGE MASTER TO` command: an error will be reported.
 
-If this feature is enabled, the _transaction\_safety_ option will be\
-automatically enabled. The binlog files will also be stored in a\
+If this feature is enabled, the _transaction\_safety_ option will be
+automatically enabled. The binlog files will also be stored in a
 hierarchical directory tree instead of a single directory.
 
 **Note:**
 
 * When the option is On, the connecting slaves can only use GTID request:\
-  specifying file and pos will end up in an error sent by MaxScale and\
+  specifying file and pos will end up in an error sent by MaxScale and
   replication cannot start.
-* The GTID request could cause the writing of events\
-  in any position of the binlog file, whose name has been sent\
+* The GTID request could cause the writing of events
+  in any position of the binlog file, whose name has been sent
   by the master server before any event.\
-  In order to avoid holes in the binlog files, MaxScale will fill all gaps\
+  In order to avoid holes in the binlog files, MaxScale will fill all gaps
   in the binlog files with ignorable events.
-* It's not possible to specify the GTID \_domain\_id: the master one\
-  is being used for all operations. All slave servers must use the same replication\
+* It's not possible to specify the GTID \_domain\_id: the master one
+  is being used for all operations. All slave servers must use the same replication
   domain as the master server.
 
 **`master_retry_count`**
 
-This option sets the maximum number of connection retries when the master server is\
+This option sets the maximum number of connection retries when the master server is
 disconnected or not reachable.\
 Default value is 1000.
 
 **`connect_retry`**
 
 The option sets the time interval for a new connection retry to master server.\
-The duration can be specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit\
-unit is provided, the value is interpreted as seconds in MaxScale 2.4. In\
-subsequent versions a value without a unit may be rejected. Note that since\
-the granularity of the parameter is seconds, a value specified in milliseconds\
+The duration can be specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit
+unit is provided, the value is interpreted as seconds in MaxScale 2.4. In
+subsequent versions a value without a unit may be rejected. Note that since
+the granularity of the parameter is seconds, a value specified in milliseconds
 will be rejected, even if the duration is longer than a second.\
 The default value is 60 seconds.
 
-**A complete example** of a service entry for a binlog router service would be as\
+**A complete example** of a service entry for a binlog router service would be as
 follows.
 
 ```
@@ -387,7 +387,7 @@ encryption_key_file=/var/binlogs/enc_key.txt
 
 #### Using secondary masters
 
-From MaxScale 2.3 onwards it is possible to specify secondary masters that\
+From MaxScale 2.3 onwards it is possible to specify secondary masters that
 the binlog router can use in case the connection to the default master fails.
 
 **Note:** This is _only_ supported in a Galera Cluster environment in which:
@@ -395,10 +395,10 @@ the binlog router can use in case the connection to the default master fails.
 * Wsrep GTID mode is enabled in the cluster.
 * All of the requirements for wsrep GTID mode are met by the cluster.
 
-_Wsrep GTID mode_ is also imperfect, so this secondary master functionality is\
+_Wsrep GTID mode_ is also imperfect, so this secondary master functionality is
 only guaranteed to work if GTIDs have not become inconsistent within the cluster.
 
-See [Wsrep GTID Mode](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/high-availability/using-mariadb-replication-with-mariadb-galera-cluster/using-mariadb-gtids-with-mariadb-galera-cluster)\
+See [Wsrep GTID Mode](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/high-availability/using-mariadb-replication-with-mariadb-galera-cluster/using-mariadb-gtids-with-mariadb-galera-cluster)
 for more information.
 
 The initial setup is performed exactly like when there is but one default master.
@@ -414,7 +414,7 @@ MariaDB> CHANGE MASTER TO
          MASTER_USE_GTID=Slave_pos;
 ```
 
-After the setup of the default master, secondary masters can be configured\
+After the setup of the default master, secondary masters can be configured
 as follows:
 
 ```
@@ -426,12 +426,12 @@ MariaDB> CHANGE MASTER ':2' TO
          MASTER_USE_GTID=Slave_pos;
 ```
 
-That is, a connection name must be provided and the name must be of the\
-format `:N` where `N` is a positive integer. If several secondary masters\
+That is, a connection name must be provided and the name must be of the
+format `:N` where `N` is a positive integer. If several secondary masters
 are specified, they must be numbered consecutively, starting from `2`.
 
-All settings that are not explicitly specified are copied from the\
-default master. That is, the following is equivalent with the command\
+All settings that are not explicitly specified are copied from the
+default master. That is, the following is equivalent with the command
 above:
 
 ```
@@ -446,17 +446,17 @@ For instance, the following command would only change the password of `:2`.
 MariaDB> CHANGE MASTER ':2' TO MASTER_PASSWORD='repl2';
 ```
 
-It is not possible to delete a particular secondary master, but if`MASTER_HOST` is set on the default master, even if it is set to the same\
+It is not possible to delete a particular secondary master, but if`MASTER_HOST` is set on the default master, even if it is set to the same
 value, then _all_ secondary master configurations are deleted.
 
-When `START SLAVE` is issued, MaxScale will first attempt to connect to the\
-default master and if that fails, try the secondary masters in order, until\
+When `START SLAVE` is issued, MaxScale will first attempt to connect to the
+default master and if that fails, try the secondary masters in order, until
 a connection can be created. Only if all connection attempts fail, will\
-MaxScale wait as specified with `connect_retry`, before doing the cycle over\
+MaxScale wait as specified with `connect_retry`, before doing the cycle over
 again.
 
-Once the binlog router has successfully connected to a server, it will stay\
-connected to that server until the connection breaks or `STOP SLAVE` is\
+Once the binlog router has successfully connected to a server, it will stay
+connected to that server until the connection breaks or `STOP SLAVE` is
 issued.
 
 The configurations of the secondary masters are also stored to the`master.ini` in sections whose name include the connection name.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-binlogrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-binlogrouter.md
@@ -1,57 +1,57 @@
 # MaxScale 21.06 Binlogrouter
 
 **NOTE:** The binlog router delivered with 2.5 is completely new and is **not**\
-100% backward compatible with the binlog router delivered with earlier\
+100% backward compatible with the binlog router delivered with earlier
 versions of MaxScale.
 
-The binlogrouter is a router that acts as a replication proxy for MariaDB\
-master-slave replication. The router connects to a master, retrieves the binary\
-logs and stores them locally. Slave servers can connect to MaxScale like they\
-would connect to a normal master server. If the master server goes down,\
-replication between MaxScale and the slaves can still continue up to the latest\
-point to which the binlogrouter replicated to. The master can be changed without\
-disconnecting the slaves and without them noticing that the master server has\
+The binlogrouter is a router that acts as a replication proxy for MariaDB
+master-slave replication. The router connects to a master, retrieves the binary
+logs and stores them locally. Slave servers can connect to MaxScale like they
+would connect to a normal master server. If the master server goes down,
+replication between MaxScale and the slaves can still continue up to the latest
+point to which the binlogrouter replicated to. The master can be changed without
+disconnecting the slaves and without them noticing that the master server has
 changed. This allows for a more highly available replication setup.
 
-In addition to the high availability benefits, the binlogrouter creates only one\
-connection to the master whereas with normal replication each individual slave\
-will create a separate connection. This reduces the amount of work the master\
-database has to do which can be significant if there are a large number of\
+In addition to the high availability benefits, the binlogrouter creates only one
+connection to the master whereas with normal replication each individual slave
+will create a separate connection. This reduces the amount of work the master
+database has to do which can be significant if there are a large number of
 replicating slaves.
 
 ### Differences Between Old and New Binlogrouter Implementations
 
-The binlogrouter in MaxScale 2.5.0 is a new and improved version of the original\
-binlogrouter found in older MaxScale versions. The new implementation contains\
-most of the features that were in the original binlogrouter but some of them\
+The binlogrouter in MaxScale 2.5.0 is a new and improved version of the original
+binlogrouter found in older MaxScale versions. The new implementation contains
+most of the features that were in the original binlogrouter but some of them
 were removed as they were either redundant or not useful.
 
 The major differences between the new and old binlog router are:
 
-* The list of servers where the database users for authentication are loaded\
-  must be explicitly configured with the `cluster`, `servers` or`targets` parameter. Alternatively, the users can be read from a file. See [user\_accounts\_file](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+* The list of servers where the database users for authentication are loaded
+  must be explicitly configured with the `cluster`, `servers` or`targets` parameter. Alternatively, the users can be read from a file. See [user\_accounts\_file](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
   for more information.
 * The old binlog router had both `server_id` and `master_id`, the new only`server_id`.
-* No need to configure heartbeat and burst interval anymore as they are\
+* No need to configure heartbeat and burst interval anymore as they are
   now automatically configured.
-* Traditional replication that uses the binary log name and file offset to\
+* Traditional replication that uses the binary log name and file offset to
   start the replication process is not supported.
 * Semi-sync support is not implemented.
 * Binlog encryption is not implemented.
 * Secondary masters are not supported, but the functionality provided by`select_master` is roughly equivalent.
-* The new binlogrouter will write its own binlog files to prevent problems that\
-  could happen when the master changes. This causes the binlog names to be\
+* The new binlogrouter will write its own binlog files to prevent problems that
+  could happen when the master changes. This causes the binlog names to be
   different in the binlogrouter when compared to the ones on the master.
 
 The documentation for the binlogrouter in MaxScale 2.4 is provided for reference [here](mariadb-maxscale-2106-maxscale-2106-binlogrouter-24.md).
 
 ### Supported SQL Commands
 
-The binlogrouter supports a subset of the SQL constructs that the MariaDB server\
+The binlogrouter supports a subset of the SQL constructs that the MariaDB server
 supports. The following commands are supported:
 
 * `CHANGE MASTER TO`
-* The binlogrouter supports the same syntax as the MariaDB server but only the\
+* The binlogrouter supports the same syntax as the MariaDB server but only the
   following values are allowed:
   * `MASTER_HOST`
   * `MASTER_PORT`
@@ -68,7 +68,7 @@ supports. The following commands are supported:
   * `MASTER_SSL_CIPHER`
   * `MASTER_SSL_VERIFY_SERVER_CERT`
 
-NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported\
+NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported
 as binlogrouter only supports GTID based replication.
 
 * `STOP SLAVE`
@@ -76,56 +76,56 @@ as binlogrouter only supports GTID based replication.
 * `START SLAVE`
 * Starts replication, same as MariaDB.
 * `RESET SLAVE`
-* Resets replication. Note that the `RESET SLAVE ALL` form that is supported\
+* Resets replication. Note that the `RESET SLAVE ALL` form that is supported
   by MariaDB isn't supported by the binlogrouter.
 * `SHOW BINARY LOGS`
-* Lists the current files and their sizes. These will be different from the\
-  ones listed by the original master where the binlogrouter is replicating\
+* Lists the current files and their sizes. These will be different from the
+  ones listed by the original master where the binlogrouter is replicating
   from.
 * `PURGE { BINARY | MASTER } LOGS TO <filename>`
-* Purges binary logs up to but not including the given file. The file name\
-  must be one of the names shown in `SHOW BINARY LOGS`. The version of this\
+* Purges binary logs up to but not including the given file. The file name
+  must be one of the names shown in `SHOW BINARY LOGS`. The version of this
   command which accepts a timestamp is not currently supported.\
-  Automatic purging is supported using the configuration\
+  Automatic purging is supported using the configuration
   parameter [expire\_log\_duration](mariadb-maxscale-2106-maxscale-2106-binlogrouter.md#expire_log_duration).\
-  The files are purged in the order they were created. If a file to be purged\
-  is detected to be in use, the purge stops. This means that the purge will\
+  The files are purged in the order they were created. If a file to be purged
+  is detected to be in use, the purge stops. This means that the purge will
   stop at the oldest file that a slave is still reading.\
-  NOTE: You should still take precaution not to purge files that a potential\
-  slave will need in the future. MaxScale can only detect that a file is\
+  NOTE: You should still take precaution not to purge files that a potential
+  slave will need in the future. MaxScale can only detect that a file is
   in active use when a slave is connected, and requesting events from it.
 * `SHOW MASTER STATUS`
-* Shows the name and position of the file to which the binlogrouter will write\
-  the next replicated data. The name and position do not correspond to the\
+* Shows the name and position of the file to which the binlogrouter will write
+  the next replicated data. The name and position do not correspond to the
   name and position in the master.
 * `SHOW SLAVE STATUS`
-* Shows the slave status information similar to what a normal MariaDB slave\
-  server shows. Some of the values are replaced with constants values that\
+* Shows the slave status information similar to what a normal MariaDB slave
+  server shows. Some of the values are replaced with constants values that
   never change. The following values are not constant:
-  * `Slave_IO_State`: Set to `Waiting for master to send event` when\
+  * `Slave_IO_State`: Set to `Waiting for master to send event` when
     replication is ongoing.
   * `Master_Host`: Address of the current master.
   * `Master_User`: The user used to replicate.
   * `Master_Port`: The port the master is listening on.
-  * `Master_Log_File`: The name of the latest file that the binlogrouter is\
+  * `Master_Log_File`: The name of the latest file that the binlogrouter is
     writing to.
-  * `Read_Master_Log_Pos`: The current position where the last event was\
+  * `Read_Master_Log_Pos`: The current position where the last event was
     written in the latest binlog.
-  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's\
+  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's
     not.
-  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's\
+  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's
     not.
   * `Exec_Master_Log_Pos`: Same as `Read_Master_Log_Pos`.
   * `Gtid_IO_Pos`: The latest replicated GTID.
 * `SELECT { Field } ...`
-* The binlogrouter implements a small subset of the MariaDB SELECT syntax as\
-  it is mainly used by the replicating slaves to query various parameters. If\
-  a field queried by a client is not known to the binlogrouter, the value\
-  will be returned back as-is. The following list of functions and variables\
+* The binlogrouter implements a small subset of the MariaDB SELECT syntax as
+  it is mainly used by the replicating slaves to query various parameters. If
+  a field queried by a client is not known to the binlogrouter, the value
+  will be returned back as-is. The following list of functions and variables
   are understood by the binlogrouter and are replaced with actual values:
-  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of\
+  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of
     these return the latest GTID replicated from the master.
-  * `version()` or `@@version`: The version string returned by MaxScale when\
+  * `version()` or `@@version`: The version string returned by MaxScale when
     a client connects to it.
   * `UNIX_TIMESTAMP()`: The current timestamp.
   * `@@version_comment`: Always `pinloki`.
@@ -153,22 +153,22 @@ as binlogrouter only supports GTID based replication.
   * `@@tx_isolation`: Always `REPEATABLE-READ`
   * `@@wait_timeout`: Always `28800`
 * `SET`
-* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should\
+* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should
   start replicating. E.g. `SET @@global.gtid_slave_pos="0-1000-1234,1-1001-5678"`
 * `SHOW VARIABLES LIKE '...'`
-* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`\
-  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`\
-  is not currently supported. In addition, the `LIKE` operator in\
+* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`
+  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`
+  is not currently supported. In addition, the `LIKE` operator in
   binlogrouter only supports exact matches.\
-  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID\
-  coordinates of the binlogrouter. In addition to these, the `server_id`\
+  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID
+  coordinates of the binlogrouter. In addition to these, the `server_id`
   variable will return the configured server ID of the binlogrouter.
 
 ### Configuration Parameters
 
 The binlogrouter is configured similarly to how normal routers are configured in\
-MaxScale. It requires at least one listener where clients can connect to and one\
-server from which the database user information can be retrieved. An example\
+MaxScale. It requires at least one listener where clients can connect to and one
+server from which the database user information can be retrieved. An example
 configuration can be found in the [example](mariadb-maxscale-2106-maxscale-2106-binlogrouter.md#example) section of this document.
 
 #### `datadir`
@@ -187,7 +187,7 @@ Directory where binary log files are stored.
 * Dynamic: No
 * Default: `1234`
 
-The server ID that MaxScale uses when connecting to the master and when serving\
+The server ID that MaxScale uses when connecting to the master and when serving
 binary logs to the slaves.
 
 #### `net_timeout`
@@ -208,26 +208,26 @@ Network connection and read timeout in seconds for the connection to the master.
 
 Automatically select the master server to replicate from.
 
-When this feature is enabled, the master which binlogrouter will replicate\
+When this feature is enabled, the master which binlogrouter will replicate
 from will be selected from the servers defined by a monitor `cluster=TheMonitor`.\
-Alternatively servers can be listed in `servers`. The servers should be monitored\
-by a monitor. Only servers with the `Master` status are used. If multiple master\
+Alternatively servers can be listed in `servers`. The servers should be monitored
+by a monitor. Only servers with the `Master` status are used. If multiple master
 servers are available, the first available master server will be used.
 
-If a `CHANGE MASTER TO` command is received while `select_master` is on, the\
+If a `CHANGE MASTER TO` command is received while `select_master` is on, the
 command will be honored and `select_master` turned off until the next reboot.\
 This allows the Monitor to perform failover, and more importantly, switchover.\
-It also allows the user to manually redirect the Binlogrouter. The current\
+It also allows the user to manually redirect the Binlogrouter. The current
 master is "sticky", meaning that the same master will be chosen on reboot.
 
-**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is\
-monitoring a binlogrouter. The binlogrouter does not support all the SQL\
-commands that the monitor will send and the rejoin will fail. This restriction\
+**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is
+monitoring a binlogrouter. The binlogrouter does not support all the SQL
+commands that the monitor will send and the rejoin will fail. This restriction
 will be lifted in a future version.
 
 The GTID the replication will start from, will be based on the latest replicated\
-GTID. If no GTID has been replicated, the router will start replication from the\
-start. Manual configuration of the GTID can be done by first configuring the\
+GTID. If no GTID has been replicated, the router will start replication from the
+start. Manual configuration of the GTID can be done by first configuring the
 replication manually with `CHANGE MASTER TO`.
 
 #### `expire_log_duration`
@@ -239,9 +239,9 @@ replication manually with `CHANGE MASTER TO`.
 
 Duration after which a binary log file can be automatically removed.
 
-The duration is measured from the last modification of the log file. Files are\
-purged in the order they were created. The automatic purge works in a similar\
-manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if\
+The duration is measured from the last modification of the log file. Files are
+purged in the order they were created. The automatic purge works in a similar
+manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if
 an eligible file is in active use, i.e. being read by a slave.
 
 The duration can be specified as explained [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
@@ -253,13 +253,13 @@ The duration can be specified as explained [here](../mariadb-maxscale-21-06-gett
 * Dynamic: No
 * Default: `2`
 
-The minimum number of log files the automatic purge keeps. At least one file\
+The minimum number of log files the automatic purge keeps. At least one file
 is always kept.
 
 ### New installation
 
 1. Configure and start MaxScale.
-2. If you have not configured `select_master=true` (automatic\
+2. If you have not configured `select_master=true` (automatic
    master selection), issue a `CHANGE MASTER TO` command to binlogrouter.
 
 ```
@@ -281,29 +281,29 @@ SHOW SLAVE STATUS \G
 
 ### Upgrading to version 2.5
 
-Binlogrouter does not read any of the data that a version prior to 2.5\
-has saved. By default binlogrouter will request the replication stream\
-from the blank state (from the start of time), which is basically meant\
-for new systems. If a system is live, the entire replication data probably\
-does not exist, and if it does, it is not necessary for binlogrouter to read\
+Binlogrouter does not read any of the data that a version prior to 2.5
+has saved. By default binlogrouter will request the replication stream
+from the blank state (from the start of time), which is basically meant
+for new systems. If a system is live, the entire replication data probably
+does not exist, and if it does, it is not necessary for binlogrouter to read
 and store all the data.
 
 #### Before you start
 
 * Note that binlogrouter only supports GTID based replication.
-* Make sure that the configured data directory for the new binlogrouter\
+* Make sure that the configured data directory for the new binlogrouter
   is different from the old one, or move old data away.\
   See [datadir](mariadb-maxscale-2106-maxscale-2106-binlogrouter.md#datadir).
-* If the master contains binlogs from the blank state, and there\
+* If the master contains binlogs from the blank state, and there
   is a large amount of data, consider purging old binlogs.\
   See [Using and Maintaining the Binary Log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log).
 
 #### Deployment
 
-The method described here inflicts the least downtime. Assuming you have\
+The method described here inflicts the least downtime. Assuming you have
 configured version 2.5, and it is ready to go:
 
-1. Redirect each slave that replicates from Binlogrouter to replicate from the\
+1. Redirect each slave that replicates from Binlogrouter to replicate from the
    master.
 
 ```
@@ -326,7 +326,7 @@ master_user=USER,master_password="PASSWORD", master_use_gtid=slave_pos;
 ```
 
 1. Run `maxctrl list servers`. Make sure all your servers are accounted for.\
-   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and\
+   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and
    issue this command to Binlogrouter:
 
 ```
@@ -335,8 +335,8 @@ SET @@global.gtid_slave_pos = "0-1000-1234,1-1001-5678";
 START SLAVE
 ```
 
-**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos\
-if any binlog files have been purged on the master. The server will only stream\
+**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos
+if any binlog files have been purged on the master. The server will only stream
 from the start of time if the first binlog file is present.\
 See [select\_master](mariadb-maxscale-2106-maxscale-2106-binlogrouter.md#select_master).
 
@@ -354,7 +354,7 @@ SHOW SLAVE STATUS \G
 
 ### Galera cluster
 
-When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2106-maxscale-2106-binlogrouter.md#select_master) must be\
+When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2106-maxscale-2106-binlogrouter.md#select_master) must be
 set to true, and the servers must be monitored by the [Galera Monitor](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-galera-monitor.md).\
 Configuring binlogrouter is the same as described above.
 
@@ -419,8 +419,8 @@ port=3306
 
 ### Limitations
 
-* Old-style replication with binlog name and file offset is not supported\
-  and the replication must be started by setting up the GTID to replicate\
+* Old-style replication with binlog name and file offset is not supported
+  and the replication must be started by setting up the GTID to replicate
   from.
 * Only replication from MariaDB servers (including Galera) is supported.
 * The MariaDB server where the replication is done from must be configured with`binlog_checksum=CRC32`.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-cat.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-cat.md
@@ -2,8 +2,8 @@
 
 The `cat` router is a special router that concatenates result sets.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Configuration
@@ -12,28 +12,28 @@ The router has no special parameters. To use it, define a service with`router=ca
 
 ### Behavior
 
-The order the servers are defined in is the order in which the servers are\
-queried. This means that the results are ordered based on the `servers`\
-parameter of the service. The result will only be completed once all servers\
+The order the servers are defined in is the order in which the servers are
+queried. This means that the results are ordered based on the `servers`
+parameter of the service. The result will only be completed once all servers
 have executed this.
 
-All commands executed via this router will be executed on all servers. This\
-means that an INSERT through the `cat` router will send it to all servers. In\
-the case of commands that do not return resultsets, the response of the last\
-server is sent to the client. This means that if one of the earlier servers\
+All commands executed via this router will be executed on all servers. This
+means that an INSERT through the `cat` router will send it to all servers. In
+the case of commands that do not return resultsets, the response of the last
+server is sent to the client. This means that if one of the earlier servers
 returns a different result, the client will not see it.
 
-As the intended use-case of the router is to mainly reduce multiple result sets\
-into one, it has no mechanisms to prevent writes from being executed on slave\
-servers (which would cause data corruption or replication failure). Take great\
+As the intended use-case of the router is to mainly reduce multiple result sets
+into one, it has no mechanisms to prevent writes from being executed on slave
+servers (which would cause data corruption or replication failure). Take great
 care when performing administrative operations though this router.
 
-If a connection to one of the servers is lost, the client connection will also\
+If a connection to one of the servers is lost, the client connection will also
 be closed.
 
 ### Example
 
-Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-configuring-servers.md) tutorial and the\
+Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-configuring-servers.md) tutorial and the
 credentials from the [MaxScale Tutorial](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-setting-up-mariadb-maxscale.md).
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-hintrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-hintrouter.md
@@ -4,27 +4,27 @@ HintRouter was introduced in 2.2 and is still beta.
 
 ### Overview
 
-The **HintRouter** module is a simple router intended to operate in conjunction\
-with the NamedServerFilter. The router looks at the hints embedded in a packet\
-buffer and attempts to route the packet according to the hint. The user can also\
-set a default action to be taken when a query has no hints or when the hints\
+The **HintRouter** module is a simple router intended to operate in conjunction
+with the NamedServerFilter. The router looks at the hints embedded in a packet
+buffer and attempts to route the packet according to the hint. The user can also
+set a default action to be taken when a query has no hints or when the hints
 could not be applied.
 
-If a packet has multiple hints attached, the router will read them in order and\
-attempt routing. Any successful routing ends the process and any further hints\
+If a packet has multiple hints attached, the router will read them in order and
+attempt routing. Any successful routing ends the process and any further hints
 are ignored for the packet.
 
 ### Configuration
 
-The HintRouter is a rather simple router and only accepts a few configuration\
+The HintRouter is a rather simple router and only accepts a few configuration
 settings.
 
 ```
 default_action=<master|slave|named|all>
 ```
 
-This setting defines what happens when a query has no routing hint or applying\
-the routing hint(s) fails. If also the default action fails, the routing will\
+This setting defines what happens when a query has no routing hint or applying
+the routing hint(s) fails. If also the default action fails, the routing will
 end in error and the session closes. The different values are:
 
 | Value  | Description                                                                |
@@ -34,40 +34,40 @@ end in error and the session closes. The different values are:
 | named  | Route to a named server. The name is given in the default\_server-setting. |
 | all    | Default value. Route to all connected servers.                             |
 
-Note that setting default action to anything other than `all` means that session\
+Note that setting default action to anything other than `all` means that session
 variable write commands are by default not routed to all backends.
 
 ```
 default_server=<server-name>
 ```
 
-Defines the default backend name if `default_action=named`. `<server-name>` must\
+Defines the default backend name if `default_action=named`. `<server-name>` must
 be a valid backend name.
 
 ```
 max_slaves=<limit>
 ```
 
-`<limit>` should be an integer, -1 by default. Defines how many backend slave\
-servers a session should attempt to connect to. Having less slaves defined in\
-the services and/or less successful connections during session creation is not\
-an error. The router will attempt to distribute slaves evenly between sessions\
-by assigning them in a round robin fashion. The session will always try to\
-connect to a master regardless of this setting, although not finding one is not\
+`<limit>` should be an integer, -1 by default. Defines how many backend slave
+servers a session should attempt to connect to. Having less slaves defined in
+the services and/or less successful connections during session creation is not
+an error. The router will attempt to distribute slaves evenly between sessions
+by assigning them in a round robin fashion. The session will always try to
+connect to a master regardless of this setting, although not finding one is not
 an error.
 
-Negative values activate default mode, in which case this value is set to the\
-number of backends in the service - 1, so that the sessions are connected to all\
+Negative values activate default mode, in which case this value is set to the
+number of backends in the service - 1, so that the sessions are connected to all
 slaves.
 
-If the hints or the `default_action` point to a named server, this setting is\
-probably best left to default to ensure that the specific server is connected to\
-at session creation. The router will not attempt to connect to additional\
+If the hints or the `default_action` point to a named server, this setting is
+probably best left to default to ensure that the specific server is connected to
+at session creation. The router will not attempt to connect to additional
 servers after session creation.
 
 ### Examples
 
-A minimal configuration doesn't require any parameters as all settings have\
+A minimal configuration doesn't require any parameters as all settings have
 reasonable defaults.
 
 ```
@@ -77,7 +77,7 @@ router=hintrouter
 servers=slave1,slave2,slave3
 ```
 
-If packets should be routed to the master server by default and only a few\
+If packets should be routed to the master server by default and only a few
 connections are required, the configuration might be as follows.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-kafkacdc.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-kafkacdc.md
@@ -2,10 +2,10 @@
 
 ### Overview
 
-The KafkaCDC module reads data changes in MariaDB via replication and converts\
+The KafkaCDC module reads data changes in MariaDB via replication and converts
 them into JSON objects that are then streamed to a Kafka broker.
 
-DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the\
+DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the
 following format (example created by `CREATE TABLE test.t1(id INT)`):
 
 ```
@@ -65,10 +65,10 @@ following format (example created by `CREATE TABLE test.t1(id INT)`):
 }
 ```
 
-The `domain`, `server_id` and `sequence` fields contain the GTID that this event\
-belongs to. The `event_number` field is the sequence number of events inside the\
-transaction starting from 1. The `timestamp` field is the UNIX timestamp when\
-the event occurred. The `event_type` field contains the type of the event, one\
+The `domain`, `server_id` and `sequence` fields contain the GTID that this event
+belongs to. The `event_number` field is the sequence number of events inside the
+transaction starting from 1. The `timestamp` field is the UNIX timestamp when
+the event occurred. The `event_type` field contains the type of the event, one
 of:
 
 * `insert`: the event is the data that was added to MariaDB
@@ -76,11 +76,11 @@ of:
 * `update_before`: the event contains the data before an update statement modified it
 * `update_after`: the event contains the data after an update statement modified it
 
-All remaining fields contains data from the table. In the example event this\
+All remaining fields contains data from the table. In the example event this
 would be the fields `id` and `data`.
 
-DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that\
-follow the format specified in the DDL event. The objects are in the following\
+DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that
+follow the format specified in the DDL event. The objects are in the following
 format (example created by `INSERT INTO test.t1 VALUES (1)`):
 
 ```
@@ -97,28 +97,28 @@ format (example created by `INSERT INTO test.t1 VALUES (1)`):
 }
 ```
 
-The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These\
+The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These
 contain the table name and schema the event targets.
 
-The router stores table metadata in the MaxScale data directory. The\
-default value is `/var/lib/maxscale/<service name>`. If data for a table\
-is replicated before a DDL event for it is replicated, the CREATE TABLE\
+The router stores table metadata in the MaxScale data directory. The
+default value is `/var/lib/maxscale/<service name>`. If data for a table
+is replicated before a DDL event for it is replicated, the CREATE TABLE
 will be queried from the master server.
 
-During shutdown, the Kafka event queue is flushed. This can take up to 60\
+During shutdown, the Kafka event queue is flushed. This can take up to 60
 seconds if the network is slow or there are network problems.
 
 ### Configuration
 
-* In order for `kafkacdc` to work, the binary logging on the source server must\
-  be configured to use row-based replication and the row image must be set to\
+* In order for `kafkacdc` to work, the binary logging on the source server must
+  be configured to use row-based replication and the row image must be set to
   full by configuring `binlog_format=ROW` and `binlog_row_image=FULL`.
-* The `servers` parameter defines the set of servers where the data is\
-  replicated from. The replication will be done from the first master server\
+* The `servers` parameter defines the set of servers where the data is
+  replicated from. The replication will be done from the first master server
   that is found.
-* The `user` and `password` of the service will be used to connect to the\
+* The `user` and `password` of the service will be used to connect to the
   master. This user requires the `REPLICATION SLAVE` grant.
-* The KafkaCDC service must not be configured to use listeners. If a listener is\
+* The KafkaCDC service must not be configured to use listeners. If a listener is
   configured, all attempts to start a session will fail.
 
 ### Parameters
@@ -129,7 +129,7 @@ seconds if the network is slow or there are network problems.
 * Mandatory: Yes
 * Dynamic: No
 
-The list of Kafka brokers to use in `host:port` format. Multiple values\
+The list of Kafka brokers to use in `host:port` format. Multiple values
 can be separated with commas. This is a mandatory parameter.
 
 #### `topic`
@@ -138,7 +138,7 @@ can be separated with commas. This is a mandatory parameter.
 * Mandatory: Yes
 * Dynamic: No
 
-The Kafka topic where the replicated events will be sent. This is a\
+The Kafka topic where the replicated events will be sent. This is a
 mandatory parameter.
 
 #### `enable_idempotence`
@@ -148,22 +148,22 @@ mandatory parameter.
 * Dynamic: No
 * Default: `false`
 
-Enable idempotent producer mode. This feature requires Kafka version 0.11 or\
+Enable idempotent producer mode. This feature requires Kafka version 0.11 or
 newer to work and is disabled by default.
 
-When enabled, the Kafka producer enters a strict mode which avoids event\
-duplication due to broker outages or other network errors. In HA scenarios where\
-there are more than two MaxScale instances, event duplication can still happen\
+When enabled, the Kafka producer enters a strict mode which avoids event
+duplication due to broker outages or other network errors. In HA scenarios where
+there are more than two MaxScale instances, event duplication can still happen
 as there is no synchronization between the MaxScale instances.
 
-The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),\
+The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),
 describes the parameter as follows:
 
-When set to true, the producer will ensure that messages are successfully\
-produced exactly once and in the original produce order. The following\
-configuration properties are adjusted automatically (if not modified by the\
-user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must\
-be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),\
+When set to true, the producer will ensure that messages are successfully
+produced exactly once and in the original produce order. The following
+configuration properties are adjusted automatically (if not modified by the
+user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must
+be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),
 acks=all, queuing.strategy=fifo.
 
 #### `timeout`
@@ -182,12 +182,12 @@ The connection and read timeout for the replication stream.
 * Dynamic: No
 * Default: `""`
 
-The initial GTID position from where the replication is started. By default the\
-replication is started from the beginning. The value of this parameter is only\
-used if no previously replicated events with GTID positions can be retrieved\
+The initial GTID position from where the replication is started. By default the
+replication is started from the beginning. The value of this parameter is only
+used if no previously replicated events with GTID positions can be retrieved
 from Kafka.
 
-Once the replication has started and a GTID position has been recorded, this\
+Once the replication has started and a GTID position has been recorded, this
 parameter will be ignored. To reset the recorded GTID position, delete the`current_gtid.txt` file located in `/var/lib/maxscale/<SERVICE>/` where`<SERVICE>` is the name of the KafkaCDC service.
 
 #### `server_id`
@@ -197,8 +197,8 @@ parameter will be ignored. To reset the recorded GTID position, delete the`curre
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
-used when replicating from the master in direct replication mode. The default\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
+used when replicating from the master in direct replication mode. The default
 value is 1234. This parameter was added in MaxScale 2.5.7.
 
 #### `match`
@@ -212,13 +212,13 @@ Only include data from tables that match this pattern.
 
 For example, if configured with `match=accounts[.].*`, only data from the`accounts` database is sent to Kafka.
 
-The pattern is matched against the combined database and table name separated by\
-a period. This means that the event for the table `t1` in the `test` database\
-would appear as `test.t1`. The behavior is the same even if the database or the\
-table name contains a period. This means that an event for the `test.table`\
+The pattern is matched against the combined database and table name separated by
+a period. This means that the event for the table `t1` in the `test` database
+would appear as `test.t1`. The behavior is the same even if the database or the
+table name contains a period. This means that an event for the `test.table`
 table in the `my.data` database would appear as `my.data.test.table`.
 
-Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are\
+Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are
 filtered out using the `exclude` parameter.
 
 ```
@@ -243,11 +243,11 @@ exclude=db1 [.](accounts|users)
 
 Exclude data from tables that match this pattern.
 
-For example, if configured with `exclude=mydb[.].*`, all data from the tables in\
+For example, if configured with `exclude=mydb[.].*`, all data from the tables in
 the `mydb` database is not sent to Kafka.
 
-The pattern matching works the same way for both of the `exclude` and `match`\
-parameters. See [match](mariadb-maxscale-2106-maxscale-2106-kafkacdc.md#match) for an explanation on how the patterns are\
+The pattern matching works the same way for both of the `exclude` and `match`
+parameters. See [match](mariadb-maxscale-2106-maxscale-2106-kafkacdc.md#match) for an explanation on how the patterns are
 matched against the database and table names.
 
 #### `cooperative_replication`
@@ -257,22 +257,22 @@ matched against the database and table names.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
+Controls whether multiple instances cooperatively replicate from the same
 cluster. This is a boolean parameter and is disabled by default. It was added in\
 MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`), the\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`), the
 replication is only active if the monitor owns the cluster it is monitoring.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID that was delivered\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID that was delivered
 to Kafka.
 
-This means that multiple MaxScale instances can replicate from the same set of\
-servers and the event is only processed once. This feature does not provide\
-exactly-once semantics for the Kafka event delivery. However, it does provide\
-high-availability for the `kafkacdc` instances which allows automated failover\
+This means that multiple MaxScale instances can replicate from the same set of
+servers and the event is only processed once. This feature does not provide
+exactly-once semantics for the Kafka event delivery. However, it does provide
+high-availability for the `kafkacdc` instances which allows automated failover
 between multiple MaxScale instances.
 
 #### `read_gtid_from_kafka`
@@ -282,10 +282,10 @@ between multiple MaxScale instances.
 * Dynamic: No
 * Default: `true`
 
-On startup, the latest GTID is by default read from the Kafka cluster. This\
+On startup, the latest GTID is by default read from the Kafka cluster. This
 makes it possible to recover the replication position stored by another\
-MaxScale. Sometimes this is not desirable and the GTID should only be read from\
-the local file or started anew. Examples of these are when the GTIDs are reset\
+MaxScale. Sometimes this is not desirable and the GTID should only be read from
+the local file or started anew. Examples of these are when the GTIDs are reset
 or the replication topology has changed.
 
 #### `kafka_ssl`
@@ -295,7 +295,7 @@ or the replication topology has changed.
 * Dynamic: No
 * Default: `false`
 
-Enable SSL for Kafka connections. This is a boolean parameter and is disabled by\
+Enable SSL for Kafka connections. This is a boolean parameter and is disabled by
 default.
 
 #### `kafka_ssl_ca`
@@ -305,7 +305,7 @@ default.
 * Dynamic: No
 * Default: `""`
 
-Path to the certificate authority file in PEM format. If this is not provided,\
+Path to the certificate authority file in PEM format. If this is not provided,
 the default system certificates will be used.
 
 #### `kafka_ssl_cert`
@@ -317,8 +317,8 @@ the default system certificates will be used.
 
 Path to the public certificate in PEM format.
 
-The client must provide a certificate if the Kafka server performs authentication\
-of the client certificates. This feature is enabled by default in Kafka and is\
+The client must provide a certificate if the Kafka server performs authentication
+of the client certificates. This feature is enabled by default in Kafka and is
 controlled by [ssl.endpoint.identification.algorithm](https://kafka.apache.org/documentation/#brokerconfigs_ssl.endpoint.identification.algorithm).
 
 If `kafka_ssl_cert` is provided, `kafka_ssl_key` must also be provided.
@@ -364,8 +364,8 @@ If `kafka_sasl_password` is provided, `kafka_sasl_user` must also be provided.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-The SASL mechanism used. The default value is `PLAIN` which uses plaintext\
-authentication. It is recommended to enable SSL whenever plaintext\
+The SASL mechanism used. The default value is `PLAIN` which uses plaintext
+authentication. It is recommended to enable SSL whenever plaintext
 authentication is used.
 
 Allowed values are:
@@ -379,7 +379,7 @@ Kafka broker.
 
 ### Example Configuration
 
-The following configuration defines the minimal setup for streaming replication\
+The following configuration defines the minimal setup for streaming replication
 events from MariaDB into Kafka as JSON:
 
 ```
@@ -411,8 +411,8 @@ topic=my-cdc-topic
 
 ### Limitations
 
-* The KafkaCDC module provides at-least-once semantics for the generated\
-  events. This means that each replication event is delivered to kafka at least\
+* The KafkaCDC module provides at-least-once semantics for the generated
+  events. This means that each replication event is delivered to kafka at least
   once but there can be duplicate events in case of failures.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-kafkaimporter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-kafkaimporter.md
@@ -3,8 +3,8 @@
 ### Overview
 
 The KafkaImporter module reads messages from Kafka and streams them into a\
-MariaDB server. The messages are inserted into a table designated by either the\
-topic name or the message key (see [table\_name\_in](mariadb-maxscale-2106-maxscale-2106-kafkaimporter.md#table_name_in) for\
+MariaDB server. The messages are inserted into a table designated by either the
+topic name or the message key (see [table\_name\_in](mariadb-maxscale-2106-maxscale-2106-kafkaimporter.md#table_name_in) for
 details). The table will be automatically created with the following SQL:
 
 ```
@@ -15,31 +15,31 @@ CREATE TABLE IF NOT EXISTS my_table (
 );
 ```
 
-The payload of the message is inserted into the `data` field from which the `id`\
-field is calculated. The payload must be a valid JSON object and it must either\
-contain a unique `_id` field or it must not exist or the value must be a JSON\
-null. This is similar to the MongoDB document format where the `_id` field is\
+The payload of the message is inserted into the `data` field from which the `id`
+field is calculated. The payload must be a valid JSON object and it must either
+contain a unique `_id` field or it must not exist or the value must be a JSON
+null. This is similar to the MongoDB document format where the `_id` field is
 the primary key of the document collection.
 
-If a message is read from Kafka and the insertion into the table fails due to a\
-violation of one of the constraints, the message is ignored. Similarly, messages\
-with duplicate `_id` value are also ignored: this is done to avoid inserting the\
-same document multiple times whenever the connection to either Kafka or MariaDB\
+If a message is read from Kafka and the insertion into the table fails due to a
+violation of one of the constraints, the message is ignored. Similarly, messages
+with duplicate `_id` value are also ignored: this is done to avoid inserting the
+same document multiple times whenever the connection to either Kafka or MariaDB
 is lost.
 
-The limitations on the data can be removed by either creating the table before\
-the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`\
-does nothing, or by altering the structure of the existing table. The minimum\
-requirement that must be met is that the table contains the `data` field to\
+The limitations on the data can be removed by either creating the table before
+the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`
+does nothing, or by altering the structure of the existing table. The minimum
+requirement that must be met is that the table contains the `data` field to
 which string values can be inserted into.
 
-The database server where the data is inserted is chosen from the set of servers\
-available to the service. The first server labeled as the Master with the best\
+The database server where the data is inserted is chosen from the set of servers
+available to the service. The first server labeled as the Master with the best
 rank will be chosen. This means that a monitor must be configured for the\
 MariaDB server where the data is to be inserted.
 
-In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 24.08.2\
-the `_id` field is not required to be present. Older versions of MaxScale used\
+In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 24.08.2
+the `_id` field is not required to be present. Older versions of MaxScale used
 the following SQL where the `_id` field was mandatory:
 
 ```
@@ -80,9 +80,9 @@ The comma separated list of topics to subscribe to.
 * Dynamic: Yes
 * Default: `100`
 
-Maximum number of uncommitted records. The KafkaImporter will buffer records\
-into batches and commit them once either enough records are gathered (controlled\
-by this parameter) or when the KafkaImporter goes idle. Any uncommitted records\
+Maximum number of uncommitted records. The KafkaImporter will buffer records
+into batches and commit them once either enough records are gathered (controlled
+by this parameter) or when the KafkaImporter goes idle. Any uncommitted records
 will be read again if a reconnection to either Kafka or MariaDB occurs.
 
 #### `kafka_sasl_mechanism`
@@ -93,7 +93,7 @@ will be read again if a reconnection to either Kafka or MariaDB occurs.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-SASL mechanism to use. The Kafka broker must be configured with the same\
+SASL mechanism to use. The Kafka broker must be configured with the same
 authentication scheme.
 
 #### `kafka_sasl_user`
@@ -112,7 +112,7 @@ SASL username used for authentication. If this parameter is defined,`kafka_sasl_
 * Dynamic: Yes
 * Default: `""`
 
-SASL password for the user. If this parameter is defined, `kafka_sasl_user` must\
+SASL password for the user. If this parameter is defined, `kafka_sasl_user` must
 also be provided.
 
 #### `kafka_ssl`
@@ -131,7 +131,7 @@ Enable SSL for Kafka connections.
 * Dynamic: Yes
 * Default: `""`
 
-SSL Certificate Authority file in PEM format. If this parameter is not\
+SSL Certificate Authority file in PEM format. If this parameter is not
 defined, the system default CA certificate is used.
 
 #### `kafka_ssl_cert`
@@ -165,14 +165,14 @@ The Kafka message part that is used to locate the table to insert the data into.
 Enumeration Values:
 
 * `topic`: The topic named is used as the fully qualified table name.
-* `key`: The message key is used as the fully qualified table name. If the Kafka\
+* `key`: The message key is used as the fully qualified table name. If the Kafka
   message does not have a key, the message is ignored.
 
-For example, all messages with a fully qualified table name of `my_db.my_table`\
-will be inserted into the table `my_table` located in the `my_db` database. If\
-the table or database names have special characters that must be escaped to make\
-them valid identifiers, the name must also contain those escape characters. For\
-example, to insert into a table named `my table` in the database `my database`,\
+For example, all messages with a fully qualified table name of `my_db.my_table`
+will be inserted into the table `my_table` located in the `my_db` database. If
+the table or database names have special characters that must be escaped to make
+them valid identifiers, the name must also contain those escape characters. For
+example, to insert into a table named `my table` in the database `my database`,
 the name would be:
 
 ```
@@ -190,7 +190,7 @@ Timeout for both Kafka and MariaDB network communication.
 
 ### Limitations
 
-* The backend servers used by this service must be MariaDB version 10.2 or\
+* The backend servers used by this service must be MariaDB version 10.2 or
   newer.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-mirror.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-mirror.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-The `mirror` router is designed for data consistency and database behavior\
-verification during system upgrades. It allows statement duplication to multiple\
+The `mirror` router is designed for data consistency and database behavior
+verification during system upgrades. It allows statement duplication to multiple
 servers in a manner similar to that of the [Tee filter](../mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-tee-filter.md) with exporting of collected query metrics.
 
-For each executed query the router exports a JSON object that describes the\
+For each executed query the router exports a JSON object that describes the
 query results and has the following fields:
 
 | Key       | Description                                              |
@@ -17,7 +17,7 @@ query results and has the following fields:
 | query\_id | Query sequence number, starts from 1                     |
 | results   | Array of query result objects                            |
 
-The objects in the `results` array describe an individual query result and have\
+The objects in the `results` array describe an individual query result and have
 the following fields:
 
 | Key      | Description                                |
@@ -37,12 +37,12 @@ the following fields:
 * Mandatory: Yes
 * Dynamic: Yes
 
-The main target from which results are returned to the client. This is a\
+The main target from which results are returned to the client. This is a
 mandatory parameter and must define one of the targets configured in the`targets` parameter of the service.
 
-If the connection to the main target cannot be created or is lost mid-session,\
-the client connection will be closed. Connection failures to other targets are\
-not fatal errors and any open connections to them will be closed. The router\
+If the connection to the main target cannot be created or is lost mid-session,
+the client connection will be closed. Connection failures to other targets are
+not fatal errors and any open connections to them will be closed. The router
 does not create new connections after the initial connections are created.
 
 #### `exporter`
@@ -52,7 +52,7 @@ does not create new connections after the initial connections are created.
 * Dynamic: Yes
 * Values: `log`, `file`, `kafka`
 
-The exporter where the data is exported. This is a mandatory parameter. Possible\
+The exporter where the data is exported. This is a mandatory parameter. Possible
 values are:
 
 * `log`
@@ -60,7 +60,7 @@ values are:
 * `file`
 * Exports metrics to a file. Configured with the [file](mariadb-maxscale-2106-maxscale-2106-mirror.md#file) parameter.
 * `kafka`
-* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2106-maxscale-2106-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2106-maxscale-2106-mirror.md#kafka_topic)\
+* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2106-maxscale-2106-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2106-maxscale-2106-mirror.md#kafka_topic)
   parameters.
 
 #### `file`
@@ -70,12 +70,12 @@ values are:
 * Mandatory: No
 * Dynamic: Yes
 
-The output file where the metrics will be written. The file must be writable by\
+The output file where the metrics will be written. The file must be writable by
 the user that is running MaxScale, usually the `maxscale` user.
 
-When the `file` parameter is altered at runtime, the old file is closed before\
-the new file is opened. This makes it a convenient way of rotating the file\
-where the metrics are exported. Note that the file name alteration must change\
+When the `file` parameter is altered at runtime, the old file is closed before
+the new file is opened. This makes it a convenient way of rotating the file
+where the metrics are exported. Note that the file name alteration must change
 the value for it to take effect.
 
 This is a mandatory parameter when configured with `exporter=file`.
@@ -87,7 +87,7 @@ This is a mandatory parameter when configured with `exporter=file`.
 * Mandatory: No
 * Dynamic: Yes
 
-The Kafka broker list. Must be given as a comma-separated list of broker hosts\
+The Kafka broker list. Must be given as a comma-separated list of broker hosts
 with optional ports in `host:port` format.
 
 This is a mandatory parameter when configured with `exporter=kafka`.
@@ -114,12 +114,12 @@ This is a mandatory parameter when configured with `exporter=kafka`.
 What to do when a backend network connection fails. Accepted values are:
 
 * `ignore`
-* Ignore the failing backend if it's not the backend that the `main` parameter\
+* Ignore the failing backend if it's not the backend that the `main` parameter
   points to.
 * `close`
 * Close the client connection when the first backend fails.
 
-This parameter was added in MaxScale 6.0. Older versions always ignored\
+This parameter was added in MaxScale 6.0. Older versions always ignored
 failing backends.
 
 #### `report`
@@ -137,7 +137,7 @@ When to report the result of the queries. Accepted values are:
 * `on_conflict`
 * Only report when one or more backends returns a conflicting result.
 
-This parameter was added in MaxScale 6.0. Older versions always reported the\
+This parameter was added in MaxScale 6.0. Older versions always reported the
 result.
 
 ### Example Configuration
@@ -182,8 +182,8 @@ port=3306
 * Broken network connections are not recreated.
 * Prepared statements are not supported.
 * Contents of non-SQL statements are not added to the exported metrics.
-* Data synchronization in dynamic environments (e.g. when replication is in use)\
-  is not guaranteed. This means that result mismatches can be reported when the\
+* Data synchronization in dynamic environments (e.g. when replication is in use)
+  is not guaranteed. This means that result mismatches can be reported when the
   data is only eventually consistent.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-readconnroute.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-readconnroute.md
@@ -1,29 +1,29 @@
 # MaxScale 21.06 Readconnroute
 
-This document provides an overview of the **readconnroute** router module\
-and its intended use case scenarios. It also displays all router\
+This document provides an overview of the **readconnroute** router module
+and its intended use case scenarios. It also displays all router
 configuration parameters with their descriptions.
 
 ### Overview
 
-The readconnroute router provides simple and lightweight load balancing\
-across a set of servers. The router can also be configured to balance\
+The readconnroute router provides simple and lightweight load balancing
+across a set of servers. The router can also be configured to balance
 connections based on a weighting parameter defined in the server's section.
 
 Note that \*_readconnroute_ balances _connections_ and not _statements_.\
-When a client connects, the router selects a server based upon the router\
-configuration and current server load, but the single created connection\
-is fixed and will not be changed for the duration of the session. If the\
-connection between MaxScale and the server breaks, the connection can not\
-be re-established and the session will be closed. The fact that the server\
+When a client connects, the router selects a server based upon the router
+configuration and current server load, but the single created connection
+is fixed and will not be changed for the duration of the session. If the
+connection between MaxScale and the server breaks, the connection can not
+be re-established and the session will be closed. The fact that the server
 is fixed when the client connects also means that routing hints are ignored.
 
-**Warning:** `readconnroute` will not prevent writes from being done even if you\
-define `router_options=slave`. The client application is responsible for\
-making sure that it only performs read-only queries in such\
-cases. `readconnroute` is simple by design: it selects a server for each\
-client connection and routes all queries there. If something more complex is\
-required, the [readwritesplit](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md) router is usually the right\
+**Warning:** `readconnroute` will not prevent writes from being done even if you
+define `router_options=slave`. The client application is responsible for
+making sure that it only performs read-only queries in such
+cases. `readconnroute` is simple by design: it selects a server for each
+client connection and routes all queries there. If something more complex is
+required, the [readwritesplit](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md) router is usually the right
 choice.
 
 ### Configuration
@@ -32,8 +32,8 @@ For more details about the standard service parameters, refer to the [Configurat
 
 #### `router_options`
 
-**`router_options`** can contain a comma separated list of valid server\
-roles. These roles are used as the valid types of servers the router will\
+**`router_options`** can contain a comma separated list of valid server
+roles. These roles are used as the valid types of servers the router will
 form connections to when new sessions are created.
 
 Examples:
@@ -52,21 +52,21 @@ Here is a list of all possible values for the `router_options`.
 | synced  | A Galera cluster node which is in a synced state with the cluster.                                                                                                                                                     |
 | running | A server that is up and running. All servers that MariaDB MaxScale can connect to are labeled as running.                                                                                                              |
 
-If no `router_options` parameter is configured in the service definition,\
-the router will use the default value of `running`. This means that it will\
-load balance connections across all running servers defined in the `servers`\
+If no `router_options` parameter is configured in the service definition,
+the router will use the default value of `running`. This means that it will
+load balance connections across all running servers defined in the `servers`
 parameter of the service.
 
-When a connection is being created and the candidate server is being chosen,\
-the list of servers is processed in from first entry to last. This means\
-that if two servers with equal weight and status are found, the one that's\
+When a connection is being created and the candidate server is being chosen,
+the list of servers is processed in from first entry to last. This means
+that if two servers with equal weight and status are found, the one that's
 listed first in the _servers_ parameter for the service is chosen.
 
 #### `master_accept_reads`
 
 This option can be used to prevent queries from being sent to the current master.\
-If `router_options` does not contain "master", the readconnroute instance is\
-usually meant for reading. Setting `master_accept_reads=false` excludes the master\
+If `router_options` does not contain "master", the readconnroute instance is
+usually meant for reading. Setting `master_accept_reads=false` excludes the master
 from server selection (and thus from receiving reads).
 
 If `router_options` contains "master", the setting of `master_accept_reads` has no effect.
@@ -75,22 +75,22 @@ By default `master_accept_reads=true`.
 
 #### `max_replication_lag`
 
-The maximum acceptable replication lag. The value is in seconds and is specified\
-as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). The\
+The maximum acceptable replication lag. The value is in seconds and is specified
+as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). The
 default value is `0s`, which means that the lag is ignored.
 
-The replication lag of a server must be less than the configured value in order\
-for it to be used for routing. To configure the router to not allow any lag, use\
+The replication lag of a server must be less than the configured value in order
+for it to be used for routing. To configure the router to not allow any lag, use
 the smallest duration larger than 0, that is, `max_replication_lag=1s`.
 
 ### Examples
 
-The most common use for the readconnroute is to provide either a read or\
-write port for an application. This provides a more lightweight routing\
-solution than the more complex readwritesplit router but requires the\
+The most common use for the readconnroute is to provide either a read or
+write port for an application. This provides a more lightweight routing
+solution than the more complex readwritesplit router but requires the
 application to be able to use distinct write and read ports.
 
-To configure a read-only service that tolerates master failures, we first\
+To configure a read-only service that tolerates master failures, we first
 need to add a new section in to the configuration file.
 
 ```
@@ -101,11 +101,11 @@ servers=slave1,slave2,slave3
 router_options=slave
 ```
 
-Here the `router_options` designates slaves as the only valid server\
-type. With this configuration, the queries are load balanced across the\
+Here the `router_options` designates slaves as the only valid server
+type. With this configuration, the queries are load balanced across the
 slave servers.
 
-For more complex examples of the readconnroute router, take a look at the\
+For more complex examples of the readconnroute router, take a look at the
 examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
 
 ### Router Diagnostics

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-readwritesplit.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-readwritesplit.md
@@ -1,52 +1,52 @@
 # MaxScale 21.06 Readwritesplit
 
-This document provides a short overview of the **readwritesplit** router module\
-and its intended use case scenarios. It also displays all router configuration\
-parameters with their descriptions. A list of current limitations of the module\
+This document provides a short overview of the **readwritesplit** router module
+and its intended use case scenarios. It also displays all router configuration
+parameters with their descriptions. A list of current limitations of the module
 is included and use examples are provided.
 
 ### Overview
 
-The **readwritesplit** router is designed to increase the read-only processing\
-capability of a cluster while maintaining consistency. This is achieved by\
-splitting the query load into read and write queries. Read queries, which do not\
-modify data, are spread across multiple nodes while all write queries will be\
+The **readwritesplit** router is designed to increase the read-only processing
+capability of a cluster while maintaining consistency. This is achieved by
+splitting the query load into read and write queries. Read queries, which do not
+modify data, are spread across multiple nodes while all write queries will be
 sent to a single node.
 
-The router is designed to be used with a traditional Master-Slave replication\
-cluster. It automatically detects changes in the master server and will use the\
-current master server of the cluster. With a Galera cluster, one can achieve a\
+The router is designed to be used with a traditional Master-Slave replication
+cluster. It automatically detects changes in the master server and will use the
+current master server of the cluster. With a Galera cluster, one can achieve a
 resilient setup and easy master failover by using one of the Galera nodes as a\
-Write-Master node, where all write queries are routed, and spreading the read\
+Write-Master node, where all write queries are routed, and spreading the read
 load over all the nodes.
 
 ### Interaction with servers in `Maintenance` and `Draining` state
 
-When a server that readwritesplit uses is put into maintenance mode, any ongoing\
-requests are allowed to finish before the connection is closed. If the server\
-that is put into maintenance mode is a master, open transaction are allowed to\
-complete before the connection is closed. Note that this means neither idle\
-session nor long-running transactions will be closed by readwritesplit. To\
+When a server that readwritesplit uses is put into maintenance mode, any ongoing
+requests are allowed to finish before the connection is closed. If the server
+that is put into maintenance mode is a master, open transaction are allowed to
+complete before the connection is closed. Note that this means neither idle
+session nor long-running transactions will be closed by readwritesplit. To
 forcefully close the connections, use the following command:
 
 ```
 maxctrl set server <server> maintenance --force
 ```
 
-If a server is put into the `Draining` state while a connection is open, the\
-connection will be used normally. Whenever a new connection needs to be created,\
-whether that be due to a network error or when a new session being opened, only\
+If a server is put into the `Draining` state while a connection is open, the
+connection will be used normally. Whenever a new connection needs to be created,
+whether that be due to a network error or when a new session being opened, only
 servers that are neither `Draining` nor `Drained` will be used.
 
 ### Configuration
 
-Readwritesplit router-specific settings are specified in the configuration file\
-of MariaDB MaxScale in its specific section. The section can be freely named but\
+Readwritesplit router-specific settings are specified in the configuration file
+of MariaDB MaxScale in its specific section. The section can be freely named but
 the name is used later as a reference in a listener section.
 
 For more details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
 
-Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be\
+Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be
 taken into use by new sessions.
 
 ### Parameters
@@ -58,45 +58,45 @@ taken into use by new sessions.
 * Dynamic: Yes
 * Default: 255
 
-`max_slave_connections` sets the maximum number of slaves a router session uses\
-at any moment. The default is to use at most 255 slave connections per client\
-connection. In older versions the default was to use all available slaves with\
+`max_slave_connections` sets the maximum number of slaves a router session uses
+at any moment. The default is to use at most 255 slave connections per client
+connection. In older versions the default was to use all available slaves with
 no limit.
 
 For MaxScale 2.5.12 and newer, the minimum value is 0.
 
-For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions\
-suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that\
-causes the parameter to accept any values but only function when a value greater\
+For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions
+suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that
+causes the parameter to accept any values but only function when a value greater
 than one was given.
 
-Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be\
+Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be
 removed in a future release.
 
-For example, if you have configured MaxScale with one master and three slaves\
-and set `max_slave_connections=2`, for each client connection a connection to\
-the master and two slave connections would be opened. The read query load\
-balancing is then done between these two slaves and writes are sent to the\
+For example, if you have configured MaxScale with one master and three slaves
+and set `max_slave_connections=2`, for each client connection a connection to
+the master and two slave connections would be opened. The read query load
+balancing is then done between these two slaves and writes are sent to the
 master.
 
-By tuning this parameter, you can control how dynamic the load balancing is at\
-the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of\
-possible slave servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more\
-resources but load balancing will almost always give the best single query\
+By tuning this parameter, you can control how dynamic the load balancing is at
+the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of
+possible slave servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more
+resources but load balancing will almost always give the best single query
 response time and performance. Longer sessions are less affected by a high`max_slave_connections` as the relative cost of opening a connection is lower.
 
 **Behavior of `max_slave_connections=0`**
 
-When readwritesplit is configured with `max_slave_connections=0`, readwritesplit\
-will behave slightly differently in that it will route all reads to the current\
-master server. This is a convenient way to force all of the traffic to go to a\
-single node while still being able to leverage the replay and reconnection\
+When readwritesplit is configured with `max_slave_connections=0`, readwritesplit
+will behave slightly differently in that it will route all reads to the current
+master server. This is a convenient way to force all of the traffic to go to a
+single node while still being able to leverage the replay and reconnection
 features of readwritesplit.
 
-In this mode, the behavior of `master_failure_mode=fail_on_write` also changes\
-slightly. If the current `Master` server fails and a read is done when there's\
-no other `Master` server available, the connection will be closed. This is done\
-to prevent an extra slave connection from being opened that would not be closed\
+In this mode, the behavior of `master_failure_mode=fail_on_write` also changes
+slightly. If the current `Master` server fails and a read is done when there's
+no other `Master` server available, the connection will be closed. This is done
+to prevent an extra slave connection from being opened that would not be closed
 if a new `Master` server would arrive.
 
 #### `slave_connections`
@@ -106,17 +106,17 @@ if a new `Master` server would arrive.
 * Dynamic: Yes
 * Default: 255
 
-This parameter controls how many slave connections each new session starts\
+This parameter controls how many slave connections each new session starts
 with. The default value is 255 which is the same as the default value of`max_slave_connections`.
 
-In contrast to `max_slave_connections`, `slave_connections` serves as a\
-soft limit on how many slave connections are created. The number of slave\
-connections can exceed `slave_connections` if the load balancing algorithm\
+In contrast to `max_slave_connections`, `slave_connections` serves as a
+soft limit on how many slave connections are created. The number of slave
+connections can exceed `slave_connections` if the load balancing algorithm
 finds an unconnected slave server better than all other slaves.
 
-Setting this parameter to 1 allows faster connection creation and improved\
-resource usage due to the smaller amount of initial backend\
-connections. It is recommended to use `slave_connections=1` when the\
+Setting this parameter to 1 allows faster connection creation and improved
+resource usage due to the smaller amount of initial backend
+connections. It is recommended to use `slave_connections=1` when the
 lifetime of the client connections is short.
 
 #### `max_slave_replication_lag`
@@ -126,32 +126,32 @@ lifetime of the client connections is short.
 * Dynamic: Yes
 * Default: 0s
 
-Specify how many seconds a slave is allowed to be behind the master. The lag of\
-a slave must be less than the configured value in order for it to be used for\
+Specify how many seconds a slave is allowed to be behind the master. The lag of
+a slave must be less than the configured value in order for it to be used for
 routing. If set to 0 (the default value), the feature is disabled.
 
-In MaxScale 2.5.0, the slave lag must be less than `max_slave_replication_lag`\
-whereas in older versions the slave lag had to be less than or equal to`max_slave_replication_lag`. This means that in MaxScale 2.5.0 it is possible to\
-define, with `max_slave_replication_lag=1`, that all slaves must be up to date\
+In MaxScale 2.5.0, the slave lag must be less than `max_slave_replication_lag`
+whereas in older versions the slave lag had to be less than or equal to`max_slave_replication_lag`. This means that in MaxScale 2.5.0 it is possible to
+define, with `max_slave_replication_lag=1`, that all slaves must be up to date
 in order for them to be used for routing.
 
-Note that this feature does not guarantee that writes done on the master are\
-visible for reads done on the slave. This is mainly due to the method of\
+Note that this feature does not guarantee that writes done on the master are
+visible for reads done on the slave. This is mainly due to the method of
 replication lag measurement. For a feature that guarantees this, refer to [causal\_reads](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md#causal_reads).
 
-The lag is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the lag is seconds, a lag specified in milliseconds will be rejected, even if\
+The lag is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the lag is seconds, a lag specified in milliseconds will be rejected, even if
 the duration is longer than a second.
 
-The Readwritesplit-router does not detect the replication lag itself. A monitor\
-such as the MariaDB-monitor for a Master/Slave-cluster is required. This option\
-only affects Master-Slave clusters. Galera clusters do not have a concept of\
-slave lag even if the application of write sets might have lag. When a server is\
-disqualified from routing because of replication lag, a warning is logged. Similarly,\
-when the server has caught up enough to be a valid routing target, another warning\
-is logged. These messages are only logged when a query is being routed and the\
+The Readwritesplit-router does not detect the replication lag itself. A monitor
+such as the MariaDB-monitor for a Master/Slave-cluster is required. This option
+only affects Master-Slave clusters. Galera clusters do not have a concept of
+slave lag even if the application of write sets might have lag. When a server is
+disqualified from routing because of replication lag, a warning is logged. Similarly,
+when the server has caught up enough to be a valid routing target, another warning
+is logged. These messages are only logged when a query is being routed and the
 replication state changes.
 
 #### `use_sql_variables_in`
@@ -162,7 +162,7 @@ replication state changes.
 * Values: `master`, `all`
 * Default: `all`
 
-**`use_sql_variables_in`** specifies where should queries, which read session\
+**`use_sql_variables_in`** specifies where should queries, which read session
 variable, be routed. The syntax for `use_sql_variable_in` is:
 
 ```
@@ -171,16 +171,16 @@ use_sql_variables_in=[master|all]
 
 The default is to use SQL variables in all servers.
 
-When value `all` is used, queries reading session variables can be routed to any\
-available slave (depending on selection criteria). Queries modifying session\
-variables are routed to all backend servers by default, excluding write queries\
+When value `all` is used, queries reading session variables can be routed to any
+available slave (depending on selection criteria). Queries modifying session
+variables are routed to all backend servers by default, excluding write queries
 with embedded session variable modifications, such as:
 
 ```
 INSERT INTO test.t1 VALUES (@myid:=@myid+1)
 ```
 
-In above-mentioned case the user-defined variable would only be updated in the\
+In above-mentioned case the user-defined variable would only be updated in the
 master where the query would be routed to due to the `INSERT` statement.
 
 ```
@@ -196,13 +196,13 @@ master_failure_mode=fail_on_write
 
 #### `connection_keepalive`
 
-**Note:** This parameter has been moved into the MaxScale core. For the\
-current documentation, read the [connection\_keepalive](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+**Note:** This parameter has been moved into the MaxScale core. For the
+current documentation, read the [connection\_keepalive](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 section in the configuration guide.
 
 Send keepalive pings to backend servers. This feature was introduced in MaxScale\
-2.2.0. The default value is 300 seconds starting with 2.3.2 and for older\
-versions the feature was disabled by default. This parameter was converted into\
+2.2.0. The default value is 300 seconds starting with 2.3.2 and for older
+versions the feature was disabled by default. This parameter was converted into
 a service parameter in MaxScale 2.5.0.
 
 #### `master_reconnection`
@@ -215,26 +215,26 @@ a service parameter in MaxScale 2.5.0.
 Allow the master server to change mid-session. This feature was introduced in\
 MaxScale 2.3.0 and is disabled by default. This feature requires that`disable_sescmd_history` is not used.
 
-When a readwritesplit session starts, it will pick a master server as the\
-current master server of that session. By default, when this master server is\
+When a readwritesplit session starts, it will pick a master server as the
+current master server of that session. By default, when this master server is
 lost or changes to another server, the connection will be closed.
 
-When `master_reconnection` is enabled, readwritesplit can sometimes recover a\
+When `master_reconnection` is enabled, readwritesplit can sometimes recover a
 lost connection to the master server. This largely depends on the value of`master_failure_mode`.
 
-With `master_failure_mode=fail_instantly`, the master server is only allowed to\
-change to another server. This change must happen without a loss of the master\
+With `master_failure_mode=fail_instantly`, the master server is only allowed to
+change to another server. This change must happen without a loss of the master
 server.
 
-With `master_failure_mode=fail_on_write`, the loss of the master server is no\
-longer a fatal error: if a replacement master server appears before any write\
-queries are received, readwritesplit will transparently reconnect to the new\
+With `master_failure_mode=fail_on_write`, the loss of the master server is no
+longer a fatal error: if a replacement master server appears before any write
+queries are received, readwritesplit will transparently reconnect to the new
 master server.
 
-In both cases the change in the master server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet\
+In both cases the change in the master server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet
 been exceeded and the session does not have an open transaction.
 
-The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance\
+The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance
 without any risk to the consistency of the database.
 
 #### `slave_selection_criteria`
@@ -245,8 +245,8 @@ without any risk to the consistency of the database.
 * Values: `LEAST_CURRENT_OPERATIONS`, `ADAPTIVE_ROUTING`, `LEAST_BEHIND_MASTER`, `LEAST_ROUTER_CONNECTIONS`, `LEAST_GLOBAL_CONNECTIONS`
 * Default: `LEAST_CURRENT_OPERATIONS`
 
-This option controls how the readwritesplit router chooses the slaves it\
-connects to and how the load balancing is done. The default behavior is to route\
+This option controls how the readwritesplit router chooses the slaves it
+connects to and how the load balancing is done. The default behavior is to route
 read queries to the slave server with the lowest amount of ongoing queries i.e.`LEAST_CURRENT_OPERATIONS`.
 
 The option syntax:
@@ -263,55 +263,55 @@ Where `<criteria>` is one of the following values.
 * `LEAST_GLOBAL_CONNECTIONS`, the slave with least connections from MariaDB MaxScale
 * `LEAST_ROUTER_CONNECTIONS`, the slave with least connections from this service
 
-`LEAST_CURRENT_OPERATIONS` uses the current number of active operations\
-(i.e. SQL queries) as the load balancing metric and it optimizes for maximal\
-query throughput. Each query gets routed to the server with the least active\
+`LEAST_CURRENT_OPERATIONS` uses the current number of active operations
+(i.e. SQL queries) as the load balancing metric and it optimizes for maximal
+query throughput. Each query gets routed to the server with the least active
 operations which results in faster servers processing more traffic.
 
-`ADAPTIVE_ROUTING` uses the server response time and current estimated server\
-load as the load balancing metric. The server that is estimated to finish an\
-additional query first is chosen. A modified average response time for each\
-server is continuously updated to allow slow servers at least some traffic and\
-quickly react to changes in server load conditions. This selection criteria is\
-designed for heterogeneous clusters: servers of differing hardware, differing\
-network distances, or when other loads are running on the servers (including a\
-backup). If the servers are queried by other clients than MaxScale, the load\
+`ADAPTIVE_ROUTING` uses the server response time and current estimated server
+load as the load balancing metric. The server that is estimated to finish an
+additional query first is chosen. A modified average response time for each
+server is continuously updated to allow slow servers at least some traffic and
+quickly react to changes in server load conditions. This selection criteria is
+designed for heterogeneous clusters: servers of differing hardware, differing
+network distances, or when other loads are running on the servers (including a
+backup). If the servers are queried by other clients than MaxScale, the load
 caused by them is indirectly taken into account.
 
-`LEAST_BEHIND_MASTER` uses the measured replication lag as the load balancing\
-metric. This means that servers that are more up-to-date are favored which\
-increases the likelihood of the data being read being up-to-date. However, this\
-is not as effective as `causal_reads` would be as there's no guarantee that\
-writes done by the same connection will be routed to a server that has\
+`LEAST_BEHIND_MASTER` uses the measured replication lag as the load balancing
+metric. This means that servers that are more up-to-date are favored which
+increases the likelihood of the data being read being up-to-date. However, this
+is not as effective as `causal_reads` would be as there's no guarantee that
+writes done by the same connection will be routed to a server that has
 replicated those changes. The recommended approach is to use`LEAST_CURRENT_OPERATIONS` or `ADAPTIVE_ROUTING` in combination with`causal_reads`
 
-**NOTE**: `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` should not\
-be used, they are legacy options that exist only for backwards\
-compatibility. Using them will result in skewed load balancing as the algorithm\
-uses a metric that's too coarse (number of connections) to load balance\
+**NOTE**: `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` should not
+be used, they are legacy options that exist only for backwards
+compatibility. Using them will result in skewed load balancing as the algorithm
+uses a metric that's too coarse (number of connections) to load balance
 something that's finer (individual SQL queries).
 
-The `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` use the\
-connections from MariaDB MaxScale to the server, not the amount of connections\
+The `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` use the
+connections from MariaDB MaxScale to the server, not the amount of connections
 reported by the server itself.
 
-Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,\
-lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid\
+Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,
+lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid
 values.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 in MaxScale 6.0.
 
 #### `prune_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 in MaxScale 6.0.
 
 #### `master_accept_reads`
@@ -321,12 +321,12 @@ in MaxScale 6.0.
 * Dynamic: Yes
 * Default: false
 
-**`master_accept_reads`** allows the master server to be used for reads. This is\
-a useful option to enable if you are using a small number of servers and wish to\
+**`master_accept_reads`** allows the master server to be used for reads. This is
+a useful option to enable if you are using a small number of servers and wish to
 use the master for reads as well.
 
-By default, no reads are sent to the master as long as there is a valid slave\
-server available. If no slaves are available, reads are sent to the master\
+By default, no reads are sent to the master as long as there is a valid slave
+server available. If no slaves are available, reads are sent to the master
 regardless of the value of `master_accept_reads`.
 
 ```
@@ -341,18 +341,18 @@ master_accept_reads=true
 * Dynamic: Yes
 * Default: false
 
-This option is disabled by default since MaxScale 2.2.1. In older versions, this\
+This option is disabled by default since MaxScale 2.2.1. In older versions, this
 option was enabled by default.
 
-When a client executes a multi-statement query, it will be treated as if it were\
-a DML statement and routed to the master. If the option is enabled, all queries\
-after a multi-statement query will be routed to the master to guarantee a\
+When a client executes a multi-statement query, it will be treated as if it were
+a DML statement and routed to the master. If the option is enabled, all queries
+after a multi-statement query will be routed to the master to guarantee a
 consistent session state.
 
-If the feature is disabled, queries are routed normally after a multi-statement\
+If the feature is disabled, queries are routed normally after a multi-statement
 query.
 
-**Warning:** Enable the strict mode only if you know that the clients will send\
+**Warning:** Enable the strict mode only if you know that the clients will send
 statements that cause inconsistencies in the session state.
 
 ```
@@ -367,8 +367,8 @@ strict_multi_stmt=true
 * Dynamic: Yes
 * Default: false
 
-Similar to `strict_multi_stmt`, this option allows all queries after a CALL\
-operation on a stored procedure to be routed to the master. This option is\
+Similar to `strict_multi_stmt`, this option allows all queries after a CALL
+operation on a stored procedure to be routed to the master. This option is
 disabled by default and was added in MaxScale 2.1.9.
 
 All warnings and restrictions that apply to `strict_multi_stmt` also apply to`strict_sp_calls`.
@@ -381,10 +381,10 @@ All warnings and restrictions that apply to `strict_multi_stmt` also apply to`st
 * Values: `fail_instantly`, `fail_on_write`, `error_on_write`
 * Default: `fail_instantly`
 
-This option controls how the failure of a master server is handled. By default,\
+This option controls how the failure of a master server is handled. By default,
 the router will close the client connection as soon as the master is lost.
 
-The following table describes the values for this option and how they treat the\
+The following table describes the values for this option and how they treat the
 loss of a master server.
 
 | Value            | Description                                                                                                                     |
@@ -393,22 +393,22 @@ loss of a master server.
 | fail\_on\_write  | The client connection is closed if a write query is received when no master is available.                                       |
 | error\_on\_write | If no master is available and a write query is received, an error is returned stating that the connection is in read-only mode. |
 
-These also apply to new sessions created after the master has failed. This means\
-that in `fail_on_write` or `error_on_write` mode, connections are accepted as\
+These also apply to new sessions created after the master has failed. This means
+that in `fail_on_write` or `error_on_write` mode, connections are accepted as
 long as slave servers are available.
 
-When configured with `fail_on_write` or `error_on_write`, sessions that are idle\
-will not be closed even if all backend connections for that session have\
-failed. This is done in the hopes that before the next query from the idle\
-session arrives, a reconnection to one of the slaves is made. However, this can\
-leave idle connections around unless the client application actively closes\
-them. To prevent this, use the [connection\_timeout](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+When configured with `fail_on_write` or `error_on_write`, sessions that are idle
+will not be closed even if all backend connections for that session have
+failed. This is done in the hopes that before the next query from the idle
+session arrives, a reconnection to one of the slaves is made. However, this can
+leave idle connections around unless the client application actively closes
+them. To prevent this, use the [connection\_timeout](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 parameter.
 
-**Note:** If `master_failure_mode` is set to `error_on_write` and the connection\
-to the master is lost, by default, clients will not be able to execute write\
-queries without reconnecting to MariaDB MaxScale once a new master is\
-available. If [master\_reconnection](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md#master_reconnection) is enabled, the\
+**Note:** If `master_failure_mode` is set to `error_on_write` and the connection
+to the master is lost, by default, clients will not be able to execute write
+queries without reconnecting to MariaDB MaxScale once a new master is
+available. If [master\_reconnection](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md#master_reconnection) is enabled, the
 session can recover if one of the slaves is promoted as the master.
 
 #### `retry_failed_reads`
@@ -421,9 +421,9 @@ session can recover if one of the slaves is promoted as the master.
 This option controls whether autocommit selects are retried in case of failure.\
 This option is enabled by default.
 
-When a simple autocommit select is being executed outside of a transaction and\
-the slave server where the query is being executed fails, readwritesplit can\
-retry the read on a replacement server. This makes the failure of a slave\
+When a simple autocommit select is being executed outside of a transaction and
+the slave server where the query is being executed fails, readwritesplit can
+retry the read on a replacement server. This makes the failure of a slave
 transparent to the client.
 
 #### `delayed_retry`
@@ -433,34 +433,34 @@ transparent to the client.
 * Dynamic: Yes
 * Default: false
 
-Retry queries over a period of time. This parameter takes a boolean value, was\
+Retry queries over a period of time. This parameter takes a boolean value, was
 added in Maxscale 2.3.0 and is disabled by default.
 
-When this feature is enabled, a failure to route a query due to a connection\
-problem will not immediately result in an error. The routing of the query is\
-delayed until either a valid candidate server is available or the retry timeout\
-is reached. If a candidate server becomes available before the timeout is\
-reached, the query is routed normally and no connection error is returned. If no\
-candidates are found and the timeout is exceeded, the router returns to normal\
+When this feature is enabled, a failure to route a query due to a connection
+problem will not immediately result in an error. The routing of the query is
+delayed until either a valid candidate server is available or the retry timeout
+is reached. If a candidate server becomes available before the timeout is
+reached, the query is routed normally and no connection error is returned. If no
+candidates are found and the timeout is exceeded, the router returns to normal
 behavior and returns an error.
 
-When combined with the `master_reconnection` parameter, failures of writes done\
-outside of transactions can be hidden from the client connection. This allows a\
+When combined with the `master_reconnection` parameter, failures of writes done
+outside of transactions can be hidden from the client connection. This allows a
 master to be replaced while writes are being sent.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, `delayed_retry` will no longer attempt to retry a query if it was\
-already sent to the database. If a query is received while a valid target server\
-is not available, the execution of the query is delayed until a valid target is\
-found or the delayed retry timeout is hit. If a query was already sent, it will\
+24.08.1, `delayed_retry` will no longer attempt to retry a query if it was
+already sent to the database. If a query is received while a valid target server
+is not available, the execution of the query is delayed until a valid target is
+found or the delayed retry timeout is hit. If a query was already sent, it will
 not be replayed to prevent duplicate execution of statements.
 
-In older versions of MaxScale, duplicate execution of a statement can occur if\
-the connection to the server is lost or the server crashes but the server comes\
-back up before the timeout for the retrying is exceeded. At this point, if the\
-server managed to read the client's statement, it will be executed. For this\
+In older versions of MaxScale, duplicate execution of a statement can occur if
+the connection to the server is lost or the server crashes but the server comes
+back up before the timeout for the retrying is exceeded. At this point, if the
+server managed to read the client's statement, it will be executed. For this
 reason, it is recommended to only enable `delayed_retry` for older versions of\
-MaxScale when the possibility of duplicate statement execution is an acceptable\
+MaxScale when the possibility of duplicate statement execution is an acceptable
 risk.
 
 #### `delayed_retry_timeout`
@@ -472,10 +472,10 @@ risk.
 
 The duration to wait until an error is returned to the client when`delayed_retry` is enabled. The default value is 10 seconds.
 
-The timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `transaction_replay`
@@ -485,20 +485,20 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Replay interrupted transactions. This parameter was added in MaxScale 2.3.0 and\
-is disabled by default. Enabling this parameter enables both `delayed_retry` and`master_reconnection` and sets `master_failure_mode` to `fail_on_write`, thereby\
+Replay interrupted transactions. This parameter was added in MaxScale 2.3.0 and
+is disabled by default. Enabling this parameter enables both `delayed_retry` and`master_reconnection` and sets `master_failure_mode` to `fail_on_write`, thereby
 overriding any configured values for these parameters.
 
-When the server where the transaction is in progress fails, readwritesplit can\
-migrate the transaction to a replacement server. This can completely hide the\
+When the server where the transaction is in progress fails, readwritesplit can
+migrate the transaction to a replacement server. This can completely hide the
 failure of a master node without any visible effects to the client.
 
 If no replacement node becomes available, the client connection is closed.
 
 To control how long a transaction replay can take, use`transaction_replay_timeout`.
 
-Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md#transaction-replay-limitations) section for\
-a more detailed explanation of what should and should not be done with\
+Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md#transaction-replay-limitations) section for
+a more detailed explanation of what should and should not be done with
 transaction replay.
 
 #### `transaction_replay_max_size`
@@ -508,20 +508,20 @@ transaction replay.
 * Dynamic: Yes
 * Default: 1 MiB
 
-The limit on transaction size for transaction replay in bytes. Any transaction\
-that exceeds this limit will not be replayed. The default value is 1 MiB. This\
-limit applies at a session level which means that the total peak memory\
-consumption can be `transaction_replay_max_size` times the number of client\
+The limit on transaction size for transaction replay in bytes. Any transaction
+that exceeds this limit will not be replayed. The default value is 1 MiB. This
+limit applies at a session level which means that the total peak memory
+consumption can be `transaction_replay_max_size` times the number of client
 connections.
 
-The amount of memory needed to store a particular transaction will be slightly\
-larger than the length in bytes of the SQL used in the transaction. If the limit\
+The amount of memory needed to store a particular transaction will be slightly
+larger than the length in bytes of the SQL used in the transaction. If the limit
 is ever exceeded, a message will be logged at the info level.
 
-Starting with MaxScale 6.4.10, the number of times that this limit has been\
+Starting with MaxScale 6.4.10, the number of times that this limit has been
 exceeded is shown in `maxctrl show service` as `trx_max_size_exceeded`.
 
-Read [the configuration guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+Read [the configuration guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 for more details on size type parameters in MaxScale.
 
 #### `transaction_replay_attempts`
@@ -531,13 +531,13 @@ for more details on size type parameters in MaxScale.
 * Dynamic: Yes
 * Default: 5
 
-The upper limit on how many times a transaction replay is attempted before\
+The upper limit on how many times a transaction replay is attempted before
 giving up. The default value is 5.
 
-A transaction replay failure can happen if the server where the transaction is\
-being replayed fails while the replay is in progress. In practice this parameter\
-controls how many server and network failures a single transaction replay\
-tolerates. If a transaction is replayed successfully, the counter for failed\
+A transaction replay failure can happen if the server where the transaction is
+being replayed fails while the replay is in progress. In practice this parameter
+controls how many server and network failures a single transaction replay
+tolerates. If a transaction is replayed successfully, the counter for failed
 attempts is reset.
 
 #### `transaction_replay_timeout`
@@ -547,30 +547,30 @@ attempts is reset.
 * Dynamic: Yes
 * Default: 0s
 
-The time how long transactions are attempted for. This feature is disabled by\
-default and was added in MaxScale 6.2.1. To explicitly disable this feature, set\
+The time how long transactions are attempted for. This feature is disabled by
+default and was added in MaxScale 6.2.1. To explicitly disable this feature, set
 the value to 0 seconds.
 
-The timeout is [a duration type](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+The timeout is [a duration type](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 and the value must include a unit for the duration.
 
-When `transaction_replay_timeout` is enabled, the time a transaction replay can\
-take is controlled solely by this parameter. This is a more convenient and\
-predictable method of controlling how long a transaction replay can be attempted\
+When `transaction_replay_timeout` is enabled, the time a transaction replay can
+take is controlled solely by this parameter. This is a more convenient and
+predictable method of controlling how long a transaction replay can be attempted
 before the connection is closed.
 
-If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set\
+If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set
 to the same value.
 
-By default the time how long a transaction can be retried is controlled by`delayed_retry_timeout` and `transaction_replay_attempts`. This can result in a\
-maximum replay time limit of `delayed_retry_timeout` multiplied by`transaction_replay_attempts`, by default this is 50 seconds. The minimum replay\
-time limit can be as low as `transaction_replay_attempts` seconds (5 seconds by\
-default) in cases where the connection fails after it was created. Usually this\
-happens due to problems like the max\_connections limit being hit on the database\
+By default the time how long a transaction can be retried is controlled by`delayed_retry_timeout` and `transaction_replay_attempts`. This can result in a
+maximum replay time limit of `delayed_retry_timeout` multiplied by`transaction_replay_attempts`, by default this is 50 seconds. The minimum replay
+time limit can be as low as `transaction_replay_attempts` seconds (5 seconds by
+default) in cases where the connection fails after it was created. Usually this
+happens due to problems like the max\_connections limit being hit on the database
 server.
 
-With the introduction of `transaction_replay_timeout`, these problems are\
-avoided. Starting with MaxScale 6.2.1, this is the recommended method of\
+With the introduction of `transaction_replay_timeout`, these problems are
+avoided. Starting with MaxScale 6.2.1, this is the recommended method of
 controlling the timeouts for transaction replay.
 
 #### `transaction_replay_retry_on_deadlock`
@@ -580,15 +580,15 @@ controlling the timeouts for transaction replay.
 * Dynamic: Yes
 * Default: false
 
-Enable automatic retrying of transactions that end up in a deadlock. This\
-parameter was added in MaxScale 2.4.6 and the feature is disabled by\
-default. MaxScale versions from 2.4.0 to 2.4.5 always tried to replay deadlocked\
+Enable automatic retrying of transactions that end up in a deadlock. This
+parameter was added in MaxScale 2.4.6 and the feature is disabled by
+default. MaxScale versions from 2.4.0 to 2.4.5 always tried to replay deadlocked
 transactions.
 
-If this feature is enabled and a transaction returns a deadlock error\
-(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),\
-the transaction is automatically retried. If the retrying of the transaction\
-results in another deadlock error, it is retried until it either succeeds or a\
+If this feature is enabled and a transaction returns a deadlock error
+(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),
+the transaction is automatically retried. If the retrying of the transaction
+results in another deadlock error, it is retried until it either succeeds or a
 transaction checksum error is encountered.
 
 #### `transaction_replay_retry_on_mismatch`
@@ -601,8 +601,8 @@ transaction checksum error is encountered.
 Retry transactions that end in checksum mismatch. This parameter was added in\
 MaxScale 6.2.1 is disabled by default.
 
-When enabled, any replayed transactions that end with a checksum mismatch are\
-retried until they either succeeds or one of the transaction replay limits is\
+When enabled, any replayed transactions that end with a checksum mismatch are
+retried until they either succeeds or one of the transaction replay limits is
 reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_replay_attempts`).
 
 #### `transaction_replay_checksum`
@@ -613,30 +613,30 @@ reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_re
 * Values: `full`, `result_only`, `no_insert_id`
 * Default: `full`
 
-Selects which transaction checksum method is used to verify the result of the\
+Selects which transaction checksum method is used to verify the result of the
 replayed transaction.
 
-Note that only `transaction_replay_checksum=full` is guaranteed to retain the\
+Note that only `transaction_replay_checksum=full` is guaranteed to retain the
 consistency of the replayed transaction.
 
 Possible values are:
 
 * `full` (default)
-* All responses from the server are included in the checksum. This retains the\
-  full consistency guarantee of the replayed transaction as it must match\
+* All responses from the server are included in the checksum. This retains the
+  full consistency guarantee of the replayed transaction as it must match
   exactly the one that was already returned to the client.
 * `result_only`
-* Only resultsets and errors are included in the checksum. OK packets\
-  (i.e. successful queries that do not return results) are ignored. This mode\
+* Only resultsets and errors are included in the checksum. OK packets
+  (i.e. successful queries that do not return results) are ignored. This mode
   is intended to be used in cases where the extra information (auto-generated\
-  ID, warnings etc.) returned in the OK packet is not used by the\
+  ID, warnings etc.) returned in the OK packet is not used by the
   application.\
-  This mode is safe to use only if the auto-generated ID is not actually used\
-  by any following queries. An example of such behavior would be a transaction\
+  This mode is safe to use only if the auto-generated ID is not actually used
+  by any following queries. An example of such behavior would be a transaction
   that ends with an `INSERT` into a table with an `AUTO_INCREMENT` field.
 * `no_insert_id`
-* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the\
-  result of the query is not used by any subsequent statement in the\
+* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the
+  result of the query is not used by any subsequent statement in the
   transaction.
 
 #### `optimistic_trx`
@@ -646,21 +646,21 @@ Possible values are:
 * Dynamic: Yes
 * Default: false
 
-Enable optimistic transaction execution. This parameter controls whether normal\
-transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across\
+Enable optimistic transaction execution. This parameter controls whether normal
+transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across
 slaves. This feature is disabled by default and enabling it implicitly enables`transaction_replay`, `delayed_retry` and `master_reconnection` parameters.
 
-When this mode is enabled, all transactions are first attempted on slave\
-servers. If the transaction contains no statements that modify data, it is\
-completed on the slave. If the transaction contains statements that modify data,\
-it is rolled back on the slave server and restarted on the master. The rollback\
-is initiated the moment a data modifying statement is intercepted by\
+When this mode is enabled, all transactions are first attempted on slave
+servers. If the transaction contains no statements that modify data, it is
+completed on the slave. If the transaction contains statements that modify data,
+it is rolled back on the slave server and restarted on the master. The rollback
+is initiated the moment a data modifying statement is intercepted by
 readwritesplit so only read-only statements are executed on slave servers.
 
-As with `transaction_replay` and transactions that are replayed, if the results\
-returned by the master server are not identical to the ones returned by the\
-slave up to the point where the first data modifying statement was executed, the\
-connection is closed. If the execution of ROLLBACK statement on the slave fails,\
+As with `transaction_replay` and transactions that are replayed, if the results
+returned by the master server are not identical to the ones returned by the
+slave up to the point where the first data modifying statement was executed, the
+connection is closed. If the execution of ROLLBACK statement on the slave fails,
 the connection to that slave is closed.
 
 All limitations that apply to `transaction_replay` also apply to`optimistic_trx`.
@@ -676,18 +676,18 @@ All limitations that apply to `transaction_replay` also apply to`optimistic_trx`
 Enable causal reads. This parameter is disabled by default and was introduced in\
 MaxScale 2.3.0.
 
-If a client connection modifies the database and `causal_reads` is enabled, any\
-subsequent reads performed on slave servers will be done in a manner that\
-prevents replication lag from affecting the results. This only applies to the\
+If a client connection modifies the database and `causal_reads` is enabled, any
+subsequent reads performed on slave servers will be done in a manner that
+prevents replication lag from affecting the results. This only applies to the
 modifications done by the client itself.
 
-**Note:** This feature requires MariaDB 10.2.16 or newer to function. In\
+**Note:** This feature requires MariaDB 10.2.16 or newer to function. In
 addition to this, the `session_track_system_variables` parameter must include`last_gtid` in its list of tracked system variables.
 
-**Note:** This feature also enables multi-statement execution of SQL in the\
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)\
+**Note:** This feature also enables multi-statement execution of SQL in the
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
-Connector/C. The _Implementation of causal\_reads_ section explains why this is\
+Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.
 
 The possible values for this parameter are:
@@ -695,61 +695,61 @@ The possible values for this parameter are:
 * `none` (default)
 * Read causality is disabled.
 * `local`
-* Writes are locally visible. Writes are guaranteed to be visible only to the\
-  connection that does it. Unrelated modifications done by other connections\
-  are not visible. This mode improves read scalability at the cost of latency\
-  and reduces the overall load placed on the master server without breaking\
+* Writes are locally visible. Writes are guaranteed to be visible only to the
+  connection that does it. Unrelated modifications done by other connections
+  are not visible. This mode improves read scalability at the cost of latency
+  and reduces the overall load placed on the master server without breaking
   causality guarantees.
 * `global`
-* Writes are globally visible. If one connection writes a value, all\
-  connections to the same service will see it. In general this mode is slower\
-  than the `local` mode due to the extra synchronization it has to do. This\
-  guarantees global happens-before ordering of reads when all transactions are\
-  inside a single GTID domain.This mode gives similar benefits as the `local`\
+* Writes are globally visible. If one connection writes a value, all
+  connections to the same service will see it. In general this mode is slower
+  than the `local` mode due to the extra synchronization it has to do. This
+  guarantees global happens-before ordering of reads when all transactions are
+  inside a single GTID domain.This mode gives similar benefits as the `local`
   mode in that it improves read scalability at the cost of latency.\
-  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads\
-  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this\
-  was fixed and all the GTID coordinates are passed alongside all requests\
+  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads
+  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this
+  was fixed and all the GTID coordinates are passed alongside all requests
   which makes multi-domain GTIDs safe to use. However, this does mean that the\
-  GTID coordinates will never be reset: if replication is reset and GTID\
-  coordinates go "backwards", readwritesplit will not consider these as being\
-  newer than the ones already stored. To reset the stored GTID coordinates in\
+  GTID coordinates will never be reset: if replication is reset and GTID
+  coordinates go "backwards", readwritesplit will not consider these as being
+  newer than the ones already stored. To reset the stored GTID coordinates in
   readwritesplit, MaxScale must be restarted.\
-  MaxScale 6.4.11 added the new `reset-gtid` module command to\
+  MaxScale 6.4.11 added the new `reset-gtid` module command to
   readwritesplit. This allows the global GTID state used by`causal_reads=global` to be reset without having to restart MaxScale.
 * `fast`
-* This mode is similar to the `local` mode where it will only affect the\
-  connection that does the write but where the `local` mode waits for a slave\
-  server to catch up, the `fast` mode will only use servers that are known to\
-  have replicated the write. This means that if no slave has replicated the\
-  write, the master where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication\
-  state is only updated by the mariadbmon monitor whenever the servers are\
-  monitored. This means that a smaller `monitor_interval` provides faster\
+* This mode is similar to the `local` mode where it will only affect the
+  connection that does the write but where the `local` mode waits for a slave
+  server to catch up, the `fast` mode will only use servers that are known to
+  have replicated the write. This means that if no slave has replicated the
+  write, the master where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication
+  state is only updated by the mariadbmon monitor whenever the servers are
+  monitored. This means that a smaller `monitor_interval` provides faster
   replication state updates and possibly better overall usage of servers.\
-  This mode is the inverse of the `local` mode in the sense that it improves\
-  read latency at the cost of read scalability while still retaining the\
-  causality guarantees for reads. This functionality can also be considered an\
+  This mode is the inverse of the `local` mode in the sense that it improves
+  read latency at the cost of read scalability while still retaining the
+  causality guarantees for reads. This functionality can also be considered an
   improved version of the functionality that the [CCRFilter](../mariadb-maxscale-21-06-filters/mariadb-maxscale-2106-maxscale-2106-consistent-critical-read-filter.md) module provides.
 
-Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean\
+Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean
 parameter. False values translated to `none` and true values translated to`local`. The use of boolean parameters is deprecated but still accepted in\
 MaxScale 2.5.0.
 
 **Implementation of `causal_reads`**
 
-This feature is based on the `MASTER_GTID_WAIT` function and the tracking of\
-server-side status variables. By tracking the latest GTID that each statement\
-generates, readwritesplit can then perform a synchronization operation with the\
+This feature is based on the `MASTER_GTID_WAIT` function and the tracking of
+server-side status variables. By tracking the latest GTID that each statement
+generates, readwritesplit can then perform a synchronization operation with the
 help of the `MASTER_GTID_WAIT` function.
 
-If the slave has not caught up to the master within the configured time, as\
-specified by [causal\_reads\_timeout](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md#causal_reads_timeout), it will\
-be retried on the master. In MaxScale 2.3.0 an error was returned to the client\
+If the slave has not caught up to the master within the configured time, as
+specified by [causal\_reads\_timeout](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md#causal_reads_timeout), it will
+be retried on the master. In MaxScale 2.3.0 an error was returned to the client
 when the slave timed out.
 
 **Normal SQL**
 
-A practical example can be given by the following set of SQL commands executed\
+A practical example can be given by the following set of SQL commands executed
 with `autocommit=1`.
 
 ```
@@ -757,17 +757,17 @@ INSERT INTO test.t1 (id) VALUES (1);
 SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-As the statements are not executed inside a transaction, from the load balancers\
-point of view, the latter statement can be routed to a slave server. The problem\
-with this is that if the value that was inserted on the master has not yet\
-replicated to the server where the SELECT statement is being performed, it can\
+As the statements are not executed inside a transaction, from the load balancers
+point of view, the latter statement can be routed to a slave server. The problem
+with this is that if the value that was inserted on the master has not yet
+replicated to the server where the SELECT statement is being performed, it can
 appear as if the value we just inserted is not there.
 
-By prefixing these types of SELECT statements with a command that guarantees\
-consistent results for the reads, read scalability can be improved without\
+By prefixing these types of SELECT statements with a command that guarantees
+consistent results for the reads, read scalability can be improved without
 sacrificing consistency.
 
-The set of example SQL above will be translated by MaxScale into the following\
+The set of example SQL above will be translated by MaxScale into the following
 statements.
 
 ```
@@ -781,18 +781,18 @@ SET @maxscale_secret_variable=(
     END); SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-The `SET` command will synchronize the slave to a certain logical point in the\
-replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more\
-details). If the synchronization fails, the query will not run and it will be\
+The `SET` command will synchronize the slave to a certain logical point in the
+replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more
+details). If the synchronization fails, the query will not run and it will be
 retried on the server where the transaction was originally done.
 
 **Prepared Statements**
 
-Binary protocol prepared statements are handled in a different manner. Instead\
-of adding the synchronization SQL into the original SQL query, it is sent as a\
+Binary protocol prepared statements are handled in a different manner. Instead
+of adding the synchronization SQL into the original SQL query, it is sent as a
 separate packet before the prepared statement is executed.
 
-We'll use the same example SQL but use a binary protocol prepared statement for\
+We'll use the same example SQL but use a binary protocol prepared statement for
 the SELECT:
 
 ```
@@ -810,24 +810,24 @@ COM_QUERY:         IF (MASTER_GTID_WAIT('0-3000-8', 10) <> 0) THEN KILL (SELECT 
 COM_STMT_EXECUTE:  ? = 123
 ```
 
-Both the synchronization query and the execution of the prepared statement are\
-sent at the same time. This is done to remove the need to wait for the result of\
-the synchronization query before routing the execution of the prepared\
-statement. This keeps the performance of causal\_reads for prepared statements\
+Both the synchronization query and the execution of the prepared statement are
+sent at the same time. This is done to remove the need to wait for the result of
+the synchronization query before routing the execution of the prepared
+statement. This keeps the performance of causal\_reads for prepared statements
 the same as it is for normal SQL queries.
 
-As a result of this, each time the synchronization query times out, the\
-connection will be killed by the `KILL` statement and readwritesplit will retry\
-the query on the master. This is done to prevent the execution of the prepared\
+As a result of this, each time the synchronization query times out, the
+connection will be killed by the `KILL` statement and readwritesplit will retry
+the query on the master. This is done to prevent the execution of the prepared
 statement that follows the synchronization query from being processed by the\
 MariaDB server.
 
-It is recommend that the session command history is enabled whenever prepared\
-statements are used with `causal_reads`. This allows new connections to be\
+It is recommend that the session command history is enabled whenever prepared
+statements are used with `causal_reads`. This allows new connections to be
 created whenever a causal read times out.
 
-Starting with MaxScale 2.5.17, a failed causal read inside of a read-only\
-transaction started with `START TRANSACTION READ ONLY` will return the following\
+Starting with MaxScale 2.5.17, a failed causal read inside of a read-only
+transaction started with `START TRANSACTION READ ONLY` will return the following
 error:
 
 ```
@@ -836,23 +836,23 @@ SQLSTATE: 25006
 Message:  Causal read timed out while in a read-only transaction, cannot retry command.
 ```
 
-Older versions of MaxScale attempted to retry the command on the current master\
+Older versions of MaxScale attempted to retry the command on the current master
 server which would cause the connection to be closed and a warning to be logged.
 
 **Limitations of Causal Reads**
 
-* This feature does not work with Galera or any other non-standard\
-  replication mechanisms. As Galera does not update the `gtid_slave_pos`\
-  variable when events are replicated via the Galera library, the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)\
-  function used by MaxScale to synchronize reads will wait until the\
-  timeout. With Galera this is not a serious issue as it, by nature, is a\
+* This feature does not work with Galera or any other non-standard
+  replication mechanisms. As Galera does not update the `gtid_slave_pos`
+  variable when events are replicated via the Galera library, the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)
+  function used by MaxScale to synchronize reads will wait until the
+  timeout. With Galera this is not a serious issue as it, by nature, is a
   mostly-synchronous replication mechanism.
-* If the combination of the original SQL statement and the modifications\
-  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),\
+* If the combination of the original SQL statement and the modifications
+  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),
   the causal read will not be attempted and a non-causal read is done instead.
-* SQL like `INSERT ... RETURNING` that commits a transaction and returns a\
+* SQL like `INSERT ... RETURNING` that commits a transaction and returns a
   resultset will only work with causal reads if the connector supports the\
-  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB\
+  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB
   connectors and whether they support the protocol feature.
 
 | Connector         | Supported | Version |
@@ -871,13 +871,13 @@ server which would cause the connection to be closed and a warning to be logged.
 * Dynamic: Yes
 * Default: 10s
 
-The timeout for the slave synchronization done by `causal_reads`. The\
+The timeout for the slave synchronization done by `causal_reads`. The
 default value is 10 seconds.
 
-The timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `lazy_connect`
@@ -887,16 +887,16 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Lazy connection creation causes connections to backend servers to be opened only\
-when they are needed. This reduces the load that is placed on the backend\
-servers when the client connections are short. This parameter is a boolean type\
+Lazy connection creation causes connections to backend servers to be opened only
+when they are needed. This reduces the load that is placed on the backend
+servers when the client connections are short. This parameter is a boolean type
 and is disabled by default.
 
-By default readwritesplit opens as many connections as it can when the session\
-is first opened. This makes the execution of the first query faster when all\
-available connections are already created. When `lazy_connect` is enabled, this\
-initial connection creation is skipped. If the client executes only read\
-queries, no connection to the master is made. If only write queries are made,\
+By default readwritesplit opens as many connections as it can when the session
+is first opened. This makes the execution of the first query faster when all
+available connections are already created. When `lazy_connect` is enabled, this
+initial connection creation is skipped. If the client executes only read
+queries, no connection to the master is made. If only write queries are made,
 only the master connection is used.
 
 #### `reuse_prepared_statements`
@@ -906,22 +906,22 @@ only the master connection is used.
 * Dynamic: Yes
 * Default: false
 
-Reuse identical prepared statements inside the same client connection. This is a\
-boolean parameter and is disabled by default. This feature only applies to\
+Reuse identical prepared statements inside the same client connection. This is a
+boolean parameter and is disabled by default. This feature only applies to
 binary protocol prepared statements.
 
-When this parameter is enabled and the connection prepares an identical prepared\
-statement multiple times, instead of preparing it on the server the existing\
-prepared statement handle is reused. This also means that whenever prepared\
+When this parameter is enabled and the connection prepares an identical prepared
+statement multiple times, instead of preparing it on the server the existing
+prepared statement handle is reused. This also means that whenever prepared
 statements are closed by the client, they will be left open by readwritesplit.
 
-Enabling this feature will increase memory usage of a session. The amount of\
-memory stored per prepared statement is proportional to the length of the\
+Enabling this feature will increase memory usage of a session. The amount of
+memory stored per prepared statement is proportional to the length of the
 prepared SQL statement and the number of parameters the statement has.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a readwritesplit service contains the\
+The `router_diagnostics` output for a readwritesplit service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -942,48 +942,48 @@ following fields.
 
 ### Server Ranks
 
-The general rule with server ranks is that primary servers will be used before\
-secondary servers. Readwritesplit is an exception to this rule. The following\
+The general rule with server ranks is that primary servers will be used before
+secondary servers. Readwritesplit is an exception to this rule. The following
 rules govern how readwritesplit behaves with servers that have different ranks.
 
-* Sessions will use the current master server as long as possible. This means\
-  that sessions with a secondary master will not use the primary master as long\
+* Sessions will use the current master server as long as possible. This means
+  that sessions with a secondary master will not use the primary master as long
   as the secondary master is available.
-* All slave connections will use the same rank as the master connection. Any\
+* All slave connections will use the same rank as the master connection. Any
   stale connections with a different rank than the master will be discarded.
-* If no master connection is available and `master_reconnection` is enabled, a\
-  connection to the best master is created. If the new master has a different\
-  priority than existing connections have, the connections with a different rank\
+* If no master connection is available and `master_reconnection` is enabled, a
+  connection to the best master is created. If the new master has a different
+  priority than existing connections have, the connections with a different rank
   will be discarded.
-* If open connections exist, these will be used for routing. This means that if\
-  the master is lost but the session still has slave servers with the same rank,\
+* If open connections exist, these will be used for routing. This means that if
+  the master is lost but the session still has slave servers with the same rank,
   they will remain in use.
 * If no open connections exist, the servers with the best rank will used.
 
 ### Routing hints
 
-The readwritesplit router supports routing hints. For a detailed guide on hint\
-syntax and functionality, please read [this](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-hint-syntax.md)\
+The readwritesplit router supports routing hints. For a detailed guide on hint
+syntax and functionality, please read [this](../mariadb-maxscale-21-06-reference/mariadb-maxscale-2106-maxscale-2106-hint-syntax.md)
 document.
 
-**Note**: Routing hints will always have the highest priority when a routing\
-decision is made. This means that it is possible to cause inconsistencies in\
-the session state and the actual data in the database by adding routing hints\
-to DDL/DML statements which are then directed to slave servers. Only use routing\
+**Note**: Routing hints will always have the highest priority when a routing
+decision is made. This means that it is possible to cause inconsistencies in
+the session state and the actual data in the database by adding routing hints
+to DDL/DML statements which are then directed to slave servers. Only use routing
 hints when you are sure that they can cause no harm.
 
-An exception to this rule is `transaction_replay`: when it is enabled, all\
-routing hints inside transaction are ignored. This is done to prevent changes\
-done inside a replayable transaction from affecting servers outside of the\
-transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed\
+An exception to this rule is `transaction_replay`: when it is enabled, all
+routing hints inside transaction are ignored. This is done to prevent changes
+done inside a replayable transaction from affecting servers outside of the
+transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed
 routing hints to override the transaction logic.
 
 #### Known Limitations of Routing Hints
 
-* If a `SELECT` statement with a `maxscale route to slave` hint is received\
-  while autocommit is disabled, the query will be routed to a slave server. This\
-  causes some metadata locks to be acquired on the database in question which\
-  will block DDL statements on the server until either the connection is closed\
+* If a `SELECT` statement with a `maxscale route to slave` hint is received
+  while autocommit is disabled, the query will be routed to a slave server. This
+  causes some metadata locks to be acquired on the database in question which
+  will block DDL statements on the server until either the connection is closed
   or autocommit is enabled again.
 
 ### Module Commands
@@ -992,11 +992,11 @@ The readwritesplit router implements the following module commands.
 
 #### `reset-gtid`
 
-The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is\
-reverted to an earlier state and the GTIDs recorded in MaxScale are no longer\
+The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is
+reverted to an earlier state and the GTIDs recorded in MaxScale are no longer
 valid.
 
-The first and only argument to the command is the router name. For example, to\
+The first and only argument to the command is the router name. For example, to
 reset the GTID state of a readwritesplit named `My-RW-Router`, the following\
 MaxCtrl command should be used:
 
@@ -1010,12 +1010,12 @@ Examples of the readwritesplit router in use can be found in the [Tutorials](htt
 
 ### Readwritesplit routing decisions
 
-Here is a small explanation which shows what kinds of queries are routed to\
+Here is a small explanation which shows what kinds of queries are routed to
 which type of server.
 
 #### Routing to Master
 
-Routing to master is important for data consistency and because majority of\
+Routing to master is important for data consistency and because majority of
 writes are written to binlog and thus become replicated to slaves.
 
 The following operations are routed to master:
@@ -1036,34 +1036,34 @@ The following operations are routed to master:
 * `@@last_insert_id`
 * `@@identity`
 
-In addition to these, if the **readwritesplit** service is configured with the`max_slave_replication_lag` parameter, and if all slaves suffer from too much\
-replication lag, then statements will be routed to the _Master_. (There might be\
-other similar configuration parameters in the future which limit the number of\
+In addition to these, if the **readwritesplit** service is configured with the`max_slave_replication_lag` parameter, and if all slaves suffer from too much
+replication lag, then statements will be routed to the _Master_. (There might be
+other similar configuration parameters in the future which limit the number of
 statements that will be routed to slaves.)
 
 **Transaction Isolation Level Tracking**
 
-Use of the SERIALIZABLE transaction isolation level with readwritesplit is not\
+Use of the SERIALIZABLE transaction isolation level with readwritesplit is not
 recommended as it somewhat goes against the goals of load balancing.
 
-If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB\
-server, readwritesplit will track the transaction isolation level and lock the\
-session to the master when the isolation level is set to serializable. This\
-retains the correctness of the isolation level which can otherwise cause\
-problems. Once a session is locked to the master, it will not be unlocked. To\
+If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB
+server, readwritesplit will track the transaction isolation level and lock the
+session to the master when the isolation level is set to serializable. This
+retains the correctness of the isolation level which can otherwise cause
+problems. Once a session is locked to the master, it will not be unlocked. To
 reinstate the normal routing behavior, a new connection must be created.
 
-For example, if transaction isolation level tracking cannot be done and an\
-autocommit SELECT is routed to a slave, it no longer behaves in a serializable\
+For example, if transaction isolation level tracking cannot be done and an
+autocommit SELECT is routed to a slave, it no longer behaves in a serializable
 manner. This can also have an effect on the replication in the slave server.
 
 #### Routing to Slaves
 
-The ability to route some statements to slaves is important because it also\
-decreases the load targeted to master. Moreover, it is possible to have multiple\
+The ability to route some statements to slaves is important because it also
+decreases the load targeted to master. Moreover, it is possible to have multiple
 slaves to share the load in contrast to single master.
 
-Queries which can be routed to slaves must be auto committed and belong to one\
+Queries which can be routed to slaves must be auto committed and belong to one
 of the following group:
 
 * Read-only statements (i.e. `SELECT`) that only use read-only built-in functions
@@ -1074,10 +1074,10 @@ The list of supported built-in functions can be found [here](https://github.com/
 
 #### Routing to every session backend
 
-A third class of statements includes those which modify session data, such as\
-session system variables, user-defined variables, the default database, etc. We\
-call them session commands, and they must be replicated as they affect the\
-future results of read and write operations. They must be executed on all\
+A third class of statements includes those which modify session data, such as
+session system variables, user-defined variables, the default database, etc. We
+call them session commands, and they must be replicated as they affect the
+future results of read and write operations. They must be executed on all
 servers that could execute statements on behalf of this client.
 
 Session commands include for example:
@@ -1087,26 +1087,26 @@ Session commands include for example:
 * Binary protocol prepared statements
 * Other miscellaneous commands (COM\_QUIT, COM\_PING etc.)
 
-**NOTE**: if variable assignment is embedded in a write statement it is routed\
-to _Master_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be\
+**NOTE**: if variable assignment is embedded in a write statement it is routed
+to _Master_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be
 routed to _Master_ only.
 
-The router stores all of the executed session commands so that in case of a\
-slave failure, a replacement slave can be chosen and the session command history\
-can be repeated on that new slave. This means that the router stores each\
-executed session command for the duration of the session. Applications that use\
-long-running sessions might cause MariaDB MaxScale to consume a growing amount\
-of memory unless the sessions are closed. This can be solved by adjusting the\
+The router stores all of the executed session commands so that in case of a
+slave failure, a replacement slave can be chosen and the session command history
+can be repeated on that new slave. This means that the router stores each
+executed session command for the duration of the session. Applications that use
+long-running sessions might cause MariaDB MaxScale to consume a growing amount
+of memory unless the sessions are closed. This can be solved by adjusting the
 value of `max_sescmd_history`.
 
 #### Routing to previous target
 
-In the following cases, a query is routed to the same server where the previous\
-query was executed. If no previous target is found, the query is routed to the\
+In the following cases, a query is routed to the same server where the previous
+query was executed. If no previous target is found, the query is routed to the
 current master.
 
-* If a query uses the `FOUND_ROWS()` function, it will be routed to the server\
-  where the last query was executed. This is done with the assumption that a\
+* If a query uses the `FOUND_ROWS()` function, it will be routed to the server
+  where the last query was executed. This is done with the assumption that a
   query with `SQL_CALC_FOUND_ROWS` was previously executed.
 * COM\_STMT\_FETCH\_ROWS will always be routed to the same server where the\
   COM\_STMT\_EXECUTE was routed.
@@ -1121,59 +1121,59 @@ Read queries are routed to the master server in the following situations:
 
 #### Prepares Statement Limitations
 
-If a prepared statement targets a temporary table on the master, the slave\
-servers will fail to execute it. This will cause all slave connections to be\
+If a prepared statement targets a temporary table on the master, the slave
+servers will fail to execute it. This will cause all slave connections to be
 closed (MXS-1816).
 
 #### Transaction Replay Limitations
 
-If the results from the replacement server are not identical when the\
-transaction is replayed, the client connection is closed. This means that any\
-transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot\
+If the results from the replacement server are not identical when the
+transaction is replayed, the client connection is closed. This means that any
+transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot
 be replayed successfully but it will still be attempted.
 
-If a transaction reads data before updating it, the rows should be locked by\
-using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when\
+If a transaction reads data before updating it, the rows should be locked by
+using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when
 multiple transactions are being replayed that modify the same set of rows.
 
-If the connection to the server where the transaction is being executed is\
-lost when the final `COMMIT` is being executed, it is impossible to know\
-whether the transaction was successfully committed. This means that there\
-is a possibility for duplicate transaction execution which can result in\
-data duplication in certain cases. Data duplication can happen if the\
+If the connection to the server where the transaction is being executed is
+lost when the final `COMMIT` is being executed, it is impossible to know
+whether the transaction was successfully committed. This means that there
+is a possibility for duplicate transaction execution which can result in
+data duplication in certain cases. Data duplication can happen if the
 transaction consists of the following statement types:
 
 * INSERT of rows into a table that does not have an auto-increment primary key
 * A "blind update" of one or more rows e.g. `UPDATE t SET c = c + 1 WHERE id = 123`
 * A "blind delete" e.g. `DELETE FROM t LIMIT 100`
 
-This is not an exhaustive list and any operations that do not check the row\
+This is not an exhaustive list and any operations that do not check the row
 contents before performing the operation on them might face this problem.
 
-In all cases the problem of duplicate transaction execution can be avoided by\
-including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that\
-in the case that the transaction fails when it is being committed, the row is\
+In all cases the problem of duplicate transaction execution can be avoided by
+including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that
+in the case that the transaction fails when it is being committed, the row is
 only modified if it matches the expected contents.
 
-Similarly, a connection loss during `COMMIT` can also result in transaction\
-replay failure. This happens due to the same reason as duplicate transaction\
-execution but the retried transaction will not be committed. This can be\
-considered a success case as the transaction replay detected that the results of\
-the two transactions are different. In these cases readwritesplit will abort the\
+Similarly, a connection loss during `COMMIT` can also result in transaction
+replay failure. This happens due to the same reason as duplicate transaction
+execution but the retried transaction will not be committed. This can be
+considered a success case as the transaction replay detected that the results of
+the two transactions are different. In these cases readwritesplit will abort the
 transaction and close the client connection.
 
-Statements that result in an implicit commit do not reset the transaction when\
-transaction\_replay is enabled. This means that if the transaction is replayed,\
-the transaction will be committed twice due to the implicit commit being\
-present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the\
+Statements that result in an implicit commit do not reset the transaction when
+transaction\_replay is enabled. This means that if the transaction is replayed,
+the transaction will be committed twice due to the implicit commit being
+present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the
 transaction to be correctly reset.
 
-Any changes to the session state (e.g. autocommit state, SQL mode) done inside a\
-transaction will remain in effect even if the connection to the server where the\
-transaction is being executed fails. When readwritesplit creates a new\
-connection to a server to replay the transaction, it will first restore the\
-session state by executing all session commands that were executed. This means\
-that if the session state is changed mid-transaction in a way that affects the\
+Any changes to the session state (e.g. autocommit state, SQL mode) done inside a
+transaction will remain in effect even if the connection to the server where the
+transaction is being executed fails. When readwritesplit creates a new
+connection to a server to replay the transaction, it will first restore the
+session state by executing all session commands that were executed. This means
+that if the session state is changed mid-transaction in a way that affects the
 results, transaction replay will fail.
 
 The following partial transaction demonstrates the problem by using [SQL\_MODE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) inside a transaction.
@@ -1186,7 +1186,7 @@ SET SQL_MODE='ANSI_QUOTES'; -- A session command
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-If this transaction has to be replayed the actual SQL that gets executed is the\
+If this transaction has to be replayed the actual SQL that gets executed is the
 following.
 
 ```
@@ -1197,55 +1197,55 @@ SELECT "hello world";       -- Returns an error
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-First the session state is restored by executing all commands that changed the\
+First the session state is restored by executing all commands that changed the
 state after which the actual transaction is replayed. Due to the fact that the\
-SQL\_MODE was changed mid-transaction, one of the queries will now return an\
+SQL\_MODE was changed mid-transaction, one of the queries will now return an
 error instead of the result we expected leading to a transaction replay failure.
 
-In a service-to-service configuration (i.e. a service using another service in\
-its `targets` list ), if the topmost service starts a transaction, all\
-lower-level readwritesplit services will also behave as if a transaction is\
-open. If a connection to a backend database fails during this, it can result in\
-unnecessary transaction replays which in turn can end up with checksum\
-conflicts. The recommended approach is to not use any commands inside a\
+In a service-to-service configuration (i.e. a service using another service in
+its `targets` list ), if the topmost service starts a transaction, all
+lower-level readwritesplit services will also behave as if a transaction is
+open. If a connection to a backend database fails during this, it can result in
+unnecessary transaction replays which in turn can end up with checksum
+conflicts. The recommended approach is to not use any commands inside a
 transaction that would be routed to more than one node.
 
-If the connection to the server where a transaction is being executed is lost\
-while a `ROLLBACK` is being executed, readwritesplit will still attempt to\
-replay the transaction in the hopes that the real response can be delivered to\
-the client. However, this does mean that it is possible that a rolled back\
-transaction which gets replayed ends up with a conflict and is reported as a\
-replay failure when in reality a rolled back transaction could be safely\
+If the connection to the server where a transaction is being executed is lost
+while a `ROLLBACK` is being executed, readwritesplit will still attempt to
+replay the transaction in the hopes that the real response can be delivered to
+the client. However, this does mean that it is possible that a rolled back
+transaction which gets replayed ends up with a conflict and is reported as a
+replay failure when in reality a rolled back transaction could be safely
 ignored.
 
 #### Legacy Configuration
 
-In older versions of MaxScale, routers were configured via the _router\_options_\
+In older versions of MaxScale, routers were configured via the _router\_options_
 parameter. This functionality was deprecated in 2.2 and was removed in 2.3.
 
 #### JDBC Batched Statements
 
-Readwritesplit does not support pipelining of JDBC batched statements. This is\
-caused by the fact that readwritesplit executes the statements one at a time to\
+Readwritesplit does not support pipelining of JDBC batched statements. This is
+caused by the fact that readwritesplit executes the statements one at a time to
 track the state of the response.
 
 **Limitations in multi-statement handling**
 
-When a multi-statement query is executed through the readwritesplit router, it\
-will always be routed to the master. See [strict\_multi\_stmt](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md) for more\
+When a multi-statement query is executed through the readwritesplit router, it
+will always be routed to the master. See [strict\_multi\_stmt](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md) for more
 details.
 
-If the multi-statement query creates a temporary table, it will not be\
-detected and reads to this table can be routed to slave servers. To\
-prevent this, always execute the temporary table creation as an individual\
+If the multi-statement query creates a temporary table, it will not be
+detected and reads to this table can be routed to slave servers. To
+prevent this, always execute the temporary table creation as an individual
 statement.
 
 **Limitations in client session handling**
 
-Some of the queries that a client sends are routed to all backends instead of\
-just to one. These queries include `USE <db name>` and `SET autocommit=0`, among\
-many others. Readwritesplit sends a copy of these queries to each backend server\
-and forwards the master's reply to the client. Below is a list of MySQL commands\
+Some of the queries that a client sends are routed to all backends instead of
+just to one. These queries include `USE <db name>` and `SET autocommit=0`, among
+many others. Readwritesplit sends a copy of these queries to each backend server
+and forwards the master's reply to the client. Below is a list of MySQL commands
 which are classified as session commands.
 
 ```
@@ -1267,19 +1267,19 @@ SELECT ..INTO variable|OUTFILE|DUMPFILE
 SET autocommit=1|0
 ```
 
-Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were\
+Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were
 not supported and caused the session to be closed.
 
-There is a possibility for misbehavior. If `USE mytable` is executed in one of\
-the slaves and fails, it may be due to replication lag rather than the database\
-not existing. Thus, the same command may produce different result in different\
-backend servers. The slaves which fail to execute a session command will be\
-dropped from the active list of slaves for this session to guarantee a\
-consistent session state across all the servers used by the session. In\
-addition, the server will not be used again for routing for the duration of the\
+There is a possibility for misbehavior. If `USE mytable` is executed in one of
+the slaves and fails, it may be due to replication lag rather than the database
+not existing. Thus, the same command may produce different result in different
+backend servers. The slaves which fail to execute a session command will be
+dropped from the active list of slaves for this session to guarantee a
+consistent session state across all the servers used by the session. In
+addition, the server will not be used again for routing for the duration of the
 session.
 
-The above-mentioned behavior for user variables can be partially controlled with\
+The above-mentioned behavior for user variables can be partially controlled with
 the configuration parameter `use_sql_variables_in`:
 
 ```
@@ -1288,10 +1288,10 @@ use_sql_variables_in=[master|all] (default: all)
 
 **WARNING**
 
-If a SELECT query modifies a user variable when the `use_sql_variables_in`\
-parameter is set to `all`, it will not be routed and the client will receive an\
-error. A log message is written into the log further explaining the reason for\
-the error. Here is an example use of a SELECT query which modifies a user\
+If a SELECT query modifies a user variable when the `use_sql_variables_in`
+parameter is set to `all`, it will not be routed and the client will receive an
+error. A log message is written into the log further explaining the reason for
+the error. Here is an example use of a SELECT query which modifies a user
 variable and how MariaDB MaxScale responds to it.
 
 ```
@@ -1302,7 +1302,7 @@ MySQL [(none)]> SELECT @id := @id + 1 FROM test.t1;
 ERROR 1064 (42000): Routing query to backend failed. See the error log for further details.
 ```
 
-Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user\
+Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user
 variables to the master.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-schemarouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-schemarouter.md
@@ -1,15 +1,15 @@
 # MaxScale 21.06 SchemaRouter
 
-The SchemaRouter provides an easy and manageable sharding solution by\
-building a single logical database server from multiple separate ones. Each\
-database is shown to the client and queries targeting unique databases are\
-routed to their respective servers. In addition to providing simple\
-database-based sharding, the schemarouter also enables cross-node\
-session variable usage by routing all queries that modify the session to all\
+The SchemaRouter provides an easy and manageable sharding solution by
+building a single logical database server from multiple separate ones. Each
+database is shown to the client and queries targeting unique databases are
+routed to their respective servers. In addition to providing simple
+database-based sharding, the schemarouter also enables cross-node
+session variable usage by routing all queries that modify the session to all
 nodes.
 
-By default the SchemaRouter assumes that each database and table is only located\
-on one server. If it finds the same database or table on multiple servers, it\
+By default the SchemaRouter assumes that each database and table is only located
+on one server. If it finds the same database or table on multiple servers, it
 will close the session with the following error:
 
 ```
@@ -18,14 +18,14 @@ ERROR 5000 (DUPDB): Error: duplicate tables found on two different shards.
 
 The exception to this rule are the system tables `mysql`, `information_schema`,`performance_schema`, `sys` that are never treated as duplicates.
 
-If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2106-maxscale-2106-schemarouter.md#ignore_tables_regex) parameter to controls which\
+If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2106-maxscale-2106-schemarouter.md#ignore_tables_regex) parameter to controls which
 duplicate tables are allowed. To disable the duplicate database detection, use`ignore_tables_regex=.*`.
 
-Schemarouter compares table and database names case-insensitively. This means\
+Schemarouter compares table and database names case-insensitively. This means
 that the tables `test.t1` and `test.T1` are assumed to refer to the same table.
 
-The main limitation of SchemaRouter is that aside from session variable writes\
-and some specific queries, a query can only target one server. This means that\
+The main limitation of SchemaRouter is that aside from session variable writes
+and some specific queries, a query can only target one server. This means that
 queries which depend on results from multiple servers give incorrect results.\
 See [Limitations](mariadb-maxscale-2106-maxscale-2106-schemarouter.md#limitations) for more information.
 
@@ -33,51 +33,51 @@ From 2.3.0 onwards, SchemaRouter is capable of limited table family sharding.
 
 ### Changes in Version 6
 
-* The `auth_all_servers` parameter is no longer automatically enabled by the\
-  schemarouter. To retain the old behavior that was present in 2.5, explicitly\
+* The `auth_all_servers` parameter is no longer automatically enabled by the
+  schemarouter. To retain the old behavior that was present in 2.5, explicitly
   define `auth_all_servers=true` for all schemarouter services.
 
 ### Routing Logic
 
-* If a command modifies the session state by modifying any session or user\
-  variables, the query is routed to all nodes. These statements include `SET`\
-  statements as well as any other statements that modify the behavior of the\
+* If a command modifies the session state by modifying any session or user
+  variables, the query is routed to all nodes. These statements include `SET`
+  statements as well as any other statements that modify the behavior of the
   client.
-* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers\
-  that contain the database. This same logic applies when a client connects with\
-  a default database: the default database is set only on servers that actually\
+* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers
+  that contain the database. This same logic applies when a client connects with
+  a default database: the default database is set only on servers that actually
   contain it.
-* If a query targets one or more tables that the schemarouter has discovered\
-  during the database mapping phase, the query is only routed if a server is\
-  found that contains all of the tables that the query uses. If no such server\
-  is found, the query is routed to the server that was previously used or to the\
-  first available backend if none have been used. If a query uses a table but\
-  doesn't define the database it is in, it is assumed to be located on the\
+* If a query targets one or more tables that the schemarouter has discovered
+  during the database mapping phase, the query is only routed if a server is
+  found that contains all of the tables that the query uses. If no such server
+  is found, the query is routed to the server that was previously used or to the
+  first available backend if none have been used. If a query uses a table but
+  doesn't define the database it is in, it is assumed to be located on the
   default database of the connection.
-* If a query targets a table or a database that is present on all nodes\
-  (e.g. `information_schema`) and the connection is using a default database,\
-  the query is routed based on the default database. This makes it possible to\
-  control where queries that do match a specific node are routed. If the\
-  connection is not using a default database, the query is routed based solely\
+* If a query targets a table or a database that is present on all nodes
+  (e.g. `information_schema`) and the connection is using a default database,
+  the query is routed based on the default database. This makes it possible to
+  control where queries that do match a specific node are routed. If the
+  connection is not using a default database, the query is routed based solely
   on the tables it contains.
-* If a query uses a table that is unknown to the schemarouter or executes a\
-  command that doesn't target a table, the query is routed to a server contains\
-  the current active default database. If the connection does not have a default\
-  database, the query is routed to the backend that was last used or to the\
-  first available backend if none have been used. If the query contains a\
+* If a query uses a table that is unknown to the schemarouter or executes a
+  command that doesn't target a table, the query is routed to a server contains
+  the current active default database. If the connection does not have a default
+  database, the query is routed to the backend that was last used or to the
+  first available backend if none have been used. If the query contains a
   routing hint that directs it to a server, the query is routed there.
 
-This means that all administrative commands, replication related command as\
-well as certain transaction control statements (XA transaction) are routed to\
-the first available server in certain cases. To avoid problems, use routing\
+This means that all administrative commands, replication related command as
+well as certain transaction control statements (XA transaction) are routed to
+the first available server in certain cases. To avoid problems, use routing
 hints to direct where these statements should go.
 
-* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`\
-  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the\
-  queries to the first available backend. This means that cross-shard\
-  transactions are technically possible but, without external synchronization,\
+* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`
+  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the
+  queries to the first available backend. This means that cross-shard
+  transactions are technically possible but, without external synchronization,
   the transactions are not guaranteed to be globally consistent.
-* `LOAD DATA LOCAL INFILE` commands are routed to the first available server\
+* `LOAD DATA LOCAL INFILE` commands are routed to the first available server
   that contains the tables listed in the query.
 
 #### Custom SQL Commands
@@ -94,24 +94,24 @@ db1.t2   |MyServer1    |
 db2.t1   |MyServer2    |
 ```
 
-The schemarouter will also intercept the `SHOW DATABASES` command and generate\
-it based on its internal data. This means that newly created databases will not\
-show up immediately and will only be visible when the cached data has been\
+The schemarouter will also intercept the `SHOW DATABASES` command and generate
+it based on its internal data. This means that newly created databases will not
+show up immediately and will only be visible when the cached data has been
 updated.
 
 #### Database Mapping
 
-The schemarouter maps each of the servers to know where each database and table\
-is located. As each user has access to a different set of tables and databases,\
-the result is unique to the username and the set of servers that the service\
-uses. These results are cached by the schemarouter. The lifetime of the cached\
+The schemarouter maps each of the servers to know where each database and table
+is located. As each user has access to a different set of tables and databases,
+the result is unique to the username and the set of servers that the service
+uses. These results are cached by the schemarouter. The lifetime of the cached
 result is controlled by the `refresh_interval` parameter.
 
-When a server needs to be mapped, the schemarouter will route a query to each of\
-the servers using the client's credentials. While this query is being executed,\
-all other sessions that would otherwise share the cached result will wait for\
-the update to complete. This waiting functionality was added in MaxScale 2.4.19,\
-older versions did not wait for existing updates to finish and would perform\
+When a server needs to be mapped, the schemarouter will route a query to each of
+the servers using the client's credentials. While this query is being executed,
+all other sessions that would otherwise share the cached result will wait for
+the update to complete. This waiting functionality was added in MaxScale 2.4.19,
+older versions did not wait for existing updates to finish and would perform
 parallel database mapping queries.
 
 ### Configuration
@@ -127,24 +127,24 @@ user=myuser
 password=mypwd
 ```
 
-The module generates the list of databases based on the servers parameter\
-using the connecting client's credentials. The user and password parameters\
-define the credentials that are used to fetch the authentication data from\
-the database servers. The credentials used only require the same grants as\
+The module generates the list of databases based on the servers parameter
+using the connecting client's credentials. The user and password parameters
+define the credentials that are used to fetch the authentication data from
+the database servers. The credentials used only require the same grants as
 mentioned in the configuration documentation.
 
-The list of databases is built by sending a SHOW DATABASES query to all the\
-servers. This requires the user to have at least USAGE and SELECT grants on\
+The list of databases is built by sending a SHOW DATABASES query to all the
+servers. This requires the user to have at least USAGE and SELECT grants on
 the databases that need be sharded.
 
-If you are connecting directly to a database or have different users on some\
-of the servers, you need to get the authentication data from all the\
-servers. You can control this with the `auth_all_servers` parameter. With\
-this parameter, MariaDB MaxScale forms a union of all the users and their\
-grants from all the servers. By default, the schemarouter will fetch the\
+If you are connecting directly to a database or have different users on some
+of the servers, you need to get the authentication data from all the
+servers. You can control this with the `auth_all_servers` parameter. With
+this parameter, MariaDB MaxScale forms a union of all the users and their
+grants from all the servers. By default, the schemarouter will fetch the
 authentication data from all servers.
 
-For example, if two servers have the database `shard` and the following\
+For example, if two servers have the database `shard` and the following
 rights are granted only on one server, all queries targeting the database`shard` would be routed to the server where the grants were given.
 
 ```
@@ -155,9 +155,9 @@ CREATE USER 'john'@'%' IDENTIFIED BY 'password';
 GRANT SELECT,USAGE ON shard.* TO 'john'@'%';
 ```
 
-This would in effect allow the user 'john' to only see the database 'shard'\
+This would in effect allow the user 'john' to only see the database 'shard'
 on this server. Take notice that these grants are matched against MariaDB\
-MaxScale's hostname instead of the client's hostname. Only user\
+MaxScale's hostname instead of the client's hostname. Only user
 authentication uses the client's hostname and all other grants use MariaDB\
 MaxScale's hostname.
 
@@ -170,7 +170,7 @@ MaxScale's hostname.
 * Dynamic: Yes
 * Default: `""`
 
-List of full table names (e.g. db1.t1) to ignore when checking for duplicate\
+List of full table names (e.g. db1.t1) to ignore when checking for duplicate
 tables. By default no tables are ignored.
 
 This parameter was once called `ignore_databases`.
@@ -182,11 +182,11 @@ This parameter was once called `ignore_databases`.
 * Dynamic: No
 * Default: `""`
 
-A [PCRE2 regular expression](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+A [PCRE2 regular expression](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 that is matched against database names when checking for duplicate databases.\
 By default no tables are ignored.
 
-The following configuration ignores duplicate tables in the databases `db1` and `db2`,\
+The following configuration ignores duplicate tables in the databases `db1` and `db2`,
 and all tables starting with "t" in `db3`.
 
 ```
@@ -203,12 +203,12 @@ This parameter was once called `ignore_databases_regex`.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md)
 in MaxScale 6.0.
 
 #### `refresh_databases`
@@ -218,11 +218,11 @@ in MaxScale 6.0.
 * Dynamic: No
 * Default: `false`
 
-Enable database map refreshing mid-session. These are triggered by a failure to\
+Enable database map refreshing mid-session. These are triggered by a failure to
 change the database i.e. `USE ...` queries. This feature is disabled by default.
 
-Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0\
-release of MaxScale this parameter now works again but it is disabled by default\
+Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0
+release of MaxScale this parameter now works again but it is disabled by default
 to retain the same behavior as in older releases.
 
 #### `refresh_interval`
@@ -232,26 +232,26 @@ to retain the same behavior as in older releases.
 * Dynamic: Yes
 * Default: `300s`
 
-The minimum interval between database map refreshes in seconds. The default\
+The minimum interval between database map refreshes in seconds. The default
 value is 300 seconds.
 
-The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 ### Table Family Sharding
 
 This functionality was introduced in 2.3.0.
 
-If the same database exists on multiple servers, but the database contains different\
-tables in each server, SchemaRouter is capable of routing queries to the right server,\
+If the same database exists on multiple servers, but the database contains different
+tables in each server, SchemaRouter is capable of routing queries to the right server,
 depending on which table is being addressed.
 
-As an example, suppose the database `db` exists on servers _server1_ and _server2_, but\
-that the database on _server1_ contains the table `tbl1` and on _server2_ contains the\
-table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table\
+As an example, suppose the database `db` exists on servers _server1_ and _server2_, but
+that the database on _server1_ contains the table `tbl1` and on _server2_ contains the
+table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table
 names must be qualified with the database names for table-level sharding to work.\
 Specifically, the query series below is not supported.
 
@@ -262,7 +262,7 @@ SELECT * FROM tbl1; // May be routed to an incorrect backend if using table shar
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a schemarouter service contains the\
+The `router_diagnostics` output for a schemarouter service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -277,46 +277,46 @@ following fields.
 
 ### Limitations
 
-* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the\
-  first explicit database in the query, the current database in use or to the first\
+* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the
+  first explicit database in the query, the current database in use or to the first
   available database, depending on which succeeds.
-* Without a default database, queries that do not use fully qualified table\
-  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will\
-  be routed to the first available server. This includes queries such as explicit\
-  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`\
-  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`\
-  statements that do not directly refer to a table. `CREATE` commands should be\
-  done directly on the node or the router should be equipped with the hint filter\
-  and a routing hint should be used. Queries that modify the session state\
-  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the\
-  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,\
-  otherwise routing hints are required to correctly route the transaction control\
-  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the\
-  routing of transaction control commands to route them to all servers used by the\
+* Without a default database, queries that do not use fully qualified table
+  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will
+  be routed to the first available server. This includes queries such as explicit
+  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`
+  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`
+  statements that do not directly refer to a table. `CREATE` commands should be
+  done directly on the node or the router should be equipped with the hint filter
+  and a routing hint should be used. Queries that modify the session state
+  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the
+  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,
+  otherwise routing hints are required to correctly route the transaction control
+  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the
+  routing of transaction control commands to route them to all servers used by the
   schemarouter.
-* SELECT queries that modify session variables are not supported because uniform results\
-  can not be guaranteed. If such a query is executed, the behavior of the router is\
+* SELECT queries that modify session variables are not supported because uniform results
+  can not be guaranteed. If such a query is executed, the behavior of the router is
   undefined. To work around this limitation, the query must be executed in separate parts.
-* If a query targets a database the SchemaRouter has not mapped to a server, the\
-  query will be routed to the first available server. This possibly returns an\
+* If a query targets a database the SchemaRouter has not mapped to a server, the
+  query will be routed to the first available server. This possibly returns an
   error about database rights instead of a missing database.
-* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the\
+* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the
   correct backend if the statement is known and only requires one backend server. EXECUTE\
-  IMMEDIATE is not supported and is routed to the first available backend and may give\
+  IMMEDIATE is not supported and is routed to the first available backend and may give
   wrong results. Similarly, preparing a statement from a variable (e.g. `PREPARE stmt FROM @a`) is not supported and may be routed wrong.
-* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only\
-  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are\
+* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only
+  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are
   ignored.
-* `SHOW TABLES` is routed to the server with the current database. If using table-level\
-  sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to\
-  the server with database `db1`, ignoring table sharding. Use `SHOW SHARDS` to get results\
+* `SHOW TABLES` is routed to the server with the current database. If using table-level
+  sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to
+  the server with database `db1`, ignoring table sharding. Use `SHOW SHARDS` to get results
   from the router itself.
-* `USE db1` is routed to the server with `db1`. If the database is divided to multiple\
+* `USE db1` is routed to the server with `db1`. If the database is divided to multiple
   servers, only one server will get the command.
 
 ### Examples
 
-[Here](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-simple-sharding-with-two-servers.md) is a small tutorial on how\
+[Here](../mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-simple-sharding-with-two-servers.md) is a small tutorial on how
 to set up a sharded database.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-smartrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-smartrouter.md
@@ -2,20 +2,20 @@
 
 ### Overview
 
-SmartRouter is the query router of the SmartQuery framework. Based on the type\
-of the query, each query is routed to the server or cluster that can best\
+SmartRouter is the query router of the SmartQuery framework. Based on the type
+of the query, each query is routed to the server or cluster that can best
 handle it.
 
 For workloads where both transactional and analytical queries are needed,\
-SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into\
-a single entry point in MaxScale. This allows a MaxScale client to freely mix\
-transactional and analytical queries using the same connection. This is known\
+SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into
+a single entry point in MaxScale. This allows a MaxScale client to freely mix
+transactional and analytical queries using the same connection. This is known
 as Hybrid Transactional and Analytical Processing, HTAP.
 
 ### Configuration
 
-SmartRouter is configured as a service that either routes to other MaxScale\
-routers or plain servers. Although one can configure SmartRouter to use a plain\
+SmartRouter is configured as a service that either routes to other MaxScale
+routers or plain servers. Although one can configure SmartRouter to use a plain
 server directly, we refer to the configured "servers" as clusters.
 
 For details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
@@ -26,10 +26,10 @@ For details about the standard service parameters, refer to the [Configuration G
 * Mandatory: Yes
 * Dynamic: No
 
-One of the clusters must be designated as the **`master`**. All writes go to the\
+One of the clusters must be designated as the **`master`**. All writes go to the
 master cluster, which for all practical purposes should be a master-slave\
-ReadWriteSplit. This document does not go into details about setting up\
-master-slave clusters, but suffice to say, that when setting up the ColumnStore\
+ReadWriteSplit. This document does not go into details about setting up
+master-slave clusters, but suffice to say, that when setting up the ColumnStore
 servers they should be configured to be slaves of a MariaDB server running an\
 InnoDB engine.\
 The ReadWriteSplit [documentation](mariadb-maxscale-2106-maxscale-2106-readwritesplit.md) has more on master-slave setup.
@@ -85,8 +85,8 @@ service = SmartQuery
 port = <port>
 ```
 
-Note that the SmartQuery listener listens on a port, while the Row and Column\
-service listeners listen on Unix domain sockets. The reason is that there is a\
+Note that the SmartQuery listener listens on a port, while the Row and Column
+service listeners listen on Unix domain sockets. The reason is that there is a
 significant performance benefit when SmartRouter accesses the services over a\
 Unix domain socket compared to accessing them over a TCP/IP socket.
 
@@ -94,31 +94,31 @@ A complete configuration example can be found at the end of this document.
 
 ### Cluster selection - how queries are routed
 
-SmartRouter keeps track of the performance, or the execution time, of queries to\
+SmartRouter keeps track of the performance, or the execution time, of queries to
 the clusters. Measurements are stored with the canonical of a query as the key.\
-The canonical of a query is the sql with all user-defined constants replaced with\
-question marks. When SmartRouter sees a read-query whose canonical has not been\
-seen before, it will send the query to all clusters. The first response from a\
-cluster will designate that cluster as the best one for that canonical. Also,\
-when the first response is received, the other queries are cancelled. The\
-response is sent to the client once all clusters have responded to the query\
+The canonical of a query is the sql with all user-defined constants replaced with
+question marks. When SmartRouter sees a read-query whose canonical has not been
+seen before, it will send the query to all clusters. The first response from a
+cluster will designate that cluster as the best one for that canonical. Also,
+when the first response is received, the other queries are cancelled. The
+response is sent to the client once all clusters have responded to the query
 or the cancel.
 
-There is obviously overhead when a new canonical is seen. This means that\
-queries after a MaxScale start will be slightly slower than normal. The\
-execution time of a query depends on the database engine, and on the contents\
-of the tables being queried. As a result, MaxScale will periodically re-measure\
+There is obviously overhead when a new canonical is seen. This means that
+queries after a MaxScale start will be slightly slower than normal. The
+execution time of a query depends on the database engine, and on the contents
+of the tables being queried. As a result, MaxScale will periodically re-measure
 queries.
 
-The performance behavior of queries under dynamic conditions, and their effect\
-on different storage engines is being studied at MariaDB. As we learn more, we\
+The performance behavior of queries under dynamic conditions, and their effect
+on different storage engines is being studied at MariaDB. As we learn more, we
 will be able to better categorize queries and move that knowledge into\
 SmartRouter.
 
 ### Limitations
 
 * `LOAD DATA LOCAL INFILE` is not supported.
-* The performance data is not persisted. The measurements will be performed\
+* The performance data is not persisted. The measurements will be performed
   anew after each startup.
 
 ### Complete configuration example

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-automatic-failover-with-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-automatic-failover-with-mariadb-monitor.md
@@ -1,23 +1,23 @@
 # MaxScale 21.06 Automatic Failover With MariaDB Monitor
 
-The [MariaDB Monitor](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md) is not only capable\
-of monitoring the state of a MariaDB master-slave cluster but is also\
-capable of performing _failover_ and _switchover_. In addition, in some\
-circumstances it is capable of _rejoining_ a master that has gone down and\
+The [MariaDB Monitor](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md) is not only capable
+of monitoring the state of a MariaDB master-slave cluster but is also
+capable of performing _failover_ and _switchover_. In addition, in some
+circumstances it is capable of _rejoining_ a master that has gone down and
 later reappears.
 
-Note that the failover (and switchover and rejoin) functionality is only\
-supported in conjunction with GTID-based replication and initially only\
+Note that the failover (and switchover and rejoin) functionality is only
+supported in conjunction with GTID-based replication and initially only
 for simple topologies, that is, 1 master and several slaves.
 
-The failover, switchover and rejoin functionality are inherent parts of\
-the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin\
+The failover, switchover and rejoin functionality are inherent parts of
+the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin
 are enabled by default.
 
-The following examples have been written with the assumption that there\
-are four servers - `server1`, `server2`, `server3` and `server4` - of\
+The following examples have been written with the assumption that there
+are four servers - `server1`, `server2`, `server3` and `server4` - of
 which `server1` is the initial master and the other servers are slaves.\
-In addition there is a monitor called _TheMonitor_ that monitors those\
+In addition there is a monitor called _TheMonitor_ that monitors those
 servers.
 
 Somewhat simplified, the MaxScale configuration file would look like:
@@ -46,7 +46,7 @@ servers=server1,server2,server3,server4
 
 ## Manual Failover
 
-If everything is in order, the state of the cluster will look something\
+If everything is in order, the state of the cluster will look something
 like this:
 
 ```
@@ -64,7 +64,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If the master now for any reason goes down, then the cluster state will\
+If the master now for any reason goes down, then the cluster state will
 look like this:
 
 ```
@@ -84,7 +84,7 @@ $ maxctrl list servers
 
 Note that the status for `server1` is _Down_.
 
-Since failover is by default _not_ enabled, the failover mechanism must be\
+Since failover is by default _not_ enabled, the failover mechanism must be
 invoked manually:
 
 ```
@@ -99,11 +99,11 @@ There are quite a few arguments, so let's look at each one separately:
 * `failover` is the command we want to invoke, and
 * `TheMonitor` is the first and only argument to that command, the name of the monitor as specified in the configuration file.
 
-The MariaDB Monitor will now autonomously deduce which slave is the most\
-appropriate one to be promoted to master, promote it to master and modify\
+The MariaDB Monitor will now autonomously deduce which slave is the most
+appropriate one to be promoted to master, promote it to master and modify
 the other slaves accordingly.
 
-If we now check the cluster state we will see that one of the remaining\
+If we now check the cluster state we will see that one of the remaining
 slaves has been made into master.
 
 ```
@@ -121,7 +121,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, it will not be rejoined to the cluster, as\
+If `server1` now reappears, it will not be rejoined to the cluster, as
 shown by the following output:
 
 ```
@@ -139,15 +139,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Had `auto_rejoin=true` been specified in the monitor section, then an\
+Had `auto_rejoin=true` been specified in the monitor section, then an
 attempt to rejoin `server1` would have been made.
 
-In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a\
+In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a
 subsequent version a command to that effect will be provided.
 
 ## Automatic Failover
 
-To enable automatic failover, simply add `auto_failover=true` to the\
+To enable automatic failover, simply add `auto_failover=true` to the
 monitor section in the configuration file.
 
 ```
@@ -176,7 +176,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now goes down, failover will automatically be performed and\
+If `server1` now goes down, failover will automatically be performed and
 an existing slave promoted to new master.
 
 ```
@@ -194,12 +194,12 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴────────────────────────┘
 ```
 
-If you are continuously monitoring the server states, you may notice for a\
+If you are continuously monitoring the server states, you may notice for a
 brief period that the state of `server1` is _Down_ and the state of`server2` is still _Slave, Running_.
 
 ## Rejoin
 
-To enable automatic rejoin, simply add `auto_rejoin=true` to the\
+To enable automatic rejoin, simply add `auto_rejoin=true` to the
 monitor section in the configuration file.
 
 ```
@@ -211,7 +211,7 @@ auto_rejoin=true
 ...
 ```
 
-When automatic rejoin is enabled, the MariaDB Monitor will attempt to\
+When automatic rejoin is enabled, the MariaDB Monitor will attempt to
 rejoin a failed master as a slave, if it reappears.
 
 When everything is running fine, the cluster state looks like follows:
@@ -231,8 +231,8 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Assuming `auto_failover=true` has been specified in the configuration\
-file, when `server1` goes down for some reason, failover will be performed\
+Assuming `auto_failover=true` has been specified in the configuration
+file, when `server1` goes down for some reason, failover will be performed
 and we end up with the following cluster state:
 
 ```
@@ -250,15 +250,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, the MariaDB Monitor will detect that and\
+If `server1` now reappears, the MariaDB Monitor will detect that and
 attempt to rejoin the old master as a slave.
 
-Whether rejoining will succeed depends upon the actual state of the old\
-master. For instance, if the old master was modified and the changes had\
-not been replicated to the new master, before the old master went down,\
+Whether rejoining will succeed depends upon the actual state of the old
+master. For instance, if the old master was modified and the changes had
+not been replicated to the new master, before the old master went down,
 then automatic rejoin will not be possible.
 
-If rejoining can be performed, then the cluster state will end up looking\
+If rejoining can be performed, then the cluster state will end up looking
 like:
 
 ```
@@ -278,11 +278,11 @@ $ maxctrl list servers
 
 ## Switchover
 
-Switchover is for cases when you explicitly want to move the master\
+Switchover is for cases when you explicitly want to move the master
 role from one server to another.
 
-If we continue from the cluster state at the end of the previous example\
-and want to make `server1` master again, then we must issue the following\
+If we continue from the cluster state at the end of the previous example
+and want to make `server1` master again, then we must issue the following
 command:
 
 ```
@@ -299,7 +299,7 @@ There are quite a few arguments, so let's look at each one separately:
 * `server1` is the second argument to the command, the name of the server we want to make into _master_, and
 * `server2` is the third argument to the command, the name of the _current master_.
 
-If the command executes successfully, we will end up with the following\
+If the command executes successfully, we will end up with the following
 cluster state:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-avrorouter-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-avrorouter-tutorial.md
@@ -1,11 +1,11 @@
 # MaxScale 21.06 Avrorouter Tutorial
 
-This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-avrorouter.md), how to set it up and how it interacts\
+This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-avrorouter.md), how to set it up and how it interacts
 with the binlogrouter.
 
-The first part configures the services and sets them up for the binary log to Avro\
-file conversion. The second part of this tutorial uses the client listener\
-interface for the avrorouter and shows how to communicate with the service\
+The first part configures the services and sets them up for the binary log to Avro
+file conversion. The second part of this tutorial uses the client listener
+interface for the avrorouter and shows how to communicate with the service
 over the network.
 
 ```mermaid
@@ -66,8 +66,8 @@ _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog
 
 ### Preparing the master server
 
-The master server where we will be replicating from needs to have binary logging\
-enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_\
+The master server where we will be replicating from needs to have binary logging
+enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_
 file of the master.
 
 ```
@@ -79,9 +79,9 @@ _You can find out more about replication formats from the_[_MariaDB documentatio
 
 ### Configuring MaxScale
 
-We start by adding two new services into the configuration file. The first\
-service is the binlogrouter service which will read the binary logs from the\
-master server. The second service will read the binlogs as they are streamed\
+We start by adding two new services into the configuration file. The first
+service is the binlogrouter service which will read the binary logs from the
+master server. The second service will read the binlogs as they are streamed
 from the master and convert them into Avro format files.
 
 ```
@@ -117,13 +117,13 @@ protocol=CDC
 port=4001
 ```
 
-The `source` parameter in the _avro-service_ points to the _replication-service_\
-we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog\
-number to start from. With these parameters, the avrorouter will start reading\
+The `source` parameter in the _avro-service_ points to the _replication-service_
+we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog
+number to start from. With these parameters, the avrorouter will start reading
 events from binlog `binlog.000015`.
 
-Note that the _filestem_ and _start\_index_ must point to the file that is the\
-first binlog that the binlogrouter will replicate. For example, if the first\
+Note that the _filestem_ and _start\_index_ must point to the file that is the
+first binlog that the binlogrouter will replicate. For example, if the first
 file you are replicating is `my-binlog-file.001234`, set the parameters to`filestem=my-binlog-file` and `start_index=1234`.
 
 For more information on the avrorouter options, read the [Avrorouter\
@@ -131,31 +131,31 @@ Documentation](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-
 
 ## Preparing the data in the master server
 
-Before starting the MaxScale process, we need to make sure that the binary logs\
-of the master server contain the DDL statements that define the table\
-layouts. What this means is that the `CREATE TABLE` statements need to be in the\
+Before starting the MaxScale process, we need to make sure that the binary logs
+of the master server contain the DDL statements that define the table
+layouts. What this means is that the `CREATE TABLE` statements need to be in the
 binary logs before the conversion process is started.
 
-If the binary logs contain data modification events for tables that aren't\
-created in the binary logs, the Avro schema of the table needs to be manually\
+If the binary logs contain data modification events for tables that aren't
+created in the binary logs, the Avro schema of the table needs to be manually
 created. There are multiple ways to do this:
 
-* Dump the database to a slave, configure it to replicate from the master and\
-  point MaxScale to this slave (this is the recommended method as it requires no\
+* Dump the database to a slave, configure it to replicate from the master and
+  point MaxScale to this slave (this is the recommended method as it requires no
   extra steps)
-* Use the [cdc\_schema Go utility](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-avrorouter.md)\
+* Use the [cdc\_schema Go utility](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-avrorouter.md)
   and copy the generated .avsc files to the avrodir
-* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)\
+* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)
   and copy the generated .avsc files to the avrodir
 
-If you used the schema generator scripts, all Avro schema files for tables that\
-are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of\
+If you used the schema generator scripts, all Avro schema files for tables that
+are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of
 the _test.t1_ table would be `test.t1.0000001.avsc`.
 
 ## Starting MariaDB MaxScale
 
-The next step is to start MariaDB MaxScale and set up the binlogrouter. We do\
-that by connecting to the MySQL listener of the _replication\_router_ service and\
+The next step is to start MariaDB MaxScale and set up the binlogrouter. We do
+that by connecting to the MySQL listener of the _replication\_router_ service and
 executing a few commands.
 
 ```
@@ -169,22 +169,22 @@ CHANGE MASTER TO MASTER_HOST='172.18.0.1',
 START SLAVE;
 ```
 
-**NOTE:** GTID replication is not currently supported and file-and-position\
+**NOTE:** GTID replication is not currently supported and file-and-position
 replication must be used.
 
 This will start the replication of binary logs from the master server at\
-172.18.0.1 listening on port 3000. The first file that the binlogrouter\
-replicates is `binlog.000015`. This is the same file that was configured as the\
+172.18.0.1 listening on port 3000. The first file that the binlogrouter
+replicates is `binlog.000015`. This is the same file that was configured as the
 starting file in the avrorouter.
 
 For more details about the SQL commands, refer to the [Binlogrouter](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-binlogrouter.md) documentation.
 
-After the binary log streaming has started, the avrorouter will automatically\
+After the binary log streaming has started, the avrorouter will automatically
 start processing the binlogs.
 
 ## Creating and Processing Data
 
-Next, create a simple test table and populated it with some data by executing\
+Next, create a simple test table and populated it with some data by executing
 the following statements.
 
 ```
@@ -192,21 +192,21 @@ CREATE TABLE test.t1 (id INT);
 INSERT INTO test.t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 ```
 
-To use the _cdc.py_ command line client to connect to the CDC service, we must first\
+To use the _cdc.py_ command line client to connect to the CDC service, we must first
 create a user. This can be done via maxctrl by executing the following command.
 
 ```
 maxctrl call command cdc add_user avro-service maxuser maxpwd
 ```
 
-This will create the _maxuser:maxpwd_ credentials which can then be used to\
+This will create the _maxuser:maxpwd_ credentials which can then be used to
 request a JSON data stream of the `test.t1` table that was created earlier.
 
 ```
 cdc.py -u maxuser -p maxpwd -h 127.0.0.1 -P 4001 test.t1
 ```
 
-The output is a stream of JSON events describing the changes done to the\
+The output is a stream of JSON events describing the changes done to the
 database.
 
 ```
@@ -223,8 +223,8 @@ database.
 {"domain": 0, "server_id": 3000, "sequence": 11, "event_number": 10, "timestamp": 1537429419, "event_type": "insert", "id": 10}
 ```
 
-The first record is always the JSON format schema for the table describing the\
-types and names of the fields. All records that follow it represent the changes\
+The first record is always the JSON format schema for the table describing the
+types and names of the fields. All records that follow it represent the changes
 that have happened on the database.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-configuring-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-configuring-servers.md
@@ -1,6 +1,6 @@
 # MaxScale 21.06 Configuring Servers
 
-The first step is to define the servers that make up the cluster. These servers\
+The first step is to define the servers that make up the cluster. These servers
 will be used by the services and are monitored by the monitor.
 
 ```
@@ -24,10 +24,10 @@ The `address` and `port` parameters tell where the server is located.
 
 ### Enabling TLS
 
-To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`\
+To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`
 to the server section. To enable server certificate verification, add`ssl_verify_peer_certificate=true`.
 
-The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line\
+The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line
 client.
 
 For more information about TLS, refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-configuring-the-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-configuring-the-galera-monitor.md
@@ -16,19 +16,19 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
-This monitor module will assign one node within the Galera Cluster as the\
-current master and other nodes as slave. Only those nodes that are active\
-members of the cluster are considered when making the choice of master node. The\
+This monitor module will assign one node within the Galera Cluster as the
+current master and other nodes as slave. Only those nodes that are active
+members of the cluster are considered when making the choice of master node. The
 master node will be the node with the lowest value of `wsrep_local_index`.
 
 ### Monitor User
 
-The monitor user does not require any special grants to monitor a Galera\
+The monitor user does not require any special grants to monitor a Galera
 cluster. To create a user for the monitor, execute the following SQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-configuring-the-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-configuring-the-mariadb-monitor.md
@@ -1,6 +1,6 @@
 # MaxScale 21.06 Configuring the MariaDB Monitor
 
-This document describes how to configure a MariaDB master-slave cluster monitor\
+This document describes how to configure a MariaDB master-slave cluster monitor
 to be used with MaxScale.
 
 ### Configuring the Monitor
@@ -17,14 +17,14 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
 ### Monitor User
 
-The monitor user requires the REPLICATION CLIENT privileges to do basic\
+The monitor user requires the REPLICATION CLIENT privileges to do basic
 monitoring. To create a user with the proper grants, execute the following SQL.
 
 ```
@@ -32,7 +32,7 @@ CREATE USER 'monitor_user'@'%' IDENTIFIED BY 'my_password';
 GRANT REPLICATION CLIENT ON *.* TO 'monitor_user'@'%';
 ```
 
-**Note:** If the automatic failover of the MariaDB Monitor will used, the user\
+**Note:** If the automatic failover of the MariaDB Monitor will used, the user
 will require additional grants. Execute the following SQL to grant them.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-connection-routing-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-connection-routing-with-mariadb-maxscale.md
@@ -1,7 +1,7 @@
 # MaxScale 21.06 Connection Routing with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that has two ports available, one for\
-write connections and another for read connections. The read connections are load-\
+The goal of this tutorial is to configure a system that has two ports available, one for
+write connections and another for read connections. The read connections are load-
 balanced across slave servers.
 
 ### Setting up MariaDB MaxScale
@@ -11,11 +11,11 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring services
 
-We want two services and ports to which the client application can connect. One service\
-routes client connections to the master server, the other load balances between slave\
+We want two services and ports to which the client application can connect. One service
+routes client connections to the master server, the other load balances between slave
 servers. To achieve this, we need to define two services in the configuration file.
 
-Create the following two sections in your configuration file. The section names are the\
+Create the following two sections in your configuration file. The section names are the
 names of the services and should be meaningful. For this tutorial, we use the names_Write-Service_ and _Read-Service_.
 
 ```
@@ -36,18 +36,18 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readconnroute_ for\
+_router_ defines the routing module used. Here we use _readconnroute_ for
 connection-level routing.
 
-A service needs a list of servers to route queries to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers to route queries to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _router\_options_-parameter tells the _readconnroute_-module which servers it should\
-route a client connection to. For the write service we use the _master_-type and for the\
+The _router\_options_-parameter tells the _readconnroute_-module which servers it should
+route a client connection to. For the write service we use the _master_-type and for the
 read service the _slave_-type.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2106-maxscale-2106-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2106-maxscale-2106-encrypting-passwords.md).
@@ -55,7 +55,7 @@ For increased security, see [password encryption](mariadb-maxscale-2106-maxscale
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one per service is enough.
 
 ```
@@ -70,13 +70,13 @@ service=Read-Service
 port=3307
 ```
 
-The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set\
+The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set
 it to _Read-Service_.
 
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-encrypting-passwords.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-encrypting-passwords.md
@@ -1,23 +1,23 @@
 # MaxScale 21.06 Encrypting Passwords
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
-There are two options for representing the password, either plain text or\
-encrypted passwords may be used. In order to use encrypted passwords a set of\
-keys must be generated that will be used by the encryption and decryption\
+There are two options for representing the password, either plain text or
+encrypted passwords may be used. In order to use encrypted passwords a set of
+keys must be generated that will be used by the encryption and decryption
 process. To generate the keys, use the `maxkeys` command.
 
 ```
 maxkeys
 ```
 
-By default the key file will be generated in `/var/lib/maxscale`. If a different\
-directory is required, it can be given as the first argument to the program. For\
+By default the key file will be generated in `/var/lib/maxscale`. If a different
+directory is required, it can be given as the first argument to the program. For
 more information, see `maxkeys --help`.
 
-Once the keys have been created the `maxpasswd` command can be used to generate\
+Once the keys have been created the `maxpasswd` command can be used to generate
 the encrypted password.
 
 ```
@@ -25,10 +25,10 @@ maxpasswd plainpassword
 96F99AA1315BDC3604B006F427DD9484
 ```
 
-The username and password, either encrypted or plain text, are stored in the\
+The username and password, either encrypted or plain text, are stored in the
 service section using the `user` and `password` parameters.
 
-If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For\
+If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For
 more information, see `maxkeys --help`.
 
 Here is an example configuration that uses an encrypted password.
@@ -43,7 +43,7 @@ user=maxscale
 password=96F99AA1315BDC3604B006F427DD9484
 ```
 
-If the key file is not in the default location, the [datadir](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) parameter must be\
+If the key file is not in the default location, the [datadir](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) parameter must be
 set to the directory that contains it.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-administration-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-administration-tutorial.md
@@ -1,31 +1,31 @@
 # MaxScale 21.06 MariaDB MaxScale Administration Tutorial
 
-The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator\
-to a few of the common administration tasks. This is intended to be an\
-introduction for administrators who are new to MariaDB MaxScale and not a\
+The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator
+to a few of the common administration tasks. This is intended to be an
+introduction for administrators who are new to MariaDB MaxScale and not a
 reference to all the tasks that may be performed.
 
 ### Starting and Stopping MariaDB MaxScale
 
-MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,\
+MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,
 use `systemctl start maxscale`. To stop it, use `systemctl stop maxscale`.
 
 The systemd service file for MaxScale is located in`/lib/systemd/system/maxscale.service`.
 
 #### Additional Options for MaxScale
 
-Additional command line options and other systemd configuration options\
-can be given to MariaDB MaxScale by creating a drop-in file for the\
-service unit file. You can do this with the `systemctl edit maxscale.service`\
-command. For more information about systemd drop-in\
-files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)\
+Additional command line options and other systemd configuration options
+can be given to MariaDB MaxScale by creating a drop-in file for the
+service unit file. You can do this with the `systemctl edit maxscale.service`
+command. For more information about systemd drop-in
+files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)
 and [the systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html).
 
 ### Checking The Status Of The MariaDB MaxScale Services
 
-It is possible to use the maxctrl command to obtain statistics about the\
-services that are running within MaxScale. The maxctrl command `list services`\
-will give very basic information regarding services. This command may be either\
+It is possible to use the maxctrl command to obtain statistics about the
+services that are running within MaxScale. The maxctrl command `list services`
+will give very basic information regarding services. This command may be either
 run in interactive mode or passed on the maxctrl command line.
 
 ```
@@ -45,16 +45,16 @@ $ maxctrl list services
 └────────────────────────┴────────────────┴─────────────┴───────────────────┴────────────────────────────────────┘
 ```
 
-Network listeners count as a user of the service, therefore there will always be\
-one user per network port in which the service listens. More details can be\
+Network listeners count as a user of the service, therefore there will always be
+one user per network port in which the service listens. More details can be
 obtained by using the "show service" command.
 
 ### What Clients Are Connected To MariaDB MaxScale
 
-To determine what client are currently connected to MariaDB MaxScale, you can\
-use the `list sessions` command within maxctrl. This will give you IP address\
-and the ID of the session for that connection. As with any maxctrl\
-command this can be passed on the command line or typed interactively in\
+To determine what client are currently connected to MariaDB MaxScale, you can
+use the `list sessions` command within maxctrl. This will give you IP address
+and the ID of the session for that connection. As with any maxctrl
+command this can be passed on the command line or typed interactively in
 maxctrl.
 
 ```
@@ -69,28 +69,28 @@ $ maxctrl list sessions
 ### Rotating the Log File
 
 MariaDB MaxScale logs messages of different priority into a single log file.\
-With the exception if error messages that are always logged, whether messages of\
-a particular priority should be logged or not can be enabled via the maxctrl\
-interface or in the configuration file. By default, MaxScale keeps on writing to\
-the same log file. To prevent the file from growing indefinitely, the\
+With the exception if error messages that are always logged, whether messages of
+a particular priority should be logged or not can be enabled via the maxctrl
+interface or in the configuration file. By default, MaxScale keeps on writing to
+the same log file. To prevent the file from growing indefinitely, the
 administrator must take action.
 
-The name of the log file is maxscale.log. When the log is rotated, MaxScale\
+The name of the log file is maxscale.log. When the log is rotated, MaxScale
 closes the current log file and opens a new one using the same name.
 
-Log file rotation is achieved by use of the `rotate logs` command\
+Log file rotation is achieved by use of the `rotate logs` command
 in maxctrl.
 
 ```
 maxctrl rotate logs
 ```
 
-As there currently is only the maxscale log, that is the only one that will be\
+As there currently is only the maxscale log, that is the only one that will be
 rotated.
 
-This may be integrated into the Linux _logrotate_ mechanism by adding a\
-configuration file to the /etc/logrotate.d directory. If we assume we want to\
-rotate the log files once per month and wish to keep 5 log files worth of\
+This may be integrated into the Linux _logrotate_ mechanism by adding a
+configuration file to the /etc/logrotate.d directory. If we assume we want to
+rotate the log files once per month and wish to keep 5 log files worth of
 history, the configuration file would look as follows.
 
 ```
@@ -109,7 +109,7 @@ endscript
 }
 ```
 
-MariaDB MaxScale will also rotate all of its log files if it receives the USR1\
+MariaDB MaxScale will also rotate all of its log files if it receives the USR1
 signal. Using this the logrotate configuration script can be rewritten as
 
 ```
@@ -125,41 +125,41 @@ endscript
 }
 ```
 
-In older versions MaxScale renamed the log file, behavior which is not fully\
-compliant with the assumptions of logrotate and may lead to issues, depending on\
-the used logrotate configuration file. From version 2.1 onward, MaxScale will\
-not itself rename the log file, but when the log is rotated, MaxScale will\
-simply close and reopen the same log file. That will make the behavior fully\
+In older versions MaxScale renamed the log file, behavior which is not fully
+compliant with the assumptions of logrotate and may lead to issues, depending on
+the used logrotate configuration file. From version 2.1 onward, MaxScale will
+not itself rename the log file, but when the log is rotated, MaxScale will
+simply close and reopen the same log file. That will make the behavior fully
 compliant with logrotate.
 
 ### Taking Objects Temporarily Out of Use
 
 #### Putting Servers into Maintenance
 
-MariaDB MaxScale supports the concept of maintenance mode for servers within a\
-cluster. This allows for planned, temporary removal of a database from the\
+MariaDB MaxScale supports the concept of maintenance mode for servers within a
+cluster. This allows for planned, temporary removal of a database from the
 cluster without the need to change the MariaDB MaxScale configuration.
 
 ```
 maxctrl set server db-server-3 maintenance
 ```
 
-To achieve this, you can use the `set server` command in maxctrl to set the\
-maintenance mode flag for the server. This may be done interactively within\
+To achieve this, you can use the `set server` command in maxctrl to set the
+maintenance mode flag for the server. This may be done interactively within
 maxctrl or by passing the command on the command line.
 
-This will cause MariaDB MaxScale to stop routing any new requests to the server,\
-however if there are currently requests executing on the server these will not\
-be interrupted. Connections to servers in maintenance mode are closed as soon as\
-the next request arrives. To close them immediately, use the `--force` option\
+This will cause MariaDB MaxScale to stop routing any new requests to the server,
+however if there are currently requests executing on the server these will not
+be interrupted. Connections to servers in maintenance mode are closed as soon as
+the next request arrives. To close them immediately, use the `--force` option
 for `maxctrl set server`.
 
 ```
 maxctrl clear server db-server-3 maintenance
 ```
 
-Clearing the maintenance mode for a server will bring it back into use. If\
-multiple MariaDB MaxScale instances are configured to use the node then\
+Clearing the maintenance mode for a server will bring it back into use. If
+multiple MariaDB MaxScale instances are configured to use the node then
 maintenance mode must be set within each MariaDB MaxScale instance.
 
 ### Stopping and Starting Services
@@ -168,16 +168,16 @@ maintenance mode must be set within each MariaDB MaxScale instance.
 maxctrl stop service db-service
 ```
 
-Services can be stopped to temporarily halt their use. Stopping a service will\
-cause it to stop accepting new connections until it is started. New connections\
-are not refused if the service is stopped and are queued instead. This means\
+Services can be stopped to temporarily halt their use. Stopping a service will
+cause it to stop accepting new connections until it is started. New connections
+are not refused if the service is stopped and are queued instead. This means
 that connecting clients will wait until the service is started again.
 
 ```
 maxctrl start service db-service
 ```
 
-Starting a service will cause it to accept all queued connections that were\
+Starting a service will cause it to accept all queued connections that were
 created while it was stopped.
 
 #### Stopping and Starting Monitors
@@ -186,35 +186,35 @@ created while it was stopped.
 maxctrl stop monitor db-monitor
 ```
 
-Stopping a monitor will cause it to stop monitoring the state of the servers\
-assigned to it. This is useful when the state of the servers is assigned\
+Stopping a monitor will cause it to stop monitoring the state of the servers
+assigned to it. This is useful when the state of the servers is assigned
 manually with `maxctrl set server`.
 
 ```
 maxctrl start monitor db-monitor
 ```
 
-Starting a monitor will make it resume monitoring of the servers. Any manually\
+Starting a monitor will make it resume monitoring of the servers. Any manually
 assigned states will be overwritten by the monitor.
 
 ### Runtime Configuration Modification
 
-The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,\
+The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,
 modify or destroy objects (servers, services, monitors etc.) inside\
-MaxScale. The exact syntax for each of the commands and any additional options\
+MaxScale. The exact syntax for each of the commands and any additional options
 that they take can be seen with `maxctrl --help <command>`.
 
-Not all parameters can be modified at runtime. Refer to the module documentation\
-for more information on which parameters can be modified at runtime. If a\
-parameter cannot be modified at runtime, the object can be destroyed and\
+Not all parameters can be modified at runtime. Refer to the module documentation
+for more information on which parameters can be modified at runtime. If a
+parameter cannot be modified at runtime, the object can be destroyed and
 recreated in order to change it.
 
-All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime\
-persist through restarts. Any changes done to objects in the main configuration\
+All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime
+persist through restarts. Any changes done to objects in the main configuration
 file are ignored if a persisted entry is found for it.
 
-For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete\
-configuration for the object. To remove all runtime changes for all objects,\
+For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete
+configuration for the object. To remove all runtime changes for all objects,
 remove all files found in `/var/lib/maxscale/maxscale.cnf.d`.
 
 #### Core Parameter Configuration
@@ -225,7 +225,7 @@ Modify global MaxScale parameters:
 maxctrl alter maxscale auth_connect_timeout 5s
 ```
 
-Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) for a full list\
+Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md) for a full list
 of parameters that can be modified at runtime.
 
 #### Managing Servers
@@ -248,8 +248,8 @@ maxctrl alter server db-server-1 port 3307
 maxctrl destroy server db-server-1
 ```
 
-A server can only be destroyed if it is not used by any services or monitors. To\
-automatically remove the server from the services and monitors that use it, use\
+A server can only be destroyed if it is not used by any services or monitors. To
+automatically remove the server from the services and monitors that use it, use
 the `--force` flag.
 
 **Drain a Server**
@@ -258,9 +258,9 @@ the `--force` flag.
 maxctrl set server db-server-1 drain
 ```
 
-When a server is set into the `drain` state, no new connections to it are\
-created. Unlike to the `maintenance` state which immediately stops all new\
-requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them\
+When a server is set into the `drain` state, no new connections to it are
+created. Unlike to the `maintenance` state which immediately stops all new
+requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them
 in order to be gracefully closed once the client disconnects.
 
 To remove the `drain` state, use `clear server` command:
@@ -269,7 +269,7 @@ To remove the `drain` state, use `clear server` command:
 maxctrl clear server db-server-1 drain
 ```
 
-Servers with the `Master` state cannot be drained. To drain them, first perform\
+Servers with the `Master` state cannot be drained. To drain them, first perform
 a switchover to another node and then drain the server.
 
 #### Managing Monitors
@@ -304,7 +304,7 @@ maxctrl unlink monitor db-monitor db-server-1
 maxctrl destroy monitor db-monitor
 ```
 
-A monitor can only be destroyed if it is not monitoring any servers. To\
+A monitor can only be destroyed if it is not monitoring any servers. To
 automatically remove the servers from the monitor, use the `--force` flag.
 
 #### Managing Services
@@ -327,7 +327,7 @@ maxctrl alter service db-service user new-db-user
 maxctrl link service db-service db-server1
 ```
 
-Any servers added to services will only be used by new sessions. Existing\
+Any servers added to services will only be used by new sessions. Existing
 sessions will use the servers that were available when they connected.
 
 **Remove Servers from a Service**
@@ -336,8 +336,8 @@ sessions will use the servers that were available when they connected.
 maxctrl unlink service db-service db-server1
 ```
 
-Similarly to adding servers, removing servers from a service will only affect\
-new sessions. Existing sessions keep using the servers even if they are removed\
+Similarly to adding servers, removing servers from a service will only affect
+new sessions. Existing sessions keep using the servers even if they are removed
 from a service.
 
 **Change the Filters of a Service**
@@ -346,9 +346,9 @@ from a service.
 maxctrl alter service-filters my-regexfilter my-qlafilter
 ```
 
-The order of the filters is significant: the first filter will be the first to\
-receive the query. The new set of filters will only be used by new\
-sessions. Existing sessions will keep using the filters that were configured\
+The order of the filters is significant: the first filter will be the first to
+receive the query. The new set of filters will only be used by new
+sessions. Existing sessions will keep using the filters that were configured
 when they connected.
 
 **Destroy a Service**
@@ -357,9 +357,9 @@ when they connected.
 maxctrl destroy service db-service
 ```
 
-The service can only be destroyed if it uses no servers or clusters and has no\
-listeners associated with it. To force destruction of a service even if it does\
-use servers or has listeners, use the `--force` flag. This will also destroy any\
+The service can only be destroyed if it uses no servers or clusters and has no
+listeners associated with it. To force destruction of a service even if it does
+use servers or has listeners, use the `--force` flag. This will also destroy any
 listeners associated with the service.
 
 #### Managing Filters
@@ -376,11 +376,11 @@ maxctrl create filter regexfilter match=ENGINE=MyISAM replace=ENGINE=InnoDB
 maxctrl destroy filter my-regexfilter
 ```
 
-A filter can only be destroyed if it is not used by any services. To\
-automatically remove the filter from all services using it, use the `--force`\
+A filter can only be destroyed if it is not used by any services. To
+automatically remove the filter from all services using it, use the `--force`
 flag.
 
-Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters\
+Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters
 of a filter, destroy it and recreate it with the modified parameters.
 
 #### Managing Listeners
@@ -397,16 +397,16 @@ maxctrl create listener db-listener db-service 4006
 maxctrl destroy listener db-listener
 ```
 
-Destroying a listener will close the network socket and stop it from accepting\
-new connections. Existing connections that were created through it will keep\
+Destroying a listener will close the network socket and stop it from accepting
+new connections. Existing connections that were created through it will keep
 displaying it as the originating listener.
 
-Listeners cannot be moved from one service to another. In order to do this, the\
+Listeners cannot be moved from one service to another. In order to do this, the
 listener must be destroyed and then recreated with the new service.
 
 ### Managing MaxCtrl and REST API Users
 
-MaxCtrl uses the same credentials as the MaxScale REST API. These users can be\
+MaxCtrl uses the same credentials as the MaxScale REST API. These users can be
 managed via MaxCtrl.
 
 #### Create a New MaxCtrl User
@@ -415,14 +415,14 @@ managed via MaxCtrl.
 maxctrl create user basic-user basic-password
 ```
 
-By default new users are only allowed to read data. To make the account an\
+By default new users are only allowed to read data. To make the account an
 administrative account, add the `--type=admin` option to the command:
 
 ```
 maxctrl create user admin-user admin-password --type=admin
 ```
 
-Administrative accounts are allowed to use all MaxCtrl commands and modify any\
+Administrative accounts are allowed to use all MaxCtrl commands and modify any
 parts of MaxScale.
 
 #### Change the Password of an Existing User

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-read-write-splitting-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-read-write-splitting-with-mariadb-maxscale.md
@@ -1,7 +1,7 @@
 # MaxScale 21.06 Read-Write Splitting with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that appears to the client as a single\
-database. MariaDB MaxScale will split the statements such that write statements are sent\
+The goal of this tutorial is to configure a system that appears to the client as a single
+database. MariaDB MaxScale will split the statements such that write statements are sent
 to the master server and read statements are balanced across the slave servers.
 
 ### Setting up MariaDB MaxScale
@@ -11,9 +11,9 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring the service
 
-After configuring the servers and the monitor, we create a read-write-splitter service\
-configuration. Create the following section in your configuration file. The section name\
-is also the name of the service and should be meaningful. For this tutorial, we use the\
+After configuring the servers and the monitor, we create a read-write-splitter service
+configuration. Create the following section in your configuration file. The section name
+is also the name of the service and should be meaningful. For this tutorial, we use the
 name _Splitter-Service_.
 
 ```
@@ -25,14 +25,14 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readwritesplit_ for\
+_router_ defines the routing module used. Here we use _readwritesplit_ for
 query-level read-write-splitting.
 
-A service needs a list of servers where queries will be routed to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers where queries will be routed to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2106-maxscale-2106-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2106-maxscale-2106-encrypting-passwords.md).
@@ -40,7 +40,7 @@ For increased security, see [password encryption](mariadb-maxscale-2106-maxscale
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one is enough.
 
 ```
@@ -55,7 +55,7 @@ The _service_ parameter tells which service the listener connects to. For the_Sp
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-rest-api-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-rest-api-tutorial.md
@@ -1,22 +1,22 @@
 # MaxScale 21.06 REST API Tutorial
 
-This tutorial is a quick overview of what the MaxScale REST API offers, how it\
-can be used to inspect the state of MaxScale and how to use it to modify the\
-runtime configuration of MaxScale. The tutorial uses the `curl` command line\
+This tutorial is a quick overview of what the MaxScale REST API offers, how it
+can be used to inspect the state of MaxScale and how to use it to modify the
+runtime configuration of MaxScale. The tutorial uses the `curl` command line
 client to demonstrate how the API is used.
 
 ### Configuration and Hardening
 
-The MaxScale REST API listens on port 8989 on the local host. The `admin_port`\
-and `admin_host` parameters control which port and address the REST API listens\
-on. Note that for security reasons the API only listens for local connections\
-with the default configuration. It is critical that the default credentials are\
-changed and TLS/SSL encryption is configured before exposing the REST API to a\
+The MaxScale REST API listens on port 8989 on the local host. The `admin_port`
+and `admin_host` parameters control which port and address the REST API listens
+on. Note that for security reasons the API only listens for local connections
+with the default configuration. It is critical that the default credentials are
+changed and TLS/SSL encryption is configured before exposing the REST API to a
 network.
 
-The default user for the REST API is `admin` and the password is `mariadb`. The\
-easiest way to secure the REST API is to use the `maxctrl` command line client\
-to create a new admin user and delete the default one. To do this, run the\
+The default user for the REST API is `admin` and the password is `mariadb`. The
+easiest way to secure the REST API is to use the `maxctrl` command line client
+to create a new admin user and delete the default one. To do this, run the
 following commands:
 
 ```
@@ -24,13 +24,13 @@ maxctrl create user my_user my_password --type=admin
 maxctrl destroy user admin
 ```
 
-This will create the user `my_user` with the password `my_password` that is an\
-administrative account. After this account is created, the default `admin`\
+This will create the user `my_user` with the password `my_password` that is an
+administrative account. After this account is created, the default `admin`
 account is removed with the next command.
 
-The next step is to enable TLS encryption. To do this, you need a CA\
-certificate, a private key and a public certificate file all in PEM format. Add\
-the following three parameters under the `[maxscale]` section of the MaxScale\
+The next step is to enable TLS encryption. To do this, you need a CA
+certificate, a private key and a public certificate file all in PEM format. Add
+the following three parameters under the `[maxscale]` section of the MaxScale
 configuration file and restart MaxScale.
 
 ```
@@ -39,15 +39,15 @@ admin_ssl_cert=/certs/server-cert.pem
 admin_ssl_ca_cert=/certs/ca-cert.pem
 ```
 
-Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our\
-server certificates are self-signed so the `--tls-verify-server-cert=false`\
+Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our
+server certificates are self-signed so the `--tls-verify-server-cert=false`
 option is required.
 
 ```
 maxctrl --user=my_user --password=my_password --secure --tls-ca-cert=/certs/ca-cert.pem --tls-verify-server-cert=false show maxscale
 ```
 
-If no errors are raised, this means that the communication via the REST API is\
+If no errors are raised, this means that the communication via the REST API is
 now secure and can be used across networks.
 
 ### Requesting Data
@@ -55,8 +55,8 @@ now secure and can be used across networks.
 **Note:** For the sake of brevity, the rest of this tutorial will omit the\
 TLS/SSL options from the `curl` command line. For more information, refer to the`curl` manpage.
 
-The most basic task to do with the REST API is to see whether MaxScale is up and\
-running. To do this, we do a HTTP request on the root resource (the `-i` option\
+The most basic task to do with the REST API is to see whether MaxScale is up and
+running. To do this, we do a HTTP request on the root resource (the `-i` option
 shows the HTTP headers).
 
 `curl -i 127.0.0.1:8989/v1/`
@@ -70,7 +70,7 @@ ETag: "0"
 Date: Mon, 04 Mar 19 08:29:41 GMT
 ```
 
-To query a resource collection endpoint, append it to the URL. The `/v1/filters/`\
+To query a resource collection endpoint, append it to the URL. The `/v1/filters/`
 endpoint shows the list of filters configured in MaxScale. This is a _resource collection_ endpoint: it contains the list of all resources of a particular type.
 
 `curl 127.0.0.1:8989/v1/filters`
@@ -145,17 +145,17 @@ endpoint shows the list of filters configured in MaxScale. This is a _resource c
 }
 ```
 
-The `data` holds the actual list of resources: the `Hint` and `Logger`\
-filters. Each object has the `id` field which is the unique name of that\
+The `data` holds the actual list of resources: the `Hint` and `Logger`
+filters. Each object has the `id` field which is the unique name of that
 object. It is the same as the section name in `maxscale.cnf`.
 
-Each resource in the list has a `relationships` object. This shows the\
-relationship links between resources. In our example, the `Hint` filter is used\
-by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in\
+Each resource in the list has a `relationships` object. This shows the
+relationship links between resources. In our example, the `Hint` filter is used
+by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in
 use.
 
-To request an individual resource, we add the object name to the resource\
-collection URL. For example, if we want to get only the `Logger` filter we\
+To request an individual resource, we add the object name to the resource
+collection URL. For example, if we want to get only the `Logger` filter we
 execute the following command.
 
 `curl 127.0.0.1:8989/v1/filters/Logger`
@@ -204,18 +204,18 @@ execute the following command.
 }
 ```
 
-Note that this time the `data` member holds an object instead of an array of\
-objects. All other parts of the response are similar to what was shown in the\
+Note that this time the `data` member holds an object instead of an array of
+objects. All other parts of the response are similar to what was shown in the
 previous example.
 
 ### Creating Objects
 
-One of the uses of the REST API is to create new objects in MaxScale at\
-runtime. This allows new servers, services, filters, monitor and listeners to be\
+One of the uses of the REST API is to create new objects in MaxScale at
+runtime. This allows new servers, services, filters, monitor and listeners to be
 created without restarting MaxScale.
 
-For example, to create a new server in MaxScale the JSON definition of a server\
-must be sent to the REST API at the `/v1/servers/` endpoint. The request body\
+For example, to create a new server in MaxScale the JSON definition of a server
+must be sent to the REST API at the `/v1/servers/` endpoint. The request body
 defines the server name as well as the parameters for it.
 
 To create objects with `curl`, first write the JSON definition into a file.
@@ -241,9 +241,9 @@ To send the data, use the following command.
 curl -X POST -d @new_server.txt 127.0.0.1:8989/v1/servers
 ```
 
-The `-d` option takes a file name prefixed with a `@` as an argument. Here we\
-have `@new_server.txt` which is the name of the file where the JSON definition\
-was stored. The `-X` option defines the HTTP verb to use and to create a new\
+The `-d` option takes a file name prefixed with a `@` as an argument. Here we
+have `@new_server.txt` which is the name of the file where the JSON definition
+was stored. The `-X` option defines the HTTP verb to use and to create a new
 object we must use the POST verb.
 
 To verify the data request the newly created object.
@@ -254,18 +254,18 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Modifying Data
 
-The easiest way to modify an object is to first request it, store the result in\
+The easiest way to modify an object is to first request it, store the result in
 a file, edit it and then send the updated object back to the REST API.
 
-Let's say we want to modify the port that the server we created earlier listens\
+Let's say we want to modify the port that the server we created earlier listens
 on. First we request the current object and store the result in a file.
 
 ```
 curl 127.0.0.1:8989/v1/servers/server1 > server1.txt
 ```
 
-After that we edit the file and change the port from 3003 to 3306. Next the\
-modified JSON object is sent to the REST API as a PATCH command. To do this,\
+After that we edit the file and change the port from 3003 to 3306. Next the
+modified JSON object is sent to the REST API as a PATCH command. To do this,
 execute the following command.
 
 ```
@@ -280,12 +280,12 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Object Relationships
 
-To continue with our previous example, we add the updated server to a\
-service. To do this, the `relationships` object of the server must be modified\
+To continue with our previous example, we add the updated server to a
+service. To do this, the `relationships` object of the server must be modified
 to include the service we want to add the server to.
 
-To define a relationship between a server and a service, the `data` member must\
-have the `relationships` field and it must contain an object with the `services`\
+To define a relationship between a server and a service, the `data` member must
+have the `relationships` field and it must contain an object with the `services`
 field (some fields omitted for brevity).
 
 ```
@@ -308,13 +308,13 @@ field (some fields omitted for brevity).
 }
 ```
 
-The `data.relationships.services.data` field contains a list of objects that\
-define the `id` and `type` fields. The id is the name of the object (a service\
-or a monitor for servers) and the type tells which type it is. Only `services`\
+The `data.relationships.services.data` field contains a list of objects that
+define the `id` and `type` fields. The id is the name of the object (a service
+or a monitor for servers) and the type tells which type it is. Only `services`
 type objects should be present in the `services` object.
 
-In our example we are linking the `server1` server to the `RW-Split-Router`\
-service. As was seen with the previous example, the easiest way to do this is to\
+In our example we are linking the `server1` server to the `RW-Split-Router`
+service. As was seen with the previous example, the easiest way to do this is to
 store the result, edit it and then send it back with a HTTP PATCH.
 
 If we want to remove a server from _all_ services and monitors, we can set the`data` member of the `services` and `monitors` relationships to an empty array:
@@ -334,39 +334,39 @@ If we want to remove a server from _all_ services and monitors, we can set the`d
 }
 ```
 
-This is useful if you want to delete the server which can only be done if it has\
+This is useful if you want to delete the server which can only be done if it has
 no relationships to other objects.
 
 ### Deleting Objects
 
-To delete an object, simply execute a HTTP DELETE request on the resource you\
-want to delete. For example, to delete the `server1` server, execute the\
+To delete an object, simply execute a HTTP DELETE request on the resource you
+want to delete. For example, to delete the `server1` server, execute the
 following command.
 
 ```
 curl -X DELETE 127.0.0.1:8989/v1/servers/server1
 ```
 
-In order to delete an object, it must not have any relationships to other\
+In order to delete an object, it must not have any relationships to other
 objects.
 
 ### Further Reading
 
 The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../mariadb-maxscale-21-06-rest-api/mariadb-maxscale-2106-maxscale-2106-rest-api.md).
 
-The `maxctrl` command line client is self-documenting and the `maxctrl help`\
-command is a good tool for exploring the various commands that are available in\
-it. The `maxctrl api get` command can be useful way to explore the REST API as\
+The `maxctrl` command line client is self-documenting and the `maxctrl help`
+command is a good tool for exploring the various commands that are available in
+it. The `maxctrl api get` command can be useful way to explore the REST API as
 it provides a way to easily extract values out of the JSON data generated by the\
 REST API.
 
-There is a multitude of REST API clients readily available and most of them are\
-far more convenient to use than `curl`. We recommend investigating what you need\
-and how you intend to either integrate or use the MaxScale REST API. Most modern\
-languages either have a built-in HTTP library or there exists a de facto\
+There is a multitude of REST API clients readily available and most of them are
+far more convenient to use than `curl`. We recommend investigating what you need
+and how you intend to either integrate or use the MaxScale REST API. Most modern
+languages either have a built-in HTTP library or there exists a de facto
 standard library.
 
-The MaxScale REST API follows the JSON API specification and there exist\
+The MaxScale REST API follows the JSON API specification and there exist
 libraries that are built specifically for these sorts of APIs
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-setting-up-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-tutorials/mariadb-maxscale-2106-maxscale-2106-setting-up-mariadb-maxscale.md
@@ -3,26 +3,26 @@
 This document is designed as a quick introduction to setting up MariaDB MaxScale.
 
 The installation and configuration of the MariaDB Server is not covered in this document.\
-See the following MariaDB documentation articles for more information on setting up a\
-master-slave-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)\
+See the following MariaDB documentation articles for more information on setting up a
+master-slave-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)
 and [Getting Started With MariaDB Galera Cluster](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster)\
 .
 
-This tutorial assumes that one of the standard MaxScale binary distributions is used and\
+This tutorial assumes that one of the standard MaxScale binary distributions is used and
 that MaxScale is installed using default options.
 
 Building from source code in GitHub is covered in [Building from Source](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-building-mariadb-maxscale-from-source-code.md).
 
 ### Installing MaxScale
 
-The precise installation process varies from one distribution to another. Details on\
+The precise installation process varies from one distribution to another. Details on
 package installation can be found in the [Installation Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-installation-guide.md).
 
 ### Creating a user account for MaxScale
 
-MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve\
-user authentication information from the backend databases. Create a special user\
-account for this purpose by executing the following SQL commands on the master server of\
+MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve
+user authentication information from the backend databases. Create a special user
+account for this purpose by executing the following SQL commands on the master server of
 your database cluster. The following tutorials will use these credentials.
 
 ```
@@ -41,12 +41,12 @@ MariaDB versions 10.2.2 to 10.2.10 also require `GRANT SELECT ON mysql.* TO 'max
 
 ### Creating client user accounts
 
-Because MariaDB MaxScale sits between the clients and the backend databases, the backend\
-databases will see all clients as if they were connecting from MaxScale's address. This\
+Because MariaDB MaxScale sits between the clients and the backend databases, the backend
+databases will see all clients as if they were connecting from MaxScale's address. This
 usually means that two sets of grants for each user are required.
 
 For example, assume that the user _'jdoe'@'client-host'_ exists and MaxScale is located at _maxscale-host_. If _'jdoe'@'client-host'_ needs to be able to connect through MaxScale,
-another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the\
+another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the
 same password and similar grants as _'jdoe'@'client-host'_.
 
 The quickest way to do this is to first create the new user:
@@ -73,18 +73,18 @@ Then copy the same grants to the `'jdoe'@'maxscale-host'` user.
 GRANT SELECT, INSERT, UPDATE, DELETE ON *.* TO 'jdoe'@'maxscale-host';
 ```
 
-An alternative to generating two separate accounts is to use one account with a wildcard\
-host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than\
+An alternative to generating two separate accounts is to use one account with a wildcard
+host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than
 having specific user accounts as it allows access from all hosts.
 
 ### Creating the configuration file
 
-MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is\
+MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is
 provided with the MaxScale installation.
 
-A global _maxscale_ section is included in every MaxScale configuration file. This section\
-sets the values of various global parameters, such as the number of threads MaxScale uses\
-to handle client requests. To set thread count to the number of available cpu cores, set\
+A global _maxscale_ section is included in every MaxScale configuration file. This section
+sets the values of various global parameters, such as the number of threads MaxScale uses
+to handle client requests. To set thread count to the number of available cpu cores, set
 the following.
 
 ```
@@ -94,7 +94,7 @@ threads=auto
 
 ### Configuring the servers
 
-Read the [Configuring Servers](mariadb-maxscale-2106-maxscale-2106-configuring-servers.md) mini-tutorial for server\
+Read the [Configuring Servers](mariadb-maxscale-2106-maxscale-2106-configuring-servers.md) mini-tutorial for server
 configuration instructions.
 
 ### Configuring the monitor
@@ -111,7 +111,7 @@ For a simple connection based setup, read the [Connection Routing Tutorial](mari
 
 ### Starting MaxScale
 
-After configuration is complete, MariaDB MaxScale is ready to start. For systems that\
+After configuration is complete, MariaDB MaxScale is ready to start. For systems that
 use systemd, use the _systemctl_ command.
 
 ```
@@ -124,13 +124,13 @@ For older SysV systems, use the _service_ command.
 sudo service maxscale start
 ```
 
-If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see\
+If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see
 if any errors are detected in the configuration file.
 
 ### Checking MaxScale status with MaxCtrl
 
-The _maxctrl_-command can be used to confirm that MaxScale is running and the services,\
-listeners and servers have been correctly configured. The following shows expected output\
+The _maxctrl_-command can be used to confirm that MaxScale is running and the services,
+listeners and servers have been correctly configured. The following shows expected output
 when using a read-write-splitting configuration.
 
 ```
@@ -163,7 +163,7 @@ when using a read-write-splitting configuration.
 └───────────────────┴──────┴──────┴─────────┘
 ```
 
-MariaDB MaxScale is now ready to start accepting client connections and route queries to\
+MariaDB MaxScale is now ready to start accepting client connections and route queries to
 the backend cluster.
 
 More options can be found in the [Configuration Guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md),[readwritesplit module documentation](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-readwritesplit.md) and [readconnroute module documentation](../mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-readconnroute.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-upgrading/mariadb-maxscale-2106-maxscale-2106-upgrading-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-upgrading/mariadb-maxscale-2106-maxscale-2106-upgrading-mariadb-maxscale.md
@@ -2,21 +2,21 @@
 
 For more information about what has changed, please refer to the ChangeLog and to the [release notes](https://mariadb.com/kb/Release-Notes/).
 
-Before starting the upgrade, any existing configuration files should\
+Before starting the upgrade, any existing configuration files should
 be backed up.
 
 ## Upgrading MariaDB MaxScale from 2.5 to 21.06
 
-**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have\
-been released as 6.4.16 in June, was released as 21.06.16. The purpose of this\
-change is to make the versioning scheme used by all MaxScale series\
+**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have
+been released as 6.4.16 in June, was released as 21.06.16. The purpose of this
+change is to make the versioning scheme used by all MaxScale series
 identical. 21.06 denotes the year and month when the first 6 release was made.
 
 ### Duration Type Parameters
 
 Using duration type parameters without an explicit suffix has been deprecated in\
 MaxScale 2.4. In MaxScale 6 they are no longer allowed when used with the REST\
-API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that\
+API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that
 use a duration type parameter must explicitly specify the suffix of the unit.
 
 For example, the following command:
@@ -31,8 +31,8 @@ should be replaced with:
 maxctrl alter service My-Service connection_keepalive 30000ms
 ```
 
-Duration type parameters can still be defined in the configuration file without\
-an explicit suffix but this behavior is deprecated. The recommended approach is\
+Duration type parameters can still be defined in the configuration file without
+an explicit suffix but this behavior is deprecated. The recommended approach is
 to add explicit suffixes to all duration type parameters when upgrading to\
 MaxScale 6.
 
@@ -54,16 +54,16 @@ The following deprecated core parameters have been removed:
 
 The deprecated aliases for the schemarouter parameters `ignore_databases` and`ignore_databases_regex` have been removed. They can be replaced with`ignore_tables` and `ignore_tables_regex`.
 
-In addition, the `preferred_server` parameter that was deprecated in 2.5 has\
+In addition, the `preferred_server` parameter that was deprecated in 2.5 has
 also been removed.
 
 ### Session Command History
 
-The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`\
-have been made into generic service parameters that are shared between all\
+The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`
+have been made into generic service parameters that are shared between all
 routers that support it.
 
-The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it\
+The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it
 being enabled or are not affected by it.
 
 ## Upgrading MariaDB MaxScale from 2.4 to 2.5
@@ -71,33 +71,33 @@ being enabled or are not affected by it.
 ### MaxAdmin
 
 The deprecated MaxAdmin interface has been removed in 2.5.0 in favor of the REST\
-API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can\
+API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can
 no longer be used.
 
 ### Authentication
 
-The credentials used by services now require additional grants. For a full list\
+The credentials used by services now require additional grants. For a full list
 of required grants, refer to the [protocol documentation](../mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-authentication-modules.md).
 
 ### MariaDB-Monitor
 
-The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in\
+The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in
 a later version.
 
 #### Password encryption
 
-The encrypted passwords feature has been updated to be more secure. Users are\
-recommended to generate a new encryption key and re-encrypt their passwords\
+The encrypted passwords feature has been updated to be more secure. Users are
+recommended to generate a new encryption key and re-encrypt their passwords
 using the `maxkeys` and `maxpasswd` utilities. Old passwords still work.
 
 ### Default Server State
 
-The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally\
+The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally
 used before they were monitored.
 
 ### Columnstore Monitor
 
-It is now mandatory to specify in the configuration what version the\
+It is now mandatory to specify in the configuration what version the
 monitored Columnstore cluster is.
 
 ```
@@ -108,20 +108,20 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-columnstore-monitor.md)\
+Please see the [documentation](../mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-columnstore-monitor.md)
 for details.
 
 ### New binlog router
 
-The binlog router delivered with MaxScale 2.5 is completely new and\
-not 100% backward compatible with the binlog router delivered with\
-earlier MaxScale versions. If you use the binlog router, carefully\
-assess whether the functionality provided by the new one fulfills\
+The binlog router delivered with MaxScale 2.5 is completely new and
+not 100% backward compatible with the binlog router delivered with
+earlier MaxScale versions. If you use the binlog router, carefully
+assess whether the functionality provided by the new one fulfills
 your requirements, before upgrading MaxScale.
 
 ### Tee Filter
 
-The tee filter parameter `service` has been deprecated in favor of the `target`\
+The tee filter parameter `service` has been deprecated in favor of the `target`
 parameter. All usages of `service` can be replaced with `target`.
 
 ## Upgrading MariaDB MaxScale from 2.3 to 2.4
@@ -130,10 +130,10 @@ parameter. All usages of `service` can be replaced with `target`.
 
 #### Reserved Names
 
-Section and object names starting with `@@` are now reserved for\
+Section and object names starting with `@@` are now reserved for
 internal use by MaxScale.
 
-In case such names have been used, they must manually be changed\
+In case such names have been used, they must manually be changed
 in all configuration files of MaxScale, before MaxScale 2.4 is started.
 
 Those files are:
@@ -144,7 +144,7 @@ Those files are:
 
 #### Whitespace in Names
 
-Whitespace in section names that was deprecated in MaxScale 2.2 will now be\
+Whitespace in section names that was deprecated in MaxScale 2.2 will now be
 rejected, which will cause the startup of MaxScale to fail.
 
 To prevent that, section names like
@@ -171,11 +171,11 @@ servers=MyServer
 
 ### Durations
 
-Durations can now be specified using one of the suffixes `h`, `m`, `s`\
-and `ms` for specifying durations in hours, minutes, seconds and\
+Durations can now be specified using one of the suffixes `h`, `m`, `s`
+and `ms` for specifying durations in hours, minutes, seconds and
 milliseconds, respectively.
 
-_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,\
+_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,
 so it is advisable to add suffixes to durations. For instance,
 
 ```
@@ -185,12 +185,12 @@ some_param=60000ms
 
 ### Improved Admin User Encryption
 
-MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a\
+MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a
 user to use the better hashing algorithm, either recreate the user or use the`maxctrl alter user` command.
 
 ### MariaDB-Monitor
 
-The following settings have been removed and cause a startup error\
+The following settings have been removed and cause a startup error
 if defined:
 
 * `mysql51_replication`
@@ -199,45 +199,45 @@ if defined:
 
 ### ReadWriteSplit
 
-* If multiple masters are available for a readwritesplit service, the one with\
+* If multiple masters are available for a readwritesplit service, the one with
   the lowest connection count is selected.
-* If a master server is placed into maintenance mode, all open transactions are\
-  allowed to gracefully finish before the session is closed. To forcefully close\
+* If a master server is placed into maintenance mode, all open transactions are
+  allowed to gracefully finish before the session is closed. To forcefully close
   the connections, use the `--force` option for `maxctrl set server`.
-* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the\
+* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the
   overall load on the system when connections are rapidly opened and closed.
-* Transaction replays now have a limit on how many times a replay is\
+* Transaction replays now have a limit on how many times a replay is
   attempted. The default values is five attempts and is controlled by the`transaction_replay_attempts` parameter.
-* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the\
+* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the
   transaction is automatically retried.
 
 ## Upgrading MariaDB MaxScale from 2.2 to 2.3
 
 ### Increased Memory Use
 
-Starting with MaxScale 2.3.0 up to 40% of the memory can be used for\
-caching parsed queries. The most noticeable change is that it improves\
-performance in almost all cases where queries need to be parsed. Most of\
+Starting with MaxScale 2.3.0 up to 40% of the memory can be used for
+caching parsed queries. The most noticeable change is that it improves
+performance in almost all cases where queries need to be parsed. Most of
 the time this happens when the readwritesplit router or filters are used.
 
-The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total\
-memory to 1GB, add `query_classifier_cache_size=1G` to your\
+The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total
+memory to 1GB, add `query_classifier_cache_size=1G` to your
 configuration. To disable it, set the value to `0`.
 
-In addition to the aforementioned query classifier caching, the\
-readwritesplit session command history is enabled by default in 2.3 but is\
-limited to a maximum of 50 commands after which the history is\
-disabled. This is unlikely to show in any metrics but it contributes to\
+In addition to the aforementioned query classifier caching, the
+readwritesplit session command history is enabled by default in 2.3 but is
+limited to a maximum of 50 commands after which the history is
+disabled. This is unlikely to show in any metrics but it contributes to
 the increased memory foorprint of MaxScale.
 
 ### Unknown Global Parameters
 
-All unknown parameters are now treated as errors. Check your configuration for\
+All unknown parameters are now treated as errors. Check your configuration for
 errors if MaxScale fails to start after upgrading to 2.3.1.
 
 ### `passwd` is deprecated
 
-In the configuration file, passwords for monitors and services should be\
+In the configuration file, passwords for monitors and services should be
 specified using `password`; the support for the deprecated`passwd` will be removed in the future. That is, the following
 
 ```
@@ -274,61 +274,61 @@ Authenticator options are now only used with listeners.
 
 #### Administrative Users
 
-The file format for the administrative users used by MaxScale has been\
-changed. Old style files are automatically upgraded and a backup of the old file is\
+The file format for the administrative users used by MaxScale has been
+changed. Old style files are automatically upgraded and a backup of the old file is
 stored in `/var/lib/maxscale/passwd.backup`.
 
 #### Regular Expression Parameters
 
-Modules may now use a built-in regular expression string parameter type instead\
-of a normal string when accepting patterns. The modules that use the new regex\
-parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the\
+Modules may now use a built-in regular expression string parameter type instead
+of a normal string when accepting patterns. The modules that use the new regex
+parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the
 string in slashes, e.g. `match=/^select/` defines the pattern `^select`.
 
 #### Binlog Server
 
-Binlog server automatically accepts GTID connection from MariaDB 10 slave servers\
+Binlog server automatically accepts GTID connection from MariaDB 10 slave servers
 by saving all incoming GTIDs into a SQLite map database.
 
 #### MaxCtrl Included in Main Package
 
-In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2\
-it is in the main `maxscale` package. If you have a previous installation\
+In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2
+it is in the main `maxscale` package. If you have a previous installation
 of MaxCtrl, please remove it before upgrading to MaxScale 2.2.2.
 
 ## Upgrading MariaDB MaxScale from 2.0 to 2.1
 
 ### IPv6 Support
 
-MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to\
-was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,\
+MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to
+was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,
 add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)\
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files
 
-The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The\
+The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The
 default location for the log file is _/var/log/maxscale/maxscale.log_.
 
-Rotating the log files will cause MaxScale to reopen the file instead of\
+Rotating the log files will cause MaxScale to reopen the file instead of
 renaming them. This makes the MaxScale logging facility _logrotate_ compatible.
 
 ### ReadWriteSplit
 
-The `disable_sescmd_history` option is now enabled by default. This means that\
-slaves will not be recovered mid-session even if a replacement slave is\
-available. To enable the legacy behavior, add the `disable_sescmd_history=true`\
+The `disable_sescmd_history` option is now enabled by default. This means that
+slaves will not be recovered mid-session even if a replacement slave is
+available. To enable the legacy behavior, add the `disable_sescmd_history=true`
 parameter to the service definition.
 
 ### Persistent Connections
 
-The MariaDB session state is reset in MaxScale 2.1 for persistent\
-connections. This means that any modifications to the session state (default\
-database, user variable etc.) will not survive if the connection is put into the\
+The MariaDB session state is reset in MaxScale 2.1 for persistent
+connections. This means that any modifications to the session state (default
+database, user variable etc.) will not survive if the connection is put into the
 connection pool. For most users, this is the expected behavior.
 
 ### User Data Cache
@@ -337,27 +337,27 @@ The location of the MariaDB user data cache was moved from`/var/cache/maxscale/<
 
 ### Galeramon Monitoring Algorithm
 
-Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with\
+Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with
 multiple MaxScales but it also causes slower changes of the master node.
 
-To enable the legacy behavior, add `root_node_as_master=false` to the Galera\
+To enable the legacy behavior, add `root_node_as_master=false` to the Galera
 monitor configuration.
 
 ### MaxAdmin Editing Mode
 
-The default editing mode was changed from _vim_ to _emacs_ mode. To start\
+The default editing mode was changed from _vim_ to _emacs_ mode. To start
 maxadmin in the legacy mode, use the `-i` option.
 
 ## Upgrading MariaDB MaxScale from 1.4 to 2.0
 
 ### MaxAdmin
 
-The default way the communication between MaxAdmin and MariaDB MaxScale is\
+The default way the communication between MaxAdmin and MariaDB MaxScale is
 handled has been changed from an internet socket to a Unix domain socket.\
 The former alternative is still available but has been _deprecated_.
 
 If no arguments are given to MaxAdmin, it will attempt to connect to\
-MariaDB MaxScale using a Unix domain socket. After the upgrade you will\
+MariaDB MaxScale using a Unix domain socket. After the upgrade you will
 need to provide at least one internet socket related flag - `-h`, `-P`,`-u` or `-p` - to force MaxAdmin to use the internet socket approach.
 
 E.g.
@@ -369,16 +369,16 @@ user@host $ maxadmin -u admin
 ### MySQL Monitor
 
 The MySQL Monitor now assigns the stale state to the master server by default.\
-In addition to this, the slave servers receive the stale slave state when they\
-lose the connection to the master. This should not cause changes in behavior\
+In addition to this, the slave servers receive the stale slave state when they
+lose the connection to the master. This should not cause changes in behavior
 but the output of MaxAdmin will show new states when replication is broken.
 
 ## Upgrading MaxScale from 1.3 to 1.4
 
 ### Service user permissions
 
-The service users now also need SELECT privileges on mysql.tables\_priv. This is\
-required for the resolution of table level grants. To grant SELECT privileges\
+The service users now also need SELECT privileges on mysql.tables\_priv. This is
+required for the resolution of table level grants. To grant SELECT privileges
 for the service user, replace the user and hostname in the following example.
 
 ```
@@ -393,8 +393,8 @@ For more information about how to do this, please read the installation guide:[M
 
 ### SSL
 
-The SSL configuration parameters are now a part of the listeners. If a service\
-used the old style SSL configuration parameters, the values should be moved to\
+The SSL configuration parameters are now a part of the listeners. If a service
+used the old style SSL configuration parameters, the values should be moved to
 the listener which is associated with that service.
 
 Here is an example of an old style configuration.
@@ -439,23 +439,23 @@ ssl_ca_cert=/home/user/certs/ca.pem
 ssl_version=TLSv12
 ```
 
-Please also note that the `enabled` SSL mode is no longer supported due to\
-the inherent security issues with allowing SSL and non-SSL connections on\
-the same port. In addition to this, SSLv3 is no longer supported due to\
+Please also note that the `enabled` SSL mode is no longer supported due to
+the inherent security issues with allowing SSL and non-SSL connections on
+the same port. In addition to this, SSLv3 is no longer supported due to
 vulnerabilities found in it.
 
 ## Upgrading MaxScale from 1.2 to 1.3
 
 ### Binlog Router
 
-The master server details are now provided with a **master.ini** file located in\
-the binlog directory and it can be changed using a CHANGE MASTER TO command issued\
+The master server details are now provided with a **master.ini** file located in
+the binlog directory and it can be changed using a CHANGE MASTER TO command issued
 via a MySQL connection to MaxScale.
 
-This file, properly filled, is now mandatory and without it the binlog router\
+This file, properly filled, is now mandatory and without it the binlog router
 cannot connect to the master database.
 
-Before starting binlog router after MaxScale 1.3 upgrade, please add relevant\
+Before starting binlog router after MaxScale 1.3 upgrade, please add relevant
 information to _master.ini_, example:
 
 ```
@@ -467,26 +467,26 @@ master_password=somepass
 filestem=repl-bin
 ```
 
-Additionally, the option `servers=masterdb` in the service definition is no\
+Additionally, the option `servers=masterdb` in the service definition is no
 longer required.
 
 ## Upgrading MaxScale from 1.1 to 1.2
 
-This document describes upgrading MaxScale from version 1.1.1 to 1.2 and\
-the major differences in the new version compared to the old version. The\
-major changes can be found in the `Changelog.txt` file in the installation\
+This document describes upgrading MaxScale from version 1.1.1 to 1.2 and
+the major differences in the new version compared to the old version. The
+major changes can be found in the `Changelog.txt` file in the installation
 directory and the official release notes in the `ReleaseNotes.txt` file.
 
 ### Installation
 
 Upgrading MaxScale will copy the `MaxScale.cnf` file in`/usr/local/mariadb-maxscale/etc/` to `/etc/` and renamed to `maxscale.cnf`.\
-Binary log files are not automatically copied and should be manually moved\
+Binary log files are not automatically copied and should be manually moved
 from `/usr/local/mariadb-maxscale` to `/var/lib/maxscale/`.
 
 ### File location changes
 
-MaxScale 1.2 follows the [FHS-standard](https://www.pathname.com/fhs/) and\
-installs to `/usr/` and `/var/` subfolders. Here are the major changes and\
+MaxScale 1.2 follows the [FHS-standard](https://www.pathname.com/fhs/) and
+installs to `/usr/` and `/var/` subfolders. Here are the major changes and
 file locations.
 
 * Configuration files are located in `/etc/` and use lowercase letters: `/etc/maxscale.cnf`
@@ -498,26 +498,26 @@ file locations.
 
 ### Running MaxScale without root permissions
 
-MaxScale can run as a non-root user with the 1.2 version. RPM and DEB\
-packages install the `maxscale` user and `maxscale` group which are used\
-by the init scripts and systemd configuration files. If you are installing\
-from a binary tarball, you can run the `postinst` script included in it to\
+MaxScale can run as a non-root user with the 1.2 version. RPM and DEB
+packages install the `maxscale` user and `maxscale` group which are used
+by the init scripts and systemd configuration files. If you are installing
+from a binary tarball, you can run the `postinst` script included in it to
 manually create these groups.
 
 ## Upgrading MaxScale from 1.0 to 1.1
 
-This document describes upgrading MaxScale from version 1.0.5 to 1.1.0 and\
-the major differences in the new version compared to the old version. The\
-major changes can be found in the `Changelog.txt` file in the installation\
+This document describes upgrading MaxScale from version 1.0.5 to 1.1.0 and
+the major differences in the new version compared to the old version. The
+major changes can be found in the `Changelog.txt` file in the installation
 directory and the official release notes in the `ReleaseNotes.txt` file.
 
 ### Installation
 
-If you are installing MaxScale from a RPM package, we recommend you back\
-up your configuration and log files and that you remove the old installation\
-of MaxScale completely. If you choose to upgrade MaxScale instead of removing\
-it and re-installing it afterwards, the init scripts in `/etc/init.d` folder\
-will be missing. This is due to the RPM packaging system but the script can\
+If you are installing MaxScale from a RPM package, we recommend you back
+up your configuration and log files and that you remove the old installation
+of MaxScale completely. If you choose to upgrade MaxScale instead of removing
+it and re-installing it afterwards, the init scripts in `/etc/init.d` folder
+will be missing. This is due to the RPM packaging system but the script can
 be re-installed by running the `postinst` script found in the`/usr/local/mariadb-maxscale` folder.
 
 ```
@@ -526,14 +526,14 @@ cd /usr/local/mariadb-maxscale
 ./postinst
 ```
 
-The 1.1.0 version of MaxScale installs into `/usr/local/mariadb-maxscale`\
-instead of `/usr/local/skysql/maxscale`. This will cause external references\
-to MaxScale's home directory to stop working so remember to update all\
+The 1.1.0 version of MaxScale installs into `/usr/local/mariadb-maxscale`
+instead of `/usr/local/skysql/maxscale`. This will cause external references
+to MaxScale's home directory to stop working so remember to update all
 paths with the new version.
 
 ### MaxAdmin changes
 
-The MaxAdmin client's default password in MaxScale 1.1.0 is `mariadb`\
+The MaxAdmin client's default password in MaxScale 1.1.0 is `mariadb`
 instead of `skysql`.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-aurora-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-aurora-monitor.md
@@ -1,41 +1,41 @@
 # MaxScale 21.06 Aurora Monitor
 
-This module monitors the status of Aurora cluster replicas. These replicas do\
-not use the standard MySQL protocol replication but rely on a mechanism provided\
+This module monitors the status of Aurora cluster replicas. These replicas do
+not use the standard MySQL protocol replication but rely on a mechanism provided
 by AWS to replicate changes.
 
 ## How Aurora Is Monitored
 
-Each node in an Aurora cluster has the variable `@@aurora_server_id` which is\
-the unique identifier for that node. An Aurora replica stores information\
-relevant to replication in the `information_schema.replica_host_status`\
-table. The table contains information about the status of all replicas in the\
-cluster. The `server_id` column in this table holds the values of`@@aurora_server_id` variables from all nodes. The `session_id` column contains\
-an unique string for all read-only replicas. For the master node, this value\
-will be `MASTER_SESSION_ID`. By executing the following query, we are able to\
+Each node in an Aurora cluster has the variable `@@aurora_server_id` which is
+the unique identifier for that node. An Aurora replica stores information
+relevant to replication in the `information_schema.replica_host_status`
+table. The table contains information about the status of all replicas in the
+cluster. The `server_id` column in this table holds the values of`@@aurora_server_id` variables from all nodes. The `session_id` column contains
+an unique string for all read-only replicas. For the master node, this value
+will be `MASTER_SESSION_ID`. By executing the following query, we are able to
 retrieve the `@@aurora_server_id` of the master node along with the`@@aurora_server_id` of the current node.
 
 ```
 SELECT @@aurora_server_id, server_id FROM information_schema.replica_host_status WHERE session_id = 'MASTER_SESSION_ID';
 ```
 
-The node which returns a row with two identical fields is the master. All other\
+The node which returns a row with two identical fields is the master. All other
 nodes are read-only replicas and will be labeled as slave servers.
 
-In addition to replica status information, the`information_schema.replica_host_status` table contains information about\
-replication lag between the master and the read-only nodes. This value is stored\
-in the `replica_lag_in_milliseconds` column. This can be used to detect read\
-replicas that are lagging behind the master node. This information can then be\
+In addition to replica status information, the`information_schema.replica_host_status` table contains information about
+replication lag between the master and the read-only nodes. This value is stored
+in the `replica_lag_in_milliseconds` column. This can be used to detect read
+replicas that are lagging behind the master node. This information can then be
 used by the routing modules to route reads to up-to-date nodes.
 
 ## Configuring the Aurora Monitor
 
-The Aurora monitor should connect directly to the unique endpoints of the Aurora\
-replicas. The cluster end point should not be included in the set of monitored\
-servers. Read the [Amazon RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html#Aurora.Overview.Endpoints)\
+The Aurora monitor should connect directly to the unique endpoints of the Aurora
+replicas. The cluster end point should not be included in the set of monitored
+servers. Read the [Amazon RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html#Aurora.Overview.Endpoints)
 for more information about how to retrieve the unique endpoints of your cluster.
 
-The Aurora monitor requires no parameters apart from the standard monitor\
+The Aurora monitor requires no parameters apart from the standard monitor
 parameters. It supports the monitor script functionality described in [Monitor Common](mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md) documentation.
 
 Here is an example Aurora monitor configuration.
@@ -50,8 +50,8 @@ password=borealis
 monitor_interval=2500ms
 ```
 
-The servers _cluster-1_, _cluster-2_ and _cluster-3_ are the unique Aurora\
-endpoints configured as MaxScale servers. The monitor will use the_aurora_:_borealis_ credentials to connect to each of the endpoint. The status\
+The servers _cluster-1_, _cluster-2_ and _cluster-3_ are the unique Aurora
+endpoints configured as MaxScale servers. The monitor will use the_aurora_:_borealis_ credentials to connect to each of the endpoint. The status
 of the nodes is inspected every 2500 milliseconds.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-columnstore-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-columnstore-monitor.md
@@ -1,14 +1,14 @@
 # MaxScale 21.06 ColumnStore Monitor
 
-The ColumnStore monitor, `csmon`, is a monitor module for MariaDB ColumnStore\
+The ColumnStore monitor, `csmon`, is a monitor module for MariaDB ColumnStore
 servers. The monitor supports ColumnStore version 1.5.
 
 ### Required Grants
 
-The credentials defined with the `user` and `password` parameters must have all\
+The credentials defined with the `user` and `password` parameters must have all
 grants on the `infinidb_vtable` database.
 
-For example, to create a user for this monitor with the required grants execute\
+For example, to create a user for this monitor with the required grants execute
 the following SQL.
 
 ```
@@ -18,83 +18,83 @@ GRANT ALL ON infinidb_vtable.* TO 'maxscale'@'maxscalehost';
 
 ### Configuration
 
-Read the [Monitor Common](mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md) document for a list of supported\
+Read the [Monitor Common](mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md) document for a list of supported
 common monitor parameters.
 
 #### `version`
 
-With this _deprecated_ optional parameter the used ColumnStore version is\
+With this _deprecated_ optional parameter the used ColumnStore version is
 specified. The only allowed value is `1.5`.
 
 #### `admin_port`
 
-This optional parameter specifies the port of the ColumnStore administrative\
-daemon. The default value is `8640`. Note that the daemons of all nodes must\
+This optional parameter specifies the port of the ColumnStore administrative
+daemon. The default value is `8640`. Note that the daemons of all nodes must
 be listening on the same port.
 
 #### `admin_base_path`
 
-This optional parameter specifies the base path of the ColumnStore\
+This optional parameter specifies the base path of the ColumnStore
 administrative daemon. The default value is `/cmapi/0.4.0`.
 
 #### `api_key`
 
-This optional parameter specifies the API key to be used in the\
-communication with the ColumnStore administrative daemon. If no\
-key is specified, then a key will be generated and stored to the\
-file `api_key.txt` in the directory with the same name as the\
-monitor in data directory of MaxScale. Typically that will\
+This optional parameter specifies the API key to be used in the
+communication with the ColumnStore administrative daemon. If no
+key is specified, then a key will be generated and stored to the
+file `api_key.txt` in the directory with the same name as the
+monitor in data directory of MaxScale. Typically that will
 be `/var/lib/maxscale/<monitor-section>/api_key.txt`.
 
-Note that ColumnStore will store the first key provided and\
-thereafter require it, so changing the key requires the\
+Note that ColumnStore will store the first key provided and
+thereafter require it, so changing the key requires the
 resetting of the key on the ColumnStore nodes as well.
 
 #### `local_address`
 
-With this parameter it is specified what IP MaxScale should\
-tell the ColumnStore nodes it resides at. Either it or`local_address` at the global level in the MaxScale\
-configuration file must be specified. If both have been\
+With this parameter it is specified what IP MaxScale should
+tell the ColumnStore nodes it resides at. Either it or`local_address` at the global level in the MaxScale
+configuration file must be specified. If both have been
 specified, then the one specified for the monitor overrides.
 
 #### `dynamic_node_detection`
 
-This optional boolean parameter specifies whether the monitor should\
-autonomously figure out the ColumnStore cluster configuration or whether\
-it should solely rely upon the monitor configuration in the configuration\
-file. Please see [Dynamic Node Detection](mariadb-maxscale-2106-maxscale-2106-columnstore-monitor.md#dynamic-node-detection) for a\
-thorough discussion on the meaning of the parameter. The default value\
+This optional boolean parameter specifies whether the monitor should
+autonomously figure out the ColumnStore cluster configuration or whether
+it should solely rely upon the monitor configuration in the configuration
+file. Please see [Dynamic Node Detection](mariadb-maxscale-2106-maxscale-2106-columnstore-monitor.md#dynamic-node-detection) for a
+thorough discussion on the meaning of the parameter. The default value
 is `false`.
 
 #### `cluster_monitor_interval`
 
-This optional parameter, meaningful only if `dynamic_node_detection` is`true` specifies how often the monitor should probe the ColumnStore\
-cluster and adapt to any changes that have occurred in the number of\
-nodes of the cluster. The default value is `10s`, that is, the\
+This optional parameter, meaningful only if `dynamic_node_detection` is`true` specifies how often the monitor should probe the ColumnStore
+cluster and adapt to any changes that have occurred in the number of
+nodes of the cluster. The default value is `10s`, that is, the
 cluster configuration is probed every 10 seconds.
 
-Note that as the probing is performed at the regular monitor round,\
+Note that as the probing is performed at the regular monitor round,
 the value should be some multiple of `monitor_interval`.
 
 ### Dynamic Node Detection
 
-**NOTE** If dynamic node detection is used, the network setup must\
-be such that the hostname/IP-address of a ColumnStore node is the\
+**NOTE** If dynamic node detection is used, the network setup must
+be such that the hostname/IP-address of a ColumnStore node is the
 same when viewed both from MaxScale and from another node.
 
-By default, the ColumnStore monitor behaves like the regular MariaDB\
-monitor. That is, it only monitors the servers it has been configured\
+By default, the ColumnStore monitor behaves like the regular MariaDB
+monitor. That is, it only monitors the servers it has been configured
 with.
 
-If `dynamic_node_detection` has been enabled, the behaviour of the monitor\
-changes significantly. Instead of being explicitly told which servers it\
-should monitor, the monitor is only told how to get into contact with the\
-cluster whereafter it autonomously figures out the cluster configuration\
+If `dynamic_node_detection` has been enabled, the behaviour of the monitor
+changes significantly. Instead of being explicitly told which servers it
+should monitor, the monitor is only told how to get into contact with the
+cluster whereafter it autonomously figures out the cluster configuration
 and creates dynamic server entries accordingly.
 
-When dynamic node detection is enabled, the servers the monitor has been\
-configured with are _only_ used for "bootstrapping" the monitor, because\
-at the initial startup the monitor does not otherwise know how to get\
+When dynamic node detection is enabled, the servers the monitor has been
+configured with are _only_ used for "bootstrapping" the monitor, because
+at the initial startup the monitor does not otherwise know how to get
 into contact with the cluster.
 
 In the following is shown a configuration using dynamic node detection.
@@ -118,20 +118,20 @@ dynamic_node_detection=true
 ...
 ```
 
-As can be seen, the server entries look just like any other server entries,\
-but to make them stand out and to indicate what they are used for, they have\
+As can be seen, the server entries look just like any other server entries,
+but to make them stand out and to indicate what they are used for, they have
 the word _bootstrap_ in their name.
 
-In principle, it is sufficient with a single entry, but to cater for the\
+In principle, it is sufficient with a single entry, but to cater for the
 case that a node happens to be down, it is advisable to have more than one.\
-Once the monitor has been able to connect to a node, it will fetch the\
-configuration and store information about the nodes locally. On subsequent\
-startups, the monitor will use the bootstrap information only if it cannot\
-connect using the persisted information. Also, if there has been any change\
+Once the monitor has been able to connect to a node, it will fetch the
+configuration and store information about the nodes locally. On subsequent
+startups, the monitor will use the bootstrap information only if it cannot
+connect using the persisted information. Also, if there has been any change
 in the bootstrap servers, the persisted information is not used.
 
-Based on the information obtained from the cluster itself, the monitor\
-will create _dynamic_ server instances that are named as `@@` followed by\
+Based on the information obtained from the cluster itself, the monitor
+will create _dynamic_ server instances that are named as `@@` followed by
 the monitor name, followed by a `:`, followed by the hostname.
 
 If the cluster in fact consists of three nodes, then the output of`maxctrl list servers` may look like
@@ -152,11 +152,11 @@ If the cluster in fact consists of three nodes, then the output of`maxctrl list 
 └──────────────────┴─────────┴──────┴─────────────┴─────────────────┴──────┘
 ```
 
-Note that there will be dynamic server entries _also_ for the nodes for\
+Note that there will be dynamic server entries _also_ for the nodes for
 which there is a bootstrap entry.
 
-When the service is defined, it is imperative that it does not explicitly\
-refer to either the bootstrap or the dynamic entries. Instead, it should\
+When the service is defined, it is imperative that it does not explicitly
+refer to either the bootstrap or the dynamic entries. Instead, it should
 refer to the monitor using the `cluster` parameter.
 
 ```
@@ -167,28 +167,28 @@ cluster=CsMonitor
 ...
 ```
 
-With this configuration the _RWS_ service will automatically adapt to any\
+With this configuration the _RWS_ service will automatically adapt to any
 changes made to the ColumnStore cluster.
 
 ### Commands
 
-The ColumnStore monitor provides module commands using which the ColumnStore\
-cluster can be managed. The commands can be invoked using the REST-API with\
+The ColumnStore monitor provides module commands using which the ColumnStore
+cluster can be managed. The commands can be invoked using the REST-API with
 a client such as curl or using maxctrl.
 
 All commands require the monitor instance name as the first parameters.\
 Additional parameters must be provided depending on the command.
 
-Note that as maxctrl itself has a timeout of 10 seconds, if a\
-timeout larger than that is provided to any command, the timeout of\
+Note that as maxctrl itself has a timeout of 10 seconds, if a
+timeout larger than that is provided to any command, the timeout of
 maxctrl must also be increased. For instance:
 
 ```
 maxctrl --timeout 30s call command csmon shutdown CsMonitor 20s
 ```
 
-Here a 30 second timeout is specified for maxctrl to ensure\
-that it does not expire before the timeout of 20s provided for\
+Here a 30 second timeout is specified for maxctrl to ensure
+that it does not expire before the timeout of 20s provided for
 the shutdown command possibly does.
 
 The output is always a JSON object.
@@ -278,11 +278,11 @@ Returns the cluster configuration.
 call command csmon config-get <monitor-name> [<server-name>]
 ```
 
-If no server is specified, the configuration is fetched from\
-the first server in the monitor configuration, otherwise from\
+If no server is specified, the configuration is fetched from
+the first server in the monitor configuration, otherwise from
 the specified server.
 
-Note that if everything is in order, the returned configuration\
+Note that if everything is in order, the returned configuration
 should be identical regardless of the server it is fetched from.
 
 Example
@@ -293,7 +293,7 @@ call command csmon config-get CsMonitor CsNode2
 
 #### `add-node`
 
-Adds a new node located on the server at the hostname or IP _host_\
+Adds a new node located on the server at the hostname or IP _host_
 to the ColumnStore cluster.
 
 ```
@@ -310,7 +310,7 @@ For a more complete example, please refer to [adding a node](mariadb-maxscale-21
 
 #### `remove-node`
 
-Remove the node located on the server at the hostname or IP _host_\
+Remove the node located on the server at the hostname or IP _host_
 from the ColumnStore cluster.
 
 ```
@@ -343,12 +343,12 @@ api_key=somekey1234
 
 ### Adding a Node
 
-Note that in the following `dynamic_node_detection` is not used, but\
+Note that in the following `dynamic_node_detection` is not used, but
 the monitor is configured in the traditional way. The impact of`dynamic_node_detection` is described [here](mariadb-maxscale-2106-maxscale-2106-columnstore-monitor.md#impact-of-dynamic_node_detection).
 
-Adding a new node to a ColumnStore cluster can be performed dynamically\
-at runtime, but it must be done in two steps. First, the node is added\
-to ColumnStore and then, the corresponding server object (that possibly\
+Adding a new node to a ColumnStore cluster can be performed dynamically
+at runtime, but it must be done in two steps. First, the node is added
+to ColumnStore and then, the corresponding server object (that possibly
 has to be created) in the MaxScale configuration is added to the\
 ColumnStore monitor.
 
@@ -383,7 +383,7 @@ Invoking `maxctrl list servers` will now show:
 └─────────┴─────────────┴──────┴─────────────┴─────────────────┴──────┘
 ```
 
-If we now want to add a new ColumnStore node, located at `mcs3/10.10.10.12`\
+If we now want to add a new ColumnStore node, located at `mcs3/10.10.10.12`
 to the cluster, the steps are as follows.
 
 First the node is added
@@ -410,7 +410,7 @@ After a while the following is output:
 }
 ```
 
-At this point, the ColumnStore cluster consists of three nodes. However,\
+At this point, the ColumnStore cluster consists of three nodes. However,
 the ColumnStore monitor is not yet aware of the new node.
 
 First we need to create the corresponding server object.
@@ -433,7 +433,7 @@ Invoking `maxctrl list servers` will now show:
 └─────────┴─────────────┴──────┴─────────────┴─────────────────┴──────┘
 ```
 
-The server `CsNode3` has been created, but its state is `Down` since\
+The server `CsNode3` has been created, but its state is `Down` since
 it is not yet being monitored.
 
 ```
@@ -474,29 +474,29 @@ The state of the new node is now also set correctly, as shown by`maxctrl list se
 └─────────┴─────────────┴──────┴─────────────┴─────────────────┴──────┘
 ```
 
-Note that the MaxScale server object can be created at any point, but\
-it must not be added to the monitor before the node has been added to\
+Note that the MaxScale server object can be created at any point, but
+it must not be added to the monitor before the node has been added to
 the ColumnStore cluster using `call command csmon add-node`.
 
 #### Impact of `dynamic_node_detection`
 
-If `dynamic_node_detection` is enabled, there is no need to create any\
-explicit server entries. All that needs to be done, is to add the node\
-and the monitor will adapt automatically. Note that it does not matter\
+If `dynamic_node_detection` is enabled, there is no need to create any
+explicit server entries. All that needs to be done, is to add the node
+and the monitor will adapt automatically. Note that it does not matter
 whether the node is added indirectly via maxscale or directly using the\
 REST-API of ColumnStore. The only difference is that in the former case,\
 MaxScale may detect the new situation slightly faster.
 
 ### Removing a Node
 
-Note that in the following `dynamic_node_detection` is not used, but\
+Note that in the following `dynamic_node_detection` is not used, but
 the monitor is configured in the traditional way. The impact of`dynamic_node_detection` is described [here](mariadb-maxscale-2106-maxscale-2106-columnstore-monitor.md#impact-of-dynamic-node-detection-1).
 
-Removing a node should be performed in the reverse order of how a\
-node was added. First, the MaxScale server should be removed from the\
+Removing a node should be performed in the reverse order of how a
+node was added. First, the MaxScale server should be removed from the
 monitor. Then, the node should be removed from the ColumnStore cluster.
 
-Suppose we want to remove the ColumnStore node at `mcs2/10.10.10.12`\
+Suppose we want to remove the ColumnStore node at `mcs2/10.10.10.12`
 and the current situation is as:
 
 ```
@@ -513,7 +513,7 @@ First, the server is removed from the monitor.
 maxctrl unlink monitor CsMonitor CsNode3
 ```
 
-Checking with `maxctrl list monitors` we see that the server has\
+Checking with `maxctrl list monitors` we see that the server has
 indeed been removed.
 
 ```
@@ -545,10 +545,10 @@ maxctrl --timeout 30s call command csmon remove-node CsMonitor mcs3 20s
 
 #### Impact of `dynamic_node_detection`
 
-If `dynamic_node_detection` is enabled, there is in general no need\
-to explicitly remove a static server entry (as there never was one in\
-the first place). The only exception is if the removed node happened\
-to be a bootstrap server. In that case, the server entry should be\
+If `dynamic_node_detection` is enabled, there is in general no need
+to explicitly remove a static server entry (as there never was one in
+the first place). The only exception is if the removed node happened
+to be a bootstrap server. In that case, the server entry should be
 removed from the monitor's list of servers (used as bootstrap nodes).\
 If that is not done, then the monitor will log a warning at each startup.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md
@@ -1,6 +1,6 @@
 # MaxScale 21.06 Common Monitor Parameters
 
-This document settings supported by all monitors. These should be defined\
+This document settings supported by all monitors. These should be defined
 in the monitor section of the configuration file.
 
 ### Parameters
@@ -19,7 +19,7 @@ The monitor module this monitor should use. Typically `mariadbmon` or`galeramon`
 * Mandatory: Yes
 * Dynamic: Yes
 
-Username used by the monitor to connect to the backend servers. If a server defines\
+Username used by the monitor to connect to the backend servers. If a server defines
 the `monitoruser` parameter, that value will be used instead.
 
 #### `password`
@@ -28,10 +28,10 @@ the `monitoruser` parameter, that value will be used instead.
 * Mandatory: Yes
 * Dynamic: Yes
 
-Password for the user defined with the `user` parameter. If a server defines\
+Password for the user defined with the `user` parameter. If a server defines
 the `monitorpw` parameter, that value will be used instead.
 
-**Note:** In older versions of MaxScale this parameter was called `passwd`. The\
+**Note:** In older versions of MaxScale this parameter was called `passwd`. The
 use of `passwd` was deprecated in MaxScale 2.3.0.
 
 #### `servers`
@@ -53,17 +53,17 @@ servers=MyServer1,MyServer2
 * Dynamic: Yes
 * Default: `2s`
 
-Defines how often the monitor updates the status of the servers. Choose a lower\
+Defines how often the monitor updates the status of the servers. Choose a lower
 value if servers should be queried more often. The smallest possible value is\
-100 milliseconds. If querying the servers takes longer than `monitor_interval`,\
+100 milliseconds. If querying the servers takes longer than `monitor_interval`,
 the effective update rate is reduced.
 
 ```
 monitor_interval=2s
 ```
 
-The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.
 
 #### `backend_connect_timeout`
@@ -74,10 +74,10 @@ versions a value without a unit may be rejected.
 * Default: `3s`
 
 This parameter controls the timeout for connecting to a monitored server.\
-The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -92,10 +92,10 @@ backend_connect_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for writing to a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 seconds.
 
 ```
@@ -110,10 +110,10 @@ backend_write_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for reading from a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -127,9 +127,9 @@ backend_read_timeout=3s
 * Dynamic: Yes
 * Default: `1`
 
-This parameter defines the maximum times a backend connection is attempted every\
-monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds\
-to perform. If none of the attempts are successful, the backend is considered to\
+This parameter defines the maximum times a backend connection is attempted every
+monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds
+to perform. If none of the attempts are successful, the backend is considered to
 be unreachable and down.
 
 ```
@@ -147,18 +147,18 @@ This parameter duplicates the `disk_space_threshold`[server parameter](../mariad
 If the parameter has _not_ been specified for a server, then the one specified\
 for the monitor is applied.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-That is, if the disk configuration is the same on all servers monitored by\
-the monitor, it is sufficient (and more convenient) to specify the disk\
-space threshold in the monitor section, but if the disk configuration is\
-different on all or some servers, then the disk space threshold can be\
+That is, if the disk configuration is the same on all servers monitored by
+the monitor, it is sufficient (and more convenient) to specify the disk
+space threshold in the monitor section, but if the disk configuration is
+different on all or some servers, then the disk space threshold can be
 specified individually for each server.
 
-For example, suppose `server1`, `server2` and `server3` are identical\
-in all respects. In that case we can specify `disk_space_threshold`\
+For example, suppose `server1`, `server2` and `server3` are identical
+in all respects. In that case we can specify `disk_space_threshold`
 in the monitor.
 
 ```
@@ -181,8 +181,8 @@ disk_space_threshold=/data:80
 ...
 ```
 
-However, if the servers are heterogeneous with the disk used for the\
-data directory mounted on different paths, then the disk space threshold\
+However, if the servers are heterogeneous with the disk used for the
+data directory mounted on different paths, then the disk space threshold
 must be specified separately for each server.
 
 ```
@@ -207,8 +207,8 @@ servers=server1,server2,server3
 ...
 ```
 
-If _most_ of the servers have the data directory disk mounted on\
-the same path, then the disk space threshold can be specified on\
+If _most_ of the servers have the data directory disk mounted on
+the same path, then the disk space threshold can be specified on
 the monitor and separately on the server with a different setup.
 
 ```
@@ -232,7 +232,7 @@ disk_space_threshold=/data:80
 ...
 ```
 
-Above, `server1` has the disk used for the data directory mounted\
+Above, `server1` has the disk used for the data directory mounted
 at `/DbData` while both `server2` and `server3` have it mounted on`/data` and thus the setting in the monitor covers them both.
 
 #### `disk_space_check_interval`
@@ -242,15 +242,15 @@ at `/DbData` while both `server2` and `server3` have it mounted on`/data` and th
 * Dynamic: Yes
 * Default: `0s`
 
-With this parameter it can be specified the minimum amount of time\
-between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+With this parameter it can be specified the minimum amount of time
+between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.\
-The default value is 0, which means that by default the disk space\
+The default value is 0, which means that by default the disk space
 will not be checked.
 
-Note that as the checking is made as part of the regular monitor interval\
-cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,\
+Note that as the checking is made as part of the regular monitor interval
+cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,
 the checking will still take place at `monitor_interval` intervals.
 
 #### `script`
@@ -260,9 +260,9 @@ the checking will still take place at `monitor_interval` intervals.
 * Dynamic: Yes
 * Default: None
 
-This command will be executed on a server state change. The parameter should\
-be an absolute path to a command or the command should be in the executable\
-path. The user running MaxScale should have execution rights to the file itself\
+This command will be executed on a server state change. The parameter should
+be an absolute path to a command or the command should be in the executable
+path. The user running MaxScale should have execution rights to the file itself
 and the directory it resides in. The script may have placeholders which\
 MaxScale will substitute with useful information when launching the script.
 
@@ -276,15 +276,15 @@ The placeholders and their substitution results are:
 * `$MASTERLIST` -> list of IPs and ports of all master servers
 * `$SYNCEDLIST` -> list of IPs and ports of all synced Galera nodes
 * `$PARENT` -> IP and port of the parent of the server which initiated the event.\
-  For master-slave setups, this will be the master if the initiating server is a\
+  For master-slave setups, this will be the master if the initiating server is a
   slave.
-* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who\
-  initiated the event. For master-slave setups, this will be a list of slave\
+* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who
+  initiated the event. For master-slave setups, this will be a list of slave
   servers if the initiating server is a master.
 
-The expanded variable value can be an empty string if no servers match the\
-variable's requirements. For example, if no masters are available `$MASTERLIST`\
-will expand into an empty string. The list-type substitutions will only contain\
+The expanded variable value can be an empty string if no servers match the
+variable's requirements. For example, if no masters are available `$MASTERLIST`
+will expand into an empty string. The list-type substitutions will only contain
 servers monitored by the current monitor.
 
 ```
@@ -299,17 +299,17 @@ The above script could be executed as:
 
 See section [Script example](mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md#script-example) below for an example script.
 
-Any output by the executed script will be logged into the MaxScale log. Each\
+Any output by the executed script will be logged into the MaxScale log. Each
 outputted line will be logged as a separate log message.
 
-The log level on which the messages are logged depends on the format of the\
-messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the\
-corresponding level. If the message is not prefixed with one of the keywords,\
-the message will be logged on the notice level. Whitespace before, after or\
-between the keyword and the colon is ignored and the matching is\
+The log level on which the messages are logged depends on the format of the
+messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the
+corresponding level. If the message is not prefixed with one of the keywords,
+the message will be logged on the notice level. Whitespace before, after or
+between the keyword and the colon is ignored and the matching is
 case-insensitive.
 
-Currently, the script must not execute any of the following MaxCtrl\
+Currently, the script must not execute any of the following MaxCtrl
 calls as they cause a deadlock:
 
 * `alter monitor` to the monitor executing the script
@@ -323,14 +323,14 @@ calls as they cause a deadlock:
 * Dynamic: Yes
 * Default: `90s`
 
-The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If the script execution exceeds the configured timeout, it is stopped by sending\
-a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be\
+If the script execution exceeds the configured timeout, it is stopped by sending
+a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be
 sent to it once the execution time is greater than twice the configured timeout.
 
 #### `events`
@@ -341,15 +341,15 @@ sent to it once the execution time is greater than twice the configured timeout.
 * Values: `master_down`, `master_up`, `slave_down`, `slave_up`, `server_down`, `server_up`, `lost_master`, `lost_slave`, `new_master`, `new_slave`
 * Default: All events
 
-A list of event names which cause the script to be executed. If this option is\
-not defined, all events cause the script to be executed. The list must contain a\
+A list of event names which cause the script to be executed. If this option is
+not defined, all events cause the script to be executed. The list must contain a
 comma separated list of event names.
 
 ```
 events=master_down,slave_down
 ```
 
-The following table contains all the possible event types and their\
+The following table contains all the possible event types and their
 descriptions.
 
 | Event Name   | Description                                  |
@@ -372,38 +372,38 @@ descriptions.
 * Dynamic: Yes
 * Default: `28800s`
 
-The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the max age is seconds, a max age specified in milliseconds will be rejected,\
+The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the max age is seconds, a max age specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-When the monitor starts, it reads any stored journal files. If the journal file\
-is older than the value of _journal\_max\_age_, it will be removed and the monitor\
+When the monitor starts, it reads any stored journal files. If the journal file
+is older than the value of _journal\_max\_age_, it will be removed and the monitor
 starts with no prior knowledge of the servers.
 
 ### Monitor Crash Safety
 
-Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the\
-latest server states. This change makes the monitors crash-safe when options\
-that introduce states are used. It also allows the monitors to retain stateful\
+Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the
+latest server states. This change makes the monitors crash-safe when options
+that introduce states are used. It also allows the monitors to retain stateful
 information when MaxScale is restarted.
 
-For MySQL monitor, options that introduce states into the monitoring process are\
-the `detect_stale_master` and `detect_stale_slave` options, both of which are\
-enabled by default. Galeramon has the `disable_master_failback` parameter which\
+For MySQL monitor, options that introduce states into the monitoring process are
+the `detect_stale_master` and `detect_stale_slave` options, both of which are
+enabled by default. Galeramon has the `disable_master_failback` parameter which
 introduces a state.
 
-The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the\
-name of the monitor section in the configuration file. If MaxScale crashes or is\
-shut down in an uncontrolled fashion, the journal will be read when MaxScale is\
-started. To skip the recovery process, manually delete the journal file before\
+The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the
+name of the monitor section in the configuration file. If MaxScale crashes or is
+shut down in an uncontrolled fashion, the journal will be read when MaxScale is
+started. To skip the recovery process, manually delete the journal file before
 starting MaxScale.
 
 ### Script example
 
-Below is an example monitor configuration which launches a script with all\
-supported substitutions. The example script reads the results and prints it to\
+Below is an example monitor configuration which launches a script with all
+supported substitutions. The example script reads the results and prints it to
 file and sends it as email.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-galera-monitor.md
@@ -2,39 +2,39 @@
 
 ### Overview
 
-The Galera Monitor is a monitoring module for MaxScale that monitors a Galera\
-cluster. It detects whether nodes are a part of the cluster and if they are in\
-sync with the rest of the cluster. It can also assign master and slave roles\
-inside MaxScale, allowing Galera clusters to be used with modules designed for\
+The Galera Monitor is a monitoring module for MaxScale that monitors a Galera
+cluster. It detects whether nodes are a part of the cluster and if they are in
+sync with the rest of the cluster. It can also assign master and slave roles
+inside MaxScale, allowing Galera clusters to be used with modules designed for
 traditional master-slave clusters.
 
-By default, the Galera Monitor will choose the node with the lowest`wsrep_local_index` value as the master. This will mean that two MaxScales\
+By default, the Galera Monitor will choose the node with the lowest`wsrep_local_index` value as the master. This will mean that two MaxScales
 running on different servers will choose the same server as the master.
 
 #### WSREP Variables and Their Effects
 
-The following WSREP variables are inspected by galeramon to see whether a node is\
-usable. If the node is not usable, it loses the `Master` and `Slave` labels and\
+The following WSREP variables are inspected by galeramon to see whether a node is
+usable. If the node is not usable, it loses the `Master` and `Slave` labels and
 will be in the `Running` state.
 
-* If `wsrep_ready=0`, the WSREP system is not yet ready and the Galera node\
+* If `wsrep_ready=0`, the WSREP system is not yet ready and the Galera node
   cannot accept queries.
-* If `wsrep_desync=1` is set, the node is desynced and is not participating in\
+* If `wsrep_desync=1` is set, the node is desynced and is not participating in
   the Galera replication.
-* If `wsrep_reject_queries=[ALL|ALL_KILL]` is set, queries are refused and the\
+* If `wsrep_reject_queries=[ALL|ALL_KILL]` is set, queries are refused and the
   node is unusable.
-* With `wsrep_sst_donor_rejects_queries=1`, donor nodes reject\
-  queries. Galeramon treats this the same as if `wsrep_reject_queries=ALL` was\
+* With `wsrep_sst_donor_rejects_queries=1`, donor nodes reject
+  queries. Galeramon treats this the same as if `wsrep_reject_queries=ALL` was
   set.
-* If `wsrep_local_state` is not 4 (or 2 with `available_when_donor=true`), the\
+* If `wsrep_local_state` is not 4 (or 2 with `available_when_donor=true`), the
   node is not in the correct state and is not used.
 
 #### Galera clusters and slaves replicating from it
 
-MaxScale 2.4.0 added support for slaves replicating off of Galera nodes. If a\
-non-Galera server monitored by galeramon is replicating from a Galera node also\
-monitored by galeramon, it will be assigned the `Slave, Running` status as long\
-as the replication works. This allows read-scaleout with Galera servers without\
+MaxScale 2.4.0 added support for slaves replicating off of Galera nodes. If a
+non-Galera server monitored by galeramon is replicating from a Galera node also
+monitored by galeramon, it will be assigned the `Slave, Running` status as long
+as the replication works. This allows read-scaleout with Galera servers without
 increasing the size of the Galera cluster.
 
 ### Required Grants
@@ -60,7 +60,7 @@ GRANT SUPER ON *.* TO 'maxscale'@'maxscalehost';
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers. The user requires the\
 REPLICATION CLIENT privilege to successfully monitor the state of the servers.
 
@@ -87,10 +87,10 @@ These are optional parameters specific to the Galera Monitor.
 * Default: false
 * Dynamic: Yes
 
-If a node marked as master inside MaxScale happens to fail and the master status\
-is assigned to another node MaxScale will normally return the master status to\
-the original node after it comes back up. With this option enabled, if the\
-master status is assigned to a new node it will not be reassigned to the\
+If a node marked as master inside MaxScale happens to fail and the master status
+is assigned to another node MaxScale will normally return the master status to
+the original node after it comes back up. With this option enabled, if the
+master status is assigned to a new node it will not be reassigned to the
 original node for as long as the new master node is running. In this case the`Master Stickiness` status bit is set which will be visible in the`maxctrl list servers` output.
 
 #### `available_when_donor`
@@ -100,17 +100,17 @@ original node for as long as the new master node is running. In this case the`Ma
 * Dynamic: Yes
 
 This option allows Galera nodes to be used normally when they are donors in an\
-SST operation when the SST method is non-blocking\
+SST operation when the SST method is non-blocking
 (e.g. `wsrep_sst_method=mariadb-backup`).
 
 Normally when an SST is performed, both participating nodes lose their Synced,\
-Master or Slave statuses. When this option is enabled, the donor is treated as\
-if it was a normal member of the cluster (i.e. `wsrep_local_state = 4`). This is\
-especially useful if the cluster drops down to one node and an SST is required\
+Master or Slave statuses. When this option is enabled, the donor is treated as
+if it was a normal member of the cluster (i.e. `wsrep_local_state = 4`). This is
+especially useful if the cluster drops down to one node and an SST is required
 to increase the cluster size.
 
-The current list of non-blocking SST\
-methods are `xtrabackup`, `xtrabackup-v2` and `mariadb-backup`. Read the [wsrep\_sst\_method](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables)\
+The current list of non-blocking SST
+methods are `xtrabackup`, `xtrabackup-v2` and `mariadb-backup`. Read the [wsrep\_sst\_method](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables)
 documentation for more details.
 
 #### `disable_master_role_setting`
@@ -119,8 +119,8 @@ documentation for more details.
 * Default: false
 * Dynamic: Yes
 
-This disables the assignment of master and slave roles to the Galera cluster\
-nodes. If this option is enabled, Synced is the only status assigned by this\
+This disables the assignment of master and slave roles to the Galera cluster
+nodes. If this option is enabled, Synced is the only status assigned by this
 monitor.
 
 #### `use_priority`
@@ -129,8 +129,8 @@ monitor.
 * Default: false
 * Dynamic: Yes
 
-Enable interaction with server priorities. This will allow the monitor to\
-deterministically pick the write node for the monitored Galera cluster and will\
+Enable interaction with server priorities. This will allow the monitor to
+deterministically pick the write node for the monitored Galera cluster and will
 allow for controlled node replacement.
 
 #### `root_node_as_master`
@@ -139,27 +139,27 @@ allow for controlled node replacement.
 * Default: false
 * Dynamic: Yes
 
-This option controls whether the write master Galera node requires a_wsrep\_local\_index_ value of 0. This option was introduced in MaxScale 2.1.0 and\
-it is disabled by default in versions 2.1.5 and newer. In versions 2.1.4 and\
+This option controls whether the write master Galera node requires a_wsrep\_local\_index_ value of 0. This option was introduced in MaxScale 2.1.0 and
+it is disabled by default in versions 2.1.5 and newer. In versions 2.1.4 and
 older, the option was enabled by default.
 
-A Galera cluster will always have a node which has a _wsrep\_local\_index_ value\
-of 0. Based on this information, multiple MaxScale instances can always pick the\
+A Galera cluster will always have a node which has a _wsrep\_local\_index_ value
+of 0. Based on this information, multiple MaxScale instances can always pick the
 same node for writes.
 
 If the `root_node_as_master` option is disabled for galeramon, the node with the\
 lowest index will always be chosen as the master. If it is enabled, only the\
 node with a _wsrep\_local\_index_ value of 0 can be chosen as the master.
 
-This parameter can work with `disable_master_failback` but using them together\
-is not advisable: the intention of `root_node_as_master` is to make sure that\
-all MaxScale instances that are configured to use the same Galera cluster will\
-send writes to the same node. If `disable_master_failback` is enabled, this is\
-no longer true if the Galera cluster reorganizes itself in a way that a\
-different node gets the node index 0, writes would still be going to the old\
-node that previously had the node index 0. A restart of one of the MaxScales or\
-a new MaxScale joining the cluster will cause writes to be sent to the wrong\
-node, thus resulting in an increasing the rate of deadlock errors and\
+This parameter can work with `disable_master_failback` but using them together
+is not advisable: the intention of `root_node_as_master` is to make sure that
+all MaxScale instances that are configured to use the same Galera cluster will
+send writes to the same node. If `disable_master_failback` is enabled, this is
+no longer true if the Galera cluster reorganizes itself in a way that a
+different node gets the node index 0, writes would still be going to the old
+node that previously had the node index 0. A restart of one of the MaxScales or
+a new MaxScale joining the cluster will cause writes to be sent to the wrong
+node, thus resulting in an increasing the rate of deadlock errors and
 sub-optimal performance.
 
 #### `set_donor_nodes`
@@ -168,12 +168,12 @@ sub-optimal performance.
 * Default: false
 * Dynamic: Yes
 
-This option controls whether the global variable _wsrep\_sst\_donor_ should be set\
+This option controls whether the global variable _wsrep\_sst\_donor_ should be set
 in each cluster node with _slave' status_.\
-The variable contains a list of slave servers, automatically sorted, with\
+The variable contains a list of slave servers, automatically sorted, with
 possible master candidates at its end.
 
-The sorting is based either on _wsrep\_local\_index_ or node server _priority_\
+The sorting is based either on _wsrep\_local\_index_ or node server _priority_
 depending on the value of _use\_priority_ option.\
 If no server has _priority_ defined the sorting switches to _wsrep\_local\_index_.\
 Node names are collected by fetching the result of the variable _wsrep\_node\_name_.
@@ -185,24 +185,24 @@ SET GLOBAL wsrep_sst_donor = "galera001,galera000"
 ```
 
 **Note**:\
-in order to set the global variable _wsrep\_sst\_donor_, proper privileges are\
+in order to set the global variable _wsrep\_sst\_donor_, proper privileges are
 required for the monitor user that connects to cluster nodes.\
 This option is disabled by default and was introduced in MaxScale 2.1.0.
 
 ### Interaction with Server Priorities
 
-If the `use_priority` option is set and a server is configured with the`priority=<int>` parameter, galeramon will use that as the basis on which the\
-master node is chosen. This requires the `disable_master_role_setting` to be\
-undefined or disabled. The server with the lowest positive value of _priority_\
-will be chosen as the master node when a replacement Galera node is promoted to\
-a master server inside MaxScale. If all candidate servers have the same\
-priority, the order of the servers in the `servers` parameter dictates which is\
+If the `use_priority` option is set and a server is configured with the`priority=<int>` parameter, galeramon will use that as the basis on which the
+master node is chosen. This requires the `disable_master_role_setting` to be
+undefined or disabled. The server with the lowest positive value of _priority_
+will be chosen as the master node when a replacement Galera node is promoted to
+a master server inside MaxScale. If all candidate servers have the same
+priority, the order of the servers in the `servers` parameter dictates which is
 chosen as the master.
 
-Nodes with a negative value (_priority_ < 0) will never be chosen as the\
-master. This allows you to mark some servers as permanent slaves by assigning a\
-non-positive value into _priority_. Nodes with the default priority of 0 are\
-only selected if no nodes with higher priority are present and the normal node\
+Nodes with a negative value (_priority_ < 0) will never be chosen as the
+master. This allows you to mark some servers as permanent slaves by assigning a
+non-positive value into _priority_. Nodes with the default priority of 0 are
+only selected if no nodes with higher priority are present and the normal node
 selection rules apply to them (i.e. selection is based on `wsrep_local_index`).
 
 Here is an example.
@@ -233,13 +233,13 @@ port=3306
 priority=-1
 ```
 
-In this example `node-1` is always used as the master if available. If `node-1`\
-is not available, then the next node with the highest priority rank is used. In\
-this case it would be `node-3`. If both `node-1` and `node-3` were down, then`node-2` would be used. Because `node-4` has a value of -1 in _priority_, it\
-will never be the master. Nodes without _priority_ parameter are considered as\
+In this example `node-1` is always used as the master if available. If `node-1`
+is not available, then the next node with the highest priority rank is used. In
+this case it would be `node-3`. If both `node-1` and `node-3` were down, then`node-2` would be used. Because `node-4` has a value of -1 in _priority_, it
+will never be the master. Nodes without _priority_ parameter are considered as
 having a priority of 0 and will be used only if all nodes with a positive_priority_ value are not available.
 
-With priority ranks you can control the order in which MaxScale chooses the\
+With priority ranks you can control the order in which MaxScale chooses the
 master node. This will allow for a controlled failure and replacement of nodes.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-MariaDB Monitor monitors a Master-Slave replication cluster. It probes the\
-state of the backends and assigns server roles such as master and slave, which\
-are used by the routers when deciding where to route a query. It can also modify\
-the replication cluster by performing failover, switchover and rejoin. Backend\
-server versions older than MariaDB/MySQL 5.5 are not supported. Failover and\
+MariaDB Monitor monitors a Master-Slave replication cluster. It probes the
+state of the backends and assigns server roles such as master and slave, which
+are used by the routers when deciding where to route a query. It can also modify
+the replication cluster by performing failover, switchover and rejoin. Backend
+server versions older than MariaDB/MySQL 5.5 are not supported. Failover and
 other similar operations require MariaDB 10.0.2 or later.
 
 Up until MariaDB MaxScale 2.2.0, this monitor was called _MySQL Monitor_.
@@ -41,7 +41,7 @@ set), then the FILE-grant is required with MariaDB Server versions 10.4.7,\
 GRANT FILE ON *.* TO 'maxscale'@'maxscalehost';
 ```
 
-MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it\
+MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it
 allows the monitor to log in even if server connection limit has been reached.
 
 ```
@@ -50,7 +50,7 @@ GRANT CONNECTION ADMIN ON *.* TO 'maxscale'@'maxscalehost';
 
 #### Cluster Manipulation Grants
 
-If [cluster manipulation operations](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cluster-manipulation-operations) are used,\
+If [cluster manipulation operations](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cluster-manipulation-operations) are used,
 the following additional grants are required:
 
 ```
@@ -58,7 +58,7 @@ GRANT SUPER, RELOAD, PROCESS, SHOW DATABASES, EVENT ON *.* TO 'maxscale'@'maxsca
 GRANT SELECT ON mysql.user TO 'maxscale'@'maxscalehost';
 ```
 
-As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of\
+As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of
 its former sub-privileges. These must be given separately.
 
 ```
@@ -76,59 +76,59 @@ GRANT REPLICATION SLAVE ON *.* TO 'replication'@'replicationhost';
 
 ### Master selection
 
-Only one backend can be master at any given time. A master must be running\
-(successfully connected to by the monitor) and its _read\_only_-setting must be\
-off. A master may not be replicating from another server in the monitored\
-cluster unless the master is part of a multimaster group. Master selection\
-prefers to select the server with the most slaves, possibly in multiple\
-replication layers. Only slaves reachable by a chain of running relays or\
-directly connected to the master count. When multiple servers are tied for\
-master status, the server which appears earlier in the `servers`-setting of the\
+Only one backend can be master at any given time. A master must be running
+(successfully connected to by the monitor) and its _read\_only_-setting must be
+off. A master may not be replicating from another server in the monitored
+cluster unless the master is part of a multimaster group. Master selection
+prefers to select the server with the most slaves, possibly in multiple
+replication layers. Only slaves reachable by a chain of running relays or
+directly connected to the master count. When multiple servers are tied for
+master status, the server which appears earlier in the `servers`-setting of the
 monitor is selected.
 
-Servers in a cyclical replication topology (multimaster group) are interpreted\
-as having all the servers in the group as slaves. Even from a multimaster group\
+Servers in a cyclical replication topology (multimaster group) are interpreted
+as having all the servers in the group as slaves. Even from a multimaster group
 only one server is selected as the overall master.
 
-After a master has been selected, the monitor prefers to stick with the choice\
-even if other potential masters with more slave servers are available. Only if\
-the current master is clearly unsuitable does the monitor try to select another\
+After a master has been selected, the monitor prefers to stick with the choice
+even if other potential masters with more slave servers are available. Only if
+the current master is clearly unsuitable does the monitor try to select another
 master. An existing master turns invalid if:
 
 1. It is unwritable (read\_only is on).
-2. It has been down for more than failcount monitor passes and has no running\
-   slaves. Running slaves behind a downed relay count. A slave in this context is\
-   any server with at least a partially running replication connection (either\
-   io or sql thread is running). The slave servers must also be down for more than\
+2. It has been down for more than failcount monitor passes and has no running
+   slaves. Running slaves behind a downed relay count. A slave in this context is
+   any server with at least a partially running replication connection (either
+   io or sql thread is running). The slave servers must also be down for more than
    failcount monitor passes to allow new master selection.
-3. It did not previously replicate from another server in the cluster but it\
+3. It did not previously replicate from another server in the cluster but it
    is now replicating.
-4. It was previously part of a multimaster group but is no longer, or the\
+4. It was previously part of a multimaster group but is no longer, or the
    multimaster group is replicating from a server not in the group.
 
-Cases 1 and 2 cover the situations in which the DBA, an external script or even\
-another MaxScale has modified the cluster such that the old master can no longer\
-act as master. Cases 3 and 4 are less severe. In these cases the topology has\
-changed significantly and the master should be re-selected, although the old\
+Cases 1 and 2 cover the situations in which the DBA, an external script or even
+another MaxScale has modified the cluster such that the old master can no longer
+act as master. Cases 3 and 4 are less severe. In these cases the topology has
+changed significantly and the master should be re-selected, although the old
 master may still be the best choice.
 
-The master change described above is different from failover and switchover\
+The master change described above is different from failover and switchover
 described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
-A master change only modifies the server roles inside MaxScale but does not\
+A master change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a master change on their own.
 
-As a general rule, it's best to avoid situations where the cluster has multiple\
+As a general rule, it's best to avoid situations where the cluster has multiple
 standalone servers, separate master-slave pairs or separate multimaster groups.\
-Due to master invalidation rule 2, a standalone master can easily lose the\
-master status to another valid master if it goes down. The new master probably\
-does not have the same data as the previous one. Non-standalone masters are less\
-vulnerable, as a single running slave or multimaster group member will keep the\
+Due to master invalidation rule 2, a standalone master can easily lose the
+master status to another valid master if it goes down. The new master probably
+does not have the same data as the previous one. Non-standalone masters are less
+vulnerable, as a single running slave or multimaster group member will keep the
 master valid even when down.
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers.
 
 ```
@@ -142,8 +142,8 @@ password=mypwd
 
 From MaxScale 2.2.1 onwards, the module name is `mariadbmon` instead of`mysqlmon`. The old name can still be used.
 
-The grants required by `user` depend on which monitor features are used. A full\
-list of the grants can be found in the [Required Grants](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#required-grants)\
+The grants required by `user` depend on which monitor features are used. A full
+list of the grants can be found in the [Required Grants](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#required-grants)
 section.
 
 ### Common Monitor Parameters
@@ -152,7 +152,7 @@ For a list of optional parameters that all monitors support, read the [Monitor C
 
 ### MariaDB Monitor optional parameters
 
-These are optional parameters specific to the MariaDB Monitor. Failover,\
+These are optional parameters specific to the MariaDB Monitor. Failover,
 switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cluster-manipulation-operations).
 
 #### `assume_unique_hostnames`
@@ -162,31 +162,31 @@ switchover and rejoin-specific parameters are listed in their own [section](mari
 * Dynamic: Yes
 * Default: `true`
 
-When active, the monitor assumes that server hostnames and\
-ports are consistent between the server definitions in the MaxScale\
-configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers\
-themselves. Specifically, the monitor assumes that if server A is replicating\
-from server B, then A must have a slave connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this\
-is not the case, e.g. an IP is used in the server while a hostname is given in\
-the file, the monitor may misinterpret the topology. In MaxScale 2.4.1, the\
-monitor attempts name resolution on the addresses if a simple string comparison\
-does not find a match. Using exact matching addresses is, however, more\
+When active, the monitor assumes that server hostnames and
+ports are consistent between the server definitions in the MaxScale
+configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers
+themselves. Specifically, the monitor assumes that if server A is replicating
+from server B, then A must have a slave connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this
+is not the case, e.g. an IP is used in the server while a hostname is given in
+the file, the monitor may misinterpret the topology. In MaxScale 2.4.1, the
+monitor attempts name resolution on the addresses if a simple string comparison
+does not find a match. Using exact matching addresses is, however, more
 reliable.
 
-This setting must be ON to use any cluster operation features such as failover\
-or switchover, because MaxScale uses the addresses and ports in the\
+This setting must be ON to use any cluster operation features such as failover
+or switchover, because MaxScale uses the addresses and ports in the
 configuration file when issuing "CHANGE MASTER TO"-commands.
 
-If the network configuration is such that the addresses MaxScale uses to connect\
-to backends are different from the ones the servers use to connect to each\
-other, `assume_unique_hostnames` should be set to OFF. In this mode, MaxScale\
-uses server id:s it queries from the servers and the `Master_Server_Id` fields\
-of the slave connections to deduce which server is replicating from which. This\
-is not perfect though, since MaxScale doesn't know the id:s of servers it has\
-never connected to (e.g. server has been down since MaxScale was started). Also,\
-the `Master_Server_Id`-field may have an incorrect value if the slave connection\
-has not been established. MaxScale will only trust the value if the monitor has\
-seen the slave connection IO thread connected at least once. If this is not the\
+If the network configuration is such that the addresses MaxScale uses to connect
+to backends are different from the ones the servers use to connect to each
+other, `assume_unique_hostnames` should be set to OFF. In this mode, MaxScale
+uses server id:s it queries from the servers and the `Master_Server_Id` fields
+of the slave connections to deduce which server is replicating from which. This
+is not perfect though, since MaxScale doesn't know the id:s of servers it has
+never connected to (e.g. server has been down since MaxScale was started). Also,
+the `Master_Server_Id`-field may have an incorrect value if the slave connection
+has not been established. MaxScale will only trust the value if the monitor has
+seen the slave connection IO thread connected at least once. If this is not the
 case, the slave connection is ignored.
 
 #### `detect_stale_master`
@@ -196,7 +196,7 @@ case, the slave connection is ignored.
 * Dynamic: Yes
 * Default: `true`
 
-Deprecated. If set to OFF, _running\_slave_ is added to [master\_conditions](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#master_conditions). Both settings may not be defined\
+Deprecated. If set to OFF, _running\_slave_ is added to [master\_conditions](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#master_conditions). Both settings may not be defined
 simultaneously.
 
 #### `detect_stale_slave`
@@ -206,7 +206,7 @@ simultaneously.
 * Dynamic: Yes
 * Default: `true`
 
-Deprecated. If set to OFF, _linked\_master_ is added to [slave\_conditions](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#slave_conditions). Both settings may not be defined\
+Deprecated. If set to OFF, _linked\_master_ is added to [slave\_conditions](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#slave_conditions). Both settings may not be defined
 simultaneously.
 
 #### `detect_standalone_master`
@@ -216,7 +216,7 @@ simultaneously.
 * Dynamic: Yes
 * Default: `true`
 
-Deprecated. If set to OFF, _connecting\_slave_ is added to [master\_conditions](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#master_conditions). Both settings may not be defined\
+Deprecated. If set to OFF, _connecting\_slave_ is added to [master\_conditions](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#master_conditions). Both settings may not be defined
 simultaneously.
 
 #### `master_conditions`
@@ -229,9 +229,9 @@ simultaneously.
 
 Designate additional conditions for\_Master\_-status, i.e qualified for read and write queries.
 
-Normally, if a suitable master candidate server is found as described in [Master selection](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#master-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a master server. This\
+Normally, if a suitable master candidate server is found as described in [Master selection](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#master-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a master server. This
 setting is an enum\_mask, allowing multiple conditions to be set simultaneously.\
-Conditions 2, 3 and 4 refer to slave servers. If combined, a single slave must\
+Conditions 2, 3 and 4 refer to slave servers. If combined, a single slave must
 fulfill all of the given conditions for the master to be viable.
 
 If the master candidate fails _master\_conditions_ but fulfills\_slave\_conditions\_, it may be designated _Slave_ instead.
@@ -239,24 +239,24 @@ If the master candidate fails _master\_conditions_ but fulfills\_slave\_conditio
 The available conditions are:
 
 1. none : No additional conditions
-2. connecting\_slave : At least one immediate slave (not behind relay) is\
+2. connecting\_slave : At least one immediate slave (not behind relay) is
    attempting to replicate or is replicating from the master (Slave\_IO\_Running is\
-   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A slave with incorrect\
-   replication credentials does not count. If the slave is currently down, results\
+   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A slave with incorrect
+   replication credentials does not count. If the slave is currently down, results
    from the last successful monitor tick are used.
-3. connected\_slave : Same as above, with the difference that the replication\
-   connection must be up (Slave\_IO\_Running is 'Yes'). If the slave is currently\
+3. connected\_slave : Same as above, with the difference that the replication
+   connection must be up (Slave\_IO\_Running is 'Yes'). If the slave is currently
    down, results from the last successful monitor tick are used.
-4. running\_slave : Same as connecting\_slave, with the addition that the\
+4. running\_slave : Same as connecting\_slave, with the addition that the
    slave must also be Running.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate master is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate master is selected also by the
    primary MaxScale.
 
-The default value of this setting is`master_requirements=primary_monitor_master` to ensure that both monitors use\
+The default value of this setting is`master_requirements=primary_monitor_master` to ensure that both monitors use
 the same master server when cooperating.
 
-For example, to require that the master must have a slave which is both\
+For example, to require that the master must have a slave which is both
 connected and running, set
 
 ```
@@ -271,29 +271,29 @@ master_conditions=connected_slave,running_slave
 * Values: `none`, `linked_master`, `running_master`, `writable_master`, `primary_monitor_master`
 * Default: `none`
 
-Designate additional conditions for _Slave_-status,\
+Designate additional conditions for _Slave_-status,
 i.e qualified for read queries.
 
-Normally, a server is _Slave_ if it is at least attempting to replicate from the\
+Normally, a server is _Slave_ if it is at least attempting to replicate from the
 master candidate or a relay (Slave\_IO\_Running is 'Yes' or 'Connecting',\
-Slave\_SQL\_Running is 'Yes', valid replication credentials). The master candidate\
-does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a slave\
-server. This setting is an enum\_mask, allowing multiple conditions to be set\
+Slave\_SQL\_Running is 'Yes', valid replication credentials). The master candidate
+does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a slave
+server. This setting is an enum\_mask, allowing multiple conditions to be set
 simultaneously.
 
 The available conditions are:
 
 1. none : No additional conditions. This is the default value.
-2. linked\_master : The slave must be connected to the master (Slave\_IO\_Running\
-   and Slave\_SQL\_Running are 'Yes') and the master must be Running. The same\
+2. linked\_master : The slave must be connected to the master (Slave\_IO\_Running
+   and Slave\_SQL\_Running are 'Yes') and the master must be Running. The same
    applies to any relays between the slave and the master.
 3. running\_master : The master must be running. Relays may be down.
 4. writable\_master : The master must be writable, i.e. labeled Master.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate master is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate master is selected also by the
    primary MaxScale.
 
-For example, to require that the master server of the cluster must be running\
+For example, to require that the master server of the cluster must be running
 and writable for any servers to have _Slave_-status, set
 
 ```
@@ -307,10 +307,10 @@ slave_conditions=running_master,writable_master
 * Dynamic: Yes
 * Default: `false`
 
-Deprecated. Ignore any servers that are not monitored by\
+Deprecated. Ignore any servers that are not monitored by
 this monitor but are a part of the replication topology.
 
-An external server is a server not monitored by this monitor. If a server is\
+An external server is a server not monitored by this monitor. If a server is
 replicating from an external server, it typically gains the _Slave of External Server_-status. If this setting is enabled, the status is not set.
 
 #### `failcount`
@@ -320,8 +320,8 @@ replicating from an external server, it typically gains the _Slave of External S
 * Dynamic: Yes
 * Default: `5`
 
-Number of consecutive monitor passes a master server must be down before it is\
-considered failed. If automatic failover is enabled (`auto_failover=true`), it\
+Number of consecutive monitor passes a master server must be down before it is
+considered failed. If automatic failover is enabled (`auto_failover=true`), it
 may be performed at this time. A value of 0 or 1 enables immediate failover.
 
 If automatic failover is not possible, the monitor will try to\
@@ -330,8 +330,8 @@ for more details. Changing the master may break replication as queries could be\
 routed to a server without previous events. To prevent this, avoid having\
 multiple valid master servers in the cluster.
 
-The worst-case delay between the master failure and the start of the failover\
-can be estimated by summing up the timeout values and `monitor_interval` and\
+The worst-case delay between the master failure and the start of the failover
+can be estimated by summing up the timeout values and `monitor_interval` and
 multiplying that by `failcount`:
 
 ```
@@ -345,19 +345,19 @@ multiplying that by `failcount`:
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-disable the _read\_only_-flag on the master when seen. The flag is\
-checked every monitor tick. The monitor user requires the SUPER-privilege for\
+If set to ON, the monitor attempts to
+disable the _read\_only_-flag on the master when seen. The flag is
+checked every monitor tick. The monitor user requires the SUPER-privilege for
 this feature to work.
 
-Typically, the master server should never be in read-only-mode. Such a situation\
-may arise due to misconfiguration or accident, or perhaps if MaxScale crashed\
+Typically, the master server should never be in read-only-mode. Such a situation
+may arise due to misconfiguration or accident, or perhaps if MaxScale crashed
 during switchover.
 
-When this feature is enabled, setting the master manually to _read\_only_ will no\
-longer cause the monitor to search for another master. The master will instead\
-for a moment lose its \[Master]-status (no writes), until the monitor again\
-enables writes on the master. When starting from scratch, the monitor still\
+When this feature is enabled, setting the master manually to _read\_only_ will no
+longer cause the monitor to search for another master. The master will instead
+for a moment lose its \[Master]-status (no writes), until the monitor again
+enables writes on the master. When starting from scratch, the monitor still
 prefers to select a writable server as master if possible.
 
 #### `enforce_read_only_slaves`
@@ -367,18 +367,18 @@ prefers to select a writable server as master if possible.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-enable the _read\_only_-flag on any writable slave server. The flag is checked\
-every monitor tick. The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this\
+If set to ON, the monitor attempts to
+enable the _read\_only_-flag on any writable slave server. The flag is checked
+every monitor tick. The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this
 feature to work. While the _read\_only_-flag is ON, only users with the\
-SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If\
-temporary write access is required, this feature should be disabled before\
-attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly\
+SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If
+temporary write access is required, this feature should be disabled before
+attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly
 re-enable it.
 
-_read\_only_ won't be enabled on the master server, even if it has\
-lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#master_conditions) and is\
+_read\_only_ won't be enabled on the master server, even if it has
+lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#master_conditions) and is
 marked \[Slave].
 
 #### `enforce_read_only_servers`
@@ -388,12 +388,12 @@ marked \[Slave].
 * Dynamic: Yes
 * Default: `false`
 
-Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in\
+Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in
 maintenance (a superset of the servers altered by _enforce\_read\_only\_slaves_).
 
-The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid\
-primary or primary candidate, _read\_only_ is not set on any server as it is\
+The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid
+primary or primary candidate, _read\_only_ is not set on any server as it is
 unclear which servers should be altered.
 
 #### `maintenance_on_low_disk_space`
@@ -403,16 +403,16 @@ unclear which servers should be altered.
 * Dynamic: Yes
 * Default: `true`
 
-If a running server that is not the master\
+If a running server that is not the master
 or a relay master is out of disk space the server is set to maintenance mode.\
-Such servers are not used for router sessions and are ignored when performing a\
-failover or other cluster modification operation. See the general monitor\
-parameters [disk\_space\_threshold](mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md) and [disk\_space\_check\_interval](mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md)\
+Such servers are not used for router sessions and are ignored when performing a
+failover or other cluster modification operation. See the general monitor
+parameters [disk\_space\_threshold](mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md) and [disk\_space\_check\_interval](mariadb-maxscale-2106-maxscale-2106-common-monitor-parameters.md)
 on how to enable disk space monitoring.
 
-Once a server has been put to maintenance mode, the disk space situation\
-of that server is no longer updated. The server will not be taken out of\
-maintenance mode even if more disk space becomes available. The maintenance\
+Once a server has been put to maintenance mode, the disk space situation
+of that server is no longer updated. The server will not be taken out of
+maintenance mode even if more disk space becomes available. The maintenance
 flag must be removed manually:
 
 ```
@@ -427,22 +427,22 @@ maxctrl clear server server2 Maint
 * Values: `none`, `majority_of_all`, `majority_of_running`
 * Default: `none`
 
-Using this setting is recommended when multiple MaxScales are monitoring the\
-same backend cluster. When enabled, the monitor attempts to acquire exclusive\
-locks on the backend servers. The monitor considers itself the primary monitor\
-if it has a majority of locks. The majority can be either over all configured\
-servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cooperative-monitoring)\
+Using this setting is recommended when multiple MaxScales are monitoring the
+same backend cluster. When enabled, the monitor attempts to acquire exclusive
+locks on the backend servers. The monitor considers itself the primary monitor
+if it has a majority of locks. The majority can be either over all configured
+servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cooperative-monitoring)
 for more details on how this feature works and which value to use.
 
 Allowed values:
 
 1. `none` Default value, no locking.
-2. `majority_of_all` Primary monitor requires a majority of locks, even counting\
+2. `majority_of_all` Primary monitor requires a majority of locks, even counting
    servers which are \[Down].
 3. `majority_of_running` Primary monitor requires a majority of locks over\
    \[Running] servers.
 
-This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has\
+This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has
 acquired the locks. Generally, it's best not to mix cooperative monitoring with\_passive\_. Either set `passive=false` or do not set it at all.
 
 #### `script_max_replication_lag`
@@ -452,55 +452,55 @@ acquired the locks. Generally, it's best not to mix cooperative monitoring with\
 * Dynamic: Yes
 * Default: `-1`
 
-Defines a replication lag limit in seconds for\
-launching the monitor script configured in the _script_-parameter. If the\
+Defines a replication lag limit in seconds for
+launching the monitor script configured in the _script_-parameter. If the
 replication lag of a server goes above this limit, the script is ran with the\
-$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the\
+$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
-Negative values disable this feature. For more information on monitor scripts,\
+Negative values disable this feature. For more information on monitor scripts,
 see [general monitor documentation](https://mariadb.com/kb/en/node:maxscale-21-06-common-monitor-parameters#script).
 
 ### Cluster manipulation operations
 
-Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster\
+Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster
 modification. The operations implemented are:
 
 * _failover_, which replaces a failed master with a slave
 * _switchover_, which swaps a running master with a slave
 * _async-switchover_, which schedules a switchover and returns
 * _rejoin_, which directs servers to replicate from the master
-* _reset-replication_ (added in MaxScale 2.3.0), which deletes binary logs and\
+* _reset-replication_ (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
-See [operation details](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#operation-details) for more information on the\
+See [operation details](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#operation-details) for more information on the
 implementation of the commands.
 
-The cluster operations require that the monitor user (`user`) has the following\
+The cluster operations require that the monitor user (`user`) has the following
 privileges:
 
-* SUPER, to modify slave connections, set globals such as read\_only and kill\
+* SUPER, to modify slave connections, set globals such as read\_only and kill
   connections from other super-users
-* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list\
+* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list
   slave connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
 * SHOW DATABASES and EVENT, to list and modify server events
 * SELECT on mysql.user, to see which users have SUPER
 
-A list of the grants can be found in the [Required Grants](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#required-grants)\
+A list of the grants can be found in the [Required Grants](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#required-grants)
 section.
 
-The privilege system was changed in MariaDB Server 10.5. The effects of this on\
-the MaxScale monitor user are minor, as the SUPER-privilege contains many of the\
-required privileges and is still required to kill connections from other\
+The privilege system was changed in MariaDB Server 10.5. The effects of this on
+the MaxScale monitor user are minor, as the SUPER-privilege contains many of the
+required privileges and is still required to kill connections from other
 super-users.
 
-In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required\
+In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required
 grants. The monitor requires:
 
 * READ\_ONLY ADMIN, to set read\_only
-* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication\
+* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication
   connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
@@ -509,39 +509,39 @@ grants. The monitor requires:
 * CONNECTION ADMIN, to kill connections
 * SELECT on mysql.user, to see which users have SUPER
 
-In addition, the monitor needs to know which username and password a\
+In addition, the monitor needs to know which username and password a
 slave should use when starting replication. These are given in`replication_user` and `replication_password`.
 
-The user can define files with SQL statements which are executed on any server\
+The user can define files with SQL statements which are executed on any server
 being demoted or promoted by cluster manipulation commands. See the sections on`promotion_sql_file` and `demotion_sql_file` for more information.
 
-The monitor can manipulate scheduled server events when promoting or demoting a\
+The monitor can manipulate scheduled server events when promoting or demoting a
 server. See the section on `handle_events` for more information.
 
-All cluster operations can be activated manually through MaxCtrl. See\
+All cluster operations can be activated manually through MaxCtrl. See
 section [Manual activation](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#manual-activation) for more details.
 
-See [Limitations and requirements](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#limitations-and-requirements) for\
+See [Limitations and requirements](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#limitations-and-requirements) for
 information on possible issues with failover and switchover.
 
 #### Operation details
 
-**Failover** replaces a failed master with a running slave. It does the\
+**Failover** replaces a failed master with a running slave. It does the
 following:
 
-1. Select the most up-to-date slave of the old master to be the new master. The\
+1. Select the most up-to-date slave of the old master to be the new master. The
    selection criteria is as follows in descending priority:
 2. gtid\_IO\_pos (latest event in relay log)
 3. gtid\_current\_pos (most processed events)
 4. log\_slave\_updates is on
 5. disk space is not low
-6. If the new master has unprocessed relay log items, cancel and try again\
+6. If the new master has unprocessed relay log items, cancel and try again
    later.
 7. Prepare the new master:
-8. Remove the slave connection the new master used to replicate from the\
+8. Remove the slave connection the new master used to replicate from the
    old master.
 9. Disable the read\_only-flag.
-10. Enable scheduled server events (if event handling is on). Only events\
+10. Enable scheduled server events (if event handling is on). Only events
     that were enabled on the old master are enabled.
 11. Run the commands in `promotion_sql_file`.
 12. Start replication from external master if one existed.
@@ -551,30 +551,30 @@ following:
 16. START SLAVE
 17. Check that all slaves are replicating.
 
-Failover is considered successful if steps 1 to 3 succeed, as the cluster then\
+Failover is considered successful if steps 1 to 3 succeed, as the cluster then
 has at least a valid master server.
 
-**Switchover** swaps a running master with a running slave. It does the\
+**Switchover** swaps a running master with a running slave. It does the
 following:
 
 1. Prepare the old master for demotion:
 2. Stop any external replication.
-3. Kill connections from super-users since read\_only does not affect\
+3. Kill connections from super-users since read\_only does not affect
    them.
 4. Enable the read\_only-flag to stop writes.
 5. Disable scheduled server events (if event handling is on).
 6. Run the commands in `demotion_sql_file`.
 7. Flush the binary log (FLUSH LOGS) so that all events are on disk.
 8. Wait for the new master to catch up with the old master.
-9. Promote new master and redirect slaves as in failover steps 3 and 4. Also\
+9. Promote new master and redirect slaves as in failover steps 3 and 4. Also
    redirect the demoted old master.
 10. Check that all slaves are replicating.
 
-Similar to failover, switchover is considered successful if the new master was\
+Similar to failover, switchover is considered successful if the new master was
 successfully promoted.
 
-**Rejoin** joins a standalone server to the cluster or redirects a slave\
-replicating from a server other than the master. A standalone server is joined\
+**Rejoin** joins a standalone server to the cluster or redirects a slave
+replicating from a server other than the master. A standalone server is joined
 by:
 
 1. Run the commands in `demotion_sql_file`.
@@ -585,9 +585,9 @@ by:
 A server which is replicating from the wrong master is redirected simply with\
 STOP SLAVE, RESET SLAVE, CHANGE MASTER TO and START SLAVE commands.
 
-**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets\
-gtid:s. This destructive command is meant for situations where the gtid:s in the\
-cluster are out of sync while the actual data is known to be in sync. The\
+**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets
+gtid:s. This destructive command is meant for situations where the gtid:s in the
+cluster are out of sync while the actual data is known to be in sync. The
 operation proceeds as follows:
 
 1. Reset gtid:s and delete binary logs on all servers:
@@ -595,38 +595,38 @@ operation proceeds as follows:
 3. Enable the read\_only-flag.
 4. Disable scheduled server events (if event handling is on).
 5. Delete binary logs (RESET MASTER).
-6. Set the sequence number of gtid\_slave\_pos to zero. This also affects\
+6. Set the sequence number of gtid\_slave\_pos to zero. This also affects
    gtid\_current\_pos.
 7. Prepare new master:
 8. Disable the read\_only-flag.
-9. Enable scheduled server events (if event handling is on). Events are\
-   only enabled if the cluster had a master server when starting the\
-   reset-replication operation. Only events that were enabled on the previous\
+9. Enable scheduled server events (if event handling is on). Events are
+   only enabled if the cluster had a master server when starting the
+   reset-replication operation. Only events that were enabled on the previous
    master are enabled on the new.
-10. Direct other servers to replicate from the new master as in the other\
+10. Direct other servers to replicate from the new master as in the other
     operations.
 
 #### Manual activation
 
 Cluster operations can be activated manually through the REST API or MaxCtrl.\
-The commands are only performed when MaxScale is in active mode. The commands\
-generally match their automatic versions. The exception is _rejoin_, in which\
-the manual command allows rejoining even when the joining server has empty\
-gtid:s. This rule allows the user to force a rejoin on a server without binary\
+The commands are only performed when MaxScale is in active mode. The commands
+generally match their automatic versions. The exception is _rejoin_, in which
+the manual command allows rejoining even when the joining server has empty
+gtid:s. This rule allows the user to force a rejoin on a server without binary
 logs.
 
-All commands require the monitor instance name as the first parameter. Failover\
-selects the new master server automatically and does not require additional\
+All commands require the monitor instance name as the first parameter. Failover
+selects the new master server automatically and does not require additional
 parameters. Rejoin requires the name of the joining server as second parameter.\
 Replication reset accepts the name of the new master server as second parameter.\
 If not given, the current master is selected.
 
-Switchover takes one to three parameters. If only the monitor name is given,\
-switchover will autoselect both the slave to promote and the current master as\
-the server to be demoted. If two parameters are given, the second parameter is\
-interpreted as the slave to promote. If three parameters are given, the third\
-parameter is interpreted as the current master. The user-given current master is\
-compared to the master server currently deduced by the monitor and if the two\
+Switchover takes one to three parameters. If only the monitor name is given,
+switchover will autoselect both the slave to promote and the current master as
+the server to be demoted. If two parameters are given, the second parameter is
+interpreted as the slave to promote. If three parameters are given, the third
+parameter is interpreted as the current master. The user-given current master is
+compared to the master server currently deduced by the monitor and if the two
 are unequal, an error is given.
 
 Example commands are below:
@@ -641,29 +641,29 @@ call command mariadbmon switchover MyMonitor NewMasterServ
 call command mariadbmon switchover MyMonitor NewMasterServ OldMasterServ
 ```
 
-The commands follow the standard module command syntax. All require the monitor\
-configuration name (MyMonitor) as the first parameter. For switchover, the\
-last two parameters define the server to promote (NewMasterServ) and the server\
-to demote (OldMasterServ). For rejoin, the server to join (OldMasterServ) is\
+The commands follow the standard module command syntax. All require the monitor
+configuration name (MyMonitor) as the first parameter. For switchover, the
+last two parameters define the server to promote (NewMasterServ) and the server
+to demote (OldMasterServ). For rejoin, the server to join (OldMasterServ) is
 required. Replication reset requires the server to promote (NewMasterServ).
 
-It is safe to perform manual operations even with automatic failover, switchover\
-or rejoin enabled since automatic operations cannot happen simultaneously\
+It is safe to perform manual operations even with automatic failover, switchover
+or rejoin enabled since automatic operations cannot happen simultaneously
 with manual ones.
 
-When a cluster modification is initiated via the REST-API, the URL path is of the\
+When a cluster modification is initiated via the REST-API, the URL path is of the
 form:
 
 ```
 /v1/maxscale/modules/mariadbmon/<operation>?<monitor-instance>&<server-param1>&<server-param2>
 ```
 
-* `<operation>` is the name of the command: failover, switchover, rejoin\
+* `<operation>` is the name of the command: failover, switchover, rejoin
   or reset-replication.
-* `<monitor-instance>` is the monitor section name from the MaxScale\
+* `<monitor-instance>` is the monitor section name from the MaxScale
   configuration file.
-* `<server-param1>` and `<server-param2>` are server parameters as described\
-  above for MaxCtrl. Only switchover accepts both, failover doesn't need any\
+* `<server-param1>` and `<server-param2>` are server parameters as described
+  above for MaxCtrl. Only switchover accepts both, failover doesn't need any
   and both rejoin and reset-replication accept one.
 
 Given a MaxScale configuration file like
@@ -676,7 +676,7 @@ servers=server1, server2, server3, server 4
 ...
 ```
 
-with the assumption that `server2` is the current master, then the URL\
+with the assumption that `server2` is the current master, then the URL
 path for making `server4` the new master would be:
 
 ```
@@ -693,9 +693,9 @@ Example REST-API paths for other commands are listed below.
 
 **Queued switchover**
 
-Most cluster modification commands wait until the operation either succeeds or\
-fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the\
-module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,\
+Most cluster modification commands wait until the operation either succeeds or
+fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the
+module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,
 whether queued or not.
 
 ```
@@ -712,116 +712,116 @@ maxctrl call command mariadbmon fetch-cmd-result Cluster1
 
 #### Automatic activation
 
-Failover can activate automatically if `auto_failover` is on. The activation\
+Failover can activate automatically if `auto_failover` is on. The activation
 begins when the master has been down at least `failcount` monitor iterations.\
-Before modifying the cluster, the monitor checks that all prerequisites for the\
-failover are fulfilled. If the cluster does not seem ready, an error is printed\
+Before modifying the cluster, the monitor checks that all prerequisites for the
+failover are fulfilled. If the cluster does not seem ready, an error is printed
 and the cluster is rechecked during the next monitor iteration.
 
-Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the master\
-server is low on disk space but otherwise the operating logic is quite similar\
+Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the master
+server is low on disk space but otherwise the operating logic is quite similar
 to automatic failover.
 
-Rejoin stands for starting replication on a standalone server or redirecting a\
-slave replicating from the wrong master (any server that is not the cluster\
-master). The rejoined servers are directed to replicate from the current cluster\
-master server, forcing the replication topology to a 1-master-N-slaves\
+Rejoin stands for starting replication on a standalone server or redirecting a
+slave replicating from the wrong master (any server that is not the cluster
+master). The rejoined servers are directed to replicate from the current cluster
+master server, forcing the replication topology to a 1-master-N-slaves
 configuration.
 
-A server is categorized as standalone if the server has no slave connections,\
-not even stopped ones. A server is replicating from the wrong master if the\
-slave IO thread is connected but the master server id seen by the slave does not\
-match the cluster master id. Alternatively, the IO thread may be stopped or\
-connecting but the master server host or port information differs from the\
-cluster master info. These criteria mean that a STOP SLAVE does not yet set a\
+A server is categorized as standalone if the server has no slave connections,
+not even stopped ones. A server is replicating from the wrong master if the
+slave IO thread is connected but the master server id seen by the slave does not
+match the cluster master id. Alternatively, the IO thread may be stopped or
+connecting but the master server host or port information differs from the
+cluster master info. These criteria mean that a STOP SLAVE does not yet set a
 slave as standalone.
 
-With `auto_rejoin` active, the monitor will try to rejoin any servers matching\
-the above requirements. Rejoin does not obey `failcount` and will attempt to\
-rejoin any valid servers immediately. When activating rejoin manually, the\
+With `auto_rejoin` active, the monitor will try to rejoin any servers matching
+the above requirements. Rejoin does not obey `failcount` and will attempt to
+rejoin any valid servers immediately. When activating rejoin manually, the
 user-designated server must fulfill the same requirements.
 
 #### Limitations and requirements
 
-Switchover and failover only understand simple topologies. They will not work if\
+Switchover and failover only understand simple topologies. They will not work if
 the cluster has multiple masters, relay masters, or if the topology is circular.\
-The server cluster is assumed to be well-behaving with no significant\
-replication lag and all commands that modify the cluster complete in a few\
+The server cluster is assumed to be well-behaving with no significant
+replication lag and all commands that modify the cluster complete in a few
 seconds (faster than `backend_read_timeout` and `backend_write_timeout`).
 
-The backends must all use GTID-based replication, and the domain id should not\
-change during a switchover or failover. Master and slaves must have\
+The backends must all use GTID-based replication, and the domain id should not
+change during a switchover or failover. Master and slaves must have
 well-behaving GTIDs with no extra events on slave servers.
 
-Failover cannot be performed if MaxScale was started only after the master\
-server went down. This is because MaxScale needs reliable information on the\
-gtid domain of the cluster and the replication topology in general to properly\
+Failover cannot be performed if MaxScale was started only after the master
+server went down. This is because MaxScale needs reliable information on the
+gtid domain of the cluster and the replication topology in general to properly
 select the new master.
 
-Failover may lose events. If a master goes down before sending new events to at\
-least one slave, those events are lost when a new master is chosen. If the old\
-master comes back online, the other servers have likely moved on with a\
+Failover may lose events. If a master goes down before sending new events to at
+least one slave, those events are lost when a new master is chosen. If the old
+master comes back online, the other servers have likely moved on with a
 diverging history and the old master can no longer join the replication cluster.
 
 To reduce the chance of losing data, use [semisynchronous replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication).\
-In semisynchronous mode, the master waits for a slave to receive an event before\
-returning an acknowledgement to the client. This does not yet guarantee a clean\
-failover. If the master fails after preparing a transaction but before receiving\
-slave acknowledgement, it will still commit the prepared transaction as part of\
-its crash recovery. Since the slaves may never have seen this transaction, the\
-old master has diverged from the slaves. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
+In semisynchronous mode, the master waits for a slave to receive an event before
+returning an acknowledgement to the client. This does not yet guarantee a clean
+failover. If the master fails after preparing a transaction but before receiving
+slave acknowledgement, it will still commit the prepared transaction as part of
+its crash recovery. Since the slaves may never have seen this transaction, the
+old master has diverged from the slaves. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
 for more information.
 
-Even a controlled shutdown of the master may lose events. The server does not by\
-default wait for all data to be replicated to the slaves when shutting down and\
-instead simply closes all connections. Before shutting down the master with the\
-intention of having a slave promoted, run _switchover_ first to ensure that all\
+Even a controlled shutdown of the master may lose events. The server does not by
+default wait for all data to be replicated to the slaves when shutting down and
+instead simply closes all connections. Before shutting down the master with the
+intention of having a slave promoted, run _switchover_ first to ensure that all
 data is replicated. For more information on server shutdown, see [Binary Log Dump Threads and the Shutdown Process](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-threads).
 
-Switchover requires that the cluster is "frozen" for the duration of the\
-operation. This means that no data modifying statements such as INSERT or UPDATE\
-are executed and the GTID position of the master server is stable. When\
-switchover begins, the monitor sets the global _read\_only_ flag on the old\
+Switchover requires that the cluster is "frozen" for the duration of the
+operation. This means that no data modifying statements such as INSERT or UPDATE
+are executed and the GTID position of the master server is stable. When
+switchover begins, the monitor sets the global _read\_only_ flag on the old
 master backend to stop any updates. _read\_only_ does not affect users with the\
-SUPER-privilege so any such user can issue writes during a switchover. These\
-writes have a high chance of breaking replication, because the write may not be\
-replicated to all slaves before they switch to the new master. To prevent this,\
-any users who commonly do updates should not have the SUPER-privilege. For even\
+SUPER-privilege so any such user can issue writes during a switchover. These
+writes have a high chance of breaking replication, because the write may not be
+replicated to all slaves before they switch to the new master. To prevent this,
+any users who commonly do updates should not have the SUPER-privilege. For even
 more security, the only SUPER-user session during a switchover should be the\
-MaxScale monitor user. This also applies to users running scheduled server\
-events. Although the monitor by default disables events on the master, an\
-event may already be executing. If the event definer has SUPER-privilege, the\
+MaxScale monitor user. This also applies to users running scheduled server
+events. Although the monitor by default disables events on the master, an
+event may already be executing. If the event definer has SUPER-privilege, the
 event can write to the database even through _read\_only_.
 
-When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest\
-of the cluster. If the current cluster master does not have binary logs from the\
-moment the rejoining server lost connection, the rejoining server cannot\
-continue replication. This is an issue if the master has changed and\
+When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest
+of the cluster. If the current cluster master does not have binary logs from the
+moment the rejoining server lost connection, the rejoining server cannot
+continue replication. This is an issue if the master has changed and
 the new master does not have _log\_slave\_updates_ on.
 
-If an automatic cluster operation such as auto-failover or auto-rejoin fails,\
-all cluster modifying operations are disabled for `failcount` monitor iterations,\
-after which the operation may be retried. Similar logic applies if the cluster is\
+If an automatic cluster operation such as auto-failover or auto-rejoin fails,
+all cluster modifying operations are disabled for `failcount` monitor iterations,
+after which the operation may be retried. Similar logic applies if the cluster is
 unsuitable for such operations, e.g. replication is not using GTID.
 
 #### External master support
 
-The monitor detects if a server in the cluster is replicating from an external\
-master (a server that is not monitored by the monitor). If the replicating\
-server is the cluster master server, then the cluster itself is considered to\
+The monitor detects if a server in the cluster is replicating from an external
+master (a server that is not monitored by the monitor). If the replicating
+server is the cluster master server, then the cluster itself is considered to
 have an external master.
 
-If a failover/switchover happens, the new master server is set to replicate from\
-the cluster external master server. The username and password for the replication\
-are defined in `replication_user` and `replication_password`. The address and\
-port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster\
-master server. In the case of switchover, the old master also stops replicating\
+If a failover/switchover happens, the new master server is set to replicate from
+the cluster external master server. The username and password for the replication
+are defined in `replication_user` and `replication_password`. The address and
+port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster
+master server. In the case of switchover, the old master also stops replicating
 from the external server to preserve the topology.
 
-After failover the new master is replicating from the external master. If the\
-failed old master comes back online, it is also replicating from the external\
-server. To normalize the situation, either have _auto\_rejoin_ on or manually\
-execute a rejoin. This will redirect the old master to the current cluster\
+After failover the new master is replicating from the external master. If the
+failed old master comes back online, it is also replicating from the external
+server. To normalize the situation, either have _auto\_rejoin_ on or manually
+execute a rejoin. This will redirect the old master to the current cluster
 master.
 
 #### Configuration parameters
@@ -833,18 +833,18 @@ master.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic master failover. When automatic failover is enabled, MaxScale\
-will elect a new master server for the cluster if the old master goes down. A\
-server is assumed _Down_ if it cannot be connected to, even if this is caused by\
+Enable automatic master failover. When automatic failover is enabled, MaxScale
+will elect a new master server for the cluster if the old master goes down. A
+server is assumed _Down_ if it cannot be connected to, even if this is caused by
 incorrect credentials. Failover triggers if the master stays down for [failcount](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#failcount) monitor intervals. Failover will not take place if\
 MaxScale is set [passive](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md).
 
-As failover alters replication, it requires more privileges than normal\
+As failover alters replication, it requires more privileges than normal
 monitoring. See [here](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cluster-manipulation-grants) for a list of grants.
 
-Failover is designed to be used with simple master-slave topologies. More\
-complicated topologies, such as multilayered or circular replication, are not\
-guaranteed to always work correctly. Test before using failover with such\
+Failover is designed to be used with simple master-slave topologies. More
+complicated topologies, such as multilayered or circular replication, are not
+guaranteed to always work correctly. Test before using failover with such
 setups.
 
 **`auto_rejoin`**
@@ -854,20 +854,20 @@ setups.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic joining of servers to the cluster. When enabled, MaxScale will\
-attempt to direct servers to replicate from the current cluster master if they\
-are not currently doing so. Replication will be started on any standalone\
+Enable automatic joining of servers to the cluster. When enabled, MaxScale will
+attempt to direct servers to replicate from the current cluster master if they
+are not currently doing so. Replication will be started on any standalone
 servers. Servers that are replicating from another server will be redirected.\
-This effectively enforces a 1-master-N-slaves topology. The current master\
-itself is not redirected, so it can continue to replicate from an external\
-master. Rejoin is also not performed on any server that is replicating from\
-multiple sources, as this indicates a complicated topology (this rule is\
+This effectively enforces a 1-master-N-slaves topology. The current master
+itself is not redirected, so it can continue to replicate from an external
+master. Rejoin is also not performed on any server that is replicating from
+multiple sources, as this indicates a complicated topology (this rule is
 overridden by [enforce\_simple\_topology](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#enforce_simple_topology)).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#auto_failover) to redirect\
-the former master when it comes back online. Sometimes this kind of rejoin will\
-fail as the old master may have transactions that were never replicated to the\
-current one. See [limitations](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#limitations-and-requirements) for more\
+This feature is often paired with [auto\_failover](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#auto_failover) to redirect
+the former master when it comes back online. Sometimes this kind of rejoin will
+fail as the old master may have transactions that were never replicated to the
+current one. See [limitations](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#limitations-and-requirements) for more
 information.
 
 As an example, consider the following series of events:
@@ -877,9 +877,9 @@ As an example, consider the following series of events:
 3. Slave A comes back
 4. Old master comes back
 
-Slave A is still trying to replicate from the downed master, since it wasn't\
-online during failover. If _auto\_rejoin_ is on, Slave A will quickly be\
-redirected to Slave B, the current master. The old master will also rejoin the\
+Slave A is still trying to replicate from the downed master, since it wasn't
+online during failover. If _auto\_rejoin_ is on, Slave A will quickly be
+redirected to Slave B, the current master. The old master will also rejoin the
 cluster if possible.
 
 **`switchover_on_low_disk_space`**
@@ -912,18 +912,18 @@ switchover_on_low_disk_space=true
 * Default: `false`
 
 This setting tells the monitor to assume that the servers should be arranged in a\
-1-master-N-slaves topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual\
+1-master-N-slaves topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual
 settings.
 
-By default, mariadbmon will not rejoin servers with more than one replication\
-stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the\
-cluster and any extra replication sources will be removed. This is done to make\
+By default, mariadbmon will not rejoin servers with more than one replication
+stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the
+cluster and any extra replication sources will be removed. This is done to make
 automated failover with multi-source external replication possible.
 
-This setting also allows the monitor to perform a failover to a cluster where the master\
-server has not been seen \[Running]. This is usually the case when the master goes down\
-before MaxScale is started. When using this feature, the monitor will guess the GTID\
-domain id of the master from the slaves. For reliable results, the GTID:s of the cluster\
+This setting also allows the monitor to perform a failover to a cluster where the master
+server has not been seen \[Running]. This is usually the case when the master goes down
+before MaxScale is started. When using this feature, the monitor will guess the GTID
+domain id of the master from the slaves. For reliable results, the GTID:s of the cluster
 should be simple.
 
 ```
@@ -937,19 +937,19 @@ enforce_simple_topology=true
 * Dynamic: Yes
 * Default: None
 
-The username and password of the replication user. These are given as the values\
-for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is\
+The username and password of the replication user. These are given as the values
+for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is
 executed.
 
-Both `replication_user` and `replication_password` parameters must be defined if\
-a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication\
+Both `replication_user` and `replication_password` parameters must be defined if
+a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication
 user.
 
-The credentials used for replication must have the `REPLICATION SLAVE`\
+The credentials used for replication must have the `REPLICATION SLAVE`
 privilege.
 
-`replication_password` uses the same encryption scheme as other password\
-parameters. If password encryption is in use, `replication_password` must be\
+`replication_password` uses the same encryption scheme as other password
+parameters. If password encryption is in use, `replication_password` must be
 encrypted with the same key to avoid erroneous decryption.
 
 **`replication_master_ssl`**
@@ -959,12 +959,12 @@ encrypted with the same key to avoid erroneous decryption.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable\
-encryption for the replication stream. This setting should only be enabled if the backend\
-servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication\
+If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable
+encryption for the replication stream. This setting should only be enabled if the backend
+servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication
 user should require an encrypted connection (`e.g. ALTER USER repl@'%' REQUIRE SSL;`).
 
-If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing\
+If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing
 settings when redirecting a slave connection.
 
 **`failover_timeout` and `switchover_timeout`**
@@ -974,19 +974,19 @@ settings when redirecting a slave connection.
 * Dynamic: Yes
 * Default: `90s`
 
-Time limit for failover and switchover operations. The default\
-values are 90 seconds for both. `switchover_timeout` is also used as the time\
-limit for a rejoin operation. Rejoin should rarely time out, since it is a\
+Time limit for failover and switchover operations. The default
+values are 90 seconds for both. `switchover_timeout` is also used as the time
+limit for a rejoin operation. Rejoin should rarely time out, since it is a
 faster operation than switchover.
 
-The timeouts are specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeouts is seconds, a timeout specified in milliseconds will be rejected,\
+The timeouts are specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeouts is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If no successful failover/switchover takes place within the configured time\
-period, a message is logged and automatic failover is disabled. This prevents\
+If no successful failover/switchover takes place within the configured time
+period, a message is logged and automatic failover is disabled. This prevents
 further automatic modifications to the misbehaving cluster.
 
 **`verify_master_failure`**
@@ -998,18 +998,18 @@ further automatic modifications to the misbehaving cluster.
 
 Enable additional master failure verification for automatic failover.`verify_master_failure` enables this feature and [master\_failure\_timeout](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#master_failure_timeout) defines the timeout.
 
-Failure verification is performed by checking whether the slave servers are\
-still connected to the master and receiving events. An event is either a change\
-in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat\
-event. Effectively, if a slave has received an event within`master_failure_timeout` duration, the master is not considered down when\
-deciding whether to failover, even if MaxScale cannot connect to the master.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of\
+Failure verification is performed by checking whether the slave servers are
+still connected to the master and receiving events. An event is either a change
+in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat
+event. Effectively, if a slave has received an event within`master_failure_timeout` duration, the master is not considered down when
+deciding whether to failover, even if MaxScale cannot connect to the master.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of
 the slave connection to be effective.
 
 If every slave loses its connection to the master (_Slave\_IO\_Running_ is not\
-"Yes"), master failure is considered verified regardless of timeout. This allows\
+"Yes"), master failure is considered verified regardless of timeout. This allows
 faster failover when the master properly disconnects.
 
-For automatic failover to activate, the `failcount` requirement must also be\
+For automatic failover to activate, the `failcount` requirement must also be
 met.
 
 **`master_failure_timeout`**
@@ -1019,10 +1019,10 @@ met.
 * Dynamic: Yes
 * Default: `10s`
 
-The master failure timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The master failure timeout is specified as documented [here](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 **`servers_no_promotion`**
@@ -1032,11 +1032,11 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: None
 
-This is a comma-separated list of server names that will not be chosen for\
-master promotion during a failover or autoselected for switchover. This does not\
-affect switchover if the user selects the server to promote. Using this setting\
-can disrupt new master selection for failover such that an non-optimal server is\
-chosen. At worst, this will cause replication to break. Alternatively, failover\
+This is a comma-separated list of server names that will not be chosen for
+master promotion during a failover or autoselected for switchover. This does not
+affect switchover if the user selects the server to promote. Using this setting
+can disrupt new master selection for failover such that an non-optimal server is
+chosen. At worst, this will cause replication to break. Alternatively, failover
 may fail if all valid promotion candidates are in the exclusion list.
 
 ```
@@ -1051,30 +1051,30 @@ servers_no_promotion=backup_dc_server1,backup_dc_server2
 * Default: None
 
 These optional settings are paths to text files with SQL statements in them.\
-During promotion or demotion, the contents are read line-by-line and executed on\
-the backend. Use these settings to execute custom statements on the servers to\
+During promotion or demotion, the contents are read line-by-line and executed on
+the backend. Use these settings to execute custom statements on the servers to
 complement the built-in operations.
 
-Empty lines or lines starting with '#' are ignored. Any results returned by the\
-statements are ignored. All statements must succeed for the failover, switchover\
-or rejoin to continue. The monitor user may require additional privileges and\
+Empty lines or lines starting with '#' are ignored. Any results returned by the
+statements are ignored. All statements must succeed for the failover, switchover
+or rejoin to continue. The monitor user may require additional privileges and
 grants for the custom commands to succeed.
 
-When promoting a slave to master during switchover or failover, the`promotion_sql_file` is read and executed on the new master server after its\
-read-only flag is disabled. The commands are ran _before_ starting replication\
+When promoting a slave to master during switchover or failover, the`promotion_sql_file` is read and executed on the new master server after its
+read-only flag is disabled. The commands are ran _before_ starting replication
 from an external master if any.
 
-`demotion_sql_file` is ran on an old master during demotion to slave, before the\
-old master starts replicating from the new master. The file is also ran before\
-rejoining a standalone server to the cluster, as the standalone server is\
-typically a former master server. When redirecting a slave replicating from a\
+`demotion_sql_file` is ran on an old master during demotion to slave, before the
+old master starts replicating from the new master. The file is also ran before
+rejoining a standalone server to the cluster, as the standalone server is
+typically a former master server. When redirecting a slave replicating from a
 wrong master, the sql-file is not executed.
 
-Since the queries in the files are ran during operations which modify\
-replication topology, care is required. If `promotion_sql_file` contains data\
-modification (DML) queries, the new master server may not be able to\
-successfully replicate from an external master. `demotion_sql_file` should never\
-contain DML queries, as these may not replicate to the slave servers before\
+Since the queries in the files are ran during operations which modify
+replication topology, care is required. If `promotion_sql_file` contains data
+modification (DML) queries, the new master server may not be able to
+successfully replicate from an external master. `demotion_sql_file` should never
+contain DML queries, as these may not replicate to the slave servers before
 slave threads are stopped, breaking replication.
 
 ```
@@ -1089,71 +1089,71 @@ demotion_sql_file=/home/root/scripts/demotion.sql
 * Dynamic: Yes
 * Default: `true`
 
-If enabled, the monitor continuously queries the\
-servers for enabled scheduled events and uses this information when performing\
+If enabled, the monitor continuously queries the
+servers for enabled scheduled events and uses this information when performing
 cluster operations, enabling and disabling events as appropriate.
 
 When a server is being demoted, any events with "ENABLED" status are set to\
 "SLAVESIDE\_DISABLED". When a server is being promoted to master, events that are either\
-"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled\
-on the old master server last time it was successfully queried. Events are considered\
-identical if they have the same schema and name. When a standalone server is rejoined to\
+"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled
+on the old master server last time it was successfully queried. Events are considered
+identical if they have the same schema and name. When a standalone server is rejoined to
 the cluster, its events are also disabled since it is now a slave.
 
-The monitor does not check whether the same events were disabled and enabled during a\
+The monitor does not check whether the same events were disabled and enabled during a
 switchover or failover/rejoin. All events that meet the criteria above are altered.
 
-The monitor does not enable or disable the event scheduler itself. For the\
-events to run on the new master server, the scheduler should be enabled by the\
+The monitor does not enable or disable the event scheduler itself. For the
+events to run on the new master server, the scheduler should be enabled by the
 admin. Enabling it in the server configuration file is recommended.
 
-Events running at high frequency may cause replication to break in a failover\
-scenario. If an old master which was failed over restarts, its event scheduler\
-will be on if set in the server configuration file. Its events will also\
-remember their "ENABLED"-status and run when scheduled. This may happen before\
-the monitor rejoins the server and disables the events. This should only be an\
-issue for events running more often than the monitor interval or events that run\
+Events running at high frequency may cause replication to break in a failover
+scenario. If an old master which was failed over restarts, its event scheduler
+will be on if set in the server configuration file. Its events will also
+remember their "ENABLED"-status and run when scheduled. This may happen before
+the monitor rejoins the server and disables the events. This should only be an
+issue for events running more often than the monitor interval or events that run
 immediately after the server has restarted.
 
 ### Cooperative monitoring
 
-As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means\
-that multiple monitors (typically in different MaxScale instances) can monitor\
-the same backend server cluster and only one will be the primary monitor. Only\
+As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means
+that multiple monitors (typically in different MaxScale instances) can monitor
+the same backend server cluster and only one will be the primary monitor. Only
 the primary monitor may perform _switchover_, _failover_ or _rejoin_ operations.\
-The primary also decides which server is the master. Cooperative monitoring is\
+The primary also decides which server is the master. Cooperative monitoring is
 enabled with the [cooperative\_monitoring\_locks](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#cooperative_monitoring_locks)-setting.\
 Even with this setting, only one monitor per server per MaxScale is allowed.\
-This limitation can be circumvented by defining multiple copies of a server in\
+This limitation can be circumvented by defining multiple copies of a server in
 the configuration file.
 
-Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)\
-for coordinating between monitors. When cooperating, the monitor regularly\
-checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and\
-acquires it if free. If the monitor acquires a majority of locks, it is the\
+Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)
+for coordinating between monitors. When cooperating, the monitor regularly
+checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and
+acquires it if free. If the monitor acquires a majority of locks, it is the
 primary. If a monitor cannot claim majority locks, it is a secondary monitor.
 
 The primary monitor of a cluster also acquires the lock _maxscale\_mariadbmonitor\_master_ on the master server. Secondary monitors check
 which server this lock is taken on and only accept that server as the master.\
-This arrangement is required so that multiple monitors can agree on which server\
-is the master regardless of replication topology. If a secondary monitor does\
-not see the master-lock taken, then it won't mark any server as \[Master],\
+This arrangement is required so that multiple monitors can agree on which server
+is the master regardless of replication topology. If a secondary monitor does
+not see the master-lock taken, then it won't mark any server as \[Master],
 causing writes to fail.
 
-The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor\
-needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three\
-servers needs two locks for majority, a cluster of four needs three, and a\
+The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor
+needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three
+servers needs two locks for majority, a cluster of four needs three, and a
 cluster of five needs three.\
-This scheme is resistant against split-brain situations in the sense\
-that multiple monitors cannot be primary simultaneously. However, a split may\
-cause both monitors to consider themselves secondary, in which case a master\
+This scheme is resistant against split-brain situations in the sense
+that multiple monitors cannot be primary simultaneously. However, a split may
+cause both monitors to consider themselves secondary, in which case a master
 server won't be detected.
 
-Even without a network split, `cooperative_monitoring_locks=majority_of_all`\
-will lead to neither monitor claiming lock majority once too many servers go\
-down. This scenario is depicted in the image below. Only two out of four servers\
-are running when three are needed for majority. Although both MaxScales see both\
-running servers, neither is certain they have majority and the cluster stays in\
+Even without a network split, `cooperative_monitoring_locks=majority_of_all`
+will lead to neither monitor claiming lock majority once too many servers go
+down. This scenario is depicted in the image below. Only two out of four servers
+are running when three are needed for majority. Although both MaxScales see both
+running servers, neither is certain they have majority and the cluster stays in
 read-only mode. If the primary server is down, no failover is performed either.
 
 ```mermaid
@@ -1184,17 +1184,17 @@ flowchart TD
 ```
 _No majority: both MaxScale instances see the same two reachable servers, so neither can lock a majority and both remain secondary._
 
-Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only\
-servers currently \[Running] are considered. This scheme adapts to multiple\
+Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only
+servers currently \[Running] are considered. This scheme adapts to multiple
 servers going down, ensuring that claiming lock majority is always possible.\
-However, it can lead to multiple monitors claiming primary status in a\
-split-brain situation. As an example, consider a cluster with servers 1 to 4\
-with MaxScales A and B, as in the image below. MaxScale A can connect to\
-servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to\
-a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B\
+However, it can lead to multiple monitors claiming primary status in a
+split-brain situation. As an example, consider a cluster with servers 1 to 4
+with MaxScales A and B, as in the image below. MaxScale A can connect to
+servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to
+a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B
 does the opposite, claiming servers 3 and 4 and assuming 1 and 2 are down.\
-Both MaxScales claim two locks out of two available and assume that they have\
-lock majority. Both MaxScales may then promote their own primaries and route\
+Both MaxScales claim two locks out of two available and assume that they have
+lock majority. Both MaxScales may then promote their own primaries and route
 writes to different servers.
 
 ```mermaid
@@ -1227,23 +1227,23 @@ flowchart TD
 ```
 _Split brain: a broken heartbeat between datacenters lets both MaxScale A and MaxScale B act as primary at once, each locking its own read-write server._
 
-The recommended strategy depends on which failure scenario is more likely and/or\
-more destructive. If it's unlikely that multiple servers are ever down\
-simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other\
-hand, if split-brain is unlikely but multiple servers may be down\
+The recommended strategy depends on which failure scenario is more likely and/or
+more destructive. If it's unlikely that multiple servers are ever down
+simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other
+hand, if split-brain is unlikely but multiple servers may be down
 simultaneously, then _majority\_of\_running_ would keep the cluster operational.
 
-To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the\
-monitor has lock majority on the cluster. If cooperative monitoring is disabled,\
-the field value is _null_. Lock information for individual servers is listed in\
-the server-specific field **lock\_held**. Again, _null_ indicates that locks are\
+To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the
+monitor has lock majority on the cluster. If cooperative monitoring is disabled,
+the field value is _null_. Lock information for individual servers is listed in
+the server-specific field **lock\_held**. Again, _null_ indicates that locks are
 not in use or the lock status is unknown.
 
-If a MaxScale instance tries to acquire the locks but fails to get majority\
-(perhaps another MaxScale was acquiring locks simultaneously) it will release\
-any acquired locks and try again after a random number of monitor ticks. This\
+If a MaxScale instance tries to acquire the locks but fails to get majority
+(perhaps another MaxScale was acquiring locks simultaneously) it will release
+any acquired locks and try again after a random number of monitor ticks. This
 prevents multiple MaxScales from fighting over the locks continuously as one\
-MaxScale will eventually wait less time than the others. Conflict probability\
+MaxScale will eventually wait less time than the others. Conflict probability
 can be further decreased by configuring each monitor with a different\_monitor\_interval\_.
 
 The flowchart below illustrates the lock handling logic.
@@ -1289,19 +1289,19 @@ _MariaDB Monitor cooperative locking: on each tick, a MaxScale that holds (or ca
 
 #### Releasing locks
 
-Monitor cooperation depends on the server locks. The locks are\
-connection-specific. The owning connection can manually release a lock, allowing\
+Monitor cooperation depends on the server locks. The locks are
+connection-specific. The owning connection can manually release a lock, allowing
 another connection to claim it. Also, if the owning connection closes, the\
-MariaDB Server process releases the lock. How quickly a lost connection is\
-detected affects how quickly the primary monitor status moves from one monitor\
+MariaDB Server process releases the lock. How quickly a lost connection is
+detected affects how quickly the primary monitor status moves from one monitor
 and MaxScale to another.
 
-If the primary MaxScale or its monitor is stopped normally, the monitor\
+If the primary MaxScale or its monitor is stopped normally, the monitor
 connections are properly closed, releasing the locks. This allows the secondary\
-MaxScale to quickly claim the locks. However, if the primary simply vanishes\
+MaxScale to quickly claim the locks. However, if the primary simply vanishes
 (broken network), the connection may just look idle. In this case, the\
-MariaDB Server may take a long time before it considers the monitor connection\
-lost. This time ultimately depends on TCP keepalive settings on the machines\
+MariaDB Server may take a long time before it considers the monitor connection
+lost. This time ultimately depends on TCP keepalive settings on the machines
 running MariaDB Server.
 
 On MariaDB Server 10.3.3 and later, the TCP keepalive settings can be configured\
@@ -1310,15 +1310,15 @@ for information on settings _tcp\_keepalive\_interval_, _tcp\_keepalive\_probes_
 level, as described [here](https://www.tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html).
 
 As of MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6 and 24.02.2, configuring\
-TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_\
-variable when acquiring a lock. This causes the MariaDB Server to close the\
-monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout\
+TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_
+variable when acquiring a lock. This causes the MariaDB Server to close the
+monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout
 settings, and is logged at MaxScale startup.
 
-A monitor can also be ordered to manually release its locks via the module\
-command _release-locks_. This is useful for manually changing the primary\
-monitor. After running the release-command, the monitor will not attempt to\
-reacquire the locks for one minute, even if it wasn't the primary monitor to\
+A monitor can also be ordered to manually release its locks via the module
+command _release-locks_. This is useful for manually changing the primary
+monitor. After running the release-command, the monitor will not attempt to
+reacquire the locks for one minute, even if it wasn't the primary monitor to
 begin with. This command can cause the cluster to become temporarily unusable by\
 MaxScale. Only use it when there is another monitor ready to claim the locks.
 
@@ -1330,34 +1330,34 @@ maxctrl call command mariadbmon release-locks MyMonitor1
 
 #### Failover/switchover fails
 
-Before performing failover or switchover, the MariaDB Monitor first checks that\
-prerequisites are fulfilled, printing any found errors. This should catch and\
-explain most issues with failover or switchover not working. If the operations\
-are attempted and still fail, then most likely one of the commands the monitor\
+Before performing failover or switchover, the MariaDB Monitor first checks that
+prerequisites are fulfilled, printing any found errors. This should catch and
+explain most issues with failover or switchover not working. If the operations
+are attempted and still fail, then most likely one of the commands the monitor
 issued to a server failed or timed out. The log should explain which query failed.\
-To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the\
-backends by monitors and authenticators. The printed queries may include\
+To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the
+backends by monitors and authenticators. The printed queries may include
 usernames and passwords.
 
-A typical reason for failure is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the\
-monitor will retry most such queries if the failure was caused by a timeout. The retrying\
-continues until the total time for a failover or switchover has been spent. If the log\
-shows warnings or errors about commands timing out, increasing the backend timeout\
+A typical reason for failure is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the
+monitor will retry most such queries if the failure was caused by a timeout. The retrying
+continues until the total time for a failover or switchover has been spent. If the log
+shows warnings or errors about commands timing out, increasing the backend timeout
 settings of the monitor should help. Another settings to look at are `query_retries` and`query_retry_timeout`. These are general MaxScale settings described in the [Configuration guide](../mariadb-maxscale-21-06-getting-started/mariadb-maxscale-2106-maxscale-2106-mariadb-maxscale-configuration-guide.md). Setting`query_retries` to 2 is a reasonable first try.
 
 #### Slave detection shows external masters
 
 If a slave is shown in _maxctrl_ as "Slave of External Server" instead of\
-"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection\
-does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default\
-assumes that the slave connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact\
-same "Master\_Host" as used the MaxScale configuration file server definitions. This is\
+"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection
+does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default
+assumes that the slave connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact
+same "Master\_Host" as used the MaxScale configuration file server definitions. This is
 controlled by the setting [assume\_unique\_hostnames](mariadb-maxscale-2106-maxscale-2106-mariadb-monitor.md#assume_unique_hostnames).
 
 ### Using the MariaDB Monitor With Binlogrouter
 
-Since MaxScale 2.2 it's possible to detect a replication setup\
-which includes Binlog Server: the required action is to add the\
+Since MaxScale 2.2 it's possible to detect a replication setup
+which includes Binlog Server: the required action is to add the
 binlog server to the list of servers only if _master\_id_ identity is set.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-2106-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-2106-contents.md
@@ -1,8 +1,8 @@
 # MaxScale 21.06 Contents
 
-**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have\
-been released as 6.4.16 in June, was released as 21.06.16. The purpose of this\
-change is to make the versioning scheme used by all MaxScale series\
+**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have
+been released as 6.4.16 in June, was released as 21.06.16. The purpose of this
+change is to make the versioning scheme used by all MaxScale series
 identical. 21.06 denotes the year and month when the first 6 release was made.\
 Anything referring to MaxScale 6 applies to MaxScale 21.06.
 
@@ -52,8 +52,8 @@ Here are tutorials on monitoring and managing MariaDB MaxScale in cluster enviro
 
 ### Routers
 
-The routing module is the core of a MariaDB MaxScale service. The router documentation\
-contains all module specific configuration options and detailed explanations\
+The routing module is the core of a MariaDB MaxScale service. The router documentation
+contains all module specific configuration options and detailed explanations
 of their use.
 
 * [Avrorouter](mariadb-maxscale-21-06-routers/mariadb-maxscale-2106-maxscale-2106-avrorouter.md)
@@ -115,7 +115,7 @@ The MaxScale CDC Connector provides a C++ API for consuming data from a CDC syst
 
 ### Authenticators
 
-A short description of the authentication module type can be found in the [Authentication Modules](mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-authentication-modules.md)\
+A short description of the authentication module type can be found in the [Authentication Modules](mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-authentication-modules.md)
 document.
 
 * [MariaDB/MySQL Authenticator](mariadb-maxscale-21-06-authenticators/mariadb-maxscale-2106-maxscale-2106-mariadbmysql-authenticator.md)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-binlog-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-binlog-filter.md
@@ -8,22 +8,22 @@ This filter was introduced in MariaDB MaxScale 2.3.0.
 
 ### Overview
 
-The `binlogfilter` can be combined with a `binlogrouter` service to selectively\
+The `binlogfilter` can be combined with a `binlogrouter` service to selectively
 replicate the binary log events to slave servers.
 
-The filter uses two settings, _match_ and _exclude_, to determine which events\
-are replicated. If a binlog event does not match or is excluded, the event is\
-replaced with an empty data event. The empty event is always 35 bytes which\
+The filter uses two settings, _match_ and _exclude_, to determine which events
+are replicated. If a binlog event does not match or is excluded, the event is
+replaced with an empty data event. The empty event is always 35 bytes which
 translates to a space reduction in most cases.
 
-When statement-based replication is used, any query events that are filtered out\
-are replaced with a SQL comment. This causes the query event to do nothing and\
-thus the event will not modify the contents of the database. The GTID position\
-of the replicating database will still advance which means that downstream\
+When statement-based replication is used, any query events that are filtered out
+are replaced with a SQL comment. This causes the query event to do nothing and
+thus the event will not modify the contents of the database. The GTID position
+of the replicating database will still advance which means that downstream
 servers replicating from it keep functioning correctly.
 
-The filter works with both row based and statement based replication but we\
-recommend using row based replication with the binlogfilter. This guarantees\
+The filter works with both row based and statement based replication but we
+recommend using row based replication with the binlogfilter. This guarantees
 that there are no ambiguities in the event filtering.
 
 ### Configuration
@@ -46,18 +46,18 @@ Include queries that match the regex. See next entry, `exclude`, for more inform
 
 Exclude queries that match the regex.
 
-If neither `match` nor `exclude` are defined, the filter does nothing and all events\
-are replicated. This filter does not accept regular expression options as a separate\
-setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for\
+If neither `match` nor `exclude` are defined, the filter does nothing and all events
+are replicated. This filter does not accept regular expression options as a separate
+setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for
 more information.
 
-The two settings are matched against the database and table name concatenated\
-with a period. For example, the string the patterns are matched against for the\
+The two settings are matched against the database and table name concatenated
+with a period. For example, the string the patterns are matched against for the
 database `test` and table `t1` is `test.t1`.
 
-For statement based replication, the pattern is matched against all the tables\
-in the statements. If any of the tables matches the _match_ pattern, the event\
-is replicated. If any of the tables matches the _exclude_ pattern, the event is\
+For statement based replication, the pattern is matched against all the tables
+in the statements. If any of the tables matches the _match_ pattern, the event
+is replicated. If any of the tables matches the _exclude_ pattern, the event is
 not replicated.
 
 #### `rewrite_src`
@@ -77,28 +77,28 @@ See the next entry, `rewrite_dest`, for more information.
 * Default: None
 
 `rewrite_src` and `rewrite_dest` control the statement rewriting of the binlogfilter.\
-The `rewrite_src` setting is a PCRE2 regular expression that is matched against\
-the default database and the SQL of statement based replication events (query\
+The `rewrite_src` setting is a PCRE2 regular expression that is matched against
+the default database and the SQL of statement based replication events (query
 events). `rewrite_dest` is the replacement string which supports the normal\
-PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,\
+PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,
 etc.).
 
 Both `rewrite_src` and `rewrite_dest` must be defined to enable statement rewriting.
 
-When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)\
-must be used. The filter will disallow replication for all slaves that attempt\
+When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)
+must be used. The filter will disallow replication for all slaves that attempt
 to replicate with traditional file-and-position based replication.
 
-The replacement is done both on the default database as well as the SQL\
-statement in the query event. This means that great care must be taken when\
-defining the rewriting rules. To prevent accidental modification of the SQL into\
-a form that is no longer valid, use database and table names that never occur in\
+The replacement is done both on the default database as well as the SQL
+statement in the query event. This means that great care must be taken when
+defining the rewriting rules. To prevent accidental modification of the SQL into
+a form that is no longer valid, use database and table names that never occur in
 the inserted data and is never used as a constant value.
 
 ### Example Configuration
 
-With the following configuration, only events belonging to database `customers`\
-are replicated. In addition to this, events for the table `orders` are excluded\
+With the following configuration, only events belonging to database `customers`
+are replicated. In addition to this, events for the table `orders` are excluded
 and thus are not replicated.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-cache.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-cache.md
@@ -8,34 +8,34 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-From MaxScale version 2.2.11 onwards, the cache filter is no longer\
-considered experimental. The following changes to the default behaviour\
+From MaxScale version 2.2.11 onwards, the cache filter is no longer
+considered experimental. The following changes to the default behaviour
 have also been made:
 
 * The default value of `cached_data` is now `thread_specific` (used to be`shared`).
 * The default value of `selects` is now `assume_cacheable` (used to be`verify_cacheable`).
 
 The cache filter is a simple cache that is capable of caching the result of\
-SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,\
+SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,
 without the queries being routed to any server.
 
 By _default_ the cache will be used and populated in the following circumstances:
 
 * There is no explicit transaction active, that is, autocommit is used,
 * there is an explicitly read-only transaction (that is,`START TRANSACTION READ ONLY`) active, or
-* there is a transaction active and no statement that modifies the database\
+* there is a transaction active and no statement that modifies the database
   has been performed.
 
-In practice, the last bullet point basically means that if a transaction has\
+In practice, the last bullet point basically means that if a transaction has
 been started with `BEGIN`, `START TRANSACTION` or `START TRANSACTION READ WRITE`, then the cache will be used and populated until the first `UPDATE`,`INSERT` or `DELETE` statement is encountered.
 
-That is, in default mode the cache effectively causes the system to behave\
-as if the _isolation level_ would be `READ COMMITTED`, irrespective of what\
+That is, in default mode the cache effectively causes the system to behave
+as if the _isolation level_ would be `READ COMMITTED`, irrespective of what
 the isolation level of the backends actually is.
 
 The default behaviour can be altered using the configuration parameter [cache\_in\_transactions](mariadb-maxscale-2208-cache.md#cache_in_transactions).
 
-By default it is assumed that all `SELECT` statements are cacheable, which\
+By default it is assumed that all `SELECT` statements are cacheable, which
 means that also statements like `SELECT LOCALTIME` are cached. Please check [selects](mariadb-maxscale-2208-cache.md#selects) for how to change the default behaviour.
 
 ### Limitations
@@ -54,34 +54,34 @@ Multi-statements are always sent to the backend and their result is**not** cache
 
 The cache is **not** aware of grants.
 
-The implication is that unless the cache has been explicitly configured\
-who the caching should apply to, the presence of the cache may provide\
+The implication is that unless the cache has been explicitly configured
+who the caching should apply to, the presence of the cache may provide
 a user with access to data he should not have access to.
 
 Please read the section [Security](mariadb-maxscale-2208-cache.md#security-1) for more detailed information.
 
-However, from 2.5 onwards it is possible to configure the cache to cache\
-the data of each user separately, which effectively means that there can\
-be no unintended sharing. Please see [users](mariadb-maxscale-2208-cache.md#users) for how to change\
+However, from 2.5 onwards it is possible to configure the cache to cache
+the data of each user separately, which effectively means that there can
+be no unintended sharing. Please see [users](mariadb-maxscale-2208-cache.md#users) for how to change
 the default behaviour.
 
 #### `information_schema`
 
-When [invalidation](mariadb-maxscale-2208-cache.md#invalidation) is enabled, SELECTs targeting tables\
-in `information_schema` are not cached. The reason is that as the content\
-of the tables changes as the side-effect of something else, the cache would\
+When [invalidation](mariadb-maxscale-2208-cache.md#invalidation) is enabled, SELECTs targeting tables
+in `information_schema` are not cached. The reason is that as the content
+of the tables changes as the side-effect of something else, the cache would
 not know when to invalidate the cache-entries.
 
 ### Invalidation
 
-Since MaxScale 2.5, the cache is capable of invalidating entries in the\
-cache when a modification (UPDATE, INSERT or DELETE) that may affect those\
+Since MaxScale 2.5, the cache is capable of invalidating entries in the
+cache when a modification (UPDATE, INSERT or DELETE) that may affect those
 entries is made.
 
-The cache invalidation works on the table-level, that is, a modification\
-made to a particular table will cause all cache entries that refer to that\
-table to be invalidated, irrespective of whether the modification actually\
-has an impact on the cache entries or not. For instance, suppose the result\
+The cache invalidation works on the table-level, that is, a modification
+made to a particular table will cause all cache entries that refer to that
+table to be invalidated, irrespective of whether the modification actually
+has an impact on the cache entries or not. For instance, suppose the result
 of the following SELECT has been cached
 
 ```
@@ -94,55 +94,55 @@ An insert like
 INSERT INTO t SET a=42;
 ```
 
-will cause the cache entry containing the result of that SELECT to be\
+will cause the cache entry containing the result of that SELECT to be
 invalidated even if the INSERT actually does not affect it. Please see [invalidate](mariadb-maxscale-2208-cache.md#invalidate) for how to enable the invalidation.
 
-When invalidation has been enabled MaxScale must be able to completely\
-parse a SELECT statement for its results to be stored in the cache. The\
-reason is that in order to be able to invalidate cache entries, MaxScale\
-must know what tables a SELECT statement depends upon. Consequently, if\
-(and only if) invalidation has been enabled and MaxScale fails to parse a\
+When invalidation has been enabled MaxScale must be able to completely
+parse a SELECT statement for its results to be stored in the cache. The
+reason is that in order to be able to invalidate cache entries, MaxScale
+must know what tables a SELECT statement depends upon. Consequently, if
+(and only if) invalidation has been enabled and MaxScale fails to parse a
 statement, the result of that particular statement will not be cached.
 
 When invalidation has been enabled, MaxScale will also parse all UPDATE,\
-INSERT and DELETE statements, in order to find out what tables are\
-modified. If that parsing fails, MaxScale will _by default_ clear the\
-entire cache. The reason is that unless MaxScale can completely parse\
-the statement it cannot know what tables are modified and hence not what\
-cache entries should be invalidated. Consequently, to prevent stale data\
-from being returned, the entire cache is cleared. The default behaviour\
+INSERT and DELETE statements, in order to find out what tables are
+modified. If that parsing fails, MaxScale will _by default_ clear the
+entire cache. The reason is that unless MaxScale can completely parse
+the statement it cannot know what tables are modified and hence not what
+cache entries should be invalidated. Consequently, to prevent stale data
+from being returned, the entire cache is cleared. The default behaviour
 can be changed using the configuration parameter [clear\_cache\_on\_parse\_errors](mariadb-maxscale-2208-cache.md#clear_cache_on_parse_errors).
 
-Note that what threading approach is used has a big impact on the\
-invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2208-cache.md#threads-users-and-invalidation)\
+Note that what threading approach is used has a big impact on the
+invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2208-cache.md#threads-users-and-invalidation)
 for how the threading approach affects the invalidation.
 
-Note also that since the invalidation may not, depending on how the\
-cache has been configured, be visible to all sessions of all users, it\
+Note also that since the invalidation may not, depending on how the
+cache has been configured, be visible to all sessions of all users, it
 is still important to configure a reasonable [soft](mariadb-maxscale-2208-cache.md#soft_ttl) and [hard](mariadb-maxscale-2208-cache.md#hard_ttl) TTL.
 
 #### Best Efforts
 
-The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the\
-cache in all circumstances reflects the state in the actual database,\
-would require that the operations involving the cache and the MariaDB\
+The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the
+cache in all circumstances reflects the state in the actual database,
+would require that the operations involving the cache and the MariaDB
 server are synchronized, which would cause an unacceptable overhead.
 
 What _best efforts_ means in this context is best illustrated using an example.
 
-Suppose a client executes the statement `SELECT * FROM tbl` and that the result\
-is cached. Next time that or any other client executes the same statement, the\
-result is returned from the cache and the MariaDB server will not be accessed\
+Suppose a client executes the statement `SELECT * FROM tbl` and that the result
+is cached. Next time that or any other client executes the same statement, the
+result is returned from the cache and the MariaDB server will not be accessed
 at all.
 
-If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the\
-cached value for the `SELECT` statement above and all other statements that are\
-dependent upon `tbl` will be invalidated. That is, the next time someone executes\
+If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the
+cached value for the `SELECT` statement above and all other statements that are
+dependent upon `tbl` will be invalidated. That is, the next time someone executes
 the statement `SELECT * FROM tbl` the result will again be fetched from the\
 MariaDB server and stored to the cache.
 
-However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`\
-at the same time someone else executes the `INSERT ...` statement. A possible\
+However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`
+at the same time someone else executes the `INSERT ...` statement. A possible
 chain of events is as follows:
 
 ```
@@ -153,7 +153,7 @@ MaxScale -> DB                                   SELECT COUNT(*) FROM tbl
 MaxScale -> DB        INSERT ...
 ```
 
-That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of\
+That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of
 each other, the events may be re-ordered as far as the cache is concerned.
 
 ```
@@ -161,16 +161,16 @@ MaxScale -> Cache     Delete invalidated values
 MaxScale -> Cache                                Store result and invalidation key
 ```
 
-That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the\
+That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the
 situation _before_ the insert and will thus not be correct.
 
-The stale result will be returned until the value has reached its _time-to-live_\
+The stale result will be returned until the value has reached its _time-to-live_
 or its invalidation is caused by some update operation.
 
 ### Configuration
 
-The cache is simple to add to any existing service. However, some experimentation\
-may be required in order to find the configuration settings that provide\
+The cache is simple to add to any existing service. However, some experimentation
+may be required in order to find the configuration settings that provide
 the maximum benefit.
 
 ```
@@ -188,21 +188,21 @@ type=service
 filters=Cache
 ```
 
-Each configured cache filter uses a storage of its own. That is, if there\
-are two services, each configured with a specific cache filter, then,\
-even if queries target the very same servers the cached data will not\
+Each configured cache filter uses a storage of its own. That is, if there
+are two services, each configured with a specific cache filter, then,
+even if queries target the very same servers the cached data will not
 be shared.
 
-Two services can use the same cache filter, but then either the services\
-should use the very same servers _or_ a completely different set of servers,\
-where the used table names are different. Otherwise there can be unintended\
+Two services can use the same cache filter, but then either the services
+should use the very same servers _or_ a completely different set of servers,
+where the used table names are different. Otherwise there can be unintended
 sharing.
 
 #### Filter Parameters
 
 The cache filter has no mandatory parameters but a range of optional ones.\
-Note that it is advisable to specify `max_size` to prevent the cache from\
-using up all memory there is, in case there is very little overlap among the\
+Note that it is advisable to specify `max_size` to prevent the cache from
+using up all memory there is, in case there is very little overlap among the
 queries.
 
 **`storage`**
@@ -212,8 +212,8 @@ queries.
 * Dynamic: No
 * Default: `storage_inmemory`
 
-The name of the module that provides the storage for the cache. That\
-module will be loaded and provided with the value of `storage_options` as\
+The name of the module that provides the storage for the cache. That
+module will be loaded and provided with the value of `storage_options` as
 argument. For instance:
 
 ```
@@ -229,8 +229,8 @@ See [Storage](mariadb-maxscale-2208-cache.md#storage-1) for what storage modules
 * Dynamic: No
 * Default:
 
-A string that is provided verbatim to the storage module specified in `storage`,\
-when the module is loaded. Note that the needed arguments and their format depend\
+A string that is provided verbatim to the storage module specified in `storage`,
+when the module is loaded. Note that the needed arguments and their format depend
 upon the specific module.
 
 **`hard_ttl`**
@@ -240,8 +240,8 @@ upon the specific module.
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Hard time to live_; the maximum amount of time the cached\
-result is used before it is discarded and the result is fetched from the\
+_Hard time to live_; the maximum amount of time the cached
+result is used before it is discarded and the result is fetched from the
 backend (and cached). See also `soft_ttl` below.
 
 ```
@@ -255,21 +255,21 @@ hard_ttl=60s
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Soft time to live_; the amount of time - in seconds - the cached result is\
-used before it is refreshed from the server. When `soft_ttl` has passed, the\
+_Soft time to live_; the amount of time - in seconds - the cached result is
+used before it is refreshed from the server. When `soft_ttl` has passed, the
 result will be refreshed when the _first_ client requests the value.
 
-However, as long as `hard_ttl` has not passed, _all_ other clients requesting\
-the same value will use the result from the cache while it is being fetched\
-from the backend. That is, as long as `soft_ttl` but not `hard_ttl` has passed,\
-even if several clients request the same value at the same time, there will be\
+However, as long as `hard_ttl` has not passed, _all_ other clients requesting
+the same value will use the result from the cache while it is being fetched
+from the backend. That is, as long as `soft_ttl` but not `hard_ttl` has passed,
+even if several clients request the same value at the same time, there will be
 just one request to the backend.
 
 ```
 soft_ttl=60s
 ```
 
-The default value is `0`, which means no limit. If the value of `soft_ttl` is\
+The default value is `0`, which means no limit. If the value of `soft_ttl` is
 larger than `hard_ttl` it will be adjusted down to the same value.
 
 **`max_resultset_rows`**
@@ -279,7 +279,7 @@ larger than `hard_ttl` it will be adjusted down to the same value.
 * Dynamic: No
 * Default: `0` (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 stored in the cache. A resultset larger than this, will not be stored.
 
 ```
@@ -294,14 +294,14 @@ max_resultset_rows=1000
 * Default: `0` (no limit)
 
 Specifies the maximum size of a resultset, for it to be stored in the cache.\
-A resultset larger than this, will not be stored. The size can be specified\
+A resultset larger than this, will not be stored. The size can be specified
 as described [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes).
 
 ```
 max_resultset_size=128Ki
 ```
 
-Note that the value of `max_resultset_size` should not be larger than the\
+Note that the value of `max_resultset_size` should not be larger than the
 value of `max_size`.
 
 **`max_count`**
@@ -311,12 +311,12 @@ value of `max_size`.
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum number of items the cache may contain. If the limit has been\
+The maximum number of items the cache may contain. If the limit has been
 reached and a new item should be stored, then an older item will be evicted.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
-is used, then the total number of cached items is #threads \* the value\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
+is used, then the total number of cached items is #threads \* the value
 of `max_count`.
 
 ```
@@ -330,12 +330,12 @@ max_count=1000
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum size the cache may occupy. If the limit has been reached and a new\
+The maximum size the cache may occupy. If the limit has been reached and a new
 item should be stored, then some older item(s) will be evicted to make space.\
 The size can be specified as described [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes).
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
 is used, then the total size is #threads \* the value of `max_size`.
 
 ```
@@ -349,7 +349,7 @@ max_size=100Mi
 * Dynamic: No
 * Default: `""` (no rules)
 
-Specifies the path of the file where the caching rules are stored. A relative\
+Specifies the path of the file where the caching rules are stored. A relative
 path is interpreted relative to the _data directory_ of MariaDB MaxScale.
 
 ```
@@ -364,22 +364,22 @@ rules=/path/to/rules-file
 * Values: `shared`, `thread_specific`
 * Default: `thread_specific`
 
-An enumeration option specifying how data is shared between threads. The\
+An enumeration option specifying how data is shared between threads. The
 allowed values are:
 
-* `shared`: The cached data is shared between threads. On the one hand\
-  it implies that there will be synchronization between threads, on\
+* `shared`: The cached data is shared between threads. On the one hand
+  it implies that there will be synchronization between threads, on
   the other hand that all threads will use data fetched by any thread.
-* `thread_specific`: The cached data is specific to a thread. On the\
-  one hand it implies that no synchronization is needed between threads,\
-  on the other hand that the very same data may be fetched and stored\
+* `thread_specific`: The cached data is specific to a thread. On the
+  one hand it implies that no synchronization is needed between threads,
+  on the other hand that the very same data may be fetched and stored
   multiple times.
 
 ```
 cached_data=shared
 ```
 
-Default is `thread_specific`. See `max_count` and `max_size` what implication\
+Default is `thread_specific`. See `max_count` and `max_size` what implication
 changing this setting to `shared` has.
 
 **`selects`**
@@ -390,35 +390,35 @@ changing this setting to `shared` has.
 * Values: `assume_cacheable`, `verify_cacheable`
 * Default: `assume_cacheable`
 
-An enumeration option specifying what approach the cache should take with\
+An enumeration option specifying what approach the cache should take with
 respect to `SELECT` statements. The allowed values are:
 
-* `assume_cacheable`: The cache can assume that all `SELECT` statements,\
+* `assume_cacheable`: The cache can assume that all `SELECT` statements,
   without exceptions, are cacheable.
-* `verify_cacheable`: The cache can not assume that all `SELECT`\
+* `verify_cacheable`: The cache can not assume that all `SELECT`
   statements are cacheable, but must verify that.
 
 ```
 selects=verify_cacheable
 ```
 
-Default is `assume_cacheable`. In this case, all `SELECT` statements are\
-assumed to be cacheable and will be parsed _only_ if some specific rule\
+Default is `assume_cacheable`. In this case, all `SELECT` statements are
+assumed to be cacheable and will be parsed _only_ if some specific rule
 requires that.
 
-If `verify_cacheable` is specified, then all `SELECT` statements will be\
-parsed and only those that are safe for caching - e.g. do _not_ call any\
-non-cacheable functions or access any non-cacheable variables - will be\
+If `verify_cacheable` is specified, then all `SELECT` statements will be
+parsed and only those that are safe for caching - e.g. do _not_ call any
+non-cacheable functions or access any non-cacheable variables - will be
 subject to caching.
 
-If `verify_cacheable` has been specified, the cache will not be used in\
+If `verify_cacheable` has been specified, the cache will not be used in
 the following circumstances:
 
 * The `SELECT` uses any of the following functions: `BENCHMARK`,`CONNECTION_ID`, `CONVERT_TZ`, `CURDATE`, `CURRENT_DATE`, `CURRENT_TIMESTAMP`,`CURTIME`, `DATABASE`, `ENCRYPT`, `FOUND_ROWS`, `GET_LOCK`, `IS_FREE_LOCK`,`IS_USED_LOCK`, `LAST_INSERT_ID`, `LOAD_FILE`, `LOCALTIME`, `LOCALTIMESTAMP`,`MASTER_POS_WAIT`, `NOW`, `RAND`, `RELEASE_LOCK`, `SESSION_USER`, `SLEEP`,`SYSDATE`, `SYSTEM_USER`, `UNIX_TIMESTAMP`, `USER`, `UUID`, `UUID_SHORT`.
 * The `SELECT` accesses any of the following fields: `CURRENT_DATE`,`CURRENT_TIMESTAMP`, `LOCALTIME`, `LOCALTIMESTAMP`
 * The `SELECT` uses system or user variables.
 
-Note that parsing all `SELECT` statements carries a performance\
+Note that parsing all `SELECT` statements carries a performance
 cost. Please read [performance](mariadb-maxscale-2208-cache.md#performance) for more details.
 
 **`cache_in_transactions`**
@@ -429,21 +429,21 @@ cost. Please read [performance](mariadb-maxscale-2208-cache.md#performance) for 
 * Values: `never`, `read_only_transactions`, `all_transactions`
 * Default: `all_transactions`
 
-An enumeration option specifying how the cache should behave when there\
+An enumeration option specifying how the cache should behave when there
 are active transactions:
 
-* `never`: When there is an active transaction, no data will be returned\
+* `never`: When there is an active transaction, no data will be returned
   from the cache, but all requests will always be sent to the backend.\
   The cache will be populated inside explicitly read-only transactions.\
-  Inside transactions that are not explicitly read-only, the cache will\
+  Inside transactions that are not explicitly read-only, the cache will
   be populated until the first non-SELECT statement.
-* `read_only_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be populated, but not used\
+* `read_only_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be populated, but not used
   until the first non-SELECT statement.
-* `all_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be used and populated until the\
+* `all_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be used and populated until the
   first non-SELECT statement.
 
 ```
@@ -452,7 +452,7 @@ cache_in_transactions=never
 
 Default is `all_transactions`.
 
-The values `read_only_transactions` and `all_transactions` have roughly the\
+The values `read_only_transactions` and `all_transactions` have roughly the
 same effect as changing the isolation level of the backend to `read_committed`.
 
 **`debug`**
@@ -462,8 +462,8 @@ same effect as changing the isolation level of the backend to `read_committed`.
 * Dynamic: No
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the cache\
-can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the cache
+can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -494,9 +494,9 @@ enabled=false
 
 Default is `true`.
 
-The value affects the initial state of the MaxScale user\
-variables using which the behaviour of the cache can be modified\
-at runtime. Please see [Runtime Configuration](mariadb-maxscale-2208-cache.md#runtime-configuration)\
+The value affects the initial state of the MaxScale user
+variables using which the behaviour of the cache can be modified
+at runtime. Please see [Runtime Configuration](mariadb-maxscale-2208-cache.md#runtime-configuration)
 for details.
 
 **`invalidate`**
@@ -507,7 +507,7 @@ for details.
 * Values: `never`, `current`
 * Default: `never`
 
-An enumeration option specifying how the cache should invalidate\
+An enumeration option specifying how the cache should invalidate
 cache entries.
 
 ```
@@ -518,18 +518,18 @@ cache entries.
   not.
 ```
 
-The effect of `current` depends upon the value of `cached_data`. If the value\
-is `shared`, that is, all threads share the same cache, then the effect of an\
+The effect of `current` depends upon the value of `cached_data`. If the value
+is `shared`, that is, all threads share the same cache, then the effect of an
 invalidation is immediately visible to all sessions, as there is just one cache.\
-However, if the value is `thread_specific`, then an invalidation will affect only\
+However, if the value is `thread_specific`, then an invalidation will affect only
 the cache that the session happens to be using.
 
-If it is important and _sufficient_ that an application immediately sees a change\
-that it itself has caused, then a combination of `invalidate=current`\
+If it is important and _sufficient_ that an application immediately sees a change
+that it itself has caused, then a combination of `invalidate=current`
 and `cached_data=thread_specific` can be used.
 
-If it is important that an application _immediately_ sees all changes, irrespective\
-of who has caused them, then a combination of `invalidate=current`\
+If it is important that an application _immediately_ sees all changes, irrespective
+of who has caused them, then a combination of `invalidate=current`
 and `cached_data=shared` _must_ be used.
 
 **`clear_cache_on_parse_errors`**
@@ -539,18 +539,18 @@ and `cached_data=shared` _must_ be used.
 * Dynamic: No
 * Default: `true`
 
-This boolean option specifies how the cache should behave in case of\
+This boolean option specifies how the cache should behave in case of
 parsing errors when invalidation has been enabled.
 
-* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE\
+* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE
   statement then all cached data will be cleared.
-* `false`: A failure to parse an UPDATE/INSERT/DELETE statement\
+* `false`: A failure to parse an UPDATE/INSERT/DELETE statement
   is ignored and no invalidation will take place due that statement.
 
 The default value is `true`.
 
-Changing the value to `false` may mean that stale data is returned from\
-the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement\
+Changing the value to `false` may mean that stale data is returned from
+the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement
 affects entries in the cache.
 
 **`users`**
@@ -561,7 +561,7 @@ affects entries in the cache.
 * Values: `mixed`, `isolated`
 * Default: `mixed`
 
-An enumeration option specifying how the cache should cache data for\
+An enumeration option specifying how the cache should cache data for
 different users.
 
 ```
@@ -572,11 +572,11 @@ different users.
   no unintended sharing.
 ```
 
-Note that if `isolated` has been specified, then each user will\
-conceptually have a cache of his own, which is populated\
-independently from each other. That is, if two users make the\
-same query, then the data will be fetched twice and also stored\
-twice. So, a `isolated` cache will in general use more memory and\
+Note that if `isolated` has been specified, then each user will
+conceptually have a cache of his own, which is populated
+independently from each other. That is, if two users make the
+same query, then the data will be fetched twice and also stored
+twice. So, a `isolated` cache will in general use more memory and
 cause more traffic to the backend compared to a `mixed` cache.
 
 **`timeout`**
@@ -586,7 +586,7 @@ cause more traffic to the backend compared to a `mixed` cache.
 * Dynamic: No
 * Default: `5s`
 
-The _timeout_ used when performing operations to distributed storages\
+The _timeout_ used when performing operations to distributed storages
 such as _redis_ or _memcached_.
 
 ```
@@ -599,19 +599,19 @@ The duration can be specified as explained [here](../mariadb-maxscale-2208-getti
 
 #### Runtime Configuration
 
-The cache filter can be configured at runtime by executing SQL commands. If\
-there is more than one cache filter in a service, only the first cache filter\
-will be able to process the variables. The remaining filters will not see them\
+The cache filter can be configured at runtime by executing SQL commands. If
+there is more than one cache filter in a service, only the first cache filter
+will be able to process the variables. The remaining filters will not see them
 and thus configuring them at runtime is not possible.
 
 **`@maxscale.cache.populate`**
 
-Using the variable `@maxscale.cache.populate` it is possible to specify at\
-runtime whether the cache should be populated or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.populate` it is possible to specify at
+runtime whether the cache should be populated or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be populated.
 
 ```
@@ -621,10 +621,10 @@ SET @maxscale.cache.populate=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-In the example above, the first `SELECT` will always be sent to the\
-server and the result will be cached, provided the actual cache rules\
-specifies that it should be. The second `SELECT` may be served from the\
-cache, depending on the value of `@maxscale.cache.use` (and the cache\
+In the example above, the first `SELECT` will always be sent to the
+server and the result will be cached, provided the actual cache rules
+specifies that it should be. The second `SELECT` may be served from the
+cache, depending on the value of `@maxscale.cache.use` (and the cache
 rules).
 
 The value of `@maxscale.cache.populate` can be queried
@@ -637,12 +637,12 @@ but only _after_ it has been explicitly set once.
 
 **`@maxscale.cache.use`**
 
-Using the variable `@maxscale.cache.use` it is possible to specify at\
-runtime whether the cache should be used or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.use` it is possible to specify at
+runtime whether the cache should be used or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be used.
 
 ```
@@ -652,15 +652,15 @@ SET @maxscale.cache.use=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-The first `SELECT` will be served from the cache, providing the rules\
-specify that the statement should be cached, the cache indeed contains\
+The first `SELECT` will be served from the cache, providing the rules
+specify that the statement should be cached, the cache indeed contains
 the result and the date is not stale (as specified by the _TTL_).
 
-If the data is stale, the `SELECT` will be sent to the server **and**\
+If the data is stale, the `SELECT` will be sent to the server **and**
 the cache entry will be updated, irrespective of the value of`@maxscale.cache.populate`.
 
-If `@maxscale.cache.use` is `true` but the result is not found in the\
-cache, and the result is subsequently fetched from the server, the\
+If `@maxscale.cache.use` is `true` but the result is not found in the
+cache, and the result is subsequently fetched from the server, the
 result will **not** be added to the cache, unless`@maxscale.cache.populate` is also `true`.
 
 The value of `@maxscale.cache.use` can be queried
@@ -673,12 +673,12 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.soft_ttl`**
 
-Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime\
-to specify _in seconds_ what _soft ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `soft_ttl`. That is,\
+Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime
+to specify _in seconds_ what _soft ttl_ should be applied. Its initial
+value is the value of the configuration parameter `soft_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _soft ttl_ should be applied.
 
 ```
@@ -688,13 +688,13 @@ SET @maxscale.cache.soft_ttl=60;
 SELECT c, d FROM important;
 ```
 
-When data is `SELECT`ed from the unimportant table `unimportant`, the data\
-will be returned from the cache provided it is no older than 10 minutes,\
-but when data is `SELECT`ed from the important table `important`, the\
+When data is `SELECT`ed from the unimportant table `unimportant`, the data
+will be returned from the cache provided it is no older than 10 minutes,
+but when data is `SELECT`ed from the important table `important`, the
 data will be returned from the cache provided it is no older than 1 minute.
 
-Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`\
-in the sense that if the former is less that the latter, then _soft ttl_\
+Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`
+in the sense that if the former is less that the latter, then _soft ttl_
 will, when used, be adjusted down to the value of _hard ttl_.
 
 The value of `@maxscale.cache.soft_ttl` can be queried
@@ -707,16 +707,16 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.hard_ttl`**
 
-Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime\
-to specify _in seconds_ what _hard ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `hard_ttl`. That is,\
+Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime
+to specify _in seconds_ what _hard ttl_ should be applied. Its initial
+value is the value of the configuration parameter `hard_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _hard ttl_ should be applied.
 
-Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,\
-is important to ensure that the former is at least as large as the latter\
+Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,
+is important to ensure that the former is at least as large as the latter
 and for best overall performance that it is larger.
 
 ```
@@ -736,11 +736,11 @@ but only after it has explicitly been set once.
 
 **Client Driven Caching**
 
-With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible\
+With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible
 to make the caching completely client driven.
 
-Provide no `rules` file, which means that _all_ `SELECT` statements are\
-subject to caching and that all users receive data from the cache. Set\
+Provide no `rules` file, which means that _all_ `SELECT` statements are
+subject to caching and that all users receive data from the cache. Set
 the startup mode of the cache to _disabled_.
 
 ```
@@ -760,10 +760,10 @@ SELECT e, f FROM tbl3;
 SET @maxscale.cache.populate=FALSE;
 ```
 
-Note that those `SELECT`s must return something in order for the\
+Note that those `SELECT`s must return something in order for the
 statement to be _marked_ for caching.
 
-After this, the value of `@maxscale.cache.use` will decide whether\
+After this, the value of `@maxscale.cache.use` will decide whether
 or not the cache is considered.
 
 ```
@@ -772,12 +772,12 @@ SELECT a, b FROM tbl1;
 SET @maxscale.cache.use=FALSE;
 ```
 
-With `@maxscale.cache.use` being `true`, the cache is considered\
-and the result returned from there, if not stale. If it is stale,\
+With `@maxscale.cache.use` being `true`, the cache is considered
+and the result returned from there, if not stale. If it is stale,
 the result is fetched from the server and the cached entry is updated.
 
-By setting a very long _TTL_ it is possible to prevent the cache\
-from ever considering an entry to be stale and instead manually\
+By setting a very long _TTL_ it is possible to prevent the cache
+from ever considering an entry to be stale and instead manually
 cause the cache to be updated when needed.
 
 ```
@@ -789,8 +789,8 @@ SET @maxscale.cache.populate=FALSE;
 
 ### Threads, Users and Invalidation
 
-What caching approach is used and how different users are treated\
-has a significant impact on the behaviour of the cache. In the\
+What caching approach is used and how different users are treated
+has a significant impact on the behaviour of the cache. In the
 following the implication of different combinations is explained.
 
 | cached\_data/users | mixed                                                                                                                          | isolated                                                                                                                        |
@@ -800,14 +800,14 @@ following the implication of different combinations is explained.
 
 #### Invalidation
 
-Invalidation takes place only in the current cache, so how _visible_\
+Invalidation takes place only in the current cache, so how _visible_
 the invalidation is, depends upon the configuration value of`cached_data`.
 
 **`cached_data=thread_specific`**
 
-The invalidation is visible only to the sessions that are handled by\
-the same worker thread where the invalidation occurred. Sessions of the\
-same or other users that are handled by different worker threads will\
+The invalidation is visible only to the sessions that are handled by
+the same worker thread where the invalidation occurred. Sessions of the
+same or other users that are handled by different worker threads will
 not see the new value before the TTL causes the value to be refreshed.
 
 **`cache_data=shared`**
@@ -818,8 +818,8 @@ The invalidation is immediately visible to all sessions of all users.
 
 The caching rules are expressed as a JSON object or as an array of JSON objects.
 
-There are two decisions to be made regarding the caching; in what circumstances\
-should data be stored to the cache and in what circumstances should the data in\
+There are two decisions to be made regarding the caching; in what circumstances
+should data be stored to the cache and in what circumstances should the data in
 the cache be used.
 
 Expressed in JSON this looks as follows
@@ -843,9 +843,9 @@ or, in case an array is used, as
 ]
 ```
 
-The `store` field specifies in what circumstances data should be stored to\
-the cache and the `use` field specifies in what circumstances the data in\
-the cache should be used. In both cases, the value is a JSON array containing\
+The `store` field specifies in what circumstances data should be stored to
+the cache and the `use` field specifies in what circumstances the data in
+the cache should be used. In both cases, the value is a JSON array containing
 objects.
 
 If an array of rule objects is specified, then, when looking for a rule that\
@@ -855,14 +855,14 @@ deciding whether data in the cache should be used.
 
 #### When to Store
 
-By default, if no rules file have been provided or if the `store` field is\
-missing from the object, the results of all queries will be stored to the\
-cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter\
+By default, if no rules file have been provided or if the `store` field is
+missing from the object, the results of all queries will be stored to the
+cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter
 parameters.
 
-By providing a `store` field in the JSON object, the decision whether to\
-store the result of a particular query to the cache can be controlled in\
-a more detailed manner. The decision to cache the results of a query can\
+By providing a `store` field in the JSON object, the decision whether to
+store the result of a particular query to the cache can be controlled in
+a more detailed manner. The decision to cache the results of a query can
 depend upon
 
 * the database,
@@ -886,21 +886,21 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`\
+If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`
 or `unlike`, then _value_ is interpreted as a _pcre2_ regular expression.\
-Note though that if _attribute_ is `database`, `table` or `column`, then\
-the string is interpreted as a name, where a dot `.` denotes qualification\
+Note though that if _attribute_ is `database`, `table` or `column`, then
+the string is interpreted as a name, where a dot `.` denotes qualification
 or scoping.
 
-The objects in the `store` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `store` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 result of the query in question will be stored to the cache.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then the result of the query is not stored to the cache.
 
-Note that as the query itself is used as the key, although the following\
+Note that as the query itself is used as the key, although the following
 queries
 
 ```
@@ -914,7 +914,7 @@ USE db1;
 SELECT * FROM tbl
 ```
 
-target the same table and produce the same results, they will be cached\
+target the same table and produce the same results, they will be cached
 separately. The same holds for queries like
 
 ```
@@ -927,13 +927,13 @@ and
 SELECT * FROM tbl WHERE b = 3 AND a = 2;
 ```
 
-as well. Although they conceptually are identical, there will be two\
+as well. Although they conceptually are identical, there will be two
 cache entries.
 
-Note that if a column has been specified in a rule, then a statement\
+Note that if a column has been specified in a rule, then a statement
 will match _irrespective_ of where that particular column appears.\
-For instance, if a rule specifies that the result of statements referring\
-to the column _a_ should be cached, then the following statement will\
+For instance, if a rule specifies that the result of statements referring
+to the column _a_ should be cached, then the following statement will
 match
 
 ```
@@ -948,7 +948,7 @@ SELECT b FROM tbl WHERE a > 5;
 
 **Qualified Names**
 
-When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,\
+When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,
 dot (`.`) denotes qualification or scope.
 
 In practice that means that if _attribute_ is `database` then _value_ may\
@@ -957,20 +957,20 @@ dot, used for separating the database and table names respectively, and\
 if _attribute_ is `column` then _value_ may contain one or two dots, used\
 for separating table and column names, or database, table and column names.
 
-Note that if a qualified name is used as a _value_, then all parts of the\
-name must be available for a match. Currently Maria DB MaxScale may not\
-always be capable of deducing in what table a particular column is. If\
-that is the case, then a value like `tbl.field` may not necessarily\
+Note that if a qualified name is used as a _value_, then all parts of the
+name must be available for a match. Currently Maria DB MaxScale may not
+always be capable of deducing in what table a particular column is. If
+that is the case, then a value like `tbl.field` may not necessarily
 be a match even if the field is `field` and the table actually is `tbl`.
 
 **Implication of the default database**
 
-If the rules concerns the `database`, then only if the statement refers\
+If the rules concerns the `database`, then only if the statement refers
 to _no_ specific database, will the default database be considered.
 
 **Regexp Matching**
 
-The string used for matching the regular expression contains as much\
+The string used for matching the regular expression contains as much
 information as there is available. For instance, in a situation like
 
 ```
@@ -1010,8 +1010,8 @@ Cache all queries _not_ targeting a particular table
 }
 ```
 
-That will exclude queries targeting table _tbl1_ irrespective of which\
-database it is in. To exclude a table in a particular database, specify\
+That will exclude queries targeting table _tbl1_ irrespective of which
+database it is in. To exclude a table in a particular database, specify
 the table name using a qualified name.
 
 ```
@@ -1040,16 +1040,16 @@ Cache all queries containing a WHERE clause
 }
 ```
 
-Note that will actually cause all queries that contain WHERE anywhere,\
+Note that will actually cause all queries that contain WHERE anywhere,
 to be cached.
 
 #### When to Use
 
-By default, if no rules file have been provided or if the `use` field is\
+By default, if no rules file have been provided or if the `use` field is
 missing from the object, all users may be returned data from the cache.
 
-By providing a `use` field in the JSON object, the decision whether to use\
-data from the cache can be controlled in a more detailed manner. The decision\
+By providing a `use` field in the JSON object, the decision whether to use
+data from the cache can be controlled in a more detailed manner. The decision
 to use data from the cache can depend upon
 
 * the user.
@@ -1070,7 +1070,7 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account\
+If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account
 string, that is, `%` means indicates wildcard, but if _op_ is `like` or`unlike` it is simply assumed _value_ is a pcre2 regular expression.
 
 For instance, the following are equivalent:
@@ -1089,26 +1089,26 @@ For instance, the following are equivalent:
 }
 ```
 
-Note that if _op_ is `=` or `!=` then the usual assumptions apply,\
-that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_\
-or _unlike_ is used, then no assumptions apply, but the string is\
+Note that if _op_ is `=` or `!=` then the usual assumptions apply,
+that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_
+or _unlike_ is used, then no assumptions apply, but the string is
 used verbatim as a regular expression.
 
-The objects in the `use` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `use` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 data in the cache will be used, subject to the value of `ttl`.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then data in the cache will not be used.
 
-Note that `use` is relevant only if the query is subject to caching,\
-that is, if all queries are cached or if a query matches a particular\
+Note that `use` is relevant only if the query is subject to caching,
+that is, if all queries are cached or if a query matches a particular
 rule in the `store` array.
 
 **Examples**
 
-Use data from the cache for all users except `admin` (actually `'admin'@'%'`),\
+Use data from the cache for all users except `admin` (actually `'admin'@'%'`),
 regardless of what host the `admin` user comes from.
 
 ```
@@ -1125,15 +1125,15 @@ regardless of what host the `admin` user comes from.
 
 ### Security
 
-As the cache is not aware of grants, unless the cache has been explicitly\
-configured who the caching should apply to, the presence of the cache\
+As the cache is not aware of grants, unless the cache has been explicitly
+configured who the caching should apply to, the presence of the cache
 may provide a user with access to data he should not have access to.\
 Note that the following applies _only_ if `users=mixed` has been configured.\
-If `users=isolated` has been configured, then there can never be any\
+If `users=isolated` has been configured, then there can never be any
 unintended sharing between users.
 
-Suppose there is a table `access` that the user _alice_ has access to,\
-but the user _bob_ does not. If _bob_ tries to access the table, he will\
+Suppose there is a table `access` that the user _alice_ has access to,
+but the user _bob_ does not. If _bob_ tries to access the table, he will
 get an error as reply:
 
 ```
@@ -1141,8 +1141,8 @@ MySQL [testdb]> select * from access;
 ERROR 1142 (42000): SELECT command denied to user 'bob'@'localhost' for table 'access'
 ```
 
-If we now setup caching for the table, using the simplest possible rules\
-file, _bob_ will get access to data from the table, provided he executes\
+If we now setup caching for the table, using the simplest possible rules
+file, _bob_ will get access to data from the table, provided he executes
 a select identical with one _alice_ has executed.
 
 For instance, suppose the rules look as follows:
@@ -1159,7 +1159,7 @@ For instance, suppose the rules look as follows:
 }
 ```
 
-If _alice_ now queries the table, she will get the result, which also will\
+If _alice_ now queries the table, she will get the result, which also will
 be cached:
 
 ```
@@ -1171,7 +1171,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-If _bob_ now executes the very same query, and the result is still in the\
+If _bob_ now executes the very same query, and the result is still in the
 cache, it will be returned to him.
 
 ```
@@ -1191,7 +1191,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-That can be prevented, by explicitly declaring in the rules that the caching\
+That can be prevented, by explicitly declaring in the rules that the caching
 should be applied to _alice_ only.
 
 ```
@@ -1213,24 +1213,24 @@ should be applied to _alice_ only.
 }
 ```
 
-With these rules in place, _bob_ is again denied access, since queries\
+With these rules in place, _bob_ is again denied access, since queries
 targeting the table `access` will in his case not be served from the cache.
 
 ### Storage
 
 There are two types of storages that can be used; _local_ and _shared_.
 
-The only _local_ storage implementation is `storage_inmemory` that simply\
-stores the cache values in memory. The storage is not persistent and is\
-destroyed when MaxScale terminates. Since the storage exists in the MaxScale\
+The only _local_ storage implementation is `storage_inmemory` that simply
+stores the cache values in memory. The storage is not persistent and is
+destroyed when MaxScale terminates. Since the storage exists in the MaxScale
 process, it is very fast and provides almost always a performance benefit.
 
-Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)\
+Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)
 and [redis](https://redis.io/) respectively.
 
 The shared storages are accessed across the network and consequently it is _not_ self-evident that their use will provide any performance benefit.
-Namely, irrespective of whether the data is fetched from the cache or from\
-the server there will be a network hop and often that network hop is, as far\
+Namely, irrespective of whether the data is fetched from the cache or from
+the server there will be a network hop and often that network hop is, as far
 as the performance goes, what costs the most.
 
 The presence of a shared cache _may_ provide a performance benefit
@@ -1239,12 +1239,12 @@ The presence of a shared cache _may_ provide a performance benefit
 * if the used SELECT statements are heavy (that is, take a significant amount of time) to process for the database server, or
 * if the presence of the cache reduces the overall load of an otherwise overloaded database server.
 
-As a general rule a _shared_ storage should not be used without first\
+As a general rule a _shared_ storage should not be used without first
 assessing its value using a realistic workload.
 
 #### `storage_inmemory`
 
-This simple storage module uses the standard memory allocator for storing\
+This simple storage module uses the standard memory allocator for storing
 the cached data.
 
 ```
@@ -1255,12 +1255,12 @@ This storage module takes no arguments.
 
 #### `storage_memcached`
 
-This storage module uses [memcached](https://memcached.org/) for storing the\
+This storage module uses [memcached](https://memcached.org/) for storing the
 cached data.
 
-Multiple MaxScale instances can share the same memcached server and items\
+Multiple MaxScale instances can share the same memcached server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
@@ -1275,11 +1275,11 @@ storage=storage_memcached
 `storage_memcached` has the following optional arguments:
 
 * `max_value_size` using which the maximum size of a cached value is specified.\
-  By default, the maximum size of a value stored to memcached is 1MB, but that\
-  configured to be something else. The value of `max_value_size` will be used\
-  for capping `max_resultset_size`, that is, unless memcached is configured to\
-  allow larger values that 1M and `max_value_size` has been set accordingly,\
-  only resultsets up to 1MB in size will be cached. The value can be specified\
+  By default, the maximum size of a value stored to memcached is 1MB, but that
+  configured to be something else. The value of `max_value_size` will be used
+  for capping `max_resultset_size`, that is, unless memcached is configured to
+  allow larger values that 1M and `max_value_size` has been set accordingly,
+  only resultsets up to 1MB in size will be cached. The value can be specified
   as documented [here](https://mariadb.com/kb/Getting-Started/Configuration-Guide/#sizes).
 
 Example:
@@ -1295,35 +1295,35 @@ storage_options="server=192.168.1.31:11211, max_value_size=10M"
 
 **Security**
 
-_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and\
-the memcached server is encrypted. Consequently, _anybody_ with access to the\
+_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and
+the memcached server is encrypted. Consequently, _anybody_ with access to the
 memcached server or to the network have access to the cached data.
 
 #### `storage_redis`
 
-This storage module uses [redis](https://redis.io/) for storing the\
+This storage module uses [redis](https://redis.io/) for storing the
 cached data.
 
-Multiple MaxScale instances can share the same redis server and items\
+Multiple MaxScale instances can share the same redis server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
 storage=storage_redis
 ```
 
-If `storage_redis` cannot connect to the Redis server, caching will silently\
-be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2208-cache.md#timeout)\
+If `storage_redis` cannot connect to the Redis server, caching will silently
+be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2208-cache.md#timeout)
 interval.
 
-If a timeout error occurs during an operation, reconnecting will be attempted\
-after a delay, which will be an increasing multiple of `timeout`. For example,\
-if `timeout` is the default 5 seconds, then reconnection attempts will first\
-be made after 10 seconds, then after 15 seconds, then 20 and so on. However,\
-once 60 seconds have been reached, the delay will no longer be increased but\
-the delay will stay at one minute. Note that each time a reconnection attempt\
-is made, unless the reason for the timeout has disappeared, the client will be\
+If a timeout error occurs during an operation, reconnecting will be attempted
+after a delay, which will be an increasing multiple of `timeout`. For example,
+if `timeout` is the default 5 seconds, then reconnection attempts will first
+be made after 10 seconds, then after 15 seconds, then 20 and so on. However,
+once 60 seconds have been reached, the delay will no longer be increased but
+the delay will stay at one minute. Note that each time a reconnection attempt
+is made, unless the reason for the timeout has disappeared, the client will be
 stalled for `timeout` seconds.
 
 `storage_redis` has the following mandatory arguments:
@@ -1337,8 +1337,8 @@ Example:
 storage_options="server=192.168.1.31:6379"
 ```
 
-Note that Redis should be configured with no idle timeout or with a timeout that\
-is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which\
+Note that Redis should be configured with no idle timeout or with a timeout that
+is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which
 will hurt both the functionality and the performance.
 
 **Limitations**
@@ -1348,12 +1348,12 @@ will hurt both the functionality and the performance.
 
 **Invalidation**
 
-`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2208-cache.md#best-efforts)\
-are of greater significance since also the communication between the cache and the\
+`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2208-cache.md#best-efforts)
+are of greater significance since also the communication between the cache and the
 cache storage is asynchronous and takes place over the network.
 
-_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation\
-mode), redis must be flushed as otherwise there will be entries in the cache that\
+_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation
+mode), redis must be flushed as otherwise there will be entries in the cache that
 will not be affected by the invalidation.
 
 ```
@@ -1362,13 +1362,13 @@ $ redis-cli flushall
 
 **Security**
 
-_Neither_ the data in the redis server _nor_ the traffic between MaxScale and\
-the redis server is encrypted. Consequently, _anybody_ with access to the\
+_Neither_ the data in the redis server _nor_ the traffic between MaxScale and
+the redis server is encrypted. Consequently, _anybody_ with access to the
 redis server or to the network have access to the cached data.
 
 ### Example
 
-In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size\
+In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size
 of the cached data is `50` mebibytes. The rules for the cache are in the file`cache_rules.json`.
 
 #### Configuration
@@ -1408,16 +1408,16 @@ The rules specify that the data of the table `sbtest` should be cached.
 
 ### Performance
 
-When the cache filter was introduced, the most significant factor affecting\
+When the cache filter was introduced, the most significant factor affecting
 the performance of the cache was whether the statements needed to be parsed.\
-Initially, all statements were parsed in order to exclude `SELECT` statements\
-that use non-cacheable functions, access non-cacheable variables or refer\
-to system or user variables. Later, the default value of the `selects` parameter\
+Initially, all statements were parsed in order to exclude `SELECT` statements
+that use non-cacheable functions, access non-cacheable variables or refer
+to system or user variables. Later, the default value of the `selects` parameter
 was changed to `assume_cacheable`, to maximize the default performance.
 
-With the default configuration, the cache itself will not cause the statements\
-to be parsed. However, even with `assume_cacheable` configured, a rule referring\
-specifically to a _database_, _table_ or _column_ will still cause the\
+With the default configuration, the cache itself will not cause the statements
+to be parsed. However, even with `assume_cacheable` configured, a rule referring
+specifically to a _database_, _table_ or _column_ will still cause the
 statement to be parsed.
 
 For instance, a simple rule like
@@ -1452,15 +1452,15 @@ If the rule is instead expressed using a regular expression
 
 then the statement will not be parsed.
 
-However, when the [query classifier cache](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#query_classifier_cache_size)\
-was introduced, the parsing cost was significantly reduced and\
-currently the cost for parsing and regular expression matching\
+However, when the [query classifier cache](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#query_classifier_cache_size)
+was introduced, the parsing cost was significantly reduced and
+currently the cost for parsing and regular expression matching
 is roughly the same.
 
-In the following is a table with numbers giving a rough picture\
+In the following is a table with numbers giving a rough picture
 of the relative cost of different approaches.
 
-In the table, _regexp match_ means that the cacheable statements\
+In the table, _regexp match_ means that the cacheable statements
 were picked out using a rule like
 
 ```
@@ -1471,7 +1471,7 @@ were picked out using a rule like
 }
 ```
 
-while _exact match_ means that the cacheable statements were picked out using a\
+while _exact match_ means that the cacheable statements were picked out using a
 rule like
 
 ```
@@ -1484,12 +1484,12 @@ rule like
 
 The exact match rule requires all statements to be parsed.
 
-As the purpose of the test is to illustrate the overhead of\
-different approaches, the rules were formulated so that\
+As the purpose of the test is to illustrate the overhead of
+different approaches, the rules were formulated so that
 all SELECT statements would match.
 
 Note that these figures were obtained by running sysbench,\
-MaxScale and the server in the same computer, so they are\
+MaxScale and the server in the same computer, so they are
 only indicative.
 
 | selects           | Rule         | qps |
@@ -1503,18 +1503,18 @@ only indicative.
 
 For comparison, without caching, the qps is `33`.
 
-As can be seen, due to the query classifier cache there is\
+As can be seen, due to the query classifier cache there is
 no difference between exact and regex based matching.
 
 #### Summary
 
 For maximum performance:
 
-* Arrange the situation so that the default `selects=assume_cacheable`\
+* Arrange the situation so that the default `selects=assume_cacheable`
   can be used, and use no rules.
 
-Otherwise it is mostly a personal preference whether exact or regex\
-based rules are used. However, one should always test with real data\
+Otherwise it is mostly a personal preference whether exact or regex
+based rules are used. However, one should always test with real data
 and real queries before choosing one over the other.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-comment-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-comment-filter.md
@@ -6,8 +6,8 @@
 
 ### Overview
 
-With the _comment_ filter it is possible to define comments that are\
-injected before the actual statements. These comments appear as sql\
+With the _comment_ filter it is possible to define comments that are
+injected before the actual statements. These comments appear as sql
 comments when they are received by the server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-consistent-critical-read-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-consistent-critical-read-filter.md
@@ -8,41 +8,41 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Consistent Critical Read (CCR) filter allows consistent critical reads to be\
+The Consistent Critical Read (CCR) filter allows consistent critical reads to be
 done through MaxScale while still allowing scaleout of non-critical reads.
 
-When the filter detects a statement that would modify the database, it attaches\
-a routing hint to all following statements done by that connection. This routing\
-hint guides the routing module to route the statement to the master server where\
-data is guaranteed to be in an up-to-date state. Writes from one session do not,\
+When the filter detects a statement that would modify the database, it attaches
+a routing hint to all following statements done by that connection. This routing
+hint guides the routing module to route the statement to the master server where
+data is guaranteed to be in an up-to-date state. Writes from one session do not,
 by default, propagate to other sessions.
 
-_Note:_ This filter does not work with prepared statements. Only text protocol\
+_Note:_ This filter does not work with prepared statements. Only text protocol
 queries are handled by this filter.
 
 #### Controlling the Filter with SQL Comments
 
-The triggering of the filter can be limited further by adding MaxScale supported\
-comments to queries and/or by using regular expressions. The query comments take\
-precedence: if a comment is found it is obeyed even if a regular expression\
+The triggering of the filter can be limited further by adding MaxScale supported
+comments to queries and/or by using regular expressions. The query comments take
+precedence: if a comment is found it is obeyed even if a regular expression
 parameter might give a different result. Even a comment cannot cause a\
-SELECT-query to trigger the filter. Such a comment is considered an error and\
+SELECT-query to trigger the filter. Such a comment is considered an error and
 ignored.
 
-The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-hint-syntax.md)\
-and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a\
-query has a MaxScale supported comment line which defines the parameter `ccr`,\
-that comment is caught by the CCR-filter. Parameter values `match` and `ignore`\
-are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)\
+The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-hint-syntax.md)
+and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a
+query has a MaxScale supported comment line which defines the parameter `ccr`,
+that comment is caught by the CCR-filter. Parameter values `match` and `ignore`
+are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)
 on receiving the write query. For example, the query
 
 ```
 INSERT INTO departments VALUES ('d1234', 'NewDepartment'); -- maxscale ccr=ignore
 ```
 
-would normally cause the filter to trigger, but does not because of the\
-comment. The `match`-comment typically has no effect, since write queries by\
-default trigger the filter anyway. It can be used to override an ignore-type\
+would normally cause the filter to trigger, but does not because of the
+comment. The `match`-comment typically has no effect, since write queries by
+default trigger the filter anyway. It can be used to override an ignore-type
 regular expression that would otherwise prevent triggering.
 
 ### Filter Parameters
@@ -56,19 +56,19 @@ The CCR filter has no mandatory parameters.
 * Dynamic: Yes
 * Default: `60s`
 
-The time window during which queries are routed to the master. The duration\
-can be specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations)\
+The time window during which queries are routed to the master. The duration
+can be specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations)
 but the value will always be rounded to the nearest second.\
-If no explicit unit has been specified, the value is interpreted as seconds\
+If no explicit unit has been specified, the value is interpreted as seconds
 in MaxScale 2.4. In subsequent versions a value without a unit may be rejected.\
 The default value for this parameter is 60 seconds.
 
-When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new\
-data modifying SQL statement is processed within the time window, the timer is\
+When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new
+data modifying SQL statement is processed within the time window, the timer is
 reset to the value of _time_.
 
-Enabling this parameter in combination with the _count_ parameter causes both\
-the time window and number of queries to be inspected. If either of the two\
+Enabling this parameter in combination with the _count_ parameter causes both
+the time window and number of queries to be inspected. If either of the two
 conditions are met, the query is re-routed to the master.
 
 #### `count`
@@ -81,10 +81,10 @@ conditions are met, the query is re-routed to the master.
 The number of SQL statements to route to master after detecting a data modifying\
 SQL statement. This feature is disabled by default.
 
-After processing a data modifying SQL statement, a counter is set to the value\
-of _count_ and all statements are routed to the master. Each executed statement\
-after a data modifying SQL statement cause the counter to be decremented. Once\
-the counter reaches zero, the statements are routed normally. If a new data\
+After processing a data modifying SQL statement, a counter is set to the value
+of _count_ and all statements are routed to the master. Each executed statement
+after a data modifying SQL statement cause the counter to be decremented. Once
+the counter reaches zero, the statements are routed normally. If a new data
 modifying SQL statement is processed, the counter is reset to the value of_count_.
 
 #### `match`, `ignore`
@@ -94,9 +94,9 @@ modifying SQL statement is processed, the counter is reset to the value of_count
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
-control which statements trigger statement re-routing. Only non-SELECT statements are\
-inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works\
+These [regular expression settings](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+control which statements trigger statement re-routing. Only non-SELECT statements are
+inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works
 similarly.
 
 ```
@@ -122,16 +122,16 @@ Regular expression options for `match` and `ignore`.
 * Dynamic: Yes
 * Default: `false`
 
-`global` is a boolean parameter that when enabled causes writes from one\
-connection to propagate to all other connections. This can be used to work\
-around cases where one connection writes data and another reads it, expecting\
+`global` is a boolean parameter that when enabled causes writes from one
+connection to propagate to all other connections. This can be used to work
+around cases where one connection writes data and another reads it, expecting
 the write done by the other connection to be visible.
 
 This parameter only works with the `time` parameter. The use of `global` and`count` at the same time is not allowed and will be treated as an error.
 
 ### Example Configuration
 
-Here is a minimal filter configuration for the CCRFilter which should solve most\
+Here is a minimal filter configuration for the CCRFilter which should solve most
 problems with critical reads after writes.
 
 ```
@@ -141,13 +141,13 @@ module=ccrfilter
 time=5
 ```
 
-With this configuration, whenever a connection does a write, all subsequent\
+With this configuration, whenever a connection does a write, all subsequent
 reads done by that connection will be forced to the master for 5 seconds.
 
-This prevents read scaling until the modifications have been replicated to the\
-slaves. For best performance, the value of _time_ should be slightly greater\
-than the actual replication lag between the master and its slaves. If the number\
-of critical read statements is known, the _count_ parameter could be used to\
+This prevents read scaling until the modifications have been replicated to the
+slaves. For best performance, the value of _time_ should be slightly greater
+than the actual replication lag between the master and its slaves. If the number
+of critical read statements is known, the _count_ parameter could be used to
 control the number reads that are sent to the master.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-hintfilter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-hintfilter.md
@@ -8,14 +8,14 @@ This filter adds routing hints to a service. The filter has no parameters.
 
 ## Hint Syntax
 
-**Note:** If a query has more than one comment only the first comment is\
-processed. Always place any MaxScale related comments first before any other\
+**Note:** If a query has more than one comment only the first comment is
+processed. Always place any MaxScale related comments first before any other
 comments that might appear in the query.
 
 ### Comments and comment types
 
-The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and\
-they need to be enabled by passing the `--comments` or `-c` option to it. Most,\
+The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and
+they need to be enabled by passing the `--comments` or `-c` option to it. Most,
 if not all, connectors keep all comments intact in executed queries.
 
 ```
@@ -23,10 +23,10 @@ if not all, connectors keep all comments intact in executed queries.
 mariadb --comments -u my-user -psecret -e "SELECT @@hostname -- maxscale route to server db1"
 ```
 
-For comment types, use either `--` (notice the whitespace after the double\
+For comment types, use either `--` (notice the whitespace after the double
 hyphen) or `#` after the semicolon or `/* ... */` before the semicolon.
 
-Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character\
+Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character
 after the start tag or before the end tag but adding the whitespace is advised.
 
 ### Hint body
@@ -37,12 +37,12 @@ All hints must start with the `maxscale` tag.
 -- maxscale <hint body>
 ```
 
-The hints have two types, ones that define a server type and others that contain\
+The hints have two types, ones that define a server type and others that contain
 name-value pairs.
 
 #### Routing destination hints
 
-These hints will instruct the router to route a query to a certain type of a\
+These hints will instruct the router to route a query to a certain type of a
 server.
 
 ```
@@ -55,8 +55,8 @@ server.
 -- maxscale route to master
 ```
 
-A `master` value in a routing hint will route the query to a master server. This\
-can be used to direct read queries to a master server for a up-to-date result\
+A `master` value in a routing hint will route the query to a master server. This
+can be used to direct read queries to a master server for a up-to-date result
 with no replication lag.
 
 **Route to slave**
@@ -65,8 +65,8 @@ with no replication lag.
 -- maxscale route to slave
 ```
 
-A `slave` value will route the query to a slave server. Please note that the\
-hints will override any decisions taken by the routers which means that it is\
+A `slave` value will route the query to a slave server. Please note that the
+hints will override any decisions taken by the routers which means that it is
 possible to force writes to a slave server.
 
 **Route to named server**
@@ -75,7 +75,7 @@ possible to force writes to a slave server.
 -- maxscale route to server <server name>
 ```
 
-A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in\
+A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in
 maxscale.cnf. If the server is not used by the service, the hint is ignored.
 
 **Route to last used server**
@@ -84,8 +84,8 @@ maxscale.cnf. If the server is not used by the service, the hint is ignored.
 -- maxscale route to last
 ```
 
-A `last` value will route the query to the server that processed the last\
-query. This hint can be used to force certain queries to be grouped to the same\
+A `last` value will route the query to the server that processed the last
+query. This hint can be used to force certain queries to be grouped to the same
 server.
 
 **Name-value hints**
@@ -94,13 +94,13 @@ server.
 -- maxscale <param>=<value>
 ```
 
-These control the behavior and affect the routing decisions made by the\
-router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower\
+These control the behavior and affect the routing decisions made by the
+router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower
 replication lag than this parameter's value.
 
 ### Hint stack
 
-Hints can be either single-use hints, which makes them affect only one query, or\
+Hints can be either single-use hints, which makes them affect only one query, or
 named hints, which can be pushed on and off a stack of active hints.
 
 Defining named hints:
@@ -127,7 +127,7 @@ You can define and activate a hint in a single command using the following:
 -- maxscale <hint name> begin <hint content>
 ```
 
-You can also push anonymous hints onto the stack which are only used as long as\
+You can also push anonymous hints onto the stack which are only used as long as
 they are on the stack:
 
 ```
@@ -136,14 +136,14 @@ they are on the stack:
 
 ## Prepared Statements
 
-The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared\
+The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared
 statements.
 
 ### Binary Protocol
 
-With binary protocol prepared statements, a routing hint in the prepared\
-statement is applied to the execution of the statement but not the preparation\
-of it. The preparation of the statement is routed normally and is sent to all\
+With binary protocol prepared statements, a routing hint in the prepared
+statement is applied to the execution of the statement but not the preparation
+of it. The preparation of the statement is routed normally and is sent to all
 servers.
 
 For example, when the following prepared statement is prepared with the MariaDB\
@@ -169,13 +169,13 @@ Support for direct execution of prepared statements was added in MaxScale\
 
 ### Text Protocol
 
-Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL\
-commands) behave differently. If a `PREPARE` command has a routing hint, it will\
-be routed according to the routing hint. Any subsequent `EXECUTE` command will\
-not be affected by the routing hint in the `PREPARE` statement. This means they\
+Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL
+commands) behave differently. If a `PREPARE` command has a routing hint, it will
+be routed according to the routing hint. Any subsequent `EXECUTE` command will
+not be affected by the routing hint in the `PREPARE` statement. This means they
 must have their own routing hints.
 
-The following example is the recommended method of executing text protocol\
+The following example is the recommended method of executing text protocol
 prepared statements with hints:
 
 ```
@@ -189,7 +189,7 @@ The `PREPARE` is routed normally and will be routed to all servers. The`EXECUTE`
 
 ### Routing `SELECT` queries to master
 
-In this example, MariaDB MaxScale is configured with the readwritesplit router\
+In this example, MariaDB MaxScale is configured with the readwritesplit router
 and the hint filter.
 
 ```
@@ -206,9 +206,9 @@ type=filter
 module=hintfilter
 ```
 
-Behind MariaDB MaxScale is a master server and a slave server. If there is\
-replication lag between the master and the slave, read queries sent to the slave\
-might return old data. To guarantee up-to-date data, we can add a routing hint\
+Behind MariaDB MaxScale is a master server and a slave server. If there is
+replication lag between the master and the slave, read queries sent to the slave
+might return old data. To guarantee up-to-date data, we can add a routing hint
 to the query.
 
 ```
@@ -216,9 +216,9 @@ INSERT INTO table1 VALUES ("John","Doe",1);
 SELECT * FROM table1; -- maxscale route to master
 ```
 
-The first INSERT query will be routed to the master. The following SELECT query\
-would normally be routed to the slave but with the added routing hint it will be\
-routed to the master. This way we can do an INSERT and a SELECT right after it\
+The first INSERT query will be routed to the master. The following SELECT query
+would normally be routed to the slave but with the added routing hint it will be
+routed to the master. This way we can do an INSERT and a SELECT right after it
 and still get up-to-date data.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-insert-stream-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-insert-stream-filter.md
@@ -6,15 +6,15 @@
 
 This filter was introduced in MariaDB MaxScale 2.1.
 
-**Note**: This filter has been deprecated in MaxScale 22.08.2 and will be\
+**Note**: This filter has been deprecated in MaxScale 22.08.2 and will be
 removed in MaxScale 23.02.
 
 ### Overview
 
-The _insertstream_ filter converts bulk inserts into CSV data streams that are\
-consumed by the backend server via the LOAD DATA LOCAL INFILE mechanism. This\
-leverages the speed advantage of LOAD DATA LOCAL INFILE over regular inserts\
-while also reducing the overall network traffic by condensing the inserted\
+The _insertstream_ filter converts bulk inserts into CSV data streams that are
+consumed by the backend server via the LOAD DATA LOCAL INFILE mechanism. This
+leverages the speed advantage of LOAD DATA LOCAL INFILE over regular inserts
+while also reducing the overall network traffic by condensing the inserted
 values into CSV.
 
 **Note**: This is an experimental filter module
@@ -25,11 +25,11 @@ This filter has no parameters.
 
 ### Details of Operation
 
-The filter translates all INSERT statements done inside an explicit transaction\
-into LOAD DATA LOCAL INFILE streams. The file name used in the request will\
+The filter translates all INSERT statements done inside an explicit transaction
+into LOAD DATA LOCAL INFILE streams. The file name used in the request will
 always be _maxscale.data_.
 
-The following example is translated into a LOAD DATA LOCAL INFILE request\
+The following example is translated into a LOAD DATA LOCAL INFILE request
 followed by two CSV rows.
 
 ```
@@ -38,10 +38,10 @@ INSERT INTO test.t1 VALUES (1, "hello"), (2, "world");
 COMMIT;
 ```
 
-Multiple inserts to the same table are combined into a single stream. This\
+Multiple inserts to the same table are combined into a single stream. This
 allows for efficient bulk loading with simple insert statements.
 
-The following example will use only one LOAD DATA LOCAL INFILE request followed\
+The following example will use only one LOAD DATA LOCAL INFILE request followed
 by four CSV rows.
 
 ```
@@ -51,11 +51,11 @@ INSERT INTO test.t1 VALUES (3, "foo"), (4, "bar");
 COMMIT;
 ```
 
-Non-INSERT statements executed inside the transaction will close the streaming\
-of the data. Avoid interleaving SELECT statements with INSERT statements inside\
+Non-INSERT statements executed inside the transaction will close the streaming
+of the data. Avoid interleaving SELECT statements with INSERT statements inside
 transactions.
 
-The following example has to use two LOAD DATA LOCAL INFILE requests, each\
+The following example has to use two LOAD DATA LOCAL INFILE requests, each
 followed by two CSV rows.
 
 **Note:** Avoid doing this!
@@ -70,8 +70,8 @@ COMMIT;
 
 #### Estimating Network Bandwidth Reduction
 
-The more inserts that are streamed, the more efficient this filter is. The\
-saving in network bandwidth in bytes can be estimated with the following\
+The more inserts that are streamed, the more efficient this filter is. The
+saving in network bandwidth in bytes can be estimated with the following
 formula:
 
 ```
@@ -87,7 +87,7 @@ Positive values indicate savings in network bandwidth usage.
 
 ### Example Configuration
 
-The filter has no parameters so it is extremely simple to configure. The\
+The filter has no parameters so it is extremely simple to configure. The
 following example shows the required filter configuration.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-lua-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-lua-filter.md
@@ -6,34 +6,34 @@
 
 The luafilter is a filter that calls a set of functions in a Lua script.
 
-Read the [Lua language documentation](https://www.lua.org/docs.html) for\
+Read the [Lua language documentation](https://www.lua.org/docs.html) for
 information on how to write Lua scripts.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Filter Parameters
 
-The luafilter has two parameters. They control which scripts will be called by\
-the filter. Both parameters are optional but at least one should be defined. If\
-both `global_script` and `session_script` are defined, the entry points in both\
+The luafilter has two parameters. They control which scripts will be called by
+the filter. Both parameters are optional but at least one should be defined. If
+both `global_script` and `session_script` are defined, the entry points in both
 scripts will be called.
 
 #### `global_script`
 
-The global Lua script. The parameter value is a path to a readable Lua script\
+The global Lua script. The parameter value is a path to a readable Lua script
 which will be executed.
 
-This script will always be called with the same global Lua state and it can be\
+This script will always be called with the same global Lua state and it can be
 used to build a global view of the whole service.
 
 #### `session_script`
 
-The session level Lua script. The parameter value is a path to a readable Lua\
+The session level Lua script. The parameter value is a path to a readable Lua
 script which will be executed once for each session.
 
-Each session will have its own Lua state meaning that each session can have a\
+Each session will have its own Lua state meaning that each session can have a
 unique Lua environment. Use this script to do session specific tasks.
 
 ### Lua Script Calling Convention
@@ -41,38 +41,38 @@ unique Lua environment. Use this script to do session specific tasks.
 The entry points for the Lua script expect the following signatures:
 
 * `nil createInstance(name)` - global script only, called when the script is first loaded
-  * When the global script is loaded, it first executes on a global level\
-    before the luafilter calls the createInstance function in the Lua script\
+  * When the global script is loaded, it first executes on a global level
+    before the luafilter calls the createInstance function in the Lua script
     with the filter's name as its argument.
 * `nil newSession(string, string)` - new session is created
-  * After the session script is loaded, the newSession function in the Lua\
-    scripts is called. The first parameter is the username of the client and\
+  * After the session script is loaded, the newSession function in the Lua
+    scripts is called. The first parameter is the username of the client and
     the second parameter is the client's network address.
 * `nil closeSession()` - session is closed
   * The `closeSession` function in the Lua scripts will be called.
 * `(nil | bool | string) routeQuery(string)` - query is being routed
-  * The Luafilter calls the `routeQuery` functions of both the session and the\
-    global script. The query is passed as a string parameter to the\
-    routeQuery Lua function and the return values of the session specific\
-    function, if any were returned, are interpreted. If the first value is\
-    bool, it is interpreted as a decision whether to route the query or to\
-    send an error packet to the client. If it is a string, the current query\
-    is replaced with the return value and the query will be routed. If nil is\
+  * The Luafilter calls the `routeQuery` functions of both the session and the
+    global script. The query is passed as a string parameter to the
+    routeQuery Lua function and the return values of the session specific
+    function, if any were returned, are interpreted. If the first value is
+    bool, it is interpreted as a decision whether to route the query or to
+    send an error packet to the client. If it is a string, the current query
+    is replaced with the return value and the query will be routed. If nil is
     returned, the query is routed normally.
 * `nil clientReply(string)` - reply to a query is being routed
   * This function is called with the name of the server that returned the response.
 * `string diagnostic()` - global script only, print diagnostic information
-  * If the Lua function returns a string that is valid JSON, it will be\
-    decoded as JSON and displayed as such in the REST API. If the object does\
+  * If the Lua function returns a string that is valid JSON, it will be
+    decoded as JSON and displayed as such in the REST API. If the object does
     not decode into JSON, it will be stored as a JSON string.
 
-These functions, if found in the script, will be called whenever a call to the\
+These functions, if found in the script, will be called whenever a call to the
 matching entry point is made.
 
 **Script Template**
 
-Here is a script template that can be used to try out the luafilter. Copy it\
-into a file and add `global_script=<path to script>` into the filter\
+Here is a script template that can be used to try out the luafilter. Copy it
+into a file and add `global_script=<path to script>` into the filter
 configuration. Make sure the file is readable by the `maxscale` user.
 
 ```
@@ -103,23 +103,23 @@ end
 
 #### Functions Exposed by the Luafilter
 
-The luafilter exposes the following functions that can be called inside the Lua\
+The luafilter exposes the following functions that can be called inside the Lua
 script API endpoints.
 
 * `string mxs_get_type_mask()`
-* Returns the type of the current query being executed as a string. The values\
-  are the string versions of the query types defined in query\_classifier.h\
+* Returns the type of the current query being executed as a string. The values
+  are the string versions of the query types defined in query\_classifier.h
   are separated by vertical bars (`|`).\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_operation()`
-* Returns the current operation type as a string. The values are defined in\
+* Returns the current operation type as a string. The values are defined in
   query\_classifier.h.\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_canonical()`
 * Returns the canonical version of a query by replacing all user-defined constant values with question marks.\
   This function can only be called from the `routeQuery` entry point.
 * `number mxs_get_session_id()`
-* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return\
+* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return
   the value 0.
 * `string mxs_get_db()`
 * Returns the current default database used by the connection.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-masking.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-masking.md
@@ -8,15 +8,15 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-With the _masking_ filter it is possible to obfuscate the returned\
+With the _masking_ filter it is possible to obfuscate the returned
 value of a particular column.
 
-For instance, suppose there is a table _person_ that, among other\
-columns, contains the column _ssn_ where the social security number\
+For instance, suppose there is a table _person_ that, among other
+columns, contains the column _ssn_ where the social security number
 of a person is stored.
 
-With the masking filter it is possible to specify that when the _ssn_\
-field is queried, a masked value is returned unless the user making\
+With the masking filter it is possible to specify that when the _ssn_
+field is queried, a masked value is returned unless the user making
 the query is a specific one. That is, when making the query
 
 ```
@@ -45,44 +45,44 @@ the _ssn_ would be masked, as in
 ...
 ```
 
-Note that the masking filter should be viewed as a best-effort solution\
-intended for protecting against accidental misuse rather than malicious\
+Note that the masking filter should be viewed as a best-effort solution
+intended for protecting against accidental misuse rather than malicious
 attacks.
 
 ### Security
 
-From MaxScale 2.3 onwards, the masking filter will reject statements\
+From MaxScale 2.3 onwards, the masking filter will reject statements
 that use functions in conjunction with columns that should be masked.\
-Allowing function usage provides a way for circumventing the masking,\
+Allowing function usage provides a way for circumventing the masking,
 unless a firewall filter is separately configured and installed.
 
-Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2208-masking.md#prevent_function_usage)\
+Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2208-masking.md#prevent_function_usage)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will check the\
-definition of user variables and reject statements that define a user\
+From MaxScale 2.3.5 onwards, the masking filter will check the
+definition of user variables and reject statements that define a user
 variable using a statement that refers to columns that should be masked.
 
-Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2208-masking.md#check_user_variables)\
+Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2208-masking.md#check_user_variables)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine unions\
-and if the second or subsequent SELECT refer to columns that should\
+From MaxScale 2.3.5 onwards, the masking filter will examine unions
+and if the second or subsequent SELECT refer to columns that should
 be masked, the statement will be rejected.
 
-Please see the configuration parameter [check\_unions](mariadb-maxscale-2208-masking.md#check_unions)\
+Please see the configuration parameter [check\_unions](mariadb-maxscale-2208-masking.md#check_unions)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine subqueries\
-and if a subquery refers to columns that should be masked, the statement\
+From MaxScale 2.3.5 onwards, the masking filter will examine subqueries
+and if a subquery refers to columns that should be masked, the statement
 will be rejected.
 
-Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2208-masking.md#check_subqueries)\
+Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2208-masking.md#check_subqueries)
 for how to change the default behaviour.
 
-Note that in order to ensure that it is not possible to get access to\
-masked data, the privileges of the users should be minimized. For instance,\
-if a user can create tables and perform inserts, he or she can execute\
+Note that in order to ensure that it is not possible to get access to
+masked data, the privileges of the users should be minimized. For instance,
+if a user can create tables and perform inserts, he or she can execute
 something like
 
 ```
@@ -93,16 +93,16 @@ SELECT revealed_ssn FROM cheat;
 
 to get access to the cleartext version of a masked field `ssn`.
 
-From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that\
+From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that
 cannot be fully parsed.
 
-Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2208-masking.md#require_fully_parsed)\
+Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2208-masking.md#require_fully_parsed)
 for how to change the default behaviour.
 
-From MaxScale 2.3.7 onwards, the masking filter will treat any strings\
+From MaxScale 2.3.7 onwards, the masking filter will treat any strings
 passed to functions as if they were fields. The reason is that as the\
-MaxScale query classifier is not aware of whether `ANSI_QUOTES` is\
-enabled or not, it is possible to bypass the masking by turning that\
+MaxScale query classifier is not aware of whether `ANSI_QUOTES` is
+enabled or not, it is possible to bypass the masking by turning that
 option on.
 
 ```
@@ -110,32 +110,32 @@ mysql> set @@sql_mode = 'ANSI_QUOTES';
 mysql> select concat("ssn") from managers;
 ```
 
-Before this change, the content of the field `ssn` would have been\
+Before this change, the content of the field `ssn` would have been
 returned in clear text even if the column should have been masked.
 
-Note that this change will mean that there may be false positives\
-if `ANSI_QUOTES` is not enabled and a string argument happens to\
+Note that this change will mean that there may be false positives
+if `ANSI_QUOTES` is not enabled and a string argument happens to
 be the same as the name of a field to be masked.
 
 Please see the configuration parameter\
-\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)\
+\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)
 for how to change the default behaviour.
 
 ### Limitations
 
-The masking filter can _only_ be used for masking columns of the following\
-types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no\
+The masking filter can _only_ be used for masking columns of the following
+types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no
 masking will be performed.
 
-Currently, the masking filter can only work on packets whose payload is less\
-than 16MB. If the masking filter encounters a packet whose payload is exactly\
-that, thus indicating a situation where the payload is delivered in multiple\
-packets, the value of the parameter `large_payloads` specifies how the masking\
+Currently, the masking filter can only work on packets whose payload is less
+than 16MB. If the masking filter encounters a packet whose payload is exactly
+that, thus indicating a situation where the payload is delivered in multiple
+packets, the value of the parameter `large_payloads` specifies how the masking
 filter should handle the situation.
 
 ### Configuration
 
-The masking filter is taken into use with the following kind of\
+The masking filter is taken into use with the following kind of
 configuration setup.
 
 ```
@@ -161,7 +161,7 @@ The masking filter has one mandatory parameter - `rules`.
 * Dynamic: Yes
 
 Specifies the path of the file where the masking rules are stored.\
-A relative path is interpreted relative to the _module configuration directory_\
+A relative path is interpreted relative to the _module configuration directory_
 of MariaDB MaxScale. The default module configuration directory is_/etc/maxscale.modules.d_.
 
 ```
@@ -176,8 +176,8 @@ rules=/path/to/rules-file
 * Values: `never`, `always`
 * Default: `never`
 
-With this optional parameter the masking filter can be instructed to log\
-a warning if a masking rule matches a column that is not of one of the\
+With this optional parameter the masking filter can be instructed to log
+a warning if a masking rule matches a column that is not of one of the
 allowed types.
 
 ```
@@ -192,17 +192,17 @@ warn_type_mismatch=always
 * Values: `ignore`, `abort`
 * Default: `abort`
 
-This optional parameter specifies how the masking filter should treat\
-payloads larger than `16MB`, that is, payloads that are delivered in\
+This optional parameter specifies how the masking filter should treat
+payloads larger than `16MB`, that is, payloads that are delivered in
 multiple MySQL protocol packets.
 
-The values that can be used are `ignore`, which means that columns in\
-such payloads are not masked, and `abort`, which means that if such\
-payloads are encountered, the client connection is closed. The default\
+The values that can be used are `ignore`, which means that columns in
+such payloads are not masked, and `abort`, which means that if such
+payloads are encountered, the client connection is closed. The default
 is `abort`.
 
-Note that the aborting behaviour is applied only to resultsets that\
-contain columns that should be masked. There are _no_ limitations on\
+Note that the aborting behaviour is applied only to resultsets that
+contain columns that should be masked. There are _no_ limitations on
 resultsets that do not contain such columns.
 
 ```
@@ -216,23 +216,23 @@ large_payload=ignore
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should behave\
-if a column that should be masked, is used in conjunction with some\
-function. As the masking filter works _only_ on the basis of the\
-information in the returned result-set, if the name of a column is\
-not present in the result-set, then the masking filter cannot mask a\
-value. This means that the masking filter basically can be bypassed\
+This optional parameter specifies how the masking filter should behave
+if a column that should be masked, is used in conjunction with some
+function. As the masking filter works _only_ on the basis of the
+information in the returned result-set, if the name of a column is
+not present in the result-set, then the masking filter cannot mask a
+value. This means that the masking filter basically can be bypassed
 with a query like:
 
 ```
 SELECT CONCAT(masked_column) FROM tbl;
 ```
 
-If the value of `prevent_function_usage` is `true`, then all\
-statements that contain functions referring to masked columns will\
-be rejected. As that means that also queries using potentially\
-harmless functions, such as `LENGTH(masked_column)`, are rejected\
-as well, this feature can be turned off. In that case, the firewall\
+If the value of `prevent_function_usage` is `true`, then all
+statements that contain functions referring to masked columns will
+be rejected. As that means that also queries using potentially
+harmless functions, such as `LENGTH(masked_column)`, are rejected
+as well, this feature can be turned off. In that case, the firewall
 filter should be setup to allow or reject the use of certain functions.
 
 ```
@@ -246,19 +246,19 @@ prevent_function_usage=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
-behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a\
+This optional parameter specifies how the masking filter should
+behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a
 statement that cannot be fully parsed,
 
-If true, then statements that cannot be fully parsed (due to a\
+If true, then statements that cannot be fully parsed (due to a
 parser limitation) will be blocked.
 
 ```
 require_fully_parsed=false
 ```
 
-Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered\
-less effective, as it with a statement that can not be fully parsed may be\
+Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered
+less effective, as it with a statement that can not be fully parsed may be
 possible to bypass the protection that they are intended to provide.
 
 **`treat_string_arg_as_field`**
@@ -268,9 +268,9 @@ possible to bypass the protection that they are intended to provide.
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should treat\
-strings used as arguments to functions. If true, they will be handled\
-as fields, which will cause fields to be masked even if `ANSI_QUOTES` has\
+This optional parameter specifies how the masking filter should treat
+strings used as arguments to functions. If true, they will be handled
+as fields, which will cause fields to be masked even if `ANSI_QUOTES` has
 been enabled and `"` is used instead of backtick.
 
 ```
@@ -284,7 +284,7 @@ treat_string_arg_as_field=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to user variables. If true, then a statement like
 
 ```
@@ -304,7 +304,7 @@ check_user_variables=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to UNIONs. If true, then a statement like
 
 ```
@@ -324,7 +324,7 @@ check_unions=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to subqueries. If true, then a statement like
 
 ```
@@ -341,7 +341,7 @@ check_subqueries=false
 
 The masking rules are expressed as a JSON object.
 
-The top-level object is expected to contain a key `rules` whose\
+The top-level object is expected to contain a key `rules` whose
 value is an array of rule objects.
 
 ```
@@ -350,8 +350,8 @@ value is an array of rule objects.
 }
 ```
 
-Each rule in the rules array is a JSON object, expected to\
-contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two\
+Each rule in the rules array is a JSON object, expected to
+contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two
 latter ones optional.
 
 ```
@@ -369,15 +369,15 @@ latter ones optional.
 
 #### `replace`
 
-The value of this key is an object that specifies the column\
-whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The\
+The value of this key is an object that specifies the column
+whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The
 value of these keys must be a string.
 
-If only `column` is specified, then a column with that name\
-matches irrespective of the table and database. If `table`\
-is specified, then the column matches only if it is in a table\
-with the specified name, and if `database` is specified when\
-the column matches only if it is in a database with the\
+If only `column` is specified, then a column with that name
+matches irrespective of the table and database. If `table`
+is specified, then the column matches only if it is in a table
+with the specified name, and if `database` is specified when
+the column matches only if it is in a database with the
 specified name.
 
 ```
@@ -397,10 +397,10 @@ specified name.
 }
 ```
 
-**NOTE** If a rule contains a table/database then if the resultset\
-does _not_ contain table/database information, it will always be\
-considered a match if the column matches. For instance, given the\
-rule above, if there is a table `person2`, also containing an `ssn`\
+**NOTE** If a rule contains a table/database then if the resultset
+does _not_ contain table/database information, it will always be
+considered a match if the column matches. For instance, given the
+rule above, if there is a table `person2`, also containing an `ssn`
 field, then a query like
 
 ```
@@ -413,24 +413,24 @@ will not return masked values, but a query like
 SELECT ssn FROM person UNION SELECT ssn FROM person2;
 ```
 
-will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is\
+will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is
 observed even with a nonsensical query like
 
 ```
 SELECT ssn FROM person2 UNION SELECT ssn FROM person2;
 ```
 
-even if nothing from `person2` should be masked. The reason is that\
-as the resultset contains no table information, the values must be\
-masked if the column name matches, as otherwise the masking could\
+even if nothing from `person2` should be masked. The reason is that
+as the resultset contains no table information, the values must be
+masked if the column name matches, as otherwise the masking could
 easily be circumvented with a query like
 
 ```
 SELECT ssn FROM person UNION SELECT ssn FROM person;
 ```
 
-The optional key `match` makes partial replacement of the original\
-value possible: only the matched part would be replaced\
+The optional key `match` makes partial replacement of the original
+value possible: only the matched part would be replaced
 with the fill character.\
 The `match` value must be a valid pcre2 regular expression.
 
@@ -446,14 +446,14 @@ The `match` value must be a valid pcre2 regular expression.
 
 #### `obfuscate`
 
-The obfuscate rule allows the obfuscation of the value\
+The obfuscate rule allows the obfuscation of the value
 by passing it through an obfuscation algorithm.\
 Current solution uses a non-reversible obfuscation approach.
 
-However, note that although it is in principle impossible to obtain the\
-original value from the obfuscated one, if the range of possible original\
-values is limited, it is straightforward to figure out the possible\
-original values by running all possible values through the obfuscation\
+However, note that although it is in principle impossible to obtain the
+original value from the obfuscated one, if the range of possible original
+values is limited, it is straightforward to figure out the possible
+original values by running all possible values through the obfuscation
 algorithm and then comparing the results.
 
 The minimal configuration is:
@@ -478,20 +478,20 @@ SELECT name from db1.tbl1;`
 
 #### `with`
 
-The value of this key is an object that specifies what the value of the matched\
-column should be replaced with for the `replace` rule. Currently, the object\
+The value of this key is an object that specifies what the value of the matched
+column should be replaced with for the `replace` rule. Currently, the object
 is expected to contain either the key `value` or the key `fill`.\
 The value of both must be a string with length greater than zero.\
 If both keys are specified, `value` takes precedence.\
 If `fill` is not specified, the default `X` is used as its value.
 
-If `value` is specified, then its value is used to replace the actual value\
-verbatim and the length of the specified value must match the actual returned\
+If `value` is specified, then its value is used to replace the actual value
+verbatim and the length of the specified value must match the actual returned
 value (from the server) exactly. If the lengths do not match, the value of`fill` is used to mask the actual value.
 
-When the value of `fill` (fill-value) is used for masking the returned value,\
-the fill-value is used as many times as necessary to match the length of the\
-return value. If required, only a part of the fill-value may be used in the end\
+When the value of `fill` (fill-value) is used for masking the returned value,
+the fill-value is used as many times as necessary to match the length of the
+return value. If required, only a part of the fill-value may be used in the end
 of the mask value to get the lengths to match.
 
 ```
@@ -534,8 +534,8 @@ of the mask value to get the lengths to match.
 
 #### `applies_to`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is applied to. Each string\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is applied to. Each string
 should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -551,13 +551,13 @@ should be a MariaDB account string, that is, `%` is a wildcard.
 }
 ```
 
-If this key is not specified, then the masking is performed for all\
+If this key is not specified, then the masking is performed for all
 users, except the ones exempted using the key `exempted`.
 
 #### `exempted`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is _not_ applied to. Each\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is _not_ applied to. Each
 string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -575,14 +575,14 @@ string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-module-commands.md) documentation for details\
+Read [Module Commands](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-module-commands.md) documentation for details
 about module commands.
 
 The masking filter supports the following module commands.
 
 #### `reload`
 
-Reload the rules from the rules file. The new rules are taken into use\
+Reload the rules from the rules file. The new rules are taken into use
 only if the loading succeeds without any errors.
 
 ```
@@ -594,8 +594,8 @@ MariaDB MaxScale configuration file.
 
 ### Example
 
-In the following we configure a masking filter _MyMasking_ that should always log a\
-warning if a masking rule matches a column that is of a type that cannot be masked,\
+In the following we configure a masking filter _MyMasking_ that should always log a
+warning if a masking rule matches a column that is of a type that cannot be masked,
 and that should abort the client connection if a resultset package is larger than\
 16MB. The rules for the masking filter are in the file `masking_rules.json`.
 
@@ -617,9 +617,9 @@ filters=MyMasking
 
 #### `masking_rules.json`
 
-The rules specify that the data of a column whose name is `ssn`, should\
-be replaced with the string _012345-ABCD_. If the length of the data is\
-not exactly the same as the length of the replacement value, then the\
+The rules specify that the data of a column whose name is `ssn`, should
+be replaced with the string _012345-ABCD_. If the length of the data is
+not exactly the same as the length of the replacement value, then the
 data should be replaced with as many _X_ characters as needed.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-maxrows.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-maxrows.md
@@ -8,11 +8,11 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Maxrows filter is capable of restricting the amount of rows that a SELECT,\
+The Maxrows filter is capable of restricting the amount of rows that a SELECT,
 a prepared statement or stored procedure could return to the client application.
 
-If a resultset from a backend server has more rows than the configured limit\
-or the resultset size exceeds the configured size,\
+If a resultset from a backend server has more rows than the configured limit
+or the resultset size exceeds the configured size,
 an empty result will be sent to the client.
 
 ### Configuration
@@ -42,7 +42,7 @@ Optional parameters are:
 * Dynamic: Yes
 * Default: (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 returned to the user.
 
 If a resultset is larger than this an empty result will be sent instead.
@@ -58,8 +58,8 @@ max_resultset_rows=1000
 * Dynamic: Yes
 * Default: `64Ki`
 
-Specifies the maximum size a resultset can have in order\
-to be sent to the client. A resultset larger than this, will\
+Specifies the maximum size a resultset can have in order
+to be sent to the client. A resultset larger than this, will
 not be sent: an empty resultset will be sent instead.
 
 ```
@@ -74,7 +74,7 @@ max_resultset_size=128Ki
 * Values: `empty`, `error`, `ok`
 * Default: `empty`
 
-Specifies what the filter sends to the client when the\
+Specifies what the filter sends to the client when the
 rows or size limit is hit, possible values:
 
 * an empty result set
@@ -95,8 +95,8 @@ ERROR 1415 (0A000): Row limit/size exceeded for query: select * from test.t4
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the Maxrows\
-filter can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the Maxrows
+filter can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -111,7 +111,7 @@ debug=2
 
 ### Example Configuration
 
-Here is an example of filter configuration where the maximum number of returned\
+Here is an example of filter configuration where the maximum number of returned
 rows is 10000 and maximum allowed resultset size is 256KB
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-named-server-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-named-server-filter.md
@@ -6,25 +6,25 @@
 
 ### Overview
 
-The **namedserverfilter** is a MariaDB MaxScale filter module able to route\
-queries to servers based on regular expression (regex) matches. Since it is a\
+The **namedserverfilter** is a MariaDB MaxScale filter module able to route
+queries to servers based on regular expression (regex) matches. Since it is a
 filter instead of a router, the NamedServerFilter only sets routing suggestions.\
-It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the\
-data packets. This filter uses the _PCRE2_ library for regular expression\
+It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the
+data packets. This filter uses the _PCRE2_ library for regular expression
 matching.
 
 ### Configuration
 
-The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of\
-the modes may be used for a given filter instance. The legacy mode is meant for\
-backwards compatibility and allows only one regular expression and one server\
-name in the configuration. In indexed mode, up to 25 regex-server pairs are\
+The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of
+the modes may be used for a given filter instance. The legacy mode is meant for
+backwards compatibility and allows only one regular expression and one server
+name in the configuration. In indexed mode, up to 25 regex-server pairs are
 allowed in the form _match01_ - _target01_, _match02_ - _target02_ and so on.\
-Also, in indexed mode, the server names (targets) may contain a list of names or\
+Also, in indexed mode, the server names (targets) may contain a list of names or
 special tags `->master` or `->slave`.
 
-All parameters except the deprecated `match` and `target` parameters can\
-be modified at runtime. Any modifications to the filter configuration will\
+All parameters except the deprecated `match` and `target` parameters can
+be modified at runtime. Any modifications to the filter configuration will
 only affect sessions created after the change has completed.
 
 Below is a configuration example for the filter in indexed-mode. The legacy mode\
@@ -65,10 +65,10 @@ NamedServerFilter requires at least one _matchXY_ - _targetXY_ pair.
 * Dynamic: Yes
 * Default: None
 
-_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#regular-expressions)\
+_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#regular-expressions)
 against which the incoming SQL query is matched. _XY_ must be a number in the range\
-01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is\
-defined, the other must be defined as well. If a query matches the pattern, the filter\
+01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is
+defined, the other must be defined as well. If a query matches the pattern, the filter
 attaches a routing hint defined by the _target_-setting to the query. The _options_-parameter affects how the patterns are compiled.
 
 ```
@@ -84,7 +84,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-[Regular expression options](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Regular expression options](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 for `matchXY`.
 
 #### `targetXY`
@@ -103,8 +103,8 @@ accordingly. The target can be one of the following:
 * `->slave` (adds a `HINT_ROUTE_TO_SLAVE` hint)
 * `->all` (adds a `HINT_ROUTE_TO_ALL` hint)
 
-The support for service names was added in MaxScale 6.3.2. Older\
-versions of MaxScale did not accept service names in the `target`\
+The support for service names was added in MaxScale 6.3.2. Older
+versions of MaxScale did not accept service names in the `target`
 parameters.
 
 ```
@@ -118,9 +118,9 @@ target01=MyServer2
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines an IP address or mask which a connecting\
-client's IP address is matched against. Only sessions whose address matches this\
-setting will have this filter active and performing the regex matching. Traffic\
+This optional parameter defines an IP address or mask which a connecting
+client's IP address is matched against. Only sessions whose address matches this
+setting will have this filter active and performing the regex matching. Traffic
 from other client IPs is simply left as is and routed straight through.
 
 ```
@@ -137,7 +137,7 @@ source=192.168.10.%
 
 Note that using `source=%` to match any IP is not allowed.
 
-Since MaxScale 2.3 it's also possible to specify multiple addresses separated\
+Since MaxScale 2.3 it's also possible to specify multiple addresses separated
 by comma. Incoming client connections are subsequently checked against each.
 
 ```
@@ -151,9 +151,9 @@ source=192.168.21.3,192.168.10.%
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines a username the connecting client username is\
-matched against. Only sessions that are connected using this username will have\
-the match and routing hints applied to them. Traffic from other users is simply\
+This optional parameter defines a username the connecting client username is
+matched against. Only sessions that are connected using this username will have
+the match and routing hints applied to them. Traffic from other users is simply
 left as is and routed straight through.
 
 ```
@@ -164,30 +164,30 @@ user=john
 
 The maximum number of accepted _match_ - _target_ pairs is 25.
 
-In the configuration file, the indexed match and target settings may be in any order\
-and may skip numbers. During SQL-query matching, however, the regexes are tested\
-in ascending order: match01, match02, match03 and so on. As soon as a match is\
-found for a given query, the routing hints are written and the packet is\
-forwarded to the next filter or router. Any remaining match regexes are\
-ignored. This means the _match_ - _target_ pairs should be indexed in priority\
-order, or, if priority is not a factor, in order of decreasing match\
+In the configuration file, the indexed match and target settings may be in any order
+and may skip numbers. During SQL-query matching, however, the regexes are tested
+in ascending order: match01, match02, match03 and so on. As soon as a match is
+found for a given query, the routing hints are written and the packet is
+forwarded to the next filter or router. Any remaining match regexes are
+ignored. This means the _match_ - _target_ pairs should be indexed in priority
+order, or, if priority is not a factor, in order of decreasing match
 probability.
 
-Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching\
-the prepared sql against the _match_-parameters. If a match is found, the\
-routing hints are attached to any execution of that prepared statement. Text-\
-mode prepared statements are not supported in this way. To divert them, use\
+Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching
+the prepared sql against the _match_-parameters. If a match is found, the
+routing hints are attached to any execution of that prepared statement. Text-
+mode prepared statements are not supported in this way. To divert them, use
 regular expressions which match the specific "EXECUTE"-query.
 
 ### Examples
 
 #### Example 1 - Route queries targeting a specific table to a server
 
-This will route all queries matching the regular expression `*from *users` to\
+This will route all queries matching the regular expression `*from *users` to
 the server named _server2_. The filter will ignore character case in queries.
 
-A query like `SELECT * FROM users` would be routed to server2 where as a query\
-like `SELECT * FROM accounts` would be routed according to the normal rules of\
+A query like `SELECT * FROM users` would be routed to server2 where as a query
+like `SELECT * FROM accounts` would be routed according to the normal rules of
 the router.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-query-log-all-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-query-log-all-filter.md
@@ -31,13 +31,13 @@ filters=MyLogFilter
 
 ### Log Rotation
 
-The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`\
-command. This will cause the log files to be reopened when the next message is\
+The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`
+command. This will cause the log files to be reopened when the next message is
 written to the file. This applies to both unified and session type logging.
 
 ### Filter Parameters
 
-The QLA filter has one mandatory parameter, `filebase`, and a number of optional\
+The QLA filter has one mandatory parameter, `filebase`, and a number of optional
 parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 
 #### `filebase`
@@ -46,7 +46,7 @@ parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 * Mandatory: Yes
 * Dynamic: No
 
-The basename of the output file created for each session. A session index is\
+The basename of the output file created for each session. A session index is
 added to the filename for each written session file. For unified log files,_.unified_ is appended.
 
 ```
@@ -143,14 +143,14 @@ Type of data to log in the log files.
 | error\_msg         | Error message from the server (if any) (v6.2)           |
 | server             | The server where the query was routed (if any) (v22.08) |
 
-The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,\
+The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,
 but can be specified to another unit using _duration\_unit_.
 
 The log entry is written when the last reply from the server is received.\
-Prior to version 6.2 the entry was written when the query was received from\
+Prior to version 6.2 the entry was written when the query was received from
 the client, or if _reply\_time_ was specified, on first reply from the server.
 
-**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_\
+**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_
 is set the error message may contain user defined constants. For example:
 
 ```
@@ -178,7 +178,7 @@ This option is available as of MaxScale version 6.2.
 * Dynamic: Yes
 * Default: `false`
 
-When this option is true the canonical form of the query is logged. In the\
+When this option is true the canonical form of the query is logged. In the
 canonical form all user defined constants are replaced with question marks.\
 This option is available as of MaxScale version 6.2.
 
@@ -205,7 +205,7 @@ Flush log files after every write.
 * Dynamic: Yes
 * Default: `","`
 
-Defines the separator string between elements of\
+Defines the separator string between elements of
 log entries. The value should be enclosed in quotes.
 
 #### `newline_replacement`
@@ -215,19 +215,19 @@ log entries. The value should be enclosed in quotes.
 * Dynamic: Yes
 * Default: `" "`
 
-Default value is `" "` (one space). SQL-queries may include line breaks, which, if\
-printed directly to the log, may break automatic parsing. This parameter defines\
-what should be written in the place of a newline sequence (\r, \n or \r\n). If\
-this is set as the empty string, then newlines are not replaced and printed as\
+Default value is `" "` (one space). SQL-queries may include line breaks, which, if
+printed directly to the log, may break automatic parsing. This parameter defines
+what should be written in the place of a newline sequence (\r, \n or \r\n). If
+this is set as the empty string, then newlines are not replaced and printed as
 is to the output. The value should be enclosed in quotes.
 
 ### Examples
 
 #### Example 1 - Query without primary key
 
-Imagine you have observed an issue with a particular table and you want to\
-determine if there are queries that are accessing that table but not using the\
-primary key of the table. Let's assume the table name is PRODUCTS and the\
+Imagine you have observed an issue with a particular table and you want to
+determine if there are queries that are accessing that table but not using the
+primary key of the table. Let's assume the table name is PRODUCTS and the
 primary key is called PRODUCT\_ID. Add a filter with the following definition:
 
 ```
@@ -247,7 +247,7 @@ password=mypasswd
 filters=ProductsSelectLogger
 ```
 
-The result of using this filter with the service used by the application would\
+The result of using this filter with the service used by the application would
 be a log file of all select queries querying PRODUCTS without using the\
 PRODUCT\_ID primary key in the predicates of the query. Executing `SELECT * FROM PRODUCTS` would log the following into `/var/logs/qla/SelectProducts`:
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-regex-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-regex-filter.md
@@ -6,13 +6,13 @@
 
 ### Overview
 
-The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite\
-query content using regular expression matches and text substitution. The\
+The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite
+query content using regular expression matches and text substitution. The
 regular expressions use the [PCRE2 syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html).
 
-PCRE2 library uses a different syntax than POSIX to refer to capture\
-groups in the replacement string. The main difference is the usage of the dollar\
-character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)\
+PCRE2 library uses a different syntax than POSIX to refer to capture
+groups in the replacement string. The main difference is the usage of the dollar
+character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)
 chapter in the PCRE2 manual.
 
 ### Configuration
@@ -68,7 +68,7 @@ The _options_-parameter affects how the patterns are compiled as [usual](https:/
 * Mandatory: Yes
 * Dynamic: Yes
 
-This is the text that should replace the part of the SQL-query matching the\
+This is the text that should replace the part of the SQL-query matching the
 pattern defined in _match_.
 
 ```
@@ -82,9 +82,9 @@ replace=ENGINE =
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
-the address from which the client connection to MariaDB MaxScale\
-originates. Only sessions that originate from this address will have the match\
+The optional source parameter defines an address that is used to match against
+the address from which the client connection to MariaDB MaxScale
+originates. Only sessions that originate from this address will have the match
 and replacement applied to them.
 
 ```
@@ -98,9 +98,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will have the match and\
+The optional user parameter defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will have the match and
 replacement applied to them.
 
 ```
@@ -114,9 +114,9 @@ user=john
 * Dynamic: Yes
 * Default: None
 
-The optional log\_file parameter defines a log file in which the filter writes\
-all queries that are not matched and matching queries with their replacement\
-queries. All sessions will log to this file so this should only be used for\
+The optional log\_file parameter defines a log file in which the filter writes
+all queries that are not matched and matching queries with their replacement
+queries. All sessions will log to this file so this should only be used for
 diagnostic purposes.
 
 ```
@@ -130,10 +130,10 @@ log_file=/tmp/regexfilter.log
 * Dynamic: Yes
 * Default: None
 
-The optional log\_trace parameter toggles the logging of non-matching and\
+The optional log\_trace parameter toggles the logging of non-matching and
 matching queries with their replacements into the log file on the _info_ level.\
-This is the preferred method of diagnosing the matching of queries since the log\
-level can be changed at runtime. For more details about logging levels and\
+This is the preferred method of diagnosing the matching of queries since the log
+level can be changed at runtime. For more details about logging levels and
 session specific logging, please read the [Configuration Guide](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#global-settings).
 
 ```
@@ -144,10 +144,10 @@ log_trace=true
 
 #### Example 1 - Replace MySQL 5.1 create table syntax with that for later versions
 
-MySQL 5.1 used the parameter TYPE = to set the storage engine that should be\
-used for a table. In later versions this changed to be ENGINE =. Imagine you\
-have an application that you can not change for some reason, but you wish to\
-migrate to a newer version of MySQL. The regexfilter can be used to transform\
+MySQL 5.1 used the parameter TYPE = to set the storage engine that should be
+used for a table. In later versions this changed to be ENGINE =. Imagine you
+have an application that you can not change for some reason, but you wish to
+migrate to a newer version of MySQL. The regexfilter can be used to transform
 the create table statements into the form that could be used by MySQL 5.5
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-rewrite-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-rewrite-filter.md
@@ -7,8 +7,8 @@
 ### Overview
 
 The rewrite filter allows modification of sql queries on the fly.\
-Reasons for modifying queries can be to rewrite a query for performance,\
-or to change a specific query when the client query is incorrect and\
+Reasons for modifying queries can be to rewrite a query for performance,
+or to change a specific query when the client query is incorrect and
 cannot be changed in a timely manner.
 
 The examples will use Rewrite Filter file format. See below.
@@ -23,7 +23,7 @@ Rewriter native syntax uses placeholders to grab and replace parts of text.
 
 The syntax for a plain placeholder is `@{N}` where N is a positive integer.
 
-The syntax for a placeholder regex is `@{N:regex}`. It allows more control\
+The syntax for a placeholder regex is `@{N:regex}`. It allows more control
 when needed.
 
 The below is a valid entry in rf format. For demonstration, all options are set.\
@@ -57,23 +57,23 @@ For a match, the two `@{2}` text grabs must be equal.
 
 The match template is used to match against the sql to be rewritten.
 
-The match template can be partial `from mytable`. But the actual underlying\
-regex match is always for the whole sql. If the match template does not\
-start or end with a placeholder, placeholders are automatically added so\
-that the above becomes `@{1}from mytable@{2}`. The automatically added\
+The match template can be partial `from mytable`. But the actual underlying
+regex match is always for the whole sql. If the match template does not
+start or end with a placeholder, placeholders are automatically added so
+that the above becomes `@{1}from mytable@{2}`. The automatically added
 placeholders cannot be used in the replace template.
 
-Matching the whole input also means that Native syntax does not support\
-(and is not intended to support) scan and replace. Only the first occurrence\
+Matching the whole input also means that Native syntax does not support
+(and is not intended to support) scan and replace. Only the first occurrence
 of the above `from mytable` can be modified in the replace template.\
-However, one can selectively choose to modify e.g. the first through\
+However, one can selectively choose to modify e.g. the first through
 third occurrence of `from mytable` by writing`from mytable @{1} from mytable @{2} from mytable @{3}`.
 
 For scan and replace use a different regex\_grammar (see below).
 
 **Replace template**
 
-The replace template uses the placeholders from the match template to\
+The replace template uses the placeholders from the match template to
 rewrite sql.
 
 ```
@@ -89,11 +89,11 @@ Input: select count(distinct author) from books where entity != "AI"
 Rewritten: select count(*) from (select distinct author from books where entity != "AI") as t123
 ```
 
-An important option for smooth matching is `ignore_whitespace`, which\
-is on (true) by default. It creates the match regex in such a way that\
-the amount and kind of whitespace does not affect matching. However,\
-to make `ignore_whitespace` always work, it is important to add\
-whitespace where allowed. If "id=42" is in the match template then\
+An important option for smooth matching is `ignore_whitespace`, which
+is on (true) by default. It creates the match regex in such a way that
+the amount and kind of whitespace does not affect matching. However,
+to make `ignore_whitespace` always work, it is important to add
+whitespace where allowed. If "id=42" is in the match template then
 only the exact "id=42" can match. But if "id = 42" is used, and`ignore_whitespace` is on, both "id=42" and "id = 42" will match.
 
 Another example, and what not to do:
@@ -110,7 +110,7 @@ Input: select name from mytable where id=42
 Rewritten: select name from mytable force index (myindex) where id=42
 ```
 
-That works, but because the match lacks specific detail about the\
+That works, but because the match lacks specific detail about the
 expected sql, things are likely to break. In this case`show indexes from my_table` would no longer work.
 
 The minimum detail in this case could be:
@@ -123,22 +123,22 @@ The minimum detail in this case could be:
 select @{2} from mytable force index (myindex)
 ```
 
-but if more detail is known, like something specific in the where clause,\
+but if more detail is known, like something specific in the where clause,
 that too should be added.
 
 **Placeholder Regex**
 
 Syntax: @{N:regex}
 
-In a placeholder regex the character `}` must be escaped to `\}`\
-(for literal matching). Plain parenthesis "()" indicate capturing\
+In a placeholder regex the character `}` must be escaped to `\}`
+(for literal matching). Plain parenthesis "()" indicate capturing
 groups, which are internally used by the Native grammar.\
 Thus plain parentheses in a placeholder regex will break matching.\
 However, non-capturing groups can be used: e.g. `@{1:(:?Jane|Joe)}`.\
 To match a literal parenthesis use an escape, e.g. `\(`.
 
 Suppose an application is misbehaving after an upgrade and a quick fix is needed.\
-This query `select zip from address_book where str_id = "AZ-124"` is correct,\
+This query `select zip from address_book where str_id = "AZ-124"` is correct,
 but if the id is an integer the where clause should be `id = 1234`.
 
 ```
@@ -159,7 +159,7 @@ For scan and replace the regex\_grammar must be set to something else than\
 Native. An example will illustrate the usage.
 
 Replace all occurrences of "wrong\_table\_name" with "correct\_table\_name".\
-Further, if the replacement was made then replace all occurrences\
+Further, if the replacement was made then replace all occurrences
 of wrong\_column\_name with correct\_column\_name.
 
 ```
@@ -264,7 +264,7 @@ Ignore whitespace differences in the match template and input sql.
 * Type: boolean
 * Default: false
 
-If a template matches and the replacement is done, continue to the\
+If a template matches and the replacement is done, continue to the
 next template and apply it to the result of the previous rewrite.
 
 **`what_if`**
@@ -272,7 +272,7 @@ next template and apply it to the result of the previous rewrite.
 * Type: boolean
 * Default: false
 
-Do not make the replacement, only log what would have\
+Do not make the replacement, only log what would have
 been replaced (NOTICE level).
 
 ### Rewrite file format
@@ -288,12 +288,12 @@ match template
 replace template
 ```
 
-The character `#` starts a single line comment when it is the\
+The character `#` starts a single line comment when it is the
 first character on a line.
 
 Empty lines are ignored.
 
-The rf format does not need any additional escaping to what the basic\
+The rf format does not need any additional escaping to what the basic
 format requires (see Placeholder Regex).
 
 Options are specified as follows:
@@ -304,11 +304,11 @@ case_sensitive: true
 
 The colon must stick to the option name.
 
-The separators `%` and `%%` must be the exact content of\
+The separators `%` and `%%` must be the exact content of
 their respective separator lines.
 
-The templates can span multiple lines. Whitespace does not\
-matter as long as `ignore_whitespace = true`. Always use space\
+The templates can span multiple lines. Whitespace does not
+matter as long as `ignore_whitespace = true`. Always use space
 where space is allowed to maximize the utility of`ignore_whitespace`.
 
 Example
@@ -328,10 +328,10 @@ and @{3} in (select user from approved_users)
 ### Json file format
 
 The json file format is harder to read and edit manually.\
-It will be needed if support for editing of rewrite templates\
+It will be needed if support for editing of rewrite templates
 is added to the GUI.
 
-All double quotes and escape characters have to be escaped in json,\
+All double quotes and escape characters have to be escaped in json,
 i.e '"' and '\\'.
 
 The same example as above is:
@@ -351,7 +351,7 @@ and @{3} in (select user from approved_users)"
 
 ### Reload template file
 
-The configuration is re-read if any dynamic value is updated\
+The configuration is re-read if any dynamic value is updated
 even if the value does not change.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-tee-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-tee-filter.md
@@ -7,17 +7,17 @@
 ### Overview
 
 The tee filter is a "plumbing" fitting in the MariaDB MaxScale filter toolkit.\
-It can be used in a filter pipeline of a service to make copies of requests from\
+It can be used in a filter pipeline of a service to make copies of requests from
 the client and send the copies to another service within MariaDB MaxScale.
 
-**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a\
-service which uses a tee filter will require a grant for the loopback address,\
+**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a
+service which uses a tee filter will require a grant for the loopback address,
 i.e. `127.0.0.1`.
 
 ### Configuration
 
-The configuration block for the TEE filter requires the minimal filter\
-parameters in its section within the MaxScale configuration file. The service to\
+The configuration block for the TEE filter requires the minimal filter
+parameters in its section within the MaxScale configuration file. The service to
 send the duplicates to must be defined.
 
 ```
@@ -37,7 +37,7 @@ filters=DataMartFilter
 
 ### Filter Parameters
 
-The tee filter requires a mandatory parameter to define the service to replicate\
+The tee filter requires a mandatory parameter to define the service to replicate
 statements to and accepts a number of optional parameters.
 
 #### `target`
@@ -47,8 +47,8 @@ statements to and accepts a number of optional parameters.
 * Dynamic: Yes
 * Default: none
 
-The target where the filter will duplicate all queries. The target can be either\
-a service or a server. The duplicate connection that is created to this target\
+The target where the filter will duplicate all queries. The target can be either
+a service or a server. The duplicate connection that is created to this target
 will be referred to as the "branch target" in this document.
 
 #### `service`
@@ -58,8 +58,8 @@ will be referred to as the "branch target" in this document.
 * Dynamic: Yes
 * Default: none
 
-The service where the filter will duplicate all queries. This parameter is\
-deprecated in favor of the `target` parameter and will be removed in a future\
+The service where the filter will duplicate all queries. This parameter is
+deprecated in favor of the `target` parameter and will be removed in a future
 release. Both `target` and `service` cannot be defined.
 
 #### `match`
@@ -109,7 +109,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
+The optional source parameter defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be replicated.
 
@@ -124,8 +124,8 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a user name that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
+The optional user parameter defines a user name that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
 sessions that are connected using this username are replicated.
 
 ```
@@ -139,63 +139,63 @@ user=john
 * Dynamic: Yes
 * Default: `false`
 
-Enable synchronous routing mode. When configured with `sync=true`, the filter\
-will queue new queries until the response from both the main and the branch\
-target has been received. This means that for `n` executed queries, `n - 1`\
-queries are guaranteed to be synchronized. Adding one extra statement\
-(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL\
+Enable synchronous routing mode. When configured with `sync=true`, the filter
+will queue new queries until the response from both the main and the branch
+target has been received. This means that for `n` executed queries, `n - 1`
+queries are guaranteed to be synchronized. Adding one extra statement
+(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL
 statements have been successfully executed on both targets.
 
-In the synchronous routing mode, a failure of the branch target will cause the\
+In the synchronous routing mode, a failure of the branch target will cause the
 client session to be closed.
 
 ### Limitations
 
-* All statements that are executed on the branch target are done in an\
-  asynchronous manner. This means that when the client receives the response\
-  there is no guarantee that the statement has completed on the branch\
-  target. The `sync` feature provides some synchronization guarantees that can\
+* All statements that are executed on the branch target are done in an
+  asynchronous manner. This means that when the client receives the response
+  there is no guarantee that the statement has completed on the branch
+  target. The `sync` feature provides some synchronization guarantees that can
   be used to verify successful execution on both targets.
-* Any errors on the branch target will cause the connection to it to be\
-  closed. If `target` is a service, it is up to the router to decide whether the\
-  connection is closed. For direct connections to servers, any network errors\
-  cause the connection to be closed. When the connection is closed, no new\
+* Any errors on the branch target will cause the connection to it to be
+  closed. If `target` is a service, it is up to the router to decide whether the
+  connection is closed. For direct connections to servers, any network errors
+  cause the connection to be closed. When the connection is closed, no new
   queries will be routed to the branch target.
 
-With `sync=true`, a failure of the branch target will cause the whole session\
+With `sync=true`, a failure of the branch target will cause the whole session
 to be closed.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-module-commands.md) documentation for
 details about module commands.
 
 The tee filter supports the following module commands.
 
 #### `tee disable [FILTER]`
 
-This command disables a tee filter instance. A disabled tee filter will not send\
+This command disables a tee filter instance. A disabled tee filter will not send
 any queries to the target service.
 
 #### `tee enable [FILTER]`
 
-Enable a disabled tee filter. This resumes the sending of queries to the target\
+Enable a disabled tee filter. This resumes the sending of queries to the target
 service.
 
 ### Examples
 
 #### Example 1 - Replicate all inserts into the orders table
 
-Assume an order processing system that has a table called orders. You also have\
-another database server, the datamart server, that requires all inserts into\
+Assume an order processing system that has a table called orders. You also have
+another database server, the datamart server, that requires all inserts into
 orders to be replicated to it. Deletes and updates are not, however, required.
 
-Set up a service in MariaDB MaxScale, called Orders, to communicate with the\
-order processing system with the tee filter applied to it. Also set up a service\
-to talk to the datamart server, using the DataMart service. The tee filter would\
+Set up a service in MariaDB MaxScale, called Orders, to communicate with the
+order processing system with the tee filter applied to it. Also set up a service
+to talk to the datamart server, using the DataMart service. The tee filter would
 have as its service entry the DataMart service, by adding a match parameter of\
-"insert into orders" would then result in all requests being sent to the order\
-processing system, and insert statements that include the orders table being\
+"insert into orders" would then result in all requests being sent to the order
+processing system, and insert statements that include the orders table being
 additionally sent to the datamart server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-throttle.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-throttle.md
@@ -8,13 +8,13 @@ This filter was added in MariaDB MaxScale 2.3
 
 ### Overview
 
-The throttle filter is used to limit the maximum query frequency (QPS - queries\
-per second) of a database session to a configurable value. The main use cases\
-are to prevent a rogue session (client side error) and a DoS attack from\
+The throttle filter is used to limit the maximum query frequency (QPS - queries
+per second) of a database session to a configurable value. The main use cases
+are to prevent a rogue session (client side error) and a DoS attack from
 overloading the system.
 
-The throttling is dynamic. The query frequency is not limited to an absolute\
-value. Depending on the configuration the throttle will allow some amount of\
+The throttling is dynamic. The query frequency is not limited to an absolute
+value. Depending on the configuration the throttle will allow some amount of
 high frequency queries, or especially short bursts with no frequency limitation.
 
 ### Configuration
@@ -35,27 +35,27 @@ filters = Throttle
 ```
 
 This configuration states that the query frequency will be throttled to around\
-500 qps, and that the time limit a query is allowed to stay at the maximum\
-frequency is 60 seconds. All values involving time are configured in\
-milliseconds. With the basic configuration the throttling will be nearly\
-immediate, i.e. a session will only be allowed very short bursts of high\
+500 qps, and that the time limit a query is allowed to stay at the maximum
+frequency is 60 seconds. All values involving time are configured in
+milliseconds. With the basic configuration the throttling will be nearly
+immediate, i.e. a session will only be allowed very short bursts of high
 frequency querying.
 
-When a session has been continuously throttled for `throttling_duration`\
-milliseconds, or 60 seconds in this example, MaxScale will disconnect the\
+When a session has been continuously throttled for `throttling_duration`
+milliseconds, or 60 seconds in this example, MaxScale will disconnect the
 session.
 
 #### Allowing high frequency bursts
 
-The two parameters `max_qps` and `sampling_duration` together define how a\
+The two parameters `max_qps` and `sampling_duration` together define how a
 session is throttled.
 
-Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not\
-an instantaneous measure, but one could say it has a granularity of 10 seconds,\
-we see that over the 10 seconds 10\*400 = 4000 queries are allowed before\
+Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not
+an instantaneous measure, but one could say it has a granularity of 10 seconds,
+we see that over the 10 seconds 10\*400 = 4000 queries are allowed before
 throttling kicks in.
 
-With these values, a fresh session can start off with a speed of 2000 qps, and\
+With these values, a fresh session can start off with a speed of 2000 qps, and
 maintain that speed for 2 seconds before throttling starts.
 
 If the client continues to query at high speed and throttling duration is set to\
@@ -71,8 +71,8 @@ If the client continues to query at high speed and throttling duration is set to
 
 Maximum queries per second.
 
-This is the frequency to which a session will be limited over a given time\
-period. QPS is not measured as an instantaneous value but over a configurable\
+This is the frequency to which a session will be limited over a given time
+period. QPS is not measured as an instantaneous value but over a configurable
 sampling duration (see `sampling_duration`).
 
 **`throttling_duration`**
@@ -81,7 +81,7 @@ sampling duration (see `sampling_duration`).
 * Mandatory: Yes
 * Dynamic: Yes
 
-This defines how long a session is allowed to be throttled before MaxScale\
+This defines how long a session is allowed to be throttled before MaxScale
 disconnects the session.
 
 #### `sampling_duration`
@@ -91,11 +91,11 @@ disconnects the session.
 * Dynamic: Yes
 * Default: 250ms
 
-Sampling duration defines the window of time over which QPS is measured. This\
-parameter directly affects the amount of time that high frequency queries are\
+Sampling duration defines the window of time over which QPS is measured. This
+parameter directly affects the amount of time that high frequency queries are
 allowed before throttling kicks in.
 
-The lower this value is, the more strict throttling becomes. Conversely, the\
+The lower this value is, the more strict throttling becomes. Conversely, the
 longer this time is, the longer bursts of high frequency querying is allowed.
 
 #### `continuous_duration`
@@ -105,8 +105,8 @@ longer this time is, the longer bursts of high frequency querying is allowed.
 * Dynamic: Yes
 * Default: 2s
 
-This value defines what continuous throttling means. Continuous throttling\
-starts as soon as the filter throttles the frequency. Continuous throttling ends\
+This value defines what continuous throttling means. Continuous throttling
+starts as soon as the filter throttles the frequency. Continuous throttling ends
 when no throttling has been performed in the past `continuous_duration` time.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-top-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-top-filter.md
@@ -6,11 +6,11 @@
 
 ### Overview
 
-The top filter is a filter module for MariaDB MaxScale that monitors every SQL\
-statement that passes through the filter. It measures the duration of that\
-statement, the time between the statement being sent and the first result being\
-returned. The top N times are kept, along with the SQL text itself and a list\
-sorted on the execution times of the query is written to a file upon closure of\
+The top filter is a filter module for MariaDB MaxScale that monitors every SQL
+statement that passes through the filter. It measures the duration of that
+statement, the time between the statement being sent and the first result being
+returned. The top N times are kept, along with the SQL text itself and a list
+sorted on the execution times of the query is written to a file upon closure of
 the client session.
 
 ### Configuration
@@ -33,7 +33,7 @@ filters=MyLogFilter
 
 #### Filter Parameters
 
-The top filter has one mandatory parameter, `filebase`, and a number of optional\
+The top filter has one mandatory parameter, `filebase`, and a number of optional
 parameters.
 
 **`filebase`**
@@ -42,15 +42,15 @@ parameters.
 * Mandatory: Yes
 * Dynamic: Yes
 
-The basename of the output file created for each session. The session ID is\
+The basename of the output file created for each session. The session ID is
 added to the filename for each file written. This is a mandatory parameter.
 
 ```
 filebase=/tmp/SqlQueryLog
 ```
 
-The filebase may also be set as the filter, the mechanism to set the filebase\
-via the filter option is superseded by the parameter. If both are set the\
+The filebase may also be set as the filter, the mechanism to set the filebase
+via the filter option is superseded by the parameter. If both are set the
 parameter setting will be used and the filter option ignored.
 
 **`count`**
@@ -73,7 +73,7 @@ count=30
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Limits](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 the queries logged by the filter.
 
 ```
@@ -89,7 +89,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Limits](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 the queries logged by the filter.
 
 **`options`**
@@ -100,7 +100,7 @@ the queries logged by the filter.
 * Values: `ignorecase`, `case`, `extended`
 * Default: `case`
 
-[Regular expression options](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Regular expression options](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 for `match` and `exclude`.
 
 **`source`**
@@ -110,7 +110,7 @@ for `match` and `exclude`.
 * Dynamic: Yes
 * Default: None
 
-Defines an address that is used to match against\
+Defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be logged.
 
@@ -125,9 +125,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-Defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will result in results being\
+Defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will result in results being
 generated.
 
 ```
@@ -138,8 +138,8 @@ user=john
 
 #### Example 1 - Heavily Contended Table
 
-You have an order system and believe the updates of the PRODUCTS table is\
-causing some performance issues for the rest of your application. You would like\
+You have an order system and believe the updates of the PRODUCTS table is
+causing some performance issues for the rest of your application. You would like
 to know which of the many updates in your application is causing the issue.
 
 Add a filter with the following definition:
@@ -154,12 +154,12 @@ exclude=UPDATE.*PRODUCTS_STOCK.*WHERE
 filebase=/var/logs/top/ProductsUpdate
 ```
 
-Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table\
+Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table
 from being included in the report.
 
 #### Example 2 - One Application Server is Slow
 
-One of your applications servers is slower than the rest, you believe it is\
+One of your applications servers is slower than the rest, you believe it is
 related to database access but you are not sure what is taking the time.
 
 Add a filter with the following definition:
@@ -173,7 +173,7 @@ source=192.168.0.32
 filebase=/var/logs/top/SlowAppServer
 ```
 
-In order to produce a comparison with an unaffected application server you can\
+In order to produce a comparison with an unaffected application server you can
 also add a second filter as a control.
 
 ```
@@ -198,14 +198,14 @@ password=mypasswd
 filters=SlowAppServer | ControlAppServer
 ```
 
-You will then have two sets of logs files written, one which profiles the top 20\
-queries of the slow application server and another that gives you the top 20\
-queries of your control application server. These two sets of files can then be\
+You will then have two sets of logs files written, one which profiles the top 20
+queries of the slow application server and another that gives you the top 20
+queries of your control application server. These two sets of files can then be
 compared to determine what if anything is different between the two.
 
 ### Output Report
 
-The following is an example report for a number of fictitious queries executed\
+The following is an example report for a number of fictitious queries executed
 against the employees example database available for MySQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-transaction-performance-monitoring-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--filters/mariadb-maxscale-2208-transaction-performance-monitoring-filter.md
@@ -4,22 +4,22 @@
 
 ## Transaction Performance Monitoring Filter
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Overview
 
-The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale\
+The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale
 that monitors every SQL statement that passes through the filter.\
 The filter groups a series of SQL statements into a transaction by detecting\
-'commit' or 'rollback' statements. It logs all committed transactions with necessary\
-information, such as timestamp, client, SQL statements, latency, etc., which\
+'commit' or 'rollback' statements. It logs all committed transactions with necessary
+information, such as timestamp, client, SQL statements, latency, etc., which
 can be used later for transaction performance analysis.
 
 ### Configuration
 
-The configuration block for the TPM filter requires the minimal filter\
+The configuration block for the TPM filter requires the minimal filter
 options in it's section within the maxscale.cnf file, stored in /etc/maxscale.cnf.
 
 ```
@@ -55,9 +55,9 @@ filename=/tmp/SqlQueryLog
 
 #### Source
 
-The optional `source` parameter defines an address that is used\
-to match against the address from which the client connection\
-to MaxScale originates. Only sessions that originate from this\
+The optional `source` parameter defines an address that is used
+to match against the address from which the client connection
+to MaxScale originates. Only sessions that originate from this
 address will be logged.
 
 ```
@@ -66,9 +66,9 @@ source=127.0.0.1
 
 #### User
 
-The optional `user` parameter defines a user name that is used\
+The optional `user` parameter defines a user name that is used
 to match against the user from which the client connection to\
-MaxScale originates. Only sessions that are connected using\
+MaxScale originates. Only sessions that are connected using
 this username are logged.
 
 ```
@@ -77,7 +77,7 @@ user=john
 
 #### Delimiter
 
-The optional `delimiter` parameter defines a delimiter that is used to\
+The optional `delimiter` parameter defines a delimiter that is used to
 distinguish columns in the log. The default delimiter is **`:::`**.
 
 ```
@@ -86,7 +86,7 @@ delimiter=:::
 
 #### Query\_delimiter
 
-The optional `query_delimiter` defines a delimiter that is used to\
+The optional `query_delimiter` defines a delimiter that is used to
 distinguish different SQL statements in a transaction.\
 The default query delimiter is **`@@@`**.
 
@@ -96,9 +96,9 @@ query_delimiter=@@@
 
 #### Named\_pipe
 
-**`named_pipe`** is the path to a named pipe, which TPM filter uses to\
+**`named_pipe`** is the path to a named pipe, which TPM filter uses to
 communicate with 3rd-party applications (e.g., [DBSeer](https://dbseer.org)).\
-Logging is enabled when the router receives the character '1' and logging is\
+Logging is enabled when the router receives the character '1' and logging is
 disabled when the router receives the character '0' from this named pipe.\
 The default named pipe is **`/tmp/tpmfilter`** and logging is **disabled** by default.
 
@@ -128,7 +128,7 @@ For each transaction, the TPM filter prints its log in the following format:
 
 #### Example 1 - Log Transactions for Performance Analysis
 
-You want to log every transaction with its SQL statements and latency\
+You want to log every transaction with its SQL statements and latency
 for future transaction performance analysis.
 
 Add a filter with the following definition:
@@ -151,7 +151,7 @@ password=mypasswd
 filters=PerformanceLogger
 ```
 
-After the filter reads the character '1' from its named pipe, the following\
+After the filter reads the character '1' from its named pipe, the following
 is an example log that is generated from the above TPM filter with the above configuration:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-admin-user-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-admin-user-resource.md
@@ -15,7 +15,7 @@ MaxScale's configuration.
 GET /v1/users/inet/:name
 ```
 
-Get a single network user. The _:name_ in the URI must be a valid network\
+Get a single network user. The _:name_ in the URI must be a valid network
 user name.
 
 **Response**
@@ -138,7 +138,7 @@ Get all administrative users.
 POST /v1/users/inet
 ```
 
-Create a new network user. The request body must define at least the\
+Create a new network user. The request body must define at least the
 following fields.
 
 * `data.id`
@@ -150,11 +150,11 @@ following fields.
 * `data.attributes.account`
 * Set to `admin` for administrative users and `basic` to read-only users
 
-Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic\
-account performs one of the aforementioned request, the REST API will respond\
+Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic
+account performs one of the aforementioned request, the REST API will respond
 with a `401 Unauthorized` error.
 
-Here is an example request body defining the network user _my-user_ with the\
+Here is an example request body defining the network user _my-user_ with the
 password _my-password_ that is allowed to execute only read-only operations.
 
 ```
@@ -182,7 +182,7 @@ Status: 204 No Content
 POST /v1/users/unix
 ```
 
-This enables an existing UNIX account on the system for administrative\
+This enables an existing UNIX account on the system for administrative
 operations. The request body must define at least the following fields.
 
 * `data.id`
@@ -246,8 +246,8 @@ Status: 204 No Content
 PATCH /v1/users/inet/:name
 ```
 
-Update network user. Currently, only the password can be updated. This\
-means that the request body must define the `data.attributes.password`\
+Update network user. Currently, only the password can be updated. This
+means that the request body must define the `data.attributes.password`
 field.
 
 Here is an example request body that updates the password.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-filter-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-filter-resource.md
@@ -4,7 +4,7 @@
 
 ## Filter Resource
 
-A filter resource represents an instance of a filter inside MaxScale. Multiple\
+A filter resource represents an instance of a filter inside MaxScale. Multiple
 services can use the same filter and a single service can use multiple filters.
 
 ### Resource Operations
@@ -182,7 +182,7 @@ GET /v1/filters
 POST /v1/filters
 ```
 
-Create a new filter. The posted object must define at\
+Create a new filter. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -194,8 +194,8 @@ least the following fields.
 
 All of the filter parameters should be defined at creation time in the`data.attributes.parameters` object.
 
-As the service to filter relationship is ordered (filters are applied in the\
-order they are listed), filter to service relationships cannot be defined at\
+As the service to filter relationship is ordered (filters are applied in the
+order they are listed), filter to service relationships cannot be defined at
 creation time.
 
 The following example defines a request body which creates a new filter.
@@ -227,8 +227,8 @@ Filter is created:
 PATCH /v1/filters/:name
 ```
 
-Filter parameters can be updated at runtime if the module supports it. Refer to\
-the individual module documentation for more details on whether it supports\
+Filter parameters can be updated at runtime if the module supports it. Refer to
+the individual module documentation for more details on whether it supports
 runtime configuration and which parameters can be updated.
 
 The following example modifies a filter by changing the `match` parameter to`.*users.*`.
@@ -260,10 +260,10 @@ DELETE /v1/filters/:filter
 The _:filter_ in the URI must map to the name of the filter to be destroyed.
 
 A filter can only be destroyed if no service uses it. This means that the`data.relationships` object for the filter must be empty. Note that the service\
-→ filter relationship cannot be modified from the filters resource and must be\
+→ filter relationship cannot be modified from the filters resource and must be
 done via the services resource.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the filter by first removing it from all services that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-listener-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-listener-resource.md
@@ -4,7 +4,7 @@
 
 ## Listener Resource
 
-A listener resource represents a listener of a service in MaxScale. All\
+A listener resource represents a listener of a service in MaxScale. All
 listeners point to a service in MaxScale.
 
 ### Resource Operations
@@ -209,10 +209,10 @@ Creates a new listener. The request body must define the following fields.
 * `data.type`
 * Type of the object, must be `listeners`
 * `data.attributes.parameters.port` OR `data.attributes.parameters.socket`
-* The TCP port or UNIX Domain Socket the listener listens on. Only one of the\
+* The TCP port or UNIX Domain Socket the listener listens on. Only one of the
   fields can be defined.
 * `data.relationships.services.data`
-* The service relationships data, must define a JSON object with an `id` value\
+* The service relationships data, must define a JSON object with an `id` value
   that defines the service to use and a `type` value set to `services`.
 
 The following is the minimal required JSON object for defining a new listener.
@@ -238,7 +238,7 @@ The following is the minimal required JSON object for defining a new listener.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) for\
+Refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) for
 a full list of listener parameters.
 
 **Response**
@@ -253,15 +253,15 @@ Listener is created:
 PATCH /v1/listeners/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the listener.
 
 All parameters marked as modifiable at runtime can be modified. Currently, all\
-TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters\
+TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters
 can be modified at runtime.
 
-Parameters that affect the network address or the port the listener listens on\
-cannot be modified at runtime. To modify these parameters, recreate the\
+Parameters that affect the network address or the port the listener listens on
+cannot be modified at runtime. To modify these parameters, recreate the
 listener.
 
 **Response**
@@ -276,7 +276,7 @@ Listener is modified:
 DELETE /v1/listeners/:name
 ```
 
-The _:name_ must be a valid listener name. When a listener is destroyed, the\
+The _:name_ must be a valid listener name. When a listener is destroyed, the
 network port it listens on is available for reuse.
 
 **Response**
@@ -295,7 +295,7 @@ Listener cannot be deleted:
 PUT /v1/listeners/:name/stop
 ```
 
-Stops a started listener. When a listener is stopped, new connections are no\
+Stops a started listener. When a listener is stopped, new connections are no
 longer accepted and are queued until the listener is started again.
 
 **Parameters**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-rest-api.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-rest-api.md
@@ -8,28 +8,28 @@ This document describes the version 1 of the MaxScale REST API.
 
 ### Note About Syntax
 
-Although JSON does not define a syntax for comments, some of the JSON examples\
-have C-style inline comments in them. These comments use `//` to mark the start\
+Although JSON does not define a syntax for comments, some of the JSON examples
+have C-style inline comments in them. These comments use `//` to mark the start
 of the comment and extend to the end of the current line.
 
 ### Configuration
 
-Read the [REST API](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#rest-api-configuration)\
+Read the [REST API](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#rest-api-configuration)
 section of the configuration guide for more details on how to configure the REST API.
 
 ### Authentication
 
-The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)\
-authentication with the MaxScale administrative interface users. The default\
+The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)
+authentication with the MaxScale administrative interface users. The default
 user is `admin:mariadb`.
 
-It is highly recommended to enable HTTPS on the MaxScale REST API to make the\
-communication between the client and MaxScale secure. Without it, the passwords\
-can be intercepted from the network traffic. Refer to the [Configuration Guide](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#admin_ssl_key) for more\
+It is highly recommended to enable HTTPS on the MaxScale REST API to make the
+communication between the client and MaxScale secure. Without it, the passwords
+can be intercepted from the network traffic. Refer to the [Configuration Guide](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#admin_ssl_key) for more
 details on how to enable HTTPS for the MaxScale REST API.
 
-For more details on how administrative interface users are created and managed,\
-refer to the [MaxCtrl](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-maxctrl.md) documentation as well as the\
+For more details on how administrative interface users are created and managed,
+refer to the [MaxCtrl](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-maxctrl.md) documentation as well as the
 documentation of the [users](mariadb-maxscale-2208-admin-user-resource.md) resource.
 
 #### JSON Web Tokens
@@ -40,7 +40,7 @@ MaxScale supports authentication via [JSON Web Tokens](https://tools.ietf.org/ht
 GET /v1/auth
 ```
 
-The `/v1/auth` endpoint can be used to generate new tokens which are returned in\
+The `/v1/auth` endpoint can be used to generate new tokens which are returned in
 the following form.
 
 ```
@@ -51,35 +51,35 @@ the following form.
 }
 ```
 
-Note that by default the `/auth` endpoint requires the connection to be\
-encrypted (HTTPS) and attempts to use it without encryption will be treated as\
+Note that by default the `/auth` endpoint requires the connection to be
+encrypted (HTTPS) and attempts to use it without encryption will be treated as
 an error. To allow use of the `/auth` endpoint without encryption, use`admin_secure_gui=false`.
 
-If the token is used to authenticate users in a web browser, the token can be\
-optionally stored in cookies. This can be enabled with the `persist=yes`\
+If the token is used to authenticate users in a web browser, the token can be
+optionally stored in cookies. This can be enabled with the `persist=yes`
 parameter in the request:
 
 ```
 GET /v1/auth?persist=yes
 ```
 
-When the token is stored in the cookies, it will be stored in the `token_sig`\
+When the token is stored in the cookies, it will be stored in the `token_sig`
 cookie using the `SameSite=Strict` and `HttpOnly` cookie options. This means the\
-JavaScript context of the browser will not have access to it. This is done to\
+JavaScript context of the browser will not have access to it. This is done to
 prevent CSRF attacks.
 
-By default, the generated tokens are valid for 8 hours. The token validity\
+By default, the generated tokens are valid for 8 hours. The token validity
 period can be set with the `max-age` request parameter:
 
 ```
 GET /v1/auth?max-age=28800
 ```
 
-When `max-age` is combined with `persist`, the `Max-Age` cookie option is\
+When `max-age` is combined with `persist`, the `Max-Age` cookie option is
 also set to the same value.
 
-To use the token for authentication, the generated token must be presented in\
-the Authorization header with the Bearer authentication scheme. For example, the\
+To use the token for authentication, the generated token must be presented in
+the Authorization header with the Bearer authentication scheme. For example, the
 token above would be used in the following manner:
 
 ```
@@ -90,24 +90,24 @@ If MaxScale is restarted, all generated tokens are invalidated.
 
 **`/auth` Request Parameters**
 
-The `/auth` endpoint supports the following request parameters that must be\
+The `/auth` endpoint supports the following request parameters that must be
 given in the HTTP query string.
 
 * `max-age`
-* Sets the token maximum age in seconds. The default is `max-age=28800`. Only\
-  positive values between 1 and 2147483646 are accepted and if a non-positive\
+* Sets the token maximum age in seconds. The default is `max-age=28800`. Only
+  positive values between 1 and 2147483646 are accepted and if a non-positive
   or a non-integer value is found, the parameter is ignored.
 * `persist`
 * Store the generated token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the
   response is 204 No Content instead of 200 OK.\
-  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie\
-  which prevents access to from JavaScript. This is done to mitigate any\
+  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie
+  which prevents access to from JavaScript. This is done to mitigate any
   attacks that might leak the token.
 
 ### Resources
 
-The MaxScale REST API provides the following resources. All resources conform to\
+The MaxScale REST API provides the following resources. All resources conform to
 the [JSON API](https://jsonapi.org/format/) specification.
 
 * [maxscale](mariadb-maxscale-2208-maxscale-resource.md)
@@ -120,45 +120,45 @@ the [JSON API](https://jsonapi.org/format/) specification.
 * [users](mariadb-maxscale-2208-admin-user-resource.md)
 * [sql](mariadb-maxscale-2208-sql-resource.md)
 
-In addition to the named resources, the REST API will respond with a HTTP 200 OK\
-response to GET requests on the root resource (`/`) as well as the namespace\
-root resource (`/v1/`). These can be used for HTTP health checks to determine\
+In addition to the named resources, the REST API will respond with a HTTP 200 OK
+response to GET requests on the root resource (`/`) as well as the namespace
+root resource (`/v1/`). These can be used for HTTP health checks to determine
 whether MaxScale is running.
 
 ### API Versioning
 
 All of the current resources are in the `/v1/` namespace of the MaxScale REST\
-API. Further additions to the namespace can be added that do not break backwards\
+API. Further additions to the namespace can be added that do not break backwards
 compatibility of any existing resources. What this means in practice is that:
 
 * No resources or URLs will be removed
 * The API will be JSON API compliant
 
-Note that this means that the contents of individual resources can change. New\
-fields can be added, old ones can be removed and the meaning of existing fields\
-can change. The aim is to be as backwards compatible as reasonably possible\
+Note that this means that the contents of individual resources can change. New
+fields can be added, old ones can be removed and the meaning of existing fields
+can change. The aim is to be as backwards compatible as reasonably possible
 without sacrificing the clarity and functionality of the API.
 
-Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the\
+Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the
 prefix is not used, the latest API version is used.
 
 #### Resource Relationships
 
-All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other\
+All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other
 objects. This closely resembles the JSON API definition of links.
 
-In the _relationships_ objects, all resources have a _self_ link that points to\
-the resource itself. This allows easy access to the objects pointed by the\
+In the _relationships_ objects, all resources have a _self_ link that points to
+the resource itself. This allows easy access to the objects pointed by the
 relationships as the reply URL is included in the response itself.
 
-To create a relationship between two objects, define it in the initial POST\
-request. To modify the relationships of existing objects, perform a PATCH\
-request with the new definition of the relevant relationship. To completely\
-remove all relationships from an object, the `data` field of the corresponding\
+To create a relationship between two objects, define it in the initial POST
+request. To modify the relationships of existing objects, perform a PATCH
+request with the new definition of the relevant relationship. To completely
+remove all relationships from an object, the `data` field of the corresponding
 relationship object must be set to an empty array.
 
-The following lists the resources and the types of links each resource can have\
-in addition to the _self_ link. Examples of these relationships can be seen in\
+The following lists the resources and the types of links each resource can have
+in addition to the _self_ link. Examples of these relationships can be seen in
 the resource documentation.
 
 * `services` - Service resource
@@ -168,7 +168,7 @@ the resource documentation.
   List of services used by the service
 * `filters`\
   List of filters used by the service\
-  NOTE: This is an ordered relationship where the order of the filters\
+  NOTE: This is an ordered relationship where the order of the filters
   defines the order in which they process queries.
 * `listeners`\
   List of listeners used by the service
@@ -190,54 +190,54 @@ the resource documentation.
 
 ### Common Request Parameters
 
-All the resources that return JSON content also support the following\
+All the resources that return JSON content also support the following
 parameters. Parameters are given in the HTTP query string:`https://localhost:8989/v1/servers?pretty=true&fields[servers]=state`.
 
 * `pretty`
 * Pretty-print output.\
-  If this parameter is set to `true` then the returned objects are formatted\
-  in a more human readable format. If the parameter is set to `false` then the\
-  returned objects are formatted in a compact format. All resources support\
+  If this parameter is set to `true` then the returned objects are formatted
+  in a more human readable format. If the parameter is set to `false` then the
+  returned objects are formatted in a compact format. All resources support
   this parameter. The default value for this parameter is `true`.
 * `fields[TYPE]=field1,field2...`
 * Return a [Sparse Fieldset](https://jsonapi.org/format/#fetching-sparse-fieldsets)\
-  This parameter controls which fields are returned in the REST API\
-  response. The `TYPE` value in the `fields` parameter must be the resource\
-  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated\
-  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which\
-  fields of the object to return. Only fields in objects in the `attributes`\
-  and `relationships` objects are inspected. This means that if the path\
-  marked by the JSON Pointer contains an array in it, it will not advance past\
+  This parameter controls which fields are returned in the REST API
+  response. The `TYPE` value in the `fields` parameter must be the resource
+  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated
+  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which
+  fields of the object to return. Only fields in objects in the `attributes`
+  and `relationships` objects are inspected. This means that if the path
+  marked by the JSON Pointer contains an array in it, it will not advance past
   this array.\
-  For example, to return only the server state output from the `/servers`\
-  endpoint, the `fields[servers]=state` parameter can be used. This would\
-  return only the `data.attributes.state` part of the resource. To return the\
-  nested value `data.attributes.statistics.connections`, the corresponding\
+  For example, to return only the server state output from the `/servers`
+  endpoint, the `fields[servers]=state` parameter can be used. This would
+  return only the `data.attributes.state` part of the resource. To return the
+  nested value `data.attributes.statistics.connections`, the corresponding
   parameter would be `fields[servers]=statistics/connections`.
 * `filter=json_ptr=expr`
 * Filter the output of the result\
-  This parameter controls which rows are returned in a REST API response that\
-  returns an array in the `data` member (i.e. a request to a resource\
+  This parameter controls which rows are returned in a REST API response that
+  returns an array in the `data` member (i.e. a request to a resource
   collection). Requests to individual resources are not filtered.\
-  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a\
-  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2208-rest-api.md#filter-expressions). The comparison is done for each\
-  individual object in the `data` array of the result. If given only a JSON\
-  value, the stored value is compared for equality. If an expression is used,\
+  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a
+  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2208-rest-api.md#filter-expressions). The comparison is done for each
+  individual object in the `data` array of the result. If given only a JSON
+  value, the stored value is compared for equality. If an expression is used,
   the expression is evaluated and only rows that match are returned.\
-  For example, if the object stored in `data[0]` has a value pointed by the\
-  given JSON pointer and that value compares equal to the given JSON value,\
-  the array row is kept in the result. Examples for filtering expression can\
+  For example, if the object stored in `data[0]` has a value pointed by the
+  given JSON pointer and that value compares equal to the given JSON value,
+  the array row is kept in the result. Examples for filtering expression can
   be found [here](mariadb-maxscale-2208-rest-api.md#filter-expression-examples).\
-  A practical use for this parameter is to return only sessions for a\
-  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can\
-  be used. Note the double quotes around the `"RW-Split-Router"`, they are\
+  A practical use for this parameter is to return only sessions for a
+  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
+  be used. Note the double quotes around the `"RW-Split-Router"`, they are
   required to correctly convert strings into JSON values.
 * `filter[json_path]=expr`
 * Filter based on a JSONPath and a filtering expression.\
-  Similar to the `filter` parameter that takes a JSON Pointer, this version of\
-  the `filter` controls which rows are returned in a REST API response for a\
+  Similar to the `filter` parameter that takes a JSON Pointer, this version of
+  the `filter` controls which rows are returned in a REST API response for a
   resource collection. Requests to individual resources are never filtered.\
-  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)\
+  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)
   expression that MaxScale supports. The currently supported syntax is:
   * dot notation: `$.store.book`
   * bracket notation: `$['store']['book']`
@@ -247,53 +247,53 @@ parameters. Parameters are given in the HTTP query string:`https://localhost:898
   * object wildcards: `$.store.bicycle.*`
   * optional root object: `store.book`
 
-The root object being optional is an extension to the JSONPath specification\
+The root object being optional is an extension to the JSONPath specification
 that MaxScale implements.\
-The `expr` value must be a [filter-expression](mariadb-maxscale-2208-rest-api.md#filter-expressions). Similarly to the other `filter`\
-parameter, the comparison is done for each individual object in the `data`\
+The `expr` value must be a [filter-expression](mariadb-maxscale-2208-rest-api.md#filter-expressions). Similarly to the other `filter`
+parameter, the comparison is done for each individual object in the `data`
 array of the result.\
-If the JSONPath expression returns multiple objects, the comparison is done\
-for each element and if any of them matches, the object is considered to\
+If the JSONPath expression returns multiple objects, the comparison is done
+for each element and if any of them matches, the object is considered to
 match. In other words, wildcard JSONPath expressions are ORed together.\
-If multiple `filter[json_path]=expr` parameters are found in the request,\
-all returned values must match all of them. In other words, the filter\
-parameters are all combined into an AND expression. For example, the\
-following filter will only return all values whose `id` field is `"srv1` and\
+If multiple `filter[json_path]=expr` parameters are found in the request,
+all returned values must match all of them. In other words, the filter
+parameters are all combined into an AND expression. For example, the
+following filter will only return all values whose `id` field is `"srv1` and
 the `attributes.parameters.port` field is 3306:`filter[id]=eq("srv1")&filter[attributes.parameters.port]=eq(3306)`
 
 * `page[size]`
-* The number of elements that are returned for resource collections. By\
-  default all elements in the resource collection are returned. The value must\
-  be a valid positive integer, otherwise the parameter is ignored. If\
-  pagination is used, the `links` object will have pagination links to the\
+* The number of elements that are returned for resource collections. By
+  default all elements in the resource collection are returned. The value must
+  be a valid positive integer, otherwise the parameter is ignored. If
+  pagination is used, the `links` object will have pagination links to the
   next page if more elements are available.
 * `page[number]`
-* How many pages of results to skip. The first page of results starts from 0\
-  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This\
-  should be considered pseudo-pagination as the results are not guaranteed to\
+* How many pages of results to skip. The first page of results starts from 0
+  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This
+  should be considered pseudo-pagination as the results are not guaranteed to
   be consistent between requests.
 * `sync`
 * Control configuration synchronization.\
-  If this parameter is set to `false` then the configuration synchronization\
-  is disabled for this request. This can be used to perform configuration\
-  changes when MaxScale is unable to reach the cluster used to synchronize the\
-  configuration. The modifications to the local configuration will be\
-  overwritten when the next modification to the cluster's configuration is\
+  If this parameter is set to `false` then the configuration synchronization
+  is disabled for this request. This can be used to perform configuration
+  changes when MaxScale is unable to reach the cluster used to synchronize the
+  configuration. The modifications to the local configuration will be
+  overwritten when the next modification to the cluster's configuration is
   done which means this should only be used to perform temporary fixes.
 
 #### Filter Expressions
 
-MaxScale 24.02 added support for expressions in the `filter` request\
-parameter. Each resource in a resource collection that evaluates to a true value\
-will be kept in the returned result. All rows that evaluate to false are\
+MaxScale 24.02 added support for expressions in the `filter` request
+parameter. Each resource in a resource collection that evaluates to a true value
+will be kept in the returned result. All rows that evaluate to false are
 removed.
 
-Equality and inequality is defined for all JSON types but ordering is defined\
-only for numbers and strings. The logical operators allow one or more\
+Equality and inequality is defined for all JSON types but ordering is defined
+only for numbers and strings. The logical operators allow one or more
 sub-expressions.
 
-The following table lists the supported operations in the filter expressions. In\
-it, the stored value is marked as `S` and the literal JSON value in the\
+The following table lists the supported operations in the filter expressions. In
+it, the stored value is marked as `S` and the literal JSON value in the
 expression as `V`. For the logical operators, the sub-expression is marked as`expr`.
 
 | Expression   | Logic          | Types               |
@@ -310,25 +310,25 @@ expression as `V`. For the logical operators, the sub-expression is marked as`ex
 
 **Filter Expression Examples**
 
-Ranges of values can be defined using an `and()` expression with the range\
-limits defined with the ordering operators `ge()` and `le()`. To filter the\
-sessions in MaxScale to ones that have an ID between 50 and 100, the following\
+Ranges of values can be defined using an `and()` expression with the range
+limits defined with the ordering operators `ge()` and `le()`. To filter the
+sessions in MaxScale to ones that have an ID between 50 and 100, the following
 filtering expression can be used.
 
 ```
 filter=id=and(ge(50),le(100))
 ```
 
-Limiting the result to only the given values can be done with an `or()`\
-expression that uses `eq()` expressions to select the rows to return. To only\
-return sessions with IDs 1, 5, 10 the following filtering expression can be\
+Limiting the result to only the given values can be done with an `or()`
+expression that uses `eq()` expressions to select the rows to return. To only
+return sessions with IDs 1, 5, 10 the following filtering expression can be
 used.
 
 ```
 filter=id=or(eq(1),eq(5),eq(10))
 ```
 
-Similarly, excluding certain rows from the result can be done by simply\
+Similarly, excluding certain rows from the result can be done by simply
 replacing `or()` with `not()`. This expression would exclude sessions with the\
 IDs 1, 5 and 10 from the result.
 
@@ -340,22 +340,22 @@ filter=id=not(eq(1),eq(5),eq(10))
 
 #### Request Headers
 
-REST makes use of the HTTP protocols in its aim to provide a natural way to\
-understand the workings of an API. The following request headers are understood\
+REST makes use of the HTTP protocols in its aim to provide a natural way to
+understand the workings of an API. The following request headers are understood
 by this API.
 
 **Authorization**
 
 Credentials for authentication. This header should consist of a HTTP Basic\
-Access authentication type payload which is the base64 encoded value of the\
+Access authentication type payload which is the base64 encoded value of the
 username and password joined by a colon e.g. `Base64("maxuser:maxpwd")`.
 
 **Content-Type**
 
-All PUT and POST requests must use the `Content-Type: application/json` media\
-type and the request body must be a complete and valid JSON representation of a\
-resource. All PATCH requests must use the `Content-Type: application/json` media\
-type and the request body must be a JSON document containing a partial\
+All PUT and POST requests must use the `Content-Type: application/json` media
+type and the request body must be a complete and valid JSON representation of a
+resource. All PATCH requests must use the `Content-Type: application/json` media
+type and the request body must be a JSON document containing a partial
 definition of the modified resource.
 
 **Host**
@@ -364,59 +364,59 @@ The address and port of the server.
 
 **If-Match**
 
-The request is performed only if the provided ETag value matches the one on the\
-server. This field should be used with PATCH requests to prevent concurrent\
+The request is performed only if the provided ETag value matches the one on the
+server. This field should be used with PATCH requests to prevent concurrent
 updates to the same resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Modified-Since**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **If-None-Match**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Unmodified-Since**
 
-The request is performed only if the requested resource has not been modified\
+The request is performed only if the requested resource has not been modified
 since the provided date.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **X-HTTP-Method-Override**
 
-Some clients only support GET and PUT requests. By providing the string value of\
-the intended method in the `X-HTTP-Method-Override` header, a client can, for\
-example, perform a POST, PATCH or DELETE request with the PUT method\
+Some clients only support GET and PUT requests. By providing the string value of
+the intended method in the `X-HTTP-Method-Override` header, a client can, for
+example, perform a POST, PATCH or DELETE request with the PUT method
 (e.g. `X-HTTP-Method-Override: PATCH`).
 
-If this header is defined in the request, the current method of the request is\
-replaced with the one in the header. The HTTP method must be in uppercase and it\
+If this header is defined in the request, the current method of the request is
+replaced with the one in the header. The HTTP method must be in uppercase and it
 must be one of the methods that the requested resource supports.
 
 #### Response Headers
 
 **Allow**
 
-All resources return the Allow header with the supported HTTP methods. For\
-example the resource `/services` will always return the `Accept: GET, PATCH, PUT`\
+All resources return the Allow header with the supported HTTP methods. For
+example the resource `/services` will always return the `Accept: GET, PATCH, PUT`
 header.
 
 **Accept-Patch**
 
-All PATCH capable resources return the `Accept-Patch: application/json-patch`\
+All PATCH capable resources return the `Accept-Patch: application/json-patch`
 header.
 
 **Date**
@@ -426,12 +426,12 @@ English and it uses the server's local timezone.
 
 **ETag**
 
-An identifier for a specific version of a resource. The value of this header\
-changes whenever a resource is modified via the REST API. It will not change if\
-an internal MaxScale event (e.g. server changing state or statistics being\
+An identifier for a specific version of a resource. The value of this header
+changes whenever a resource is modified via the REST API. It will not change if
+an internal MaxScale event (e.g. server changing state or statistics being
 updated) causes a change.
 
-When the client sends the `If-Match` or `If-None-Match` header, the provided\
+When the client sends the `If-Match` or `If-None-Match` header, the provided
 value should be the value of the `ETag` header of an earlier GET.
 
 **Last-Modified**
@@ -440,29 +440,29 @@ The date when the resource was last modified in "HTTP-date" format.
 
 **Location**
 
-If an out of date resource location is requested, a HTTP return code of 3XX with\
-the `Location` header is returned. The value of the header contains the new\
+If an out of date resource location is requested, a HTTP return code of 3XX with
+the `Location` header is returned. The value of the header contains the new
 location of the requested resource as a relative URI.
 
 **WWW-Authenticate**
 
-The requested authentication method. For example, `WWW-Authenticate: Basic`\
+The requested authentication method. For example, `WWW-Authenticate: Basic`
 would require basic HTTP authentication.
 
 **Mxs-Warning**
 
-This header is used for sending generic warnings to clients about actions that\
-were successful and valid but could cause problems in the future. Currently\
-these are used to indicate when a configuration change was made to a static\
-object and an overriding configuration is created or when a static object is\
+This header is used for sending generic warnings to clients about actions that
+were successful and valid but could cause problems in the future. Currently
+these are used to indicate when a configuration change was made to a static
+object and an overriding configuration is created or when a static object is
 being deleted at runtime.
 
-The content of the header is the human-readable warning that should be displayed\
+The content of the header is the human-readable warning that should be displayed
 to a user.
 
 ### Response Codes
 
-Every HTTP response starts with a line with a return code which indicates the\
+Every HTTP response starts with a line with a return code which indicates the
 outcome of the request. The API uses some of the standard HTTP values:
 
 #### 2xx Success
@@ -472,37 +472,37 @@ outcome of the request. The API uses some of the standard HTTP values:
 * 201 Created
 * A new resource was created.
 * 202 Accepted
-* The request has been accepted for processing, but the processing has not\
+* The request has been accepted for processing, but the processing has not
   been completed.
 * 204 No Content
 * Successful HTTP requests, response has no body.
 
 #### 3xx Redirection
 
-This class of status code indicates the client must take additional action to\
+This class of status code indicates the client must take additional action to
 complete the request.
 
 * 301 Moved Permanently
 * This and all future requests should be directed to the given URI.
 * 302 Found
-* The response to the request can be found under another URI using the same\
+* The response to the request can be found under another URI using the same
   method as in the original request.
 * 303 See Other
-* The response to the request can be found under another URI using a GET\
+* The response to the request can be found under another URI using a GET
   method.
 * 304 Not Modified
-* Indicates that the resource has not been modified since the version\
+* Indicates that the resource has not been modified since the version
   specified by the request headers If-Modified-Since or If-None-Match.
 * 307 Temporary Redirect
-* The request should be repeated with another URI but future requests should\
+* The request should be repeated with another URI but future requests should
   use the original URI.
 * 308 Permanent Redirect
 * The request and all future requests should be repeated using another URI.
 
 #### 4xx Client Error
 
-The 4xx class of status code is when the client seems to have erred. Except when\
-responding to a HEAD request, the body of the response _MAY_ contains a JSON\
+The 4xx class of status code is when the client seems to have erred. Except when
+responding to a HEAD request, the body of the response _MAY_ contains a JSON
 representation of the error.
 
 ```
@@ -513,7 +513,7 @@ representation of the error.
 }
 ```
 
-The _error_ field contains a short error description and the _description_ field\
+The _error_ field contains a short error description and the _description_ field
 contains a more detailed version of the error message.
 
 * 400 Bad Request
@@ -521,41 +521,41 @@ contains a more detailed version of the error message.
 * 401 Unauthorized
 * Authentication is required. The response includes a WWW-Authenticate header.
 * 403 Forbidden
-* The request was a valid request, but the client does not have the necessary\
+* The request was a valid request, but the client does not have the necessary
   permissions for the resource.
 * 404 Not Found
 * The requested resource could not be found.
 * 405 Method Not Allowed
 * A request method is not supported for the requested resource.
 * 406 Not Acceptable
-* The requested resource is capable of generating only content not acceptable\
+* The requested resource is capable of generating only content not acceptable
   according to the Accept headers sent in the request.
 * 409 Conflict
-* Indicates that the request could not be processed because of conflict in the\
+* Indicates that the request could not be processed because of conflict in the
   request, such as an edit conflict be tween multiple simultaneous updates.
 * 411 Length Required
-* The request did not specify the length of its content, which is required by\
+* The request did not specify the length of its content, which is required by
   the requested resource.
 * 412 Precondition Failed
-* The server does not meet one of the preconditions that the requester put on\
+* The server does not meet one of the preconditions that the requester put on
   the request.
 * 413 Payload Too Large
 * The request is larger than the server is willing or able to process.
 * 414 URI Too Long
 * The URI provided was too long for the server to process.
 * 415 Unsupported Media Type
-* The request entity has a media type which the server or resource does not\
+* The request entity has a media type which the server or resource does not
   support.
 * 422 Unprocessable Entity
-* The request was well-formed but was unable to be followed due to semantic\
+* The request was well-formed but was unable to be followed due to semantic
   errors.
 * 423 Locked
 * The resource that is being accessed is locked.
 * 428 Precondition Required
-* The origin server requires the request to be conditional. This error code is\
+* The origin server requires the request to be conditional. This error code is
   returned when none of the `Modified-Since` or `Match` type headers are used.
 * 431 Request Header Fields Too Large
-* The server is unwilling to process the request because either an individual\
+* The server is unwilling to process the request because either an individual
   header field, or all the header fields collectively, are too large.
 
 #### 5xx Server Error
@@ -563,30 +563,30 @@ contains a more detailed version of the error message.
 The server failed to fulfill an apparently valid request.
 
 * 500 Internal Server Error
-* A generic error message, given when an unexpected condition was encountered\
+* A generic error message, given when an unexpected condition was encountered
   and no more specific message is suitable.
 * 501 Not Implemented
-* The server either does not recognize the request method, or it lacks the\
+* The server either does not recognize the request method, or it lacks the
   ability to fulfill the request.
 * 502 Bad Gateway
-* The server was acting as a gateway or proxy and received an invalid response\
+* The server was acting as a gateway or proxy and received an invalid response
   from the upstream server.
 * 503 Service Unavailable
-* The server is currently unavailable (because it is overloaded or down for\
+* The server is currently unavailable (because it is overloaded or down for
   maintenance). Generally, this is a temporary state.
 * 504 Gateway Timeout
-* The server was acting as a gateway or proxy and did not receive a timely\
+* The server was acting as a gateway or proxy and did not receive a timely
   response from the upstream server.
 * 505 HTTP Version Not Supported
 * The server does not support the HTTP protocol version used in the request.
 * 506 Variant Also Negotiates
-* Transparent content negotiation for the request results in a circular\
+* Transparent content negotiation for the request results in a circular
   reference.
 * 507 Insufficient Storage
-* The server is unable to store the representation needed to complete the\
+* The server is unable to store the representation needed to complete the
   request.
 * 508 Loop Detected
-* The server detected an infinite loop while processing the request (sent in\
+* The server detected an infinite loop while processing the request (sent in
   lieu of 208 Already Reported).
 * 510 Not Extended
 * Further extensions to the request are required for the server to fulfil it.
@@ -597,23 +597,23 @@ The following response headers are not currently in use. Future versions of the\
 API could return them.
 
 * 206 Partial Content
-* The server is delivering only part of the resource (byte serving) due to a\
+* The server is delivering only part of the resource (byte serving) due to a
   range header sent by the client.
 * 300 Multiple Choices
-* Indicates multiple options for the resource from which the client may choose\
+* Indicates multiple options for the resource from which the client may choose
   (via agent-driven content negotiation).
 * 407 Proxy Authentication Required
 * The client must first authenticate itself with the proxy.
 * 408 Request Timeout
-* The server timed out waiting for the request. According to HTTP\
-  specifications: "The client did not produce a request within the time that\
-  the server was prepared to wait. The client MAY repeat the request without\
+* The server timed out waiting for the request. According to HTTP
+  specifications: "The client did not produce a request within the time that
+  the server was prepared to wait. The client MAY repeat the request without
   modifications at any later time."
 * 410 Gone
-* Indicates that the resource requested is no longer available and will not be\
+* Indicates that the resource requested is no longer available and will not be
   available again.
 * 416 Range Not Satisfiable
-* The client has asked for a portion of the file (byte serving), but the\
+* The client has asked for a portion of the file (byte serving), but the
   server cannot supply that portion.
 * 417 Expectation Failed
 * The server cannot meet the requirements of the Expect request-header field.
@@ -622,10 +622,10 @@ API could return them.
 * 424 Failed Dependency
 * The request failed due to failure of a previous request.
 * 426 Upgrade Required
-* The client should switch to a different protocol such as TLS/1.0, given in\
+* The client should switch to a different protocol such as TLS/1.0, given in
   the Upgrade header field.
 * 429 Too Many Requests
-* The user has sent too many requests in a given amount of time. Intended for\
+* The user has sent too many requests in a given amount of time. Intended for
   use with rate-limiting schemes.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-server-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-server-resource.md
@@ -765,7 +765,7 @@ Response contains a resource collection with all servers.
 POST /v1/servers
 ```
 
-Create a new server by defining the resource. The posted object must define at\
+Create a new server by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -773,10 +773,10 @@ least the following fields.
 * `data.type`
 * Type of the object, must be `servers`
 * `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-* The [address](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#address) or [socket](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#socket) to use. Only\
+* The [address](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#address) or [socket](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#socket) to use. Only
   one of the fields can be defined.
 * `data.attributes.parameters.port`
-* The [port](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#port) to use. Needs\
+* The [port](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#port) to use. Needs
   to be defined if the `address` field is defined.
 
 The following is the minimal required JSON object for defining a new server.
@@ -796,7 +796,7 @@ The following is the minimal required JSON object for defining a new server.
 }
 ```
 
-The relationships of a server can also be defined at creation time. This allows\
+The relationships of a server can also be defined at creation time. This allows
 new servers to be created and immediately taken into use.
 
 ```
@@ -836,7 +836,7 @@ new servers to be created and immediately taken into use.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md)
 for a full list of server parameters.
 
 **Response**
@@ -855,19 +855,19 @@ Invalid JSON body:
 PATCH /v1/servers/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 server.
 
 #### Modifiable Fields
 
-In addition to the server [parameters](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#server-1), the _services_\
-and _monitors_ fields of the _relationships_ object can be modified. Removal,\
-addition and modification of the links will change which service and monitors\
+In addition to the server [parameters](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#server-1), the _services_
+and _monitors_ fields of the _relationships_ object can be modified. Removal,
+addition and modification of the links will change which service and monitors
 use this server.
 
 For example, removing the first value in the _services_ list in the_relationships_ object from the following JSON document will remove the_server1_ from the service _RW-Split-Router_.
 
-Removing a service from a server is analogous to removing the server from the\
+Removing a service from a server is analogous to removing the server from the
 service. Both unlink the two objects from each other.
 
 Request for `PATCH /v1/servers/server1` that modifies the address of the server:
@@ -905,9 +905,9 @@ Request for `PATCH /v1/servers/server1` that modifies the server relationships:
 }
 ```
 
-If parts of the resource are not defined (e.g. the `attributes` field in the\
-above example), those parts of the resource are not modified. All parts that are\
-defined are interpreted as the new definition of those part of the resource. In\
+If parts of the resource are not defined (e.g. the `attributes` field in the
+above example), those parts of the resource are not modified. All parts that are
+defined are interpreted as the new definition of those part of the resource. In
 the above example, the `relationships` of the resource are completely redefined.
 
 **Response**
@@ -926,15 +926,15 @@ Invalid JSON body:
 PATCH /v1/servers/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _services_, for service\
+The _:type_ in the URI must be either _services_, for service
 relationships, or _monitors_, for monitor relationships.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the particular type from the server.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 service relationship for a server.
 
 ```
@@ -973,11 +973,11 @@ Invalid JSON body:
 DELETE /v1/servers/:name
 ```
 
-A server can only be deleted if it is not used by any services or\
+A server can only be deleted if it is not used by any services or
 monitors.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the server by first unlinking it from all services and monitors that use\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the server by first unlinking it from all services and monitors that use
 it.
 
 **Response**
@@ -996,7 +996,7 @@ Server is in use:
 PUT /v1/servers/:name/set
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the following values.
 
 | Value       | State Description                |
@@ -1008,19 +1008,19 @@ request. The value of `state` must be one of the following values.
 | synced      | Server is a Galera node          |
 | drain       | Server is drained of connections |
 
-For example, to set the server _db-server-1_ into maintenance mode, a request to\
+For example, to set the server _db-server-1_ into maintenance mode, a request to
 the following URL must be made:
 
 ```
 PUT /v1/servers/db-server-1/set?state=maintenance
 ```
 
-This endpoint also supports the `force=yes` parameter that will cause all\
-connections to the server to be closed if `state=maintenance` is also set. By\
-default setting a server into maintenance mode will cause connections to be\
+This endpoint also supports the `force=yes` parameter that will cause all
+connections to the server to be closed if `state=maintenance` is also set. By
+default setting a server into maintenance mode will cause connections to be
 closed only after the next request is sent.
 
-The following example forcefully closes all connections to server _db-server-1_\
+The following example forcefully closes all connections to server _db-server-1_
 and sets it into maintenance mode:
 
 ```
@@ -1043,7 +1043,7 @@ Missing or invalid parameter:
 PUT /v1/servers/:name/clear
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the values defined in the_set_ endpoint documentation.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-service-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-service-resource.md
@@ -4,7 +4,7 @@
 
 ## Service Resource
 
-A service resource represents a service inside MaxScale. A service is a\
+A service resource represents a service inside MaxScale. A service is a
 collection of network listeners, filters, a router and a set of backend servers.
 
 ### Resource Operations
@@ -725,7 +725,7 @@ Get all services.
 POST /v1/services
 ```
 
-Create a new service by defining the resource. The posted object must define at\
+Create a new service by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -739,24 +739,24 @@ least the following fields.
 * `data.attributes.parameters.password`
 * The [password](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#password) to use
 
-The `data.attributes.parameters` object is used to define router and service\
-parameters. All configuration parameters that can be defined in the\
-configuration file can also be added to the parameters object. The exceptions to\
-this are the `type`, `router`, `servers` and `filters` parameters which must not\
+The `data.attributes.parameters` object is used to define router and service
+parameters. All configuration parameters that can be defined in the
+configuration file can also be added to the parameters object. The exceptions to
+this are the `type`, `router`, `servers` and `filters` parameters which must not
 be defined.
 
-As with other REST API resources, the `data.relationships` field defines the\
-relationships of the service to other resources. Services can have two types of\
+As with other REST API resources, the `data.relationships` field defines the
+relationships of the service to other resources. Services can have two types of
 relationships: `servers` and `filters` relationships.
 
-If the request body defines a valid `relationships` object, the service is\
-linked to those resources. For servers, this is equivalent to adding the list of\
-server names into the [servers](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#servers) parameter. For\
-filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#filters) parameter in the\
-order they appear. For other services, this is equivalent to adding the list of\
+If the request body defines a valid `relationships` object, the service is
+linked to those resources. For servers, this is equivalent to adding the list of
+server names into the [servers](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#servers) parameter. For
+filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#filters) parameter in the
+order they appear. For other services, this is equivalent to adding the list of
 server names into the [targets](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#targets) parameter.
 
-The following example defines a new service with both a server and a filter\
+The following example defines a new service with both a server and a filter
 relationship.
 
 ```
@@ -805,21 +805,21 @@ Service is created:
 DELETE /v1/services/:name
 ```
 
-A service can only be destroyed if the service uses no servers or filters and\
-all the listeners pointing to the service have been destroyed. This means that\
-the `data.relationships` must be an empty object and `data.attributes.listeners`\
+A service can only be destroyed if the service uses no servers or filters and
+all the listeners pointing to the service have been destroyed. This means that
+the `data.relationships` must be an empty object and `data.attributes.listeners`
 must be an empty array in order for the service to qualify for destruction.
 
-If there are open client connections that use the service when it is destroyed,\
-they are allowed to gracefully close before the service is destroyed. This means\
-that the destruction of a service can be acknowledged via the REST API before\
+If there are open client connections that use the service when it is destroyed,
+they are allowed to gracefully close before the service is destroyed. This means
+that the destruction of a service can be acknowledged via the REST API before
 the destruction process has fully completed.
 
-To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2208-session-resource.md) resource should be used. If a session for\
+To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2208-session-resource.md) resource should be used. If a session for
 the service is still open, it has not yet been destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the service by first unlinking it from all servers and filters that it\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the service by first unlinking it from all servers and filters that it
 uses.
 
 **Response**
@@ -834,15 +834,15 @@ Service is destroyed:
 PATCH /v1/services/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the service.
 
-All standard service parameters can be modified. Refer to the [service](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#service) documentation on\
+All standard service parameters can be modified. Refer to the [service](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#service) documentation on
 the details of these parameters.
 
-In addition to the standard service parameters, router parameters can be updated\
-at runtime if the router module supports it. Refer to the individual router\
-documentation for more details on whether the router supports it and which\
+In addition to the standard service parameters, router parameters can be updated
+at runtime if the router module supports it. Refer to the individual router
+documentation for more details on whether the router supports it and which
 parameters can be updated at runtime.
 
 The following example modifies a service by changing the `user` parameter to `admin`.
@@ -871,22 +871,22 @@ Service is modified:
 PATCH /v1/services/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _servers_, _services_ or _filters_,\
+The _:type_ in the URI must be either _servers_, _services_ or _filters_,
 depending on which relationship is being modified.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of this type for the service.
 
-_Note:_ The order of the values in the `filters` relationship will define the\
-order the filters are set up in. The order in which the filters appear in the\
-array will be the order in which the filters are applied to each query. Refer\
-to the [filters](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#filters) parameter\
+_Note:_ The order of the values in the `filters` relationship will define the
+order the filters are set up in. The order in which the filters appear in the
+array will be the order in which the filters are applied to each query. Refer
+to the [filters](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#filters) parameter
 for more details.
 
-The following is an example request and request body that defines a single\
-server relationship for a service that is equivalent to a `servers=my-server`\
+The following is an example request and request body that defines a single
+server relationship for a service that is equivalent to a `servers=my-server`
 parameter.
 
 ```
@@ -982,7 +982,7 @@ This endpoint is deprecated, use the [this](mariadb-maxscale-2208-listener-resou
 GET /v1/services/:name/listeners/:listener
 ```
 
-This endpoint is deprecated, use the [this](mariadb-maxscale-2208-listener-resource.md#get-a-listener)\
+This endpoint is deprecated, use the [this](mariadb-maxscale-2208-listener-resource.md#get-a-listener)
 listeners endpoint instead.
 
 #### Create a new listener

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-session-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-session-resource.md
@@ -4,8 +4,8 @@
 
 ## Session Resource
 
-A session is an abstraction of a client connection, any number of related backend\
-connections, a router module session and possibly filter module sessions. Each\
+A session is an abstraction of a client connection, any number of related backend
+connections, a router module session and possibly filter module sessions. Each
 session is created on a service and each service can have multiple sessions.
 
 ### Resource Operations
@@ -16,11 +16,11 @@ session is created on a service and each service can have multiple sessions.
 GET /v1/sessions/:id
 ```
 
-Get a single session. _:id_ must be a valid session ID. The session ID is the\
+Get a single session. _:id_ must be a valid session ID. The session ID is the
 same that is exposed to the client as the connection ID.
 
-This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to\
-perform reverse DNS on the client IP address. As this requires communicating with\
+This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to
+perform reverse DNS on the client IP address. As this requires communicating with
 an external server, the operation may be expensive.
 
 **Response**
@@ -183,10 +183,10 @@ Get all sessions.
 PATCH /v1/sessions/:id
 ```
 
-The request body must be a JSON object which represents the new configuration of\
+The request body must be a JSON object which represents the new configuration of
 the session. The `:id` must be a valid session ID that is active.
 
-The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean\
+The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean
 parameters control whether the associated logging level is enabled:
 
 ```
@@ -201,11 +201,11 @@ parameters control whether the associated logging level is enabled:
 }
 ```
 
-The filters that a session uses can be updated by re-defining the filter\
-relationship of the session. This causes new filter sessions to be opened\
-immediately. The old filter session are closed and replaced with the new filter\
-session the next time the session is idle. The order in which the filters are\
-defined in the request body is the order in which the filters are installed,\
+The filters that a session uses can be updated by re-defining the filter
+relationship of the session. This causes new filter sessions to be opened
+immediately. The old filter session are closed and replaced with the new filter
+session the next time the session is idle. The order in which the filters are
+defined in the request body is the order in which the filters are installed,
 similar to how the filter relationship for services behaves.
 
 ```
@@ -237,14 +237,14 @@ Session is modified:
 POST /v1/sessions/:id/restart
 ```
 
-This endpoint causes the session to re-read the configuration from the\
-service. As a result of this, all backend connections will be closed and then\
-opened again. All router and filter sessions will be created again which means\
-that for modules that perform something whenever a new module session is opened,\
+This endpoint causes the session to re-read the configuration from the
+service. As a result of this, all backend connections will be closed and then
+opened again. All router and filter sessions will be created again which means
+that for modules that perform something whenever a new module session is opened,
 this behaves as if a new session was started.
 
-This endpoint can be used to apply configuration changes that were done after\
-the session was started. This can be useful for situations where the client\
+This endpoint can be used to apply configuration changes that were done after
+the session was started. This can be useful for situations where the client
 connections live for a long time and connections are not recycled often enough.
 
 **Response**
@@ -259,7 +259,7 @@ Session is was restarted:
 POST /v1/sessions/restart
 ```
 
-This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint\
+This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint
 except that it applies to all sessions.
 
 **Response**
@@ -281,8 +281,8 @@ This endpoint causes the session to be forcefully closed.
 This endpoint supports the following request parameters.
 
 * `ttl`
-* The time after which the session is killed. If this parameter is not given,\
-  the session is killed immediately. This can be used to give the session time\
+* The time after which the session is killed. If this parameter is not given,
+  the session is killed immediately. This can be used to give the session time
   to finish the work it is performing before the connection is closed.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-sql-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-sql-resource.md
@@ -11,31 +11,31 @@ The SQL resource represents a database connection.
 The following endpoints provide a simple REST API interface for executing\
 SQL queries on servers and services in MaxScale.
 
-This document uses the `:id` value in the URL to represent a connection ID and\
-the `:query_id` to represent a query ID. These values do not need to be manually\
+This document uses the `:id` value in the URL to represent a connection ID and
+the `:query_id` to represent a query ID. These values do not need to be manually
 added as the relevant links are returned in the request body of each endpoint.
 
-The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A\
-connection token can be acquired with a `POST /v1/sql` request and can be used\
-with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in\
+The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A
+connection token can be acquired with a `POST /v1/sql` request and can be used
+with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in
 the `token` parameter of the request:
 
 ```
 POST /v1/sql/query?token=eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhZG1pbiIsImV4cCI6MTU4MzI1NDE1MSwiaWF0IjoxNTgzMjI1MzUxLCJpc3MiOiJtYXhzY2FsZSJ9.B1BqhjjKaCWKe3gVXLszpOPfeu8cLiwSb4CMIJAoyqw
 ```
 
-In addition to request parameters, the token can be stored in cookies in which\
-case they are automatically used by the REST API. For more information about\
+In addition to request parameters, the token can be stored in cookies in which
+case they are automatically used by the REST API. For more information about
 token storage in cookies, see the documentation for `POST /v1/sql`.
 
 ### Request Parameters
 
-All of the endpoints that operate on a single connection support the following\
-request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an\
+All of the endpoints that operate on a single connection support the following
+request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an
 exception as they ignore the current connection token.
 
 * `token`
-* The connection token to use for the request. If provided, the value is\
+* The connection token to use for the request. If provided, the value is
   unconditionally used even if a cookie with a valid token exists.
 
 #### Get one SQL connection
@@ -116,7 +116,7 @@ POST /v1/sql
 The request body must be a JSON object consisting of the following fields:
 
 * `target`
-* The object in MaxScale to connect to. This is a mandatory value and the\
+* The object in MaxScale to connect to. This is a mandatory value and the
   given value must be the name of a valid server, service or listener in\
   MaxScale.
 * `user`
@@ -124,11 +124,11 @@ The request body must be a JSON object consisting of the following fields:
 * `password`
 * The password for the user. This is a mandatory value.
 * `db`
-* The default database for the connection. By default the connection will have\
+* The default database for the connection. By default the connection will have
   no default database.
 * `timeout`
-* Connection timeout in seconds. The default connection timeout is 10\
-  seconds. This controls how long the SQL connection creation can take before\
+* Connection timeout in seconds. The default connection timeout is 10
+  seconds. This controls how long the SQL connection creation can take before
   an error is returned.
 
 Here is an example request body:
@@ -143,16 +143,16 @@ Here is an example request body:
 }
 ```
 
-The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token\
-is stored in cookies instead of the metadata object and the response body will\
+The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token
+is stored in cookies instead of the metadata object and the response body will
 not contain the token.
 
-The location of the newly created connection will be stored at `links.self` in\
+The location of the newly created connection will be stored at `links.self` in
 the response body as well as in the `Location` header.
 
-The token must be given to all subsequent requests that use the connection. It\
-must be either given in the `token` parameter of a request or it must be stored\
-in the cookies. If both a `token` parameter and a cookie exist at the same time,\
+The token must be given to all subsequent requests that use the connection. It
+must be either given in the `token` parameter of a request or it must be stored
+in the cookies. If both a `token` parameter and a cookie exist at the same time,
 the `token` parameter will be used instead of the cookie.
 
 **Request Parameters**
@@ -161,12 +161,12 @@ This endpoint supports the following request parameters.
 
 * `persist`
 * Store the connection token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie
   where the `<id>` part is replaced by the ID of the connection.
 * `max-age`
-* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or\
-  a non-integer value is found, the parameter is ignored. Once the token age\
-  exceeds the configured maximum value, the token can no longer be used and a\
+* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or
+  a non-integer value is found, the parameter is ignored. Once the token age
+  exceeds the configured maximum value, the token can no longer be used and a
   new connection must be created.
 
 **Response**
@@ -225,12 +225,12 @@ Missing or invalid connection token:
 POST /v1/sql/:id/reconnect
 ```
 
-Reconnects an existing connection. This can also be used if the connection to\
+Reconnects an existing connection. This can also be used if the connection to
 the backend server was lost due to a network error.
 
 The connection will use the same credentials that were passed to the `POST /v1/sql` endpoint. The new connection will still have the same ID in the REST\
-API but will be treated as a new connection by the database. A reconnection\
-re-initializes the connection and resets the session state. Reconnections cannot\
+API but will be treated as a new connection by the database. A reconnection
+re-initializes the connection and resets the session state. Reconnections cannot
 take place while a transaction is open.
 
 **Response**
@@ -253,17 +253,17 @@ Missing or invalid connection token:
 POST /v1/sql/:id/clone
 ```
 
-Clones an existing connection. This is done by opening a new connection using\
+Clones an existing connection. This is done by opening a new connection using
 the credentials and configuration from the given connection.
 
 **Request Parameters**
 
-This endpoint supports the same request parameters as the `POST /v1/sql`\
+This endpoint supports the same request parameters as the `POST /v1/sql`
 endpoint.
 
 **Response**
 
-The response is identical to the one in the `POST /v1/sql` endpoint. In\
+The response is identical to the one in the `POST /v1/sql` endpoint. In
 addition, this endpoint can return the following responses.
 
 Connection is already in use:
@@ -280,7 +280,7 @@ Missing or invalid connection token:
 POST /v1/sql/:id/queries
 ```
 
-The request body must be a JSON object with the value of the `sql` field set to\
+The request body must be a JSON object with the value of the `sql` field set to
 the SQL to be executed:
 
 ```
@@ -293,22 +293,22 @@ the SQL to be executed:
 The request body must be a JSON object consisting of the following fields:
 
 * `sql`
-* The SQL to be executed. If the SQL contain multiple statements, multiple\
+* The SQL to be executed. If the SQL contain multiple statements, multiple
   results are returned in the response body.
 * `max_rows`
-* The maximum number of rows returned in the response. By default this is 1000\
-  rows. Setting the value to 0 means no limit. Any extra rows in the result\
+* The maximum number of rows returned in the response. By default this is 1000
+  rows. Setting the value to 0 means no limit. Any extra rows in the result
   will be discarded.
 
-By default, the complete result is returned in the response body. If the SQL\
-query returns more than one result, the `results` array will contain all the\
+By default, the complete result is returned in the response body. If the SQL
+query returns more than one result, the `results` array will contain all the
 results.
 
-The `results` array can have three types of objects: resultsets, errors, and OK\
+The `results` array can have three types of objects: resultsets, errors, and OK
 responses.
 
-* A resultset consists of the `data` field with the result data stored as a two\
-  dimensional array. The names of the fields are stored in an array in the`fields` field. These types of results will be returned for any operation that\
+* A resultset consists of the `data` field with the result data stored as a two
+  dimensional array. The names of the fields are stored in an array in the`fields` field. These types of results will be returned for any operation that
   returns rows (i.e. `SELECT` statements)
 
 ```
@@ -344,7 +344,7 @@ responses.
 }
 ```
 
-* An error consists of an object with the `errno` field set to the MariaDB error\
+* An error consists of an object with the `errno` field set to the MariaDB error
   code, the `message` field set to the human-readable error message and the`sqlstate` field set to the current SQLSTATE of the connection.
 
 ```
@@ -369,9 +369,9 @@ responses.
 }
 ```
 
-* An OK response is returned for any result that completes successfully but not\
-  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`\
-  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field\
+* An OK response is returned for any result that completes successfully but not
+  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`
+  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field
   contains the number of warnings raised by the operation.
 
 ```
@@ -396,9 +396,9 @@ responses.
 }
 ```
 
-It is also possible for the fields of the error response to be present in the\
-resultset response if the result ended with an error but still generated some\
-data. Usually this happens when query execution is interrupted but a partial\
+It is also possible for the fields of the error response to be present in the
+resultset response if the result ended with an error but still generated some
+data. Usually this happens when query execution is interrupted but a partial
 result was generated by the server.
 
 **Response**
@@ -437,7 +437,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-about-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-about-mariadb-maxscale.md
@@ -4,49 +4,49 @@
 
 ## About MariaDB MaxScale
 
-**MariaDB MaxScale** is a database proxy that forwards database statements to\
+**MariaDB MaxScale** is a database proxy that forwards database statements to
 one or more database servers.
 
-The forwarding is performed using rules based on the semantic understanding of\
-the database statements and on the roles of the servers within the backend\
+The forwarding is performed using rules based on the semantic understanding of
+the database statements and on the roles of the servers within the backend
 cluster of databases.
 
-MariaDB MaxScale is designed to provide, transparently to applications, load\
-balancing and high availability functionality. MariaDB MaxScale has a scalable\
-and flexible architecture, with plugin components to support different protocols\
+MariaDB MaxScale is designed to provide, transparently to applications, load
+balancing and high availability functionality. MariaDB MaxScale has a scalable
+and flexible architecture, with plugin components to support different protocols
 and routing approaches.
 
 MariaDB MaxScale makes extensive use of the asynchronous I/O capabilities of the\
-Linux operating system, combined with a fixed number of worker threads. _epoll_\
-is used to provide the event driven framework for the input and output via\
+Linux operating system, combined with a fixed number of worker threads. _epoll_
+is used to provide the event driven framework for the input and output via
 sockets.
 
-Many of the services provided by MariaDB MaxScale are implemented as external\
-shared object modules loaded at runtime. These modules support a fixed\
-interface, communicating the entry points via a structure consisting of a set of\
-function pointers. This structure is called the "module object". Additional\
+Many of the services provided by MariaDB MaxScale are implemented as external
+shared object modules loaded at runtime. These modules support a fixed
+interface, communicating the entry points via a structure consisting of a set of
+function pointers. This structure is called the "module object". Additional
 modules can be created to work with MariaDB MaxScale.
 
-Commonly used module types are _protocol_, _router_ and _filter_. Protocol\
-modules implement the communication between clients and MariaDB MaxScale, and\
-between MariaDB MaxScale and backend servers. Routers inspect the queries from\
-clients and decide the target backend. The decisions are usually based on\
-routing rules and backend server status. Filters work on data as it passes\
-through MariaDB MaxScale. Filter are often used for logging queries or modifying\
+Commonly used module types are _protocol_, _router_ and _filter_. Protocol
+modules implement the communication between clients and MariaDB MaxScale, and
+between MariaDB MaxScale and backend servers. Routers inspect the queries from
+clients and decide the target backend. The decisions are usually based on
+routing rules and backend server status. Filters work on data as it passes
+through MariaDB MaxScale. Filter are often used for logging queries or modifying
 server responses.
 
-A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,\
+A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,
 issues and communicate with the MariaDB MaxScale community. Send email to [maxscale@googlegroups.com](https://mariadb.com/kb/en/mailto:maxscale@googlegroups.com) or use the [forum](https://groups.google.com/forum/#!forum/maxscale) interface.
 
 Bugs can be reported in the MariaDB Jira [jira.mariadb.org](https://jira.mariadb.org)
 
 ### Installing MariaDB MaxScale
 
-Information about installing MariaDB MaxScale, either from a repository or by\
+Information about installing MariaDB MaxScale, either from a repository or by
 building from source code, is included in the [MariaDB MaxScale Installation\
 Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-installation-guide.md).
 
-The same guide also provides basic information on running MariaDB MaxScale. More\
+The same guide also provides basic information on running MariaDB MaxScale. More
 detailed information about configuring MariaDB MaxScale can be found in the [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/).
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md
@@ -4,43 +4,43 @@
 
 ## Limitations and Known Issues within MariaDB MaxScale
 
-This document lists known issues and limitations in MariaDB MaxScale and its\
-plugins. Since limitations are related to specific plugins, this document is\
+This document lists known issues and limitations in MariaDB MaxScale and its
+plugins. Since limitations are related to specific plugins, this document is
 divided into several sections.
 
 ### Configuration limitations
 
-In versions 2.1.2 and earlier, the configuration files are limited to 1024\
+In versions 2.1.2 and earlier, the configuration files are limited to 1024
 characters per line. This limitation was increased to 16384 characters in\
 MaxScale 2.1.3. MaxScale 2.3.0 increased this limit to 16777216 characters.
 
-In versions 2.2.12 and earlier, the section names in the configuration files\
-were limited to 49 characters. This limitation was increased to 1023 characters\
+In versions 2.2.12 and earlier, the section names in the configuration files
+were limited to 49 characters. This limitation was increased to 1023 characters
 in MaxScale 2.2.13.
 
 #### Multiple MaxScales on same server
 
-Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to\
-the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale\
-instances to listen on the same network port if the directories used by both\
-instances are completely separate and there are no conflicts which can cause\
-unexpected splitting of connections. This will only happen if users explicitly\
-tell MaxScale to ignore the default directories and will not happen in normal\
+Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to
+the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale
+instances to listen on the same network port if the directories used by both
+instances are completely separate and there are no conflicts which can cause
+unexpected splitting of connections. This will only happen if users explicitly
+tell MaxScale to ignore the default directories and will not happen in normal
 use.
 
 ### Security limitations
 
 #### MariaDB 10.2
 
-The parser of MaxScale correctly parses `WITH` statements, but fails to\
+The parser of MaxScale correctly parses `WITH` statements, but fails to
 collect columns, functions and tables used in the `SELECT` defining the`WITH` clause.
 
-Consequently, the database firewall will **not** block `WITH` statements\
+Consequently, the database firewall will **not** block `WITH` statements
 where the `SELECT` of the `WITH` clause refers to forbidden columns.
 
 ### MariaDB Default Values
 
-MaxScale assumes that certain configuration parameters in MariaDB are set to\
+MaxScale assumes that certain configuration parameters in MariaDB are set to
 their default values. These include but are not limited to:
 
 * `autocommit`: Autocommit is enabled for all new connections.
@@ -55,38 +55,38 @@ require query classification, a custom parser is used to detect them. Currently\
 the only situation in which this parser is used is when a `readconnroute`\
 service uses the `cache` filter.
 
-The custom parser detects a subset of the full SQL syntax used to start\
-transactions. This means that more complex statements will not be fully parsed\
-and will cause the transaction state to not match the real state on the\
-database. For example, `SET @my_var = (SELECT 1), autocommit = 0` is not parsed\
+The custom parser detects a subset of the full SQL syntax used to start
+transactions. This means that more complex statements will not be fully parsed
+and will cause the transaction state to not match the real state on the
+database. For example, `SET @my_var = (SELECT 1), autocommit = 0` is not parsed
 by the custom parser and causes the autocommit modification to not be noticed.
 
 #### XA Transactions
 
-MaxScale will treat statements executed after `XA START` and before `XA END` as\
-if they were executed in a normal read-write transaction started with `START TRANSACTION`. This means that only XA transactions in the ACTIVE state will be\
+MaxScale will treat statements executed after `XA START` and before `XA END` as
+if they were executed in a normal read-write transaction started with `START TRANSACTION`. This means that only XA transactions in the ACTIVE state will be
 routed as transactions and all statements after `XA END` are routed normally.
 
-XA transactions and normal transactions are mutually exclusive in MariaDB. This\
-means that a `START TRANSACTION` command will fail if the connection already has\
-an open XA transaction. MaxScale currently only inspects the SQL and deduces the\
-transaction state from that. If a transaction fails to start due to an open XA\
-transaction, the state in MaxScale and in MariaDB can be different and MaxScale\
-will keep routing statements as if they were inside of a transaction. However,\
+XA transactions and normal transactions are mutually exclusive in MariaDB. This
+means that a `START TRANSACTION` command will fail if the connection already has
+an open XA transaction. MaxScale currently only inspects the SQL and deduces the
+transaction state from that. If a transaction fails to start due to an open XA
+transaction, the state in MaxScale and in MariaDB can be different and MaxScale
+will keep routing statements as if they were inside of a transaction. However,
 as this is an unlikely scenario, usually no action needs to be taken.
 
 ### Prepared Statements
 
-For its proper functioning, MaxScale needs in general to be aware of the\
-transaction state and _autocommit_ mode. In order to be that, MaxScale\
+For its proper functioning, MaxScale needs in general to be aware of the
+transaction state and _autocommit_ mode. In order to be that, MaxScale
 parses statements going through it.
 
-However, if a transaction is committed or rolled back, or the autocommit\
-mode is changed using a prepared statement, MaxScale will miss that and its\
-internal state will be incorrect, until the transaction state or autocommit\
+However, if a transaction is committed or rolled back, or the autocommit
+mode is changed using a prepared statement, MaxScale will miss that and its
+internal state will be incorrect, until the transaction state or autocommit
 mode is changed using an explicit statement.
 
-For instance, after the following sequence of commands, MaxScale will still\
+For instance, after the following sequence of commands, MaxScale will still
 think _autocommit_ is on:
 
 ```
@@ -95,7 +95,7 @@ PREPARE hide_autocommit FROM "set autocommit=0"
 EXECUTE hide_autocommit
 ```
 
-To ensure that MaxScale functions properly, do not commit or rollback a\
+To ensure that MaxScale functions properly, do not commit or rollback a
 transaction or change the autocommit mode using a prepared statement.
 
 ### Protocol limitations
@@ -103,65 +103,65 @@ transaction or change the autocommit mode using a prepared statement.
 #### Limitations with MySQL/MariaDB Protocol support (MariaDBClient)
 
 * Compression is not included in the server handshake.
-* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept\
-  it. If the ID matches a MaxScale session ID, it will be closed by sending\
-  modified `KILL` commands of the same type to all backend server to which the\
-  session in question is connected to. This results in behavior that is similar\
-  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,\
+* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept
+  it. If the ID matches a MaxScale session ID, it will be closed by sending
+  modified `KILL` commands of the same type to all backend server to which the
+  session in question is connected to. This results in behavior that is similar
+  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,
   all connections with a matching username will be closed instead.
-* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type\
-  statements. If a query by a query ID is to be killed, it needs to be done\
+* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type
+  statements. If a query by a query ID is to be killed, it needs to be done
   directly on the backend databases.
 * Any `KILL` commands executed using a prepared statement are ignored by\
-  MaxScale. If any are executed, it is highly likely that the wrong connection\
+  MaxScale. If any are executed, it is highly likely that the wrong connection
   ends up being killed.
-* If a `KILL` connection kills a session that is connected to a readwritesplit\
-  service that has `transaction_replay` or `delayed_retry` enabled, it is\
-  possible that the query is retried even if the connection is killed. To avoid\
+* If a `KILL` connection kills a session that is connected to a readwritesplit
+  service that has `transaction_replay` or `delayed_retry` enabled, it is
+  possible that the query is retried even if the connection is killed. To avoid
   this, use `KILL QUERY` instead.
-* A `KILL` on one service can cause a connection from another service to be\
+* A `KILL` on one service can cause a connection from another service to be
   closed even if it uses a different protocol.
-* The change user command (COM\_CHANGE\_USER) only works with standard\
+* The change user command (COM\_CHANGE\_USER) only works with standard
   authentication.
-* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session\
-  ends up in an inconsistent state. This can happen if the password of the\
-  target user is changed and MaxScale uses old user account data when processing\
-  the change user. In such a situation, MaxScale and server will disagree on the\
+* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session
+  ends up in an inconsistent state. This can happen if the password of the
+  target user is changed and MaxScale uses old user account data when processing
+  the change user. In such a situation, MaxScale and server will disagree on the
   current user. This can affect e.g. reconnections.
 
 ### Authenticator limitations
 
 #### Limitations in the MySQL authenticator (MariaDBAuth)
 
-* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use\
+* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use
   a new authentication protocol which does not support pre-4.1 style passwords.
 * When users have different passwords based on the host from which they connect\
-  MariaDB MaxScale is unable to determine which password it should use to connect\
-  to the backend database. This results in failed connections and unusable\
+  MariaDB MaxScale is unable to determine which password it should use to connect
+  to the backend database. This results in failed connections and unusable
   usernames in MariaDB MaxScale.
 
 ### Filter limitations
 
 #### Tee filter limitations (tee)
 
-The Tee filter does not support binary protocol prepared statements. The\
-execution of a prepared statements through a service that uses the tee filter is\
-not guaranteed to succeed on the service where the filter branches to as it does\
+The Tee filter does not support binary protocol prepared statements. The
+execution of a prepared statements through a service that uses the tee filter is
+not guaranteed to succeed on the service where the filter branches to as it does
 on the original service.
 
-This possibility exists due to the fact that the binary protocol prepared\
-statements are identified by a server-generated ID. The ID sent to the client\
-from the main service is not guaranteed to be the same that is sent by the\
+This possibility exists due to the fact that the binary protocol prepared
+statements are identified by a server-generated ID. The ID sent to the client
+from the main service is not guaranteed to be the same that is sent by the
 branch service.
 
 ### Monitor limitations
 
-A server can only be monitored by one monitor. Two or more monitors monitoring\
+A server can only be monitored by one monitor. Two or more monitors monitoring
 the same server is considered an error.
 
 #### Limitations with Galera Cluster Monitoring (galeramon)
 
-The default master selection is based only on MIN(wsrep\_local\_index). This\
+The default master selection is based only on MIN(wsrep\_local\_index). This
 can be influenced with the server priority mechanic described in the [Galera Monitor](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-galera-monitor.md) manual.
 
 ### Router limitations

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-authentication-modules.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-authentication-modules.md
@@ -7,45 +7,45 @@
 This document describes general MySQL protocol authentication in MaxScale. For\
 REST-api authentication, see the [configuration guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/) and the [REST-api guide](../../../../../en/mariadb-maxscale-2208-maxscale-rest-api/).
 
-Similar to the MariaDB Server, MaxScale uses authentication plugins to implement\
-different authentication schemes for incoming clients. The same plugins also\
-handle authenticating the clients to backend servers. The authentication plugins\
+Similar to the MariaDB Server, MaxScale uses authentication plugins to implement
+different authentication schemes for incoming clients. The same plugins also
+handle authenticating the clients to backend servers. The authentication plugins
 available in MaxScale are [standard MySQL password](mariadb-maxscale-2208-mysql-authenticator.md),[GSSAPI](mariadb-maxscale-2208-gssapi-client-authenticator.md) and [pluggable authentication modules (PAM)](mariadb-maxscale-2208-pam-authenticator.md).
 
-Most of the authentication processing is performed on the protocol level, before\
-handing it over to one of the plugins. This shared part is described in this\
+Most of the authentication processing is performed on the protocol level, before
+handing it over to one of the plugins. This shared part is described in this
 document. For information on an individual plugin, see its documentation.
 
 ### User account management
 
-Every MaxScale service with a MariaDB protocol listener requires knowledge of\
-the user accounts defined on the backend databases. The service maintains this\
+Every MaxScale service with a MariaDB protocol listener requires knowledge of
+the user accounts defined on the backend databases. The service maintains this
 information in an internal component called the _user account manager_ (UAM).\
-The UAM queries relevant data from the _mysql_-database of the backends and\
-stores it. Typically, only the current master server is queried, as all servers\
-are assumed to have the same users. The service settings _user_ and _password_\
+The UAM queries relevant data from the _mysql_-database of the backends and
+stores it. Typically, only the current master server is queried, as all servers
+are assumed to have the same users. The service settings _user_ and _password_
 define the credentials used when fetching user accounts.
 
-The service uses the stored data when authenticating clients, checking their\
-passwords and database access rights. This results in an authentication process\
-very similar to the MariaDB Server itself. Unauthorized users are generally\
-detected already at the MaxScale level instead of the backend servers. This may\
+The service uses the stored data when authenticating clients, checking their
+passwords and database access rights. This results in an authentication process
+very similar to the MariaDB Server itself. Unauthorized users are generally
+detected already at the MaxScale level instead of the backend servers. This may
 not apply in some cases, for example if MaxScale is using old user account data.
 
-If authentication fails, the UAM updates its data from a backend. MaxScale may\
-attempt authenticating the client again with the refreshed data without\
-communicating the first failure to the client. This transparent user data update\
+If authentication fails, the UAM updates its data from a backend. MaxScale may
+attempt authenticating the client again with the refreshed data without
+communicating the first failure to the client. This transparent user data update
 does not always work, in which case the client should try to log in again.
 
-As the UAM is shared between all listeners of a service, its settings are\
-defined in the service configuration. For more information, search the [configuration guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/)\
-for _users\_refresh\_time_, _users\_refresh\_interval_ and\_auth\_all\_servers\_. Other settings which affect how the UAM connects to backends\
-are the global settings _auth\_connect\_timeout_ and _local\_address_, and\
+As the UAM is shared between all listeners of a service, its settings are
+defined in the service configuration. For more information, search the [configuration guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/)
+for _users\_refresh\_time_, _users\_refresh\_interval_ and\_auth\_all\_servers\_. Other settings which affect how the UAM connects to backends
+are the global settings _auth\_connect\_timeout_ and _local\_address_, and
 the various server-level ssl-settings.
 
 #### Required grants
 
-To properly fetch user account information, the MaxScale service user must be\
+To properly fetch user account information, the MaxScale service user must be
 able to read from various tables in the _mysql_-database: _user_, _db_,_tables\_priv_, _columns\_priv_, _procs\_priv_, _proxies\_priv_ and _roles\_mapping_.\
 The user should also have the _SHOW DATABASES_-grant.
 
@@ -70,23 +70,23 @@ GRANT ALL ON infinidb_vtable.* TO 'maxscale'@'maxscalehost';
 ### Limitations and troubleshooting
 
 When a client logs in to MaxScale, MaxScale sees the client's IP address. When\
-MaxScale then connects the client to backends (using the client's username and\
+MaxScale then connects the client to backends (using the client's username and
 password), the backends see the connection coming from the IP address of\
-MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this\
-is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),\
+MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this
+is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),
 authentication to backends will fail.
 
 There are two primary ways to deal with this:
 
-1. Duplicate user accounts. For every user account with a restricted hostname an\
+1. Duplicate user accounts. For every user account with a restricted hostname an
    equivalent user account for MaxScale is added (`'alice'@'maxscale-ip'`).
 2. Use [proxy protocol](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#proxy_protocol).
 
-Option 1 limits the passwords for user accounts with shared usernames. Such\
+Option 1 limits the passwords for user accounts with shared usernames. Such
 accounts must use the same password since they will effectively share the\
 MaxScale-to-backend user account. Option 2 requires server support.
 
-See [MaxScale Troubleshooting](../../../../maxscale-versions/maxscale-troubleshooting.md)\
+See [MaxScale Troubleshooting](../../../../maxscale-versions/maxscale-troubleshooting.md)
 for additional information on how to solve authentication issues.
 
 #### Wildcard database grants
@@ -94,14 +94,14 @@ for additional information on how to solve authentication issues.
 MaxScale supports wildcards `_` and `%` for database-level grants. As with\
 MariaDB Server, `grant select on test_.* to 'alice'@'%';` gives access to _test\__ as well as _test1_, _test2_ and so on. If the GRANT command escapes the
 wildcard (`grant select on` test\_`.* to 'alice'@'%';`) both MaxScale and the\
-MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`\
+MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`
 are only interpreted as wildcards when the grant is to a database:`grant select on` test\_`.t1 to 'alice'@'%';` only grants access to the\_test\_.t1\_-table, not to _test1.t1_.
 
 ### Authenticator options
 
-The listener configuration defines authentication options which only affect the\
-listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an\
-individual authentication plugin or the authentication as a whole. The latter\
+The listener configuration defines authentication options which only affect the
+listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an
+individual authentication plugin or the authentication as a whole. The latter
 are explained below. Multiple options can be given as a comma-separated list.
 
 ```
@@ -115,20 +115,20 @@ authenticator_options=skip_authentication=true,lower_case_table_names=1
 * Dynamic: No
 * Default: `false`
 
-If enabled, MaxScale will not check the\
+If enabled, MaxScale will not check the
 passwords of incoming clients and just assumes that they are correct.\
-Wrong passwords are instead detected when MaxScale tries to authenticate to the\
+Wrong passwords are instead detected when MaxScale tries to authenticate to the
 backend servers.
 
-This setting is mainly meant for failure tolerance in situations where the\
-password check is performed outside of MaxScale. If, for example, MaxScale\
-cannot use an LDAP-server but the backend databases can, enabling this setting\
-allows clients to log in. Even with this setting enabled, a user account\
+This setting is mainly meant for failure tolerance in situations where the
+password check is performed outside of MaxScale. If, for example, MaxScale
+cannot use an LDAP-server but the backend databases can, enabling this setting
+allows clients to log in. Even with this setting enabled, a user account
 matching the incoming client username and IP must exist on the backends for\
 MaxScale to accept the client.
 
 This setting is incompatible with standard MariaDB/MySQL authentication plugin\
-(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to\
+(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to
 backend servers using standard authentication.
 
 ```
@@ -142,14 +142,14 @@ authenticator_options=skip_authentication=true
 * Dynamic: No
 * Default: `true`
 
-If disabled, MaxScale does not require that a\
+If disabled, MaxScale does not require that a
 valid user account entry for incoming clients exists on the backends.\
-Specifically, only the client username needs to match a user account,\
+Specifically, only the client username needs to match a user account,
 hostname/IP is ignored.
 
-This setting may be used to force clients to connect through MaxScale. Normally,\
+This setting may be used to force clients to connect through MaxScale. Normally,
 creating the user _jdoe@%_ will allow the user _jdoe_ to connect from any\
-IP-address. By disabling _match\_host_ and replacing the user with\_jdoe@maxscale-IP\_, the user can still connect from any client IP but will be\
+IP-address. By disabling _match\_host_ and replacing the user with\_jdoe@maxscale-IP\_, the user can still connect from any client IP but will be
 forced to go through MaxScale.
 
 ```
@@ -163,29 +163,29 @@ authenticator_options=match_host=false
 * Dynamic: No
 * Default: `0`
 
-Controls database name matching for authentication\
-when an incoming client logs in to a non-empty database. The setting functions\
-similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)\
+Controls database name matching for authentication
+when an incoming client logs in to a non-empty database. The setting functions
+similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)
 and should be set to the value used by the backends.
 
 The setting accepts the values 0, 1 or 2:
 
 * `0`: case-sensitive matching (default)
-* `1`: convert the requested database name to lower case before using case-insensitive\
+* `1`: convert the requested database name to lower case before using case-insensitive
   matching. Assumes that database names on the server are stored in lower case.
 * `2`: use case-insensitive matching.
 
-_true_ and _false_ are also accepted for backwards compatibility. These map to 1\
+_true_ and _false_ are also accepted for backwards compatibility. These map to 1
 and 0, respectively.
 
-The identifier names are converted using an ASCII-only function. This means that\
+The identifier names are converted using an ASCII-only function. This means that
 non-ASCII characters will retain their case-sensitivity.
 
-Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior\
-of `lower_case_table_names=1` is identical with how the MariaDB server\
-behaves. In older releases the comparisons were done in a case-sensitive manner\
-after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes\
-it a safe alternative to use when a mix of older and newer MaxScale versions is\
+Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior
+of `lower_case_table_names=1` is identical with how the MariaDB server
+behaves. In older releases the comparisons were done in a case-sensitive manner
+after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes
+it a safe alternative to use when a mix of older and newer MaxScale versions is
 being used.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-gssapi-client-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-gssapi-client-authenticator.md
@@ -4,25 +4,25 @@
 
 ## GSSAPI Client Authenticator
 
-GSSAPI is an authentication protocol that is commonly implemented with Kerberos\
-on Unix or Active Directory on Windows. This document describes GSSAPI\
+GSSAPI is an authentication protocol that is commonly implemented with Kerberos
+on Unix or Active Directory on Windows. This document describes GSSAPI
 authentication in MaxScale. The authentication module name in MaxScale is_GSSAPIAuth_.
 
 ### Preparing the GSSAPI system
 
-For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short\
+For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short
 guide on how to set up Kerberos for MaxScale.
 
-The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB\
-documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)\
+The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB
+documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)
 is a good example on how to set it up.
 
-The next step is to copy the keytab file from the server where MariaDB is\
-installed to the server where MaxScale is located. The keytab file must be\
-placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an\
+The next step is to copy the keytab file from the server where MariaDB is
+installed to the server where MaxScale is located. The keytab file must be
+placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an
 authenticator option.
 
-The location of the keytab file can be changed with the KRB5\_KTNAME environment\
+The location of the keytab file can be changed with the KRB5\_KTNAME environment
 variable: [keytab\_def.html](https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html)
 
 To take GSSAPI authentication into use, add the following to the listener.
@@ -43,10 +43,10 @@ The principal name should be the same as on the MariaDB servers.
 * Dynamic: No
 * Default: `mariadb/localhost.localdomain`
 
-The service principal name to send to the client. This parameter is a string\
+The service principal name to send to the client. This parameter is a string
 parameter which is used by the client to request the token.
 
-This parameter _must_ be the same as the principal name that the backend MariaDB\
+This parameter _must_ be the same as the principal name that the backend MariaDB
 server uses.
 
 #### `gssapi_keytab_path`
@@ -56,10 +56,10 @@ server uses.
 * Dynamic: No
 * Default: Kerberos Default
 
-Keytab file location. This should be an absolute path to the file containing the\
-keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that\
+Keytab file location. This should be an absolute path to the file containing the
+keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that
 multiple listeners with GSSAPIAuth will override each other. If using multiple\
-GSSAPI authenticators, either do not set this option or use the same value for\
+GSSAPI authenticators, either do not set this option or use the same value for
 all listeners.
 
 ```
@@ -68,23 +68,23 @@ authenticator_options=principal_name=mymariadb@EXAMPLE.COM,gssapi_keytab_path=/h
 
 ### Implementation details
 
-Read the [Authentication Modules](../../../../../en/mariadb-maxscale-2208-maxscale-2208-authentication-modules/) document for more\
+Read the [Authentication Modules](../../../../../en/mariadb-maxscale-2208-maxscale-2208-authentication-modules/) document for more
 details on how authentication modules work in MaxScale.
 
 #### GSSAPI authentication
 
-The GSSAPI plugin authentication starts when the database server sends the\
-service principal name in the AuthSwitchRequest packet. The principal name will\
+The GSSAPI plugin authentication starts when the database server sends the
+service principal name in the AuthSwitchRequest packet. The principal name will
 usually be in the form `service@REALM.COM`.
 
-The client searches its local cache for a token for the service or may request\
-it from the GSSAPI server. If found, the client sends the token to the database\
-server. The database server verifies the authenticity of the token using its\
+The client searches its local cache for a token for the service or may request
+it from the GSSAPI server. If found, the client sends the token to the database
+server. The database server verifies the authenticity of the token using its
 keytab file and sends the final OK packet to the client.
 
 ### Building the module
 
-The GSSAPI authenticator modules require the GSSAPI development libraries\
+The GSSAPI authenticator modules require the GSSAPI development libraries
 (krb5-devel on CentOS 7).
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-mysql-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-mysql-authenticator.md
@@ -4,13 +4,13 @@
 
 ## MariaDB/MySQL Authenticator
 
-The _MariaDBAuth_-module implements the client and backend authentication for the\
-server plugin _mysql\_native\_password_. This is the default authentication\
+The _MariaDBAuth_-module implements the client and backend authentication for the
+server plugin _mysql\_native\_password_. This is the default authentication
 plugin used by both MariaDB and MySQL.
 
 ### Authenticator options
 
-The following settings may be given in the _authenticator\_options_ of the\
+The following settings may be given in the _authenticator\_options_ of the
 listener.
 
 #### `log_password_mismatch`
@@ -20,10 +20,10 @@ listener.
 * Dynamic: No
 * Default: `false`
 
-The service setting _log\_auth\_warnings_ must\
-also be enabled for this setting to have effect. When both settings are enabled,\
-password hashes are logged if a client gives a wrong password. This feature may\
-be useful when diagnosing authentication issues. It should only be enabled on a\
+The service setting _log\_auth\_warnings_ must
+also be enabled for this setting to have effect. When both settings are enabled,
+password hashes are logged if a client gives a wrong password. This feature may
+be useful when diagnosing authentication issues. It should only be enabled on a
 secure system as the logging of password hashes may be a security risk.
 
 #### `cache_dir`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-pam-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-pam-authenticator.md
@@ -5,15 +5,15 @@
 ## PAM Authenticator
 
 Pluggable authentication module (PAM) is a general purpose authentication API.\
-An application using PAM can authenticate a user without knowledge about the\
-underlying authentication implementation. The actual authentication scheme is\
-defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be\
-quite elaborate. MaxScale supports a very limited form of the PAM protocol,\
+An application using PAM can authenticate a user without knowledge about the
+underlying authentication implementation. The actual authentication scheme is
+defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be
+quite elaborate. MaxScale supports a very limited form of the PAM protocol,
 which this document details.
 
 ### Configuration
 
-The MaxScale PAM module requires little configuration. All that is required\
+The MaxScale PAM module requires little configuration. All that is required
 is to change the listener authenticator module to "PAMAuth".
 
 ```
@@ -29,14 +29,14 @@ address=123.456.789.10
 port=12345
 ```
 
-MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_\
-set to "pam" in the _mysql.user_-table. The PAM service name of a user is read\
-from the _authetication\_string_-column. The matching PAM service in the\
-operating system PAM config is used for authenticating the user. If the\_authetication\_string\_ for a user is empty, the fallback service "mysql" is\
+MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_
+set to "pam" in the _mysql.user_-table. The PAM service name of a user is read
+from the _authetication\_string_-column. The matching PAM service in the
+operating system PAM config is used for authenticating the user. If the\_authetication\_string\_ for a user is empty, the fallback service "mysql" is
 used.
 
-PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)\
-for more information. A simple service definition used for testing this module\
+PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)
+for more information. A simple service definition used for testing this module
 is below.
 
 ```
@@ -52,8 +52,8 @@ account         required        pam_unix.so
 * Default: `false`
 
 If enabled, MaxScale communicates with the client as if using [mysql\_clear\_password](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/1-connecting/connection#mysql_clear_password-plugin).\
-This setting has no effect on MaxScale-to-backend communication, which adapts to\
-either "dialog" or "mysql\_clear\_password", depending on which one the backend\
+This setting has no effect on MaxScale-to-backend communication, which adapts to
+either "dialog" or "mysql\_clear\_password", depending on which one the backend
 suggests. This setting is meant to be used with the similarly named MariaDB\
 Server setting.
 
@@ -78,11 +78,11 @@ This setting defines the authentication mode used. Two values are supported:
 authenticator_options=pam_mode=password_2FA
 ```
 
-If set to "password\_2FA", any users authenticating via PAM will be asked two\
-passwords ("Password" and "Verification code") during login. MaxScale uses the\
+If set to "password\_2FA", any users authenticating via PAM will be asked two
+passwords ("Password" and "Verification code") during login. MaxScale uses the
 normal password when either the local PAM api or a backend asks for "Password".\
-MaxScale answers any other password prompt (e.g. "Verification code") with the\
-second password. See [the limitations section](mariadb-maxscale-2208-pam-authenticator.md#implementation-details-and-limitations)\
+MaxScale answers any other password prompt (e.g. "Verification code") with the
+second password. See [the limitations section](mariadb-maxscale-2208-pam-authenticator.md#implementation-details-and-limitations)
 for more details. Two-factor mode is incompatible with\_pam\_use\_cleartext\_plugin\_.
 
 #### `pam_backend_mapping`
@@ -93,7 +93,7 @@ for more details. Two-factor mode is incompatible with\_pam\_use\_cleartext\_plu
 * Values: `none`, `mariadb`
 * Default: `none`
 
-Defines backend authentication mapping, i.e. switch of authentication method\
+Defines backend authentication mapping, i.e. switch of authentication method
 between client-to-MaxScale and MaxScale-to-backend. Supported values:
 
 * `none` No mapping
@@ -103,28 +103,28 @@ between client-to-MaxScale and MaxScale-to-backend. Supported values:
 authenticator_options=pam_backend_mapping=mariadb
 ```
 
-If set to "mariadb", MaxScale will authenticate clients to backends using\
+If set to "mariadb", MaxScale will authenticate clients to backends using
 standard MariaDB authentication. Authentication to MaxScale itself still uses\
-PAM. MaxScale asks the local PAM system if the client username was mapped\
-to another username during authentication, and use the mapped username when\
-logging in to backends. Passwords for the mapped users can be given in a file,\
-see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to\
-authenticate without a password. Because of this, normal PAM users and mapped\
+PAM. MaxScale asks the local PAM system if the client username was mapped
+to another username during authentication, and use the mapped username when
+logging in to backends. Passwords for the mapped users can be given in a file,
+see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to
+authenticate without a password. Because of this, normal PAM users and mapped
 users cannot be used on the same listener.
 
-Because the client still needs to authenticate to MaxScale normally, an\
-anonymous user may be required. If the backends do not allow such a user, one\
+Because the client still needs to authenticate to MaxScale normally, an
+anonymous user may be required. If the backends do not allow such a user, one
 can be manually added using the service setting [user\_accounts\_file](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#user_accounts_file).
 
-To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be\
-installed separately. It is included in recent MariaDB Server packages and can\
-also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)\
-for more information on how to configure the module. If the goal is to only map\
-users from PAM to MariaDB in MaxScale, then configuring user mapping\
+To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be
+installed separately. It is included in recent MariaDB Server packages and can
+also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)
+for more information on how to configure the module. If the goal is to only map
+users from PAM to MariaDB in MaxScale, then configuring user mapping
 on just the machine running MaxScale is enough.
 
-Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#user_mapping_file),\
-as it is easier to configure. `pam_backend_mapping` should only be used when\
+Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#user_mapping_file),
+as it is easier to configure. `pam_backend_mapping` should only be used when
 the user mapping needs to be defined by pam.
 
 #### `pam_mapped_pw_file`
@@ -134,19 +134,19 @@ the user mapping needs to be defined by pam.
 * Dynamic: No
 * Default: None
 
-Path to a json-text file with user passwords. Default value is empty, which\
+Path to a json-text file with user passwords. Default value is empty, which
 disables the feature.
 
 ```
 authenticator_options=pam_mapped_pw_file=/home/root/passwords.json,pam_backend_mapping=mariadb
 ```
 
-This feature only works together with `pam_backend_mapping=mariadb`. The file is\
-only read during listener creation (typically MaxScale start) or when a listener\
-is modified during runtime. The file should contain passwords for the mapped\
-users. When a client is authenticating, MaxScale searches the password data for a\
-matching username. If one is found, MaxScale uses the supplied password when\
-logging in to backends. Otherwise, MaxScale tries to authenticate without a\
+This feature only works together with `pam_backend_mapping=mariadb`. The file is
+only read during listener creation (typically MaxScale start) or when a listener
+is modified during runtime. The file should contain passwords for the mapped
+users. When a client is authenticating, MaxScale searches the password data for a
+matching username. If one is found, MaxScale uses the supplied password when
+logging in to backends. Otherwise, MaxScale tries to authenticate without a
 password.
 
 One array, "users\_and\_passwords", is read from the file. Each array element in the array must define the following fields:
@@ -173,105 +173,105 @@ An example file is below.
 
 ### Anonymous user mapping
 
-When backend authenticator mapping is not in use\
-(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator\
+When backend authenticator mapping is not in use
+(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator
 supports a limited version of [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
 It requires less configuration but is also less accurate than proper mapping.\
 Anonymous mapping is enabled in MaxScale if the following user exists:
 
 * Empty username (e.g. `''@'%'` or `''@'myhost.com'`)
 * `plugin = 'pam'`
-* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one\
+* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one
   row with `GRANT PROXY ON ...`)
 
-When the authenticator detects such users, anonymous account mapping is enabled\
-for the hosts of the anonymous users. To verify this, enable the info log\
-(`log_info=1` in MaxScale config file). When a client is logging in using the\
-anonymous user account, MaxScale will log a message starting with "Found\
+When the authenticator detects such users, anonymous account mapping is enabled
+for the hosts of the anonymous users. To verify this, enable the info log
+(`log_info=1` in MaxScale config file). When a client is logging in using the
+anonymous user account, MaxScale will log a message starting with "Found
 matching anonymous user ...".
 
-When mapping is on, the MaxScale PAM authenticator does not require client\
-accounts to exist in the `mysql.user`-table received from the backend. MaxScale\
-only requires that the hostname of the incoming client matches the host field of\
-one of the anonymous users (comparison performed using `LIKE`). If a match is\
-found, MaxScale attempts to authenticate the client to the local machine with\
-the username and password supplied. The PAM service used for authentication is\
-read from the `authentication_string`-field of the anonymous user. If\
-authentication was successful, MaxScale then uses the username and password to\
+When mapping is on, the MaxScale PAM authenticator does not require client
+accounts to exist in the `mysql.user`-table received from the backend. MaxScale
+only requires that the hostname of the incoming client matches the host field of
+one of the anonymous users (comparison performed using `LIKE`). If a match is
+found, MaxScale attempts to authenticate the client to the local machine with
+the username and password supplied. The PAM service used for authentication is
+read from the `authentication_string`-field of the anonymous user. If
+authentication was successful, MaxScale then uses the username and password to
 log to the backends.
 
-Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2208-pam-authenticator.md#configuration). This means,\
-that if a user is found and the authentication fails, anonymous authentication\
-is not attempted even when it could use a different PAM service with a different\
+Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2208-pam-authenticator.md#configuration). This means,
+that if a user is found and the authentication fails, anonymous authentication
+is not attempted even when it could use a different PAM service with a different
 outcome.
 
-Setting up PAM group mapping for the MariaDB server is a more involved process\
+Setting up PAM group mapping for the MariaDB server is a more involved process
 as the server requires details on which Unix user or group is mapped to which\
-MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)\
-for more details. Performing all the steps in the guide also on the MaxScale\
-machine is not required, as the MaxScale PAM plugin only checks that the client\
-host matches an anonymous user and that the client (with the username and\
-password it provided) can log into the local PAM configuration. If using normal\
-password authentication, simply generating the Unix user and password should be\
+MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)
+for more details. Performing all the steps in the guide also on the MaxScale
+machine is not required, as the MaxScale PAM plugin only checks that the client
+host matches an anonymous user and that the client (with the username and
+password it provided) can log into the local PAM configuration. If using normal
+password authentication, simply generating the Unix user and password should be
 enough.
 
 ### Implementation details and limitations
 
 The general PAM authentication scheme is difficult for a proxy such as MaxScale.\
-An application using the PAM interface needs to define a _conversation function_\
-to allow the OS PAM modules to communicate with the client, possibly exchanging\
-multiple messages. This works when a client logs in to a normal server, but not\
+An application using the PAM interface needs to define a _conversation function_
+to allow the OS PAM modules to communicate with the client, possibly exchanging
+multiple messages. This works when a client logs in to a normal server, but not
 with MaxScale since it needs to autonomously log into multiple backends. For\
-MaxScale to successfully log into the servers, the messages and answers need to\
-be predefined. The passwords given to MaxScale need to work as is when MaxScale\
+MaxScale to successfully log into the servers, the messages and answers need to
+be predefined. The passwords given to MaxScale need to work as is when MaxScale
 logs into the backends. This requirement prevents the use of one-time passwords.
 
-The MaxScale PAM authentication module supports two password modes. In normal\
+The MaxScale PAM authentication module supports two password modes. In normal
 mode, client authentication begins with MaxScale sending an\
-AuthSwitchRequest packet. In addition to the command, the packet contains the\
-client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)\
-and the message "Password: ". In the next packet, the client should send the\
-password, which MaxScale will forward to the PAM api running on the local\
-machine. If the password is correct, an OK packet is sent to the client. If the\
-local PAM api asks for additional credentials as is typical in two-factor\
-authentication schemes, authentication fails. Informational messages such as\
-password expiration notifications are allowed. These are simply printed to the\
+AuthSwitchRequest packet. In addition to the command, the packet contains the
+client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)
+and the message "Password: ". In the next packet, the client should send the
+password, which MaxScale will forward to the PAM api running on the local
+machine. If the password is correct, an OK packet is sent to the client. If the
+local PAM api asks for additional credentials as is typical in two-factor
+authentication schemes, authentication fails. Informational messages such as
+password expiration notifications are allowed. These are simply printed to the
 log.
 
-On the backend side, MaxScale expects the servers to act as MaxScale did towards\
-the client. The servers should send an AuthSwitchRequest packet as defined\
-above, MaxScale responds with the password received by the client authenticator\
-and finally backend replies with OK. Informational messages from backends are\
+On the backend side, MaxScale expects the servers to act as MaxScale did towards
+the client. The servers should send an AuthSwitchRequest packet as defined
+above, MaxScale responds with the password received by the client authenticator
+and finally backend replies with OK. Informational messages from backends are
 only printed to the info-log.
 
 #### Two-factor authentication support
 
-MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the\
-client to log in to the local PAM api as well as all the backends, the code must\
-be reusable. This prevents the use of any kind of centrally checked one-use\
-codes. Time-based codes work, assuming the backends are checking the codes\
+MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the
+client to log in to the local PAM api as well as all the backends, the code must
+be reusable. This prevents the use of any kind of centrally checked one-use
+codes. Time-based codes work, assuming the backends are checking the codes
 independently of each other. Automatic reconnection features (e.g.\
-readwritesplit-router) will not work, as the code has likely changed since\
+readwritesplit-router) will not work, as the code has likely changed since
 original authentication.
 
-Optionally, the PAM configuration on the backend servers can be weakened such\
-that the servers only asks for the normal password. This way, MaxScale will\
-check the 2FA-code of the incoming client, while MaxScale logs into the backends\
+Optionally, the PAM configuration on the backend servers can be weakened such
+that the servers only asks for the normal password. This way, MaxScale will
+check the 2FA-code of the incoming client, while MaxScale logs into the backends
 using only the password.
 
-Due to technical reasons, MaxScale does not forward the password prompts from\
+Due to technical reasons, MaxScale does not forward the password prompts from
 the PAM api to the client. MaxScale will always ask for "Password" and\
-"Verification code", even if the PAM api asks for other items. This prevents the\
+"Verification code", even if the PAM api asks for other items. This prevents the
 use of authentication schemes where a specific question must be answered (e.g.\
-"Input code Nr. 5"). This is not a significant limitation, as such schemes would\
+"Input code Nr. 5"). This is not a significant limitation, as such schemes would
 not work with backend servers anyway.
 
 ### Test tool
 
-MaxScale binary directory contains the _test\_pam\_login_-executable. This simple\
-program asks for a username, password and PAM service and then uses the given\
-credentials to login to the given service. _test\_pam\_login_ uses the same code\
-as MaxScale itself to communicate with the OS PAM interface and may be useful\
+MaxScale binary directory contains the _test\_pam\_login_-executable. This simple
+program asks for a username, password and PAM service and then uses the given
+credentials to login to the given service. _test\_pam\_login_ uses the same code
+as MaxScale itself to communicate with the OS PAM interface and may be useful
 for diagnosing PAM login issues.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-connectors/mariadb-maxscale-2208-maxscale-cdc-connector.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-connectors/mariadb-maxscale-2208-maxscale-cdc-connector.md
@@ -8,29 +8,29 @@ The C++ connector for the [MariaDB MaxScale](https://mariadb.com/products/techno
 
 ### Usage
 
-The CDC connector is a single-file connector which allows it to be relatively\
+The CDC connector is a single-file connector which allows it to be relatively
 easily embedded into existing applications.
 
-To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
+To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
 and install the `maxscale-cdc-connector` package.
 
 ### API Overview
 
-A CDC connection object is prepared by instantiating the `CDC::Connection`\
-class. To create the actual connection, call the `CDC::Connection::connect`\
+A CDC connection object is prepared by instantiating the `CDC::Connection`
+class. To create the actual connection, call the `CDC::Connection::connect`
 method of the class.
 
-After the connection has been created, call the `CDC::Connection::read` method\
-to get a row of data. The `CDC::Row::length` method tells how many values a row\
-has and `CDC::Row::value` is used to access that value. The field name of a\
-value can be extracted with the `CDC::Row::key` method and the current GTID of a\
+After the connection has been created, call the `CDC::Connection::read` method
+to get a row of data. The `CDC::Row::length` method tells how many values a row
+has and `CDC::Row::value` is used to access that value. The field name of a
+value can be extracted with the `CDC::Row::key` method and the current GTID of a
 row of data is retrieved with the `CDC::Row::gtid` method.
 
 To close the connection, destroy the instantiated object.
 
 ### Examples
 
-The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)\
+The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)
 that demonstrates basic usage of the MaxScale CDC Connector.
 
 ### Dependencies
@@ -69,7 +69,7 @@ sudo zypper install -y libjansson-devel openssl-devel cmake make gcc-c++ git
 
 ### Building and Packaging
 
-To build and package the connector as a library, follow MaxScale build\
+To build and package the connector as a library, follow MaxScale build
 instructions with the exception of adding `-DTARGET_COMPONENT=devel` to the\
 CMake call.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-contents.md
@@ -50,8 +50,8 @@ Here are tutorials on monitoring and managing MariaDB MaxScale in cluster enviro
 
 ### Routers
 
-The routing module is the core of a MariaDB MaxScale service. The router documentation\
-contains all module specific configuration options and detailed explanations\
+The routing module is the core of a MariaDB MaxScale service. The router documentation
+contains all module specific configuration options and detailed explanations
 of their use.
 
 * [Avrorouter](mariadb-maxscale-2208-routers/mariadb-maxscale-2208-avrorouter.md)
@@ -113,7 +113,7 @@ The MaxScale CDC Connector provides a C++ API for consuming data from a CDC syst
 
 ### Authenticators
 
-A short description of the authentication module type can be found in the [Authentication Modules](https://mariadb.com/kb/en/mariadb-maxscale-2208-maxscale-2208-authentication-modules/)\
+A short description of the authentication module type can be found in the [Authentication Modules](https://mariadb.com/kb/en/mariadb-maxscale-2208-maxscale-2208-authentication-modules/)
 document.
 
 * [MariaDB/MySQL Authenticator](mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-mysql-authenticator.md)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-building-mariadb-maxscale-from-source-code.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-building-mariadb-maxscale-from-source-code.md
@@ -4,7 +4,7 @@
 
 ## Building MariaDB MaxScale from Source Code
 
-MariaDB MaxScale can be built on any system that meets the requirements. The main\
+MariaDB MaxScale can be built on any system that meets the requirements. The main
 requirements are as follows:
 
 * CMake version 3.16 or later (Packaging requires CMake 3.25.1 or later)
@@ -26,7 +26,7 @@ requirements are as follows:
 * libssh
 * pcre2
 
-This is the minimum set of requirements that must be met to build the MaxScale\
+This is the minimum set of requirements that must be met to build the MaxScale
 core package. Some modules in MaxScale require optional extra dependencies.
 
 * libuuid (binlogrouter)
@@ -37,9 +37,9 @@ core package. Some modules in MaxScale require optional extra dependencies.
 * memcached (storage\_memcached for the cache filter)
 * hiredis (storage\_redis for the cache filter)
 
-Some of these dependencies are not available on all operating systems and are\
-downloaded automatically during the build step. To skip the building of modules\
-that need automatic downloading of the dependencies, use `-DBUNDLE=N` when\
+Some of these dependencies are not available on all operating systems and are
+downloaded automatically during the build step. To skip the building of modules
+that need automatic downloading of the dependencies, use `-DBUNDLE=N` when
 configuring CMake.
 
 ### Quickstart
@@ -65,7 +65,7 @@ For a definitive list of packages, consult the [install\_build\_deps.sh](https:/
 
 The tests and other parts of the build can be controlled via CMake arguments.
 
-Here is a small table with the names of the most common parameters and what\
+Here is a small table with the names of the most common parameters and what
 they control. These should all be given as parameters to the -D switch in _NAME_=_VALUE_ format (e.g. `-DBUILD_TESTS=Y`).
 
 | Argument Name          | Explanation                                                                                                                                                                |
@@ -77,25 +77,25 @@ they control. These should all be given as parameters to the -D switch in _NAME_
 | TARGET\_COMPONENT      | Which component to install, default is the 'core' package. Other targets are 'experimental', which installs experimental packages and 'all' which installs all components. |
 | TARBALL                | Build tar.gz packages, requires PACKAGE=Y                                                                                                                                  |
 
-**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a\
+**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a
 list of the CMake variables.
 
 ### Running unit tests
 
-To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,\
+To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,
 compile and then run the `make test` command.
 
 ## Building MariaDB MaxScale packages
 
-If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation\
-and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your\
+If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation
+and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your
 system.
 
-To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create\
+To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create
 a _maxscale-x.y.z.tar.gz_ file where _x.y.z_ is the version number.
 
-Some Debian and Ubuntu systems suffer from a bug where `make package` fails\
-with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to\
+Some Debian and Ubuntu systems suffer from a bug where `make package` fails
+with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to
 the LD\_LIBRARY\_PATH environment variable.
 
 ```
@@ -105,14 +105,14 @@ LD_LIBRARY_PATH=$PWD/server/core/ make package
 
 ### Installing optional components
 
-The MaxScale build system is split into multiple components. The main component\
-is the `core` MaxScale package which contains MaxScale and all the modules. This\
-is the default component that is build, installed and packaged. There is also\
-the `experimental` component that contains all experimental modules which are\
-not considered as part of the core MaxScale package and are either alpha or beta\
+The MaxScale build system is split into multiple components. The main component
+is the `core` MaxScale package which contains MaxScale and all the modules. This
+is the default component that is build, installed and packaged. There is also
+the `experimental` component that contains all experimental modules which are
+not considered as part of the core MaxScale package and are either alpha or beta
 quality modules.
 
-To build the experimental modules along with the MaxScale core components,\
+To build the experimental modules along with the MaxScale core components,
 invoke CMake with `-DTARGET_COMPONENT=core,experimental`.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-installing-mariadb-maxscale-using-a-tarball.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-installing-mariadb-maxscale-using-a-tarball.md
@@ -4,7 +4,7 @@
 
 ## Installing MariaDB MaxScale using a tarball
 
-MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`\
+MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`
 identifies the operating system, e.g. `maxscale-2.5.6.centos.7.tar.gz`.
 
 In order to use the tarball, the following libraries are required:
@@ -16,12 +16,12 @@ In order to use the tarball, the following libraries are required:
 * libatomic
 
 The tarball has been built with the assumption that it will be installed in `/usr/local`.\
-However, it is possible to install it in any directory, but in that case MariaDB MaxScale\
+However, it is possible to install it in any directory, but in that case MariaDB MaxScale
 must be invoked with a flag.
 
 ### Installing as root in `/usr/local`
 
-If you have root access to the system you probably want to install MariaDB MaxScale under\
+If you have root access to the system you probably want to install MariaDB MaxScale under
 the user and group `maxscale`.
 
 The required steps are as follows:
@@ -36,14 +36,14 @@ $ cd maxscale
 $ sudo chown -R maxscale var
 ```
 
-Creating the symbolic link is necessary, since MariaDB MaxScale has been built\
+Creating the symbolic link is necessary, since MariaDB MaxScale has been built
 with the assumption that the plugin directory is `/usr/local/maxscale/lib/maxscale`.
 
 The symbolic link also makes it easy to switch between different versions of\
 MariaDB MaxScale that have been installed side by side in `/usr/local`;\
 just make the symbolic link point to another installation.
 
-In addition, the first time you install MariaDB MaxScale from a tarball\
+In addition, the first time you install MariaDB MaxScale from a tarball
 you need to create the following directories:
 
 ```
@@ -72,14 +72,14 @@ When the configuration file has been created, MariaDB MaxScale can be started.
 $ sudo bin/maxscale --user=maxscale -d
 ```
 
-The `-d` flag causes maxscale _not_ to turn itself into a daemon,\
+The `-d` flag causes maxscale _not_ to turn itself into a daemon,
 which is advisable the first time MariaDB MaxScale is started, as it makes it easier to spot problems.
 
 If you want to place the configuration file somewhere else but in `/etc`\
 you can invoke MariaDB MaxScale with the `--config` flag,\
 for instance, `--config=/usr/local/maxscale/etc/maxscale.cnf`.
 
-Note also that if you want to keep _everything_ under `/usr/local/maxscale`\
+Note also that if you want to keep _everything_ under `/usr/local/maxscale`
 you can invoke MariaDB MaxScale using the flag `--basedir`.
 
 ```
@@ -107,12 +107,12 @@ $ cd maxscale-x.y.z.OS
 $ bin/maxscale -d --basedir=.
 ```
 
-With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`\
-directories are found. Unless it is specified, MariaDB MaxScale assumes\
-the `lib` directory is found in `/usr/local/maxscale`,\
+With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`
+directories are found. Unless it is specified, MariaDB MaxScale assumes
+the `lib` directory is found in `/usr/local/maxscale`,
 and the `var` and `etc` directories in `/`.
 
-It is also possible to specify the directories and the location of\
+It is also possible to specify the directories and the location of
 the configuration file individually. Invoke MaxScale like
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md
@@ -6,9 +6,9 @@
 
 ## Introduction
 
-This document describes how to configure MariaDB MaxScale and presents some\
-possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,\
-and consists of an event processing core with various support functions and\
+This document describes how to configure MariaDB MaxScale and presents some
+possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,
+and consists of an event processing core with various support functions and
 plugin modules that tailor the behavior of the program.
 
 ## Concepts
@@ -28,9 +28,9 @@ plugin modules that tailor the behavior of the program.
 
 #### Server
 
-A server represents an individual database server to which a client can be\
-connected via MariaDB MaxScale. The status of a server varies during the lifetime\
-of the server and typically the status is updated by some monitor. However, it\
+A server represents an individual database server to which a client can be
+connected via MariaDB MaxScale. The status of a server varies during the lifetime
+of the server and typically the status is updated by some monitor. However, it
 is also possible to update the status of a server manually.
 
 | Status                   | Description                                                                                                                                                                                                                                                                                                               |
@@ -49,55 +49,55 @@ For more information on how to manually set these states via MaxCtrl, read the [
 
 #### Monitor
 
-A monitor module is capable of monitoring the state of a particular kind\
+A monitor module is capable of monitoring the state of a particular kind
 of cluster and making that state available to the routers of MaxScale.
 
-Examples of monitor modules are `mariadbmon` that is capable of monitoring\
-a regular master-slave cluster and in addition of performing both _switchover_\
-and _failover_, `galeramon` that is capable of monitoring a Galera cluster,\
+Examples of monitor modules are `mariadbmon` that is capable of monitoring
+a regular master-slave cluster and in addition of performing both _switchover_
+and _failover_, `galeramon` that is capable of monitoring a Galera cluster,
 and `csmon` that is capable of monitoring a Columnstore cluster.
 
-Monitor modules have sections of their own in the MaxScale configuration\
+Monitor modules have sections of their own in the MaxScale configuration
 file.
 
 #### Filter
 
-A filter module resides in front of routers in the request processing chain\
-of MaxScale. That is, a filter will see a request before it reaches the router\
-and before a response is sent back to the client. This allows filters to\
+A filter module resides in front of routers in the request processing chain
+of MaxScale. That is, a filter will see a request before it reaches the router
+and before a response is sent back to the client. This allows filters to
 reject, handle, alter or log information about a request.
 
 Examples of filters `cache` that provides query caching according to rules,`regexfilter` that can rewrite requests according to regular expressions, and`qlafilter` that logs information about requests.
 
-Filters have sections of their own in the MaxScale configuration file that are\
+Filters have sections of their own in the MaxScale configuration file that are
 referred to from _services_.
 
 #### Router
 
-A router module is capable of routing requests to backend servers according to\
-the characteristics of a request and/or the algorithm the router\
+A router module is capable of routing requests to backend servers according to
+the characteristics of a request and/or the algorithm the router
 implements. Examples of routers are `readconnroute` that provides _connection routing_, that is, the server is chosen according to specified rules when the
-session is created and all requests are subsequently routed to that server,\
-and `readwritesplit` that provides _statement routing_, that is, each\
+session is created and all requests are subsequently routed to that server,
+and `readwritesplit` that provides _statement routing_, that is, each
 individual request is routed to the most appropriate server.
 
-Routers do not have sections of their own in the MaxScale configuration file,\
+Routers do not have sections of their own in the MaxScale configuration file,
 but are referred to from _services_.
 
 #### Service
 
-A service abstracts a set of databases and makes them appear as a single one\
-to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular\
-way. If the service uses filters, then all requests will be pre-processed in\
+A service abstracts a set of databases and makes them appear as a single one
+to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular
+way. If the service uses filters, then all requests will be pre-processed in
 some way before they reach the router.
 
 Services have sections of their own in the MaxScale configuration file.
 
 #### Listener
 
-A listener defines a port MaxScale listens on. Connection requests arriving on\
-that port will be forwarded to the service the listener is associated with. A\
-listener may be associated with a single service, but several listeners may be\
+A listener defines a port MaxScale listens on. Connection requests arriving on
+that port will be forwarded to the service the listener is associated with. A
+listener may be associated with a single service, but several listeners may be
 associated with the same service.
 
 Listeners have sections of their own in the MaxScale configuration file.
@@ -109,25 +109,25 @@ The administration of MaxScale can be divided in two parts:
 * Writing the MaxScale configuration file, which is described in the following [section](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#configuration).
 * Performing runtime modifications using [MaxCtrl](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-maxctrl.md)
 
-For detailed information about _MaxCtrl_ please refer to the specific\
+For detailed information about _MaxCtrl_ please refer to the specific
 documentation referred to above. In the following it will only be explained how\
 MaxCtrl relate to each other, as far as user credentials go.
 
-**Note**: By default all runtime configuration changes are saved on disk and\
-loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details\
+**Note**: By default all runtime configuration changes are saved on disk and
+loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details
 on how it works and how to disable it.
 
 MaxCtrl can connect using TCP/IP sockets. When connecting with MaxCtrl using\
-TCP/IP sockets, the user and password must be provided and are checked against a\
+TCP/IP sockets, the user and password must be provided and are checked against a
 separate user credentials database. By default, that database contains the user`admin` whose password is `mariadb`.
 
-Note that if MaxCtrl is invoked without explicitly providing a user and password\
-then it will by default use `admin` and `mariadb`. That means that when the\
+Note that if MaxCtrl is invoked without explicitly providing a user and password
+then it will by default use `admin` and `mariadb`. That means that when the
 default user is removed, the credentials must always be provided.
 
 ### Static Configuration Parameters
 
-The following list of global configuration parameters can **NOT** be changed at\
+The following list of global configuration parameters can **NOT** be changed at
 runtime and can only be defined in a configuration file:
 
 * `admin_auth`
@@ -168,35 +168,35 @@ runtime and can only be defined in a configuration file:
 * `substitute_variables`
 * `threads`
 
-All other parameters that relate to objects can be altered at runtime or can be\
+All other parameters that relate to objects can be altered at runtime or can be
 changed by destroying and recreating the object in question.
 
 ## Configuration
 
-MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If\
-the command line argument `--configdir=<path>` is given, `maxscale.cnf` is\
-searched for in _\<path>_ instead. If the argument `--config=<file>` is given,\
+MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If
+the command line argument `--configdir=<path>` is given, `maxscale.cnf` is
+searched for in _\<path>_ instead. If the argument `--config=<file>` is given,
 configuration is read from the file _\<file>_.
 
-MaxScale also looks for a directory with the same name as the configuration\
-file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale\
+MaxScale also looks for a directory with the same name as the configuration
+file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale
 recursively reads all files with the ".cnf" suffix in the directory hierarchy.\
 Other files are ignored.
 
-After loading normal configuration files, MaxScale reads runtime-generated\
+After loading normal configuration files, MaxScale reads runtime-generated
 configuration files, if any, from the [persisted configuration files directory](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#persistdir).
 
 Different configuration sections can be arranged with little restrictions.\
-Global path settings such as `logdir`, `piddir` and `datadir` are only read from\
-the main configuration file. Other global settings are also best left in the\
-main file to ensure they are read before other configuration sections are\
+Global path settings such as `logdir`, `piddir` and `datadir` are only read from
+the main configuration file. Other global settings are also best left in the
+main file to ensure they are read before other configuration sections are
 parsed.
 
 The configuration file format used is [INI](https://en.wikipedia.org/wiki/INI_file), similar to the\
-MariaDB Server. The files contain sections and each section can contain multiple\
+MariaDB Server. The files contain sections and each section can contain multiple
 key-value pairs.
 
-Comments are defined by prefixing a row with a hash (#). Trailing comments are\
+Comments are defined by prefixing a row with a hash (#). Trailing comments are
 not supported.
 
 ```
@@ -204,8 +204,8 @@ not supported.
 some_parameter=123
 ```
 
-A parameter can be defined on multiple lines as shown below. A value spread over\
-multiple lines is simply concatenated. The additional lines of the value\
+A parameter can be defined on multiple lines as shown below. A value spread over
+multiple lines is simply concatenated. The additional lines of the value
 definition need to have at least one whitespace character in the beginning.
 
 ```
@@ -221,40 +221,40 @@ servers=server1,
 
 Section names may not contain whitespace and must not start with the characters`@@`.
 
-As the object names are used to form URLs in the MaxScale REST API, they must be\
+As the object names are used to form URLs in the MaxScale REST API, they must be
 safe for use in URLs. This means that only alphanumeric characters (i.e. `a-zA-Z` and `0-9`) and the special characters `_.~-` can be used.
 
 ### Dynamic Configuration
 
 By default all changes done at runtime via the MaxScale GUI, MaxCtrl or the REST\
-API will be saved on disk, inside the [persistdir](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#persistdir) directory. The\
-changes done at runtime will override the configuration found in the static\
+API will be saved on disk, inside the [persistdir](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#persistdir) directory. The
+changes done at runtime will override the configuration found in the static
 configuration files for that particular object.
 
-This means that if an object that is found in `/etc/maxscale.cnf` is modified at\
-runtime, all future changes to it must also be done at runtime. Any\
-modifications done to `/etc/maxscale.cnf` after a runtime change has been made\
+This means that if an object that is found in `/etc/maxscale.cnf` is modified at
+runtime, all future changes to it must also be done at runtime. Any
+modifications done to `/etc/maxscale.cnf` after a runtime change has been made
 are ignored for that object.
 
-To prevent the saving of runtime changes and to make all runtime changes\
-volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`\
-section. This will make MaxScale behave like the MariaDB server does: any\
+To prevent the saving of runtime changes and to make all runtime changes
+volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`
+section. This will make MaxScale behave like the MariaDB server does: any
 changes done with `SET GLOBAL` statements are lost if the process is restarted.
 
 ### Special Parameter Types
 
 #### Booleans
 
-Boolean type parameters interpret the values `true`, `yes`, `on` and `1` as\_true\_ values and `false`, `no`, `off` and `0` as _false_ values. The REST API\
+Boolean type parameters interpret the values `true`, `yes`, `on` and `1` as\_true\_ values and `false`, `no`, `off` and `0` as _false_ values. The REST API
 only accepts JSON boolean values for boolean type parameters.
 
 #### Sizes
 
-Where _specifically noted_, a number denoting a size can be suffixed by a subset\
-of the IEC binary prefixes or the SI prefixes. In the former case the number\
-will be interpreted as a certain multiple of 1024 and in the latter case as a\
-certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`\
-and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,\
+Where _specifically noted_, a number denoting a size can be suffixed by a subset
+of the IEC binary prefixes or the SI prefixes. In the former case the number
+will be interpreted as a certain multiple of 1024 and in the latter case as a
+certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`
+and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,
 the matching is case insensitive.
 
 For instance, the following entries
@@ -279,8 +279,8 @@ max_size=1T
 
 #### Durations
 
-A number denoting a duration can be suffixed by one of the case-insensitive\
-suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,\
+A number denoting a duration can be suffixed by one of the case-insensitive
+suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,
 minutes, seconds and milliseconds, respectively.
 
 For instance, the following entries
@@ -295,79 +295,79 @@ soft_ttl=3600000ms
 
 are equivalent.
 
-Note that if an explicit unit is not specified, then it is specific to the\
-configuration parameter whether the duration is interpreted as seconds or\
+Note that if an explicit unit is not specified, then it is specific to the
+configuration parameter whether the duration is interpreted as seconds or
 milliseconds.
 
 _Not_ providing an explicit unit has been deprecated in MaxScale 2.4.
 
 #### Regular Expressions
 
-Many modules have settings which accept a regular expression. In most cases, these\
+Many modules have settings which accept a regular expression. In most cases, these
 settings are named either _match_ or _exclude_, and are used to filter users or queries.\
-MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching\
+MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching
 regular expressions.
 
-When writing a regular expression (regex) type parameter to a MaxScale configuration file,\
-the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This\
-clarifies where the pattern begins and ends, even if it includes whitespace. Without\
-slashes the configuration loader trims the pattern from the ends. The slashes are removed\
-before compiling the pattern. For backwards compatibility, the slashes are not yet\
-mandatory. Omitting them is, however, deprecated and will be rejected in a future release\
-of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_\
-accept parameters in this type of regular expression form. Some other modules may not\
+When writing a regular expression (regex) type parameter to a MaxScale configuration file,
+the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This
+clarifies where the pattern begins and ends, even if it includes whitespace. Without
+slashes the configuration loader trims the pattern from the ends. The slashes are removed
+before compiling the pattern. For backwards compatibility, the slashes are not yet
+mandatory. Omitting them is, however, deprecated and will be rejected in a future release
+of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_
+accept parameters in this type of regular expression form. Some other modules may not
 handle the slashes yet correctly.
 
-PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses\
-regular expressions simply, only checking whether the pattern and subject match at some\
-point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to\
-accept any query with the text "SELECT" somewhere within. To force the pattern to only\
+PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses
+regular expressions simply, only checking whether the pattern and subject match at some
+point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to
+accept any query with the text "SELECT" somewhere within. To force the pattern to only
 match at the beginning of the query, set `match=/^SELECT/`. To only match the end, set`match=/SELECT$/`.
 
-Modules which accept regular expression parameters also often accept options which affect\
-how the patterns are compiled. Typically, this setting is called _options_ and accepts\
+Modules which accept regular expression parameters also often accept options which affect
+how the patterns are compiled. Typically, this setting is called _options_ and accepts
 values such as `ignorecase`, `case` and `extended`.
 
-* `ignorecase`: Causes the regular expression matcher to ignore letter case, and\
+* `ignorecase`: Causes the regular expression matcher to ignore letter case, and
   is often on by default. When enabled, `/SELECT/` would match both `SELECT` and`select`.
-* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this\
+* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this
   is not the same as the extended regular expression syntax that for example`grep -E` uses.
-* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not\
+* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not
   match `select`.
 
-These settings can also be defined in the pattern itself, so they can be\
-used even in modules without pattern compilation settings. The pattern\
-settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)\
+These settings can also be defined in the pattern itself, so they can be
+used even in modules without pattern compilation settings. The pattern
+settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)
 for more information.
 
 **Standard regular expression settings for filters**
 
-Many filters use the settings _match_, _exclude_ and _options_. Since these settings are\
-used in a similar way across these filters, the settings are explained here. The\
-documentation of the filters link here and describe any exceptions to this\
+Many filters use the settings _match_, _exclude_ and _options_. Since these settings are
+used in a similar way across these filters, the settings are explained here. The
+documentation of the filters link here and describe any exceptions to this
 generalized explanation.
 
-These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the\
+These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the
 patterns are compiled. _options_ works as explained above, accepting the values`ignorecase`, `case` and `extended`, with `ignorecase` being the default.
 
-The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is\
+The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is
 not defined, all queries are considered to match.
 
 If _exclude_ is defined, the filter only acts on queries not matching that pattern. If\_exclude\_ is not defined, nothing is excluded.
 
 If both are defined, the query needs to match _match_ but not match _exclude_.
 
-Even if a filter does not act on a query, the query is not lost. The query is simply\
+Even if a filter does not act on a query, the query is not lost. The query is simply
 passed on to the next module in the processing chain as if the filter was not there.
 
 #### Enumerations
 
-Enumeration type parameters have a pre-defined set of accepted values. For types\
-declared as `enum`, only one value is accepted. For `enum_mask` types, multiple\
+Enumeration type parameters have a pre-defined set of accepted values. For types
+declared as `enum`, only one value is accepted. For `enum_mask` types, multiple
 values can be defined by separating them with commas. All enumeration values in\
 MaxScale are case-sensitive.
 
-For example the `router_options` parameter in the `readconnroute` router is a\
+For example the `router_options` parameter in the `readconnroute` router is a
 mask type enumeration:
 
 ```
@@ -376,7 +376,7 @@ router_options=master,slave
 
 #### Path Lists
 
-A `pathlist` type parameter expects one or more filesystem paths separated by\
+A `pathlist` type parameter expects one or more filesystem paths separated by
 colons. The value must not include space between the separators.
 
 Here is an example path list parameter that points to `/tmp/something.log` and`/var/log/maxscale/maxscale.log`:
@@ -387,8 +387,8 @@ path_list_parameter=/tmp/something.log:/var/log/maxscale/maxscale.log
 
 ### Global Settings
 
-The global settings, in a section named `[MaxScale]`, allow various parameters\
-that affect MariaDB MaxScale as a whole to be tuned. This section must be\
+The global settings, in a section named `[MaxScale]`, allow various parameters
+that affect MariaDB MaxScale as a whole to be tuned. This section must be
 defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 
 #### `auto_tune`
@@ -399,7 +399,7 @@ defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 * Mandatory: No
 * Dynamic: No
 
-An _auto tunable_ parameter is a parameter whose value can be derived from a\
+An _auto tunable_ parameter is a parameter whose value can be derived from a
 particular server variable. With this parameter it can be specified whether`all` or a specific set of parameters should automatically be set.
 
 The current auto tunable parameters are:
@@ -409,13 +409,13 @@ The current auto tunable parameters are:
 | [connection\_keepalive](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#connection_keepalive) | 80% of the smallest [wait\_timeout](https://mariadb.com/docs/reference/mdb/system-variables/wait_timeout/) value of the servers used by the service |
 | [connection\_timeout](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#connection_timeout)     | The smallest [wait\_timeout](https://mariadb.com/docs/reference/mdb/system-variables/wait_timeout/) value of the servers used by the service        |
 
-The values of the server variables are collected by monitors, which means that\
-if the servers of a service are not monitored by a monitor, then the parameters\
+The values of the server variables are collected by monitors, which means that
+if the servers of a service are not monitored by a monitor, then the parameters
 of that service will not be auto tuned.
 
-Note that even if `auto_tune` is set to `all`, the auto tunable parameters\
+Note that even if `auto_tune` is set to `all`, the auto tunable parameters
 can still be set in the configuration file and modified with _maxctrl_.\
-However, the specified value will be overwritten at the next auto tuning\
+However, the specified value will be overwritten at the next auto tuning
 round, but only if the servers of the service are monitored by a monitor.
 
 #### `threads`
@@ -425,20 +425,20 @@ round, but only if the servers of the service are monitored by a monitor.
 * Dynamic: No
 * Default: `auto`
 
-This parameter controls the number of worker threads that are handling the\
-events coming from the kernel. The default is `auto` which uses as many threads\
-as there are CPU cores. MaxScale versions older than 6 used one thread by\
+This parameter controls the number of worker threads that are handling the
+events coming from the kernel. The default is `auto` which uses as many threads
+as there are CPU cores. MaxScale versions older than 6 used one thread by
 default.
 
-You can explicitly enable automatic configuration of this value by setting the\
-value to `auto`. This way MariaDB MaxScale will detect the number of available\
+You can explicitly enable automatic configuration of this value by setting the
+value to `auto`. This way MariaDB MaxScale will detect the number of available
 processors and set the amount of threads to be equal to that number.
 
-Note that if MaxScale is running in a container where the CPU resources\
-have been limited, the use of `auto` may cause MaxScale to use more resources\
-than what is available. In such a situation `auto` should not be used, but instead\
-an explicit number that corresponds to the amount of CPU resources available in\
-the container. As a rule of thumb, an appropriate value for `threads` is the\_vCPU\_ of the container rounded up to the nearest integer. For instance, if\
+Note that if MaxScale is running in a container where the CPU resources
+have been limited, the use of `auto` may cause MaxScale to use more resources
+than what is available. In such a situation `auto` should not be used, but instead
+an explicit number that corresponds to the amount of CPU resources available in
+the container. As a rule of thumb, an appropriate value for `threads` is the\_vCPU\_ of the container rounded up to the nearest integer. For instance, if
 the _vCPU_ of the container is `0.5` then `1` is an appropriate value for`threads`, if the _vCPU_ is `2.3` then `3` is.
 
 The maximum value for threads is 256.
@@ -452,7 +452,7 @@ threads=auto
 ```
 
 Additional threads will be created to execute other internal services within\
-MariaDB MaxScale. This setting is used to configure the number of threads that\
+MariaDB MaxScale. This setting is used to configure the number of threads that
 will be used to manage the user connections.
 
 #### `rebalance_period`
@@ -462,19 +462,19 @@ will be used to manage the user connections.
 * Dynamic: Yes
 * Default: `0s`
 
-This duration parameter controls how often the load of the worker threads\
-should be checked. The default value is 0, which means that no checks and\
+This duration parameter controls how often the load of the worker threads
+should be checked. The default value is 0, which means that no checks and
 no rebalancing will be performed.
 
 ```
 rebalance_period=10s
 ```
 
-Note that the value of `rebalance_period` should not be smaller than the\
+Note that the value of `rebalance_period` should not be smaller than the
 value of `rebalance_window` whose default value is 10.
 
-If the value of `rebalance_period` is significantly shorter than that\
-of `rebalance_window`, it may lead to oscillation where work is constantly\
+If the value of `rebalance_period` is significantly shorter than that
+of `rebalance_window`, it may lead to oscillation where work is constantly
 moved from one thread to another.
 
 #### `rebalance_threshold`
@@ -484,21 +484,21 @@ moved from one thread to another.
 * Dynamic: Yes
 * Default: `20`
 
-This integer parameter controls at which point MaxScale should start\
+This integer parameter controls at which point MaxScale should start
 moving work from one worker thread to another.
 
 If the difference in load between the thread with the maximum load and\
 the thread with the minimum load is larger than the value of this parameter,\
 then work will be moved from the former to the latter.
 
-Although the load of a thread can vary between 0 and 100, the value of this\
+Although the load of a thread can vary between 0 and 100, the value of this
 parameter must be between 5 and 100.
 
 ```
 rebalance_threshold=15
 ```
 
-Note that rebalancing will not be performed unless `rebalance_period`\
+Note that rebalancing will not be performed unless `rebalance_period`
 has been specified.
 
 #### `rebalance_window`
@@ -508,11 +508,11 @@ has been specified.
 * Dynamic: Yes
 * Default: `10`
 
-This integer parameter controls how many seconds of load should be\
-taken into account when deciding whether work should be moved from\
+This integer parameter controls how many seconds of load should be
+taken into account when deciding whether work should be moved from
 one thread to another.
 
-The default value is 10, which means that the load during the last 10\
+The default value is 10, which means that the load during the last 10
 seconds is considered when deciding whether work should be moved.
 
 The minimum value is 1 and the maximum 60.
@@ -524,8 +524,8 @@ The minimum value is 1 and the maximum 60.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether reverse domain name lookups are made to convert\
-client IP addresses to hostnames. If enabled, client IP addresses will not be\
+This parameter controls whether reverse domain name lookups are made to convert
+client IP addresses to hostnames. If enabled, client IP addresses will not be
 resolved to hostnames during authentication or for the REST API even if requested.
 
 If you have database users that use a hostname in the host part of the user\
@@ -541,8 +541,8 @@ an IP address.
 * Dynamic: Yes
 * Default: `10s`
 
-Duration, default 10s. This setting defines the connection timeout when\
-attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same\
+Duration, default 10s. This setting defines the connection timeout when
+attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same
 value is also used for read and write timeouts. Increasing this value causes\
 MaxScale to wait longer for a response from a server before user fetching fails.\
 Other servers may then be attempted.
@@ -551,10 +551,10 @@ Other servers may then be attempted.
 auth_connect_timeout=10s
 ```
 
-The value is given as [a duration](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,\
-the value is interpreted as seconds. In subsequent versions a value without a\
-unit may be rejected. Since the granularity of the timeout is seconds, a timeout\
-specified in milliseconds will be rejected even if the given value is longer\
+The value is given as [a duration](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,
+the value is interpreted as seconds. In subsequent versions a value without a
+unit may be rejected. Since the granularity of the timeout is seconds, a timeout
+specified in milliseconds will be rejected even if the given value is longer
 than a second.
 
 #### `auth_read_timeout`
@@ -572,14 +572,14 @@ Deprecated and ignored as of MaxScale 2.5.0. See _auth\_connect\_timeout_ above.
 * Dynamic: No
 * Default: `1`
 
-The number of times an interrupted internal query will be retried. The default\
-is to retry the query once. This feature was added in MaxScale 2.1.10 and was\
+The number of times an interrupted internal query will be retried. The default
+is to retry the query once. This feature was added in MaxScale 2.1.10 and was
 disabled by default until MaxScale 2.3.0.
 
-An interrupted query is any query that is interrupted by a network\
-error. Connection timeouts are included in network errors and thus is it\
-advisable to make sure that the value of `query_retry_timeout` is set to an\
-adequate value. Internal queries are only used to retrieve authentication data\
+An interrupted query is any query that is interrupted by a network
+error. Connection timeouts are included in network errors and thus is it
+advisable to make sure that the value of `query_retry_timeout` is set to an
+adequate value. Internal queries are only used to retrieve authentication data
 and monitor the servers.
 
 #### `query_retry_timeout`
@@ -589,16 +589,16 @@ and monitor the servers.
 * Dynamic: Yes
 * Default: `10s`
 
-The total timeout in seconds for any retried queries. The default value is 5\
+The total timeout in seconds for any retried queries. The default value is 5
 seconds.
 
-An interrupted query is retried for either the configured amount of attempts or\
+An interrupted query is retried for either the configured amount of attempts or
 until the configured timeout is reached.
 
-The value is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `passive`
@@ -608,11 +608,11 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `false`
 
-Controls whether MaxScale is a passive node in a cluster of multiple MaxScale\
+Controls whether MaxScale is a passive node in a cluster of multiple MaxScale
 instances.
 
-This parameter is intended to be used with multiple MaxScale instances that use\
-failover functionality to manipulate the cluster in some form. Passive nodes\
+This parameter is intended to be used with multiple MaxScale instances that use
+failover functionality to manipulate the cluster in some form. Passive nodes
 only observe the clusters being monitored and take no direct actions.
 
 The following functionality is disabled when passive mode is enabled:
@@ -621,8 +621,8 @@ The following functionality is disabled when passive mode is enabled:
 * Automatic rejoin in the `mariadbmon` module
 * Launching of monitor scripts
 
-**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and\
-route any traffic sent to it. The **only** operations affected by the passive\
+**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and
+route any traffic sent to it. The **only** operations affected by the passive
 mode are the ones listed above.
 
 #### `ms_timestamp`
@@ -632,7 +632,7 @@ mode are the ones listed above.
 * Dynamic: Yes
 * Default: `false`
 
-Enable or disable the high precision timestamps in logfiles. Enabling this adds\
+Enable or disable the high precision timestamps in logfiles. Enabling this adds
 millisecond precision to all logfile timestamps.
 
 #### `skip_permission_checks`
@@ -642,13 +642,13 @@ millisecond precision to all logfile timestamps.
 * Dynamic: Yes
 * Default: `false`
 
-Skip service and monitor user permission checks. This is useful when you know\
+Skip service and monitor user permission checks. This is useful when you know
 the permissions are OK and you want to speed up the startup process.
 
-It is recommended to not disable the permission checks so that any missing\
-privileges are detected when maxscale is starting up. If you are experiencing a\
-slow startup of MaxScale due to large amounts of connection timeouts when\
-permissions are checked, disabling the permission checks could speed up the\
+It is recommended to not disable the permission checks so that any missing
+privileges are detected when maxscale is starting up. If you are experiencing a
+slow startup of MaxScale due to large amounts of connection timeouts when
+permissions are checked, disabling the permission checks could speed up the
 startup process.
 
 ```
@@ -662,10 +662,10 @@ skip_permission_checks=true
 * Dynamic: Yes
 * Default: `false`
 
-Log messages to the system journal. This logs messages using the native SystemD\
+Log messages to the system journal. This logs messages using the native SystemD
 journal interface. The logs can be viewed with `journalctl`.
 
-MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be\
+MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be
 logged twice: once into the system journal and once into MaxScale's own logfile.
 
 #### `maxlog`
@@ -686,8 +686,8 @@ Log messages to MariaDB MaxScale's log file. The name of the log file is`maxscal
 
 Log messages whose syslog priority is _warning_.
 
-MaxScale logs warning level messages whenever a condition is encountered that\
-the user should be notified of but does not require immediate action or it\
+MaxScale logs warning level messages whenever a condition is encountered that
+the user should be notified of but does not require immediate action or it
 indicates a minor problem.
 
 #### `log_notice`
@@ -699,8 +699,8 @@ indicates a minor problem.
 
 Log messages whose syslog priority is _notice_.
 
-These messages contain information that is helpful for the user and they usually\
-do not indicate a problem. These are logged whenever something worth nothing\
+These messages contain information that is helpful for the user and they usually
+do not indicate a problem. These are logged whenever something worth nothing
 happens in either MaxScale or in the servers it monitors.
 
 #### `log_info`
@@ -713,10 +713,10 @@ happens in either MaxScale or in the servers it monitors.
 Log messages whose syslog priority is _info_.
 
 These messages provide detailed information about the internal workings of\
-MariaDB MaxScale. These messages should only be enabled when there is a need to\
-inspect the internal logic of MaxScale. A common use-case is to see why a\
-particular query was handled in a certain way. Almost all modules log some\
-messages on the info level and this can be very helpful when trying to solve\
+MariaDB MaxScale. These messages should only be enabled when there is a need to
+inspect the internal logic of MaxScale. A common use-case is to see why a
+particular query was handled in a certain way. Almost all modules log some
+messages on the info level and this can be very helpful when trying to solve
 routing related problems.
 
 #### `log_debug`
@@ -728,11 +728,11 @@ routing related problems.
 
 Log messages whose syslog priority is _debug_.
 
-These messages are intended for development purposes and are disabled by\
+These messages are intended for development purposes and are disabled by
 default. These are rarely useful outside of debugging core MaxScale issues.
 
-**Note:** If MariaDB MaxScale has been built in release mode, then debug\
-messages are excluded from the build and this setting will not have any\
+**Note:** If MariaDB MaxScale has been built in release mode, then debug
+messages are excluded from the build and this setting will not have any
 effect. If an attempt to enable these is made, a warning is logged.
 
 #### `log_warn_super_user`
@@ -742,10 +742,10 @@ effect. If an attempt to enable these is made, a warning is logged.
 * Dynamic: No
 * Default: `false`
 
-When enabled, a warning is logged whenever a client with SUPER-privilege\
-successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The\
-setting is intended for diagnosing situations where a client interferes with a\
-master server switchover. Super-users bypass the _read\_only_-flag which\
+When enabled, a warning is logged whenever a client with SUPER-privilege
+successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The
+setting is intended for diagnosing situations where a client interferes with a
+master server switchover. Super-users bypass the _read\_only_-flag which
 switchover uses to block writes to the master.
 
 #### `log_augmentation`
@@ -755,9 +755,9 @@ switchover uses to block writes to the master.
 * Dynamic: Yes
 * Default: `0`
 
-Enable or disable the augmentation of messages. If this is enabled, then each\
-logged message is appended with the name of the function where the message was\
-logged. This is primarily for development purposes and hence is disabled by\
+Enable or disable the augmentation of messages. If this is enabled, then each
+logged message is appended with the name of the function where the message was
+logged. This is primarily for development purposes and hence is disabled by
 default.
 
 ```
@@ -775,10 +775,10 @@ To disable the augmentation use the value 0 and to enable it use the value 1.
 * Dynamic: Yes
 * Default: `10, 1000ms, 10000ms`
 
-It is possible that a particular error (or warning) is logged over and over\
-again, if the cause for the error persistently remains. To prevent the log from\
-flooding, it is possible to specify how many times a particular error may be\
-logged within a time period, before the logging of that error is suppressed for\
+It is possible that a particular error (or warning) is logged over and over
+again, if the cause for the error persistently remains. To prevent the log from
+flooding, it is possible to specify how many times a particular error may be
+logged within a time period, before the logging of that error is suppressed for
 a while.
 
 ```
@@ -794,18 +794,18 @@ log_throttling=8, 2s, 15000ms
 In the example above, the logging of a particular error will be suppressed for\
 15 seconds if the error has been logged 8 times in 2 seconds.
 
-The default is `10, 1000ms, 10000ms`, which means that if the same error is\
-logged 10 times in one second, the logging of that error is suppressed for the\
+The default is `10, 1000ms, 10000ms`, which means that if the same error is
+logged 10 times in one second, the logging of that error is suppressed for the
 following 10 seconds.
 
-Whenever an error message that is being throttled is logged within the\
-triggering window (the second argument), the suppression window is\
-extended. This continues until there is a pause in the messages that is longer\
+Whenever an error message that is being throttled is logged within the
+triggering window (the second argument), the suppression window is
+extended. This continues until there is a pause in the messages that is longer
 than the triggering window.
 
-For example, with the default configuration the messages must pause for at least\
-one second in order for the throttling to eventually stop. This mechanism\
-prevents long-lasting error conditions from slowly filling up the log with short\
+For example, with the default configuration the messages must pause for at least
+one second in order for the throttling to eventually stop. This mechanism
+prevents long-lasting error conditions from slowly filling up the log with short
 bursts of messages.
 
 To disable log throttling, add an entry with an empty value
@@ -820,8 +820,8 @@ or one where any of the integers is 0.
 log_throttling=0, 0, 0
 ```
 
-The durations can be specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In\
+The durations can be specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In
 subsequent versions a value without a unit may be rejected.
 
 Note that _notice_, _info_ and _debug_ messages are never throttled.
@@ -833,7 +833,7 @@ Note that _notice_, _info_ and _debug_ messages are never throttled.
 * Dynamic: No
 * Default: `/var/log/maxscale`
 
-Set the directory where the logfiles are stored. The folder needs to be both\
+Set the directory where the logfiles are stored. The folder needs to be both
 readable and writable by the user running MariaDB MaxScale.
 
 ```
@@ -848,10 +848,10 @@ logdir=/var/log/maxscale/
 * Default: `/var/lib/maxscale`
 
 Set the directory where the data files used by MariaDB MaxScale are stored.\
-Modules can write to this directory and for example the binlogrouter uses this\
+Modules can write to this directory and for example the binlogrouter uses this
 folder as the default location for storing binary logs.
 
-This is also the directory where the password encryption key is read from that\
+This is also the directory where the password encryption key is read from that
 is generated by `maxkeys`.
 
 ```
@@ -865,10 +865,10 @@ datadir=/var/lib/maxscale/
 * Dynamic: No
 * Default: `""`
 
-The location where the `.secrets` file is read from. If `secretsdir` is not\
+The location where the `.secrets` file is read from. If `secretsdir` is not
 defined, the file is read from [datadir](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#datadir).
 
-This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6\
+This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6
 and 24.02.2.
 
 #### `libdir`
@@ -878,12 +878,12 @@ and 24.02.2.
 * Dynamic: No
 * Default: OS Dependent
 
-Set the directory where MariaDB MaxScale looks for modules. The library\
-directory is the only directory that MariaDB MaxScale uses when it searches for\
-modules. If you have custom modules for MariaDB MaxScale, make sure you have\
+Set the directory where MariaDB MaxScale looks for modules. The library
+directory is the only directory that MariaDB MaxScale uses when it searches for
+modules. If you have custom modules for MariaDB MaxScale, make sure you have
 them in this folder.
 
-The default value depends on the operating system. For RHEL versions the value\
+The default value depends on the operating system. For RHEL versions the value
 is `/usr/lib64/maxscale/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/`
 
 ```
@@ -899,14 +899,14 @@ libdir=/usr/lib64/maxscale/
 
 Sets the directory where static data assets are loaded.
 
-The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI\
-files have been manually moved somewhere else, this path must be configured to\
+The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI
+files have been manually moved somewhere else, this path must be configured to
 point to the parent directory of the `gui/` subdirectory.
 
-The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path\
-resolves to outside of this directory are not served by the MaxScale GUI: this\
+The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path
+resolves to outside of this directory are not served by the MaxScale GUI: this
 is done to prevent other files from being accessible via the MaxScale REST\
-API. This means that path to the GUI source directory can contain symbolic links\
+API. This means that path to the GUI source directory can contain symbolic links
 but all parts after the `/gui/` directory must reside inside it.
 
 #### `cachedir`
@@ -929,7 +929,7 @@ cachedir=/var/cache/maxscale/
 * Dynamic: No
 * Default: `/var/run/maxscale`
 
-Configure the directory for the PID file for MariaDB MaxScale. This file\
+Configure the directory for the PID file for MariaDB MaxScale. This file
 contains the Process ID for the running MariaDB MaxScale process.
 
 ```
@@ -943,8 +943,8 @@ piddir=/var/run/maxscale/
 * Dynamic: No
 * Default: `/usr/bin`
 
-Configure the directory where the executable files reside. All internal\
-processes which are launched will use this directory to look for executable\
+Configure the directory where the executable files reside. All internal
+processes which are launched will use this directory to look for executable
 files.
 
 ```
@@ -958,13 +958,13 @@ execdir=/usr/bin/
 * Dynamic: No
 * Default: OS Dependent
 
-Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C\
-used in MaxScale can use this directory to load authentication plugins. The\
-versions of the plugins must be binary compatible with the connector version\
+Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C
+used in MaxScale can use this directory to load authentication plugins. The
+versions of the plugins must be binary compatible with the connector version
 that MaxScale was built with.
 
-Starting with version 6.2.0, the plugins are bundled with MaxScale and the\
-default value now points to the bundled plugins. The location where the plugins\
+Starting with version 6.2.0, the plugins are bundled with MaxScale and the
+default value now points to the bundled plugins. The location where the plugins
 are stored depends on the operating system. For RHEL versions the value is`/usr/lib64/maxscale/plugin/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/plugin/`.
 
 Older versions of MaxScale used `/usr/lib/mysql/plugin/` as the default value.
@@ -980,10 +980,10 @@ connector_plugindir=/usr/lib64/maxscale/plugin/
 * Dynamic: No
 * Default: `/var/lib/maxscale/maxscale.cnf.d/`
 
-Configure the directory where persisted configurations are stored. When a new\
-object is created via MaxCtrl, it will be stored in this directory. Do not use\
-this directory for normal configuration files, use _/etc/maxscale.cnf.d/_\
-instead. The user MaxScale is running as must be able to write into this\
+Configure the directory where persisted configurations are stored. When a new
+object is created via MaxCtrl, it will be stored in this directory. Do not use
+this directory for normal configuration files, use _/etc/maxscale.cnf.d/_
+instead. The user MaxScale is running as must be able to write into this
 directory.
 
 ```
@@ -997,16 +997,16 @@ persistdir=/var/lib/maxscale/maxscale.cnf.d/
 * Dynamic: No
 * Default: `/etc/maxscale.modules.d/`
 
-Configure the directory where module configurations are stored. Path arguments\
-are resolved relative to this directory. This directory should be used to store\
+Configure the directory where module configurations are stored. Path arguments
+are resolved relative to this directory. This directory should be used to store
 module specific configurations.
 
-Any configuration parameter that is not an absolute path will be interpreted as\
-a relative path. The relative paths use the module configuration directory as\
+Any configuration parameter that is not an absolute path will be interpreted as
+a relative path. The relative paths use the module configuration directory as
 the working directory.
 
-For example, the configuration parameter `file=my_file.txt` would be interpreted\
-as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would\
+For example, the configuration parameter `file=my_file.txt` would be interpreted
+as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would
 be interpreted as `/home/user/my_file.txt`.
 
 ```
@@ -1020,7 +1020,7 @@ module_configdir=/etc/maxscale.modules.d/
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will\
+Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will
 look for the errmsg.sys file installed with MariaDB MaxScale from this folder.
 
 ```
@@ -1034,8 +1034,8 @@ language=/var/lib/maxscale/
 * Dynamic: No
 * Default: `qc_sqlite`
 
-The module used by MariaDB MaxScale for query classification. The information\
-provided by this module is used by MariaDB MaxScale when deciding where a\
+The module used by MariaDB MaxScale for query classification. The information
+provided by this module is used by MariaDB MaxScale when deciding where a
 particular statement should be sent. The default query classifier is\_qc\_sqlite\_.
 
 #### `query_classifier_cache_size`
@@ -1046,20 +1046,20 @@ particular statement should be sent. The default query classifier is\_qc\_sqlite
 * Default: System Dependent
 
 Specifies the maximum size of the query classifier cache. The default limit is\
-15% of total system memory starting with MaxScale 2.3.7. In older versions the\
+15% of total system memory starting with MaxScale 2.3.7. In older versions the
 default limit was 40% of total system memory. This feature was added in MaxScale\
 2.3.0.
 
-When the query classifier cache has been enabled, MaxScale will, after a\
-statement has been parsed, store the classification result using the\
+When the query classifier cache has been enabled, MaxScale will, after a
+statement has been parsed, store the classification result using the
 canonicalized version of the statement as the key.
 
-If the classification result for a statement is needed, MaxScale will first\
-canonicalize the statement and check whether the result can be found in the\
-cache. If it can, the statement will not be parsed at all but the cached result\
+If the classification result for a statement is needed, MaxScale will first
+canonicalize the statement and check whether the result can be found in the
+cache. If it can, the statement will not be parsed at all but the cached result
 is used.
 
-The configuration parameter takes one integer that specifies the maximum size of\
+The configuration parameter takes one integer that specifies the maximum size of
 the cache. The size of the cache can be specified as explained [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes).
 
 ```
@@ -1067,17 +1067,17 @@ the cache. The size of the cache can be specified as explained [here](mariadb-ma
 query_classifier_cache_size=1MB
 ```
 
-Note that MaxScale uses a separate cache for each worker thread. To obtain the\
-amount of memory available for each thread, divide the cache size with the value\
-of `threads`. If statements are evicted from the cache (visible in the\
+Note that MaxScale uses a separate cache for each worker thread. To obtain the
+amount of memory available for each thread, divide the cache size with the value
+of `threads`. If statements are evicted from the cache (visible in the
 diagnostic output), consider increasing the cache size.
 
-Note also that limit is not a hard limit, but an approximate one. Namely, although\
-the memory needed for storing the canonicalized statement and the classification\
-result is correctly accounted for, there is additional overhead whose size is not\
+Note also that limit is not a hard limit, but an approximate one. Namely, although
+the memory needed for storing the canonicalized statement and the classification
+result is correctly accounted for, there is additional overhead whose size is not
 exactly known and over which we do not have direct control.
 
-Using `maxctrl show threads` it is possible to check what the actual size of\
+Using `maxctrl show threads` it is possible to check what the actual size of
 the cache is and to see performance statistics.
 
 | Key                | Meaning                                                                                                                 |
@@ -1095,7 +1095,7 @@ the cache is and to see performance statistics.
 * Dynamic: No
 * Default: `""`
 
-Arguments for the query classifier. What arguments are accepted depends on the\
+Arguments for the query classifier. What arguments are accepted depends on the
 particular query classifier being used. The default query classifier -_qc\_sqlite_ - supports the following arguments:
 
 **`log_unrecognized_statements`**
@@ -1103,9 +1103,9 @@ particular query classifier being used. The default query classifier -_qc\_sqlit
 An integer argument taking the following values:
 
 * 0: Nothing is logged. This is the default.
-* 1: Statements that cannot be parsed completely are logged. They may have been\
+* 1: Statements that cannot be parsed completely are logged. They may have been
   partially parsed, or classified based on keyword matching.
-* 2: Statements that cannot even be partially parsed are logged. They may have\
+* 2: Statements that cannot even be partially parsed are logged. They may have
   been classified based on keyword matching.
 * 3: Statements that cannot even be classified by keyword matching are logged.
 
@@ -1114,8 +1114,8 @@ query_classifier=qc_sqlite
 query_classifier_args=log_unrecognized_statements=1
 ```
 
-This will log all statements that cannot be parsed completely. This may be\
-useful if you suspect that MariaDB MaxScale routes statements to the wrong\
+This will log all statements that cannot be parsed completely. This may be
+useful if you suspect that MariaDB MaxScale routes statements to the wrong
 server (e.g. to a slave instead of to a master).
 
 #### `substitute_variables`
@@ -1125,15 +1125,15 @@ server (e.g. to a slave instead of to a master).
 * Dynamic: No
 * Default: `false`
 
-Enable or disable the substitution of environment variables in the MaxScale\
-configuration file. If the substitution of variables is enabled and a\
+Enable or disable the substitution of environment variables in the MaxScale
+configuration file. If the substitution of variables is enabled and a
 configuration line like
 
 ```
 some_parameter=$SOME_VALUE
 ```
 
-is encountered, then `$SOME_VALUE` will be replaced with the actual value\
+is encountered, then `$SOME_VALUE` will be replaced with the actual value
 of the environment variable `SOME_VALUE`. Note: _Variable substitution will be made only if '$' is the first character of the value._ _Everything_ following '$' is interpreted as the name of the environment
 variable.
 
@@ -1143,9 +1143,9 @@ variable.
 substitute_variables=true
 ```
 
-The setting of `substitute_variables` will have an effect on all parameters\
-in the all other sections, irrespective of where the `[maxscale]` section\
-is placed in the configuration file. However, in the `[maxscale]` section,\
+The setting of `substitute_variables` will have an effect on all parameters
+in the all other sections, irrespective of where the `[maxscale]` section
+is placed in the configuration file. However, in the `[maxscale]` section,
 to ensure that substitution will take place, place the`substitute_variables=true` line first.
 
 #### `sql_mode`
@@ -1156,7 +1156,7 @@ to ensure that substitution will take place, place the`substitute_variables=true
 * Values: `default`, `oracle`
 * Default: `default`
 
-Specifies whether the query classifier parser should initially expect _MariaDB_\
+Specifies whether the query classifier parser should initially expect _MariaDB_
 or _PL/SQL_ kind of SQL.
 
 The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`oracle` : The parser expects PL/SQL.
@@ -1165,7 +1165,7 @@ The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`orac
 sql_mode=oracle
 ```
 
-**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume\
+**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume
 that `autocommit` initially is off.
 
 At runtime, MariaDB MaxScale will recognize statements like
@@ -1182,12 +1182,12 @@ set sql_mode=default;
 
 and change mode accordingly.
 
-**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also\
-behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave\
+**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also
+behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave
 as if `autocommit` had been turned on.
 
-Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of\
-the server, so the value of `sql_mode` should reflect the sql mode used\
+Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of
+the server, so the value of `sql_mode` should reflect the sql mode used
 when the server is started.
 
 #### `local_address`
@@ -1199,8 +1199,8 @@ when the server is started.
 
 What specific local address/interface to use when connecting to servers.
 
-This can be used for ensuring that MaxScale uses a particular interface\
-when connecting to servers, in case the computer MaxScale is running on\
+This can be used for ensuring that MaxScale uses a particular interface
+when connecting to servers, in case the computer MaxScale is running on
 has multiple interfaces.
 
 ```
@@ -1214,27 +1214,27 @@ local_address=192.168.1.254
 * Dynamic: Yes
 * Default: `30s`
 
-How often, in seconds, MaxScale at most may refresh the users from the\
+How often, in seconds, MaxScale at most may refresh the users from the
 backend server.
 
-MaxScale will at startup load the users from the backend server, but if\
-the authentication of a user fails, MaxScale assumes it is because a new\
-user has been created and will thus refresh the users. By default, MaxScale\
-will do that at most once per 30 seconds and with this configuration option\
-that can be changed. A value of 0 allows infinite refreshes and a negative\
+MaxScale will at startup load the users from the backend server, but if
+the authentication of a user fails, MaxScale assumes it is because a new
+user has been created and will thus refresh the users. By default, MaxScale
+will do that at most once per 30 seconds and with this configuration option
+that can be changed. A value of 0 allows infinite refreshes and a negative
 value disables the refreshing entirely.
 
 ```
 users_refresh_time=120s
 ```
 
-The value is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds\
+In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds
 but, due to a bug, the default value was 0 which allowed infinite refreshes.
 
 #### `users_refresh_interval`
@@ -1244,12 +1244,12 @@ but, due to a bug, the default value was 0 which allowed infinite refreshes.
 * Dynamic: Yes
 * Default: `0s`
 
-How often, in seconds, MaxScale will automatically refresh the users from the\
+How often, in seconds, MaxScale will automatically refresh the users from the
 backend server.
 
-This configuration is used to periodically refresh the backend users, making sure\
-they are up to date. The default value for this setting is 0, meaning the users\
-are not periodically refreshed. However, they can still be refreshed in case of\
+This configuration is used to periodically refresh the backend users, making sure
+they are up to date. The default value for this setting is 0, meaning the users
+are not periodically refreshed. However, they can still be refreshed in case of
 failed authentication depending on `users_refresh_time`.
 
 ```
@@ -1263,13 +1263,13 @@ users_refresh_interval=2h
 * Dynamic: Yes
 * Default: `0`
 
-How many statements MaxScale should store for each session. This is for\
-debugging purposes, as in case of problems it is often of value to be able\
-to find out exactly what statements were sent before a particular\
+How many statements MaxScale should store for each session. This is for
+debugging purposes, as in case of problems it is often of value to be able
+to find out exactly what statements were sent before a particular
 problem turned up.
 
-**Note:** See also `dump_last_statements` using which the actual dumping\
-of the statements is enabled. Unless both of the parameters are defined,\
+**Note:** See also `dump_last_statements` using which the actual dumping
+of the statements is enabled. Unless both of the parameters are defined,
 the statement dumping mechanism doesn't work.
 
 ```
@@ -1284,10 +1284,10 @@ retain_last_statements=20
 * Values: `on_close`, `on_error`, `never`
 * Default: `never`
 
-With this configuration item it is specified in what circumstances MaxScale\
-should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never\
-logged, with `on_error` they are logged if the client closes the connection\
-improperly, and with `on_close` they are always logged when a client session\
+With this configuration item it is specified in what circumstances MaxScale
+should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never
+logged, with `on_error` they are logged if the client closes the connection
+improperly, and with `on_close` they are always logged when a client session
 is closed.
 
 ```
@@ -1295,7 +1295,7 @@ dump_last_statements=on_error
 ```
 
 Note that you need to specify with `retain_last_statements` how many statements\
-MaxScale should retain for each session. Unless it has been set to another value\
+MaxScale should retain for each session. Unless it has been set to another value
 than `0`, this configuration setting will not have an effect.
 
 #### `session_trace`
@@ -1305,8 +1305,8 @@ than `0`, this configuration setting will not have an effect.
 * Dynamic: Yes
 * Default: `0`
 
-How many log entries are stored in the session specific trace log. This log is\
-written to disk when a session ends abnormally and can be used for debugging\
+How many log entries are stored in the session specific trace log. This log is
+written to disk when a session ends abnormally and can be used for debugging
 purposes. Currently the session trace log is written to the log in the following situations:
 
 * When MaxScale receives a fatal signal and is about to crash.
@@ -1314,8 +1314,8 @@ purposes. Currently the session trace log is written to the log in the following
 * If the session is not closed gracefully (i.e. client doesn't send a COM\_QUIT packet)
 * Whenever readwritesplit receives a response that is was not expecting.
 
-It would be good to enable this if a session is disconnected and the log is not\
-detailed enough. In this case the info log might reveal the true cause of why\
+It would be good to enable this if a session is disconnected and the log is not
+detailed enough. In this case the info log might reveal the true cause of why
 the connection was closed.
 
 ```
@@ -1327,9 +1327,9 @@ Default is `0`.
 The session trace log is also exposed by REST API and is shown with`maxctrl show sessions`.
 
 The order in which the session trace messages are logged into the log changed in\
-MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal\
-log order" of older events coming first and newer events appearing later in the\
-file. Older versions of MaxScale logged the trace dump in the reverse order with\
+MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal
+log order" of older events coming first and newer events appearing later in the
+file. Older versions of MaxScale logged the trace dump in the reverse order with
 the newest messages first and oldest ones last.
 
 #### `session_trace_match`
@@ -1339,17 +1339,17 @@ the newest messages first and oldest ones last.
 * Dynamic: Yes
 * Default: None
 
-If both `session_trace` and `session_trace_match` are defined, and a trace log\
-entry of a session matches the regular expression, the trace log is written to\
+If both `session_trace` and `session_trace_match` are defined, and a trace log
+entry of a session matches the regular expression, the trace log is written to
 disk. The check for the match is done when the session is stopping.
 
-The most effective way to debug MaxScale related issues is to turn on `log_info`\
-and observe the events written into the MaxScale log. The only problem with this\
-approach is that it can cause a severe performance bottleneck and can easily\
-fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged\
+The most effective way to debug MaxScale related issues is to turn on `log_info`
+and observe the events written into the MaxScale log. The only problem with this
+approach is that it can cause a severe performance bottleneck and can easily
+fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged
 can be filtered to only what is needed.
 
-For example, the following configuration would only log the trace log messages\
+For example, the following configuration would only log the trace log messages
 from sessions that execute SQL queries with syntax errors:
 
 ```
@@ -1357,10 +1357,10 @@ session_trace=1000
 session_trace_match=/You have an error in your SQL syntax/
 ```
 
-This could be used to easily identify which applications execute the queries\
-without having to gather the info level log output from all the sessions that\
-connect to MaxScale. For every session that ends up logging a syntax error\
-message, the last 1000 lines of log output done by that session is written into\
+This could be used to easily identify which applications execute the queries
+without having to gather the info level log output from all the sessions that
+connect to MaxScale. For every session that ends up logging a syntax error
+message, the last 1000 lines of log output done by that session is written into
 the MaxScale log.
 
 #### `writeq_high_water`
@@ -1370,20 +1370,20 @@ the MaxScale log.
 * Dynamic: Yes
 * Default: `65536`
 
-High water mark for network write buffer. When the size of the outbound network\
-buffer in MaxScale for a single connection exceeds this value, network traffic\
-throttling for that connection is started. The parameter accepts [size type\
+High water mark for network write buffer. When the size of the outbound network
+buffer in MaxScale for a single connection exceeds this value, network traffic
+throttling for that connection is started. The parameter accepts [size type
 values](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes). The default value was 16777216 bytes before 22.08.4.
 
-More specifically, if the client side write queue is above this value, it will\
-block traffic coming from backend servers. If the backend side write queue is\
+More specifically, if the client side write queue is above this value, it will
+block traffic coming from backend servers. If the backend side write queue is
 above this value, it will block traffic from client.
 
-The buffer that this parameter controls is the buffer internal to MaxScale and\
-is not the kernel TCP send buffer. This means that the total amount of buffered\
+The buffer that this parameter controls is the buffer internal to MaxScale and
+is not the kernel TCP send buffer. This means that the total amount of buffered
 data is determined by both the kernel TCP buffers and the value of`writeq_high_water`.
 
-Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value\
+Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value
 to 0.
 
 #### `writeq_low_water`
@@ -1393,13 +1393,13 @@ to 0.
 * Dynamic: Yes
 * Default: `1024`
 
-Low water mark for network write buffer. Once the traffic throttling is enabled,\
-it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes). The\
+Low water mark for network write buffer. Once the traffic throttling is enabled,
+it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes). The
 default value was 8192 bytes before 22.08.4.
 
 The value of `writeq_high_water` must always be greater than the value of`writeq_low_water`.
 
-Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value\
+Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value
 to 0.
 
 #### `persist_runtime_changes`
@@ -1410,10 +1410,10 @@ to 0.
 
 Persist changes done at runtime. This parameter was added in MaxScale 22.08.0.
 
-When `persist_runtime_changes` is enabled, runtime configuration changes done\
-with the GUI, MaxCtrl or via the REST API cause a new configuration file to be\
-saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is\
-enabled, these files will be applied on top of any existing values found in\
+When `persist_runtime_changes` is enabled, runtime configuration changes done
+with the GUI, MaxCtrl or via the REST API cause a new configuration file to be
+saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is
+enabled, these files will be applied on top of any existing values found in
 static configuration files whenever MaxScale is starting up.
 
 #### `load_persisted_configs`
@@ -1426,11 +1426,11 @@ static configuration files whenever MaxScale is starting up.
 Load persisted runtime changes on startup. This parameter was added in MaxScale\
 2.3.6.
 
-All runtime configuration changes are persisted in generated configuration files\
-located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on\
-startup after main configuration files have been read. To make runtime\
-configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores\
-the current runtime state of MaxScale. This makes problem analysis easier if an\
+All runtime configuration changes are persisted in generated configuration files
+located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on
+startup after main configuration files have been read. To make runtime
+configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores
+the current runtime state of MaxScale. This makes problem analysis easier if an
 unexpected outage happens.
 
 #### `max_auth_errors_until_block`
@@ -1440,14 +1440,14 @@ unexpected outage happens.
 * Dynamic: Yes
 * Default: `10`
 
-The maximum number of authentication failures that are tolerated before a host\
-is temporarily blocked. The default value is 10 failures. After a host is\
-blocked, connections from it are rejected for 60 seconds. To disable this\
+The maximum number of authentication failures that are tolerated before a host
+is temporarily blocked. The default value is 10 failures. After a host is
+blocked, connections from it are rejected for 60 seconds. To disable this
 feature, set the value to 0.
 
-Note that the configured value is not a hard limit. The number of tolerated\
-failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the\
-configured value of this parameter and `threads` is the number of configured\
+Note that the configured value is not a hard limit. The number of tolerated
+failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the
+configured value of this parameter and `threads` is the number of configured
 threads.
 
 #### `debug`
@@ -1457,16 +1457,16 @@ threads.
 * Dynamic: No
 * Default: `""`
 
-Define debug options from the --debug command line option. Either the command\
-line option or the parameter should be used, not both. The debug options are\
+Define debug options from the --debug command line option. Either the command
+line option or the parameter should be used, not both. The debug options are
 only for testing purposes and are not to be used in production.
 
 #### REST API Configuration
 
-The MaxScale REST API is an HTTP interface that provides JSON format data\
+The MaxScale REST API is an HTTP interface that provides JSON format data
 intended to be consumed by monitoring applications and visualization tools.
 
-The following options must be defined under the `[maxscale]` section in the\
+The following options must be defined under the `[maxscale]` section in the
 configuration file.
 
 #### `admin_host`
@@ -1495,8 +1495,8 @@ The port where the REST API listens on. The default value is port 8989.
 * Dynamic: No
 * Default: `true`
 
-Enable REST API authentication using HTTP Basic Access\
-authentication. This is not a secure method of authentication without HTTPS but\
+Enable REST API authentication using HTTP Basic Access
+authentication. This is not a secure method of authentication without HTTPS but
 it does add a small layer of security.
 
 For more information, read the [REST API documentation](../mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-rest-api.md).
@@ -1510,11 +1510,11 @@ For more information, read the [REST API documentation](../mariadb-maxscale-2208
 
 The path to the TLS private key in PEM format for the admin interface.
 
-If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin\
+If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin
 interface will use encrypted HTTPS instead of plain HTTP.
 
-The REST-API only supports PKCS#8 PEM private keys and using a PKCS#1 PEM\
-private key will result in an error. If your private key is in PKCS#1 PEM\
+The REST-API only supports PKCS#8 PEM private keys and using a PKCS#1 PEM
+private key will result in an error. If your private key is in PKCS#1 PEM
 format, convert it to PKCS#8 PEM format first before starting up MaxScale.
 
 #### `admin_ssl_cert`
@@ -1524,7 +1524,7 @@ format, convert it to PKCS#8 PEM format first before starting up MaxScale.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS public certificate in PEM format. See `admin_ssl_key`\
+The path to the TLS public certificate in PEM format. See `admin_ssl_key`
 documentation for more details.
 
 #### `admin_ssl_ca_cert`
@@ -1538,11 +1538,11 @@ Deprecated since MariaDB MaxScale 22.08. See `admin_ssl_ca`.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS CA certificate in PEM format. If defined, the client\
-certificate, if provided, will be validated against it. This parameter is\
+The path to the TLS CA certificate in PEM format. If defined, the client
+certificate, if provided, will be validated against it. This parameter is
 optional starting with MaxScale 2.3.19.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,
 which is still accepted as an alias for `admin_ssl_ca`.
 
 #### `admin_ssl_version`
@@ -1553,7 +1553,7 @@ which is still accepted as an alias for `admin_ssl_ca`.
 * Values: `MAX`, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`, `TLSv10`, `TLSv11`, `TLSv12`, `TLSv13`
 * Default: `MAX`
 
-This parameter controls the enabled TLS versions in the REST API. Accepted\
+This parameter controls the enabled TLS versions in the REST API. Accepted
 values are:
 
 * `TLSv10`
@@ -1562,7 +1562,7 @@ values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -1570,19 +1570,19 @@ releases accept also the following alias values:
 * `TLSv1.2`
 * `TLSv1.3` (not supported on OpenSSL 1.0)
 
-The default value is `MAX` which negotiates the highest level of encryption that\
-both the client and server support. The list of supported TLS versions depends\
+The default value is `MAX` which negotiates the highest level of encryption that
+both the client and server support. The list of supported TLS versions depends
 on the operating system and what TLS versions the GnuTLS library supports.
 
 For example, to enable only TLSv1.1 and TLSv1.3, use`admin_ssl_version=TLSv1.1,TLSv1.3`.
 
 This parameter was added in MaxScale 2.5.7.
 
-Older versions of MaxScale interpreted `admin_ssl_version` as the minimum\
+Older versions of MaxScale interpreted `admin_ssl_version` as the minimum
 allowed TLS version. In those versions, `admin_ssl_version=TLSv1.2` allowed both\
-TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2\
-and all newer versions, the value is a enumeration of accepted TLS protocol\
-versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To\
+TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2
+and all newer versions, the value is a enumeration of accepted TLS protocol
+versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To
 retain the old behavior, specify all the accepted values with`admin_ssl_version=TLSv1.2,TLSv1.3`
 
 #### `admin_enabled`
@@ -1592,7 +1592,7 @@ retain the old behavior, specify all the accepted values with`admin_ssl_version=
 * Dynamic: No
 * Default: `true`
 
-Enable or disable the admin interface. This allows the admin interface to\
+Enable or disable the admin interface. This allows the admin interface to
 be completely disabled to prevent access to it.
 
 #### `admin_gui`
@@ -1605,9 +1605,9 @@ be completely disabled to prevent access to it.
 Enable or disable the admin graphical user interface.
 
 MaxScale provides a GUI for administrative operations via the REST API. When the\
-GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will\
-serve the GUI. When disabled, the REST API will respond with a 200 OK to the\
-request. By disabling the GUI, the root resource can be used as a low overhead\
+GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will
+serve the GUI. When disabled, the REST API will respond with a 200 OK to the
+request. By disabling the GUI, the root resource can be used as a low overhead
 health check.
 
 #### `admin_secure_gui`
@@ -1619,10 +1619,10 @@ health check.
 
 Whether to serve the GUI only over secure HTTPS connections.
 
-To be secure by default, the GUI is only served over HTTPS connections as\
+To be secure by default, the GUI is only served over HTTPS connections as
 it uses a token authentication scheme. This also controls whether the`/auth` endpoint requires an encrypted connection.
 
-To allow use of the GUI without having to configure TLS certificates for\
+To allow use of the GUI without having to configure TLS certificates for
 the MaxScale REST API, set this parameter to false.
 
 #### `admin_log_auth_failures`
@@ -1641,17 +1641,17 @@ Log authentication failures for the admin interface.
 * Dynamic: No
 * Default: `""`
 
-Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings\
-accept a PAM service name which is used during authentication if normal authentication\
+Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings
+accept a PAM service name which is used during authentication if normal authentication
 fails. `admin_pam_readwrite_service` should accept users who can do any\
-MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only\
-do read operations. Because REST-API does not support back and forth communication between\
-the client and MaxScale, the PAM services must be simple. They should only ask for the\
+MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only
+do read operations. Because REST-API does not support back and forth communication between
+the client and MaxScale, the PAM services must be simple. They should only ask for the
 password and nothing else.
 
-If only `admin_pam_readwrite_service` is configured, both read and write operations can be\
-authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read\
-operations can be authenticated by PAM. If both are set, the service used is determined by\
+If only `admin_pam_readwrite_service` is configured, both read and write operations can be
+authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read
+operations can be authenticated by PAM. If both are set, the service used is determined by
 the requested operation. Leave or set both empty to disable PAM for REST-API.
 
 #### `admin_jwt_algorithm`
@@ -1665,47 +1665,47 @@ the requested operation. Leave or set both empty to disable PAM for REST-API.
 The signature algorithm used by the MaxScale REST API when generating JSON Web\
 Tokens.
 
-For more information about the tokens and how they work, refer to [the REST API\
+For more information about the tokens and how they work, refer to [the REST API
 documentation](../mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-rest-api.md).
 
-If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale\
-will generate a random encryption key on startup and use that to sign the\
+If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale
+will generate a random encryption key on startup and use that to sign the
 messages. The symmetric key can also be retrieved from an [Encryption Key\
 Manager](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#encryption-key-managers) if the `admin_jwt_key` parameter is defined.
 
-If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must\
-contain a private key and a public certificate of the correct type. If the wrong\
+If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must
+contain a private key and a public certificate of the correct type. If the wrong
 key type, key length or elliptic curve is used, MaxScale will refuse to start.
 
-Asymmetric key algorithms make it possible for the clients of the REST API to\
+Asymmetric key algorithms make it possible for the clients of the REST API to
 validate that the token was indeed generated by the correct entity.
 
-Symmetric algorithms make it easy to share the same tokens between\
-multiple MaxScale instances as the shared secret can be stored in a key\
+Symmetric algorithms make it easy to share the same tokens between
+multiple MaxScale instances as the shared secret can be stored in a key
 management system.
 
 The possible values for this parameter are:
 
 * `auto`
-* MaxScale will attempt to detect the best algorithm to use for\
+* MaxScale will attempt to detect the best algorithm to use for
   signatures. The algorithm used depends on the private key type: RSA keys use`PS256`, EC keys use the `ES256`, `ES384` or `ES512` depending on the curve,\
-  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot\
+  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot
   auto-detect the key type, it falls back to `HS256` as the default algorithm.
 * `HS256`, `HS384` or `HS512`
 * [HMAC with SHA-2\
-  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct\
+  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct
   size.
 * `RS256`, `RS384` or `RS512`
 * [Digital Signature with\
-  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires\
+  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires
   at least a 2048-bit RSA key.
 * `PS256`, `PS384` or `PS512`
 * [Digital Signature with\
-  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires\
+  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires
   at least a 2048-bit RSA key.
 * `ES256`, `ES384` or `ES512`
 * [Digital Signature with\
-  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires\
+  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires
   an EC key with the correct curve: P-256 for `ES256`, P-384 for `ES384` and\
   P-512 for `ES512`.
 * `ED25519` or `ED448`
@@ -1720,15 +1720,15 @@ The possible values for this parameter are:
 * Dynamic: No
 * Default: `""`
 
-The ID for the encryption key used to sign the JSON Web Tokens. If configured,\
-an [Encryption Key Manager](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured\
-and it must contain the key with the given ID. If no key is defined, MaxScale\
-will use a random encryption key whenever a symmetric signature algorithm is\
+The ID for the encryption key used to sign the JSON Web Tokens. If configured,
+an [Encryption Key Manager](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured
+and it must contain the key with the given ID. If no key is defined, MaxScale
+will use a random encryption key whenever a symmetric signature algorithm is
 used.
 
-Currently, the encryption key is only read on startup. This means that the\
+Currently, the encryption key is only read on startup. This means that the
 tokens will be signed by the latest key version that is available on startup:\
-rotating the encryption key in the key management system will not cause the JWTs\
+rotating the encryption key in the key management system will not cause the JWTs
 to be signed with newer versions of the key.
 
 #### `admin_oidc_url`
@@ -1740,19 +1740,19 @@ to be signed with newer versions of the key.
 
 The URL to a OpenID Connect server that is used for JWT validation.
 
-If defined, any tokens signed by this server are accepted as valid bearer tokens\
-for the MaxScale REST API. The `"sub"` field of the token is assumed to be the\
-username of an administrative user in MaxScale and the `"account"` claim is\
-assumed to be the type of the user: `"admin"` for administrative users with full\
+If defined, any tokens signed by this server are accepted as valid bearer tokens
+for the MaxScale REST API. The `"sub"` field of the token is assumed to be the
+username of an administrative user in MaxScale and the `"account"` claim is
+assumed to be the type of the user: `"admin"` for administrative users with full
 access to the REST-API and `"basic"` for users with read-only access to the\
 REST-API. This means that all users must be first created with `maxctrl create user` before the tokens are accepted if the OIDC provider is not able to add the`"account"` claim.
 
-Modifying `admin_oidc_url` will cause the certificates to be fetched\
-again. They are also fetched when the `maxctrl reload tls` command is\
-executed or when the `admin_ssl_cert` and `admin_ssl_key` settings are\
+Modifying `admin_oidc_url` will cause the certificates to be fetched
+again. They are also fetched when the `maxctrl reload tls` command is
+executed or when the `admin_ssl_cert` and `admin_ssl_key` settings are
 modified.
 
-MaxScale versions 22.08.16 and earlier only fetched the new certificates when\
+MaxScale versions 22.08.16 and earlier only fetched the new certificates when
 the `maxctrl reload tls` command was executed.
 
 #### `admin_verify_url`
@@ -1764,19 +1764,19 @@ the `maxctrl reload tls` command was executed.
 
 URL to a server to which the REST API token verification is delegated.
 
-If the URL is defined, any tokens passed to the REST API will be validated by\
-doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client\
+If the URL is defined, any tokens passed to the REST API will be validated by
+doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client
 and the custom `X-Referrer-Method` header is set to the HTTP method being used\
 (PUT, GET etc.).
 
-**Note**: When `admin_verify_url` is used and the remote server cannot\
-be accessed, all REST API access that uses tokens will be disabled. The\
-only way to use the REST API with tokens is to remove `admin_verify_url`\
-from the configuration which requires restarting MaxScale. The REST API\
-still accepts HTTP Basic Access authentication even if the remote server\
+**Note**: When `admin_verify_url` is used and the remote server cannot
+be accessed, all REST API access that uses tokens will be disabled. The
+only way to use the REST API with tokens is to remove `admin_verify_url`
+from the configuration which requires restarting MaxScale. The REST API
+still accepts HTTP Basic Access authentication even if the remote server
 cannot be reached.
 
-By delegating the authentication and authorization of the REST API to an\
+By delegating the authentication and authorization of the REST API to an
 external server, users can implement custom access control systems for the\
 MaxScale REST API.
 
@@ -1787,10 +1787,10 @@ MaxScale REST API.
 * Dynamic: Yes
 * Default: None
 
-This parameter controls which cluster (i.e. monitor) is used to synchronize\
+This parameter controls which cluster (i.e. monitor) is used to synchronize
 configuration changes between MaxScale instances. The first server labeled`Master` will be used for the synchronization.
 
-By default configuration synchronization is not enabled and it must be\
+By default configuration synchronization is not enabled and it must be
 explicitly enabled by defining a monitor name for `config_sync_cluster`.
 
 When `config_sync_cluster` is defined, `config_sync_user` and`config_sync_password` must also be defined.
@@ -1805,8 +1805,8 @@ Synchronization](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#c
 * Dynamic: Yes
 * Default: None
 
-The username for the account that is used to synchronize configuration changes\
-across MaxScale instances. Both this parameter and `config_sync_password` are\
+The username for the account that is used to synchronize configuration changes
+across MaxScale instances. Both this parameter and `config_sync_password` are
 required if `config_sync_cluster` is configured.
 
 This account must have the following grants:
@@ -1815,7 +1815,7 @@ This account must have the following grants:
 GRANT SELECT, INSERT, UPDATE, CREATE ON `mysql`.`maxscale_config`
 ```
 
-The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`\
+The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`
 grant is not needed by the user configured in `config_sync_user`. The following\
 SQL is used to create the table.
 
@@ -1829,7 +1829,7 @@ CREATE TABLE IF NOT EXISTS mysql.maxscale_config(
 ) ENGINE=InnoDB;
 ```
 
-If the database where the table is created is changed with `config_sync_db`, the\
+If the database where the table is created is changed with `config_sync_db`, the
 grants must be adjusted to target that database instead.
 
 #### `config_sync_password`
@@ -1839,8 +1839,8 @@ grants must be adjusted to target that database instead.
 * Dynamic: Yes
 * Default: None
 
-The password for `config_sync_user`. Both this parameter and `config_sync_user`\
-are required if `config_sync_cluster` is configured. This password can\
+The password for `config_sync_user`. Both this parameter and `config_sync_user`
+are required if `config_sync_cluster` is configured. This password can
 optionally be encrypted using `maxpasswd`.
 
 #### `config_sync_db`
@@ -1850,13 +1850,13 @@ optionally be encrypted using `maxpasswd`.
 * Dynamic: No
 * Default: `mysql`
 
-The database where the `maxscale_config` table is created. By default the table\
-is created in the `mysql` database. This parameter was added in MaxScale\
+The database where the `maxscale_config` table is created. By default the table
+is created in the `mysql` database. This parameter was added in MaxScale
 versions 6.4.6 and 22.08.5.
 
-As tables in the `mysql` database cannot have triggers on them, the database\
+As tables in the `mysql` database cannot have triggers on them, the database
 must be changed to a user-created one in order to create triggers on the table.\
-An example use-case for triggers on this table is to track all configuration\
+An example use-case for triggers on this table is to track all configuration
 changes done to MaxScale by inserting them into a separate table.
 
 #### `config_sync_interval`
@@ -1868,9 +1868,9 @@ changes done to MaxScale by inserting them into a separate table.
 
 How often to synchronize the configuration with the cluster.
 
-As the synchronization involves selecting the configuration version from the\
-database, this value should not be set to an unreasonably low value. The default\
-value of 5 second should provide a good compromise between responsiveness and\
+As the synchronization involves selecting the configuration version from the
+database, this value should not be set to an unreasonably low value. The default
+value of 5 second should provide a good compromise between responsiveness and
 how much load it places on the database.
 
 #### `config_sync_timeout`
@@ -1880,8 +1880,8 @@ how much load it places on the database.
 * Dynamic: Yes
 * Default: `10s`
 
-Timeout for all SQL operations done during the configuration synchronization. If\
-an operation exceeds this timeout, the configuration change is treated as failed\
+Timeout for all SQL operations done during the configuration synchronization. If
+an operation exceeds this timeout, the configuration change is treated as failed
 and an error is reported to the client that did the change.
 
 #### `key_manager`
@@ -1896,13 +1896,13 @@ The encryption key manager to use. The available encryption key managers are:
 * `none` - No key manager, encryption keys are not available.
 * `file` - [File-based key manager](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#file-based-key-manager)
 * `kmip` - [KMIP key manager](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#kmip-key-manager)
-* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This\
-  key manager is only included on systems with GCC 9 or newer which\
+* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This
+  key manager is only included on systems with GCC 9 or newer which
   means it cannot be used on Ubuntu 18.04.
 
-Refer to the [Encryption Key Managers](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for\
-more information on how to configure the key managers. The key managers each\
-have their configuration in their own namespace and must have their name as a\
+Refer to the [Encryption Key Managers](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for
+more information on how to configure the key managers. The key managers each
+have their configuration in their own namespace and must have their name as a
 prefix.
 
 For example to configure the `file` key manager, the following must be used:
@@ -1914,16 +1914,16 @@ file.keyfile=/path/to/keyfile
 
 ### Events
 
-MaxScale logs warnings and errors for various reasons and often it is self-\
-evident and generally applicable whether some occurrence should warrant a\
+MaxScale logs warnings and errors for various reasons and often it is self-
+evident and generally applicable whether some occurrence should warrant a
 warning or an error, or perhaps just an info-level message.
 
-However, there are events whose seriousness is not self-evident. For\
-instance, in some environments an authentication failure may simply indicate\
-that someone has made a typo, while in some other environment that can only\
+However, there are events whose seriousness is not self-evident. For
+instance, in some environments an authentication failure may simply indicate
+that someone has made a typo, while in some other environment that can only
 happen in case there has been a security breech.
 
-To handle events like these, MaxScale defines _events_ whose logging\
+To handle events like these, MaxScale defines _events_ whose logging
 facility and level can be controlled by the administrator. Given an event`X`, its facility and level are controlled in the following manner:
 
 ```
@@ -1931,21 +1931,21 @@ event.X.facility=LOG_LOCAL0
 event.X.level=LOG_ERR
 ```
 
-The above means that if event _X_ occurs, then that is logged using the\
+The above means that if event _X_ occurs, then that is logged using the
 facility `LOG_LOCAL0` and the level `LOG_ERR`.
 
-The valid values of facility`are the facility values reported by`man\
+The valid values of facility`are the facility values reported by`man
 syslog`, e.g.`LOG\_AUTH`,`LOG\_LOCAL0`and`LOG\_USER`. Likewise, the valid values for`level`are the ones also reported by`man syslog`, e.g.`LOG\_WARNING`,`LOG\_ERR`and`LOG\_CRIT\`.
 
-Note that MaxScale does not act upon the level, that is, even if the level\
-of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut\
+Note that MaxScale does not act upon the level, that is, even if the level
+of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut
 down if that event occurs.
 
 The default facility is `LOG_USER` and the default level is `LOG_WARNING`.
 
-Note that you may also have to configure `rsyslog` to ensure that the\
-event can be logged to the intended log file. For instance, if the facility\
-is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line\
+Note that you may also have to configure `rsyslog` to ensure that the
+event can be logged to the intended log file. For instance, if the facility
+is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line
 like
 
 ```
@@ -1967,22 +1967,22 @@ event.authentication_failure.level=LOG_CRIT
 
 ### Service
 
-A service represents the database service that MariaDB MaxScale offers to the\
-clients. In general a service consists of a set of backend database servers and\
-a routing algorithm that determines how MariaDB MaxScale decides to send\
+A service represents the database service that MariaDB MaxScale offers to the
+clients. In general a service consists of a set of backend database servers and
+a routing algorithm that determines how MariaDB MaxScale decides to send
 statements or route connections to those backend servers.
 
-A service may be considered as a virtual database server that MariaDB MaxScale\
+A service may be considered as a virtual database server that MariaDB MaxScale
 makes available to its clients.
 
 Several different services may be defined using the same set of backend servers.\
-For example a connection based routing service might be used by clients that\
-already performed internal read/write splitting, whilst a different statement\
-based router may be used by clients that are not written with this functionality\
-in place. Both sets of applications could access the same data in the same\
+For example a connection based routing service might be used by clients that
+already performed internal read/write splitting, whilst a different statement
+based router may be used by clients that are not written with this functionality
+in place. Both sets of applications could access the same data in the same
 databases.
 
-A service is identified by a service name, which is the name of the\
+A service is identified by a service name, which is the name of the
 configuration file section and a type parameter of service.
 
 ```
@@ -1990,9 +1990,9 @@ configuration file section and a type parameter of service.
 type=service
 ```
 
-In order for MariaDB MaxScale to forward any requests it must have at least one\
-service defined within the configuration file. The definition of a service alone\
-is not enough to allow MariaDB MaxScale to forward requests however, the service\
+In order for MariaDB MaxScale to forward any requests it must have at least one
+service defined within the configuration file. The definition of a service alone
+is not enough to allow MariaDB MaxScale to forward requests however, the service
 is merely present to link together the other configuration elements.
 
 #### `router`
@@ -2001,15 +2001,15 @@ is merely present to link together the other configuration elements.
 * Mandatory: Yes
 * Dynamic: No
 
-The router parameter of a service defines the name of the router module that\
+The router parameter of a service defines the name of the router module that
 will be used to implement the routing algorithm between the client of MariaDB\
-MaxScale and the backend databases. Additionally routers may also be passed a\
-comma separated list of options that are used to control the behavior of the\
-routing algorithm. The two parameters that control the routing choice are router\
-and router\_options. The router options are specific to a particular router and\
-are used to modify the behavior of the router. The read connection router can be\
-passed options of master, slave or synced, an example of configuring a service\
-to use this router and limiting the choice of servers to those in slave state\
+MaxScale and the backend databases. Additionally routers may also be passed a
+comma separated list of options that are used to control the behavior of the
+routing algorithm. The two parameters that control the routing choice are router
+and router\_options. The router options are specific to a particular router and
+are used to modify the behavior of the router. The read connection router can be
+passed options of master, slave or synced, an example of configuring a service
+to use this router and limiting the choice of servers to those in slave state
 would be as follows.
 
 ```
@@ -2017,7 +2017,7 @@ router=readconnroute
 router_options=slave
 ```
 
-To change the router to connect on to servers in the master state as well as\
+To change the router to connect on to servers in the master state as well as
 slave servers, the router options can be modified to include the master state.
 
 ```
@@ -2025,7 +2025,7 @@ router=readconnroute
 router_options=master,slave
 ```
 
-A more complete description of router options and what is available for a given\
+A more complete description of router options and what is available for a given
 router is included with the documentation of the router itself.
 
 #### `filters`
@@ -2035,17 +2035,17 @@ router is included with the documentation of the router itself.
 * Dynamic: Yes
 * Default: None
 
-The filters option allow a set of filters to be defined for a service; requests\
-from the client are passed through these filters before being sent to the router\
-for dispatch to the backend server. The filters parameter takes one or more\
-filter names, as defined within the filter definition section of the\
+The filters option allow a set of filters to be defined for a service; requests
+from the client are passed through these filters before being sent to the router
+for dispatch to the backend server. The filters parameter takes one or more
+filter names, as defined within the filter definition section of the
 configuration file. Multiple filters are separated using the | character.
 
 ```
 filters=counter | QLA
 ```
 
-The requests pass through the filters from left to right in the order defined in\
+The requests pass through the filters from left to right in the order defined in
 the configuration parameter.
 
 #### `targets`
@@ -2055,7 +2055,7 @@ the configuration parameter.
 * Dynamic: Yes
 * Default: None
 
-The `targets` parameter is a comma separated list of server and/or service names\
+The `targets` parameter is a comma separated list of server and/or service names
 that comprise the routing targets of the service. This parameter was added in\
 MaxScale 2.5.0.
 
@@ -2063,9 +2063,9 @@ MaxScale 2.5.0.
 targets=My-Service,server2
 ```
 
-This parameter allows nested service configurations to be defined without having\
-to configure listeners for all services. For example, one use-case is to use\
-multiple readwritesplit services behind a schemarouter service to have both the\
+This parameter allows nested service configurations to be defined without having
+to configure listeners for all services. For example, one use-case is to use
+multiple readwritesplit services behind a schemarouter service to have both the
 sharding of schemarouter with the high-availability of readwritesplit.
 
 **NOTE:** The `targets` parameter is mutually exclusive with the `cluster` and`servers` parameters.
@@ -2077,8 +2077,8 @@ sharding of schemarouter with the high-availability of readwritesplit.
 * Dynamic: Yes
 * Default: None
 
-The servers parameter in a service definition provides a comma separated list of\
-the backend servers that comprise the service. The server names are those used\
+The servers parameter in a service definition provides a comma separated list of
+the backend servers that comprise the service. The server names are those used
 in the name section of a block with a type parameter of server (see below).
 
 ```
@@ -2094,7 +2094,7 @@ servers=server1,server2,server3
 * Dynamic: Yes
 * Default: None
 
-The servers the service uses are defined by the monitor specified as value\
+The servers the service uses are defined by the monitor specified as value
 of this configuration parameter.
 
 ```
@@ -2109,7 +2109,7 @@ cluster=TheMonitor
 * Mandatory: Yes
 * Dynamic: Yes
 
-This setting defines the _user_ the service uses to fetch user account\
+This setting defines the _user_ the service uses to fetch user account
 information from backends. A _password_ is specified using [password](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#password).
 
 ```
@@ -2117,8 +2117,8 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
 #### `password`
@@ -2127,9 +2127,9 @@ regarding user account management and client authentication.
 * Mandatory: Yes
 * Dynamic: Yes
 
-This settings defines the _password_ the service uses to fetch user account\
-information from backends. The _password_ may be either a plain text password or\
-an [encrypted password](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified\
+This settings defines the _password_ the service uses to fetch user account
+information from backends. The _password_ may be either a plain text password or
+an [encrypted password](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified
 using [user](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#user).
 
 ```
@@ -2137,8 +2137,8 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
 #### `enable_root_user`
@@ -2162,7 +2162,7 @@ Deprecated and ignored.
 * Dynamic: No
 * Default: None
 
-This parameter sets a custom version string that is sent in the MySQL Handshake\
+This parameter sets a custom version string that is sent in the MySQL Handshake
 from MariaDB MaxScale to clients.
 
 Example:
@@ -2171,13 +2171,13 @@ Example:
 version_string=10.11.2-MariaDB-RWsplit
 ```
 
-If not set, MaxScale will attempt to use a version string from the\
-backend databases by selecting the version string of the database with\
+If not set, MaxScale will attempt to use a version string from the
+backend databases by selecting the version string of the database with
 the lowest version number. If the selected version is from the MariaDB\
 10 series, a `5.5.5-` prefix will be added to it similarly to how the\
 MariaDB 10 series versions added it.
 
-If MaxScale has not been able to connect to a single database and the\
+If MaxScale has not been able to connect to a single database and the
 versions are unknown, the default value of `5.5.5-10.4.32 <MaxScale version>-maxscale` is used where `<MaxScale version>` is the version of\
 MaxScale.
 
@@ -2188,11 +2188,11 @@ MaxScale.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether only a single server or all of the servers are\
+This parameter controls whether only a single server or all of the servers are
 used when loading the users from the backend servers.
 
-By default MaxScale uses the first server labeled as `Master` as the source of\
-the authentication data. When this option is enabled, the authentication data is\
+By default MaxScale uses the first server labeled as `Master` as the source of
+the authentication data. When this option is enabled, the authentication data is
 loaded from all the servers and combined into one big data set.
 
 #### `strip_db_esc`
@@ -2207,12 +2207,12 @@ names when loading user grants from a backend server. When enabled, a grant\
 such as `grant select on` test\_`.* to 'user'@'%';` is read as `grant select on` test\_`.* to 'user'@'%';`
 
 This setting has no effect on database-level grants fetched from a MariaDB\
-Server. The database names of a MariaDB Server are compared using the LIKE\
-operator to properly handle wildcards and escaped wildcards. This setting may\
-affect database names in table and column level grants, although these typically\
+Server. The database names of a MariaDB Server are compared using the LIKE
+operator to properly handle wildcards and escaped wildcards. This setting may
+affect database names in table and column level grants, although these typically
 do not contain backlashes.
 
-Some visual database management tools automatically escape some characters and\
+Some visual database management tools automatically escape some characters and
 this might cause conflicts when MaxScale tries to authenticate users.
 
 #### `log_auth_warnings`
@@ -2222,8 +2222,8 @@ this might cause conflicts when MaxScale tries to authenticate users.
 * Dynamic: Yes
 * Default: `true`
 
-Enable or disable the logging of authentication failures and warnings. If\
-enabled, messages about failed authentication attempts will be logged with\
+Enable or disable the logging of authentication failures and warnings. If
+enabled, messages about failed authentication attempts will be logged with
 details about who tried to connect to MariaDB MaxScale and from where.
 
 #### `log_warning`
@@ -2233,10 +2233,10 @@ details about who tried to connect to MariaDB MaxScale and from where.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log warning messages even if the global\
+When enabled, this allows a service to log warning messages even if the global
 log level configuration disables them.
 
-Note that disabling the service level logging does not override the global\
+Note that disabling the service level logging does not override the global
 logging configuration: with `log_warning=false` in the service and`log_warning=true` globally, warnings will still be logged for all services.
 
 #### `log_notice`
@@ -2246,7 +2246,7 @@ logging configuration: with `log_warning=false` in the service and`log_warning=t
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log notice messages even if the global\
+When enabled, this allows a service to log notice messages even if the global
 log level configuration disables them.
 
 #### `log_info`
@@ -2256,7 +2256,7 @@ log level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log info messages even if the global log\
+When enabled, this allows a service to log info messages even if the global log
 level configuration disables them.
 
 #### `log_debug`
@@ -2266,10 +2266,10 @@ level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log debug messages even if the global log\
+When enabled, this allows a service to log debug messages even if the global log
 level configuration disables them.
 
-Debug messages are only enabled for debug builds. Enabling `log_debug` in a\
+Debug messages are only enabled for debug builds. Enabling `log_debug` in a
 release build does nothing.
 
 #### `connection_timeout`
@@ -2281,35 +2281,35 @@ release build does nothing.
 * Auto tune: [Yes](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#auto_tune)
 
 The connection\_timeout parameter is used to disconnect sessions to MariaDB\
-MaxScale that have been idle for too long. The session timeouts are disabled by\
-default. To enable them, define the timeout in seconds in the service's\
-configuration section. A value of zero is interpreted as no timeout, the same\
+MaxScale that have been idle for too long. The session timeouts are disabled by
+default. To enable them, define the timeout in seconds in the service's
+configuration section. A value of zero is interpreted as no timeout, the same
 as if the parameter is not defined.
 
-The value is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `connection_timeout` for those is not used.
 
-The value of `connection_timeout` should be lower than the lowest `wait_timeout`\
-value on the backend servers. This way idle clients are disconnected by MaxScale\
-before the backend servers have to close them. Any client-side idle timeouts\
-(e.g. maximum lifetime for connection pools) should be lower than both`connection_timeout` and `wait_timeout`. This way the client application will\
-end up closing the connection itself which most of the time results in better\
+The value of `connection_timeout` should be lower than the lowest `wait_timeout`
+value on the backend servers. This way idle clients are disconnected by MaxScale
+before the backend servers have to close them. Any client-side idle timeouts
+(e.g. maximum lifetime for connection pools) should be lower than both`connection_timeout` and `wait_timeout`. This way the client application will
+end up closing the connection itself which most of the time results in better
 and more helpful error messages.
 
-**Warning:** If a connection is idle for longer than the configured connection\
+**Warning:** If a connection is idle for longer than the configured connection
 timeout, it will be forcefully disconnected and a warning will be logged in the\
 MaxScale log file.
 
-In MaxScale versions 6.2.0 and older, if long-running operations (e.g. `ALTER TABLE`) were performed, MaxScale would close the connections if they look longer\
+In MaxScale versions 6.2.0 and older, if long-running operations (e.g. `ALTER TABLE`) were performed, MaxScale would close the connections if they look longer
 than `connection_timeout` seconds to execute\
-([MXS-3893](https://jira.mariadb.org/browse/MXS-3893)). In MaxScale 6.2.1 this\
+([MXS-3893](https://jira.mariadb.org/browse/MXS-3893)). In MaxScale 6.2.1 this
 has been fixed and the active operations are now correctly tracked.
 
 Example:
@@ -2326,13 +2326,13 @@ connection_timeout=300s
 * Dynamic: Yes
 * Default: `0`
 
-The maximum number of simultaneous connections MaxScale should permit to this\
-service. If the parameter is zero or is omitted, there is no limit. Any attempt\
-to make more connections after the limit is reached will result in a "Too many\
+The maximum number of simultaneous connections MaxScale should permit to this
+service. If the parameter is zero or is omitted, there is no limit. Any attempt
+to make more connections after the limit is reached will result in a "Too many
 connections" error being returned.
 
-**Warning**: In MaxScale 2.5, it is possible that the number of concurrent\
-connections temporarily exceeds the value of `max_connections`. This has been\
+**Warning**: In MaxScale 2.5, it is possible that the number of concurrent
+connections temporarily exceeds the value of `max_connections`. This has been
 fixed in MaxScale 6.
 
 Example:
@@ -2350,19 +2350,19 @@ max_connections=100
 * Default: `false`
 
 Enable transaction state tracking by offloading it to the backend servers.\
-Getting the transaction state from the server will be more accurate for stored\
-procedures or multi-statement SQL that modifies the transaction state\
+Getting the transaction state from the server will be more accurate for stored
+procedures or multi-statement SQL that modifies the transaction state
 non-atomically.
 
-In general, it is better to avoid using this type of SQL as tracking the\
-transaction state via the server responses is not compatible with features such\
-as `transaction_replay` in readwritesplit. `session_track_trx_state` should only\
-be enabled if the default transaction tracking done by MaxScale does not produce\
+In general, it is better to avoid using this type of SQL as tracking the
+transaction state via the server responses is not compatible with features such
+as `transaction_replay` in readwritesplit. `session_track_trx_state` should only
+be enabled if the default transaction tracking done by MaxScale does not produce
 the desired outcome.
 
-This is only supported by MariaDB versions 10.3 or newer. The following must be\
-configured in the MariaDB server in order for this feature to work. Not\
-configuring the MariaDB server with it can result in the transaction state being\
+This is only supported by MariaDB versions 10.3 or newer. The following must be
+configured in the MariaDB server in order for this feature to work. Not
+configuring the MariaDB server with it can result in the transaction state being
 wrong in MaxScale which can result in data inconsistency.
 
 ```
@@ -2379,12 +2379,12 @@ session_track_transaction_info = CHARACTERISTICS
 
 How many statements MaxScale should store for each session of this service.\
 This overrides the value of the global setting with the same name. If`retain_last_statements` has been specified in the global section of the\
-MaxScale configuration file, then if it has _not_ been explicitly specified\
-for the service, the global value holds, otherwise the service specific\
-value rules. That is, it is possible to enable the setting globally and\
+MaxScale configuration file, then if it has _not_ been explicitly specified
+for the service, the global value holds, otherwise the service specific
+value rules. That is, it is possible to enable the setting globally and
 turn it off for a specific service, or just enable it for specific services.
 
-The value of this parameter can be changed at runtime using `maxctrl` and the\
+The value of this parameter can be changed at runtime using `maxctrl` and the
 new value will take effect for sessions created thereafter.
 
 ```
@@ -2399,38 +2399,38 @@ maxctrl alter service MyService retain_last_statements 5
 * Default: `300s`
 * Auto tune: [Yes](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#auto_tune)
 
-Keep idle connections alive by sending pings to backend servers. This feature\
-was introduced in MaxScale 2.5.0 where it was changed from a\
-readwritesplit-specific feature to a generic service feature. The default value\
+Keep idle connections alive by sending pings to backend servers. This feature
+was introduced in MaxScale 2.5.0 where it was changed from a
+readwritesplit-specific feature to a generic service feature. The default value
 for this parameter is 300 seconds. To disable this feature, set the value to 0.
 
-The keepalive interval is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no\
+The keepalive interval is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no
 explicit unit is provided, the value is interpreted as seconds in MaxScale\
-2.5. In subsequent versions a value without a unit may be rejected. Note that\
-since the granularity of the keepalive is seconds, a keepalive specified in\
+2.5. In subsequent versions a value without a unit may be rejected. Note that
+since the granularity of the keepalive is seconds, a keepalive specified in
 milliseconds will be rejected, even if the duration is longer than a second.
 
-The parameter value is the interval in seconds between each keepalive ping. A\
-keepalive ping will be sent to a backend server if the connection has been idle\
+The parameter value is the interval in seconds between each keepalive ping. A
+keepalive ping will be sent to a backend server if the connection has been idle
 for longer than the configured keepalive interval.
 
-Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client\
-has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings\
+Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client
+has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings
 regardless of the client state.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `connection_keepalive` for those is not used.
 
-If the value of `connection_keepalive` is changed at runtime, the change in the\
+If the value of `connection_keepalive` is changed at runtime, the change in the
 value takes effect immediately.
 
-As the connection keepalive pings must be done only when there's no ongoing\
-query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that\
-rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the\
+As the connection keepalive pings must be done only when there's no ongoing
+query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that
+rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the
 performance will be the same with or without `connection_keepalive`.
 
-If you want to avoid the performance cost and you don't need the connection\
+If you want to avoid the performance cost and you don't need the connection
 keepalive feature, you can disable it with `connection_keepalive=0s`.
 
 #### `force_connection_keepalive`
@@ -2440,16 +2440,16 @@ keepalive feature, you can disable it with `connection_keepalive=0s`.
 * Dynamic: Yes
 * Default: `false`
 
-By default, connection keepalive pings are only sent if the client is either\
-executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are\
-unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can\
-be used to emulate the pre-2.5.21 behavior if long-lived application connections\
+By default, connection keepalive pings are only sent if the client is either
+executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are
+unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can
+be used to emulate the pre-2.5.21 behavior if long-lived application connections
 rely on the old unconditional keepalive pings.
 
 _Note:_ if `force_connection_keepalive` is enabled and `connection_keepalive` in\
-MaxScale is set to a lower value than the `wait_timeout` on the database, the\
-client idle timeouts that `wait_timeout` control are no longer effective. This\
-happens because MaxScale unconditionally sends the pings which make the client\
+MaxScale is set to a lower value than the `wait_timeout` on the database, the
+client idle timeouts that `wait_timeout` control are no longer effective. This
+happens because MaxScale unconditionally sends the pings which make the client
 behave like it is not idle and thus the connections will never be killed due to`wait_timeout`.
 
 #### `net_write_timeout`
@@ -2459,17 +2459,17 @@ behave like it is not idle and thus the connections will never be killed due to`
 * Dynamic: Yes
 * Default: `0s`
 
-This parameter controls how long a network write to the client can stay\
+This parameter controls how long a network write to the client can stay
 buffered. This feature is disabled by default.
 
-When `net_write_timeout` is configured and data is buffered on the client\
-network connection, if the time since the last successful network write exceeds\
+When `net_write_timeout` is configured and data is buffered on the client
+network connection, if the time since the last successful network write exceeds
 the configured limit, the client connection will be disconnected.
 
-The value is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `max_sescmd_history`
@@ -2479,45 +2479,45 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `50`
 
-`max_sescmd_history` sets a limit on how many distinct session commands are\
-stored in the session command history. When the history limit is exceeded, the\
-history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server\
+`max_sescmd_history` sets a limit on how many distinct session commands are
+stored in the session command history. When the history limit is exceeded, the
+history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server
 reconnections are no longer possible.
 
-The required history size can be estimated by counting the total number of\
-session state modifying commands (e.g `SET NAMES`) that are used by a\
-client. Note that connectors usually add some commands that aren't visible to\
-the application developer which means a safety margin should be added. A good\
-rule of thumb is to count the expected number of statements and double that\
-number. The default value of 50 is a value that'll work for most applications\
+The required history size can be estimated by counting the total number of
+session state modifying commands (e.g `SET NAMES`) that are used by a
+client. Note that connectors usually add some commands that aren't visible to
+the application developer which means a safety margin should be added. A good
+rule of thumb is to count the expected number of statements and double that
+number. The default value of 50 is a value that'll work for most applications
 that do not rely heavily on user variables.
 
-Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4\
-and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol\
-prepared statements opened by the client are also kept open by MaxScale and are\
+Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4
+and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol
+prepared statements opened by the client are also kept open by MaxScale and are
 restored whenever a reconnection to a server happens. The limits imposed by`max_sescmd_history` apply to other text protocol commands e.g. `SET NAMES`.\
-Note that text protocol prepared statements count as text protocol commands and\
-are thus potentially pruned when history pruning happens. If an application uses\
+Note that text protocol prepared statements count as text protocol commands and
+are thus potentially pruned when history pruning happens. If an application uses
 a lot of `PREPARE stmt FROM <sql>` commands, it is recommended that the value of`max_sescmd_history` is increased accordingly.
 
-In older versions of MaxScale, binary protocol prepared statements were limited\
-by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this\
-caused problems when the binary protocol prepared statement were pruned while\
-they were still open from the client's point of view. In older versions, the\
-recommended value of `max_sescmd_history` is the number of state modifying\
-commands plus the maximum number of open prepared statements that any application\
+In older versions of MaxScale, binary protocol prepared statements were limited
+by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this
+caused problems when the binary protocol prepared statement were pruned while
+they were still open from the client's point of view. In older versions, the
+recommended value of `max_sescmd_history` is the number of state modifying
+commands plus the maximum number of open prepared statements that any application
 may use.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
-In addition to limiting the number of commands to store, it also acts as a hard\
-limit on the number of packets that may be queued up on a backend before it is\
-closed. Packets are queued while the TCP socket is being opened and when\
-prepared statements are being prepared. In certain rare cases, a slow server may\
-fall behind and not catch up to the rest of the cluster and a backlog of packets\
-forms. In these cases, if more than `max_sescmd_history` packets are queued, the\
+In addition to limiting the number of commands to store, it also acts as a hard
+limit on the number of packets that may be queued up on a backend before it is
+closed. Packets are queued while the TCP socket is being opened and when
+prepared statements are being prepared. In certain rare cases, a slow server may
+fall behind and not catch up to the rest of the cluster and a backlog of packets
+forms. In these cases, if more than `max_sescmd_history` packets are queued, the
 connection to the server is closed.
 
 #### `prune_sescmd_history`
@@ -2527,37 +2527,37 @@ connection to the server is closed.
 * Dynamic: Yes
 * Default: `true`
 
-This option enables pruning of the session command history when it exceeds the\
-value configured in `max_sescmd_history`. When this option is enabled, only a\
-set number of statements are stored in the history. This limits the per-session\
+This option enables pruning of the session command history when it exceeds the
+value configured in `max_sescmd_history`. When this option is enabled, only a
+set number of statements are stored in the history. This limits the per-session
 memory use while still allowing safe reconnections.
 
-This parameter is intended to be used with pooled connections that remain in use\
-for a very long time. Most connection pool implementations do not reset the\
-session state and instead re-initialize it with new values. This causes the\
-session command history to grow at roughly a constant rate for the lifetime of\
+This parameter is intended to be used with pooled connections that remain in use
+for a very long time. Most connection pool implementations do not reset the
+session state and instead re-initialize it with new values. This causes the
+session command history to grow at roughly a constant rate for the lifetime of
 the pooled connection.
 
-Each client-side session that uses a pooled connection only executes a finite\
-amount of session commands. By retaining a shorter history that encompasses all\
-session commands the individual clients execute, the session state of a pooled\
+Each client-side session that uses a pooled connection only executes a finite
+amount of session commands. By retaining a shorter history that encompasses all
+session commands the individual clients execute, the session state of a pooled
 connection can be accurately recreated on another server.
 
-When the session command history pruning is enabled, there is a theoretical\
-possibility that upon server reconnection the session states of the connections\
-are inconsistent. This can only happen if the length of the stored history is\
-shorter than the list of relevant statements that affect the session state. In\
-practice the default value of 50 session commands is a fairly reasonable value\
+When the session command history pruning is enabled, there is a theoretical
+possibility that upon server reconnection the session states of the connections
+are inconsistent. This can only happen if the length of the stored history is
+shorter than the list of relevant statements that affect the session state. In
+practice the default value of 50 session commands is a fairly reasonable value
 and the risk of inconsistent session state is relatively low.
 
-In case the default history length is too short for safe pruning, set the value\
-of `max_sescmd_history` to the total number of commands that affect the session\
-state plus a safety margin of 10. The safety margin reserves some extra space\
-for new commands that might be executed due to changes in the client side\
+In case the default history length is too short for safe pruning, set the value
+of `max_sescmd_history` to the total number of commands that affect the session
+state plus a safety margin of 10. The safety margin reserves some extra space
+for new commands that might be executed due to changes in the client side
 application.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `disable_sescmd_history`
@@ -2567,17 +2567,17 @@ history. Currently only `readwritesplit` and `schemarouter` support it.
 * Dynamic: Yes
 * Default: `false`
 
-This option disables the session command history. This way no history is stored\
-and if a slave server fails, the router will not try to replace the failed\
-slave. Disabling session command history will allow long-lived connections\
+This option disables the session command history. This way no history is stored
+and if a slave server fails, the router will not try to replace the failed
+slave. Disabling session command history will allow long-lived connections
 without causing a constant growth in the memory consumption.
 
-This parameter should only be used when either the memory footprint must be as\
-small as possible or when the pruning of the session command history is not\
+This parameter should only be used when either the memory footprint must be as
+small as possible or when the pruning of the session command history is not
 acceptable.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `user_accounts_file`
@@ -2594,25 +2594,25 @@ Default value is empty, which disables the feature.
 user_accounts_file=/home/root/users.json
 ```
 
-In addition to querying the backends, MaxScale can read users from a file. This\
-feature is useful when backends have limitations on the type of users that can\
-be created, or if MaxScale needs to allow users to log in even\
-when backends are down (e.g. binlog router). The users read from the file are\
-only present on MaxScale, so logging into backends can still fail. The format of\
-the file is protocol-specific. The following only applies to MariaDB-protocol,\
+In addition to querying the backends, MaxScale can read users from a file. This
+feature is useful when backends have limitations on the type of users that can
+be created, or if MaxScale needs to allow users to log in even
+when backends are down (e.g. binlog router). The users read from the file are
+only present on MaxScale, so logging into backends can still fail. The format of
+the file is protocol-specific. The following only applies to MariaDB-protocol,
 which is also the only protocol supporting this feature.
 
-The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which\
-contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at\
-least the string fields _user_ and _host_, which define the user account to add\
+The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which
+contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at
+least the string fields _user_ and _host_, which define the user account to add
 or modify.
 
-The elements in the _user_-array may contain the following additional fields. If\
+The elements in the _user_-array may contain the following additional fields. If
 a field is not defined, it is assumed either empty (string) or false (boolean).
 
 * password: String. Password hash, similar to the equivalent column on server.
 * plugin: String. Authentication plugin used by client, similar to server.
-* authentication\_string: String. Additional authentication info, similar to\
+* authentication\_string: String. Additional authentication info, similar to
   server.
 * default\_role: String. Default role of user, similar to server.
 * super\_priv: Boolean. True if user has SUPER grant.
@@ -2622,17 +2622,17 @@ a field is not defined, it is assumed either empty (string) or false (boolean).
 
 The elements in the _db_-array must contain the following additional field:
 
-* db: String. Database which the user can access. Can contain % and \_\
+* db: String. Database which the user can access. Can contain % and \_
   wildcards.
 
-The elements in the _roles\_mapping_-array must contain the following additional\
+The elements in the _roles\_mapping_-array must contain the following additional
 field:
 
 * role: String. Role the user can access.
 
 When users are read from both servers and the file, the server takes priority.\
 That is, if user `'joe'@'%'` is defined on both, the file-version is discarded.\
-The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant\
+The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant
 and role lists.
 
 An example users file is below.
@@ -2691,9 +2691,9 @@ Defines when _user\_accounts\_file_ is read. The value is an enum, either\
 read from a server. The file contents are then added to the server-based data.\
 If reading from server fails (e.g. servers are down), the file is ignored.
 
-"file\_only\_always" means that users are not read from the servers at all and the\
-file contents is all that matters. The state of the servers is ignored. This\
-mode can be useful with the binlog router, as it allows clients to log in and\
+"file\_only\_always" means that users are not read from the servers at all and the
+file contents is all that matters. The state of the servers is ignored. This
+mode can be useful with the binlog router, as it allows clients to log in and
 fetch binary logs from MaxScale even when backend servers are down.
 
 ```
@@ -2707,36 +2707,36 @@ user_accounts_file_usage=file_only_always
 * Dynamic: Yes
 * Default: `-1s`
 
-Normally, MaxScale only pools backend connections when\
-a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections\
+Normally, MaxScale only pools backend connections when
+a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections
 instead of creating new connections to backends. If connection sharing is enabled,\
-MaxScale can pool backend connections also from running sessions, and\
-re-attach a pooled connection when a session is doing a query. This effectively\
+MaxScale can pool backend connections also from running sessions, and
+re-attach a pooled connection when a session is doing a query. This effectively
 allows multiple sessions to share backend connections.
 
-_idle\_session\_pool\_time_ defines the amount of time a session must be idle\
-before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in\
+_idle\_session\_pool\_time_ defines the amount of time a session must be idle
+before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in
 seconds or milliseconds.
 
-This feature has a significant drawback: when a backend connection is reused, it\
-needs to be restored to the correct state. This means reauthenticating and\
-replaying session commands. This can add a significant delay before the\
-connection is actually ready for a query. If the session command history size\
-exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for\
+This feature has a significant drawback: when a backend connection is reused, it
+needs to be restored to the correct state. This means reauthenticating and
+replaying session commands. This can add a significant delay before the
+connection is actually ready for a query. If the session command history size
+exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for
 the session.
 
-This feature should only be used when limiting the backend connection count is\
-a priority, even at the cost of query delay and throughput. This feature only\
+This feature should only be used when limiting the backend connection count is
+a priority, even at the cost of query delay and throughput. This feature only
 works when the following server settings are also set in MaxScale configuration:
 
 1. [max\_routing\_connections](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#max_routing_connections)
 2. [persistpoolmax](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#persistpoolmax)
 3. [persistmaxtime](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#persistmaxtime)
 
-Since reusing a backend connection is an expensive operation, MaxScale only\
-pools connections when another session requires them. _idle\_session\_pool\_time_\
-thus effectively limits the frequency at which a connection can be moved from\
-one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to\
+Since reusing a backend connection is an expensive operation, MaxScale only
+pools connections when another session requires them. _idle\_session\_pool\_time_
+thus effectively limits the frequency at which a connection can be moved from
+one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to
 move connections as soon as possible.
 
 ```
@@ -2748,57 +2748,57 @@ See below for more information on configuring connection sharing.
 **Details, limitations and suggestions for connection sharing**
 
 As noted above, when a connection is pooled and reused its state is lost.\
-Although session variables and prepared statements are restored by replaying\
+Although session variables and prepared statements are restored by replaying
 session commands, some state information cannot be transferred.
 
-The most common such state is a transaction. When a transaction is on,\
+The most common such state is a transaction. When a transaction is on,
 connection sharing is disabled for that session until the transaction completes.\
-Other similar situations may not be properly detected, and it's the\
-responsibility of the user to avoid introducing such state to the session when\
+Other similar situations may not be properly detected, and it's the
+responsibility of the user to avoid introducing such state to the session when
 using connection sharing. This means that the following should not be used:
 
-* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that\
+* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that
   introduces state into the connection.
-* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector\
+* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector
   must be used instead of the variable.
 * Stored procedures that cause session level side-effects.
 
-Several settings affect connection sharing and its effectiveness. Reusing a\
-connection is an expensive operation so its frequency should be minimized. The\
+Several settings affect connection sharing and its effectiveness. Reusing a
+connection is an expensive operation so its frequency should be minimized. The
 important configuration settings in addition to _idle\_session\_pool\_time_ are\
 MaxScale server settings [persistpoolmax](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#persistpoolmax),[persistmaxtime](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#persistmaxtime) and [max\_routing\_connections](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#max_routing_connections).\
-The service settings [max\_sescmd\_history](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These\
+The service settings [max\_sescmd\_history](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These
 settings should be tuned according to the use case.
 
-_persistpoolmax_ limits how many connections can be kept in a pool for a given\
-server. If the pool is full, no more connections are detached from sessions even\
-if they are idle and required. The pool size should be large enough to contain\
+_persistpoolmax_ limits how many connections can be kept in a pool for a given
+server. If the pool is full, no more connections are detached from sessions even
+if they are idle and required. The pool size should be large enough to contain
 any connections being transferred between sessions, but not be greater than _max\_routing\_connections_. Using the value of _max\_routing\_connections_ is a
 reasonable starting point.
 
-_persistmaxtime_ limits the time a connection may stay in the pool. This should\
-be high enough so that pooled connections are not unnecessarily closed. Cleaning\
+_persistmaxtime_ limits the time a connection may stay in the pool. This should
+be high enough so that pooled connections are not unnecessarily closed. Cleaning
 up clearly unneeded connections from the pool may be useful when _max\_routing\_connections_ is restrictively tuned. Because each MaxScale routing
-thread has its own connection pool, one thread can monopolize access to a\
-server. For example, if the pool of thread 1 has 100 connections to _ServerA_\
-with `max_routing_connections=100`, other threads can no longer connect to the\
-server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as\
-it would cause unneeded connections in the pool to be closed faster. Such\
-connection slots then become available to other routing threads. Reducing the\
-number of [routing threads](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool\
-fragmentation. This may reduce overall throughput, though. When using connection\
+thread has its own connection pool, one thread can monopolize access to a
+server. For example, if the pool of thread 1 has 100 connections to _ServerA_
+with `max_routing_connections=100`, other threads can no longer connect to the
+server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as
+it would cause unneeded connections in the pool to be closed faster. Such
+connection slots then become available to other routing threads. Reducing the
+number of [routing threads](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool
+fragmentation. This may reduce overall throughput, though. When using connection
 sharing, backend connections are only in the pool momentarily. Consequently,_persistmaxtime_ can be set quite low, e.g. 10s.
 
-If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is\
-disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find\
-a backend connection. This can be avoided with _prune\_sescmd\_history_. However,\
-pruning means that old session commands will not be replayed when a pooled\
-connection is reused. If the pruned commands are important\
+If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is
+disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find
+a backend connection. This can be avoided with _prune\_sescmd\_history_. However,
+pruning means that old session commands will not be replayed when a pooled
+connection is reused. If the pruned commands are important
 (e.g. statement preparations), the session may fail later on.
 
 If the number of clients actively running queries is greater than _max\_routing\_connections_, query throughput will suffer as clients will need to
-take turns. In this situation, it's imperative to minimize the number of\
-backend connections a single session uses. The settings to achieve this depend\
+take turns. In this situation, it's imperative to minimize the number of
+backend connections a single session uses. The settings to achieve this depend
 on the router. For ReadWriteSplit the following should be used:
 
 ```
@@ -2807,12 +2807,12 @@ lazy_connect=1
 transaction_replay=true
 ```
 
-The above settings mean that MaxScale can process roughly\
-(_number of slave servers_ X _max\_routing\_connections_) read queries\
-simultaneously. Write queries will still need to take turns as there is only one\
+The above settings mean that MaxScale can process roughly
+(_number of slave servers_ X _max\_routing\_connections_) read queries
+simultaneously. Write queries will still need to take turns as there is only one
 master server.
 
-The following configuration snippet shows example server and service\
+The following configuration snippet shows example server and service
 configurations for connection sharing with ReadWriteSplit.
 
 ```
@@ -2839,11 +2839,11 @@ lazy_connect=1
 * Dynamic: Yes
 * Default: `60s`
 
-When connection sharing (as described above) is on, clients\
-may have to wait for their turn to use a backend connection. If too much time\
-passes without a connection becoming available, MaxScale returns an error to\
-the client, usually also ending the session. _multiplex\_timeout_ sets this\
-timeout. Increase it if queries are failing with "Timed out when waiting for a\
+When connection sharing (as described above) is on, clients
+may have to wait for their turn to use a backend connection. If too much time
+passes without a connection becoming available, MaxScale returns an error to
+the client, usually also ending the session. _multiplex\_timeout_ sets this
+timeout. Increase it if queries are failing with "Timed out when waiting for a
 connection". Decrease it if failing early is preferable to stalling.
 
 ```
@@ -2852,10 +2852,10 @@ multiplex_timeout=33s
 
 ### Server
 
-Server sections define the backend database servers MaxScale uses. A server is\
-identified by its section name in the configuration file. The only mandatory\
-parameter of a server is _type_, but _address_ and _port_ are also usually\
-defined. A server may be a member of one or more services. A server may only be\
+Server sections define the backend database servers MaxScale uses. A server is
+identified by its section name in the configuration file. The only mandatory
+parameter of a server is _type_, but _address_ and _port_ are also usually
+defined. A server may be a member of one or more services. A server may only be
 monitored by at most one monitor.
 
 ```
@@ -2872,7 +2872,7 @@ port=3000
 * Dynamic: Yes
 * Default: `""`
 
-The IP-address or hostname of the machine running the database server. MaxScale\
+The IP-address or hostname of the machine running the database server. MaxScale
 uses this address to connect to the server.
 
 Either _address_ or _socket_ must be defined, but not both.
@@ -2884,7 +2884,7 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: `3306`
 
-The port the backend server listens on for incoming connections. MaxScale uses\
+The port the backend server listens on for incoming connections. MaxScale uses
 this port to connect to the server.
 
 #### `socket`
@@ -2894,7 +2894,7 @@ this port to connect to the server.
 * Dynamic: Yes
 * Default: `""`
 
-The absolute path to a UNIX domain socket the MariaDB server is listening\
+The absolute path to a UNIX domain socket the MariaDB server is listening
 on.
 
 Either _address_ or _socket_ must be defined, but not both.
@@ -2906,9 +2906,9 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitorpasswd](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -2923,9 +2923,9 @@ monitorpw=mymonitorpasswd
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitoruser](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitoruser](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -2933,7 +2933,7 @@ monitoruser=mymonitoruser
 monitorpw=mymonitorpasswd
 ```
 
-`monitorpw` may be either a plain text password or an encrypted password. See\
+`monitorpw` may be either a plain text password or an encrypted password. See
 the section [encrypting passwords](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#encrypting-passwords) for more information.
 
 #### `extra_port`
@@ -2943,19 +2943,19 @@ the section [encrypting passwords](mariadb-maxscale-2208-mariadb-maxscale-config
 * Dynamic: Yes
 * Default: `0`
 
-An alternative port used for administrative connections to the server. If this\
-setting is defined, MaxScale uses it for monitoring the server and to fetch user\
+An alternative port used for administrative connections to the server. If this
+setting is defined, MaxScale uses it for monitoring the server and to fetch user
 accounts. Client sessions will still use the normal port.
 
-Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on\
-the backend server has been reached. Extra-port connections have their own\
-connection limit, which is one by default. This needs to be increased to allow\
+Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on
+the backend server has been reached. Extra-port connections have their own
+connection limit, which is one by default. This needs to be increased to allow
 both monitor and user account manager to connect.
 
-If the connection to the extra-port fails due to connection number limit or if\
+If the connection to the extra-port fails due to connection number limit or if
 the port is not open on the server, normal port is used.
 
-For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)\
+For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)
 and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables#extra_max_connections).
 
 #### `persistpoolmax`
@@ -2966,15 +2966,15 @@ and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-
 * Default: `0`
 
 Sets the size of the server connection pool. Disabled by default. When enabled,\
-MaxScale places unused connections to the server to a pool and reuses them\
-later. Connections typically become unused when a session closes. If the size of\
+MaxScale places unused connections to the server to a pool and reuses them
+later. Connections typically become unused when a session closes. If the size of
 the pool reaches _persistpoolmax_, unused connections are closed instead.
 
-Every routing thread has its own pool. As of version 6.3.0, MaxScale will round\
+Every routing thread has its own pool. As of version 6.3.0, MaxScale will round
 up _persistpoolmax_ so that every thread has an equal size pool.
 
-When a MariaDB-protocol connection is taken from the pool to be used in a new\
-session, the state of the connection is dependent on the router. ReadWriteSplit\
+When a MariaDB-protocol connection is taken from the pool to be used in a new
+session, the state of the connection is dependent on the router. ReadWriteSplit
 restores the connection to match the session state. Other routers do not.
 
 #### `persistmaxtime`
@@ -2984,15 +2984,15 @@ restores the connection to match the session state. Other routers do not.
 * Dynamic: Yes
 * Default: `0s`
 
-The `persistmaxtime` parameter defaults to zero but can be set to a duration as\
-documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is\
-interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a\
-unit may be rejected. Note that since the granularity of the parameter is\
-seconds, a value specified in milliseconds will be rejected, even if the\
+The `persistmaxtime` parameter defaults to zero but can be set to a duration as
+documented [here](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is
+interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a
+unit may be rejected. Note that since the granularity of the parameter is
+seconds, a value specified in milliseconds will be rejected, even if the
 duration is longer than a second.
 
-A DCB placed in the persistent pool for a server will only be reused if the\
-elapsed time since it joined the pool is less than the given value. Otherwise,\
+A DCB placed in the persistent pool for a server will only be reused if the
+elapsed time since it joined the pool is less than the given value. Otherwise,
 the DCB will be discarded and the connection closed.
 
 #### `max_routing_connections`
@@ -3002,18 +3002,18 @@ the DCB will be discarded and the connection closed.
 * Dynamic: Yes
 * Default: `0`
 
-Maximum number of routing connections to this server. Connections held in a pool\
-also count towards this maximum. Does not limit monitor connections or user\
+Maximum number of routing connections to this server. Connections held in a pool
+also count towards this maximum. Does not limit monitor connections or user
 account fetching. A value of 0 (default) means no limit.
 
-Since every client session can generate a connection to a server, the server may\
-run out of memory when the number of clients is high enough. This setting limits\
-server memory use caused by MaxScale. The effect depends on if the service\
-setting [idle\_session\_pool\_time](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection\
+Since every client session can generate a connection to a server, the server may
+run out of memory when the number of clients is high enough. This setting limits
+server memory use caused by MaxScale. The effect depends on if the service
+setting [idle\_session\_pool\_time](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection
 sharing, is enabled or not.
 
 If connection sharing is not on, _max\_routing\_connections_ simply sets a limit.\
-Any sessions attempting to exceed this limit will fail to connect to the\
+Any sessions attempting to exceed this limit will fail to connect to the
 backend. The client can still connect to MaxScale, but queries will fail.
 
 If connection sharing is on, sessions exceeding the limit will be put on hold\
@@ -3031,32 +3031,32 @@ max_routing_connections=1234
 * Dynamic: Yes
 * Default: `false`
 
-If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-header when connecting client sessions to the server. The header contains the\
-original client IP address and port, as seen by MaxScale. The server will then\
-read the header and perform authentication as if the connection originated from\
-this address instead of MaxScale's IP address. With this feature, the user\
-accounts on the backend server can be simplified to only contain the actual\
+If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+header when connecting client sessions to the server. The header contains the
+original client IP address and port, as seen by MaxScale. The server will then
+read the header and perform authentication as if the connection originated from
+this address instead of MaxScale's IP address. With this feature, the user
+accounts on the backend server can be simplified to only contain the actual
 client hosts and not the MaxScale host.
 
-PROXY protocol will be supported by MariaDB 10.3, which this feature has been\
-tested with. To use it, enable the PROXY protocol in MaxScale for every\
-compatible server and configure the MariaDB servers themselves to accept the\
-protocol headers from MaxScale's IP address. On the server side, the protocol\
-should be enabled only for trusted IPs, as it allows the sender to spoof the\
-connection origin. If a proxy header is sent to a server not expecting it, the\
-connection will fail. Usually PROXY protocol should be enabled for every\
+PROXY protocol will be supported by MariaDB 10.3, which this feature has been
+tested with. To use it, enable the PROXY protocol in MaxScale for every
+compatible server and configure the MariaDB servers themselves to accept the
+protocol headers from MaxScale's IP address. On the server side, the protocol
+should be enabled only for trusted IPs, as it allows the sender to spoof the
+connection origin. If a proxy header is sent to a server not expecting it, the
+connection will fail. Usually PROXY protocol should be enabled for every
 server in a cluster, as they typically have similar grants.
 
-Other SQL-servers may support PROXY protocol as well, but the implementation may\
-be highly restricting. Strict adherence to the protocol requires that the\
-backend server does not allow mixing of un-proxied and proxied connections from\
-a given IP. MaxScale requires normal connections to backends for monitoring and\
-authentication data queries, which would be blocked. To bypass this restriction,\
-the server monitor needs to be disabled and the service listener needs to be\
+Other SQL-servers may support PROXY protocol as well, but the implementation may
+be highly restricting. Strict adherence to the protocol requires that the
+backend server does not allow mixing of un-proxied and proxied connections from
+a given IP. MaxScale requires normal connections to backends for monitoring and
+authentication data queries, which would be blocked. To bypass this restriction,
+the server monitor needs to be disabled and the service listener needs to be
 configured to disregard authentication errors (`skip_authentication=true`).\
-Server states also need to be set manually in MaxCtrl. These steps are _not_\
-required for MariaDB 10.3, since its implementation is more flexible and allows\
+Server states also need to be set manually in MaxCtrl. These steps are _not_
+required for MariaDB 10.3, since its implementation is more flexible and allows
 both PROXY-headered and headerless connections from a proxy-enabled IP.
 
 #### `disk_space_threshold`
@@ -3066,30 +3066,30 @@ both PROXY-headered and headerless connections from a proxy-enabled IP.
 * Dynamic: No
 * Default: None
 
-This parameter specifies how full a disk may be, before MaxScale should start\
-logging warnings or take other actions (e.g. perform a switchover). This\
+This parameter specifies how full a disk may be, before MaxScale should start
+logging warnings or take other actions (e.g. perform a switchover). This
 functionality will only work with MariaDB server versions 10.1.32, 10.2.14 and\
 10.3.6 onwards, if the `DISKS` _information schema plugin_ has been installed.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-A limit is specified as a path followed by a colon and a percentage specifying\
+A limit is specified as a path followed by a colon and a percentage specifying
 how full the corresponding disk may be, before action is taken. E.g. an entry like
 
 ```
 /data:80
 ```
 
-specifies that the disk that has been mounted on `/data` may be used until 80%\
-of the total space has been consumed. Multiple entries can be specified by\
-separating them by a comma. If the path is specified using `*`, then the limit\
-applies to all disks. However, the value of `*` is only applied if there is not\
+specifies that the disk that has been mounted on `/data` may be used until 80%
+of the total space has been consumed. Multiple entries can be specified by
+separating them by a comma. If the path is specified using `*`, then the limit
+applies to all disks. However, the value of `*` is only applied if there is not
 an exact match.
 
-Note that if a particular disk has been mounted on several paths, only one path\
-need to be specified. If several are specified, then the one with the smallest\
+Note that if a particular disk has been mounted on several paths, only one path
+need to be specified. If several are specified, then the one with the smallest
 percentage will be applied.
 
 Examples:
@@ -3101,7 +3101,7 @@ disk_space_threshold=/data1:80,/data2:60,*:90
 ```
 
 The last line means that the disk mounted at `/data1` may be used up to\
-80%, the disk mounted at `/data2` may be used up to 60% and all other disks\
+80%, the disk mounted at `/data2` may be used up to 60% and all other disks
 mounted at any paths may be used up until 90% of maximum capacity, before\
 MaxScale starts to warn to take action.
 
@@ -3118,7 +3118,7 @@ Note that the path to be used, is one of the paths returned by:
 ...
 ```
 
-There is no default value, but this parameter must be explicitly specified\
+There is no default value, but this parameter must be explicitly specified
 if the disk space situation should be monitored.
 
 #### `rank`
@@ -3129,20 +3129,20 @@ if the disk space situation should be monitored.
 * Values: `primary`, `secondary`
 * Default: `primary`
 
-This parameter controls the order in which servers are used. Valid values for\
+This parameter controls the order in which servers are used. Valid values for
 this parameter are `primary` and `secondary`. The default value is`primary`.
 
-This behavior depends on the router implementation but the general rule of thumb\
+This behavior depends on the router implementation but the general rule of thumb
 is that primary servers will be used before secondary servers.
 
-Readconnroute will always use primary servers before secondary servers as long\
+Readconnroute will always use primary servers before secondary servers as long
 as they match the configured server type.
 
-Readwritesplit will pick servers that have the same rank as the current\
-master. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md#server-ranks)\
+Readwritesplit will pick servers that have the same rank as the current
+master. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md#server-ranks)
 for a detailed description of the behavior.
 
-The following example server configuration demonstrates how `rank` can be used\
+The following example server configuration demonstrates how `rank` can be used
 to exclude `DR-site` servers from routing.
 
 ```
@@ -3167,7 +3167,7 @@ address=192.168.0.22
 rank=secondary
 ```
 
-The `main-site-master` and `main-site-slave` servers will be used as long as\
+The `main-site-master` and `main-site-slave` servers will be used as long as
 they are available. When they are no longer available, the `DR-site-master` and`DR-site-slave` will be used.
 
 #### `priority`
@@ -3177,31 +3177,31 @@ they are available. When they are no longer available, the `DR-site-master` and`
 * Dynamic: Yes
 * Default: 0
 
-Server priority. Currently only used by galeramon to choose the order in which\
-nodes are selected as the current master server. Refer to the [Server Priorities](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-galera-monitor.md#interaction-with-server-priorities)\
+Server priority. Currently only used by galeramon to choose the order in which
+nodes are selected as the current master server. Refer to the [Server Priorities](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-galera-monitor.md#interaction-with-server-priorities)
 section of the galeramon documentation for more information on how to use it.
 
-Starting with MaxScale 2.5.21, this parameter also accepts negative values. In\
+Starting with MaxScale 2.5.21, this parameter also accepts negative values. In
 older versions, the parameter only accepted non-negative values.
 
 ### Monitor
 
-Monitor sections are used to define the monitoring module that watches a set of\
+Monitor sections are used to define the monitoring module that watches a set of
 servers. Each server can only be monitored by one monitor.
 
 Common monitor parameters [can be found here](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-common-monitor-parameters.md).
 
 ### Listener
 
-A listener defines a port MaxScale listens on for incoming connections. Accepted\
-connections are linked with a MaxScale service. Multiple listeners can feed the\
-same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface\
+A listener defines a port MaxScale listens on for incoming connections. Accepted
+connections are linked with a MaxScale service. Multiple listeners can feed the
+same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface
 only. _socket_ is also optional and is used for Unix socket connections.
 
-The network socket where the listener listens may have a backlog of\
+The network socket where the listener listens may have a backlog of
 connections. The size of this backlog is controlled by the\_net.ipv4.tcp\_max\_syn\_backlog\_ and _net.core.somaxconn_ kernel parameters.
 
-Increasing the size of the backlog by modifying the kernel parameters helps with\
+Increasing the size of the backlog by modifying the kernel parameters helps with
 sudden connection spikes and rejected connections. For more information see [listen(2)](https://man7.org/linux/man-pages/man2/listen.2.html).
 
 ```
@@ -3217,7 +3217,7 @@ port=3006
 * Mandatory: Yes
 * Dynamic: No
 
-The service to which the listener is associated. This is the name of a service\
+The service to which the listener is associated. This is the name of a service
 that is defined elsewhere in the configuration file.
 
 #### `protocol`
@@ -3230,11 +3230,11 @@ that is defined elsewhere in the configuration file.
 The name of the protocol module used for communication between the client and\
 MaxScale. The same protocol is also used for backend communication.
 
-Usually this does not need to be defined as the default protocol is the MariaDB\
+Usually this does not need to be defined as the default protocol is the MariaDB
 network protocol that is used by SQL connections.
 
-For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL\
-protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-nosql-protocol-module.md) module\
+For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL
+protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-nosql-protocol-module.md) module
 documentation.
 
 #### `address`
@@ -3244,8 +3244,8 @@ documentation.
 * Dynamic: No
 * Default: `"::"`
 
-This sets the address the listening socket is bound to. The address may be\
-specified as an IP address in 'dot notation' or as a hostname. If left undefined\
+This sets the address the listening socket is bound to. The address may be
+specified as an IP address in 'dot notation' or as a hostname. If left undefined
 the listener will bind to all network interfaces.
 
 #### `port`
@@ -3255,7 +3255,7 @@ the listener will bind to all network interfaces.
 * Dynamic: No
 * Default: `0`
 
-The port the listener listens on. If left undefined a default port for the\
+The port the listener listens on. If left undefined a default port for the
 protocol is used.
 
 #### `socket`
@@ -3265,10 +3265,10 @@ protocol is used.
 * Dynamic: No
 * Default: `""`
 
-If defined, the listener uses Unix domain sockets to listen for incoming\
+If defined, the listener uses Unix domain sockets to listen for incoming
 connections. The parameter value is the name of the socket to use.
 
-If you want to use both network ports and UNIX domain sockets with a service,\
+If you want to use both network ports and UNIX domain sockets with a service,
 define two separate listeners that connect to the same service.
 
 #### `authenticator`
@@ -3278,8 +3278,8 @@ define two separate listeners that connect to the same service.
 * Dynamic: No
 * Default: `""`
 
-The authenticator module to use. Each protocol module defines a default\
-authentication module, which is used if the setting is left undefined._MariaDBClient_-protocol supports multiple authenticators and they can be used\
+The authenticator module to use. Each protocol module defines a default
+authentication module, which is used if the setting is left undefined._MariaDBClient_-protocol supports multiple authenticators and they can be used
 simultaneously by giving a comma-separated list e.g.`authenticator=PAMAuth,mariadbauth,gssapiauth`
 
 #### `authenticator_options`
@@ -3289,8 +3289,8 @@ simultaneously by giving a comma-separated list e.g.`authenticator=PAMAuth,maria
 * Dynamic: No
 * Default: `""`
 
-This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of\
-this parameter should be a comma-separated list of key-value pairs. See\
+This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of
+this parameter should be a comma-separated list of key-value pairs. See
 authenticator specific documentation for more details.
 
 #### `sql_mode`
@@ -3311,10 +3311,10 @@ If both are used this setting will override the global setting for this listener
 * Dynamic: Yes
 * Default: `""`
 
-Path to a text file with sql queries. Any sessions created from the listener\
-will send the contents of the file to backends after authentication. Each\
-non-empty line in the file is interpreted as a query. Each query must succeed\
-for the backend connection to be usable for client queries. The queries should\
+Path to a text file with sql queries. Any sessions created from the listener
+will send the contents of the file to backends after authentication. Each
+non-empty line in the file is interpreted as a query. Each query must succeed
+for the backend connection to be usable for client queries. The queries should
 not return any data.
 
 ```
@@ -3335,28 +3335,28 @@ set @myvar2 = 4;
 * Dynamic: Yes
 * Default: `""`
 
-Path to a json-text file with user and group mapping, as well as server\
-credentials. Only affects MariaDB-protocol based listeners. Default value is\
+Path to a json-text file with user and group mapping, as well as server
+credentials. Only affects MariaDB-protocol based listeners. Default value is
 empty, which disables the feature.
 
 ```
 user_mapping_file=/home/root/mapping.json
 ```
 
-Should not be used together with [PAM Authenticator](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-pam-authenticator.md)\
-settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite\
-the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on\
+Should not be used together with [PAM Authenticator](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-pam-authenticator.md)
+settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite
+the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on
 backends and map them to backend users.
 
 This file functions very similar to [PAM-based mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
-Both user-to-user and group-to-user mappings can be defined. Also, the password\
-and authentication plugin for the mapped users can be added. The file is only\
-read during listener creation (typically MaxScale start) or when a listener is\
-modified during runtime. When a client logs into MaxScale, their username is\
+Both user-to-user and group-to-user mappings can be defined. Also, the password
+and authentication plugin for the mapped users can be added. The file is only
+read during listener creation (typically MaxScale start) or when a listener is
+modified during runtime. When a client logs into MaxScale, their username is
 searched from the mapping data. If the name matches either a name mapping or a\
-Linux group mapping, the username is replaced by the mapped name. The mapped\
-name is then used when logging into backends. If the file also contains\
-credentials for the mapped user, then those are used. Otherwise, MaxScale tries\
+Linux group mapping, the username is replaced by the mapped name. The mapped
+name is then used when logging into backends. If the file also contains
+credentials for the mapped user, then those are used. Otherwise, MaxScale tries
 to log in with an empty password and default MariaDB authentication.
 
 Three arrays are read from the file: _user\_map_, _group\_map_ and\_server\_credentials\_, none of which are mandatory.
@@ -3371,25 +3371,25 @@ Each array element in the _group\_map_-array must define the following fields:
 * original\_group: String. Incoming client Linux group.
 * mapped\_user: String. Username the client is mapped to.
 
-Each array element in the _server\_credentials_-array can define the following\
+Each array element in the _server\_credentials_-array can define the following
 fields:
 
 * mapped\_user: String. The mapped username this password is for.
-* password: String. Backend server password. Can be encrypted with\
+* password: String. Backend server password. Can be encrypted with
   maxpasswd.
-* plugin: String, optional. Authentication plugin to use. Must be enabled on\
-  the listener. Defaults to empty, which results in standard MariaDB\
+* plugin: String, optional. Authentication plugin to use. Must be enabled on
+  the listener. Defaults to empty, which results in standard MariaDB
   authentication.
 
-When a client successfully logs into MaxScale, MaxScale first searches for\
-name-based mapping. The incoming client does not need to be a Linux user for\
-name-based mapping to take place. If the name is not found, MaxScale checks if\
-the client is a Linux user with a group membership matching an element in the\
-group mapping array. If the client is a member of more than 100 groups, this\
+When a client successfully logs into MaxScale, MaxScale first searches for
+name-based mapping. The incoming client does not need to be a Linux user for
+name-based mapping to take place. If the name is not found, MaxScale checks if
+the client is a Linux user with a group membership matching an element in the
+group mapping array. If the client is a member of more than 100 groups, this
 check may fail.
 
-If a mapping is found, MaxScale searches the credentials array for a matching\
-username, and uses the password and plugin listed. The plugin need not be the\
+If a mapping is found, MaxScale searches the credentials array for a matching
+username, and uses the password and plugin listed. The plugin need not be the
 same as the one the original user used. Currently, "mysql\_native\_password" and\
 "pam" are supported as mapped plugins.
 
@@ -3430,18 +3430,18 @@ An example mapping file is below.
 
 ## Available Protocols
 
-The protocols supported by MariaDB MaxScale are implemented as external modules\
+The protocols supported by MariaDB MaxScale are implemented as external modules
 that are loaded dynamically into the MariaDB MaxScale core. They allow MariaDB\
-MaxScale to communicate in various protocols both on the client side and the\
-backend side. Each of the protocols can be either a client protocol or a backend\
-protocol. Client protocols are used for client-MariaDB MaxScale communication\
+MaxScale to communicate in various protocols both on the client side and the
+backend side. Each of the protocols can be either a client protocol or a backend
+protocol. Client protocols are used for client-MariaDB MaxScale communication
 and backend protocols are for MariaDB MaxScale-database communication.
 
 ### `MariaDBClient`
 
-This is the implementation of the MySQL-protocol. When defined for a listener,\
+This is the implementation of the MySQL-protocol. When defined for a listener,
 the listener will accept MySQL-connections from clients, assign them to a\
-MaxScale service and route the queries from the client to backend servers. Any\
+MaxScale service and route the queries from the client to backend servers. Any
 backends used by the service should be MariaDB/MySQL-servers or compatible.
 
 ### `CDC`
@@ -3450,42 +3450,42 @@ See [Change Data Capture Protocol](../mariadb-maxscale-2208-protocols/mariadb-ma
 
 ## TLS/SSL encryption
 
-This section describes configuration parameters for both servers and listeners\
-that control the TLS/SSL encryption method and the various certificate files\
+This section describes configuration parameters for both servers and listeners
+that control the TLS/SSL encryption method and the various certificate files
 involved in it.
 
 To enable TLS/SSL for a listener, you must set the `ssl` parameter to`true` and provide at least the `ssl_cert` and `ssl_key` parameters.
 
-To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification\
+To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification
 enabled, the `ssl_cert` and `ssl_key` parameters must also be defined.
 
 Custom CA certificates can be defined with the `ssl_ca` parameter.
 
-After this, MaxScale connections between the server and/or the client will be\
-encrypted. Note that the database must also be configured to use TLS/SSL\
+After this, MaxScale connections between the server and/or the client will be
+encrypted. Note that the database must also be configured to use TLS/SSL
 connections if backend connection encryption is used.
 
-**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on\
+**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on
 the same port.
 
-If TLS encryption is enabled for a listener, any unencrypted connections to it\
-will be rejected. MaxScale does this to improve security by preventing\
+If TLS encryption is enabled for a listener, any unencrypted connections to it
+will be rejected. MaxScale does this to improve security by preventing
 accidental creation of unencrypted connections.
 
-The separation of secure and insecure connections differs from the MariaDB\
+The separation of secure and insecure connections differs from the MariaDB
 server which allows both secure and insecure connections on the same port. As\
-MaxScale is the gateway through which all connections go, in order to guarantee\
-a more secure system MaxScale enforces a stricter security policy than what the\
+MaxScale is the gateway through which all connections go, in order to guarantee
+a more secure system MaxScale enforces a stricter security policy than what the
 server does.
 
-TLS encryption must be enabled for listeners when they are created. For servers,\
+TLS encryption must be enabled for listeners when they are created. For servers,
 the TLS can be enabled after creation but it cannot be disabled or altered.
 
 Starting with MaxScale 2.5.20, if the TLS certificate given to MaxScale has the\
-X509v3 extended key usage information, MaxScale will check it and refuse to use\
-a certificate with the wrong usage. This means that a certificate with only\
-clientAuth can only be used with servers and a certificate with only serverAuth\
-can only be used with listeners. In order to use the same certificate for both\
+X509v3 extended key usage information, MaxScale will check it and refuse to use
+a certificate with the wrong usage. This means that a certificate with only
+clientAuth can only be used with servers and a certificate with only serverAuth
+can only be used with listeners. In order to use the same certificate for both
 listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 #### `ssl`
@@ -3497,12 +3497,12 @@ listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 This enables SSL connections when set to true. The legacy values `required` and`disabled` were removed in MaxScale 6.0.
 
-If enabled, the certificate files mentioned above must also be\
+If enabled, the certificate files mentioned above must also be
 supplied. MaxScale connections to will then be encrypted with TLS/SSL.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require\
-ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created\
+24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require
+ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created
 with `REQUIRE SSL` or `REQUIRE X509`.
 
 #### `ssl_key`
@@ -3512,8 +3512,8 @@ with `REQUIRE SSL` or `REQUIRE X509`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client private key MaxScale should use. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client private key MaxScale should use. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_cert`
@@ -3523,9 +3523,9 @@ parameter for listeners but an optional parameter for servers.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client certificate MaxScale should use with the server. The\
-certificate must match the key defined in `ssl_key`. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client certificate MaxScale should use with the server. The
+certificate must match the key defined in `ssl_key`. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_ca_cert`
@@ -3539,13 +3539,13 @@ Deprecated since MariaDB MaxScale 22.08. See `ssl_ca`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the Certificate Authority (CA) certificate for the CA that signed the\
-certificate referred to in the previous parameter. It will be used to verify\
-that the certificate is valid. This is a required parameter for both listeners\
+A string giving a file path that identifies an existing readable file. The file
+must be the Certificate Authority (CA) certificate for the CA that signed the
+certificate referred to in the previous parameter. It will be used to verify
+that the certificate is valid. This is a required parameter for both listeners
 and servers. The CA certificate can consist of a certificate chain.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,
 which is still accepted as an alias for `ssl_ca`.
 
 #### `ssl_version`
@@ -3564,7 +3564,7 @@ This parameter controls the allowed TLS version. Accepted values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -3576,18 +3576,18 @@ The default setting (MAX) allows all supported versions. MaxScale supports\
 TLSv1.0, TLSv1.1, TLSv1.2 and TLSv1.3 depending on the OpenSSL library version.\
 TLSv1.0 and TLSv1.1 are considered deprecated and should not be used, so setting`ssl_version=TLSv1.2,TLSv1.3` or `ssl_version=TLSv1.3` is recommended.
 
-In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this\
-setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would\
+In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this
+setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would
 only enable TLSv12. The interpretation changed in MaxScale versions 6.4.14,\
-22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while\
-allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`\
+22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while
+allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`
 enabled both TLSv1.2 and TLSv1.3.
 
 The interpretation changed again in MaxScale versions 6.4.16, 22.08.13,\
-23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an\
-enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior\
-from the previous releases where the newer versions were automatically enabled,\
-the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)\
+23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an
+enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior
+from the previous releases where the newer versions were automatically enabled,
+the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)
 parameter works.
 
 #### `ssl_cipher`
@@ -3597,8 +3597,8 @@ parameter works.
 * Dynamic: Yes
 * Default: `""`
 
-Set the list of TLS ciphers. By default, no explicit ciphers are defined and the\
-system defaults are used. Note that this parameter does not modify TLSv1.3\
+Set the list of TLS ciphers. By default, no explicit ciphers are defined and the
+system defaults are used. Note that this parameter does not modify TLSv1.3
 ciphers.
 
 #### `ssl_cert_verify_depth`
@@ -3608,8 +3608,8 @@ ciphers.
 * Dynamic: Yes
 * Default: `9`
 
-The maximum length of the certificate authority chain that will be accepted. The\
-default value is 9, same as the OpenSSL default. The configured value must be\
+The maximum length of the certificate authority chain that will be accepted. The
+default value is 9, same as the OpenSSL default. The configured value must be
 larger than 0.
 
 #### `ssl_verify_peer_certificate`
@@ -3619,11 +3619,11 @@ larger than 0.
 * Dynamic: Yes
 * Default: `false`
 
-Peer certificate verification. This functionality is disabled by default. In\
+Peer certificate verification. This functionality is disabled by default. In
 versions prior to 2.3.17 the feature was enabled by default.
 
-When this feature is enabled, the peer must send a certificate. The certificate\
-sent by the peer is verified against the configured Certificate Authority to\
+When this feature is enabled, the peer must send a certificate. The certificate
+sent by the peer is verified against the configured Certificate Authority to
 make sure the peer is who they claim to be. For listeners, this behaves as if`REQUIRE X509` was defined for all users. For servers, this behaves like the`--ssl-verify-server-cert` command line option for the `mysql` client.
 
 #### `ssl_verify_peer_host`
@@ -3635,10 +3635,10 @@ make sure the peer is who they claim to be. For listeners, this behaves as if`RE
 
 Peer host verification.
 
-When this feature is enabled, the peer hostname or IP is verified against the\
-certificate that is sent by the peer. If the IP address or the hostname does not\
-match the one in the certificate returned by the peer, the connection will be\
-closed. If the peer does not provide a certificate, the host verification is not\
+When this feature is enabled, the peer hostname or IP is verified against the
+certificate that is sent by the peer. If the IP address or the hostname does not
+match the one in the certificate returned by the peer, the connection will be
+closed. If the peer does not provide a certificate, the host verification is not
 done. To require peer certificates, use `ssl_verify_peer_certificate`.
 
 #### `ssl_crl`
@@ -3648,8 +3648,8 @@ done. To require peer certificates, use `ssl_verify_peer_certificate`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be a Certificate Revocation List in the PEM format that defines the revoked\
+A string giving a file path that identifies an existing readable file. The file
+must be a Certificate Revocation List in the PEM format that defines the revoked
 certificates. This parameter is only accepted by listeners.
 
 **Example SSL enabled server configuration**
@@ -3665,7 +3665,7 @@ ssl_key=/usr/local/mariadb/maxscale/ssl/key.max-client.pem
 ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
-This example configuration requires all connections to this server to be\
+This example configuration requires all connections to this server to be
 encrypted with SSL. The paths to the certificate files and the Certificate\
 Authority file are also provided.
 
@@ -3683,18 +3683,18 @@ ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
 This example configuration requires all connections to be encrypted with\
-SSL. The paths to the certificate files and the Certificate Authority file are\
+SSL. The paths to the certificate files and the Certificate Authority file are
 also provided.
 
 ## Module Types
 
 ### Routing Modules
 
-The main task of MariaDB MaxScale is to accept database connections from client\
-applications and route the connections or the statements sent over those\
+The main task of MariaDB MaxScale is to accept database connections from client
+applications and route the connections or the statements sent over those
 connections to the various services supported by MariaDB MaxScale.
 
-Currently a number of routing modules are available, these are designed for a\
+Currently a number of routing modules are available, these are designed for a
 range of different needs.
 
 Connection based load balancing:
@@ -3715,28 +3715,28 @@ Binary log server:
 
 ### Monitor Modules
 
-Monitor modules are used by MariaDB MaxScale to internally monitor the state of\
-the backend databases in order to set the server flags for each of those\
-servers. The router modules then use these flags to determine if the particular\
-server is a suitable destination for routing connections for particular query\
+Monitor modules are used by MariaDB MaxScale to internally monitor the state of
+the backend databases in order to set the server flags for each of those
+servers. The router modules then use these flags to determine if the particular
+server is a suitable destination for routing connections for particular query
 classifications. The monitors are run within separate threads of MariaDB\
 MaxScale and do not affect MariaDB MaxScale's routing performance.
 
 * [MariaDB Monitor](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-mariadb-monitor.md)
 * [Galera Monitor](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-galera-monitor.md)
 
-The use of monitors in MaxScale is not absolutely mandatory: it is possible to\
-run MariaDB MaxScale without a monitor module. In this case an external\
+The use of monitors in MaxScale is not absolutely mandatory: it is possible to
+run MariaDB MaxScale without a monitor module. In this case an external
 monitoring system must the status of each server via MaxCtrl or the REST\
 API. **Only do this if you know what you are doing.**
 
 ### Filter Modules
 
 Filters provide a means to manipulate or process requests as they pass through\
-MariaDB MaxScale between the client side protocol and the query router. A full\
+MariaDB MaxScale between the client side protocol and the query router. A full
 explanation of each filter's functionality can be found in its documentation.
 
-The [Filter Tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-filters.md) document shows how you\
+The [Filter Tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-filters.md) document shows how you
 can add a filter to a service and combine multiple filters in one service.
 
 * [Query Log All (QLA) Filter](../mariadb-maxscale-2208--filters/mariadb-maxscale-2208-query-log-all-filter.md)
@@ -3749,8 +3749,8 @@ can add a filter to a service and combine multiple filters in one service.
 
 Passwords stored in the maxscale.cnf file may optionally be encrypted for added security.\
 This is done by creation of an encryption key on installation of MariaDB MaxScale.\
-Encryption keys may be created manually by executing the maxkeys utility with the argument\
-of the filename to store the key. The default location MariaDB MaxScale stores\
+Encryption keys may be created manually by executing the maxkeys utility with the argument
+of the filename to store the key. The default location MariaDB MaxScale stores
 the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES CBC encryption.
 
 ```
@@ -3758,16 +3758,16 @@ the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES C
 maxkeys /var/lib/maxscale/
 ```
 
-Changing the encryption key for MariaDB MaxScale will invalidate any currently\
+Changing the encryption key for MariaDB MaxScale will invalidate any currently
 encrypted keys stored in the maxscale.cnf file.
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
 ### Creating Encrypted Passwords
 
-Encrypted passwords are created by executing the maxpasswd command with the location\
+Encrypted passwords are created by executing the maxpasswd command with the location
 of the .secrets file and the password you require to encrypt as an argument.
 
 ```
@@ -3776,9 +3776,9 @@ maxpasswd /var/lib/maxscale/ MaxScalePw001
 61DD955512C39A4A8BC4BB1E5F116705
 ```
 
-The output of the maxpasswd command is a hexadecimal string, this should be inserted\
+The output of the maxpasswd command is a hexadecimal string, this should be inserted
 into the maxscale.cnf file in place of the ordinary, plain text, password.\
-MariaDB MaxScale will determine this as an encrypted password and automatically decrypt\
+MariaDB MaxScale will determine this as an encrypted password and automatically decrypt
 it before sending it the database server.
 
 ```
@@ -3792,7 +3792,7 @@ password=61DD955512C39A4A8BC4BB1E5F116705
 
 ## Runtime Configuration Changes
 
-Read the following documents for different methods of altering the MaxScale\
+Read the following documents for different methods of altering the MaxScale
 configuration at runtime.
 
 * MaxCtrl
@@ -3803,88 +3803,88 @@ configuration at runtime.
 * [alter](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-maxctrl.md#alter)
 * [REST API](../mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-rest-api.md) documentation
 
-All changes to the configuration done via MaxCtrl are persisted as individual\
-configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these\
-files will override any configurations found in the main configuration file or\
+All changes to the configuration done via MaxCtrl are persisted as individual
+configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these
+files will override any configurations found in the main configuration file or
 any auxiliary configuration files.
 
-Refer to the [Dynamic Configuration](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more\
+Refer to the [Dynamic Configuration](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more
 details on how this mechanism works and how to disable it.
 
 ### Configuration Synchronization
 
-The configuration synchronization mechanism is intended for synchronizing\
-configuration changes done on one MaxScale to all other MaxScales. This is done\
+The configuration synchronization mechanism is intended for synchronizing
+configuration changes done on one MaxScale to all other MaxScales. This is done
 by propagating the changes via the database cluster used by Maxscale.
 
-When configuring configuration synchronization for the first time, the same\
-static configuration files should be used on all MaxScale instances that use the\
+When configuring configuration synchronization for the first time, the same
+static configuration files should be used on all MaxScale instances that use the
 same cluster: the value of `config_sync_cluster` must be the same on all\
-MaxScale instances and the cluster (i.e. the monitor) pointed by it and its\
+MaxScale instances and the cluster (i.e. the monitor) pointed by it and its
 servers must be the same in every configuration.
 
-Whenever the MaxScale configuration is modified at runtime, the latest\
-configuration is stored in the database cluster in the `mysql.maxscale_config`\
-table. The table is created when the first modification to the configuration is\
+Whenever the MaxScale configuration is modified at runtime, the latest
+configuration is stored in the database cluster in the `mysql.maxscale_config`
+table. The table is created when the first modification to the configuration is
 done. A local copy of the configuration is stored in the data directory to allow\
-MaxScale to function even if a connection to the cluster cannot be made. By\
+MaxScale to function even if a connection to the cluster cannot be made. By
 default this file is stored at `/var/lib/maxscale/maxscale-config.json`.
 
-Whenever MaxScale starts up, it checks if a local version of this configuration\
-exists. If it does and it is a valid cached configuration, the static\
-configuration file as well as any other generated configuration files are\
-ignored. The exception is the `[maxscale]` section of the main static\
+Whenever MaxScale starts up, it checks if a local version of this configuration
+exists. If it does and it is a valid cached configuration, the static
+configuration file as well as any other generated configuration files are
+ignored. The exception is the `[maxscale]` section of the main static
 configuration file which is always read.
 
-Each configuration has a version number with the initial configuration being\
-version 0. Each time the configuration is modified, the version number is\
-incremented. This version number is used to detect when MaxScale needs to update\
+Each configuration has a version number with the initial configuration being
+version 0. Each time the configuration is modified, the version number is
+incremented. This version number is used to detect when MaxScale needs to update
 its configuration.
 
 #### Error Handling in Configuration Synchronization
 
-When doing a configuration change on the local MaxScale, if the configuration\
-change completes on MaxScale but fails to be committed to the database, MaxScale\
+When doing a configuration change on the local MaxScale, if the configuration
+change completes on MaxScale but fails to be committed to the database, MaxScale
 will attempt to revert the local configuration change. If this attempt fails,\
 MaxScale will discard the cached configuration and abort the process.
 
-When synchronizing with the cluster, if MaxScale fails to apply a configuration\
-retrieved from the cluster, it attempts to revert the configuration to the\
-previous version. If successful, the failed configuration update is ignored. If\
-the configuration update that fails cannot be reverted, the MaxScale\
-configuration will be in an indeterminate state. When this happens, MaxScale\
+When synchronizing with the cluster, if MaxScale fails to apply a configuration
+retrieved from the cluster, it attempts to revert the configuration to the
+previous version. If successful, the failed configuration update is ignored. If
+the configuration update that fails cannot be reverted, the MaxScale
+configuration will be in an indeterminate state. When this happens, MaxScale
 will discard the cached configuration and abort the process.
 
-When loading a locally cached configuration during startup, if any errors are\
-found in the cached configuration, it is discarded and the MaxScale process will\
-attempt to restart by exiting with code 75 from the main process. If MaxScale is\
+When loading a locally cached configuration during startup, if any errors are
+found in the cached configuration, it is discarded and the MaxScale process will
+attempt to restart by exiting with code 75 from the main process. If MaxScale is
 being used as a SystemD service, this will automatically trigger a restart of\
 MaxScale and no further actions are needed.
 
-The most common reason for a failed configuration update is missing files. For\
-example, if a configuration update adds encrypted connections to a server and\
-the TLS certificates it uses were not copied over to all MaxScale nodes before\
-the change was done, the operation will fail on all nodes that do not have these\
+The most common reason for a failed configuration update is missing files. For
+example, if a configuration update adds encrypted connections to a server and
+the TLS certificates it uses were not copied over to all MaxScale nodes before
+the change was done, the operation will fail on all nodes that do not have these
 files.
 
-If the synchronization of the configuration change fails at the step when the\
-database transaction is being committed, the new configuration can be\
-momentarily visible to the local MaxScale. This means the changes are not\
-guaranteed to be atomic on the local MaxScale but are atomic from the cluster's\
+If the synchronization of the configuration change fails at the step when the
+database transaction is being committed, the new configuration can be
+momentarily visible to the local MaxScale. This means the changes are not
+guaranteed to be atomic on the local MaxScale but are atomic from the cluster's
 point of view.
 
 #### Synchronization of Encrypted Passwords
 
-Starting with MaxScale 6.4.9, any passwords that are transmitted by the\
-configuration synchronization are encrypted if password encryption has been\
-enabled in MaxScale. This means that all MaxScale nodes in the same\
-configuration cluster must be configured to use password encryption and they\
+Starting with MaxScale 6.4.9, any passwords that are transmitted by the
+configuration synchronization are encrypted if password encryption has been
+enabled in MaxScale. This means that all MaxScale nodes in the same
+configuration cluster must be configured to use password encryption and they
 need to all use the same encryption keys that were created with `maxkeys`.
 
 #### Managing Configuration Synchronization
 
-The output of `maxctrl show maxscale` contains the `Config Sync` field with\
-information about the current configuration state of the local Maxscale as well\
+The output of `maxctrl show maxscale` contains the `Config Sync` field with
+information about the current configuration state of the local Maxscale as well
 as the state of any other nodes using this cluster.
 
 ```
@@ -3902,17 +3902,17 @@ as the state of any other nodes using this cluster.
 ├──────────────┼─────────────────────────────────────────────────────────────┤
 ```
 
-The `version` field is the logical configuration version and the `origin` is the\
-node that originates the latest configuration change. The `checksum` field is\
+The `version` field is the logical configuration version and the `origin` is the
+node that originates the latest configuration change. The `checksum` field is
 the checksum of the logical configuration and can be used to compare whether two\
-Maxscale instances are in the same configuration state. The `nodes` field\
-contains the status of each MaxScale instance mapped to the hostname of the\
-server. This field is updated whenever MaxScale reads the configuration from the\
-cluster and can thus be used to detect which MaxScales have updated their\
+Maxscale instances are in the same configuration state. The `nodes` field
+contains the status of each MaxScale instance mapped to the hostname of the
+server. This field is updated whenever MaxScale reads the configuration from the
+cluster and can thus be used to detect which MaxScales have updated their
 configuration.
 
-The `mysql.maxscale_config` table where the configuration changes are stored\
-must not be modified manually. The only case when the table should be modified\
+The `mysql.maxscale_config` table where the configuration changes are stored
+must not be modified manually. The only case when the table should be modified
 is when resetting the configuration synchronization.
 
 To reset the configuration synchronization:
@@ -3922,71 +3922,71 @@ To reset the configuration synchronization:
 3. Drop the `mysql.maxscale_config` table
 4. Start all MaxScale instances
 
-To disable configuration synchronization, remove `config_sync_cluster` from the\
-configuration file or set it to an empty string: `config_sync_cluster=""`. This\
+To disable configuration synchronization, remove `config_sync_cluster` from the
+configuration file or set it to an empty string: `config_sync_cluster=""`. This
 can be done at runtime with MaxCtrl by passing an empty string to`config_sync_cluster`:
 
 ```
 maxctrl alter maxscale config_sync_cluster ""
 ```
 
-If MaxScale cannot create a connection to the database cluster, configuration\
-changes are not possible until communication with the database is possible. To\
-override this behavior and force the changes to be done, use the `--skip-sync`\
-option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any\
-updates done with `--skip-sync` will overwritten by changes coming from the\
+If MaxScale cannot create a connection to the database cluster, configuration
+changes are not possible until communication with the database is possible. To
+override this behavior and force the changes to be done, use the `--skip-sync`
+option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any
+updates done with `--skip-sync` will overwritten by changes coming from the
 cluster.
 
 #### Limitations in Configuration Synchronization
 
-Only the MaxScale configuration is synchronized. Any external files (TLS\
-certificates, configuration files for modules or data generated by MaxScale) are\
-not synchronized. For example, the rule files for the cache filter must be\
+Only the MaxScale configuration is synchronized. Any external files (TLS
+certificates, configuration files for modules or data generated by MaxScale) are
+not synchronized. For example, the rule files for the cache filter must be
 synchronized separately if the filter itself is modified.
 
-Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers\
-and modifications to the administrative users will be synchronized. In older\
-versions servers had to be put into maintenance mode and users had to be\
+Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers
+and modifications to the administrative users will be synchronized. In older
+versions servers had to be put into maintenance mode and users had to be
 modified separately on each MaxScale.
 
-* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not\
+* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not
   synchronized.
-* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`\
-  option will not export the cluster configuration and instead exports only the\
-  static configuration files. To start a new MaxScale based off of a clustered\
-  configuration, copy the static configuration files as well as the JSON\
-  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale\
+* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`
+  option will not export the cluster configuration and instead exports only the
+  static configuration files. To start a new MaxScale based off of a clustered
+  configuration, copy the static configuration files as well as the JSON
+  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale
   instance.
 
 ### Backing Up Configuration Changes
 
-The combination of configuration files can be done either manually\
-(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line\
+The combination of configuration files can be done either manually
+(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line
 option. See `maxscale --help` for more information about how to use the`--export-config` flag.
 
-For example, to export the current runtime configuration, run the following\
+For example, to export the current runtime configuration, run the following
 command.
 
 ```
 maxscale --export-config=/tmp/maxscale.cnf.combined
 ```
 
-This will create the `/tmp/maxscale.cnf.combined` file and write the current\
-configuration into the it. This allows new MaxScale instances to be easily set\
-up without requiring copying of all runtime configuration files. The user\
-executing the command must be able to read all MaxScale configuration files as\
+This will create the `/tmp/maxscale.cnf.combined` file and write the current
+configuration into the it. This allows new MaxScale instances to be easily set
+up without requiring copying of all runtime configuration files. The user
+executing the command must be able to read all MaxScale configuration files as
 well as create and write the provided filename.
 
 ## Encryption Key Managers
 
-The encryption key managers are how MaxScale retrieves symmetric encryption keys\
-from a key management system. Some parts of MaxScale require the `key_manager`\
-to be configured in order to work. The key manager that is used is selected with\
-the [key\_manager](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is\
+The encryption key managers are how MaxScale retrieves symmetric encryption keys
+from a key management system. Some parts of MaxScale require the `key_manager`
+to be configured in order to work. The key manager that is used is selected with
+the [key\_manager](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is
 configured by placing the parameters in the `[maxscale]` section.
 
-The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key\
-management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration\
+The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key
+management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration
 files.
 
 ### File-based Key Manager
@@ -3994,13 +3994,13 @@ files.
 The encryption keys are stored in a text file stored on a local filesystem.
 
 The file uses the same format as the MariaDB server [File Key Management\
-Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file\
-consisting of an encryption key ID number and the hex-encoded encryption key\
+Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file
+consisting of an encryption key ID number and the hex-encoded encryption key
 separated by a semicolon. Read [Creating the Key\
-File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)\
+File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)
 for more details on how to create the file.
 
-For example, to configure encryption for the `nosqlprotocol` shared credentials\
+For example, to configure encryption for the `nosqlprotocol` shared credentials
 using the file-based encryption key:
 
 1. Create the key file with `(echo -n '1;' ; openssl rand -hex 32) | cat > /var/lib/maxscale/encryption.key`
@@ -4037,9 +4037,9 @@ nosqlprotocol.authentication_password=my_password
 * Mandatory: Yes
 * Dynamic: Yes
 
-Path to the file that contains the encryption keys. The user MaxScale runs as\
-(almost always `maxscale`) must be able to read this file. Encryption keys are\
-read from disk only during startup or when any global MaxScale parameter is\
+Path to the file that contains the encryption keys. The user MaxScale runs as
+(almost always `maxscale`) must be able to read this file. Encryption keys are
+read from disk only during startup or when any global MaxScale parameter is
 modified at runtime.
 
 ### KMIP Key Manager
@@ -4051,7 +4051,7 @@ The KMIP key manager has been verified to work with the PyKMIP server.
 #### Limitations
 
 * Key versioning is not supported
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the KMIP server.
 
 #### Parameters
@@ -4098,17 +4098,17 @@ The CA certificate to use. By default the system default certificates are used.
 
 ### HashiCorp Vault Key Manager
 
-Encryption keys are read from a local or remote Vault server using the secret\
-engine included in the Vault. This key manager supports versioned keys. Only\
+Encryption keys are read from a local or remote Vault server using the secret
+engine included in the Vault. This key manager supports versioned keys. Only
 version 2 key-value stores are supported.
 
 The encryption keys use the same format as the MariaDB [HashiCorp Vault Key\
 Management Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/hashicorp-key-management-plugin):\
-The key-value secret for each encryption key ID must contain the field `data`\
-which must contain a hex-encoded string that is either 32, 48 or 64 characters\
+The key-value secret for each encryption key ID must contain the field `data`
+which must contain a hex-encoded string that is either 32, 48 or 64 characters
 long.
 
-An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit\
+An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit
 encryption key using `openssl` and stores it using the key ID `1`:
 
 ```
@@ -4128,7 +4128,7 @@ version            1
 
 #### Limitations
 
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the Vault server.
 
 #### Parameters
@@ -4139,7 +4139,7 @@ version            1
 * Mandatory: Yes
 * Dynamic: Yes
 
-The authentication token used to connect to the Vault server. This can be\
+The authentication token used to connect to the Vault server. This can be
 encrypted using `maxpasswd`, similar to how other passwords are encrypted.
 
 **`vault.host`**
@@ -4172,7 +4172,7 @@ The CA certificate to use. By default the system default certificates are used.
 * Default: true
 * Dynamic: Yes
 
-Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating\
+Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating
 with the Vault server.
 
 **`vault.mount`**
@@ -4181,7 +4181,7 @@ with the Vault server.
 * Default: `secret`
 * Dynamic: Yes
 
-The Key-Value mount where the secret is stored. By default the `secret` mount is\
+The Key-Value mount where the secret is stored. By default the `secret` mount is
 used which is present by default in most Vault installations.
 
 **`vault.timeout`**
@@ -4194,8 +4194,8 @@ The connection and request timeout used with the Vault server.
 
 ## Error Reporting
 
-MariaDB MaxScale is designed to be executed as a service, therefore all error\
-reports, including configuration errors, are written to the MariaDB MaxScale\
+MariaDB MaxScale is designed to be executed as a service, therefore all error
+reports, including configuration errors, are written to the MariaDB MaxScale
 error log file. By default, MariaDB MaxScale will log to a file in`/var/log/maxscale` and the system log.
 
 ## Limitations
@@ -4204,31 +4204,31 @@ The current limitations of MaxScale are listed in the [Limitations](../mariadb-m
 
 ## Performance Optimization
 
-* Tune `query_classifier_cache_size` to allow maximal use of the query\
-  classifier cache. Increase the value and/or system memory until the set of\
-  unique SQL patterns fits into memory. By default at most 15% of the system\
-  memory is used for this cache. To detect if the SQL statements fit into\
-  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to\
-  see how many evictions take place. If it keeps increasing, increase the size\
-  of the query classifier cache. Using the query classifier cache with a CPU\
-  bound workload gives a roughly 20% improvement in performance compared to when\
+* Tune `query_classifier_cache_size` to allow maximal use of the query
+  classifier cache. Increase the value and/or system memory until the set of
+  unique SQL patterns fits into memory. By default at most 15% of the system
+  memory is used for this cache. To detect if the SQL statements fit into
+  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to
+  see how many evictions take place. If it keeps increasing, increase the size
+  of the query classifier cache. Using the query classifier cache with a CPU
+  bound workload gives a roughly 20% improvement in performance compared to when
   it is turned off.
-* A faster CPU with more CPU cores is better. This is true for most applications\
+* A faster CPU with more CPU cores is better. This is true for most applications
   but especially for MaxScale as it is mostly limited by the speed of the\
   CPU. Using `threads=auto` is recommended (the default starting with MaxScale\
   6\).
-* Network throughput between the client, MaxScale and the database nodes governs\
-  how much traffic can be handled. The client-to-MaxScale network is likely to\
-  be saturated first: having multiple MaxScales in front of the cluster is an\
+* Network throughput between the client, MaxScale and the database nodes governs
+  how much traffic can be handled. The client-to-MaxScale network is likely to
+  be saturated first: having multiple MaxScales in front of the cluster is an
   easy way of solving this problem.
-* Certain MaxScale modules store data on disk. A faster disk improves their\
-  performance but depending on the module, this might not be a big enough of a\
-  problem to worry about. Filters like the `qlafilter` that write information to\
+* Certain MaxScale modules store data on disk. A faster disk improves their
+  performance but depending on the module, this might not be a big enough of a
+  problem to worry about. Filters like the `qlafilter` that write information to
   disk for every SQL query can cause performance bottlenecks.
 
 ### MaxScale Diagnostics using MaxCtrl
 
-From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with\
+From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with
 information about the system MaxScale is running on. The fields are:
 
 | Field                                   | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -4247,34 +4247,34 @@ In addition there is an `os` object that contains what the Linux command `uname`
 
 **`threads`**
 
-If `threads` has not been specified at all in the MaxScale configuration file,\
-or if its value is `auto`, then MaxScale will use as many routing threads as\
-there are physical cores on the machine. This is the right choice, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
+If `threads` has not been specified at all in the MaxScale configuration file,
+or if its value is `auto`, then MaxScale will use as many routing threads as
+there are physical cores on the machine. This is the right choice, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
 in any way.
 
-However, if the number of cores available to MaxScale have been restricted or\
-if MaxScale is running in a container whose CPU quota and period have been\
-limited, then it will lead to MaxScale using more routing threads than what\
+However, if the number of cores available to MaxScale have been restricted or
+if MaxScale is running in a container whose CPU quota and period have been
+limited, then it will lead to MaxScale using more routing threads than what
 is appropriate in the environment where it is running.
 
-If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`\
-should be specified explicitly in the MaxScale configuration file and its value\
-should be that of `machine.cores_virtual` rounded up to the nearest integer. If\
+If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`
+should be specified explicitly in the MaxScale configuration file and its value
+should be that of `machine.cores_virtual` rounded up to the nearest integer. If
 that value is `1` it may be beneficial to check whether `2` gives better performance.
 
 **`query_classifier_cache_size`**
 
-If `query_classifier_cache_size` has not been specified in the MaxScale\
-configuration file, then MaxScale will use at most 15% of the amount of physical\
-memory in the machine for the cache. This is a good starting point, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
-in any way. Note that the amount specifies how much memory the cache at maximum\
+If `query_classifier_cache_size` has not been specified in the MaxScale
+configuration file, then MaxScale will use at most 15% of the amount of physical
+memory in the machine for the cache. This is a good starting point, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
+in any way. Note that the amount specifies how much memory the cache at maximum
 is allowed to use, not what would immediately be allocated for the cache.
 
-However, if the amount of memory available to MaxScale has been restricted,\
-which may be the case if MaxScale is running in a container, this may cause the\
-cache to grow beyond what is available, which will lead to a crash or MaxScale\
+However, if the amount of memory available to MaxScale has been restricted,
+which may be the case if MaxScale is running in a container, this may cause the
+cache to grow beyond what is available, which will lead to a crash or MaxScale
 being killed.
 
 If the value of `machine.memory_available` is less than that of`machine.memory_physical`, then `query_classifier_cache_size` should be explicitly\
@@ -4313,7 +4313,7 @@ $ maxctrl show maxscale
 As can be seen, `maxscale.threads` is larger than `machine.cores_virtual` and thus,`threads=4` should explicitly be specified in the MaxScale configuration file.
 
 `maxscale.query_classifier_cache_size` is the default 15% of `machine.memory_physical`\
-but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be\
+but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be
 added to the configuration file.
 
 ```
@@ -4325,12 +4325,12 @@ query_classifier_cache_size=3100000000
 
 ## Troubleshooting
 
-For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)\
+For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 article on the MariaDB documentation.
 
 ### Systemd Watchdog
 
-If MaxScale is running as a systemd service, the systemd Watchdog will be\
+If MaxScale is running as a systemd service, the systemd Watchdog will be
 enabled by default. To configure it, change the `WatchdogSec` option in the\
 Service section of the maxscale systemd configuration file located in`/lib/systemd/system/maxscale.service`:
 
@@ -4338,8 +4338,8 @@ Service section of the maxscale systemd configuration file located in`/lib/syste
 WatchdogSec=30s
 ```
 
-It is not recommended to use a watchdog timeout less than 30 seconds. When\
-enabled MaxScale will check that all threads are running and notify systemd\
+It is not recommended to use a watchdog timeout less than 30 seconds. When
+enabled MaxScale will check that all threads are running and notify systemd
 with a "keep-alive ping".
 
 Systemd reference: [systemd.service.html](https://www.freedesktop.org/software/systemd/man/systemd.service.html)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-installation-guide.md
@@ -4,15 +4,15 @@
 
 ## MariaDB MaxScale Installation Guide
 
-We recommend to install MaxScale on a separate server, to ensure that there\
-can be no competition of resources between MaxScale and a MariaDB Server that\
+We recommend to install MaxScale on a separate server, to ensure that there
+can be no competition of resources between MaxScale and a MariaDB Server that
 it manages.
 
 ### Install MariaDB MaxScale From MariaDB Repositories
 
-The recommended approach is to use [the MariaDB package\
-repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
-to install MaxScale. After enabling the repository by following the\
+The recommended approach is to use [the MariaDB package
+repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
+to install MaxScale. After enabling the repository by following the
 instructions, MaxScale can be installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install maxscale`.
@@ -21,9 +21,9 @@ instructions, MaxScale can be installed with the following commands.
 
 ### Install MariaDB MaxScale From a RPM/DEB Package
 
-Download the correct MaxScale package for your CPU architecture and operating\
-system from [the MariaDB Downloads\
-page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be\
+Download the correct MaxScale package for your CPU architecture and operating
+system from [the MariaDB Downloads
+page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be
 installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install /path/to/maxscale-*.rpm`
@@ -33,7 +33,7 @@ installed with the following commands.
 ### Install MariaDB MaxScale Using a Tarball
 
 MaxScale can also be installed using a tarball.\
-That may be required if you are using a Linux distribution for which there\
+That may be required if you are using a Linux distribution for which there
 exist no installation package or if you want to install many different\
 MaxScale versions side by side. For instructions on how to do that, please refer to [Install MariaDB MaxScale using a Tarball](mariadb-maxscale-2208-installing-mariadb-maxscale-using-a-tarball.md).
 
@@ -46,20 +46,20 @@ To do this, refer to the separate document [Building MariaDB MaxScale from Sourc
 
 #### Memory allocation behavior
 
-MaxScale assumes that memory allocations always succeed and in general does\
-not check for memory allocation failures. This assumption is compatible with\
-the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)\
+MaxScale assumes that memory allocations always succeed and in general does
+not check for memory allocation failures. This assumption is compatible with
+the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)
 having the value `0`, which is also the default on most systems.
 
-With `vm.overcommit_memory` being `0`, memory _allocations_ made by an\
-application never fail, but instead the application may be killed by the\
-so-called OOM (out-of-memory) killer if, by the time the application\
-actually attempts to _use_ the allocated memory, there is not available\
+With `vm.overcommit_memory` being `0`, memory _allocations_ made by an
+application never fail, but instead the application may be killed by the
+so-called OOM (out-of-memory) killer if, by the time the application
+actually attempts to _use_ the allocated memory, there is not available
 free memory on the system.
 
-If the value is `2`, then a memory allocation made by an application may\
-fail and unless the application is prepared for that possibility, it will\
-likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory\
+If the value is `2`, then a memory allocation made by an application may
+fail and unless the application is prepared for that possibility, it will
+likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory
 allocation failures, it will crash in this situation.
 
 The current value of `vm.overcommit_memory` can be checked with
@@ -76,36 +76,36 @@ cat /proc/sys/vm/overcommit_memory
 
 ### Configuring MariaDB MaxScale
 
-[The MaxScale Tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-setting-up-mariadb-maxscale.md) covers the first\
-steps in configuring your MariaDB MaxScale installation. Follow this tutorial\
+[The MaxScale Tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-setting-up-mariadb-maxscale.md) covers the first
+steps in configuring your MariaDB MaxScale installation. Follow this tutorial
 to learn how to configure and start using MaxScale.
 
-For a detailed list of all configuration parameters, refer to the [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/) and the module specific documents\
+For a detailed list of all configuration parameters, refer to the [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/) and the module specific documents
 listed in the [Documentation Contents](https://mariadb.com/kb/en/mariadb-maxscale-2208-maxscale-2208-contents/#routers).
 
 ### Encrypting Passwords
 
-Read the [Encrypting Passwords](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#encrypting-passwords)\
-section of the configuration guide to set up password encryption for the\
+Read the [Encrypting Passwords](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#encrypting-passwords)
+section of the configuration guide to set up password encryption for the
 configuration file.
 
 ### Administration Of MariaDB MaxScale
 
 There are various administration tasks that may be done with MariaDB MaxScale.\
-A command line tools is available, [maxctrl](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-maxctrl.md), that will\
+A command line tools is available, [maxctrl](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-maxctrl.md), that will
 interact with a running MariaDB MaxScale and allow the status of MariaDB\
-MaxScale to be monitored and give some control of the MariaDB MaxScale\
+MaxScale to be monitored and give some control of the MariaDB MaxScale
 functionality.
 
-[The administration tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-mariadb-maxscale-administration-tutorial.md)\
+[The administration tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-mariadb-maxscale-administration-tutorial.md)
 covers the common administration tasks that need to be done with MariaDB MaxScale.
 
 ### Copying or Backing Up MaxScale
 
-The main configuration file for MaxScale is in `/etc/maxscale.cnf` and\
+The main configuration file for MaxScale is in `/etc/maxscale.cnf` and
 additional user-created configuration files are in`/etc/maxscale.cnf.d/`. Objects created or modified at runtime are stored in`/var/lib/maxscale/maxscale.cnf.d/`. Some modules also store internal data in`/var/lib/maxscale/` named after the module or the configuration object.
 
-The simplest way to back up the configuration and runtime data of a MaxScale\
+The simplest way to back up the configuration and runtime data of a MaxScale
 installation is to create an archive from the following files and directories:
 
 * `/etc/maxscale.cnf`
@@ -118,7 +118,7 @@ This can be done with the following command:
 tar -caf maxscale-backup.tar.gz /etc/maxscale.cnf /etc/maxscale.cnf.d/ /var/lib/maxscale/
 ```
 
-If MaxScale is configured to store data in custom locations, these should be\
+If MaxScale is configured to store data in custom locations, these should be
 included in the backup as well.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-maxgui-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-maxgui-guide.md
@@ -10,27 +10,27 @@ _MaxGUI_ is a browser-based interface for MaxScale REST-API and query execution.
 
 ## Enabling MaxGUI
 
-To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale\
+To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale
 configuration file. Once enabled, MaxGUI will be available on port 8989:`http://127.0.0.1:8989/`
 
 ### Securing the GUI
 
 To make MaxGUI secure, set `admin_secure_gui=true` and configure both the`admin_ssl_key` and `admin_ssl_cert` parameters.
 
-See [Configuration Guide](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-rest-api-tutorial.md#configuration-and-hardening)\
+See [Configuration Guide](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-rest-api-tutorial.md#configuration-and-hardening)
 for instructions on how to harden your MaxScale installation for production use.
 
 ## Authentication
 
-MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`\
+MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`
 with `mariadb` as the password.
 
-Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the\
-authentication method for persisting the user's session. If the _Remember me_\
-checkbox is ticked, the session will persist for 24 hours. Otherwise, the\
+Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the
+authentication method for persisting the user's session. If the _Remember me_
+checkbox is ticked, the session will persist for 24 hours. Otherwise, the
 session will expire as soon as MaxGUI is closed.
 
-To log out, simply click the username section in the top right corner of the\
+To log out, simply click the username section in the top right corner of the
 page header to access the logout menu.
 
 ## Pages
@@ -44,7 +44,7 @@ By default, the refresh interval is 10 seconds.
 
 ### Detail
 
-This page shows information on each [MaxScale object](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#objects) and allow to edit its\
+This page shows information on each [MaxScale object](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#objects) and allow to edit its
 parameter, relationships and perform other manipulation operations.
 
 Access this page by clicking on the MaxScale object name on the [dashboard page](mariadb-maxscale-2208-mariadb-maxscale-maxgui-guide.md#dashboard)
@@ -54,8 +54,8 @@ Access this page by clicking on the MaxScale object name on the [dashboard page]
 This page visualizes MaxScale configuration and clusters.
 
 * Configuration: Visualizing MaxScale configuration.
-* Cluster: Visualizing a replication cluster into a tree graph and provides\
-  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the\
+* Cluster: Visualizing a replication cluster into a tree graph and provides
+  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the
   moment, it supports only servers monitored by Monitor using [mariadbmon](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-mariadb-monitor.md) module.
 
 Access this page by clicking the graph icon on the sidebar navigation.
@@ -68,13 +68,13 @@ Access this page by clicking the gear icon on the sidebar navigation.
 
 ### Logs Archive
 
-Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar\
+Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar
 navigation.
 
 ### Query Editor
 
-Query Editor is a SQL editor tool allowing to run queries on a server, service,\
-or listener. The query results can be visualized into a line, bar, or scatter\
+Query Editor is a SQL editor tool allowing to run queries on a server, service,
+or listener. The query results can be visualized into a line, bar, or scatter
 graph and exported as CSV or JSON.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-aurora-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-aurora-monitor.md
@@ -6,42 +6,42 @@
 
 **Note** The Aurora Monitor is deprecated in 22.08.2 and will be removed in 23.02.0.
 
-This module monitors the status of Aurora cluster replicas. These replicas do\
-not use the standard MySQL protocol replication but rely on a mechanism provided\
+This module monitors the status of Aurora cluster replicas. These replicas do
+not use the standard MySQL protocol replication but rely on a mechanism provided
 by AWS to replicate changes.
 
 ## How Aurora Is Monitored
 
-Each node in an Aurora cluster has the variable `@@aurora_server_id` which is\
-the unique identifier for that node. An Aurora replica stores information\
-relevant to replication in the `information_schema.replica_host_status`\
-table. The table contains information about the status of all replicas in the\
-cluster. The `server_id` column in this table holds the values of`@@aurora_server_id` variables from all nodes. The `session_id` column contains\
-an unique string for all read-only replicas. For the master node, this value\
-will be `MASTER_SESSION_ID`. By executing the following query, we are able to\
+Each node in an Aurora cluster has the variable `@@aurora_server_id` which is
+the unique identifier for that node. An Aurora replica stores information
+relevant to replication in the `information_schema.replica_host_status`
+table. The table contains information about the status of all replicas in the
+cluster. The `server_id` column in this table holds the values of`@@aurora_server_id` variables from all nodes. The `session_id` column contains
+an unique string for all read-only replicas. For the master node, this value
+will be `MASTER_SESSION_ID`. By executing the following query, we are able to
 retrieve the `@@aurora_server_id` of the master node along with the`@@aurora_server_id` of the current node.
 
 ```
 SELECT @@aurora_server_id, server_id FROM information_schema.replica_host_status WHERE session_id = 'MASTER_SESSION_ID';
 ```
 
-The node which returns a row with two identical fields is the master. All other\
+The node which returns a row with two identical fields is the master. All other
 nodes are read-only replicas and will be labeled as slave servers.
 
-In addition to replica status information, the`information_schema.replica_host_status` table contains information about\
-replication lag between the master and the read-only nodes. This value is stored\
-in the `replica_lag_in_milliseconds` column. This can be used to detect read\
-replicas that are lagging behind the master node. This information can then be\
+In addition to replica status information, the`information_schema.replica_host_status` table contains information about
+replication lag between the master and the read-only nodes. This value is stored
+in the `replica_lag_in_milliseconds` column. This can be used to detect read
+replicas that are lagging behind the master node. This information can then be
 used by the routing modules to route reads to up-to-date nodes.
 
 ## Configuring the Aurora Monitor
 
-The Aurora monitor should connect directly to the unique endpoints of the Aurora\
-replicas. The cluster end point should not be included in the set of monitored\
-servers. Read the [Amazon RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html#Aurora.Overview.Endpoints)\
+The Aurora monitor should connect directly to the unique endpoints of the Aurora
+replicas. The cluster end point should not be included in the set of monitored
+servers. Read the [Amazon RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html#Aurora.Overview.Endpoints)
 for more information about how to retrieve the unique endpoints of your cluster.
 
-The Aurora monitor requires no parameters apart from the standard monitor\
+The Aurora monitor requires no parameters apart from the standard monitor
 parameters. It supports the monitor script functionality described in [Monitor Common](mariadb-maxscale-2208-common-monitor-parameters.md) documentation.
 
 Here is an example Aurora monitor configuration.
@@ -56,8 +56,8 @@ password=borealis
 monitor_interval=2500ms
 ```
 
-The servers _cluster-1_, _cluster-2_ and _cluster-3_ are the unique Aurora\
-endpoints configured as MaxScale servers. The monitor will use the_aurora_:_borealis_ credentials to connect to each of the endpoint. The status\
+The servers _cluster-1_, _cluster-2_ and _cluster-3_ are the unique Aurora
+endpoints configured as MaxScale servers. The monitor will use the_aurora_:_borealis_ credentials to connect to each of the endpoint. The status
 of the nodes is inspected every 2500 milliseconds.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-columnstore-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-columnstore-monitor.md
@@ -4,18 +4,18 @@
 
 ## ColumnStore Monitor
 
-**Note** The ColumnStore monitor is deprecated in 22.08.2 and will be removed\
+**Note** The ColumnStore monitor is deprecated in 22.08.2 and will be removed
 in 23.02.0. It is superseded by [MariaDB Monitor](mariadb-maxscale-2208-mariadb-monitor.md).
 
-The ColumnStore monitor, `csmon`, is a monitor module for MariaDB ColumnStore\
+The ColumnStore monitor, `csmon`, is a monitor module for MariaDB ColumnStore
 servers. The monitor supports ColumnStore version 1.5.
 
 ### Required Grants
 
-The credentials defined with the `user` and `password` parameters must have all\
+The credentials defined with the `user` and `password` parameters must have all
 grants on the `infinidb_vtable` database.
 
-For example, to create a user for this monitor with the required grants execute\
+For example, to create a user for this monitor with the required grants execute
 the following SQL.
 
 ```
@@ -25,83 +25,83 @@ GRANT ALL ON infinidb_vtable.* TO 'maxscale'@'maxscalehost';
 
 ### Configuration
 
-Read the [Monitor Common](mariadb-maxscale-2208-common-monitor-parameters.md) document for a list of supported\
+Read the [Monitor Common](mariadb-maxscale-2208-common-monitor-parameters.md) document for a list of supported
 common monitor parameters.
 
 #### `version`
 
-With this _deprecated_ optional parameter the used ColumnStore version is\
+With this _deprecated_ optional parameter the used ColumnStore version is
 specified. The only allowed value is `1.5`.
 
 #### `admin_port`
 
-This optional parameter specifies the port of the ColumnStore administrative\
-daemon. The default value is `8640`. Note that the daemons of all nodes must\
+This optional parameter specifies the port of the ColumnStore administrative
+daemon. The default value is `8640`. Note that the daemons of all nodes must
 be listening on the same port.
 
 #### `admin_base_path`
 
-This optional parameter specifies the base path of the ColumnStore\
+This optional parameter specifies the base path of the ColumnStore
 administrative daemon. The default value is `/cmapi/0.4.0`.
 
 #### `api_key`
 
-This optional parameter specifies the API key to be used in the\
-communication with the ColumnStore administrative daemon. If no\
-key is specified, then a key will be generated and stored to the\
-file `api_key.txt` in the directory with the same name as the\
-monitor in data directory of MaxScale. Typically that will\
+This optional parameter specifies the API key to be used in the
+communication with the ColumnStore administrative daemon. If no
+key is specified, then a key will be generated and stored to the
+file `api_key.txt` in the directory with the same name as the
+monitor in data directory of MaxScale. Typically that will
 be `/var/lib/maxscale/<monitor-section>/api_key.txt`.
 
-Note that ColumnStore will store the first key provided and\
-thereafter require it, so changing the key requires the\
+Note that ColumnStore will store the first key provided and
+thereafter require it, so changing the key requires the
 resetting of the key on the ColumnStore nodes as well.
 
 #### `local_address`
 
-With this parameter it is specified what IP MaxScale should\
-tell the ColumnStore nodes it resides at. Either it or`local_address` at the global level in the MaxScale\
-configuration file must be specified. If both have been\
+With this parameter it is specified what IP MaxScale should
+tell the ColumnStore nodes it resides at. Either it or`local_address` at the global level in the MaxScale
+configuration file must be specified. If both have been
 specified, then the one specified for the monitor overrides.
 
 #### `dynamic_node_detection`
 
-This optional boolean parameter specifies whether the monitor should\
-autonomously figure out the ColumnStore cluster configuration or whether\
-it should solely rely upon the monitor configuration in the configuration\
-file. Please see [Dynamic Node Detection](mariadb-maxscale-2208-columnstore-monitor.md#dynamic-node-detection) for a\
-thorough discussion on the meaning of the parameter. The default value\
+This optional boolean parameter specifies whether the monitor should
+autonomously figure out the ColumnStore cluster configuration or whether
+it should solely rely upon the monitor configuration in the configuration
+file. Please see [Dynamic Node Detection](mariadb-maxscale-2208-columnstore-monitor.md#dynamic-node-detection) for a
+thorough discussion on the meaning of the parameter. The default value
 is `false`.
 
 #### `cluster_monitor_interval`
 
-This optional parameter, meaningful only if `dynamic_node_detection` is`true` specifies how often the monitor should probe the ColumnStore\
-cluster and adapt to any changes that have occurred in the number of\
-nodes of the cluster. The default value is `10s`, that is, the\
+This optional parameter, meaningful only if `dynamic_node_detection` is`true` specifies how often the monitor should probe the ColumnStore
+cluster and adapt to any changes that have occurred in the number of
+nodes of the cluster. The default value is `10s`, that is, the
 cluster configuration is probed every 10 seconds.
 
-Note that as the probing is performed at the regular monitor round,\
+Note that as the probing is performed at the regular monitor round,
 the value should be some multiple of `monitor_interval`.
 
 ### Dynamic Node Detection
 
-**NOTE** If dynamic node detection is used, the network setup must\
-be such that the hostname/IP-address of a ColumnStore node is the\
+**NOTE** If dynamic node detection is used, the network setup must
+be such that the hostname/IP-address of a ColumnStore node is the
 same when viewed both from MaxScale and from another node.
 
-By default, the ColumnStore monitor behaves like the regular MariaDB\
-monitor. That is, it only monitors the servers it has been configured\
+By default, the ColumnStore monitor behaves like the regular MariaDB
+monitor. That is, it only monitors the servers it has been configured
 with.
 
-If `dynamic_node_detection` has been enabled, the behaviour of the monitor\
-changes significantly. Instead of being explicitly told which servers it\
-should monitor, the monitor is only told how to get into contact with the\
-cluster whereafter it autonomously figures out the cluster configuration\
+If `dynamic_node_detection` has been enabled, the behaviour of the monitor
+changes significantly. Instead of being explicitly told which servers it
+should monitor, the monitor is only told how to get into contact with the
+cluster whereafter it autonomously figures out the cluster configuration
 and creates dynamic server entries accordingly.
 
-When dynamic node detection is enabled, the servers the monitor has been\
-configured with are _only_ used for "bootstrapping" the monitor, because\
-at the initial startup the monitor does not otherwise know how to get\
+When dynamic node detection is enabled, the servers the monitor has been
+configured with are _only_ used for "bootstrapping" the monitor, because
+at the initial startup the monitor does not otherwise know how to get
 into contact with the cluster.
 
 In the following is shown a configuration using dynamic node detection.
@@ -125,20 +125,20 @@ dynamic_node_detection=true
 ...
 ```
 
-As can be seen, the server entries look just like any other server entries,\
-but to make them stand out and to indicate what they are used for, they have\
+As can be seen, the server entries look just like any other server entries,
+but to make them stand out and to indicate what they are used for, they have
 the word _bootstrap_ in their name.
 
-In principle, it is sufficient with a single entry, but to cater for the\
+In principle, it is sufficient with a single entry, but to cater for the
 case that a node happens to be down, it is advisable to have more than one.\
-Once the monitor has been able to connect to a node, it will fetch the\
-configuration and store information about the nodes locally. On subsequent\
-startups, the monitor will use the bootstrap information only if it cannot\
-connect using the persisted information. Also, if there has been any change\
+Once the monitor has been able to connect to a node, it will fetch the
+configuration and store information about the nodes locally. On subsequent
+startups, the monitor will use the bootstrap information only if it cannot
+connect using the persisted information. Also, if there has been any change
 in the bootstrap servers, the persisted information is not used.
 
-Based on the information obtained from the cluster itself, the monitor\
-will create _dynamic_ server instances that are named as `@@` followed by\
+Based on the information obtained from the cluster itself, the monitor
+will create _dynamic_ server instances that are named as `@@` followed by
 the monitor name, followed by a `:`, followed by the hostname.
 
 If the cluster in fact consists of three nodes, then the output of`maxctrl list servers` may look like
@@ -159,11 +159,11 @@ If the cluster in fact consists of three nodes, then the output of`maxctrl list 
 └──────────────────┴─────────┴──────┴─────────────┴─────────────────┴──────┘
 ```
 
-Note that there will be dynamic server entries _also_ for the nodes for\
+Note that there will be dynamic server entries _also_ for the nodes for
 which there is a bootstrap entry.
 
-When the service is defined, it is imperative that it does not explicitly\
-refer to either the bootstrap or the dynamic entries. Instead, it should\
+When the service is defined, it is imperative that it does not explicitly
+refer to either the bootstrap or the dynamic entries. Instead, it should
 refer to the monitor using the `cluster` parameter.
 
 ```
@@ -174,28 +174,28 @@ cluster=CsMonitor
 ...
 ```
 
-With this configuration the _RWS_ service will automatically adapt to any\
+With this configuration the _RWS_ service will automatically adapt to any
 changes made to the ColumnStore cluster.
 
 ### Commands
 
-The ColumnStore monitor provides module commands using which the ColumnStore\
-cluster can be managed. The commands can be invoked using the REST-API with\
+The ColumnStore monitor provides module commands using which the ColumnStore
+cluster can be managed. The commands can be invoked using the REST-API with
 a client such as curl or using maxctrl.
 
 All commands require the monitor instance name as the first parameters.\
 Additional parameters must be provided depending on the command.
 
-Note that as maxctrl itself has a timeout of 10 seconds, if a\
-timeout larger than that is provided to any command, the timeout of\
+Note that as maxctrl itself has a timeout of 10 seconds, if a
+timeout larger than that is provided to any command, the timeout of
 maxctrl must also be increased. For instance:
 
 ```
 maxctrl --timeout 30s call command csmon shutdown CsMonitor 20s
 ```
 
-Here a 30 second timeout is specified for maxctrl to ensure\
-that it does not expire before the timeout of 20s provided for\
+Here a 30 second timeout is specified for maxctrl to ensure
+that it does not expire before the timeout of 20s provided for
 the shutdown command possibly does.
 
 The output is always a JSON object.
@@ -285,11 +285,11 @@ Returns the cluster configuration.
 call command csmon config-get <monitor-name> [<server-name>]
 ```
 
-If no server is specified, the configuration is fetched from\
-the first server in the monitor configuration, otherwise from\
+If no server is specified, the configuration is fetched from
+the first server in the monitor configuration, otherwise from
 the specified server.
 
-Note that if everything is in order, the returned configuration\
+Note that if everything is in order, the returned configuration
 should be identical regardless of the server it is fetched from.
 
 Example
@@ -300,7 +300,7 @@ call command csmon config-get CsMonitor CsNode2
 
 #### `add-node`
 
-Adds a new node located on the server at the hostname or IP _host_\
+Adds a new node located on the server at the hostname or IP _host_
 to the ColumnStore cluster.
 
 ```
@@ -317,7 +317,7 @@ For a more complete example, please refer to [adding a node](mariadb-maxscale-22
 
 #### `remove-node`
 
-Remove the node located on the server at the hostname or IP _host_\
+Remove the node located on the server at the hostname or IP _host_
 from the ColumnStore cluster.
 
 ```
@@ -350,12 +350,12 @@ api_key=somekey1234
 
 ### Adding a Node
 
-Note that in the following `dynamic_node_detection` is not used, but\
+Note that in the following `dynamic_node_detection` is not used, but
 the monitor is configured in the traditional way. The impact of`dynamic_node_detection` is described [here](mariadb-maxscale-2208-columnstore-monitor.md#impact-of-dynamic_node_detection).
 
-Adding a new node to a ColumnStore cluster can be performed dynamically\
-at runtime, but it must be done in two steps. First, the node is added\
-to ColumnStore and then, the corresponding server object (that possibly\
+Adding a new node to a ColumnStore cluster can be performed dynamically
+at runtime, but it must be done in two steps. First, the node is added
+to ColumnStore and then, the corresponding server object (that possibly
 has to be created) in the MaxScale configuration is added to the\
 ColumnStore monitor.
 
@@ -390,7 +390,7 @@ Invoking `maxctrl list servers` will now show:
 └─────────┴─────────────┴──────┴─────────────┴─────────────────┴──────┘
 ```
 
-If we now want to add a new ColumnStore node, located at `mcs3/10.10.10.12`\
+If we now want to add a new ColumnStore node, located at `mcs3/10.10.10.12`
 to the cluster, the steps are as follows.
 
 First the node is added
@@ -417,7 +417,7 @@ After a while the following is output:
 }
 ```
 
-At this point, the ColumnStore cluster consists of three nodes. However,\
+At this point, the ColumnStore cluster consists of three nodes. However,
 the ColumnStore monitor is not yet aware of the new node.
 
 First we need to create the corresponding server object.
@@ -440,7 +440,7 @@ Invoking `maxctrl list servers` will now show:
 └─────────┴─────────────┴──────┴─────────────┴─────────────────┴──────┘
 ```
 
-The server `CsNode3` has been created, but its state is `Down` since\
+The server `CsNode3` has been created, but its state is `Down` since
 it is not yet being monitored.
 
 ```
@@ -481,29 +481,29 @@ The state of the new node is now also set correctly, as shown by`maxctrl list se
 └─────────┴─────────────┴──────┴─────────────┴─────────────────┴──────┘
 ```
 
-Note that the MaxScale server object can be created at any point, but\
-it must not be added to the monitor before the node has been added to\
+Note that the MaxScale server object can be created at any point, but
+it must not be added to the monitor before the node has been added to
 the ColumnStore cluster using `call command csmon add-node`.
 
 #### Impact of `dynamic_node_detection`
 
-If `dynamic_node_detection` is enabled, there is no need to create any\
-explicit server entries. All that needs to be done, is to add the node\
-and the monitor will adapt automatically. Note that it does not matter\
+If `dynamic_node_detection` is enabled, there is no need to create any
+explicit server entries. All that needs to be done, is to add the node
+and the monitor will adapt automatically. Note that it does not matter
 whether the node is added indirectly via maxscale or directly using the\
 REST-API of ColumnStore. The only difference is that in the former case,\
 MaxScale may detect the new situation slightly faster.
 
 ### Removing a Node
 
-Note that in the following `dynamic_node_detection` is not used, but\
+Note that in the following `dynamic_node_detection` is not used, but
 the monitor is configured in the traditional way. The impact of`dynamic_node_detection` is described [here](mariadb-maxscale-2208-columnstore-monitor.md#impact-of-dynamic-node-detection-1).
 
-Removing a node should be performed in the reverse order of how a\
-node was added. First, the MaxScale server should be removed from the\
+Removing a node should be performed in the reverse order of how a
+node was added. First, the MaxScale server should be removed from the
 monitor. Then, the node should be removed from the ColumnStore cluster.
 
-Suppose we want to remove the ColumnStore node at `mcs2/10.10.10.12`\
+Suppose we want to remove the ColumnStore node at `mcs2/10.10.10.12`
 and the current situation is as:
 
 ```
@@ -520,7 +520,7 @@ First, the server is removed from the monitor.
 maxctrl unlink monitor CsMonitor CsNode3
 ```
 
-Checking with `maxctrl list monitors` we see that the server has\
+Checking with `maxctrl list monitors` we see that the server has
 indeed been removed.
 
 ```
@@ -552,10 +552,10 @@ maxctrl --timeout 30s call command csmon remove-node CsMonitor mcs3 20s
 
 #### Impact of `dynamic_node_detection`
 
-If `dynamic_node_detection` is enabled, there is in general no need\
-to explicitly remove a static server entry (as there never was one in\
-the first place). The only exception is if the removed node happened\
-to be a bootstrap server. In that case, the server entry should be\
+If `dynamic_node_detection` is enabled, there is in general no need
+to explicitly remove a static server entry (as there never was one in
+the first place). The only exception is if the removed node happened
+to be a bootstrap server. In that case, the server entry should be
 removed from the monitor's list of servers (used as bootstrap nodes).\
 If that is not done, then the monitor will log a warning at each startup.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-common-monitor-parameters.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-common-monitor-parameters.md
@@ -4,7 +4,7 @@
 
 ## Common Monitor Parameters
 
-This document settings supported by all monitors. These should be defined\
+This document settings supported by all monitors. These should be defined
 in the monitor section of the configuration file.
 
 ### Parameters
@@ -23,7 +23,7 @@ The monitor module this monitor should use. Typically `mariadbmon` or`galeramon`
 * Mandatory: Yes
 * Dynamic: Yes
 
-Username used by the monitor to connect to the backend servers. If a server defines\
+Username used by the monitor to connect to the backend servers. If a server defines
 the `monitoruser` parameter, that value will be used instead.
 
 #### `password`
@@ -32,10 +32,10 @@ the `monitoruser` parameter, that value will be used instead.
 * Mandatory: Yes
 * Dynamic: Yes
 
-Password for the user defined with the `user` parameter. If a server defines\
+Password for the user defined with the `user` parameter. If a server defines
 the `monitorpw` parameter, that value will be used instead.
 
-**Note:** In older versions of MaxScale this parameter was called `passwd`. The\
+**Note:** In older versions of MaxScale this parameter was called `passwd`. The
 use of `passwd` was deprecated in MaxScale 2.3.0.
 
 #### `servers`
@@ -57,17 +57,17 @@ servers=MyServer1,MyServer2
 * Dynamic: Yes
 * Default: `2s`
 
-Defines how often the monitor updates the status of the servers. Choose a lower\
+Defines how often the monitor updates the status of the servers. Choose a lower
 value if servers should be queried more often. The smallest possible value is\
-100 milliseconds. If querying the servers takes longer than `monitor_interval`,\
+100 milliseconds. If querying the servers takes longer than `monitor_interval`,
 the effective update rate is reduced.
 
 ```
 monitor_interval=2s
 ```
 
-The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.
 
 #### `backend_connect_timeout`
@@ -78,10 +78,10 @@ versions a value without a unit may be rejected.
 * Default: `3s`
 
 This parameter controls the timeout for connecting to a monitored server.\
-The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -96,10 +96,10 @@ backend_connect_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for writing to a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 seconds.
 
 ```
@@ -114,10 +114,10 @@ backend_write_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for reading from a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -131,9 +131,9 @@ backend_read_timeout=3s
 * Dynamic: Yes
 * Default: `1`
 
-This parameter defines the maximum times a backend connection is attempted every\
-monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds\
-to perform. If none of the attempts are successful, the backend is considered to\
+This parameter defines the maximum times a backend connection is attempted every
+monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds
+to perform. If none of the attempts are successful, the backend is considered to
 be unreachable and down.
 
 ```
@@ -151,18 +151,18 @@ This parameter duplicates the `disk_space_threshold`[server parameter](../mariad
 If the parameter has _not_ been specified for a server, then the one specified\
 for the monitor is applied.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-That is, if the disk configuration is the same on all servers monitored by\
-the monitor, it is sufficient (and more convenient) to specify the disk\
-space threshold in the monitor section, but if the disk configuration is\
-different on all or some servers, then the disk space threshold can be\
+That is, if the disk configuration is the same on all servers monitored by
+the monitor, it is sufficient (and more convenient) to specify the disk
+space threshold in the monitor section, but if the disk configuration is
+different on all or some servers, then the disk space threshold can be
 specified individually for each server.
 
-For example, suppose `server1`, `server2` and `server3` are identical\
-in all respects. In that case we can specify `disk_space_threshold`\
+For example, suppose `server1`, `server2` and `server3` are identical
+in all respects. In that case we can specify `disk_space_threshold`
 in the monitor.
 
 ```
@@ -185,8 +185,8 @@ disk_space_threshold=/data:80
 ...
 ```
 
-However, if the servers are heterogeneous with the disk used for the\
-data directory mounted on different paths, then the disk space threshold\
+However, if the servers are heterogeneous with the disk used for the
+data directory mounted on different paths, then the disk space threshold
 must be specified separately for each server.
 
 ```
@@ -211,8 +211,8 @@ servers=server1,server2,server3
 ...
 ```
 
-If _most_ of the servers have the data directory disk mounted on\
-the same path, then the disk space threshold can be specified on\
+If _most_ of the servers have the data directory disk mounted on
+the same path, then the disk space threshold can be specified on
 the monitor and separately on the server with a different setup.
 
 ```
@@ -236,7 +236,7 @@ disk_space_threshold=/data:80
 ...
 ```
 
-Above, `server1` has the disk used for the data directory mounted\
+Above, `server1` has the disk used for the data directory mounted
 at `/DbData` while both `server2` and `server3` have it mounted on`/data` and thus the setting in the monitor covers them both.
 
 #### `disk_space_check_interval`
@@ -246,15 +246,15 @@ at `/DbData` while both `server2` and `server3` have it mounted on`/data` and th
 * Dynamic: Yes
 * Default: `0s`
 
-With this parameter it can be specified the minimum amount of time\
-between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+With this parameter it can be specified the minimum amount of time
+between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.\
-The default value is 0, which means that by default the disk space\
+The default value is 0, which means that by default the disk space
 will not be checked.
 
-Note that as the checking is made as part of the regular monitor interval\
-cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,\
+Note that as the checking is made as part of the regular monitor interval
+cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,
 the checking will still take place at `monitor_interval` intervals.
 
 #### `script`
@@ -264,9 +264,9 @@ the checking will still take place at `monitor_interval` intervals.
 * Dynamic: Yes
 * Default: None
 
-This command will be executed on a server state change. The parameter should\
-be an absolute path to a command or the command should be in the executable\
-path. The user running MaxScale should have execution rights to the file itself\
+This command will be executed on a server state change. The parameter should
+be an absolute path to a command or the command should be in the executable
+path. The user running MaxScale should have execution rights to the file itself
 and the directory it resides in. The script may have placeholders which\
 MaxScale will substitute with useful information when launching the script.
 
@@ -280,15 +280,15 @@ The placeholders and their substitution results are:
 * `$MASTERLIST` -> list of IPs and ports of all master servers
 * `$SYNCEDLIST` -> list of IPs and ports of all synced Galera nodes
 * `$PARENT` -> IP and port of the parent of the server which initiated the event.\
-  For master-slave setups, this will be the master if the initiating server is a\
+  For master-slave setups, this will be the master if the initiating server is a
   slave.
-* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who\
-  initiated the event. For master-slave setups, this will be a list of slave\
+* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who
+  initiated the event. For master-slave setups, this will be a list of slave
   servers if the initiating server is a master.
 
-The expanded variable value can be an empty string if no servers match the\
-variable's requirements. For example, if no masters are available `$MASTERLIST`\
-will expand into an empty string. The list-type substitutions will only contain\
+The expanded variable value can be an empty string if no servers match the
+variable's requirements. For example, if no masters are available `$MASTERLIST`
+will expand into an empty string. The list-type substitutions will only contain
 servers monitored by the current monitor.
 
 ```
@@ -303,17 +303,17 @@ The above script could be executed as:
 
 See section [Script example](mariadb-maxscale-2208-common-monitor-parameters.md#script-example) below for an example script.
 
-Any output by the executed script will be logged into the MaxScale log. Each\
+Any output by the executed script will be logged into the MaxScale log. Each
 outputted line will be logged as a separate log message.
 
-The log level on which the messages are logged depends on the format of the\
-messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the\
-corresponding level. If the message is not prefixed with one of the keywords,\
-the message will be logged on the notice level. Whitespace before, after or\
-between the keyword and the colon is ignored and the matching is\
+The log level on which the messages are logged depends on the format of the
+messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the
+corresponding level. If the message is not prefixed with one of the keywords,
+the message will be logged on the notice level. Whitespace before, after or
+between the keyword and the colon is ignored and the matching is
 case-insensitive.
 
-Currently, the script must not execute any of the following MaxCtrl\
+Currently, the script must not execute any of the following MaxCtrl
 calls as they cause a deadlock:
 
 * `alter monitor` to the monitor executing the script
@@ -327,14 +327,14 @@ calls as they cause a deadlock:
 * Dynamic: Yes
 * Default: `90s`
 
-The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If the script execution exceeds the configured timeout, it is stopped by sending\
-a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be\
+If the script execution exceeds the configured timeout, it is stopped by sending
+a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be
 sent to it once the execution time is greater than twice the configured timeout.
 
 #### `events`
@@ -345,15 +345,15 @@ sent to it once the execution time is greater than twice the configured timeout.
 * Values: `master_down`, `master_up`, `slave_down`, `slave_up`, `server_down`, `server_up`, `lost_master`, `lost_slave`, `new_master`, `new_slave`
 * Default: All events
 
-A list of event names which cause the script to be executed. If this option is\
-not defined, all events cause the script to be executed. The list must contain a\
+A list of event names which cause the script to be executed. If this option is
+not defined, all events cause the script to be executed. The list must contain a
 comma separated list of event names.
 
 ```
 events=master_down,slave_down
 ```
 
-The following table contains all the possible event types and their\
+The following table contains all the possible event types and their
 descriptions.
 
 | Event Name   | Description                                  |
@@ -376,38 +376,38 @@ descriptions.
 * Dynamic: Yes
 * Default: `28800s`
 
-The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the max age is seconds, a max age specified in milliseconds will be rejected,\
+The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the max age is seconds, a max age specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-When the monitor starts, it reads any stored journal files. If the journal file\
-is older than the value of _journal\_max\_age_, it will be removed and the monitor\
+When the monitor starts, it reads any stored journal files. If the journal file
+is older than the value of _journal\_max\_age_, it will be removed and the monitor
 starts with no prior knowledge of the servers.
 
 ### Monitor Crash Safety
 
-Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the\
-latest server states. This change makes the monitors crash-safe when options\
-that introduce states are used. It also allows the monitors to retain stateful\
+Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the
+latest server states. This change makes the monitors crash-safe when options
+that introduce states are used. It also allows the monitors to retain stateful
 information when MaxScale is restarted.
 
-For MySQL monitor, options that introduce states into the monitoring process are\
-the `detect_stale_master` and `detect_stale_slave` options, both of which are\
-enabled by default. Galeramon has the `disable_master_failback` parameter which\
+For MySQL monitor, options that introduce states into the monitoring process are
+the `detect_stale_master` and `detect_stale_slave` options, both of which are
+enabled by default. Galeramon has the `disable_master_failback` parameter which
 introduces a state.
 
-The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the\
-name of the monitor section in the configuration file. If MaxScale crashes or is\
-shut down in an uncontrolled fashion, the journal will be read when MaxScale is\
-started. To skip the recovery process, manually delete the journal file before\
+The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the
+name of the monitor section in the configuration file. If MaxScale crashes or is
+shut down in an uncontrolled fashion, the journal will be read when MaxScale is
+started. To skip the recovery process, manually delete the journal file before
 starting MaxScale.
 
 ### Script example
 
-Below is an example monitor configuration which launches a script with all\
-supported substitutions. The example script reads the results and prints it to\
+Below is an example monitor configuration which launches a script with all
+supported substitutions. The example script reads the results and prints it to
 file and sends it as email.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-mariadb-monitor.md
@@ -6,11 +6,11 @@
 
 ### Overview
 
-MariaDB Monitor monitors a Master-Slave replication cluster. It probes the\
-state of the backends and assigns server roles such as master and slave, which\
-are used by the routers when deciding where to route a query. It can also modify\
-the replication cluster by performing failover, switchover and rejoin. Backend\
-server versions older than MariaDB/MySQL 5.5 are not supported. Failover and\
+MariaDB Monitor monitors a Master-Slave replication cluster. It probes the
+state of the backends and assigns server roles such as master and slave, which
+are used by the routers when deciding where to route a query. It can also modify
+the replication cluster by performing failover, switchover and rejoin. Backend
+server versions older than MariaDB/MySQL 5.5 are not supported. Failover and
 other similar operations require MariaDB 10.0.2 or later.
 
 Up until MariaDB MaxScale 2.2.0, this monitor was called _MySQL Monitor_.
@@ -45,7 +45,7 @@ set), then the FILE-grant is required with MariaDB Server versions 10.4.7,\
 GRANT FILE ON *.* TO 'maxscale'@'maxscalehost';
 ```
 
-MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it\
+MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it
 allows the monitor to log in even if server connection limit has been reached.
 
 ```
@@ -54,7 +54,7 @@ GRANT CONNECTION ADMIN ON *.* TO 'maxscale'@'maxscalehost';
 
 #### Cluster Manipulation Grants
 
-If [cluster manipulation operations](mariadb-maxscale-2208-mariadb-monitor.md#cluster-manipulation-operations) are used,\
+If [cluster manipulation operations](mariadb-maxscale-2208-mariadb-monitor.md#cluster-manipulation-operations) are used,
 the following additional grants are required:
 
 ```
@@ -62,7 +62,7 @@ GRANT SUPER, RELOAD, PROCESS, SHOW DATABASES, EVENT ON *.* TO 'maxscale'@'maxsca
 GRANT SELECT ON mysql.user TO 'maxscale'@'maxscalehost';
 ```
 
-As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of\
+As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of
 its former sub-privileges. These must be given separately.
 
 ```
@@ -80,59 +80,59 @@ GRANT REPLICATION SLAVE ON *.* TO 'replication'@'replicationhost';
 
 ### Master selection
 
-Only one backend can be master at any given time. A master must be running\
-(successfully connected to by the monitor) and its _read\_only_-setting must be\
-off. A master may not be replicating from another server in the monitored\
-cluster unless the master is part of a multimaster group. Master selection\
-prefers to select the server with the most slaves, possibly in multiple\
-replication layers. Only slaves reachable by a chain of running relays or\
-directly connected to the master count. When multiple servers are tied for\
-master status, the server which appears earlier in the `servers`-setting of the\
+Only one backend can be master at any given time. A master must be running
+(successfully connected to by the monitor) and its _read\_only_-setting must be
+off. A master may not be replicating from another server in the monitored
+cluster unless the master is part of a multimaster group. Master selection
+prefers to select the server with the most slaves, possibly in multiple
+replication layers. Only slaves reachable by a chain of running relays or
+directly connected to the master count. When multiple servers are tied for
+master status, the server which appears earlier in the `servers`-setting of the
 monitor is selected.
 
-Servers in a cyclical replication topology (multimaster group) are interpreted\
-as having all the servers in the group as slaves. Even from a multimaster group\
+Servers in a cyclical replication topology (multimaster group) are interpreted
+as having all the servers in the group as slaves. Even from a multimaster group
 only one server is selected as the overall master.
 
-After a master has been selected, the monitor prefers to stick with the choice\
-even if other potential masters with more slave servers are available. Only if\
-the current master is clearly unsuitable does the monitor try to select another\
+After a master has been selected, the monitor prefers to stick with the choice
+even if other potential masters with more slave servers are available. Only if
+the current master is clearly unsuitable does the monitor try to select another
 master. An existing master turns invalid if:
 
 1. It is unwritable (read\_only is on).
-2. It has been down for more than failcount monitor passes and has no running\
-   slaves. Running slaves behind a downed relay count. A slave in this context is\
-   any server with at least a partially running replication connection (either\
-   io or sql thread is running). The slave servers must also be down for more than\
+2. It has been down for more than failcount monitor passes and has no running
+   slaves. Running slaves behind a downed relay count. A slave in this context is
+   any server with at least a partially running replication connection (either
+   io or sql thread is running). The slave servers must also be down for more than
    failcount monitor passes to allow new master selection.
-3. It did not previously replicate from another server in the cluster but it\
+3. It did not previously replicate from another server in the cluster but it
    is now replicating.
-4. It was previously part of a multimaster group but is no longer, or the\
+4. It was previously part of a multimaster group but is no longer, or the
    multimaster group is replicating from a server not in the group.
 
-Cases 1 and 2 cover the situations in which the DBA, an external script or even\
-another MaxScale has modified the cluster such that the old master can no longer\
-act as master. Cases 3 and 4 are less severe. In these cases the topology has\
-changed significantly and the master should be re-selected, although the old\
+Cases 1 and 2 cover the situations in which the DBA, an external script or even
+another MaxScale has modified the cluster such that the old master can no longer
+act as master. Cases 3 and 4 are less severe. In these cases the topology has
+changed significantly and the master should be re-selected, although the old
 master may still be the best choice.
 
-The master change described above is different from failover and switchover\
+The master change described above is different from failover and switchover
 described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2208-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
-A master change only modifies the server roles inside MaxScale but does not\
+A master change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a master change on their own.
 
-As a general rule, it's best to avoid situations where the cluster has multiple\
+As a general rule, it's best to avoid situations where the cluster has multiple
 standalone servers, separate master-slave pairs or separate multimaster groups.\
-Due to master invalidation rule 2, a standalone master can easily lose the\
-master status to another valid master if it goes down. The new master probably\
-does not have the same data as the previous one. Non-standalone masters are less\
-vulnerable, as a single running slave or multimaster group member will keep the\
+Due to master invalidation rule 2, a standalone master can easily lose the
+master status to another valid master if it goes down. The new master probably
+does not have the same data as the previous one. Non-standalone masters are less
+vulnerable, as a single running slave or multimaster group member will keep the
 master valid even when down.
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers.
 
 ```
@@ -146,8 +146,8 @@ password=mypwd
 
 From MaxScale 2.2.1 onwards, the module name is `mariadbmon` instead of`mysqlmon`. The old name can still be used.
 
-The grants required by `user` depend on which monitor features are used. A full\
-list of the grants can be found in the [Required Grants](mariadb-maxscale-2208-mariadb-monitor.md#required-grants)\
+The grants required by `user` depend on which monitor features are used. A full
+list of the grants can be found in the [Required Grants](mariadb-maxscale-2208-mariadb-monitor.md#required-grants)
 section.
 
 ### Common Monitor Parameters
@@ -156,9 +156,9 @@ For a list of optional parameters that all monitors support, read the [Monitor C
 
 ### MariaDB Monitor optional parameters
 
-These are optional parameters specific to the MariaDB Monitor. Failover,\
-switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2208-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are\
-described in the [Rebuild server-section](mariadb-maxscale-2208-mariadb-monitor.md#rebuild-server). ColumnStore\
+These are optional parameters specific to the MariaDB Monitor. Failover,
+switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2208-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are
+described in the [Rebuild server-section](mariadb-maxscale-2208-mariadb-monitor.md#rebuild-server). ColumnStore
 parameters are described in the [ColumnStore commands-section](mariadb-maxscale-2208-mariadb-monitor.md#settings).
 
 #### `assume_unique_hostnames`
@@ -168,31 +168,31 @@ parameters are described in the [ColumnStore commands-section](mariadb-maxscale-
 * Dynamic: Yes
 * Default: `true`
 
-When active, the monitor assumes that server hostnames and\
-ports are consistent between the server definitions in the MaxScale\
-configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers\
-themselves. Specifically, the monitor assumes that if server A is replicating\
-from server B, then A must have a slave connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this\
-is not the case, e.g. an IP is used in the server while a hostname is given in\
-the file, the monitor may misinterpret the topology. In MaxScale 2.4.1, the\
-monitor attempts name resolution on the addresses if a simple string comparison\
-does not find a match. Using exact matching addresses is, however, more\
+When active, the monitor assumes that server hostnames and
+ports are consistent between the server definitions in the MaxScale
+configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers
+themselves. Specifically, the monitor assumes that if server A is replicating
+from server B, then A must have a slave connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this
+is not the case, e.g. an IP is used in the server while a hostname is given in
+the file, the monitor may misinterpret the topology. In MaxScale 2.4.1, the
+monitor attempts name resolution on the addresses if a simple string comparison
+does not find a match. Using exact matching addresses is, however, more
 reliable.
 
-This setting must be ON to use any cluster operation features such as failover\
-or switchover, because MaxScale uses the addresses and ports in the\
+This setting must be ON to use any cluster operation features such as failover
+or switchover, because MaxScale uses the addresses and ports in the
 configuration file when issuing "CHANGE MASTER TO"-commands.
 
-If the network configuration is such that the addresses MaxScale uses to connect\
-to backends are different from the ones the servers use to connect to each\
-other, `assume_unique_hostnames` should be set to OFF. In this mode, MaxScale\
-uses server id:s it queries from the servers and the `Master_Server_Id` fields\
-of the slave connections to deduce which server is replicating from which. This\
-is not perfect though, since MaxScale doesn't know the id:s of servers it has\
-never connected to (e.g. server has been down since MaxScale was started). Also,\
-the `Master_Server_Id`-field may have an incorrect value if the slave connection\
-has not been established. MaxScale will only trust the value if the monitor has\
-seen the slave connection IO thread connected at least once. If this is not the\
+If the network configuration is such that the addresses MaxScale uses to connect
+to backends are different from the ones the servers use to connect to each
+other, `assume_unique_hostnames` should be set to OFF. In this mode, MaxScale
+uses server id:s it queries from the servers and the `Master_Server_Id` fields
+of the slave connections to deduce which server is replicating from which. This
+is not perfect though, since MaxScale doesn't know the id:s of servers it has
+never connected to (e.g. server has been down since MaxScale was started). Also,
+the `Master_Server_Id`-field may have an incorrect value if the slave connection
+has not been established. MaxScale will only trust the value if the monitor has
+seen the slave connection IO thread connected at least once. If this is not the
 case, the slave connection is ignored.
 
 #### `master_conditions`
@@ -205,9 +205,9 @@ case, the slave connection is ignored.
 
 Designate additional conditions for\_Master\_-status, i.e qualified for read and write queries.
 
-Normally, if a suitable master candidate server is found as described in [Master selection](mariadb-maxscale-2208-mariadb-monitor.md#master-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a master server. This\
+Normally, if a suitable master candidate server is found as described in [Master selection](mariadb-maxscale-2208-mariadb-monitor.md#master-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a master server. This
 setting is an enum\_mask, allowing multiple conditions to be set simultaneously.\
-Conditions 2, 3 and 4 refer to slave servers. If combined, a single slave must\
+Conditions 2, 3 and 4 refer to slave servers. If combined, a single slave must
 fulfill all of the given conditions for the master to be viable.
 
 If the master candidate fails _master\_conditions_ but fulfills\_slave\_conditions\_, it may be designated _Slave_ instead.
@@ -215,24 +215,24 @@ If the master candidate fails _master\_conditions_ but fulfills\_slave\_conditio
 The available conditions are:
 
 1. none : No additional conditions
-2. connecting\_slave : At least one immediate slave (not behind relay) is\
+2. connecting\_slave : At least one immediate slave (not behind relay) is
    attempting to replicate or is replicating from the master (Slave\_IO\_Running is\
-   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A slave with incorrect\
-   replication credentials does not count. If the slave is currently down, results\
+   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A slave with incorrect
+   replication credentials does not count. If the slave is currently down, results
    from the last successful monitor tick are used.
-3. connected\_slave : Same as above, with the difference that the replication\
-   connection must be up (Slave\_IO\_Running is 'Yes'). If the slave is currently\
+3. connected\_slave : Same as above, with the difference that the replication
+   connection must be up (Slave\_IO\_Running is 'Yes'). If the slave is currently
    down, results from the last successful monitor tick are used.
-4. running\_slave : Same as connecting\_slave, with the addition that the\
+4. running\_slave : Same as connecting\_slave, with the addition that the
    slave must also be Running.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2208-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate master is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2208-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate master is selected also by the
    primary MaxScale.
 
-The default value of this setting is`master_requirements=primary_monitor_master` to ensure that both monitors use\
+The default value of this setting is`master_requirements=primary_monitor_master` to ensure that both monitors use
 the same master server when cooperating.
 
-For example, to require that the master must have a slave which is both\
+For example, to require that the master must have a slave which is both
 connected and running, set
 
 ```
@@ -247,29 +247,29 @@ master_conditions=connected_slave,running_slave
 * Values: `none`, `linked_master`, `running_master`, `writable_master`, `primary_monitor_master`
 * Default: `none`
 
-Designate additional conditions for _Slave_-status,\
+Designate additional conditions for _Slave_-status,
 i.e qualified for read queries.
 
-Normally, a server is _Slave_ if it is at least attempting to replicate from the\
+Normally, a server is _Slave_ if it is at least attempting to replicate from the
 master candidate or a relay (Slave\_IO\_Running is 'Yes' or 'Connecting',\
-Slave\_SQL\_Running is 'Yes', valid replication credentials). The master candidate\
-does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a slave\
-server. This setting is an enum\_mask, allowing multiple conditions to be set\
+Slave\_SQL\_Running is 'Yes', valid replication credentials). The master candidate
+does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a slave
+server. This setting is an enum\_mask, allowing multiple conditions to be set
 simultaneously.
 
 The available conditions are:
 
 1. none : No additional conditions. This is the default value.
-2. linked\_master : The slave must be connected to the master (Slave\_IO\_Running\
-   and Slave\_SQL\_Running are 'Yes') and the master must be Running. The same\
+2. linked\_master : The slave must be connected to the master (Slave\_IO\_Running
+   and Slave\_SQL\_Running are 'Yes') and the master must be Running. The same
    applies to any relays between the slave and the master.
 3. running\_master : The master must be running. Relays may be down.
 4. writable\_master : The master must be writable, i.e. labeled Master.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2208-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate master is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2208-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate master is selected also by the
    primary MaxScale.
 
-For example, to require that the master server of the cluster must be running\
+For example, to require that the master server of the cluster must be running
 and writable for any servers to have _Slave_-status, set
 
 ```
@@ -283,8 +283,8 @@ slave_conditions=running_master,writable_master
 * Dynamic: Yes
 * Default: `5`
 
-Number of consecutive monitor passes a master server must be down before it is\
-considered failed. If automatic failover is enabled (`auto_failover=true`), it\
+Number of consecutive monitor passes a master server must be down before it is
+considered failed. If automatic failover is enabled (`auto_failover=true`), it
 may be performed at this time. A value of 0 or 1 enables immediate failover.
 
 If automatic failover is not possible, the monitor will try to\
@@ -293,8 +293,8 @@ for more details. Changing the master may break replication as queries could be\
 routed to a server without previous events. To prevent this, avoid having\
 multiple valid master servers in the cluster.
 
-The worst-case delay between the master failure and the start of the failover\
-can be estimated by summing up the timeout values and `monitor_interval` and\
+The worst-case delay between the master failure and the start of the failover
+can be estimated by summing up the timeout values and `monitor_interval` and
 multiplying that by `failcount`:
 
 ```
@@ -308,19 +308,19 @@ multiplying that by `failcount`:
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-disable the _read\_only_-flag on the master when seen. The flag is\
-checked every monitor tick. The monitor user requires the SUPER-privilege for\
+If set to ON, the monitor attempts to
+disable the _read\_only_-flag on the master when seen. The flag is
+checked every monitor tick. The monitor user requires the SUPER-privilege for
 this feature to work.
 
-Typically, the master server should never be in read-only-mode. Such a situation\
-may arise due to misconfiguration or accident, or perhaps if MaxScale crashed\
+Typically, the master server should never be in read-only-mode. Such a situation
+may arise due to misconfiguration or accident, or perhaps if MaxScale crashed
 during switchover.
 
-When this feature is enabled, setting the master manually to _read\_only_ will no\
-longer cause the monitor to search for another master. The master will instead\
-for a moment lose its \[Master]-status (no writes), until the monitor again\
-enables writes on the master. When starting from scratch, the monitor still\
+When this feature is enabled, setting the master manually to _read\_only_ will no
+longer cause the monitor to search for another master. The master will instead
+for a moment lose its \[Master]-status (no writes), until the monitor again
+enables writes on the master. When starting from scratch, the monitor still
 prefers to select a writable server as master if possible.
 
 #### `enforce_read_only_slaves`
@@ -330,18 +330,18 @@ prefers to select a writable server as master if possible.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-enable the _read\_only_-flag on any writable slave server. The flag is checked\
-every monitor tick. The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this\
+If set to ON, the monitor attempts to
+enable the _read\_only_-flag on any writable slave server. The flag is checked
+every monitor tick. The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this
 feature to work. While the _read\_only_-flag is ON, only users with the\
-SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If\
-temporary write access is required, this feature should be disabled before\
-attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly\
+SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If
+temporary write access is required, this feature should be disabled before
+attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly
 re-enable it.
 
-_read\_only_ won't be enabled on the master server, even if it has\
-lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2208-mariadb-monitor.md#master_conditions) and is\
+_read\_only_ won't be enabled on the master server, even if it has
+lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2208-mariadb-monitor.md#master_conditions) and is
 marked \[Slave].
 
 #### `enforce_read_only_servers`
@@ -351,12 +351,12 @@ marked \[Slave].
 * Dynamic: Yes
 * Default: `false`
 
-Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2208-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in\
+Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2208-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in
 maintenance (a superset of the servers altered by _enforce\_read\_only\_slaves_).
 
-The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid\
-primary or primary candidate, _read\_only_ is not set on any server as it is\
+The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid
+primary or primary candidate, _read\_only_ is not set on any server as it is
 unclear which servers should be altered.
 
 #### `maintenance_on_low_disk_space`
@@ -366,16 +366,16 @@ unclear which servers should be altered.
 * Dynamic: Yes
 * Default: `true`
 
-If a running server that is not the master\
+If a running server that is not the master
 or a relay master is out of disk space the server is set to maintenance mode.\
-Such servers are not used for router sessions and are ignored when performing a\
-failover or other cluster modification operation. See the general monitor\
-parameters [disk\_space\_threshold](mariadb-maxscale-2208-common-monitor-parameters.md#disk_space_threshold) and [disk\_space\_check\_interval](mariadb-maxscale-2208-common-monitor-parameters.md#disk_space_check_interval)\
+Such servers are not used for router sessions and are ignored when performing a
+failover or other cluster modification operation. See the general monitor
+parameters [disk\_space\_threshold](mariadb-maxscale-2208-common-monitor-parameters.md#disk_space_threshold) and [disk\_space\_check\_interval](mariadb-maxscale-2208-common-monitor-parameters.md#disk_space_check_interval)
 on how to enable disk space monitoring.
 
-Once a server has been put to maintenance mode, the disk space situation\
-of that server is no longer updated. The server will not be taken out of\
-maintenance mode even if more disk space becomes available. The maintenance\
+Once a server has been put to maintenance mode, the disk space situation
+of that server is no longer updated. The server will not be taken out of
+maintenance mode even if more disk space becomes available. The maintenance
 flag must be removed manually:
 
 ```
@@ -390,22 +390,22 @@ maxctrl clear server server2 Maint
 * Values: `none`, `majority_of_all`, `majority_of_running`
 * Default: `none`
 
-Using this setting is recommended when multiple MaxScales are monitoring the\
-same backend cluster. When enabled, the monitor attempts to acquire exclusive\
-locks on the backend servers. The monitor considers itself the primary monitor\
-if it has a majority of locks. The majority can be either over all configured\
-servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2208-mariadb-monitor.md#cooperative-monitoring)\
+Using this setting is recommended when multiple MaxScales are monitoring the
+same backend cluster. When enabled, the monitor attempts to acquire exclusive
+locks on the backend servers. The monitor considers itself the primary monitor
+if it has a majority of locks. The majority can be either over all configured
+servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2208-mariadb-monitor.md#cooperative-monitoring)
 for more details on how this feature works and which value to use.
 
 Allowed values:
 
 1. `none` Default value, no locking.
-2. `majority_of_all` Primary monitor requires a majority of locks, even counting\
+2. `majority_of_all` Primary monitor requires a majority of locks, even counting
    servers which are \[Down].
 3. `majority_of_running` Primary monitor requires a majority of locks over\
    \[Running] servers.
 
-This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has\
+This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has
 acquired the locks. Generally, it's best not to mix cooperative monitoring with\_passive\_. Either set `passive=false` or do not set it at all.
 
 #### `script_max_replication_lag`
@@ -415,55 +415,55 @@ acquired the locks. Generally, it's best not to mix cooperative monitoring with\
 * Dynamic: Yes
 * Default: `-1`
 
-Defines a replication lag limit in seconds for\
-launching the monitor script configured in the _script_-parameter. If the\
+Defines a replication lag limit in seconds for
+launching the monitor script configured in the _script_-parameter. If the
 replication lag of a server goes above this limit, the script is ran with the\
-$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the\
+$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
-Negative values disable this feature. For more information on monitor scripts,\
+Negative values disable this feature. For more information on monitor scripts,
 see [general monitor documentation](https://mariadb.com/kb/en/node:mariadb-maxscale-2208-common-monitor-parameters#script).
 
 ### Cluster manipulation operations
 
-Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster\
+Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster
 modification. The operations implemented are:
 
 * _failover_, which replaces a failed master with a slave
 * _switchover_, which swaps a running master with a slave
 * _async-switchover_, which schedules a switchover and returns
 * _rejoin_, which directs servers to replicate from the master
-* _reset-replication_ (added in MaxScale 2.3.0), which deletes binary logs and\
+* _reset-replication_ (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
-See [operation details](mariadb-maxscale-2208-mariadb-monitor.md#operation-details) for more information on the\
+See [operation details](mariadb-maxscale-2208-mariadb-monitor.md#operation-details) for more information on the
 implementation of the commands.
 
-The cluster operations require that the monitor user (`user`) has the following\
+The cluster operations require that the monitor user (`user`) has the following
 privileges:
 
-* SUPER, to modify slave connections, set globals such as read\_only and kill\
+* SUPER, to modify slave connections, set globals such as read\_only and kill
   connections from other super-users
-* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list\
+* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list
   slave connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
 * SHOW DATABASES and EVENT, to list and modify server events
 * SELECT on mysql.user, to see which users have SUPER
 
-A list of the grants can be found in the [Required Grants](mariadb-maxscale-2208-mariadb-monitor.md#required-grants)\
+A list of the grants can be found in the [Required Grants](mariadb-maxscale-2208-mariadb-monitor.md#required-grants)
 section.
 
-The privilege system was changed in MariaDB Server 10.5. The effects of this on\
-the MaxScale monitor user are minor, as the SUPER-privilege contains many of the\
-required privileges and is still required to kill connections from other\
+The privilege system was changed in MariaDB Server 10.5. The effects of this on
+the MaxScale monitor user are minor, as the SUPER-privilege contains many of the
+required privileges and is still required to kill connections from other
 super-users.
 
-In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required\
+In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required
 grants. The monitor requires:
 
 * READ\_ONLY ADMIN, to set read\_only
-* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication\
+* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication
   connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
@@ -472,39 +472,39 @@ grants. The monitor requires:
 * CONNECTION ADMIN, to kill connections
 * SELECT on mysql.user, to see which users have SUPER
 
-In addition, the monitor needs to know which username and password a\
+In addition, the monitor needs to know which username and password a
 slave should use when starting replication. These are given in`replication_user` and `replication_password`.
 
-The user can define files with SQL statements which are executed on any server\
+The user can define files with SQL statements which are executed on any server
 being demoted or promoted by cluster manipulation commands. See the sections on`promotion_sql_file` and `demotion_sql_file` for more information.
 
-The monitor can manipulate scheduled server events when promoting or demoting a\
+The monitor can manipulate scheduled server events when promoting or demoting a
 server. See the section on `handle_events` for more information.
 
-All cluster operations can be activated manually through MaxCtrl. See\
+All cluster operations can be activated manually through MaxCtrl. See
 section [Manual activation](mariadb-maxscale-2208-mariadb-monitor.md#manual-activation) for more details.
 
-See [Limitations and requirements](mariadb-maxscale-2208-mariadb-monitor.md#limitations-and-requirements) for\
+See [Limitations and requirements](mariadb-maxscale-2208-mariadb-monitor.md#limitations-and-requirements) for
 information on possible issues with failover and switchover.
 
 #### Operation details
 
-**Failover** replaces a failed master with a running slave. It does the\
+**Failover** replaces a failed master with a running slave. It does the
 following:
 
-1. Select the most up-to-date slave of the old master to be the new master. The\
+1. Select the most up-to-date slave of the old master to be the new master. The
    selection criteria is as follows in descending priority:
 2. gtid\_IO\_pos (latest event in relay log)
 3. gtid\_current\_pos (most processed events)
 4. log\_slave\_updates is on
 5. disk space is not low
-6. If the new master has unprocessed relay log items, cancel and try again\
+6. If the new master has unprocessed relay log items, cancel and try again
    later.
 7. Prepare the new master:
-8. Remove the slave connection the new master used to replicate from the\
+8. Remove the slave connection the new master used to replicate from the
    old master.
 9. Disable the read\_only-flag.
-10. Enable scheduled server events (if event handling is on). Only events\
+10. Enable scheduled server events (if event handling is on). Only events
     that were enabled on the old master are enabled.
 11. Run the commands in `promotion_sql_file`.
 12. Start replication from external master if one existed.
@@ -514,30 +514,30 @@ following:
 16. START SLAVE
 17. Check that all slaves are replicating.
 
-Failover is considered successful if steps 1 to 3 succeed, as the cluster then\
+Failover is considered successful if steps 1 to 3 succeed, as the cluster then
 has at least a valid master server.
 
-**Switchover** swaps a running master with a running slave. It does the\
+**Switchover** swaps a running master with a running slave. It does the
 following:
 
 1. Prepare the old master for demotion:
 2. Stop any external replication.
-3. Kill connections from super-users since read\_only does not affect\
+3. Kill connections from super-users since read\_only does not affect
    them.
 4. Enable the read\_only-flag to stop writes.
 5. Disable scheduled server events (if event handling is on).
 6. Run the commands in `demotion_sql_file`.
 7. Flush the binary log (FLUSH LOGS) so that all events are on disk.
 8. Wait for the new master to catch up with the old master.
-9. Promote new master and redirect slaves as in failover steps 3 and 4. Also\
+9. Promote new master and redirect slaves as in failover steps 3 and 4. Also
    redirect the demoted old master.
 10. Check that all slaves are replicating.
 
-Similar to failover, switchover is considered successful if the new master was\
+Similar to failover, switchover is considered successful if the new master was
 successfully promoted.
 
-**Rejoin** joins a standalone server to the cluster or redirects a slave\
-replicating from a server other than the master. A standalone server is joined\
+**Rejoin** joins a standalone server to the cluster or redirects a slave
+replicating from a server other than the master. A standalone server is joined
 by:
 
 1. Run the commands in `demotion_sql_file`.
@@ -548,9 +548,9 @@ by:
 A server which is replicating from the wrong master is redirected simply with\
 STOP SLAVE, RESET SLAVE, CHANGE MASTER TO and START SLAVE commands.
 
-**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets\
-gtid:s. This destructive command is meant for situations where the gtid:s in the\
-cluster are out of sync while the actual data is known to be in sync. The\
+**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets
+gtid:s. This destructive command is meant for situations where the gtid:s in the
+cluster are out of sync while the actual data is known to be in sync. The
 operation proceeds as follows:
 
 1. Reset gtid:s and delete binary logs on all servers:
@@ -558,38 +558,38 @@ operation proceeds as follows:
 3. Enable the read\_only-flag.
 4. Disable scheduled server events (if event handling is on).
 5. Delete binary logs (RESET MASTER).
-6. Set the sequence number of gtid\_slave\_pos to zero. This also affects\
+6. Set the sequence number of gtid\_slave\_pos to zero. This also affects
    gtid\_current\_pos.
 7. Prepare new master:
 8. Disable the read\_only-flag.
-9. Enable scheduled server events (if event handling is on). Events are\
-   only enabled if the cluster had a master server when starting the\
-   reset-replication operation. Only events that were enabled on the previous\
+9. Enable scheduled server events (if event handling is on). Events are
+   only enabled if the cluster had a master server when starting the
+   reset-replication operation. Only events that were enabled on the previous
    master are enabled on the new.
-10. Direct other servers to replicate from the new master as in the other\
+10. Direct other servers to replicate from the new master as in the other
     operations.
 
 #### Manual activation
 
 Cluster operations can be activated manually through the REST API or MaxCtrl.\
-The commands are only performed when MaxScale is in active mode. The commands\
-generally match their automatic versions. The exception is _rejoin_, in which\
-the manual command allows rejoining even when the joining server has empty\
-gtid:s. This rule allows the user to force a rejoin on a server without binary\
+The commands are only performed when MaxScale is in active mode. The commands
+generally match their automatic versions. The exception is _rejoin_, in which
+the manual command allows rejoining even when the joining server has empty
+gtid:s. This rule allows the user to force a rejoin on a server without binary
 logs.
 
-All commands require the monitor instance name as the first parameter. Failover\
-selects the new master server automatically and does not require additional\
+All commands require the monitor instance name as the first parameter. Failover
+selects the new master server automatically and does not require additional
 parameters. Rejoin requires the name of the joining server as second parameter.\
 Replication reset accepts the name of the new master server as second parameter.\
 If not given, the current master is selected.
 
-Switchover takes one to three parameters. If only the monitor name is given,\
-switchover will autoselect both the slave to promote and the current master as\
-the server to be demoted. If two parameters are given, the second parameter is\
-interpreted as the slave to promote. If three parameters are given, the third\
-parameter is interpreted as the current master. The user-given current master is\
-compared to the master server currently deduced by the monitor and if the two\
+Switchover takes one to three parameters. If only the monitor name is given,
+switchover will autoselect both the slave to promote and the current master as
+the server to be demoted. If two parameters are given, the second parameter is
+interpreted as the slave to promote. If three parameters are given, the third
+parameter is interpreted as the current master. The user-given current master is
+compared to the master server currently deduced by the monitor and if the two
 are unequal, an error is given.
 
 Example commands are below:
@@ -604,29 +604,29 @@ call command mariadbmon switchover MyMonitor NewMasterServ
 call command mariadbmon switchover MyMonitor NewMasterServ OldMasterServ
 ```
 
-The commands follow the standard module command syntax. All require the monitor\
-configuration name (MyMonitor) as the first parameter. For switchover, the\
-last two parameters define the server to promote (NewMasterServ) and the server\
-to demote (OldMasterServ). For rejoin, the server to join (OldMasterServ) is\
+The commands follow the standard module command syntax. All require the monitor
+configuration name (MyMonitor) as the first parameter. For switchover, the
+last two parameters define the server to promote (NewMasterServ) and the server
+to demote (OldMasterServ). For rejoin, the server to join (OldMasterServ) is
 required. Replication reset requires the server to promote (NewMasterServ).
 
-It is safe to perform manual operations even with automatic failover, switchover\
-or rejoin enabled since automatic operations cannot happen simultaneously\
+It is safe to perform manual operations even with automatic failover, switchover
+or rejoin enabled since automatic operations cannot happen simultaneously
 with manual ones.
 
-When a cluster modification is initiated via the REST-API, the URL path is of the\
+When a cluster modification is initiated via the REST-API, the URL path is of the
 form:
 
 ```
 /v1/maxscale/modules/mariadbmon/<operation>?<monitor-instance>&<server-param1>&<server-param2>
 ```
 
-* `<operation>` is the name of the command: failover, switchover, rejoin\
+* `<operation>` is the name of the command: failover, switchover, rejoin
   or reset-replication.
-* `<monitor-instance>` is the monitor section name from the MaxScale\
+* `<monitor-instance>` is the monitor section name from the MaxScale
   configuration file.
-* `<server-param1>` and `<server-param2>` are server parameters as described\
-  above for MaxCtrl. Only switchover accepts both, failover doesn't need any\
+* `<server-param1>` and `<server-param2>` are server parameters as described
+  above for MaxCtrl. Only switchover accepts both, failover doesn't need any
   and both rejoin and reset-replication accept one.
 
 Given a MaxScale configuration file like
@@ -639,7 +639,7 @@ servers=server1, server2, server3, server 4
 ...
 ```
 
-with the assumption that `server2` is the current master, then the URL\
+with the assumption that `server2` is the current master, then the URL
 path for making `server4` the new master would be:
 
 ```
@@ -656,9 +656,9 @@ Example REST-API paths for other commands are listed below.
 
 **Queued switchover**
 
-Most cluster modification commands wait until the operation either succeeds or\
-fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the\
-module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,\
+Most cluster modification commands wait until the operation either succeeds or
+fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the
+module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,
 whether queued or not.
 
 ```
@@ -675,123 +675,123 @@ maxctrl call command mariadbmon fetch-cmd-result Cluster1
 
 #### Automatic activation
 
-Failover can activate automatically if `auto_failover` is on. The activation\
+Failover can activate automatically if `auto_failover` is on. The activation
 begins when the master has been down at least `failcount` monitor iterations.\
-Before modifying the cluster, the monitor checks that all prerequisites for the\
-failover are fulfilled. If the cluster does not seem ready, an error is printed\
+Before modifying the cluster, the monitor checks that all prerequisites for the
+failover are fulfilled. If the cluster does not seem ready, an error is printed
 and the cluster is rechecked during the next monitor iteration.
 
-Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the master\
-server is low on disk space but otherwise the operating logic is quite similar\
+Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the master
+server is low on disk space but otherwise the operating logic is quite similar
 to automatic failover.
 
-Rejoin stands for starting replication on a standalone server or redirecting a\
-slave replicating from the wrong master (any server that is not the cluster\
-master). The rejoined servers are directed to replicate from the current cluster\
-master server, forcing the replication topology to a 1-master-N-slaves\
+Rejoin stands for starting replication on a standalone server or redirecting a
+slave replicating from the wrong master (any server that is not the cluster
+master). The rejoined servers are directed to replicate from the current cluster
+master server, forcing the replication topology to a 1-master-N-slaves
 configuration.
 
-A server is categorized as standalone if the server has no slave connections,\
-not even stopped ones. A server is replicating from the wrong master if the\
-slave IO thread is connected but the master server id seen by the slave does not\
-match the cluster master id. Alternatively, the IO thread may be stopped or\
-connecting but the master server host or port information differs from the\
-cluster master info. These criteria mean that a STOP SLAVE does not yet set a\
+A server is categorized as standalone if the server has no slave connections,
+not even stopped ones. A server is replicating from the wrong master if the
+slave IO thread is connected but the master server id seen by the slave does not
+match the cluster master id. Alternatively, the IO thread may be stopped or
+connecting but the master server host or port information differs from the
+cluster master info. These criteria mean that a STOP SLAVE does not yet set a
 slave as standalone.
 
-With `auto_rejoin` active, the monitor will try to rejoin any servers matching\
-the above requirements. Rejoin does not obey `failcount` and will attempt to\
-rejoin any valid servers immediately. When activating rejoin manually, the\
+With `auto_rejoin` active, the monitor will try to rejoin any servers matching
+the above requirements. Rejoin does not obey `failcount` and will attempt to
+rejoin any valid servers immediately. When activating rejoin manually, the
 user-designated server must fulfill the same requirements.
 
 #### Limitations and requirements
 
-Switchover and failover are meant for simple topologies (one master and\
-several slaves). Using these commands with complicated topologies\
-(multiple masters, relays, circular replication) may give unpredictable results\
+Switchover and failover are meant for simple topologies (one master and
+several slaves). Using these commands with complicated topologies
+(multiple masters, relays, circular replication) may give unpredictable results
 and should be tested before use on a production system.
 
-The server cluster is assumed to be well-behaving with no significant\
-replication lag (within `failover_timeout`/`switchover_timeout`) and all\
+The server cluster is assumed to be well-behaving with no significant
+replication lag (within `failover_timeout`/`switchover_timeout`) and all
 commands that modify the cluster (such as "STOP SLAVE", "CHANGE MASTER",\
-"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`\
+"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`
 and `backend_write_timeout`).
 
-The backends must all use GTID-based replication, and the domain id should not\
-change during a switchover or failover. Slave servers should not have extra\
+The backends must all use GTID-based replication, and the domain id should not
+change during a switchover or failover. Slave servers should not have extra
 local events so that GTIDs are compatible across the cluster.
 
-Failover cannot be performed if MaxScale was started only after the master\
-server went down. This is because MaxScale needs reliable information on the\
-gtid domain of the cluster and the replication topology in general to properly\
+Failover cannot be performed if MaxScale was started only after the master
+server went down. This is because MaxScale needs reliable information on the
+gtid domain of the cluster and the replication topology in general to properly
 select the new master. `enforce_simple_topology=1` relaxes this requirement.
 
-Failover may lose events. If a master goes down before sending new events to at\
-least one slave, those events are lost when a new master is chosen. If the old\
-master comes back online, the other servers have likely moved on with a\
+Failover may lose events. If a master goes down before sending new events to at
+least one slave, those events are lost when a new master is chosen. If the old
+master comes back online, the other servers have likely moved on with a
 diverging history and the old master can no longer join the replication cluster.
 
 To reduce the chance of losing data, use [semisynchronous replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication).\
-In semisynchronous mode, the master waits for a slave to receive an event before\
-returning an acknowledgement to the client. This does not yet guarantee a clean\
-failover. If the master fails after preparing a transaction but before receiving\
-slave acknowledgement, it will still commit the prepared transaction as part of\
-its crash recovery. If the slaves never saw this transaction, the\
-old master has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
+In semisynchronous mode, the master waits for a slave to receive an event before
+returning an acknowledgement to the client. This does not yet guarantee a clean
+failover. If the master fails after preparing a transaction but before receiving
+slave acknowledgement, it will still commit the prepared transaction as part of
+its crash recovery. If the slaves never saw this transaction, the
+old master has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
 for more information. This situation is much less likely in MariaDB Server\
-10.6.2 and later, as the improved crash recovery logic will delete such\
+10.6.2 and later, as the improved crash recovery logic will delete such
 transactions.
 
-Even a controlled shutdown of the master may lose events. The server does not by\
-default wait for all data to be replicated to the slaves when shutting down and\
-instead simply closes all connections. Before shutting down the master with the\
-intention of having a slave promoted, run _switchover_ first to ensure that all\
+Even a controlled shutdown of the master may lose events. The server does not by
+default wait for all data to be replicated to the slaves when shutting down and
+instead simply closes all connections. Before shutting down the master with the
+intention of having a slave promoted, run _switchover_ first to ensure that all
 data is replicated. For more information on server shutdown, see [Binary Log Dump Threads and the Shutdown Process](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-threads).
 
-Switchover requires that the cluster is "frozen" for the duration of the\
-operation. This means that no data modifying statements such as INSERT or UPDATE\
-are executed and the GTID position of the master server is stable. When\
-switchover begins, the monitor sets the global _read\_only_ flag on the old\
+Switchover requires that the cluster is "frozen" for the duration of the
+operation. This means that no data modifying statements such as INSERT or UPDATE
+are executed and the GTID position of the master server is stable. When
+switchover begins, the monitor sets the global _read\_only_ flag on the old
 master backend to stop any updates. _read\_only_ does not affect users with the\
-SUPER-privilege so any such user can issue writes during a switchover. These\
-writes have a high chance of breaking replication, because the write may not be\
-replicated to all slaves before they switch to the new master. To prevent this,\
-any users who commonly do updates should NOT have the SUPER-privilege. For even\
+SUPER-privilege so any such user can issue writes during a switchover. These
+writes have a high chance of breaking replication, because the write may not be
+replicated to all slaves before they switch to the new master. To prevent this,
+any users who commonly do updates should NOT have the SUPER-privilege. For even
 more security, the only SUPER-user session during a switchover should be the\
-MaxScale monitor user. This also applies to users running scheduled server\
-events. Although the monitor by default disables events on the master, an\
-event may already be executing. If the event definer has SUPER-privilege, the\
+MaxScale monitor user. This also applies to users running scheduled server
+events. Although the monitor by default disables events on the master, an
+event may already be executing. If the event definer has SUPER-privilege, the
 event can write to the database even through _read\_only_.
 
-When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest\
-of the cluster. If the current cluster master does not have binary logs from the\
-moment the rejoining server lost connection, the rejoining server cannot\
-continue replication. This is an issue if the master has changed and\
+When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest
+of the cluster. If the current cluster master does not have binary logs from the
+moment the rejoining server lost connection, the rejoining server cannot
+continue replication. This is an issue if the master has changed and
 the new master does not have _log\_slave\_updates_ on.
 
-If an automatic cluster operation such as auto-failover or auto-rejoin fails,\
-all cluster modifying operations are disabled for `failcount` monitor iterations,\
-after which the operation may be retried. Similar logic applies if the cluster is\
+If an automatic cluster operation such as auto-failover or auto-rejoin fails,
+all cluster modifying operations are disabled for `failcount` monitor iterations,
+after which the operation may be retried. Similar logic applies if the cluster is
 unsuitable for such operations, e.g. replication is not using GTID.
 
 #### External master support
 
-The monitor detects if a server in the cluster is replicating from an external\
-master (a server that is not monitored by the monitor). If the replicating\
-server is the cluster master server, then the cluster itself is considered to\
+The monitor detects if a server in the cluster is replicating from an external
+master (a server that is not monitored by the monitor). If the replicating
+server is the cluster master server, then the cluster itself is considered to
 have an external master.
 
-If a failover/switchover happens, the new master server is set to replicate from\
-the cluster external master server. The username and password for the replication\
-are defined in `replication_user` and `replication_password`. The address and\
-port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster\
-master server. In the case of switchover, the old master also stops replicating\
+If a failover/switchover happens, the new master server is set to replicate from
+the cluster external master server. The username and password for the replication
+are defined in `replication_user` and `replication_password`. The address and
+port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster
+master server. In the case of switchover, the old master also stops replicating
 from the external server to preserve the topology.
 
-After failover the new master is replicating from the external master. If the\
-failed old master comes back online, it is also replicating from the external\
-server. To normalize the situation, either have _auto\_rejoin_ on or manually\
-execute a rejoin. This will redirect the old master to the current cluster\
+After failover the new master is replicating from the external master. If the
+failed old master comes back online, it is also replicating from the external
+server. To normalize the situation, either have _auto\_rejoin_ on or manually
+execute a rejoin. This will redirect the old master to the current cluster
 master.
 
 #### Configuration parameters
@@ -803,18 +803,18 @@ master.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic master failover. When automatic failover is enabled, MaxScale\
-will elect a new master server for the cluster if the old master goes down. A\
-server is assumed _Down_ if it cannot be connected to, even if this is caused by\
+Enable automatic master failover. When automatic failover is enabled, MaxScale
+will elect a new master server for the cluster if the old master goes down. A
+server is assumed _Down_ if it cannot be connected to, even if this is caused by
 incorrect credentials. Failover triggers if the master stays down for [failcount](mariadb-maxscale-2208-mariadb-monitor.md#failcount) monitor intervals. Failover will not take place if\
 MaxScale is set [passive](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#passive).
 
-As failover alters replication, it requires more privileges than normal\
+As failover alters replication, it requires more privileges than normal
 monitoring. See [here](mariadb-maxscale-2208-mariadb-monitor.md#cluster-manipulation-grants) for a list of grants.
 
-Failover is designed to be used with simple master-slave topologies. More\
-complicated topologies, such as multilayered or circular replication, are not\
-guaranteed to always work correctly. Test before using failover with such\
+Failover is designed to be used with simple master-slave topologies. More
+complicated topologies, such as multilayered or circular replication, are not
+guaranteed to always work correctly. Test before using failover with such
 setups.
 
 **`auto_rejoin`**
@@ -824,20 +824,20 @@ setups.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic joining of servers to the cluster. When enabled, MaxScale will\
-attempt to direct servers to replicate from the current cluster master if they\
-are not currently doing so. Replication will be started on any standalone\
+Enable automatic joining of servers to the cluster. When enabled, MaxScale will
+attempt to direct servers to replicate from the current cluster master if they
+are not currently doing so. Replication will be started on any standalone
 servers. Servers that are replicating from another server will be redirected.\
-This effectively enforces a 1-master-N-slaves topology. The current master\
-itself is not redirected, so it can continue to replicate from an external\
-master. Rejoin is also not performed on any server that is replicating from\
-multiple sources, as this indicates a complicated topology (this rule is\
+This effectively enforces a 1-master-N-slaves topology. The current master
+itself is not redirected, so it can continue to replicate from an external
+master. Rejoin is also not performed on any server that is replicating from
+multiple sources, as this indicates a complicated topology (this rule is
 overridden by [enforce\_simple\_topology](mariadb-maxscale-2208-mariadb-monitor.md#enforce_simple_topology)).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2208-mariadb-monitor.md#auto_failover) to redirect\
-the former master when it comes back online. Sometimes this kind of rejoin will\
-fail as the old master may have transactions that were never replicated to the\
-current one. See [limitations](mariadb-maxscale-2208-mariadb-monitor.md#limitations-and-requirements) for more\
+This feature is often paired with [auto\_failover](mariadb-maxscale-2208-mariadb-monitor.md#auto_failover) to redirect
+the former master when it comes back online. Sometimes this kind of rejoin will
+fail as the old master may have transactions that were never replicated to the
+current one. See [limitations](mariadb-maxscale-2208-mariadb-monitor.md#limitations-and-requirements) for more
 information.
 
 As an example, consider the following series of events:
@@ -847,9 +847,9 @@ As an example, consider the following series of events:
 3. Slave A comes back
 4. Old master comes back
 
-Slave A is still trying to replicate from the downed master, since it wasn't\
-online during failover. If _auto\_rejoin_ is on, Slave A will quickly be\
-redirected to Slave B, the current master. The old master will also rejoin the\
+Slave A is still trying to replicate from the downed master, since it wasn't
+online during failover. If _auto\_rejoin_ is on, Slave A will quickly be
+redirected to Slave B, the current master. The old master will also rejoin the
 cluster if possible.
 
 **`switchover_on_low_disk_space`**
@@ -882,18 +882,18 @@ switchover_on_low_disk_space=true
 * Default: `false`
 
 This setting tells the monitor to assume that the servers should be arranged in a\
-1-master-N-slaves topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual\
+1-master-N-slaves topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual
 settings.
 
-By default, mariadbmon will not rejoin servers with more than one replication\
-stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the\
-cluster and any extra replication sources will be removed. This is done to make\
+By default, mariadbmon will not rejoin servers with more than one replication
+stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the
+cluster and any extra replication sources will be removed. This is done to make
 automated failover with multi-source external replication possible.
 
-This setting also allows the monitor to perform a failover to a cluster where the master\
-server has not been seen \[Running]. This is usually the case when the master goes down\
-before MaxScale is started. When using this feature, the monitor will guess the GTID\
-domain id of the master from the slaves. For reliable results, the GTID:s of the cluster\
+This setting also allows the monitor to perform a failover to a cluster where the master
+server has not been seen \[Running]. This is usually the case when the master goes down
+before MaxScale is started. When using this feature, the monitor will guess the GTID
+domain id of the master from the slaves. For reliable results, the GTID:s of the cluster
 should be simple.
 
 ```
@@ -907,19 +907,19 @@ enforce_simple_topology=true
 * Dynamic: Yes
 * Default: None
 
-The username and password of the replication user. These are given as the values\
-for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is\
+The username and password of the replication user. These are given as the values
+for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is
 executed.
 
-Both `replication_user` and `replication_password` parameters must be defined if\
-a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication\
+Both `replication_user` and `replication_password` parameters must be defined if
+a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication
 user.
 
-The credentials used for replication must have the `REPLICATION SLAVE`\
+The credentials used for replication must have the `REPLICATION SLAVE`
 privilege.
 
-`replication_password` uses the same encryption scheme as other password\
-parameters. If password encryption is in use, `replication_password` must be\
+`replication_password` uses the same encryption scheme as other password
+parameters. If password encryption is in use, `replication_password` must be
 encrypted with the same key to avoid erroneous decryption.
 
 **`replication_master_ssl`**
@@ -929,12 +929,12 @@ encrypted with the same key to avoid erroneous decryption.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable\
-encryption for the replication stream. This setting should only be enabled if the backend\
-servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication\
+If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable
+encryption for the replication stream. This setting should only be enabled if the backend
+servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication
 user should require an encrypted connection (`e.g. ALTER USER repl@'%' REQUIRE SSL;`).
 
-If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing\
+If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing
 settings when redirecting a slave connection.
 
 **`failover_timeout` and `switchover_timeout`**
@@ -944,19 +944,19 @@ settings when redirecting a slave connection.
 * Dynamic: Yes
 * Default: `90s`
 
-Time limit for failover and switchover operations. The default\
-values are 90 seconds for both. `switchover_timeout` is also used as the time\
-limit for a rejoin operation. Rejoin should rarely time out, since it is a\
+Time limit for failover and switchover operations. The default
+values are 90 seconds for both. `switchover_timeout` is also used as the time
+limit for a rejoin operation. Rejoin should rarely time out, since it is a
 faster operation than switchover.
 
-The timeouts are specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeouts is seconds, a timeout specified in milliseconds will be rejected,\
+The timeouts are specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeouts is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If no successful failover/switchover takes place within the configured time\
-period, a message is logged and automatic failover is disabled. This prevents\
+If no successful failover/switchover takes place within the configured time
+period, a message is logged and automatic failover is disabled. This prevents
 further automatic modifications to the misbehaving cluster.
 
 **`verify_master_failure`**
@@ -968,18 +968,18 @@ further automatic modifications to the misbehaving cluster.
 
 Enable additional master failure verification for automatic failover.`verify_master_failure` enables this feature and [master\_failure\_timeout](mariadb-maxscale-2208-mariadb-monitor.md#master_failure_timeout) defines the timeout.
 
-Failure verification is performed by checking whether the slave servers are\
-still connected to the master and receiving events. An event is either a change\
-in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat\
-event. Effectively, if a slave has received an event within`master_failure_timeout` duration, the master is not considered down when\
-deciding whether to failover, even if MaxScale cannot connect to the master.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of\
+Failure verification is performed by checking whether the slave servers are
+still connected to the master and receiving events. An event is either a change
+in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat
+event. Effectively, if a slave has received an event within`master_failure_timeout` duration, the master is not considered down when
+deciding whether to failover, even if MaxScale cannot connect to the master.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of
 the slave connection to be effective.
 
 If every slave loses its connection to the master (_Slave\_IO\_Running_ is not\
-"Yes"), master failure is considered verified regardless of timeout. This allows\
+"Yes"), master failure is considered verified regardless of timeout. This allows
 faster failover when the master properly disconnects.
 
-For automatic failover to activate, the `failcount` requirement must also be\
+For automatic failover to activate, the `failcount` requirement must also be
 met.
 
 **`master_failure_timeout`**
@@ -989,10 +989,10 @@ met.
 * Dynamic: Yes
 * Default: `10s`
 
-The master failure timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The master failure timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 **`servers_no_promotion`**
@@ -1002,11 +1002,11 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: None
 
-This is a comma-separated list of server names that will not be chosen for\
-master promotion during a failover or autoselected for switchover. This does not\
-affect switchover if the user selects the server to promote. Using this setting\
-can disrupt new master selection for failover such that an non-optimal server is\
-chosen. At worst, this will cause replication to break. Alternatively, failover\
+This is a comma-separated list of server names that will not be chosen for
+master promotion during a failover or autoselected for switchover. This does not
+affect switchover if the user selects the server to promote. Using this setting
+can disrupt new master selection for failover such that an non-optimal server is
+chosen. At worst, this will cause replication to break. Alternatively, failover
 may fail if all valid promotion candidates are in the exclusion list.
 
 ```
@@ -1021,30 +1021,30 @@ servers_no_promotion=backup_dc_server1,backup_dc_server2
 * Default: None
 
 These optional settings are paths to text files with SQL statements in them.\
-During promotion or demotion, the contents are read line-by-line and executed on\
-the backend. Use these settings to execute custom statements on the servers to\
+During promotion or demotion, the contents are read line-by-line and executed on
+the backend. Use these settings to execute custom statements on the servers to
 complement the built-in operations.
 
-Empty lines or lines starting with '#' are ignored. Any results returned by the\
-statements are ignored. All statements must succeed for the failover, switchover\
-or rejoin to continue. The monitor user may require additional privileges and\
+Empty lines or lines starting with '#' are ignored. Any results returned by the
+statements are ignored. All statements must succeed for the failover, switchover
+or rejoin to continue. The monitor user may require additional privileges and
 grants for the custom commands to succeed.
 
-When promoting a slave to master during switchover or failover, the`promotion_sql_file` is read and executed on the new master server after its\
-read-only flag is disabled. The commands are ran _before_ starting replication\
+When promoting a slave to master during switchover or failover, the`promotion_sql_file` is read and executed on the new master server after its
+read-only flag is disabled. The commands are ran _before_ starting replication
 from an external master if any.
 
-`demotion_sql_file` is ran on an old master during demotion to slave, before the\
-old master starts replicating from the new master. The file is also ran before\
-rejoining a standalone server to the cluster, as the standalone server is\
-typically a former master server. When redirecting a slave replicating from a\
+`demotion_sql_file` is ran on an old master during demotion to slave, before the
+old master starts replicating from the new master. The file is also ran before
+rejoining a standalone server to the cluster, as the standalone server is
+typically a former master server. When redirecting a slave replicating from a
 wrong master, the sql-file is not executed.
 
-Since the queries in the files are ran during operations which modify\
-replication topology, care is required. If `promotion_sql_file` contains data\
-modification (DML) queries, the new master server may not be able to\
-successfully replicate from an external master. `demotion_sql_file` should never\
-contain DML queries, as these may not replicate to the slave servers before\
+Since the queries in the files are ran during operations which modify
+replication topology, care is required. If `promotion_sql_file` contains data
+modification (DML) queries, the new master server may not be able to
+successfully replicate from an external master. `demotion_sql_file` should never
+contain DML queries, as these may not replicate to the slave servers before
 slave threads are stopped, breaking replication.
 
 ```
@@ -1059,122 +1059,122 @@ demotion_sql_file=/home/root/scripts/demotion.sql
 * Dynamic: Yes
 * Default: `true`
 
-If enabled, the monitor continuously queries the\
-servers for enabled scheduled events and uses this information when performing\
+If enabled, the monitor continuously queries the
+servers for enabled scheduled events and uses this information when performing
 cluster operations, enabling and disabling events as appropriate.
 
 When a server is being demoted, any events with "ENABLED" status are set to\
 "SLAVESIDE\_DISABLED". When a server is being promoted to master, events that are either\
-"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled\
-on the old master server last time it was successfully queried. Events are considered\
-identical if they have the same schema and name. When a standalone server is rejoined to\
+"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled
+on the old master server last time it was successfully queried. Events are considered
+identical if they have the same schema and name. When a standalone server is rejoined to
 the cluster, its events are also disabled since it is now a slave.
 
-The monitor does not check whether the same events were disabled and enabled during a\
+The monitor does not check whether the same events were disabled and enabled during a
 switchover or failover/rejoin. All events that meet the criteria above are altered.
 
-The monitor does not enable or disable the event scheduler itself. For the\
-events to run on the new master server, the scheduler should be enabled by the\
+The monitor does not enable or disable the event scheduler itself. For the
+events to run on the new master server, the scheduler should be enabled by the
 admin. Enabling it in the server configuration file is recommended.
 
-Events running at high frequency may cause replication to break in a failover\
-scenario. If an old master which was failed over restarts, its event scheduler\
-will be on if set in the server configuration file. Its events will also\
-remember their "ENABLED"-status and run when scheduled. This may happen before\
-the monitor rejoins the server and disables the events. This should only be an\
-issue for events running more often than the monitor interval or events that run\
+Events running at high frequency may cause replication to break in a failover
+scenario. If an old master which was failed over restarts, its event scheduler
+will be on if set in the server configuration file. Its events will also
+remember their "ENABLED"-status and run when scheduled. This may happen before
+the monitor rejoins the server and disables the events. This should only be an
+issue for events running more often than the monitor interval or events that run
 immediately after the server has restarted.
 
 ### Cooperative monitoring
 
-As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means\
-that multiple monitors (typically in different MaxScale instances) can monitor\
-the same backend server cluster and only one will be the primary monitor. Only\
+As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means
+that multiple monitors (typically in different MaxScale instances) can monitor
+the same backend server cluster and only one will be the primary monitor. Only
 the primary monitor may perform _switchover_, _failover_ or _rejoin_ operations.\
-The primary also decides which server is the master. Cooperative monitoring is\
+The primary also decides which server is the master. Cooperative monitoring is
 enabled with the [cooperative\_monitoring\_locks](mariadb-maxscale-2208-mariadb-monitor.md#cooperative_monitoring_locks)-setting.\
 Even with this setting, only one monitor per server per MaxScale is allowed.\
-This limitation can be circumvented by defining multiple copies of a server in\
+This limitation can be circumvented by defining multiple copies of a server in
 the configuration file.
 
-Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)\
-for coordinating between monitors. When cooperating, the monitor regularly\
-checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and\
-acquires it if free. If the monitor acquires a majority of locks, it is the\
+Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)
+for coordinating between monitors. When cooperating, the monitor regularly
+checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and
+acquires it if free. If the monitor acquires a majority of locks, it is the
 primary. If a monitor cannot claim majority locks, it is a secondary monitor.
 
 The primary monitor of a cluster also acquires the lock _maxscale\_mariadbmonitor\_master_ on the master server. Secondary monitors check
 which server this lock is taken on and only accept that server as the master.\
-This arrangement is required so that multiple monitors can agree on which server\
-is the master regardless of replication topology. If a secondary monitor does\
-not see the master-lock taken, then it won't mark any server as \[Master],\
+This arrangement is required so that multiple monitors can agree on which server
+is the master regardless of replication topology. If a secondary monitor does
+not see the master-lock taken, then it won't mark any server as \[Master],
 causing writes to fail.
 
-The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor\
-needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three\
-servers needs two locks for majority, a cluster of four needs three, and a\
+The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor
+needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three
+servers needs two locks for majority, a cluster of four needs three, and a
 cluster of five needs three.\
-This scheme is resistant against split-brain situations in the sense\
-that multiple monitors cannot be primary simultaneously. However, a split may\
-cause both monitors to consider themselves secondary, in which case a master\
+This scheme is resistant against split-brain situations in the sense
+that multiple monitors cannot be primary simultaneously. However, a split may
+cause both monitors to consider themselves secondary, in which case a master
 server won't be detected.
 
-Even without a network split, `cooperative_monitoring_locks=majority_of_all`\
-will lead to neither monitor claiming lock majority once too many servers go\
-down. This scenario is depicted in the image below. Only two out of four servers\
-are running when three are needed for majority. Although both MaxScales see both\
-running servers, neither is certain they have majority and the cluster stays in\
+Even without a network split, `cooperative_monitoring_locks=majority_of_all`
+will lead to neither monitor claiming lock majority once too many servers go
+down. This scenario is depicted in the image below. Only two out of four servers
+are running when three are needed for majority. Although both MaxScales see both
+running servers, neither is certain they have majority and the cluster stays in
 read-only mode. If the primary server is down, no failover is performed either.
 
-Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only\
-servers currently \[Running] are considered. This scheme adapts to multiple\
+Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only
+servers currently \[Running] are considered. This scheme adapts to multiple
 servers going down, ensuring that claiming lock majority is always possible.\
-However, it can lead to multiple monitors claiming primary status in a\
-split-brain situation. As an example, consider a cluster with servers 1 to 4\
-with MaxScales A and B, as in the image below. MaxScale A can connect to\
-servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to\
-a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B\
+However, it can lead to multiple monitors claiming primary status in a
+split-brain situation. As an example, consider a cluster with servers 1 to 4
+with MaxScales A and B, as in the image below. MaxScale A can connect to
+servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to
+a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B
 does the opposite, claiming servers 3 and 4 and assuming 1 and 2 are down.\
-Both MaxScales claim two locks out of two available and assume that they have\
-lock majority. Both MaxScales may then promote their own primaries and route\
+Both MaxScales claim two locks out of two available and assume that they have
+lock majority. Both MaxScales may then promote their own primaries and route
 writes to different servers.
 
-The recommended strategy depends on which failure scenario is more likely and/or\
-more destructive. If it's unlikely that multiple servers are ever down\
-simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other\
-hand, if split-brain is unlikely but multiple servers may be down\
+The recommended strategy depends on which failure scenario is more likely and/or
+more destructive. If it's unlikely that multiple servers are ever down
+simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other
+hand, if split-brain is unlikely but multiple servers may be down
 simultaneously, then _majority\_of\_running_ would keep the cluster operational.
 
-To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the\
-monitor has lock majority on the cluster. If cooperative monitoring is disabled,\
-the field value is _null_. Lock information for individual servers is listed in\
-the server-specific field **lock\_held**. Again, _null_ indicates that locks are\
+To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the
+monitor has lock majority on the cluster. If cooperative monitoring is disabled,
+the field value is _null_. Lock information for individual servers is listed in
+the server-specific field **lock\_held**. Again, _null_ indicates that locks are
 not in use or the lock status is unknown.
 
-If a MaxScale instance tries to acquire the locks but fails to get majority\
-(perhaps another MaxScale was acquiring locks simultaneously) it will release\
-any acquired locks and try again after a random number of monitor ticks. This\
+If a MaxScale instance tries to acquire the locks but fails to get majority
+(perhaps another MaxScale was acquiring locks simultaneously) it will release
+any acquired locks and try again after a random number of monitor ticks. This
 prevents multiple MaxScales from fighting over the locks continuously as one\
-MaxScale will eventually wait less time than the others. Conflict probability\
+MaxScale will eventually wait less time than the others. Conflict probability
 can be further decreased by configuring each monitor with a different\_monitor\_interval\_.
 
 The flowchart below illustrates the lock handling logic.
 
 #### Releasing locks
 
-Monitor cooperation depends on the server locks. The locks are\
-connection-specific. The owning connection can manually release a lock, allowing\
+Monitor cooperation depends on the server locks. The locks are
+connection-specific. The owning connection can manually release a lock, allowing
 another connection to claim it. Also, if the owning connection closes, the\
-MariaDB Server process releases the lock. How quickly a lost connection is\
-detected affects how quickly the primary monitor status moves from one monitor\
+MariaDB Server process releases the lock. How quickly a lost connection is
+detected affects how quickly the primary monitor status moves from one monitor
 and MaxScale to another.
 
-If the primary MaxScale or its monitor is stopped normally, the monitor\
+If the primary MaxScale or its monitor is stopped normally, the monitor
 connections are properly closed, releasing the locks. This allows the secondary\
-MaxScale to quickly claim the locks. However, if the primary simply vanishes\
+MaxScale to quickly claim the locks. However, if the primary simply vanishes
 (broken network), the connection may just look idle. In this case, the\
-MariaDB Server may take a long time before it considers the monitor connection\
-lost. This time ultimately depends on TCP keepalive settings on the machines\
+MariaDB Server may take a long time before it considers the monitor connection
+lost. This time ultimately depends on TCP keepalive settings on the machines
 running MariaDB Server.
 
 On MariaDB Server 10.3.3 and later, the TCP keepalive settings can be configured\
@@ -1183,15 +1183,15 @@ for information on settings _tcp\_keepalive\_interval_, _tcp\_keepalive\_probes_
 level, as described [here](https://www.tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html).
 
 As of MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6 and 24.02.2, configuring\
-TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_\
-variable when acquiring a lock. This causes the MariaDB Server to close the\
-monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout\
+TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_
+variable when acquiring a lock. This causes the MariaDB Server to close the
+monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout
 settings, and is logged at MaxScale startup.
 
-A monitor can also be ordered to manually release its locks via the module\
-command _release-locks_. This is useful for manually changing the primary\
-monitor. After running the release-command, the monitor will not attempt to\
-reacquire the locks for one minute, even if it wasn't the primary monitor to\
+A monitor can also be ordered to manually release its locks via the module
+command _release-locks_. This is useful for manually changing the primary
+monitor. After running the release-command, the monitor will not attempt to
+reacquire the locks for one minute, even if it wasn't the primary monitor to
 begin with. This command can cause the cluster to become temporarily unusable by\
 MaxScale. Only use it when there is another monitor ready to claim the locks.
 
@@ -1201,74 +1201,74 @@ maxctrl call command mariadbmon release-locks MyMonitor1
 
 ### Rebuild server
 
-The rebuild server-feature replaces the contents of a database server with the\
-contents of another server. The source server is effectively cloned and all data\
-on the target server is lost. This is useful when a slave server has diverged\
+The rebuild server-feature replaces the contents of a database server with the
+contents of another server. The source server is effectively cloned and all data
+on the target server is lost. This is useful when a slave server has diverged
 from the master server, or when adding a new server to the cluster. The\
 MariaDB Server configuration files are not affected.
 
-MariaDB-Monitor can perform this operation by running [mariadb-backup](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/) on both the source and\
+MariaDB-Monitor can perform this operation by running [mariadb-backup](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/) on both the source and
 target servers. To do this, MaxScale needs to have ssh-access on the machines.\
-Also, the following tools need to be installed on the source and target\
+Also, the following tools need to be installed on the source and target
 machines:
 
 1. mariadb-backup. Backups and restores MariaDB Server contents. Installed e.g.\
    with `yum install MariaDB-backup`.
 2. pigz. Compresses and decompresses the backup stream. Installed e.g. with`yum install pigz`.
-3. socat. Streams data from one machine to another. Is likely already\
+3. socat. Streams data from one machine to another. Is likely already
    installed. If not, can be installed e.g. with `yum install socat`.
 
-The _ssh\_user_ and _ssh\_keyfile_-settings define the SSH credentials MaxScale\
-uses to access the servers. MaxScale must be able to run commands with _sudo_ on\
-both the source and target servers. mariadb-backup, on the other hand, needs to\
-authenticate to the MariaDB Server being copied from. For this, MaxScale uses\
-the monitor user. The monitor user may thus require additional privileges. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-overview#authentication-and-privileges)\
+The _ssh\_user_ and _ssh\_keyfile_-settings define the SSH credentials MaxScale
+uses to access the servers. MaxScale must be able to run commands with _sudo_ on
+both the source and target servers. mariadb-backup, on the other hand, needs to
+authenticate to the MariaDB Server being copied from. For this, MaxScale uses
+the monitor user. The monitor user may thus require additional privileges. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-overview#authentication-and-privileges)
 for more details.
 
-When launched, the rebuild operation proceeds as below. If any step fails, the\
+When launched, the rebuild operation proceeds as below. If any step fails, the
 operation is stopped and the target server will be left in an unspecified state.
 
-1. Log in to both servers with ssh and check that the tools listed above are\
+1. Log in to both servers with ssh and check that the tools listed above are
    present (e.g. `mariadb-backup -v` should succeed).
-2. Check that the port used for transferring the backup is free on the source\
-   server. If not, kill the process holding it. This requires running lsof and\
+2. Check that the port used for transferring the backup is free on the source
+   server. If not, kill the process holding it. This requires running lsof and
    kill.
-3. Test the connection by streaming a short message from the source host to the\
+3. Test the connection by streaming a short message from the source host to the
    target.
-4. Launch mariadb-backup on the source machine, compress the stream and listen\
+4. Launch mariadb-backup on the source machine, compress the stream and listen
    for an incoming connection. This is performed with a command like`mariadb-backup --backup --safe-slave-backup --stream=xbstream | pigz -c | socat - TCP-LISTEN:<port>`.
-5. Stop MariaDB-server on the target machine and delete all contents of the data\
+5. Stop MariaDB-server on the target machine and delete all contents of the data
    directory /var/lib/mysql.
-6. On the target machine, connect to the source machine, read the backup stream,\
-   decompress it and write to the data directory. This is performed with a command\
-   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can\
+6. On the target machine, connect to the source machine, read the backup stream,
+   decompress it and write to the data directory. This is performed with a command
+   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can
    take a long time if there is much data to transfer.
 7. Check that the data directory is not empty.
-8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if\
+8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if
    the source server performed writes during data transfer.
-9. On the target server, change ownership of datadir contents to the\
+9. On the target server, change ownership of datadir contents to the
    mysql-user and start MariaDB-server.
-10. Read gtid from the data directory. Have the target server start replicating\
+10. Read gtid from the data directory. Have the target server start replicating
     from the master.
 
 The rebuild-operation is a monitor module command and is best launched with\
-MaxCtrl. The command takes three arguments: the monitor name, target server name\
-and source server name. The source server can be left out, in which case it is\
-autoselected. When autoselecting, the monitor prefers to pick an up-to-date\
-slave server. Due to the `--safe-slave-backup`-option, the slave will stop\
+MaxCtrl. The command takes three arguments: the monitor name, target server name
+and source server name. The source server can be left out, in which case it is
+autoselected. When autoselecting, the monitor prefers to pick an up-to-date
+slave server. Due to the `--safe-slave-backup`-option, the slave will stop
 replicating until the backup data has been transferred.
 
 ```
 maxctrl call command mariadbmon async-rebuild-server MariaDB-Monitor MyServer3 MyServer2
 ```
 
-The operation does not launch if the target server is already replicating or if\
+The operation does not launch if the target server is already replicating or if
 the source server is not a master or slave.
 
-Steps 6 and 8 can take a long time depending on the size of the database and if\
-writes are ongoing. During these steps, the monitor will continue monitoring the\
-cluster normally. After each monitor tick the monitor checks if the\
-rebuild-operation can proceed. No other monitor operations, either manual or\
+Steps 6 and 8 can take a long time depending on the size of the database and if
+writes are ongoing. During these steps, the monitor will continue monitoring the
+cluster normally. After each monitor tick the monitor checks if the
+rebuild-operation can proceed. No other monitor operations, either manual or
 automatic, can run until the rebuild completes.
 
 #### Settings
@@ -1289,7 +1289,7 @@ Ssh username. Used when logging in to backend servers to run commands.
 * Dynamic: Yes
 * Default: None
 
-Path to file with an ssh private key. Used when logging in to backend servers to\
+Path to file with an ssh private key. Used when logging in to backend servers to
 run commands.
 
 **`ssh_check_host_key`**
@@ -1299,7 +1299,7 @@ run commands.
 * Dynamic: Yes
 * Default: `true`
 
-Boolean, default: true. When logging in to backends, require that the server is\
+Boolean, default: true. When logging in to backends, require that the server is
 already listed in the known\_hosts-file of the user running MaxScale.
 
 **`ssh_timeout`**
@@ -1309,10 +1309,10 @@ already listed in the known\_hosts-file of the user running MaxScale.
 * Dynamic: Yes
 * Default: `10s`
 
-The rebuild operation consists of multiple ssh\
-commands. Most of the commands are assumed to complete quickly. If these\
-commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust\
-this setting if rebuild fails due to ssh commands timing out. This setting does\
+The rebuild operation consists of multiple ssh
+commands. Most of the commands are assumed to complete quickly. If these
+commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust
+this setting if rebuild fails due to ssh commands timing out. This setting does
 not affect steps 5 and 6, as these are assumed to take significant time.
 
 **`ssh_port`**
@@ -1331,17 +1331,17 @@ SSH port. Used for running remote commands on servers.
 * Dynamic: Yes
 * Default: `4444`
 
-The port which the source server listens on for a\
-connection. The port must not be blocked by a firewall or listened on by any\
-other program. If another process is listening on the port when rebuild is\
+The port which the source server listens on for a
+connection. The port must not be blocked by a firewall or listened on by any
+other program. If another process is listening on the port when rebuild is
 starting, MaxScale will attempt to kill the process.
 
 #### sudoers.d configuration
 
-If giving MaxScale general sudo-access is out of the question, MaxScale must be\
-allowed to run the specific commands required by the rebuild-operation. This can\
-be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the\
-power to run commands as root. The contents of the file may need to be tweaked\
+If giving MaxScale general sudo-access is out of the question, MaxScale must be
+allowed to run the specific commands required by the rebuild-operation. This can
+be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the
+power to run commands as root. The contents of the file may need to be tweaked
 due to changes in install locations.
 
 ```
@@ -1359,31 +1359,31 @@ johnny ALL= NOPASSWD: /bin/cat
 
 ### ColumnStore commands
 
-Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative\
+Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative
 commands against a ColumnStore cluster. The commands interact with the\
-ColumnStore REST-API present in recent ColumnStore versions and have been tested\
-with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the\
-commands affect monitor configuration or replication topology. MariaDB Monitor\
+ColumnStore REST-API present in recent ColumnStore versions and have been tested
+with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the
+commands affect monitor configuration or replication topology. MariaDB Monitor
 simply relays the commands to the backend cluster.
 
-MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop\
-the cluster, and set cluster read-only or readwrite. MaxScale only communicates\
+MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop
+the cluster, and set cluster read-only or readwrite. MaxScale only communicates
 with the first server in the `servers`-list.
 
-Most of the commands are asynchronous, i.e. they do not wait for the operation\
+Most of the commands are asynchronous, i.e. they do not wait for the operation
 to complete on the ColumnStore backend before returning to the command prompt.\
-MariaDB Monitor itself, however, runs the command in the background and does not\
-perform normal monitoring until the operation completes or fails. After an\
-operation has started the user should use _fetch-cmd-result_ to check its\
-status. The examples below show how to run the commands using MaxCtrl. If a\
-command takes a timeout-parameter, the timeout can be given in seconds (s),\
+MariaDB Monitor itself, however, runs the command in the background and does not
+perform normal monitoring until the operation completes or fails. After an
+operation has started the user should use _fetch-cmd-result_ to check its
+status. The examples below show how to run the commands using MaxCtrl. If a
+command takes a timeout-parameter, the timeout can be given in seconds (s),
 minutes (m) or hours (h).
 
 ColumnStore command settings are listed [here](mariadb-maxscale-2208-mariadb-monitor.md#settings). At least`cs_admin_api_key` must be set.
 
 #### Get status
 
-Fetch cluster status. Returns the result as is. Status fetching has an automatic\
+Fetch cluster status. Returns the result as is. Status fetching has an automatic
 timeout of ten seconds.
 
 ```
@@ -1497,7 +1497,7 @@ maxctrl call command mariadbmon fetch-cmd-result MyMonitor
 
 **`cs_admin_port`**
 
-Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes\
+Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes
 are assumed to listen on the same port.
 
 ```
@@ -1521,9 +1521,9 @@ String, default: _/cmapi/0.4.0_. Base path sent with the REST-API request.
 
 #### `fetch-cmd-result`
 
-Fetches the result of the last manual command. Requires monitor name as\
-parameter. Most commands only return a generic success message or an error\
-description. ColumnStore commands may return more data. Scheduling another\
+Fetches the result of the last manual command. Requires monitor name as
+parameter. Most commands only return a generic success message or an error
+description. ColumnStore commands may return more data. Scheduling another
 command clears a stored result.
 
 ```
@@ -1533,11 +1533,11 @@ maxctrl call command mariadbmon fetch-cmd-result MariaDB-Monitor
 
 #### `cancel-cmd`
 
-Cancels the latest operation, whether manual or automatic, if possible. Requires\
-monitor name as parameter. A scheduled manual command is simply canceled\
-before it can run. If a command is already running, it stops as soon as\
+Cancels the latest operation, whether manual or automatic, if possible. Requires
+monitor name as parameter. A scheduled manual command is simply canceled
+before it can run. If a command is already running, it stops as soon as
 possible. The _cancel-cmd_ itself does not wait for a running operation to stop.\
-Use _fetch-cmd-result_ or check the log to see if the operation has truly\
+Use _fetch-cmd-result_ or check the log to see if the operation has truly
 completed. Canceling is most useful for stopping a stalled rebuild operation.
 
 ```
@@ -1551,48 +1551,48 @@ OK
 
 See the [Limitations and requirements-section](mariadb-maxscale-2208-mariadb-monitor.md#limitations_and_requirements).
 
-Before performing failover or switchover, the monitor checks that\
-prerequisites are fulfilled, printing any errors and warnings found. This should\
+Before performing failover or switchover, the monitor checks that
+prerequisites are fulfilled, printing any errors and warnings found. This should
 catch and explain most issues with failover or switchover not working.\
-If the operations are attempted and still fail, then most likely one of\
-the commands the monitor issued to a server failed or timed out. The log should\
+If the operations are attempted and still fail, then most likely one of
+the commands the monitor issued to a server failed or timed out. The log should
 explain which query failed.
 
-A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the\
-monitor will retry most such queries if the failure was caused by a timeout. The retrying\
-continues until the total time for a failover or switchover has been spent. If the log\
-shows warnings or errors about commands timing out, increasing the backend timeout\
+A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the
+monitor will retry most such queries if the failure was caused by a timeout. The retrying
+continues until the total time for a failover or switchover has been spent. If the log
+shows warnings or errors about commands timing out, increasing the backend timeout
 settings of the monitor should help. Other settings to look at are `query_retries` and`query_retry_timeout`. These are general MaxScale settings described in the [Configuration guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md). Setting`query_retries` to 2 is a reasonable first try.
 
-If switchover causes the old master (now slave) to fail replication, then most\
-likely a user or perhaps a scheduled event performed a write while monitor\
+If switchover causes the old master (now slave) to fail replication, then most
+likely a user or perhaps a scheduled event performed a write while monitor
 had set `read_only=1`. This is possible if the user performing the write has\
-"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick\
-out SUPER-users but this is not certain to succeed. Remove these privileges\
-from any users that regularly do writes to prevent them from interfering with\
+"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick
+out SUPER-users but this is not certain to succeed. Remove these privileges
+from any users that regularly do writes to prevent them from interfering with
 switchover.
 
-The server configuration files should have `log-slave-updates=1` to ensure that\
-a newly promoted master has binary logs of previous events. This allows the new\
+The server configuration files should have `log-slave-updates=1` to ensure that
+a newly promoted master has binary logs of previous events. This allows the new
 master to replicate past events to any lagging slaves.
 
-To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the\
-backends by monitors and authenticators. The printed queries may include\
+To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the
+backends by monitors and authenticators. The printed queries may include
 usernames and passwords.
 
 #### Slave detection shows external masters
 
 If a slave is shown in _maxctrl_ as "Slave of External Server" instead of\
-"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection\
-does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default\
-assumes that the slave connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact\
-same "Master\_Host" as used the MaxScale configuration file server definitions. This is\
+"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection
+does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default
+assumes that the slave connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact
+same "Master\_Host" as used the MaxScale configuration file server definitions. This is
 controlled by the setting [assume\_unique\_hostnames](mariadb-maxscale-2208-mariadb-monitor.md#assume_unique_hostnames).
 
 ### Using the MariaDB Monitor With Binlogrouter
 
-Since MaxScale 2.2 it's possible to detect a replication setup\
-which includes Binlog Server: the required action is to add the\
+Since MaxScale 2.2 it's possible to detect a replication setup
+which includes Binlog Server: the required action is to add the
 binlog server to the list of servers only if _master\_id_ identity is set.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-xpand-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-xpand-monitor.md
@@ -6,8 +6,8 @@
 
 ### Overview
 
-The Xpand Monitor is a monitor that monitors a Xpand cluster. It is\
-capable of detecting the cluster setup and creating corresponding server\
+The Xpand Monitor is a monitor that monitors a Xpand cluster. It is
+capable of detecting the cluster setup and creating corresponding server
 instances within MaxScale.
 
 ### Required Grants
@@ -21,7 +21,7 @@ GRANT SELECT ON system.nodeinfo TO 'maxscale'@'maxscalehost';
 GRANT SELECT ON system.softfailed_nodes TO 'maxscale'@'maxscalehost';
 ```
 
-Further, if you want be able to _softfail_ and _unsoftfail_ a node via MaxScale,\
+Further, if you want be able to _softfail_ and _unsoftfail_ a node via MaxScale,
 then the monitor user must have `SUPER` privileges:
 
 ```
@@ -30,19 +30,19 @@ GRANT SUPER ON *.* TO 'maxscale'@'maxscalehost';
 
 ### Configuration
 
-A minimal configuration for a monitor requires one server in the Xpand\
-cluster, and a username and a password to connect to the server. Note that\
-by default the Xpand monitor will only use that server in order to\
-dynamically find out the configuration of the cluster; after startup it\
-will completely rely upon information obtained at runtime. To change the\
+A minimal configuration for a monitor requires one server in the Xpand
+cluster, and a username and a password to connect to the server. Note that
+by default the Xpand monitor will only use that server in order to
+dynamically find out the configuration of the cluster; after startup it
+will completely rely upon information obtained at runtime. To change the
 default behaviour, please see the parameter [dynamic\_node\_detection](mariadb-maxscale-2208-xpand-monitor.md#dynamic_node_detection).
 
-To ensure that the Xpand monitor will be able to start, it is advisable\
-to provide _more_ than one server to cater for the case that not all nodes\
+To ensure that the Xpand monitor will be able to start, it is advisable
+to provide _more_ than one server to cater for the case that not all nodes
 are always up when MaxScale starts.
 
-**Note:** All services that use servers monitored by xpandmon should use\
-the `cluster` parameter to define the set of servers they use. This will\
+**Note:** All services that use servers monitored by xpandmon should use
+the `cluster` parameter to define the set of servers they use. This will
 guarantee that the services use servers that are valid members of the\
 XPand cluster.
 
@@ -71,12 +71,12 @@ Xpand node will be named like
 @@<name-of-xpand-monitor>:node-<id>
 ```
 
-where `<name-of-xpand-monitor>` is the name of the Xpand monitor\
-instance, as defined in the MaxScale configuration file, and `<id>` is the\
+where `<name-of-xpand-monitor>` is the name of the Xpand monitor
+instance, as defined in the MaxScale configuration file, and `<id>` is the
 id of the Xpand node.
 
-For instance, with the Xpand monitor defined as above and a Xpand\
-cluster consisting of 3 nodes whose ids are `1`, `2` and `3` respectively,\
+For instance, with the Xpand monitor defined as above and a Xpand
+cluster consisting of 3 nodes whose ids are `1`, `2` and `3` respectively,
 the names of the created server objects will be:
 
 ```
@@ -86,7 +86,7 @@ the names of the created server objects will be:
 ```
 
 When dynamic servers are created, the values for the configuration settings`max_routing_connections`, `persistmaxtime`, `persistpoolmax` and`proxy_protocol` are copied from the settings of the bootstrap servers.\
-Note that the values of these settings must be **identical** on every\
+Note that the values of these settings must be **identical** on every
 bootstrap server.
 
 ### Common Monitor Parameters
@@ -99,21 +99,21 @@ These are optional parameters specific to the Xpand Monitor.
 
 #### `cluster_monitor_interval`
 
-Defines, in milliseconds, how often the monitor checks the state of the\
-entire cluster. The default value is 60000 (1 minute), which should not\
+Defines, in milliseconds, how often the monitor checks the state of the
+entire cluster. The default value is 60000 (1 minute), which should not
 be lowered as that may have an adverse effect on the Cluster itself.
 
 ```
 cluster_monitor_interval=120000ms
 ```
 
-The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.
 
 #### `health_check_threshold`
 
-Defines how many times the health check may fail before the monitor\
+Defines how many times the health check may fail before the monitor
 considers a particular node to be down. The default value is 2.
 
 ```
@@ -122,11 +122,11 @@ health_check_threshold=3
 
 #### `dynamic_node_detection`
 
-By default, the Xpand monitor will only use the bootstrap nodes\
-in order to connect to the Xpand cluster and then find out the\
+By default, the Xpand monitor will only use the bootstrap nodes
+in order to connect to the Xpand cluster and then find out the
 cluster configuration dynamically at runtime.
 
-That behaviour can be turned off with this optional parameter, in\
+That behaviour can be turned off with this optional parameter, in
 which case all Xpand nodes must manually be defined as shown below.
 
 ```
@@ -155,7 +155,7 @@ See also [health\_check\_port](mariadb-maxscale-2208-xpand-monitor.md#health_che
 
 #### `health_check_port`
 
-With this optional parameter it can be specified what health check\
+With this optional parameter it can be specified what health check
 port to use, if `dynamic_node_detection` has been disabled.
 
 ```
@@ -164,7 +164,7 @@ health_check_port=4711
 
 The default value is `3581`.
 
-Note that this parameter is _ignored_ unless `dynamic_node_detection`\
+Note that this parameter is _ignored_ unless `dynamic_node_detection`
 is `false`. Note also that the port must be the same for all nodes.
 
 ### Commands
@@ -174,8 +174,8 @@ The Xpand monitor supports the following module commands.
 #### `softfail`
 
 With the `softfail` module command, a node can be _softfailed_ via\
-MaxScale. The command requires as argument the name of the Xpand\
-monitor instance (as defined in the configuration file) and the name\
+MaxScale. The command requires as argument the name of the Xpand
+monitor instance (as defined in the configuration file) and the name
 of the node to be softfailed.
 
 For instance, with a configuration file like
@@ -187,56 +187,56 @@ module=xpandmon
 ...
 ```
 
-then the node whose server name is `@@TheXpandMonitor:node-1` can\
+then the node whose server name is `@@TheXpandMonitor:node-1` can
 be softfailed like
 
 ```
 $ maxctrl call command xpandmon softfail TheXpandMonitor @@TheXpandMonitor:node-1
 ```
 
-If the softfailing of a node is successfully initiated, then the status\
-of the corresponding MaxScale server object will be set to `Draining`,\
+If the softfailing of a node is successfully initiated, then the status
+of the corresponding MaxScale server object will be set to `Draining`,
 which will prevent new connections from being created to the node.
 
-When the number of connections through MaxScale to the node has dropped\
-to 0, its state will change to `Drained`. Note that the state `Drained`\
-only tells that there are no connections to the node, not what the state\
+When the number of connections through MaxScale to the node has dropped
+to 0, its state will change to `Drained`. Note that the state `Drained`
+only tells that there are no connections to the node, not what the state
 of the softfailing operation is.
 
 #### `unsoftfail`
 
 With the `unsoftfail` module command, a node can be _unsoftfailed_ via\
-MaxScale. The command requires as argument the name of the Xpand\
-monitor instance (as defined in the configuration file) and the name\
+MaxScale. The command requires as argument the name of the Xpand
+monitor instance (as defined in the configuration file) and the name
 of the node to be unsoftfailed.
 
-With a setup similar to the `softfail` case, a node can be unsoftfailed\
+With a setup similar to the `softfail` case, a node can be unsoftfailed
 like:
 
 ```
 $ maxctrl call command xpandmon unsoftfail TheXpandMonitor @@TheXpandMonitor:node-1
 ```
 
-If a node is successfully softfailed, then a `Draining` status of\
+If a node is successfully softfailed, then a `Draining` status of
 the corresponding MaxScale server object will be cleared.
 
 ### SOFTFAILed nodes
 
-During the cluster check, which is performed once per`cluster_monitor_interval`, the monitor will also check whether any\
-nodes are being softfailed. The status of the corresponding server\
-object of a node being softfailed will be set to `Draining`,\
+During the cluster check, which is performed once per`cluster_monitor_interval`, the monitor will also check whether any
+nodes are being softfailed. The status of the corresponding server
+object of a node being softfailed will be set to `Draining`,
 which will prevent new connections from being created to that node.
 
-When the number of connections through MaxScale to the node has dropped\
-to 0, its state will change to `Drained`. Note that the state `Drained`\
-only tells that there are no connections to the node, not what the state\
+When the number of connections through MaxScale to the node has dropped
+to 0, its state will change to `Drained`. Note that the state `Drained`
+only tells that there are no connections to the node, not what the state
 of the softfailing operation is.
 
-If a node that was softfailed is UNSOFTFAILed then the `Draining`\
+If a node that was softfailed is UNSOFTFAILed then the `Draining`
 status will be cleared.
 
-If the softfailing and unsoftfailing is initiated using the `softfail`\
-and `unsoftfail` commands of the Xpand monitor, then there will be\
+If the softfailing and unsoftfailing is initiated using the `softfail`
+and `unsoftfail` commands of the Xpand monitor, then there will be
 no delay between the softfailing or unsoftfailing being initiated and the`Draining` status being turned on/off.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-change-data-capture-cdc-protocol.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-change-data-capture-cdc-protocol.md
@@ -4,11 +4,11 @@
 
 ## Change Data Capture (CDC) Protocol
 
-CDC is a new protocol that allows compatible clients to authenticate and\
-register for Change Data Capture events. The new protocol must be use in\
+CDC is a new protocol that allows compatible clients to authenticate and
+register for Change Data Capture events. The new protocol must be use in
 conjunction with AVRO router which currently converts MariaDB binlog events into\
-AVRO records. Change Data Capture protocol is used by clients in order to\
-interact with stored AVRO file and also allows registered clients to be notified\
+AVRO records. Change Data Capture protocol is used by clients in order to
+interact with stored AVRO file and also allows registered clients to be notified
 with the new events coming from MariaDB 10.0/10.1 database.
 
 ### Creating Users
@@ -51,12 +51,12 @@ In the future, optional flags could be implemented.
 
 #### Authentication
 
-The authentication starts when the client sends the hexadecimal representation\
+The authentication starts when the client sends the hexadecimal representation
 of the username concatenated with a colon (`:`) and the SHA1 of the password.
 
 `bin2hex(username + ':' + SHA1(password))`
 
-For example the user _foobar_ with a password of _foopasswd_ should send the\
+For example the user _foobar_ with a password of _foopasswd_ should send the
 following hexadecimal string
 
 ```
@@ -87,9 +87,9 @@ Server returns `OK` on success and `ERR` on failure.
 
 `REQUEST-DATA DATABASE.TABLE[.VERSION] [GTID]`
 
-This command fetches data from specified table in a database and returns the\
-output in the requested format (AVRO or JSON). Data records are sent to clients\
-and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new\
+This command fetches data from specified table in a database and returns the
+output in the requested format (AVRO or JSON). Data records are sent to clients
+and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new
 schema and data will be sent as well.
 
 The data will be streamed until the client closes the connection.
@@ -106,7 +106,7 @@ REQUEST-DATA db2.table4 0-11-345
 
 ### Example Client
 
-MaxScale includes an example CDC client application written in Python 3. You can\
+MaxScale includes an example CDC client application written in Python 3. You can
 find the source code for it [in the MaxScale repository](https://github.com/mariadb-corporation/MaxScale/tree/2.0/server/modules/protocol/examples/cdc.py).
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-change-data-capture-cdc-users.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-change-data-capture-cdc-users.md
@@ -4,13 +4,13 @@
 
 ## Change Data Capture (CDC) users
 
-Change Data Capture (CDC) is a new MaxScale protocol that allows compatible\
-clients to authenticate and register for Change Data Capture events. The new\
+Change Data Capture (CDC) is a new MaxScale protocol that allows compatible
+clients to authenticate and register for Change Data Capture events. The new
 protocol must be use in conjunction with AVRO router which currently converts\
-MariaDB binlog events into AVRO records. Clients connect to CDC listener and\
+MariaDB binlog events into AVRO records. Clients connect to CDC listener and
 authenticate using credentials provided in a format described in the [CDC Protocol documentation](mariadb-maxscale-2208-change-data-capture-cdc-protocol.md).
 
-**Note**: If no users are found in that file or if it doesn't exist, the only\
+**Note**: If no users are found in that file or if it doesn't exist, the only
 available user will be the _service user_:
 
 ```
@@ -30,7 +30,7 @@ Starting with MaxScale 2.1, users can also be created through maxctrl:
 maxctrl call command cdc add_user <service> <name> <password>
 ```
 
-The should be the service name where the user is created. Older\
+The should be the service name where the user is created. Older
 versions of MaxScale should use the _cdc\_users.py_ script.
 
 ```
@@ -43,7 +43,7 @@ The output of this command should be appended to the _cdcusers_ file at`/var/lib
 bash$ cdc_users.py user1 pass1 >> /var/lib/maxscale/avro-service/cdcusers
 ```
 
-Users can be deleted by removing the related rows in 'cdcusers' file. For\
+Users can be deleted by removing the related rows in 'cdcusers' file. For
 more details on the format of the _cdcusers_ file, read the [CDC Protocol documentation](mariadb-maxscale-2208-change-data-capture-cdc-protocol.md).
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-mariadb-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-mariadb-protocol-module.md
@@ -6,7 +6,7 @@
 
 The `mariadbprotocol` module implements the MariaDB client-server protocol.
 
-The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all\
+The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all
 aliases to `mariadbprotocol`.
 
 * [MariaDB Protocol Module](mariadb-maxscale-2208-mariadb-protocol-module.md#mariadb-protocol-module)
@@ -15,7 +15,7 @@ aliases to `mariadbprotocol`.
 
 ### Configuration
 
-Protocol level parameters are defined in the listeners. They must be defined\
+Protocol level parameters are defined in the listeners. They must be defined
 using the scoped parameter syntax where the protocol name is used as the prefix.
 
 ```
@@ -36,8 +36,8 @@ For the MariaDB protocol module, the prefix is always `mariadbprotocol`.
 * Dynamic: Yes
 * Default: true
 
-Whether the use of the replication protocol is allowed through this listener. If\
-disabled with `mariadbprotocol.allow_replication=false`, all attempts to start\
+Whether the use of the replication protocol is allowed through this listener. If
+disabled with `mariadbprotocol.allow_replication=false`, all attempts to start
 replication will be rejected with a ER\_FEATURE\_DISABLED error (error number\
 1289\).
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-nosql-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-nosql-protocol-module.md
@@ -4,21 +4,21 @@
 
 ## NoSQL Protocol Module
 
-The `nosqlprotocol` module allows a MariaDB server or cluster to be\
+The `nosqlprotocol` module allows a MariaDB server or cluster to be
 used as the backend of an application using a MongoDB® client library.\
 Internally, all documents are stored in a table containing two columns;\
 an `id` column for the object id and a `doc` column for the document itself.
 
-When the MongoDB® client application issues MongoDB protocol _commands_,\
-either directly or indirectly via the client library, they are transparently\
+When the MongoDB® client application issues MongoDB protocol _commands_,
+either directly or indirectly via the client library, they are transparently
 converted into the equivalent SQL and executed against the MariaDB backend.\
-The MariaDB responses are then in turn converted into the format expected by\
+The MariaDB responses are then in turn converted into the format expected by
 the MongoDB® client library and application.
 
 ## Configuring
 
-There are a number of [parameters](mariadb-maxscale-2208-nosql-protocol-module.md#parameters) with which the behavior\
-of _nosqlprotocol_ can be adjusted. A minimal configuration looks\
+There are a number of [parameters](mariadb-maxscale-2208-nosql-protocol-module.md#parameters) with which the behavior
+of _nosqlprotocol_ can be adjusted. A minimal configuration looks
 like:
 
 ```
@@ -35,13 +35,13 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-`nosqlprotocol.user` and `nosqlprotocol.password` specify the\
-credentials that will be used when accessing the backend database or\
+`nosqlprotocol.user` and `nosqlprotocol.password` specify the
+credentials that will be used when accessing the backend database or
 cluster. Note that the same credentials will be used for _all_ connecting\
 MongoDB® clients.
 
-Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which\
-the client requests will be sent. _Nosqlprotocol_ places no limitations\
+Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which
+the client requests will be sent. _Nosqlprotocol_ places no limitations
 on what filters, routers or backends can be used.
 
 To configure the same listener with MaxCtrl, the parameters must be passed in a\
@@ -51,7 +51,7 @@ JSON object in the following manner:
 maxctrl create listener TheService MongoDB-Listener --protocol=nosqlprotocol 'nosqlprotocol={"user":"the_user", "password": "the_password"}'
 ```
 
-All the parameters that the nosqlprotocol module takes must be passed in the\
+All the parameters that the nosqlprotocol module takes must be passed in the
 same JSON object.
 
 A complete example can be found at the [end](mariadb-maxscale-2208-nosql-protocol-module.md#example) of this document.
@@ -61,18 +61,18 @@ A complete example can be found at the [end](mariadb-maxscale-2208-nosql-protoco
 Nosqlprotocol supports _SCRAM_ _authentication_ as implemented by MongoDB®.\
 The mechanisms `SCRAM-SHA-1` and `SCRAM-SHA-256` are both supported.
 
-If nosqlprotocol has been setup so that no authentication is required, then\
-when connecting only the host and port should be provided, but neither a\
+If nosqlprotocol has been setup so that no authentication is required, then
+when connecting only the host and port should be provided, but neither a
 username nor a password.
 
-For instance, if the _MongoDB Node.JS Driver_ is used, then the connection\
+For instance, if the _MongoDB Node.JS Driver_ is used, then the connection
 string should look like:
 
 ```
 const uri = "mongodb://127.0.0.1:17017"
 ```
 
-Similarly, if the _Mongo Shell_ is used, only the host and port should\
+Similarly, if the _Mongo Shell_ is used, only the host and port should
 be provided:
 
 ```
@@ -84,26 +84,26 @@ MongoDB shell version v4.4.1
 
 ### NoSQL and MariaDB Users
 
-A MariaDB user consists of a name and a host part. A user `'user'@'%'`\
-and a user `'user'@'127.0.0.1'` are completely different. The host part\
-specifies where a user may connect from, with `%` being a wildcard that\
-matches all hosts. What data a user is allowed to access and modify is\
+A MariaDB user consists of a name and a host part. A user `'user'@'%'`
+and a user `'user'@'127.0.0.1'` are completely different. The host part
+specifies where a user may connect from, with `%` being a wildcard that
+matches all hosts. What data a user is allowed to access and modify is
 specified by what _privileges_ are granted to the user.
 
-A NoSQL user is somewhat different. It is created in the context of a\
-particular database, so there may be a user `userx` in the database `dbA`\
-and different user with the same name `userx` in the database `dbB`. What\
-hosts a user may connect from can be restricted, but that is a property of\
-the user and not an implicit part of it. What data a user is allowed to\
-access and modify is specified by the _roles_ that have been assigned to\
+A NoSQL user is somewhat different. It is created in the context of a
+particular database, so there may be a user `userx` in the database `dbA`
+and different user with the same name `userx` in the database `dbB`. What
+hosts a user may connect from can be restricted, but that is a property of
+the user and not an implicit part of it. What data a user is allowed to
+access and modify is specified by the _roles_ that have been assigned to
 the user.
 
-From the above it should be clear that there is not a 1-to-1\
-correspondence between the concept of a user in NoSQL and the concept\
+From the above it should be clear that there is not a 1-to-1
+correspondence between the concept of a user in NoSQL and the concept
 of a user in MariaDB, but that some additional conventions are needed.
 
-To make it possible to have different NoSQL users with the same name,\
-the database in whose context the user is created is prepended to the\
+To make it possible to have different NoSQL users with the same name,
+the database in whose context the user is created is prepended to the
 user name, separated with a dot, when the MariaDB user is created.
 
 This is perhaps easiest to illustrate using an example:
@@ -119,7 +119,7 @@ MariaDB [(none)]> select user, host from mysql.user;
 2 rows in set (0.001 sec)
 ```
 
-Currently there are two user accounts defined. Even though there is\
+Currently there are two user accounts defined. Even though there is
 a user `bob`, creating a NoSQL user `bob` succeeds.
 
 ```
@@ -143,20 +143,20 @@ MariaDB [(none)]> select user, host from mysql.user;
 3 rows in set (0.001 sec)
 ```
 
-The MariaDB user corresponding to the NoSQL user `bob`, created in the\
+The MariaDB user corresponding to the NoSQL user `bob`, created in the
 context of the database `test`, has `test` as a prefix.
 
 #### The `mariadb` database
 
-The fact that NoSQL users have the database embedded in the MariaDB\
-name may be inconvenient if the same data is accessed both as NoSQL\
-via nosqlprotocol and as SQL directly from MariaDB. It also makes\
+The fact that NoSQL users have the database embedded in the MariaDB
+name may be inconvenient if the same data is accessed both as NoSQL
+via nosqlprotocol and as SQL directly from MariaDB. It also makes
 it impossible to use an existing MariaDB account from NoSQL.
 
-To provide a solution for this problem, the database `mariadb` is treated\
-in a specific fashion. A user created in the context of the `mariadb`\
+To provide a solution for this problem, the database `mariadb` is treated
+in a specific fashion. A user created in the context of the `mariadb`
 database is created in the MariaDB server without the database prefix.\
-If we now try to create a user `bob` in the `mariadb` database it will fail,\
+If we now try to create a user `bob` in the `mariadb` database it will fail,
 because the user `'bob'@'%'` exists already.
 
 ```
@@ -199,7 +199,7 @@ we will see that `alice` was created without a database prefix.
 
 When creating a user nosqlprotocol accepts all roles as predefined by\
 MongoDB®, but not all of them are translated into GRANT privileges.\
-The following table shows what privilege(s) a particular role is\
+The following table shows what privilege(s) a particular role is
 converted to.
 
 | Role      | Privileges                                    |
@@ -216,21 +216,21 @@ The following roles are shorthands for several other roles.
 | dbOwner | dbAdmin, readWrite, userAdmin |
 | root    | dbAdmin, readWrite, userAdmin |
 
-`dbOwner` differs from `root` in that the privileges of the former\
-apply only to a particular database, while the privileges of the\
-latter apply to _all_ databases. However, the role `root` can\
+`dbOwner` differs from `root` in that the privileges of the former
+apply only to a particular database, while the privileges of the
+latter apply to _all_ databases. However, the role `root` can
 only be assigned to a user in the `admin` database.
 
-In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in\
-the `admin` database. If so, then the privilege is granted on `*.*`,\
+In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in
+the `admin` database. If so, then the privilege is granted on `*.*`,
 otherwise on `<db>.*`.
 
-If the `root` role is assigned to a user in the `admin` database,\
+If the `root` role is assigned to a user in the `admin` database,
 then the privileges are granted on `*.*`, otherwise on `<db>.*`.
 
-Other pre-defined roles are recognized and stored in the local\
-nosqlprotocol account database, but they do not affect what privileges\
-are granted to the MariaDB user. Currently user-defined roles are\
+Other pre-defined roles are recognized and stored in the local
+nosqlprotocol account database, but they do not affect what privileges
+are granted to the MariaDB user. Currently user-defined roles are
 not supported.
 
 ### Client Authentication
@@ -243,11 +243,11 @@ Authenticationwise nosqlprotocol can be used in three different ways:
 
 #### Anonymously
 
-If there is an anonymous user on the MariaDB server and if nosqlprotocol\
-is configured without a user/password, then all nosqlprotocol clients will\
+If there is an anonymous user on the MariaDB server and if nosqlprotocol
+is configured without a user/password, then all nosqlprotocol clients will
 access the MariaDB server as anonymous users.
 
-Note that the anonymous MariaDB user is only intended for testing and\
+Note that the anonymous MariaDB user is only intended for testing and
 should in general not be used, but deleted.
 
 #### Shared Credentials
@@ -261,18 +261,18 @@ nosqlprotocol.password=thepassword
 ```
 
 then each MongoDB® client will use those credentials when accessing the\
-MariaDB server. Note that from the perspective of the MariaDB server, it\
+MariaDB server. Note that from the perspective of the MariaDB server, it
 is not possible to distinguish between different MongoDB® clients.
 
 #### Unique Credentials
 
-If nosqlprotocol authentication has been taken into use and a MongoDB®\
-client authenticates, either when connecting or later, then the credentials\
+If nosqlprotocol authentication has been taken into use and a MongoDB®
+client authenticates, either when connecting or later, then the credentials
 of MongoDB® client will be used when accessing the MariaDB server.
 
-Note that even if nosqlprotocol authentication has been enabled, authentication\
-is not required, and if the MongoDB® client has not authenticated itself, the\
-credentials specified with `nosqlprotocol.[user|password]` (or the anonymous\
+Note that even if nosqlprotocol authentication has been enabled, authentication
+is not required, and if the MongoDB® client has not authenticated itself, the
+credentials specified with `nosqlprotocol.[user|password]` (or the anonymous
 user) will be used when accessing the MariaDB server.
 
 #### Enforce Authentication
@@ -283,14 +283,14 @@ To enforce authentication, specify
 nosqlprotocol.authentication_required=true
 ```
 
-in the configuration. If authentication is required, then any command\
-that requires access to the MariaDB server will fail, unless the client\
+in the configuration. If authentication is required, then any command
+that requires access to the MariaDB server will fail, unless the client
 has authenticated.
 
 ### Authorization
 
-By default nosqlprotocol does no authorization. However, a nosqlprotocol\
-client is _always_ subject to the authorization performed by the MariaDB\
+By default nosqlprotocol does no authorization. However, a nosqlprotocol
+client is _always_ subject to the authorization performed by the MariaDB
 server.
 
 When nosqlprotocol authorization is enabled by adding
@@ -299,8 +299,8 @@ When nosqlprotocol authorization is enabled by adding
 nosqlprotocol.authorization_enabled=true
 ```
 
-to the configuration file, some commands will be subject to authorization,\
-by nosqlprotocol. The following table lists the commands and what role they\
+to the configuration file, some commands will be subject to authorization,
+by nosqlprotocol. The following table lists the commands and what role they
 require.
 
 | Command                                                                                   | Role      |
@@ -315,27 +315,27 @@ require.
 | [updateUser](mariadb-maxscale-2208-nosql-protocol-module.md#updateUser)                   | userAdmin |
 | [usersInfo](mariadb-maxscale-2208-nosql-protocol-module.md#usersInfo)                     | userAdmin |
 
-It is important to note that even if nosqlprotocol authorization\
-is enabled, the MariaDB server has the final word. That is, even if the\
-roles of a user would be sufficient for a particular operation, if the\
-granted privileges are not, the operation will not succeed. There may\
-be a mismatch between roles and grants, for instance, if the wrong roles\
-were specified when the user was added, or if the grants have been\
+It is important to note that even if nosqlprotocol authorization
+is enabled, the MariaDB server has the final word. That is, even if the
+roles of a user would be sufficient for a particular operation, if the
+granted privileges are not, the operation will not succeed. There may
+be a mismatch between roles and grants, for instance, if the wrong roles
+were specified when the user was added, or if the grants have been
 altered directly and not via nosqlprotocol.
 
 ### Bootstrapping the Authentication/Authorization
 
-The authentication/authorization can be bootstrapped explicitly\
-or implicitly. Bootstrapping explicitly provides more control, while\
+The authentication/authorization can be bootstrapped explicitly
+or implicitly. Bootstrapping explicitly provides more control, while
 bootstrapping implicitly is much more convenient.
 
 #### Explicit bootstrapping
 
-In order to enable authorization you need to have NoSQL users and\
-those can be created with [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser) or added\
+In order to enable authorization you need to have NoSQL users and
+those can be created with [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser) or added
 with [mxsAddUser](mariadb-maxscale-2208-nosql-protocol-module.md#addUser).
 
-If you want to _create_ a user, then you first need to configure\
+If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
 
 ```
@@ -343,7 +343,7 @@ nosqlprotocol.user = user_with_privileges_for_creating_a_user
 nosqlprotocol.password = the_users_password
 ```
 
-At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that\
+At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that
 as those are their default values, they do not have to be specified.
 
 Start MaxScale and connect to it with the MongoDB® command line client
@@ -363,8 +363,8 @@ switched to db admin
 { "ok" : 1 }
 ```
 
-Alternatively you can add an existing user. Note that it should be\
-added to the `mariadb` database, unless it was created with the\
+Alternatively you can add an existing user. Note that it should be
+added to the `mariadb` database, unless it was created with the
 convention of having the database as a prefix, e.g. `db.bob`.
 
 ```
@@ -383,12 +383,12 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but\
-as they will be ignored with `nosqlprotocol.authentication_required=true`\
+The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but
+as they will be ignored with `nosqlprotocol.authentication_required=true`
 being present, it is not mandatory.
 
-If you now try to create a user when not having been authenticated or\
-when authenticated as a user without the `userAdmin` role, the result\
+If you now try to create a user when not having been authenticated or
+when authenticated as a user without the `userAdmin` role, the result
 will be:
 
 ```
@@ -403,105 +403,105 @@ switched to db test
 }
 ```
 
-**NOTE** When a client authenticates, the password will not be\
-transferred in cleartext over the network, so, even without SSL,\
-it is not possible to gain access to a password by monitoring the\
+**NOTE** When a client authenticates, the password will not be
+transferred in cleartext over the network, so, even without SSL,
+it is not possible to gain access to a password by monitoring the
 network traffic.
 
-However, when a user is created or added (or the password is changed),\
-the password will be transferred in _cleartext_. To prevent eavesdropping,\
+However, when a user is created or added (or the password is changed),
+the password will be transferred in _cleartext_. To prevent eavesdropping,
 create/add users when connecting over a domain socket, or use [TLS/SSL](mariadb-maxscale-2208-nosql-protocol-module.md#tlsssl)
 
 #### Implicit bootstrapping
 
-With implicit bootstrapping, you should first create the MariaDB\
-user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2208-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat\
-different in MariaDB and NoSQL, which means that certain factors\
-must be taken into account when creating the MariaDB user. Then\
+With implicit bootstrapping, you should first create the MariaDB
+user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2208-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat
+different in MariaDB and NoSQL, which means that certain factors
+must be taken into account when creating the MariaDB user. Then
 at first startup, nosqlprotocol will create the corresponding\
-NoSQL user, which will enable the authenticated and authorized\
+NoSQL user, which will enable the authenticated and authorized
 use of nosqlprotocol.
 
 When MaxScale is started, if the following hold
 
-* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration\
+* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration
   section of the nosqlprotocol listener,
 * `nosqlprotocol.user` and `nosqlprotocol.password` are provided, and
 * there are no NoSQL users in the NoSQL account database.
 
 then, MaxScale will
 
-* wait until the master of the service pointed to by the listener\
+* wait until the master of the service pointed to by the listener
   is available,
-* connect using the credentials specified in `nosqlprotocol.user`\
+* connect using the credentials specified in `nosqlprotocol.user`
   and `nosqlprotocol.password`,
 * execute `SHOW GRANTS`,
 * translate the privileges into the equivalent NoSQL roles, and
 * create a corresponding NoSQL user into the NoSQL account database.
 
-Immediately thereafter it is possible to connect to the nosqlprotocol\
+Immediately thereafter it is possible to connect to the nosqlprotocol
 port with a MongoDB® client using the specified credentials.
 
-Note that after the bootstrapping, nosqlprotocol will not use\
+Note that after the bootstrapping, nosqlprotocol will not use
 the `user` and `password` settings and they can be removed.
 
 **Grants**
 
-When a NoSQL user is created using [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser)\
-the MariaDB grants are obtained from the specified NoSQL roles\
+When a NoSQL user is created using [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser)
+the MariaDB grants are obtained from the specified NoSQL roles
 as explained [here](mariadb-maxscale-2208-nosql-protocol-module.md#Roles_and_privileges).
 
 When implicitly creating a NoSQL user from an existing user in\
-MariaDB, the inverse operation must be performed. There are\
-many factors that affect what NoSQL roles the grants of a user\
+MariaDB, the inverse operation must be performed. There are
+many factors that affect what NoSQL roles the grants of a user
 are translated into:
 
 * whether the user is a regular or admin user,
 * whether the privileges are on `*.*` or some specific `db.*`, and
 * the privileges themselves, e.g. `SELECT`, `DELETE`, etc.
 
-In NoSQL, every user resides in a specific database. Note that\
-this does **not** mean that database would have to exist\
+In NoSQL, every user resides in a specific database. Note that
+this does **not** mean that database would have to exist
 in MariaDB.
 
-When it comes to users, the database effectively means a scope,\
-which in the case of nosqlprotocol is handled by prefixing the\
+When it comes to users, the database effectively means a scope,
+which in the case of nosqlprotocol is handled by prefixing the
 corresponding MariaDB user name with the database/scope name.
 
-When creating a user to be used from NoSQL, there are three\
+When creating a user to be used from NoSQL, there are three
 options for the user's name:
 
 * The name can be of the format `some_db.user_name` where`some_db` can be anything (subject to the naming rules of\
-  MariaDB), except `admin` or `mariadb`. In this case, the\
-  user will be a regular user, who can access data in\
+  MariaDB), except `admin` or `mariadb`. In this case, the
+  user will be a regular user, who can access data in
   databases that she has been granted access to.
-* The name can be of the format `admin.user_name` where `admin`\
-  is exactly just that. In this case, the user will be an\
+* The name can be of the format `admin.user_name` where `admin`
+  is exactly just that. In this case, the user will be an
   admin user, who can access any database.
-* The name can be of the format `user_name`. In this case, the\
-  user will be a regular user that from the NoSQL side appears\
-  to reside in the `mariadb` database. The primary purpose of\
-  this alternative is to enable the use of existing users from\
+* The name can be of the format `user_name`. In this case, the
+  user will be a regular user that from the NoSQL side appears
+  to reside in the `mariadb` database. The primary purpose of
+  this alternative is to enable the use of existing users from
   the NoSQL side.
 
-What database the privileges can be specified `ON` depends on\
+What database the privileges can be specified `ON` depends on
 what kind of user is being created.
 
-* If it is a regular user, the privileges must be granted on a\
+* If it is a regular user, the privileges must be granted on a
   specific database, such as `\`dbA\`\`.\*\`. Note that there is no\
   dependency between this database and the (conceptual) database\
   the user resides in.
 * If it is an admin user, the privileges must be granted on\
   the `*.*` database.
 
-In NoSQL, a role can be database specific or generic. However,\
-a generic role can _only_ be assigned to a user in the _admin_\
-database. In practice this means that if the privileges are\
-on `*.*`, then the user must reside in the _admin_ database\
+In NoSQL, a role can be database specific or generic. However,
+a generic role can _only_ be assigned to a user in the _admin_
+database. In practice this means that if the privileges are
+on `*.*`, then the user must reside in the _admin_ database
 (e.g. `admin.bob`) or it is treated as an error.
 
-The following table shows what privileges are required for a\
-role to be assigned. Note that `ALL PRIVILEGES` can be used as\
+The following table shows what privileges are required for a
+role to be assigned. Note that `ALL PRIVILEGES` can be used as
 well.
 
 | ALTER | CREATE | CREATE USER | DROP | DELETE | INDEX | INSERT | SHOW DATABASES(1) | SELECT | UPDATE | WITH GRANT OPTION | Role                    |
@@ -513,19 +513,19 @@ well.
 
 1. Only required if the user is an admin user.
 
-The `AnyDatabase` version will be assigned, if the user is\
+The `AnyDatabase` version will be assigned, if the user is
 an _admin_ user.
 
-If certain roles are assigned, then other roles will be\
+If certain roles are assigned, then other roles will be
 assigned as well.
 
-* If the roles `dbAdmin`, `readWrite` and `userAdmin` are\
+* If the roles `dbAdmin`, `readWrite` and `userAdmin` are
   assigned, then `dbOwner` will be assigned as well.
-* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`\
-  and `userAdminAnyDatabase` are assigned, then `root` will\
+* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`
+  and `userAdminAnyDatabase` are assigned, then `root` will
   be assigned as well.
 
-Once the user has been created and the desired privileges have\
+Once the user has been created and the desired privileges have
 been granted, the NoSQL listener should be configured as follows:
 
 ```
@@ -544,7 +544,7 @@ At MaxScale startup, the NoSQL user will then be created.
 
 **Admin User**
 
-We want the initial NoSQL user to be an administrator, with\
+We want the initial NoSQL user to be an administrator, with
 full rights.
 
 ```
@@ -552,8 +552,8 @@ CREATE USER 'admin.nosql_admin'@'%' IDENTIFIED BY 'nosql_password';
 GRANT ALL PRIVILEGES ON *.* TO 'admin.nosql_admin'@'%' WITH GRANT OPTION;
 ```
 
-As we want an admin user, the name is prefixed with `admin`,\
-which will have that effect. And since it is an admin user, the\
+As we want an admin user, the name is prefixed with `admin`,
+which will have that effect. And since it is an admin user, the
 privileges are granted ON `*.*`.
 
 Thereafter, we specify the following in the configuration file,
@@ -571,16 +571,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as master,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as master,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'admin.nosql_admin'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -590,9 +590,9 @@ $ mongo --quiet --port 17017 -u nosql_admin -p nosql_password admin
 >
 ```
 
-Note that when connecting the user is passed as `nosql_admin` and _not_\
-as `admin.nosql_admin`. The fact that we want to authenticate against\
-the `admin` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `nosql_admin` and _not_
+as `admin.nosql_admin`. The fact that we want to authenticate against
+the `admin` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -631,13 +631,13 @@ argument.
 }
 ```
 
-As can be seen, the user has the _any_ roles on the `admin`\
-database, which means that all databases can be accessed and\
+As can be seen, the user has the _any_ roles on the `admin`
+database, which means that all databases can be accessed and
 modified, and that new users can be created.
 
 **Test User**
 
-We want the initial NoSQL user to be a user with limited rights,\
+We want the initial NoSQL user to be a user with limited rights,
 intended to be used for testing.
 
 ```
@@ -645,11 +645,11 @@ CREATE USER 'test.test_user'@'%' IDENTIFIED BY 'test_password';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX ON `test`.* TO 'test.test_user'@'%';
 ```
 
-As we want a user with limited rights, the name is _not_ prefixed\
+As we want a user with limited rights, the name is _not_ prefixed
 with `admin`. The privileges are granted specifically on database`test.*`. Indeed, if `*.*` had been used, the creation of the initial\
-NoSQL user would have failed with an error. Here, the user is created\
-in the same database that the user is given access to, but it could\
-have been another one. Further, several `GRANT` statements could have\
+NoSQL user would have failed with an error. Here, the user is created
+in the same database that the user is given access to, but it could
+have been another one. Further, several `GRANT` statements could have
 been used, had we wanted to give access to several databases.
 
 Thereafter, we specify the following in the configuration file,
@@ -667,16 +667,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as master,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as master,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'test.test_user'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -686,9 +686,9 @@ $ mongo --quiet --port 17017 -u test_user -p test_password test
 >
 ```
 
-Note that when connecting the user is passed as `test_user` and _not_\
-as `test.test_user`. The fact that we want to authenticate against\
-the `test` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `test_user` and _not_
+as `test.test_user`. The fact that we want to authenticate against
+the `test` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -715,44 +715,44 @@ argument.
 }
 ```
 
-As can be seen, the user has the `readWrite` role on the `test` database,\
+As can be seen, the user has the `readWrite` role on the `test` database,
 which means that only the `test` database can be accessed and modified.
 
 #### TLS/SSL
 
-Since `nosqlprotocol` is a regular protocol module used in a listener,\
-the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](https://mariadb.com/kb/en/Getting-Started/Configuration-Guide#tsl-encryption)\
+Since `nosqlprotocol` is a regular protocol module used in a listener,
+the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](https://mariadb.com/kb/en/Getting-Started/Configuration-Guide#tsl-encryption)
 for details.
 
 ### NoSQL Account Database
 
-So as to be able to connect to the MariaDB server on behalf of\
-clients, nosqlprotocol must know their password. As the password\
-is not transferred to nosqlprotocol during the authentication in\
-a way that could be used when logging into MariaDB, the password\
-must be stored when the user is created with [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser)\
+So as to be able to connect to the MariaDB server on behalf of
+clients, nosqlprotocol must know their password. As the password
+is not transferred to nosqlprotocol during the authentication in
+a way that could be used when logging into MariaDB, the password
+must be stored when the user is created with [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser)
 or added with [mxsAddUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsAddUser).
 
-Note that the password is not stored in cleartext but as three\
-different hashes; hashed with sha1 for use with MariaDB, salted\
-and hashed with sha1 for use with the `SCRAM-SHA-1` authentication\
-mechanism (if that is enabled for the user) and salted and hashed\
-with sha256 for use with the `SCRAM-SHA-256` authentication mechanism\
+Note that the password is not stored in cleartext but as three
+different hashes; hashed with sha1 for use with MariaDB, salted
+and hashed with sha1 for use with the `SCRAM-SHA-1` authentication
+mechanism (if that is enabled for the user) and salted and hashed
+with sha256 for use with the `SCRAM-SHA-256` authentication mechanism
 (if that is enabled for the user).
 
-The account information can be stored _privately_, in which case it\
-can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can\
-share the information and a user created/added on one instance\
+The account information can be stored _privately_, in which case it
+can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can
+share the information and a user created/added on one instance
 can be used on another.
 
 #### Private
 
-In the private case, the account information of nosqlprotocol is\
-stored in an [sqlite3](https://sqlite.org/index.html) database\
-whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,\
-where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the\
-listener section in the MaxScale configuration file, and `-v1`\
-a suffix for making schema evolution easier, should there be\
+In the private case, the account information of nosqlprotocol is
+stored in an [sqlite3](https://sqlite.org/index.html) database
+whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,
+where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the
+listener section in the MaxScale configuration file, and `-v1`
+a suffix for making schema evolution easier, should there be
 a need for that.
 
 For instance, given a configuration like
@@ -767,41 +767,41 @@ protocol=nosqlprotocol
 
 the account information will be stored in the file`<libdir>/nosqlprotocol/NoSQL-Listener-v1.db`.
 
-Note that since the database name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the database name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
-To retain the accounts, the database file should also be\
+To retain the accounts, the database file should also be
 renamed.
 
-At first startup, the `nosqlprotocol` directory and\
-the file `NoSQL-Listener-v1.db` will be created. They will\
-be created with file permissions that only allow MaxScale\
-access. At subsequent startups the permissions will be checked\
-and MaxScale will refuse to start if the permissions allow\
+At first startup, the `nosqlprotocol` directory and
+the file `NoSQL-Listener-v1.db` will be created. They will
+be created with file permissions that only allow MaxScale
+access. At subsequent startups the permissions will be checked
+and MaxScale will refuse to start if the permissions allow
 access to others.
 
 **We strongly recommend that no manual modifications are made**\
 **to the database.**
 
-Note that we make **no** guarantees that the way in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the way in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ### Shared
 
-In the shared case, the account information of nosqlprotocol\
+In the shared case, the account information of nosqlprotocol
 is stored in the cluster of the service in front of which the\
-NoSQL listener resides. The master of the cluster will be used\
+NoSQL listener resides. The master of the cluster will be used
 both for reading and writing data.
 
 A table whose name is the same as the listener's name in the\
-MaxScale configuration will be created in the database\
-specified with the [authentication\_db](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_db)\
-parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of\
+MaxScale configuration will be created in the database
+specified with the [authentication\_db](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_db)
+parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of
 the listener section in the MaxScale configuration file.
 
 For instance, given a configuration like
@@ -816,61 +816,61 @@ protocol=nosqlprotocol
 
 the account information will be stored in the table`nosqlprotocol.NoSQL-Listener`.
 
-Note that since the table name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the table name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
 To retain the accounts, the table should also be renamed.
 
-`nosqlprotocol` will create the table when needed, so the\
-user specified with [authentication\_user](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_user)\
+`nosqlprotocol` will create the table when needed, so the
+user specified with [authentication\_user](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_user)
 must have sufficient grants to be able to do that.
 
-`nosqlprotocol` will store in the table, data that allow\
-any MaxScale to authenticate a MongoDB® client, irrespective\
+`nosqlprotocol` will store in the table, data that allow
+any MaxScale to authenticate a MongoDB® client, irrespective
 of which MaxScale instance was used when the user was created.
 
-`nosqlprotocol` also stores in the table the SHA1 of a user's\
+`nosqlprotocol` also stores in the table the SHA1 of a user's
 password, to be able to authenticate against the MariaDB server.\
-Therefore it is **strongly** suggested to enable encryption key\
-management in MaxScale and to provide an authentication\
-key ID with [authentication\_key\_id](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_key_id) so\
+Therefore it is **strongly** suggested to enable encryption key
+management in MaxScale and to provide an authentication
+key ID with [authentication\_key\_id](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_key_id) so
 that the data will be encrypted.
 
-If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_password) must also\
-be provided. With [authentication\_db](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_db) the\
-database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_key_id) an\
-encryption key ID, using which the sensitive data is encrypted,\
+If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_password) must also
+be provided. With [authentication\_db](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_db) the
+database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2208-nosql-protocol-module.md#authentication_key_id) an
+encryption key ID, using which the sensitive data is encrypted,
 can optionally be provided.
 
-Note that we make **no** guarantees that the table in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the table in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ## Wire Protocol
 
-_Nosqlprotocol_ fully supports wire protocol version 6 and only provides\
-rudimentary support for earlier wire protocol versions, but reports at\
-startup that it would support versions 0 to 6. The reason is that some\
-client libraries are buggy and use an old wire protocol version if the\
-server claims to support only version 6. Consequently, one should use a\
+_Nosqlprotocol_ fully supports wire protocol version 6 and only provides
+rudimentary support for earlier wire protocol versions, but reports at
+startup that it would support versions 0 to 6. The reason is that some
+client libraries are buggy and use an old wire protocol version if the
+server claims to support only version 6. Consequently, one should use a
 client library version that at least supports wire protocol version 6.
 
 ## Client Library
 
-As the goal of _nosqlprotocol_ is to implement, to the extent that it\
-is feasible, the wire protocol and the database commands the way MongoDB®\
+As the goal of _nosqlprotocol_ is to implement, to the extent that it
+is feasible, the wire protocol and the database commands the way MongoDB®
 implements them, it should be possible to use any language specific driver.
 
-However, during the development of _nosqlprotocol_, the _only_ client library\
+However, during the development of _nosqlprotocol_, the _only_ client library
 that has been verified to work is version 3.6 of _MongoDB Node.JS Driver_.
 
 ## Parameters
 
-Using the following parameters, the behavior of _nosqlprotocol_ can be\
+Using the following parameters, the behavior of _nosqlprotocol_ can be
 adjusted. As they are not generic listener parameters, but specific to _nosqlprotocol_ they must be qualified with the `nosqlprotocol`-prefix.
 
 For instance:
@@ -892,7 +892,7 @@ nosqlprotocol.on_unknown_command=return_error
 * Mandatory: No
 * Default: `""`
 
-Specifies the _user_ to be used when connecting to the backend, if the MongoDB®\
+Specifies the _user_ to be used when connecting to the backend, if the MongoDB®
 client is not authenticated.
 
 ### `password`
@@ -901,8 +901,8 @@ client is not authenticated.
 * Mandatory: No
 * Default: `""`
 
-Specifies the _password_ to be used when connecting to the backend, is the MongoDB®\
-client is not authenticated. Note that the same _user_/_password_ combination will be\
+Specifies the _password_ to be used when connecting to the backend, is the MongoDB®
+client is not authenticated. Note that the same _user_/_password_ combination will be
 used for all unauthenticated MongoDB® clients connecting to the same listener port.
 
 ### `authentication_required`
@@ -911,11 +911,11 @@ used for all unauthenticated MongoDB® clients connecting to the same listener p
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the client always must authenticate. If authentication is required,\
-it does not matter whether `user` and `password` have been specified, the client must\
+Specifies whether the client always must authenticate. If authentication is required,
+it does not matter whether `user` and `password` have been specified, the client must
 authenticate.
 
-Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsAddUser),\
+Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsAddUser),
 with authentication being optional and authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -927,7 +927,7 @@ MariaDB server.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the NoSQL account information should be stored in a shared\
+Specifies whether the NoSQL account information should be stored in a shared
 manner or privately.
 
 ### `authentication_db`
@@ -936,10 +936,10 @@ manner or privately.
 * Mandatory: No
 * Default: `"NoSQL"`
 
-Specifies the database of the table where the NoSQL account information\
-is stored, if `authentication_shared` is `true`. If the database does not\
-exist, nosqlprotocol will attempt to create it, so either is should be\
-manually created or the used specified with `authentication_user` should\
+Specifies the database of the table where the NoSQL account information
+is stored, if `authentication_shared` is `true`. If the database does not
+exist, nosqlprotocol will attempt to create it, so either is should be
+manually created or the used specified with `authentication_user` should
 have the grants required to do so.
 
 ### `authentication_key_id`
@@ -948,11 +948,11 @@ have the grants required to do so.
 * Mandatory: No
 * Default: `""`
 
-The encryption key ID, using which the NoSQL account information should be\
-encrypted with when stored in the MariaDB server. If an encryption key ID is\
+The encryption key ID, using which the NoSQL account information should be
+encrypted with when stored in the MariaDB server. If an encryption key ID is
 given, the encryption key manager in MaxScale must also be enabled.
 
-The encryption key must be a 256-bit key. Keys of shorter length are rejected\
+The encryption key must be a 256-bit key. Keys of shorter length are rejected
 as invalid encryption keys.
 
 ### `authentication_user`
@@ -960,7 +960,7 @@ as invalid encryption keys.
 * Type: string
 * Mandatory: Yes, if `authentication_shared` is true.
 
-Specifies the _user_ to be used when modifying and accessing the NoSQL\
+Specifies the _user_ to be used when modifying and accessing the NoSQL
 account information stored in the MariaDB server.
 
 ### `authentication_password`
@@ -977,9 +977,9 @@ Specifies the _password_ of `authentication_user`.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether nosqlprotocol itself should perform authorization in the context\
-of the commands [mxsAddUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users\
-have been created with [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsAddUser)\
+Specifies whether nosqlprotocol itself should perform authorization in the context
+of the commands [mxsAddUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users
+have been created with [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2208-nosql-protocol-module.md#mxsAddUser)
 with authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -992,8 +992,8 @@ MariaDB server.
 * Default: `"%"`
 
 Specifies the _host_ to be used when a MariaDB user is created via nosqlprotocol.\
-By default all users are created as `...@'%'`, which means that it is possible to\
-connect to the MariaDB server from any host using the credentials of the created\
+By default all users are created as `...@'%'`, which means that it is possible to
+connect to the MariaDB server from any host using the credentials of the created
 user. For tighter security, the IP-address of the MaxScale host can be specified.
 
 NOTE: This value does **not** specify from which host it is allowed to connect to\
@@ -1019,8 +1019,8 @@ Enumeration values:
 * Mandatory: No
 * Default: `false`
 
-Specifies whether an unknown command should be logged. This is primarily\
-for debugging purposes, to find out whether a client uses a command that\
+Specifies whether an unknown command should be logged. This is primarily
+for debugging purposes, to find out whether a client uses a command that
 currently is not supported.
 
 ### `auto_create_databases`
@@ -1042,7 +1042,7 @@ Note that setting this parameter to `true`, without also setting`auto_create_tab
 Specifies whether tables should automatically be created, as needed.
 
 Note that this applies only if the relevant database already exists.\
-If a database should also be created if needed, then `auto_create_databases`\
+If a database should also be created if needed, then `auto_create_databases`
 must also be set to `true`.
 
 ### `id_length`
@@ -1063,16 +1063,16 @@ Specifies the length of the id column in tables that are automatically created.
 
 Enumeration values:
 
-* `default`: Each document is inserted using a separate `INSERT`, either in a\
-  multi-statement or in a compound statement. Whether an error causes the remaining\
-  insertions to be aborted, depends on the value of `ordered` specified in the\
+* `default`: Each document is inserted using a separate `INSERT`, either in a
+  multi-statement or in a compound statement. Whether an error causes the remaining
+  insertions to be aborted, depends on the value of `ordered` specified in the
   insert command.
-* `atomic`: If the value of `ordered` in the insert command is `true`\
-  (the default) then all documents are inserted using a single `INSERT` statement,\
-  that is, either all insertions succeed or none will. If `ordered` is false, then\
+* `atomic`: If the value of `ordered` in the insert command is `true`
+  (the default) then all documents are inserted using a single `INSERT` statement,
+  that is, either all insertions succeed or none will. If `ordered` is false, then
   the behavior is as in the `default` case.
 
-What combination of `ordered_insert_behavior` and `ordered` (in the insert command\
+What combination of `ordered_insert_behavior` and `ordered` (in the insert command
 document) is used, has an impact on the performance. Please see the discussion at [insert](mariadb-maxscale-2208-nosql-protocol-module.md#insert).
 
 ### `cursor_timeout`
@@ -1081,7 +1081,7 @@ document) is used, has an impact on the performance. Please see the discussion a
 * Mandatory: No
 * Default: `60s`
 
-Specifies how long a cursor can be idle, that is, not accessed, before it is\
+Specifies how long a cursor can be idle, that is, not accessed, before it is
 automatically closed.
 
 ### `debug`
@@ -1106,21 +1106,21 @@ So, specify
 nosqlprotocol.debug=in,out,back
 ```
 
-to have the incoming command, the corresponding SQL sent to the backend\
+to have the incoming command, the corresponding SQL sent to the backend
 and the resulting response sent to the client logged.
 
 ## Databases and Tables
 
 By default, _nosqlprotocol_ automatically creates databases as needed.\
-The default behavior can be changed by setting `auto_create_databases` to\
+The default behavior can be changed by setting `auto_create_databases` to
 false. In that case, databases must manually be created.
 
 Each MongoDB® _collection_ corresponds to a MariaDB table with the same name.\
-However, it is always possible to access a collection irrespective of whether\
+However, it is always possible to access a collection irrespective of whether
 the corresponding table exists or not; it will simply appear to be empty.
 
-Inserting documents into a collection, whose corresponding table does not\
-exist, succeeds, provided `auto_create_tables` is `true`, as the table will\
+Inserting documents into a collection, whose corresponding table does not
+exist, succeeds, provided `auto_create_tables` is `true`, as the table will
 in that case be created.
 
 When _nosqlprotocol_ creates a table, it uses a statement like
@@ -1131,19 +1131,19 @@ CREATE TABLE name (id VARCHAR(35) AS (JSON_COMPACT(JSON_EXTRACT(doc, "$._id"))) 
                    CONSTRAINT id_not_null CHECK(id IS NOT NULL));
 ```
 
-where the length of the `VARCHAR` is specified by the value of `id_length`,\
+where the length of the `VARCHAR` is specified by the value of `id_length`,
 whose default and minimum is 35.
 
-_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain\
+_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain
 a similar constraint.
 
-Note that _nosqlprotocol_ does not in any way verify that the table\
-corresponding to a collection being accessed or modified does indeed\
-have the expected columns `id` and `doc` of the expected types, but it\
-simply uses the table, which will fail if the layout is not the expected\
+Note that _nosqlprotocol_ does not in any way verify that the table
+corresponding to a collection being accessed or modified does indeed
+have the expected columns `id` and `doc` of the expected types, but it
+simply uses the table, which will fail if the layout is not the expected
 one.
 
-To reduce the risk for confusion, the recommendation is to use a specific\
+To reduce the risk for confusion, the recommendation is to use a specific
 database for tables that contain documents.
 
 ## Operators
@@ -1179,7 +1179,7 @@ The following operators are currently supported.
 
 **`$type`**
 
-When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset\
+When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset
 of types can be used in `$type` queries:
 
 | Type           | Number | Alias    | MariaDB Type |
@@ -1226,10 +1226,10 @@ As arguments, only the operators `$eq` and `$ne` are supported.
 
 ## Database Commands
 
-The following commands are supported. At each command is specified\
+The following commands are supported. At each command is specified
 what fields are relevant for the command.
 
-**All** non-listed fields are ignored; their presence or absence have no\
+**All** non-listed fields are ignored; their presence or absence have no
 impact, unless otherwise explicitly specified.
 
 ### Aggregation Commands
@@ -1300,7 +1300,7 @@ The `projection` parameter takes a document of the following form:
 { <field1>: <value>, <field2>: <value> ... }
 ```
 
-If a `projection` document is not provided or if it is empty, the entire document\
+If a `projection` document is not provided or if it is empty, the entire document
 will be returned.
 
 | Projection     | Description                         |
@@ -1314,23 +1314,23 @@ For fields in an embedded documents, the field can be specified using:
 
 * dot notation; e.g. `"field.nestedfield": <value>`
 
-In particular, specifying fields in embedded documents using nested form\
+In particular, specifying fields in embedded documents using nested form
 is not supported.
 
 **`_id` Field Projection**
 
-The `_id` field is included in the returned documents by default unless you\
+The `_id` field is included in the returned documents by default unless you
 explicitly specify `_id: 0` in the projection to suppress the field.
 
 **Inclusion or Exclusion**
 
-A `projection` cannot contain both include and exclude specifications,\
+A `projection` cannot contain both include and exclude specifications,
 with the exception of the `_id` field:
 
 * In projections that explicitly include fields, the `_id` field is the only field that can be explicitly excluded.
 * In projections that explicitly excludes fields, the `_id` field is the only field that can be explicitly include; however, the `_id` field is included by default.
 
-_NOTE_ Currently `_id` is the only field that can be excluded, and _only_\
+_NOTE_ Currently `_id` is the only field that can be excluded, and _only_
 if other fields are explicitly included._NOTE_ Currently exclusion of other fields but `_id` is not supported.
 
 **Filtering by `_id`**
@@ -1359,7 +1359,7 @@ and in the latter
 ... WHERE (JSON_EXTRACT(doc, '$._id') = 4711)
 ```
 
-That is, in the former case the _indexed_ column `id` will be used, in the\
+That is, in the former case the _indexed_ column `id` will be used, in the
 latter it will not.
 
 #### findAndModify
@@ -1399,9 +1399,9 @@ The following fields are relevant.
 
 #### insert
 
-The `insert` command inserts one or more documents into the table whose\
-name is the same as that of the collection. If the option `auto_create_tables`\
-is `true`, then the table is created if it does not already exist. If the\
+The `insert` command inserts one or more documents into the table whose
+name is the same as that of the collection. If the option `auto_create_tables`
+is `true`, then the table is created if it does not already exist. If the
 value is `false`, then the insert will fail unless the table already exists.
 
 The following fields are relevant.
@@ -1418,9 +1418,9 @@ The impact of `ordered` is dependent upon the value of `ordered_insert_behavior`
 
 **`default`**
 
-In this case `ordered` has the same impact as in MongoDB®. That is, if the value\
-is `true`, then when an insert of a document fails, return without inserting any\
-remaining documents listed in the inserts array. If `false`, then when an insert\
+In this case `ordered` has the same impact as in MongoDB®. That is, if the value
+is `true`, then when an insert of a document fails, return without inserting any
+remaining documents listed in the inserts array. If `false`, then when an insert
 of a document fails, continue to insert the remaining documents.
 
 **`atomic`**
@@ -1432,7 +1432,7 @@ then the behavior is identical with that of `default`.
 
 **Performance**
 
-What combination of `ordered_insert_behavior` and `ordered` is used, has an\
+What combination of `ordered_insert_behavior` and `ordered` is used, has an
 impact on the performance.
 
 | ordered\_insert\_behavior | ordered = true                                                                                                                        | ordered = false                                                                                                                        |
@@ -1440,8 +1440,8 @@ impact on the performance.
 | default                   | All documents are inserted within a compound statement, in a transaction containing as many INSERT statements as there are documents. | All documents are inserted in a single multi-statement transaction containing as many INSERT IGNORE statements as there are documents. |
 | atomic                    | All documents are inserted using a single INSERT statement.                                                                           | Same as above                                                                                                                          |
 
-Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,\
-being roughly twice as slow. The performance of 'default + true' is halfway between\
+Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,
+being roughly twice as slow. The performance of 'default + true' is halfway between
 the two.
 
 #### resetError
@@ -1474,10 +1474,10 @@ Each document contains the following fields:
 | u     | document | The modifications to apply. See behavior below for details.                                                                                                        |
 | multi | boolean  | Optional. If true, updates all documents that meet the query criteria. If false limit the update to one document that meets the query criteria. Defaults to false. |
 
-Note that currently it is possible to set `multi` to `true` in conjunction\
+Note that currently it is possible to set `multi` to `true` in conjunction
 with a _replacement-style_ update, even though MongoDB® rejects that.
 
-All other fields are ignored, with the exception of `upsert` that if present\
+All other fields are ignored, with the exception of `upsert` that if present
 with the value of `true` will cause the command to fail.
 
 **Behavior**
@@ -1503,7 +1503,7 @@ In this case, the update command updates only the corresponding fields in the do
 
 **Update with a Replacement Document**
 
-The update statement field `u` field can accept a _replacement document_,\
+The update statement field `u` field can accept a _replacement document_,
 i.e. the document contains only `field:value` expressions. For example:
 
 ```
@@ -1518,12 +1518,12 @@ updates: [
 ```
 
 In this case, the update command replaces the matching document with the update document.\
-The update command can only replace a single matching document; i.e. the multi field\
+The update command can only replace a single matching document; i.e. the multi field
 cannot be true.
 
-**Note** If the replacement document contains an `_id` field, it will be ignored and the\
-document id will remain non-changed while the document otherwise is replaced. This is\
-different from MongoDB® where the presence of the `_id` field in the replacement document\
+**Note** If the replacement document contains an `_id` field, it will be ignored and the
+document id will remain non-changed while the document otherwise is replaced. This is
+different from MongoDB® where the presence of the `_id` field in the replacement document
 causes an error, if the value is not the same as it is in the document being replaced.
 
 ### Authentication Commands
@@ -1538,7 +1538,7 @@ The following fields are relevant.
 
 If you are not logged in and using authentication, `logout` has no effect.
 
-Note that in order to be logged out, the logging out must be done while\
+Note that in order to be logged out, the logging out must be done while
 using the same database that was used when you logged on.
 
 Always returns
@@ -1551,7 +1551,7 @@ Always returns
 
 #### createUser
 
-Creates a new MariaDB user and adds an entry to the local nosqlprotocol\
+Creates a new MariaDB user and adds an entry to the local nosqlprotocol
 account database.
 
 The following fields are relevant.
@@ -1565,8 +1565,8 @@ The following fields are relevant.
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is\
-the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the\
+The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is
+the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the
 following command
 
 ```
@@ -1576,19 +1576,19 @@ following command
 
 the MariaDB user `'myDatabase.user1'@'%'` will be created.
 
-The elements of the `roles` array are converted into privileges\
+The elements of the `roles` array are converted into privileges
 as explained in [here](mariadb-maxscale-2208-nosql-protocol-module.md#roles_and_privileges).
 
 In practice the creation is performed as follows:_First the MariaDB user is created._ Then the privileges are granted.
 
 * Finally the local nosqlprotocol account database is updated.
 
-If the granting of privileges fails, an attempt will be made to\
+If the granting of privileges fails, an attempt will be made to
 drop the user.
 
 #### dropAllUsersFromDatabase
 
-Drops all users from the local nosqlprotocol account database and\
+Drops all users from the local nosqlprotocol account database and
 the corresponding MariaDB users.
 
 The following fields are relevant.
@@ -1610,13 +1610,13 @@ The following fields are relevant.
 | -------- | ------ | ----------------------------------- |
 | dropUser | string | The name of the user to be dropped. |
 
-The user will first be dropped from the MariaDB server and if\
+The user will first be dropped from the MariaDB server and if
 that succeeds also from the local nosqlprotocol account database.
 
 #### grantRolesToUser
 
-This command _adds_ more roles to a NoSQL user, which may imply\
-that additional privileges are granted to the corresponding MariaDB\
+This command _adds_ more roles to a NoSQL user, which may imply
+that additional privileges are granted to the corresponding MariaDB
 user.
 
 | Field            | Type   | Description                                    |
@@ -1625,12 +1625,12 @@ user.
 | roles            | array  | An array of additional roles.                  |
 
 Note that roles assigned to different databases will result in separate\
-GRANT statements, which means that it is possible that some succeed and\
+GRANT statements, which means that it is possible that some succeed and
 others do not.
 
 #### revokeRolesFromUser
 
-This command _removes_ roles from an NoSQL user, which may imply\
+This command _removes_ roles from an NoSQL user, which may imply
 that privileges are revoked from the corresponding MariaDB user.
 
 | Field               | Type   | Description                                |
@@ -1638,8 +1638,8 @@ that privileges are revoked from the corresponding MariaDB user.
 | revokeRolesFromUser | string | The name of the user to remove roles from. |
 | roles               | array  | An array of roles to remove.               |
 
-Note that roles to be removed from different databases will result in\
-separate REVOKE statements, which means that it is possible that some\
+Note that roles to be removed from different databases will result in
+separate REVOKE statements, which means that it is possible that some
 succeed and others do not.
 
 #### updateUser
@@ -1654,8 +1654,8 @@ This command updates the information about a particular user.
 | roles      | array    | Optional. The roles granted to the user. Note that the existing ones are replaced and not amended with these roles.                                                                                                                                                |
 | mechanisms | array    | Optional. The specific SCRAM mechanisms for user credentials. Note that if a new pwd is provided, then the array can contain all supported SCRAM mechanisms. If a new pwd is not provided, then the array must be a subset of the existing mechanisms of the user. |
 
-Changes to `customData` or `mechanisism` are made only to the local\
-nosqlprotocol database, but changes to `pwd` or `roles` require\
+Changes to `customData` or `mechanisism` are made only to the local
+nosqlprotocol database, but changes to `pwd` or `roles` require
 the MariaDB server to be updated.
 
 #### usersInfo
@@ -1679,11 +1679,11 @@ The returned information depends the value of `usersInfo`:
 | { usersInfo: \[{ user: , db: }, ...]} | Returns information about specified users.                                          |
 | { usersInfo: \[ , ... ]}              | Returns information about specified users in the database where the command is run. |
 
-Note that users may always view their own information. Otherwise the user must\
+Note that users may always view their own information. Otherwise the user must
 have the `userAdmin` or `userAdminAnyDatabase` role.
 
 If `showCredentials` is true, the returned object(s) will contain a`mariadb: { password: "*..."}` field, where `password` is the`SHA1(SHA1())` value of the password used when logging to MariaDB.\
-That is, the same string that is found in the `password` column in\
+That is, the same string that is found in the `password` column in
 the `mysql.user` table.
 
 ### Replication Commands
@@ -1745,8 +1745,8 @@ The following fields are relevant.
 | capped | boolean | Optional. If specified, the value must be false as capped collections are not supported. |
 | viewOn | string  | Optional. If specified, the command will fail as views are not supported.                |
 
-Currently, _capped collections_ and _views_ are not supported. Consequently,\
-specifying that the collection should be capped or that it should be a\
+Currently, _capped collections_ and _views_ are not supported. Consequently,
+specifying that the collection should be capped or that it should be a
 view on another collection, will cause the command to fail.
 
 #### createIndexes
@@ -1757,9 +1757,9 @@ The following fields are relevant.
 | ------------- | ------ | ------------------------------------------- |
 | createIndexes | string | The collection for which to create indexes. |
 
-**NOTE** Currently it is not possible to create indexes, but the command\
-will nonetheless return success, provide the index specification passes\
-some rudimentary sanity checks. Note also that the collection will be\
+**NOTE** Currently it is not possible to create indexes, but the command
+will nonetheless return success, provide the index specification passes
+some rudimentary sanity checks. Note also that the collection will be
 created if it does not exist.
 
 #### drop
@@ -1786,9 +1786,9 @@ The following fields are relevant.
 | ----------- | ---- | ----------- |
 | dropIndexes | any  | Ignored.    |
 
-**NOTE** Currently it is not possible to create indexes and thus there\
-will never be any indexes that could be dropped. However, provided the\
-specified collection exists, dropping indexes will always succeed except\
+**NOTE** Currently it is not possible to create indexes and thus there
+will never be any indexes that could be dropped. However, provided the
+specified collection exists, dropping indexes will always succeed except
 for an attempt to drop the built-in `_id_` index.
 
 #### fsync
@@ -1829,8 +1829,8 @@ The following fields are relevant.
 | filter          | document | The field name is honored, other fields are not but cause warnings to be logged.                                                                 |
 | nameOnly        | boolean  | Optional. A flag to indicate whether the command should return just the collection names and type or return both the name and other information. |
 
-Note that the command lists all collections (that is, tables) that are found\
-in the current database. The listed collections may or may not be suitable\
+Note that the command lists all collections (that is, tables) that are found
+in the current database. The listed collections may or may not be suitable
 for being accessed using _nosqlprotocol_.
 
 #### listDatabases
@@ -1850,9 +1850,9 @@ The following fields are relevant.
 | ----------- | ------ | --------------------------- |
 | listIndexes | string | The name of the collection. |
 
-**NOTE** As it currently is not possible to actually create indexes,\
-although an attempt to do so using `createIndexes` will succeed, the\
-result will always only contain information about the built-in\
+**NOTE** As it currently is not possible to actually create indexes,
+although an attempt to do so using `createIndexes` will succeed, the
+result will always only contain information about the built-in
 index `_id_`.
 
 #### renameCollection
@@ -1960,8 +1960,8 @@ The following fields are relevant.
 | -------- | ------ | --------------------------------------- |
 | validate | string | The name of the collection to validate. |
 
-The command does not actually perform any validation but for checking\
-that the collection exists. The response will contain in `nrecords`\
+The command does not actually perform any validation but for checking
+that the collection exists. The response will contain in `nrecords`
 the current number of documents/rows it contains.
 
 #### whatsmyuri
@@ -1998,11 +1998,11 @@ The following document will always be returned:
 
 **mxsAddUser**
 
-The `mxsAddUser` command adds an _existing_ MariaDB user to the local\
+The `mxsAddUser` command adds an _existing_ MariaDB user to the local
 nosqlprotocol account database. Use [createUser](mariadb-maxscale-2208-nosql-protocol-module.md#createUser) if the\
 MariaDB user should be created as well.
 
-Note that the `mxsAddUser` command does not check that the user exists\
+Note that the `mxsAddUser` command does not check that the user exists
 or that the specified roles are compatible with the grants of the user.
 
 **Syntax**
@@ -2038,17 +2038,17 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The value of `mxsAddUser` should be the name (without the host part) of\
-an existing user in the MariaDB server and the value of `pwd` should be\
+The value of `mxsAddUser` should be the name (without the host part) of
+an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2208-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2208-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the addition of the user succeeds, the command returns a document\
+If the addition of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2074,7 +2074,7 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsCreateDatabase**
 
-The 'mxsCreateDatabase' command creates a new database and must be run\
+The 'mxsCreateDatabase' command creates a new database and must be run
 against the `admin` database.
 
 **Syntax**
@@ -2099,7 +2099,7 @@ The command takes the following fields:
 
 **Returns**
 
-If database creation succeeds, the command returns a document with the\
+If database creation succeeds, the command returns a document with the
 single field `ok` whose value is `1`.
 
 ```
@@ -2150,7 +2150,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains diagnostics of the command\
+The command returns a document that contains diagnostics of the command
 provided as argument. For example:
 
 ```
@@ -2175,19 +2175,19 @@ provided as argument. For example:
 }
 ```
 
-`kind` specifies of what kind the command is; an _immediate_ command is one for\
-which MaxScale autonomously can generate the response, a _single_ command is one\
-where the command will cause a single SQL statement to be sent to the backend, and\
-a _multi_ command is one where potentially multiple SQL statements will be sent to\
+`kind` specifies of what kind the command is; an _immediate_ command is one for
+which MaxScale autonomously can generate the response, a _single_ command is one
+where the command will cause a single SQL statement to be sent to the backend, and
+a _multi_ command is one where potentially multiple SQL statements will be sent to
 the backend.
 
-If the command is _immediate_ then there will be a field `response` containing\
-the actual response of the command, if the command is _single_ then there will be\
-a field `sql` containing the actual statement that would have been sent to the backend,\
-and if the command is _multi_ then there will be a field `sql` containing an array\
+If the command is _immediate_ then there will be a field `response` containing
+the actual response of the command, if the command is _single_ then there will be
+a field `sql` containing the actual statement that would have been sent to the backend,
+and if the command is _multi_ then there will be a field `sql` containing an array
 of statements that would have been sent to the backend.
 
-If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that\
+If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that
 the value of `ok` will always be 1.
 
 #### mxsGetConfig
@@ -2196,7 +2196,7 @@ the value of `ok` will always be 1.
 
 **mxsGetConfig**
 
-The `mxsGetConfig` command returns the current configuration of the session\
+The `mxsGetConfig` command returns the current configuration of the session
 and must be run against the 'admin' database.
 
 **Syntax**
@@ -2220,7 +2220,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the current configuration of\
+The command returns a document that contains the current configuration of
 the session. For example:
 
 ```
@@ -2242,8 +2242,8 @@ the session. For example:
 
 **mxsRemoveUser**
 
-The `mxsRemoveUser` removes a user from the local nosqlprotocol account\
-database. Use [dropUser](mariadb-maxscale-2208-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped\
+The `mxsRemoveUser` removes a user from the local nosqlprotocol account
+database. Use [dropUser](mariadb-maxscale-2208-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped
 as well.
 
 **Syntax**
@@ -2268,7 +2268,7 @@ The command has the following fields:
 
 **Returns**
 
-If the removal of the user succeeds, the command returns a document\
+If the removal of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2294,10 +2294,10 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsSetConfig**
 
-The `mxsSetConfig` command changes the configuration of the session\
+The `mxsSetConfig` command changes the configuration of the session
 and must be run against the 'admin' database.
 
-Note that the changes only affect the current session and are **not**\
+Note that the changes only affect the current session and are **not**
 persisted.
 
 **Syntax**
@@ -2329,7 +2329,7 @@ The document takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the changed configuration of\
+The command returns a document that contains the changed configuration of
 the session. For example:
 
 ```
@@ -2361,12 +2361,12 @@ the session. For example:
 
 **mxsUpdateUser**
 
-The `mxsUpdateUser` command updates a user in the local nosqlprotocol\
-account database. Use [updateUser](mariadb-maxscale-2208-nosql-protocol-module.md#updateUser) to update MariaDB user\
+The `mxsUpdateUser` command updates a user in the local nosqlprotocol
+account database. Use [updateUser](mariadb-maxscale-2208-nosql-protocol-module.md#updateUser) to update MariaDB user
 as well.
 
-Note that the `mxsUpdateUser` command does not check that the changed\
-data is compatible e.g. with the grants of the corresponding MariaDB\
+Note that the `mxsUpdateUser` command does not check that the changed
+data is compatible e.g. with the grants of the corresponding MariaDB
 user.
 
 **Syntax**
@@ -2402,13 +2402,13 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. If a new password is not provided, the specified mechanisms must be a subset of the current mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2208-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2208-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the updating of the user succeeds, the command returns a document\
+If the updating of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2430,27 +2430,27 @@ If there is a failure of some kind, the command returns an error document
 
 ## Object Id
 
-When a document is created, an id of type `ObjectId` will be autogenerated by\
-the MongoDB® client library. If the id is provided explicitly, by assigning a\
-value to the `_id` field, the value must be an `ObjectId`, a string or an\
+When a document is created, an id of type `ObjectId` will be autogenerated by
+the MongoDB® client library. If the id is provided explicitly, by assigning a
+value to the `_id` field, the value must be an `ObjectId`, a string or an
 integer.
 
 ## Compatibility
 
-Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)\
+Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)
 test-suite pass.
 
 ## Example
 
-The following is a minimal setup for getting _nosqlprotocol_ up and\
-running. It is assumed the reader knows how to configure MaxScale for\
+The following is a minimal setup for getting _nosqlprotocol_ up and
+running. It is assumed the reader knows how to configure MaxScale for
 normal use. If not, please start with the [MaxScale tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-setting-up-mariadb-maxscale.md).\
-Note that as _nosqlprotocol_ is the first component in the MaxScale\
+Note that as _nosqlprotocol_ is the first component in the MaxScale
 routing chain, it can be used with all routers and filters.
 
 ### Configuring MaxScale
 
-In the following it is assumed that MaxScale already has been configured\
+In the following it is assumed that MaxScale already has been configured
 for normal use and that there exists a _service_ `[TheService]`.
 
 ```
@@ -2467,10 +2467,10 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-The values `the_user` and `the_password` must be replaced with the\
+The values `the_user` and `the_password` must be replaced with the
 actual credentials to be used for every MongoDB® client that connects.
 
-If MaxScale is now started, the following entry should appear in the\
+If MaxScale is now started, the following entry should appear in the
 log file.
 
 ```
@@ -2481,8 +2481,8 @@ log file.
 
 The mongo Shell is a powerful tool with which to access and manipulate a\
 MongoDB database. It is part of the MongoDB® package. Having the native\
-MongoDB database installed is convenient, as it makes it easy to ascertain\
-whether a problem is due to _nosqlprotocol_ not fully implementing something\
+MongoDB database installed is convenient, as it makes it easy to ascertain
+whether a problem is due to _nosqlprotocol_ not fully implementing something
 or due to the API not being used in the correct fashion.
 
 With the _mongo shell_, all that is needed is to invoke it with the port\_nosqlprotocol\_ is listening on:
@@ -2499,7 +2499,7 @@ MongoDB server version: 4.4.1
 >
 ```
 
-If the shell prompt appears, then a connection was successfully\
+If the shell prompt appears, then a connection was successfully
 established and the shell can be used.
 
 ```
@@ -2507,13 +2507,13 @@ established and the shell can be used.
 { "n" : 1, "ok" : 1 }
 ```
 
-The `db` variable is implicitly available, and refers by default to\
+The `db` variable is implicitly available, and refers by default to
 the `test` database.
 
 The command inserted a document into the collection called `collection`.\
-The table corresponding to that collection is created implicitly because\
-the default value of `auto_create_tables` is `true`. Here, the object id\
-is specified explicitly, but there is no need for that, as one will be\
+The table corresponding to that collection is created implicitly because
+the default value of `auto_create_tables` is `true`. Here, the object id
+is specified explicitly, but there is no need for that, as one will be
 created if needed.
 
 To check whether the documents was inserted into the collection, the`find` command can be issued:
@@ -2548,18 +2548,18 @@ MariaDB [(none)]> select * from test.collection;
 +------+------------------------------------+
 ```
 
-The collection `collection` is represented by a table `collection` with\
-the two columns `id` and `doc`. `id` is a virtual column whose content is\
+The collection `collection` is represented by a table `collection` with
+the two columns `id` and `doc`. `id` is a virtual column whose content is
 the value of the `_id` field of the document in the `doc` column.
 
-All MongoDB® commands that _mongdbprotocol_ support (but for the ones that\
-do not require database access), basically access or manipulate the\
+All MongoDB® commands that _mongdbprotocol_ support (but for the ones that
+do not require database access), basically access or manipulate the
 content in the `doc` column using the [JSON functions](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements-and-structure/sql-statements/built-in-functions/special-functions/json-functions/) of MariaDB.
 
-From within the mongo shell itself it is easy to find out just what SQL\
+From within the mongo shell itself it is easy to find out just what SQL
 a particular MongoDB command is translated into.
 
-For instance, the SQL that the insert command with which the document was\
+For instance, the SQL that the insert command with which the document was
 added can be found out like:
 
 ```
@@ -2584,18 +2584,18 @@ Similarly, the SQL of the `find` command can be find out like:
 }
 ```
 
-The returned SQL can be directly pasted at the `mysql` prompt, which is\
+The returned SQL can be directly pasted at the `mysql` prompt, which is
 quite convenient in case the MongoDB® command does not behave as expected.
 
 ### MongoDB® Node.JS Driver
 
-As all client libraries implement and depend on the MongoDB® wire protocol,\
-all client libraries should work with _nosqlprotocol_. However, the\
-only client library that has been used and that has been verified to work\
+As all client libraries implement and depend on the MongoDB® wire protocol,
+all client libraries should work with _nosqlprotocol_. However, the
+only client library that has been used and that has been verified to work
 is version 3.6 of the _MongoDB Node.JS Driver_.
 
-In principle, the only thing that needs to be altered in an existing\
-program using the library is to change the uri string that typically\
+In principle, the only thing that needs to be altered in an existing
+program using the library is to change the uri string that typically
 is something like
 
 ```
@@ -2610,8 +2610,8 @@ const uri = "mongodb://<maxscale-ip>:17017";
 
 with the assumption that the default _nosqlprotocol_ port is used.
 
-In practice, additional modifications may be needed since _nosqlprotocol_\
-does not implement all commands and does not in all cases implement the\
+In practice, additional modifications may be needed since _nosqlprotocol_
+does not implement all commands and does not in all cases implement the
 full functionality of the commands that it supports.
 
 #### Inserting a Document

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-reference/mariadb-maxscale-2208-maxctrl.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-reference/mariadb-maxscale-2208-maxctrl.md
@@ -4,14 +4,14 @@
 
 ## MaxCtrl
 
-MaxCtrl is a command line administrative client for MaxScale which uses\
-the MaxScale REST API for communication. It has replaced the legacy MaxAdmin\
+MaxCtrl is a command line administrative client for MaxScale which uses
+the MaxScale REST API for communication. It has replaced the legacy MaxAdmin
 command line client that is no longer supported or included.
 
-By default, the MaxScale REST API listens on port 8989 on the local host. The\
+By default, the MaxScale REST API listens on port 8989 on the local host. The
 default credentials for the REST API are `admin:mariadb`. The users used by the\
-REST API are the same that are used by the MaxAdmin network interface. This\
-means that any users created for the MaxAdmin network interface should work with\
+REST API are the same that are used by the MaxAdmin network interface. This
+means that any users created for the MaxAdmin network interface should work with
 the MaxScale REST API and MaxCtrl.
 
 For more information about the MaxScale REST API, refer to the [REST API documentation](../mariadb-maxscale-2208--rest-api/mariadb-maxscale-2208-rest-api.md) and the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md).
@@ -22,10 +22,10 @@ For more information about the MaxScale REST API, refer to the [REST API documen
 
 ## .maxctrl.cnf
 
-If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the\
-section `[maxctrl]` as defaults for command line arguments. For instance,\
-to avoid having to specify the user and password on the command line,\
-create the file `.maxctrl.cnf` in your home directory, with the following\
+If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the
+section `[maxctrl]` as defaults for command line arguments. For instance,
+to avoid having to specify the user and password on the command line,
+create the file `.maxctrl.cnf` in your home directory, with the following
 content:
 
 ```
@@ -34,11 +34,11 @@ u = my-name
 p = my-password
 ```
 
-Note that all access rights to the file must be removed from everybody else\
-but the owner. MaxCtrl refuses to use the file unless the rights have been\
+Note that all access rights to the file must be removed from everybody else
+but the owner. MaxCtrl refuses to use the file unless the rights have been
 removed.
 
-Another file from which to read the defaults can be specified with the `-c`\
+Another file from which to read the defaults can be specified with the `-c`
 flag.
 
 ## Commands

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-reference/mariadb-maxscale-2208-module-commands.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-reference/mariadb-maxscale-2208-module-commands.md
@@ -4,17 +4,17 @@
 
 ## Module commands
 
-Introduced in MaxScale 2.1, the module commands are special, module-specific\
+Introduced in MaxScale 2.1, the module commands are special, module-specific
 commands. They allow the modules to expand beyond the capabilities of the module\
 API. Currently, only MaxCtrl implements an interface to the module commands.
 
-All registered module commands can be shown with `maxctrl list commands` and\
+All registered module commands can be shown with `maxctrl list commands` and
 they can be executed with `maxctrl call command <module> <name> ARGS...` whereis the name of the module and is the name of the command._ARGS_ is a command specific list of arguments.
 
 ### Developer reference
 
-The module command API is defined in the _modulecmd.h_ header. It consists of\
-various functions to register and call module commands. Read the function\
+The module command API is defined in the _modulecmd.h_ header. It consists of
+various functions to register and call module commands. Read the function
 documentation in the header for more details.
 
 The following example registers the module command _my\_command_ for module _my\_module_.
@@ -54,11 +54,11 @@ int main(int argc, char **argv)
 }
 ```
 
-The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of\
-arguments the command expects. The first argument is a boolean and the second\
+The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of
+arguments the command expects. The first argument is a boolean and the second
 argument is an optional string.
 
-Arguments are passed to the parsing function as an array of void pointers. They\
+Arguments are passed to the parsing function as an array of void pointers. They
 are interpreted as the types the command expects.
 
 When the module command is executed, the _argv_ parameter for the _my\_simple\_cmd_ contains the parsed arguments received from the caller of the

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-avrorouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-avrorouter.md
@@ -4,14 +4,14 @@
 
 ## Avrorouter
 
-The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes\
+The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes
 binary logs from a local directory and transforms them into a set of Avro files.\
 These files can then be queried by clients for various purposes.
 
 This router is intended to be used in tandem with the [Binlog Server](mariadb-maxscale-2208-binlogrouter.md).\
 The Binlog Server can connect to a master server and request binlog records.\
-These records can then consumed by the avrorouter directly from the binlog cache\
-of the Binlog Server. This allows MariaDB MaxScale to automatically transform\
+These records can then consumed by the avrorouter directly from the binlog cache
+of the Binlog Server. This allows MariaDB MaxScale to automatically transform
 binlog events on the master to local Avro format files.
 
 ```mermaid
@@ -68,25 +68,25 @@ flowchart LR
 ```
 _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog events are converted to Avro-formatted change data and streamed to CDC clients, Kafka, and Hadoop._
 
-The avrorouter can also consume binary logs straight from the master. This will\
-remove the need to configure the Binlog Server but it will increase the disk space\
+The avrorouter can also consume binary logs straight from the master. This will
+remove the need to configure the Binlog Server but it will increase the disk space
 requirement on the master server by at least a factor of two.
 
-The converted Avro files can be requested with the CDC protocol. This protocol\
-should be used to communicate with the avrorouter and currently it is the only\
-supported protocol. The clients can request either Avro or JSON format data\
+The converted Avro files can be requested with the CDC protocol. This protocol
+should be used to communicate with the avrorouter and currently it is the only
+supported protocol. The clients can request either Avro or JSON format data
 streams from a database table.
 
 ### Direct Replication Mode
 
-MaxScale 2.4.0 added a direct replication mode that connects the avrorouter\
-directly to a MariaDB server. This mode is an improvement over the binlogrouter\
-based replication as it provides a more space-efficient and faster conversion\
-process. This is the recommended method of using the avrorouter as it is faster,\
+MaxScale 2.4.0 added a direct replication mode that connects the avrorouter
+directly to a MariaDB server. This mode is an improvement over the binlogrouter
+based replication as it provides a more space-efficient and faster conversion
+process. This is the recommended method of using the avrorouter as it is faster,
 more efficient and less prone to errors caused by missing DDL events.
 
-To enable the direct replication mode, add either the `servers` or the `cluster`\
-parameter to the avrorouter service. The avrorouter will then use one of the\
+To enable the direct replication mode, add either the `servers` or the `cluster`
+parameter to the avrorouter service. The avrorouter will then use one of the
 servers as the replication source.
 
 Here is a minimal avrorouter direct replication configuration:
@@ -114,12 +114,12 @@ protocol=CDC
 port=4001
 ```
 
-In direct replication mode, the avrorouter stores the latest replicated GTID in\
-the `last_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove\
+In direct replication mode, the avrorouter stores the latest replicated GTID in
+the `last_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove
 the file.
 
-Additionally, the avrorouter will attempt to automatically create any missing\
-schema files for tables that have data events for them but the DDL for those\
+Additionally, the avrorouter will attempt to automatically create any missing
+schema files for tables that have data events for them but the DDL for those
 tables is not contained in the binlogs.
 
 ### Configuration
@@ -135,13 +135,13 @@ For information about common service parameters, refer to the [Configuration Gui
 * Dynamic: No
 * Default: `""`
 
-The GTID where avrorouter starts the replication from in direct replication\
-mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where\
-the first number is the replication domain, the second the server\_id value of\
+The GTID where avrorouter starts the replication from in direct replication
+mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where
+the first number is the replication domain, the second the server\_id value of
 the server and the last is the GTID sequence number.
 
-This parameter has no effect in the traditional mode. If this parameter is\
-defined, the replication will start from the implicit GTID that the master first\
+This parameter has no effect in the traditional mode. If this parameter is
+defined, the replication will start from the implicit GTID that the master first
 serves.
 
 **`server_id`**
@@ -151,7 +151,7 @@ serves.
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
 used when replicating from the master in direct replication mode.
 
 **`codec`**
@@ -165,7 +165,7 @@ used when replicating from the master in direct replication mode.
 The compression codec to use. By default, the avrorouter does not use compression.
 
 This parameter takes one of the following two values; _null_ or\_deflate\_. These are the mandatory compression algorithms required by the\
-Avro specification. For more information about the compression types,\
+Avro specification. For more information about the compression types,
 refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specification/#required-codecs).
 
 **`match` and `exclude`**
@@ -175,13 +175,13 @@ refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specificat
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+These [regular expression settings](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 filter events for processing depending on table names. Avrorouter does not support the\_options\_-parameter for regular expressions.
 
-To prevent excessive matching of similarly named tables, surround each table\
-name with the `^` and `$` tokens. For example, to match the `test.clients` table\
-but not `test.clients_old` table use `match=^test[.]clients$`. For multiple\
-tables, surround each table in parentheses and add a pipe character between\
+To prevent excessive matching of similarly named tables, surround each table
+name with the `^` and `$` tokens. For example, to match the `test.clients` table
+but not `test.clients_old` table use `match=^test[.]clients$`. For multiple
+tables, surround each table in parentheses and add a pipe character between
 them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 
 **`binlogdir`**
@@ -191,8 +191,8 @@ them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location of the binary log files. This is the first mandatory parameter\
-and it defines where the module will read binlog files from. Read access to\
+The location of the binary log files. This is the first mandatory parameter
+and it defines where the module will read binlog files from. Read access to
 this directory is required.
 
 **`avrodir`**
@@ -202,14 +202,14 @@ this directory is required.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location where the Avro files are stored. This is the second mandatory\
-parameter and it governs where the converted files are stored. This directory\
-will be used to store the Avro files, plain-text Avro schemas and other files\
-needed by the avrorouter. The user running MariaDB MaxScale will need both read and\
+The location where the Avro files are stored. This is the second mandatory
+parameter and it governs where the converted files are stored. This directory
+will be used to store the Avro files, plain-text Avro schemas and other files
+needed by the avrorouter. The user running MariaDB MaxScale will need both read and
 write access to this directory.
 
-The avrorouter will also use the _avrodir_ to store various internal\
-files. These files are named _avro.index_ and _avro-conversion.ini_. By default,\
+The avrorouter will also use the _avrodir_ to store various internal
+files. These files are named _avro.index_ and _avro-conversion.ini_. By default,
 the default data directory, _/var/lib/maxscale/_, is used. Before version 2.1 of\
 MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 
@@ -220,7 +220,7 @@ MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 * Dynamic: No
 * Default: `mysql-bin`
 
-The base name of the binlog files. The binlog files are assumed to follow the\
+The base name of the binlog files. The binlog files are assumed to follow the
 naming schema _._ where is the binlog number and is the value of this router option.
 
 For example, with the following parameters:
@@ -240,11 +240,11 @@ The first binlog file the avrorouter would look for is `/var/lib/mysql/binlogs/m
 * Default: `1`
 
 The starting index number of the binlog file. The default value is 1.\
-For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_\
+For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_
 the index would be 5.
 
-If you need to start from a binlog file other than 1, you need to set the value\
-of this option to the correct index. The avrorouter will always start from the\
+If you need to start from a binlog file other than 1, you need to set the value
+of this option to the correct index. The avrorouter will always start from the
 beginning of the binary log file.
 
 #### `cooperative_replication`
@@ -254,39 +254,39 @@ beginning of the binary log file.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
-cluster. This is a boolean parameter and is disabled by default. It was\
+Controls whether multiple instances cooperatively replicate from the same
+cluster. This is a boolean parameter and is disabled by default. It was
 added in MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`),\
-the replication is only active if the monitor owns the cluster it is\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`),
+the replication is only active if the monitor owns the cluster it is
 monitoring.
 
-With this feature, multiple MaxScale instances can replicate from the same set\
-of servers and only one of them actively processes the replication stream. This\
-allows the avrorouter instances to be made highly-available without having to\
+With this feature, multiple MaxScale instances can replicate from the same set
+of servers and only one of them actively processes the replication stream. This
+allows the avrorouter instances to be made highly-available without having to
 have them all process the events at the same time.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID processed by that\
-instance. This means that if the instance hasn't replicated events that have\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID processed by that
+instance. This means that if the instance hasn't replicated events that have
 been purged from the binary logs, the replication cannot continue.
 
 **Avro File Related Parameters**
 
 These options control how large the Avro file data blocks can get.\
-Increasing or lowering the block size could have a positive effect\
-depending on your use case. For more information about the Avro file\
+Increasing or lowering the block size could have a positive effect
+depending on your use case. For more information about the Avro file
 format and how it organizes data, refer to the [Avro documentation](https://avro.apache.org/docs/current/).
 
-The avrorouter will flush a block and start a new one when either `group_trx`\
-transactions or `group_rows` row events have been processed. Changing these\
-options will also allow more frequent updates to stored data but this\
+The avrorouter will flush a block and start a new one when either `group_trx`
+transactions or `group_rows` row events have been processed. Changing these
+options will also allow more frequent updates to stored data but this
 will cause a small increase in file size and search times.
 
-It is highly recommended to keep the block sizes relatively large to allow\
-larger chunks of memory to be flushed to disk at one time. This will make\
+It is highly recommended to keep the block sizes relatively large to allow
+larger chunks of memory to be flushed to disk at one time. This will make
 the conversion process noticeably faster.
 
 **`group_trx`**
@@ -296,7 +296,7 @@ the conversion process noticeably faster.
 * Dynamic: No
 * Default: `1`
 
-Controls the number of transactions that are grouped into a single Avro\
+Controls the number of transactions that are grouped into a single Avro
 data block.
 
 **`group_rows`**
@@ -306,7 +306,7 @@ data block.
 * Dynamic: No
 * Default: `1000`
 
-Controls the number of row events that are grouped into a single Avro\
+Controls the number of row events that are grouped into a single Avro
 data block.
 
 **`block_size`**
@@ -316,10 +316,10 @@ data block.
 * Dynamic: Yes
 * Default: `16KiB`
 
-The Avro data block size in bytes. The default is 16 kilobytes. Increase this\
-value if individual events in the binary logs are very large. The value is a\
+The Avro data block size in bytes. The default is 16 kilobytes. Increase this
+value if individual events in the binary logs are very large. The value is a
 size type parameter which means that it can also be defined with an SI suffix.\
-Refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md)
 for more details about size type parameters and how to use them.
 
 **`max_file_size`**
@@ -329,17 +329,17 @@ for more details about size type parameters and how to use them.
 * Dynamic: No
 * Default: 0
 
-If the size of a single Avro data file exceeds this limit, the avrorouter will\
-rotate to a new file. This is done by closing the existing file and creating a\
-new one with the next version number. By default the avrorouter does not rotate\
-files based on their size. Setting the value to 0 disables file rotation based on\
+If the size of a single Avro data file exceeds this limit, the avrorouter will
+rotate to a new file. This is done by closing the existing file and creating a
+new one with the next version number. By default the avrorouter does not rotate
+files based on their size. Setting the value to 0 disables file rotation based on
 size.
 
-This uses the size of the file as reported by the operating system. The check\
-for the file size is done after a transaction has been processed which means\
+This uses the size of the file as reported by the operating system. The check
+for the file size is done after a transaction has been processed which means
 that large transactions can still cause the file size to exceed the given limit.
 
-File rotation only works with the direct replication mode. The legacy file based\
+File rotation only works with the direct replication mode. The legacy file based
 replication mode does not support this.
 
 **`max_data_age`**
@@ -349,17 +349,17 @@ replication mode does not support this.
 * Dynamic: No
 * Default: 0s
 
-When enabled, the avrorouter will automatically purge any files that only have\
-data that is older than the given limit. This means that all data files with at\
-least one event that is newer than the configured limit will not be removed,\
-even if the age of all the other events is above the limit. The purge operation\
-is only done when a file rotation takes place (either manual or automatic) or\
+When enabled, the avrorouter will automatically purge any files that only have
+data that is older than the given limit. This means that all data files with at
+least one event that is newer than the configured limit will not be removed,
+even if the age of all the other events is above the limit. The purge operation
+is only done when a file rotation takes place (either manual or automatic) or
 when a schema change is detected.
 
-This parameter is best combined with `max_file_size` to provide automatic\
+This parameter is best combined with `max_file_size` to provide automatic
 removal of stale data.
 
-Automatic file purging only works with the direct replication mode. The legacy\
+Automatic file purging only works with the direct replication mode. The legacy
 file based replication mode does not support this.
 
 **Example configuration**
@@ -382,94 +382,94 @@ avrodir=/var/lib/maxscale
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-module-commands.md) documentation for
 details about module commands.
 
 The avrorouter supports the following module commands.
 
 #### `avrorouter::convert SERVICE {start | stop}`
 
-Start or stop the binary log to Avro conversion. The first parameter is the name\
-of the service to stop and the second parameter tells whether to start the\
+Start or stop the binary log to Avro conversion. The first parameter is the name
+of the service to stop and the second parameter tells whether to start the
 conversion process or to stop it.
 
 #### `avrorouter::purge SERVICE`
 
 This command will delete all files created by the avrorouter. This includes all\
-.avsc schema files and .avro data files as well as the internal state tracking\
+.avsc schema files and .avro data files as well as the internal state tracking
 files. Use this to completely reset the conversion process.
 
-**Note:** Once the command has completed, MaxScale must be restarted to restart\
+**Note:** Once the command has completed, MaxScale must be restarted to restart
 the conversion process. Issuing a `convert start` command **will not work**.
 
-**WARNING:** You will lose any and all converted data when this command is\
+**WARNING:** You will lose any and all converted data when this command is
 executed.
 
 ### Files Created by the Avrorouter
 
-The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store\
-the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains\
-the last converted position and GTID in the binlogs. If you need to reset the\
+The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store
+the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains
+the last converted position and GTID in the binlogs. If you need to reset the
 conversion process, delete these two files and restart MaxScale.
 
 ### Resetting the Conversion Process
 
-To reset the binlog conversion process, issue the `purge` module command by\
-executing it via MaxCtrl and stop MaxScale. If manually created schema files\
+To reset the binlog conversion process, issue the `purge` module command by
+executing it via MaxCtrl and stop MaxScale. If manually created schema files
 were used, they need to be recreated once MaxScale is stopped. After stopping\
-MaxScale and optionally creating the schema files, the conversion process can be\
+MaxScale and optionally creating the schema files, the conversion process can be
 started by starting MaxScale.
 
 ### Stopping the Avrorouter
 
-The safest way to stop the avrorouter when used with the binlogrouter is to\
+The safest way to stop the avrorouter when used with the binlogrouter is to
 follow the following steps:
 
 * Issue `STOP SLAVE` on the binlogrouter
 * Wait for the avrorouter to process all files
 * Stop MaxScale with `systemctl stop maxscale`
 
-This guarantees that the conversion process halts at a known good position in\
+This guarantees that the conversion process halts at a known good position in
 the latest binlog file.
 
 ### Example Client
 
 The avrorouter comes with an example client program, _cdc.py_, written in Python 3.\
-This client can connect to a MaxScale configured with the CDC protocol and the\
+This client can connect to a MaxScale configured with the CDC protocol and the
 avrorouter.
 
-Before using this client, you will need to install the Python 3 interpreter and\
-add users to the service with the _cdc\_users.py_ script. Fore more details about\
-the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-change-data-capture-cdc-protocol.md)\
+Before using this client, you will need to install the Python 3 interpreter and
+add users to the service with the _cdc\_users.py_ script. Fore more details about
+the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-change-data-capture-cdc-protocol.md)
 and [CDC Users](../mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-change-data-capture-cdc-users.md) documentation.
 
-Read the output of `cdc.py --help` for a full list of supported options\
+Read the output of `cdc.py --help` for a full list of supported options
 and a short usage description of the client program.
 
 ### Avro Schema Generator
 
-The avrorouter needs to have access to the CREATE TABLE statement for all tables\
-for which there are data events in the binary logs. If the CREATE TABLE\
-statements for the tables aren't present in the current binary logs, the schema\
+The avrorouter needs to have access to the CREATE TABLE statement for all tables
+for which there are data events in the binary logs. If the CREATE TABLE
+statements for the tables aren't present in the current binary logs, the schema
 files must be created.
 
-In the direct replication mode, avrorouter will automatically create the missing\
-schema files by connecting to the database and executing a `SHOW CREATE TABLE`\
-statement. If a connection cannot be made or the service user lacks the\
-permission, an error will be logged and the data events for that table will not\
+In the direct replication mode, avrorouter will automatically create the missing
+schema files by connecting to the database and executing a `SHOW CREATE TABLE`
+statement. If a connection cannot be made or the service user lacks the
+permission, an error will be logged and the data events for that table will not
 be processed.
 
-For the legacy binlog mode, the files must be generated with a schema file\
+For the legacy binlog mode, the files must be generated with a schema file
 generator. There are currently two methods to generate the .avsc schema files.
 
 #### Simple Schema Generator
 
-The `cdc_one_schema.py` generates a schema file for a single table by reading a\
-tab separated list of field and type names from the standard input. This is the\
-recommended schema generation tool as it does not directly communicate with the\
+The `cdc_one_schema.py` generates a schema file for a single table by reading a
+tab separated list of field and type names from the standard input. This is the
+recommended schema generation tool as it does not directly communicate with the
 database thus making it more flexible.
 
-The only requirement to run the script is that a Python interpreter is\
+The only requirement to run the script is that a Python interpreter is
 installed.
 
 To use this script, pipe the output of the `mysql` command line into the`cdc_one_schema.py` script:
@@ -478,15 +478,15 @@ To use this script, pipe the output of the `mysql` command line into the`cdc_one
 mysql -ss -u <user> -p -h <host> -P <port> -e 'DESCRIBE `<database>`.`<table>`'|./cdc_one_schema.py <database> <table>
 ```
 
-Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with\
-appropriate values and run the command. Note that the `-ss` parameter is\
-mandatory as that will generate the tab separated output instead of the default\
+Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with
+appropriate values and run the command. Note that the `-ss` parameter is
+mandatory as that will generate the tab separated output instead of the default
 pretty-printed output.
 
-An .avsc file named after the database and table name will be generated in the\
+An .avsc file named after the database and table name will be generated in the
 current working directory. Copy this file to the location pointed by the`avrodir` parameter of the avrorouter.
 
-Alternatively, you can also copy the output of the `mysql` command to a file and\
+Alternatively, you can also copy the output of the `mysql` command to a file and
 feed it into the script if you cannot execute the SQL command directly:
 
 ```
@@ -509,31 +509,31 @@ usage: cdc_schema.py [--help] [-h HOST] [-P PORT] [-u USER] [-p PASSWORD] DATABA
 The _cdc\_schema.py_ executable is installed as a part of MaxScale. This is a\
 Python 3 script that generates Avro schema files from an existing database.
 
-The script will generate the .avsc schema files into the current directory. Run\
-the script for all required databases copy the generated .avsc files to the\
+The script will generate the .avsc schema files into the current directory. Run
+the script for all required databases copy the generated .avsc files to the
 directory where the avrorouter stores the .avro files (the value of `avrodir`).
 
 #### Go Schema Generator
 
-The _cdc\_schema.go_ example Go program is provided with MaxScale. This file\
-can be used to create Avro schemas for the avrorouter by connecting to a\
-database and reading the table definitions. You can find the file in MaxScale's\
+The _cdc\_schema.go_ example Go program is provided with MaxScale. This file
+can be used to create Avro schemas for the avrorouter by connecting to a
+database and reading the table definitions. You can find the file in MaxScale's
 share directory in `/usr/share/maxscale/`.
 
-You'll need to install the Go compiler and run `go get` to resolve Go\
-dependencies before you can use the _cdc\_schema_ program. After resolving the\
-dependencies you can run the program with `go run cdc_schema.go`. The program\
-will create .avsc files in the current directory. These files should be moved\
-to the location pointed by the _avrodir_ option of the avrorouter if they are\
+You'll need to install the Go compiler and run `go get` to resolve Go
+dependencies before you can use the _cdc\_schema_ program. After resolving the
+dependencies you can run the program with `go run cdc_schema.go`. The program
+will create .avsc files in the current directory. These files should be moved
+to the location pointed by the _avrodir_ option of the avrorouter if they are
 to be used by the router itself.
 
-Read the output of `go run cdc_schema.go -help` for more information on how\
+Read the output of `go run cdc_schema.go -help` for more information on how
 to run the program.
 
 ### Examples
 
-The [Avrorouter Tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-avrorouter-tutorial.md) shows you how\
-the Avrorouter works with the Binlog Server to convert binlogs from a master server\
+The [Avrorouter Tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-avrorouter-tutorial.md) shows you how
+the Avrorouter works with the Binlog Server to convert binlogs from a master server
 into easy to process Avro data.
 
 Here is a simple configuration example which reads binary logs locally from`/var/lib/mysql/` and stores them as Avro files in `/var/lib/maxscale/avro/`.\
@@ -563,7 +563,7 @@ Python script. It queries the table _test.mytable_ for all change records.
 cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytable
 ```
 
-You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change\
+You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change
 records to a Kafka broker.
 
 ```
@@ -571,28 +571,28 @@ cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytab
 cdc_kafka_producer.py --kafka-broker 127.0.0.1:9092 --kafka-topic test.mytable
 ```
 
-For more information on how to use these scripts, see the output of `cdc.py -h`\
+For more information on how to use these scripts, see the output of `cdc.py -h`
 and `cdc_kafka_producer.py -h`.
 
 ### Building Avrorouter
 
-To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development\
+To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development
 headers. When configuring MaxScale with CMake, you will need to add`-DBUILD_CDC=Y` to build the CDC module set.
 
-The Avro C library needs to be build with position independent code enabled. You\
-can do this by adding the following flags to the CMake invocation when\
+The Avro C library needs to be build with position independent code enabled. You
+can do this by adding the following flags to the CMake invocation when
 configuring the Avro C library.
 
 ```
 -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC
 ```
 
-For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-building-mariadb-maxscale-from-source-code.md)\
+For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-building-mariadb-maxscale-from-source-code.md)
 document.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for an avrorouter service contains the following\
+The `router_diagnostics` output for an avrorouter service contains the following
 fields.
 
 * `infofile`: File where the avrorouter stores the conversion process state.
@@ -612,8 +612,8 @@ The avrorouter does not support the following data types, conversions or SQL sta
 * Fields CAST from integer types to string types
 * [CREATE TABLE ... AS SELECT statements](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/tables/create-table)
 
-The avrorouter does not do any crash recovery. This means that the avro files\
-need to be removed or truncated to valid block lengths before starting the\
+The avrorouter does not do any crash recovery. This means that the avro files
+need to be removed or truncated to valid block lengths before starting the
 avrorouter.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-binlogrouter-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-binlogrouter-24.md
@@ -5,63 +5,63 @@
 ## Binlogrouter 2.4
 
 **NOTE** This is the documentation for the binlogrouter in\
-MaxScale 2.4 and is only provided for reference. The documentation\
+MaxScale 2.4 and is only provided for reference. The documentation
 for the binlogrouter in MaxScale 2.5 is provided [here](mariadb-maxscale-2208-binlogrouter.md).
 
 ### Introduction
 
 The binlogrouter is a replication protocol proxy module for MariaDB\
-MaxScale. This module allows MariaDB MaxScale to connect to a master server and\
-retrieve binary logs while slave servers can connect to MariaDB MaxScale like\
-they would connect to a normal master server. If the master server goes down,\
-the slave servers can still connect to MariaDB MaxScale and read binary\
-logs. You can switch to a new master server without the slaves noticing that the\
-actual master server has changed. This allows for a more highly available\
+MaxScale. This module allows MariaDB MaxScale to connect to a master server and
+retrieve binary logs while slave servers can connect to MariaDB MaxScale like
+they would connect to a normal master server. If the master server goes down,
+the slave servers can still connect to MariaDB MaxScale and read binary
+logs. You can switch to a new master server without the slaves noticing that the
+actual master server has changed. This allows for a more highly available
 replication setup where replication is high-priority.
 
 ### Configuration
 
 #### Mandatory Router Parameters
 
-The binlogrouter requires the `user` and `password` parameters. These should be\
+The binlogrouter requires the `user` and `password` parameters. These should be
 configured according to the [Configuration Guide](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#service).
 
-In addition to these two parameters, the `server_id` and `binlogdir` parameters\
+In addition to these two parameters, the `server_id` and `binlogdir` parameters
 needs to be defined.
 
 #### Router Parameters
 
 The binlogrouter accepts the following parameters.
 
-**Note:** Earlier versions of MaxScale supported the configuration of the\
-binlogrouter only via `router_options` (a the comma-separated list of key-value\
-pairs). As of MaxScale 2.1, all of the router options should be defined as\
-parameters. The values defined in `router_options` will have priority over the\
-parameters to support legacy configurations. The use of `router_options` is\
+**Note:** Earlier versions of MaxScale supported the configuration of the
+binlogrouter only via `router_options` (a the comma-separated list of key-value
+pairs). As of MaxScale 2.1, all of the router options should be defined as
+parameters. The values defined in `router_options` will have priority over the
+parameters to support legacy configurations. The use of `router_options` is
 deprecated.
 
 **`binlogdir`**
 
-This parameter controls the location where MariaDB MaxScale stores the binary log\
+This parameter controls the location where MariaDB MaxScale stores the binary log
 files. This is a mandatory parameter.
 
-The _binlogdir_ also contains the _cache_ subdirectory which stores data\
-retrieved from the master during the slave registration phase. The\
-master.ini file also resides in the _binlogdir_. This file keeps track of\
+The _binlogdir_ also contains the _cache_ subdirectory which stores data
+retrieved from the master during the slave registration phase. The
+master.ini file also resides in the _binlogdir_. This file keeps track of
 the current master configuration and it is updated when a `CHANGE MASTER TO` query is executed.
 
-From 2.1 onwards, the 'cache' directory is stored in the same location as other\
-user credential caches. This means that with the default options, the user\
+From 2.1 onwards, the 'cache' directory is stored in the same location as other
+user credential caches. This means that with the default options, the user
 credential cache is stored in`/var/cache/maxscale/<Service Name>/<Listener Name>/cache/`.
 
-Read the [MySQL Authenticator](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-mysql-authenticator.md)\
-documentation for instructions on how to define a custom location for the user\
+Read the [MySQL Authenticator](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-mysql-authenticator.md)
+documentation for instructions on how to define a custom location for the user
 cache.
 
 **`server_id`**
 
-MariaDB MaxScale must have a unique _server\_id_. This parameter configures\
-the value of the _server\_id_ that MariaDB MaxScale will use when\
+MariaDB MaxScale must have a unique _server\_id_. This parameter configures
+the value of the _server\_id_ that MariaDB MaxScale will use when
 connecting to the master. This is a mandatory parameter.
 
 Older versions of MaxScale allowed the ID to be specified using `server-id`.\
@@ -69,11 +69,11 @@ This has been deprecated and will be removed in a future release of MariaDB MaxS
 
 **`master_id`**
 
-The _server\_id_ value that MariaDB MaxScale should use to report to the slaves\
+The _server\_id_ value that MariaDB MaxScale should use to report to the slaves
 that connect to MariaDB MaxScale.
 
-This may either be the same as the server id of the real master or can be\
-chosen to be different if the slaves need to be aware of the proxy\
+This may either be the same as the server id of the real master or can be
+chosen to be different if the slaves need to be aware of the proxy
 layer. The real master server ID will be used if the option is not set.
 
 Older versions of MaxScale allowed the ID to be specified using `master-id`.\
@@ -81,52 +81,52 @@ This has been deprecated and will be removed in a future release of MariaDB MaxS
 
 **`uuid`**
 
-This is used to set the unique UUID that the binlog router uses when it connects\
+This is used to set the unique UUID that the binlog router uses when it connects
 to the master server. By default the UUID will be generated.
 
 **`master_uuid`**
 
-It is a requirement of replication that each server has a unique UUID value. If\
-this option is not set, binlogrouter will identify itself to the slaves using\
+It is a requirement of replication that each server has a unique UUID value. If
+this option is not set, binlogrouter will identify itself to the slaves using
 the UUID of the real master.
 
 **`master_version`**
 
-By default, the router will identify itself to the slaves using the server\
-version of the real master. This option allows the router to use a custom\
+By default, the router will identify itself to the slaves using the server
+version of the real master. This option allows the router to use a custom
 version string.
 
 **`master_hostname`**
 
-By default, the router will identify itself to the slaves using the hostname of\
+By default, the router will identify itself to the slaves using the hostname of
 the real master. This option allows the router to use a custom hostname.
 
 **`slave_hostname`**
 
-Since MaxScale 2.1.6 the router can optionally identify itself to the master\
-using a custom hostname. The specified hostname can be seen in the master via`SHOW SLAVE HOSTS` command. The default is not to send any hostname string\
+Since MaxScale 2.1.6 the router can optionally identify itself to the master
+using a custom hostname. The specified hostname can be seen in the master via`SHOW SLAVE HOSTS` command. The default is not to send any hostname string
 during registration.
 
 **`user`**
 
-_Note:_ This is option can only be given to the `router_options` parameter. Use\
+_Note:_ This is option can only be given to the `router_options` parameter. Use
 the `user` parameter of the service instead.
 
-This is the user name that MariaDB MaxScale uses when it connects to the\
-master. This user name must have the rights required for replication as with any\
-other user that a slave uses for replication purposes. If the user parameter is\
-not given in the router options then the same user as is used to retrieve the\
-credential information will be used for the replication connection, i.e. the\
+This is the user name that MariaDB MaxScale uses when it connects to the
+master. This user name must have the rights required for replication as with any
+other user that a slave uses for replication purposes. If the user parameter is
+not given in the router options then the same user as is used to retrieve the
+credential information will be used for the replication connection, i.e. the
 user in the service entry.
 
 This user is the only one available for MySQL connection to MaxScale Binlog\
 Server for administration when master connection is not done yet.
 
-In MaxScale 2.1, the service user injection is done by the MySQLAuth\
-authenticator module. Read the [MySQL Authenticator](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-mysql-authenticator.md)\
+In MaxScale 2.1, the service user injection is done by the MySQLAuth
+authenticator module. Read the [MySQL Authenticator](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-mysql-authenticator.md)
 documentation for more details.
 
-The user that is used for replication must be granted replication privileges on\
+The user that is used for replication must be granted replication privileges on
 the database server.
 
 ```
@@ -136,47 +136,47 @@ GRANT REPLICATION SLAVE ON *.* TO 'repl'@'maxscalehost';
 
 **`password`**
 
-_Note:_ This is option can only be given to the `router_options` parameter. Use\
+_Note:_ This is option can only be given to the `router_options` parameter. Use
 the `password` parameter of the service instead.
 
-The password for the user. If the password is not explicitly given then the\
-password in the service entry will be used. For compatibility with other\
-username and password definitions within the MariaDB MaxScale configuration file\
+The password for the user. If the password is not explicitly given then the
+password in the service entry will be used. For compatibility with other
+username and password definitions within the MariaDB MaxScale configuration file
 it is also possible to use the parameter `passwd`.
 
 **`heartbeat`**
 
-This defines the value of the heartbeat interval for the connection\
-to the master. The duration can be specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as seconds in MaxScale 2.4. In\
-subsequent versions a value without a unit may be rejected. Note that since\
-the granularity of the parameter is seconds, a value specified in milliseconds\
+This defines the value of the heartbeat interval for the connection
+to the master. The duration can be specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as seconds in MaxScale 2.4. In
+subsequent versions a value without a unit may be rejected. Note that since
+the granularity of the parameter is seconds, a value specified in milliseconds
 will be rejected, even if the duration is longer than a second.\
 The default value for the heartbeat period is every 5 minutes.
 
-MariaDB MaxScale requests the master to ensure that a binlog event is sent at\
-least every heartbeat period. If there are no real binlog events to send the\
-master will sent a special heartbeat event. The current interval value is\
+MariaDB MaxScale requests the master to ensure that a binlog event is sent at
+least every heartbeat period. If there are no real binlog events to send the
+master will sent a special heartbeat event. The current interval value is
 reported in the diagnostic output.
 
 **`burstsize`**
 
-This parameter is used to define the maximum amount of data that will be sent to\
-a slave by MariaDB MaxScale when that slave is lagging behind the master. The\
+This parameter is used to define the maximum amount of data that will be sent to
+a slave by MariaDB MaxScale when that slave is lagging behind the master. The
 default value is `1M`.
 
-The burst size can be provided as specified [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes), except that IEC binary\
-prefixes can be used as suffixes only from MaxScale 2.1 onwards. MaxScale 2.0\
+The burst size can be provided as specified [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes), except that IEC binary
+prefixes can be used as suffixes only from MaxScale 2.1 onwards. MaxScale 2.0
 and earlier only support `burstsize` defined in bytes.
 
-In this situation the slave is said to be in "catchup mode", this parameter is\
-designed to both prevent flooding of that slave and also to prevent threads\
-within MariaDB MaxScale spending disproportionate amounts of time with slaves\
+In this situation the slave is said to be in "catchup mode", this parameter is
+designed to both prevent flooding of that slave and also to prevent threads
+within MariaDB MaxScale spending disproportionate amounts of time with slaves
 that are lagging behind the master.
 
 **`mariadb10-compatibility`**
 
-This parameter allows binlogrouter to replicate from a MariaDB 10.0 master\
+This parameter allows binlogrouter to replicate from a MariaDB 10.0 master
 server: this parameter is enabled by default since MaxScale 2.2.0.\
 In earlier versions the parameter was disabled by default.
 
@@ -185,7 +185,7 @@ In earlier versions the parameter was disabled by default.
 mariadb10-compatibility=1
 ```
 
-Additionally, since MaxScale 2.2.1, MariaDB 10.x slave servers\
+Additionally, since MaxScale 2.2.1, MariaDB 10.x slave servers
 can connect to binlog server using GTID value instead of binlog name and position.
 
 Example of a MariaDB 10.x slave connection to MaxScale
@@ -202,51 +202,51 @@ MariaDB> START SLAVE;
 **Note:**
 
 * Slave servers can connect either with file and pos or GTID.
-* MaxScale saves all the incoming MariaDB GTIDs (DDLs and DMLs)\
+* MaxScale saves all the incoming MariaDB GTIDs (DDLs and DMLs)
   in a sqlite3 database located in binlogdir (`gtid_maps.db`).\
-  When a slave server connects with a GTID request a lookup is made for\
+  When a slave server connects with a GTID request a lookup is made for
   the value match and following binlog events will be sent.
 
 **`transaction_safety`**
 
-This parameter is used to enable/disable incomplete transactions detection in\
+This parameter is used to enable/disable incomplete transactions detection in
 binlog router. The default value is _off_.
 
-When MariaDB MaxScale starts an error message may appear if current binlog file\
-is corrupted or an incomplete transaction is found. During normal operations\
-binlog events are not distributed to the slaves until a COMMIT is seen. Set\
+When MariaDB MaxScale starts an error message may appear if current binlog file
+is corrupted or an incomplete transaction is found. During normal operations
+binlog events are not distributed to the slaves until a COMMIT is seen. Set
 transaction\_safety=on to enable detection of incomplete transactions.
 
 **`send_slave_heartbeat`**
 
-This defines whether MariaDB MaxScale sends the heartbeat packet to the slave\
-when there are no real binlog events to send. This parameter takes a boolean\
-value and the default value is false. This means that no heartbeat events are\
+This defines whether MariaDB MaxScale sends the heartbeat packet to the slave
+when there are no real binlog events to send. This parameter takes a boolean
+value and the default value is false. This means that no heartbeat events are
 sent to slave servers.
 
-If value is set to true the interval value (requested by the slave during\
-registration) is reported in the diagnostic output and the packet is send after\
+If value is set to true the interval value (requested by the slave during
+registration) is reported in the diagnostic output and the packet is send after
 the time interval without any event to send.
 
 **`semisync`**
 
-This parameter controls whether binlog server could ask Master server to start\
-the Semi-Synchronous replication. This parameter takes a boolean value and the\
+This parameter controls whether binlog server could ask Master server to start
+the Semi-Synchronous replication. This parameter takes a boolean value and the
 default value is false.
 
-In order to get semi-sync working, the Master server must have the_rpl\_semi\_sync\_master_ plugin installed. The availability of the plugin and the\
+In order to get semi-sync working, the Master server must have the_rpl\_semi\_sync\_master_ plugin installed. The availability of the plugin and the
 value of the GLOBAL VARIABLE _rpl\_semi\_sync\_master\_enabled_ are checked in the\
-Master registration phase: if the plugin is installed in the Master database,\
+Master registration phase: if the plugin is installed in the Master database,
 the binlog server subsequently requests the semi-sync option.
 
 **Note:**
 
-* the network replication stream from Master has two additional bytes before\
+* the network replication stream from Master has two additional bytes before
   each binlog event.
 * the Semi-Sync protocol requires an acknowledge packet to be sent back to\
   Master only when requested: the semi-sync flag will have value of 1.\
   This flag is set only if _rpl\_semi\_sync\_master\_enabled=1_ is set in the\
-  Master, otherwise it will always have value of 0 and no ack packet is sent\
+  Master, otherwise it will always have value of 0 and no ack packet is sent
   back.
 
 Please note that semi-sync replication is only related to binlog server to\
@@ -254,32 +254,32 @@ Master communication.
 
 **`ssl_cert_verification_depth`**
 
-This parameter sets the maximum length of the certificate authority chain that\
-will be accepted. Legal values are positive integers. This applies to SSL\
-connection to master server that could be activated either by writing options in\
-master.ini or later via a _CHANGE MASTER TO_ command. This parameter cannot be\
+This parameter sets the maximum length of the certificate authority chain that
+will be accepted. Legal values are positive integers. This applies to SSL
+connection to master server that could be activated either by writing options in
+master.ini or later via a _CHANGE MASTER TO_ command. This parameter cannot be
 modified at runtime. The default verification depth is 9.
 
 **`encrypt_binlog`**
 
 Whether to encrypt binlog files: the default is _off_.
 
-When set to _on_ the binlog files will be encrypted using specified AES algorithm\
+When set to _on_ the binlog files will be encrypted using specified AES algorithm
 and the KEY in the specified key file.
 
-**Note:** binlog encryption must be used while replicating from a MariaDB 10.1\
-server and serving data to MariaDB 10.x slaves. In order to use binlog\
-encryption the master server MariaDB 10.1 must have encryption active\
-(encrypt-binlog=1 in my.cnf). This is required because both master and maxscale\
-must store encrypted data for a working scenario for Secure\
+**Note:** binlog encryption must be used while replicating from a MariaDB 10.1
+server and serving data to MariaDB 10.x slaves. In order to use binlog
+encryption the master server MariaDB 10.1 must have encryption active
+(encrypt-binlog=1 in my.cnf). This is required because both master and maxscale
+must store encrypted data for a working scenario for Secure
 data-at-rest. Additionally, as long as Master server doesn't send the\
-StartEncryption event (which contains encryption setup information for the\
-binlog file), there is a position gap between end of FormatDescription event pos\
-and next event start pos. The StartEncryption event size is 36 or 40 (depending\
+StartEncryption event (which contains encryption setup information for the
+binlog file), there is a position gap between end of FormatDescription event pos
+and next event start pos. The StartEncryption event size is 36 or 40 (depending
 on CRC32 being used), so the gap has that size.
 
-MaxScale binlog server adds its own StartEncryption to binlog files consequently\
-the binlog events positions in binlog file are the same as in the master binlog\
+MaxScale binlog server adds its own StartEncryption to binlog files consequently
+the binlog events positions in binlog file are the same as in the master binlog
 file and there is no position mismatch.
 
 **`encryption_algorithm`**
@@ -294,11 +294,11 @@ The specified key file must contains lines with following format:
 
 Id is the scheme identifier, which must have the value 1 for binlog encryption\
 , the ';' is a separator and HEX(KEY) contains the hex representation of the KEY.\
-The KEY must have exact 16, 24 or 32 bytes size and the selected algorithm\
+The KEY must have exact 16, 24 or 32 bytes size and the selected algorithm
 (aes\_ctr or aes\_cbc) with 128, 192 or 256 ciphers will be used.
 
-**Note:** the key file has the same format as MariaDB 10.1 server so it's\
-possible to use an existing key file (not encrypted) which could contain several`scheme;key` values: only key id with value 1 will be parsed, and if not found\
+**Note:** the key file has the same format as MariaDB 10.1 server so it's
+possible to use an existing key file (not encrypted) which could contain several`scheme;key` values: only key id with value 1 will be parsed, and if not found
 an error will be reported.
 
 Example key file with multiple keys:
@@ -316,11 +316,11 @@ Example key file with multiple keys:
 
 **`mariadb10_master_gtid`**
 
-This option allows MaxScale binlog router to register with MariaDB 10.X master\
-using GTID instead of _binlog\_file_ name and _position_ in CHANGE MASTER TO\
+This option allows MaxScale binlog router to register with MariaDB 10.X master
+using GTID instead of _binlog\_file_ name and _position_ in CHANGE MASTER TO
 admin command. This feature is disabled by default.
 
-The user can set a known GTID or an empty value (in this case the Master server\
+The user can set a known GTID or an empty value (in this case the Master server
 will send events from it's first available binlog file).
 
 Example of MaxScale connection to a MariaDB 10.X Master
@@ -338,41 +338,41 @@ MariaDB> START SLAVE;
 If using GTID request then it's no longer possible to use MASTER\_LOG\_FILE and\
 MASTER\_LOG\_POS in `CHANGE MASTER TO` command: an error will be reported.
 
-If this feature is enabled, the _transaction\_safety_ option will be\
-automatically enabled. The binlog files will also be stored in a\
+If this feature is enabled, the _transaction\_safety_ option will be
+automatically enabled. The binlog files will also be stored in a
 hierarchical directory tree instead of a single directory.
 
 **Note:**
 
 * When the option is On, the connecting slaves can only use GTID request:\
-  specifying file and pos will end up in an error sent by MaxScale and\
+  specifying file and pos will end up in an error sent by MaxScale and
   replication cannot start.
-* The GTID request could cause the writing of events\
-  in any position of the binlog file, whose name has been sent\
+* The GTID request could cause the writing of events
+  in any position of the binlog file, whose name has been sent
   by the master server before any event.\
-  In order to avoid holes in the binlog files, MaxScale will fill all gaps\
+  In order to avoid holes in the binlog files, MaxScale will fill all gaps
   in the binlog files with ignorable events.
-* It's not possible to specify the GTID \_domain\_id: the master one\
-  is being used for all operations. All slave servers must use the same replication\
+* It's not possible to specify the GTID \_domain\_id: the master one
+  is being used for all operations. All slave servers must use the same replication
   domain as the master server.
 
 **`master_retry_count`**
 
-This option sets the maximum number of connection retries when the master server is\
+This option sets the maximum number of connection retries when the master server is
 disconnected or not reachable.\
 Default value is 1000.
 
 **`connect_retry`**
 
 The option sets the time interval for a new connection retry to master server.\
-The duration can be specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as seconds in MaxScale 2.4. In\
-subsequent versions a value without a unit may be rejected. Note that since\
-the granularity of the parameter is seconds, a value specified in milliseconds\
+The duration can be specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as seconds in MaxScale 2.4. In
+subsequent versions a value without a unit may be rejected. Note that since
+the granularity of the parameter is seconds, a value specified in milliseconds
 will be rejected, even if the duration is longer than a second.\
 The default value is 60 seconds.
 
-**A complete example** of a service entry for a binlog router service would be as\
+**A complete example** of a service entry for a binlog router service would be as
 follows.
 
 ```
@@ -391,7 +391,7 @@ encryption_key_file=/var/binlogs/enc_key.txt
 
 #### Using secondary masters
 
-From MaxScale 2.3 onwards it is possible to specify secondary masters that\
+From MaxScale 2.3 onwards it is possible to specify secondary masters that
 the binlog router can use in case the connection to the default master fails.
 
 **Note:** This is _only_ supported in a Galera Cluster environment in which:
@@ -399,10 +399,10 @@ the binlog router can use in case the connection to the default master fails.
 * Wsrep GTID mode is enabled in the cluster.
 * All of the requirements for wsrep GTID mode are met by the cluster.
 
-_Wsrep GTID mode_ is also imperfect, so this secondary master functionality is\
+_Wsrep GTID mode_ is also imperfect, so this secondary master functionality is
 only guaranteed to work if GTIDs have not become inconsistent within the cluster.
 
-See [Wsrep GTID Mode](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/high-availability/using-mariadb-replication-with-mariadb-galera-cluster/using-mariadb-gtids-with-mariadb-galera-cluster)\
+See [Wsrep GTID Mode](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/high-availability/using-mariadb-replication-with-mariadb-galera-cluster/using-mariadb-gtids-with-mariadb-galera-cluster)
 for more information.
 
 The initial setup is performed exactly like when there is but one default master.
@@ -418,7 +418,7 @@ MariaDB> CHANGE MASTER TO
          MASTER_USE_GTID=Slave_pos;
 ```
 
-After the setup of the default master, secondary masters can be configured\
+After the setup of the default master, secondary masters can be configured
 as follows:
 
 ```
@@ -430,12 +430,12 @@ MariaDB> CHANGE MASTER ':2' TO
          MASTER_USE_GTID=Slave_pos;
 ```
 
-That is, a connection name must be provided and the name must be of the\
-format `:N` where `N` is a positive integer. If several secondary masters\
+That is, a connection name must be provided and the name must be of the
+format `:N` where `N` is a positive integer. If several secondary masters
 are specified, they must be numbered consecutively, starting from `2`.
 
-All settings that are not explicitly specified are copied from the\
-default master. That is, the following is equivalent with the command\
+All settings that are not explicitly specified are copied from the
+default master. That is, the following is equivalent with the command
 above:
 
 ```
@@ -450,17 +450,17 @@ For instance, the following command would only change the password of `:2`.
 MariaDB> CHANGE MASTER ':2' TO MASTER_PASSWORD='repl2';
 ```
 
-It is not possible to delete a particular secondary master, but if`MASTER_HOST` is set on the default master, even if it is set to the same\
+It is not possible to delete a particular secondary master, but if`MASTER_HOST` is set on the default master, even if it is set to the same
 value, then _all_ secondary master configurations are deleted.
 
-When `START SLAVE` is issued, MaxScale will first attempt to connect to the\
-default master and if that fails, try the secondary masters in order, until\
+When `START SLAVE` is issued, MaxScale will first attempt to connect to the
+default master and if that fails, try the secondary masters in order, until
 a connection can be created. Only if all connection attempts fail, will\
-MaxScale wait as specified with `connect_retry`, before doing the cycle over\
+MaxScale wait as specified with `connect_retry`, before doing the cycle over
 again.
 
-Once the binlog router has successfully connected to a server, it will stay\
-connected to that server until the connection breaks or `STOP SLAVE` is\
+Once the binlog router has successfully connected to a server, it will stay
+connected to that server until the connection breaks or `STOP SLAVE` is
 issued.
 
 The configurations of the secondary masters are also stored to the`master.ini` in sections whose name include the connection name.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-binlogrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-binlogrouter.md
@@ -5,56 +5,56 @@
 ## Binlogrouter
 
 **NOTE:** The binlog router delivered with 2.5 is completely new and is **not**\
-100% backward compatible with the binlog router delivered with earlier\
+100% backward compatible with the binlog router delivered with earlier
 versions of MaxScale.
 
-The binlogrouter is a router that acts as a replication proxy for MariaDB\
-master-slave replication. The router connects to a master, retrieves the binary\
-logs and stores them locally. Slave servers can connect to MaxScale like they\
-would connect to a normal master server. If the master server goes down,\
-replication between MaxScale and the slaves can still continue up to the latest\
-point to which the binlogrouter replicated to. The master can be changed without\
-disconnecting the slaves and without them noticing that the master server has\
+The binlogrouter is a router that acts as a replication proxy for MariaDB
+master-slave replication. The router connects to a master, retrieves the binary
+logs and stores them locally. Slave servers can connect to MaxScale like they
+would connect to a normal master server. If the master server goes down,
+replication between MaxScale and the slaves can still continue up to the latest
+point to which the binlogrouter replicated to. The master can be changed without
+disconnecting the slaves and without them noticing that the master server has
 changed. This allows for a more highly available replication setup.
 
-In addition to the high availability benefits, the binlogrouter creates only one\
-connection to the master whereas with normal replication each individual slave\
-will create a separate connection. This reduces the amount of work the master\
-database has to do which can be significant if there are a large number of\
+In addition to the high availability benefits, the binlogrouter creates only one
+connection to the master whereas with normal replication each individual slave
+will create a separate connection. This reduces the amount of work the master
+database has to do which can be significant if there are a large number of
 replicating slaves.
 
 ### Differences Between Old and New Binlogrouter Implementations
 
-The binlogrouter in MaxScale 2.5.0 is a new and improved version of the original\
-binlogrouter found in older MaxScale versions. The new implementation contains\
-most of the features that were in the original binlogrouter but some of them\
+The binlogrouter in MaxScale 2.5.0 is a new and improved version of the original
+binlogrouter found in older MaxScale versions. The new implementation contains
+most of the features that were in the original binlogrouter but some of them
 were removed as they were either redundant or not useful.
 
 The major differences between the new and old binlog router are:
 
-* The list of servers where the database users for authentication are loaded\
-  must be explicitly configured with the `cluster`, `servers` or`targets` parameter. Alternatively, the users can be read from a file. See [user\_accounts\_file](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#user_accounts_file)\
+* The list of servers where the database users for authentication are loaded
+  must be explicitly configured with the `cluster`, `servers` or`targets` parameter. Alternatively, the users can be read from a file. See [user\_accounts\_file](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#user_accounts_file)
   for more information.
 * The old binlog router had both `server_id` and `master_id`, the new only`server_id`.
-* No need to configure heartbeat and burst interval anymore as they are\
+* No need to configure heartbeat and burst interval anymore as they are
   now automatically configured.
-* Traditional replication that uses the binary log name and file offset to\
+* Traditional replication that uses the binary log name and file offset to
   start the replication process is not supported.
 * Semi-sync support is not implemented.
 * Secondary masters are not supported, but the functionality provided by`select_master` is roughly equivalent.
-* The new binlogrouter will write its own binlog files to prevent problems that\
-  could happen when the master changes. This causes the binlog names to be\
+* The new binlogrouter will write its own binlog files to prevent problems that
+  could happen when the master changes. This causes the binlog names to be
   different in the binlogrouter when compared to the ones on the master.
 
 The documentation for the binlogrouter in MaxScale 2.4 is provided for reference [here](mariadb-maxscale-2208-binlogrouter-24.md).
 
 ### Supported SQL Commands
 
-The binlogrouter supports a subset of the SQL constructs that the MariaDB server\
+The binlogrouter supports a subset of the SQL constructs that the MariaDB server
 supports. The following commands are supported:
 
 * `CHANGE MASTER TO`
-* The binlogrouter supports the same syntax as the MariaDB server but only the\
+* The binlogrouter supports the same syntax as the MariaDB server but only the
   following values are allowed:
   * `MASTER_HOST`
   * `MASTER_PORT`
@@ -71,7 +71,7 @@ supports. The following commands are supported:
   * `MASTER_SSL_CIPHER`
   * `MASTER_SSL_VERIFY_SERVER_CERT`
 
-NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported\
+NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported
 as binlogrouter only supports GTID based replication.
 
 * `STOP SLAVE`
@@ -79,56 +79,56 @@ as binlogrouter only supports GTID based replication.
 * `START SLAVE`
 * Starts replication, same as MariaDB.
 * `RESET SLAVE`
-* Resets replication. Note that the `RESET SLAVE ALL` form that is supported\
+* Resets replication. Note that the `RESET SLAVE ALL` form that is supported
   by MariaDB isn't supported by the binlogrouter.
 * `SHOW BINARY LOGS`
-* Lists the current files and their sizes. These will be different from the\
-  ones listed by the original master where the binlogrouter is replicating\
+* Lists the current files and their sizes. These will be different from the
+  ones listed by the original master where the binlogrouter is replicating
   from.
 * `PURGE { BINARY | MASTER } LOGS TO <filename>`
-* Purges binary logs up to but not including the given file. The file name\
-  must be one of the names shown in `SHOW BINARY LOGS`. The version of this\
+* Purges binary logs up to but not including the given file. The file name
+  must be one of the names shown in `SHOW BINARY LOGS`. The version of this
   command which accepts a timestamp is not currently supported.\
-  Automatic purging is supported using the configuration\
+  Automatic purging is supported using the configuration
   parameter [expire\_log\_duration](mariadb-maxscale-2208-binlogrouter.md#expire_log_duration).\
-  The files are purged in the order they were created. If a file to be purged\
-  is detected to be in use, the purge stops. This means that the purge will\
+  The files are purged in the order they were created. If a file to be purged
+  is detected to be in use, the purge stops. This means that the purge will
   stop at the oldest file that a slave is still reading.\
-  NOTE: You should still take precaution not to purge files that a potential\
-  slave will need in the future. MaxScale can only detect that a file is\
+  NOTE: You should still take precaution not to purge files that a potential
+  slave will need in the future. MaxScale can only detect that a file is
   in active use when a slave is connected, and requesting events from it.
 * `SHOW MASTER STATUS`
-* Shows the name and position of the file to which the binlogrouter will write\
-  the next replicated data. The name and position do not correspond to the\
+* Shows the name and position of the file to which the binlogrouter will write
+  the next replicated data. The name and position do not correspond to the
   name and position in the master.
 * `SHOW SLAVE STATUS`
-* Shows the slave status information similar to what a normal MariaDB slave\
-  server shows. Some of the values are replaced with constants values that\
+* Shows the slave status information similar to what a normal MariaDB slave
+  server shows. Some of the values are replaced with constants values that
   never change. The following values are not constant:
-  * `Slave_IO_State`: Set to `Waiting for master to send event` when\
+  * `Slave_IO_State`: Set to `Waiting for master to send event` when
     replication is ongoing.
   * `Master_Host`: Address of the current master.
   * `Master_User`: The user used to replicate.
   * `Master_Port`: The port the master is listening on.
-  * `Master_Log_File`: The name of the latest file that the binlogrouter is\
+  * `Master_Log_File`: The name of the latest file that the binlogrouter is
     writing to.
-  * `Read_Master_Log_Pos`: The current position where the last event was\
+  * `Read_Master_Log_Pos`: The current position where the last event was
     written in the latest binlog.
-  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's\
+  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's
     not.
-  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's\
+  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's
     not.
   * `Exec_Master_Log_Pos`: Same as `Read_Master_Log_Pos`.
   * `Gtid_IO_Pos`: The latest replicated GTID.
 * `SELECT { Field } ...`
-* The binlogrouter implements a small subset of the MariaDB SELECT syntax as\
-  it is mainly used by the replicating slaves to query various parameters. If\
-  a field queried by a client is not known to the binlogrouter, the value\
-  will be returned back as-is. The following list of functions and variables\
+* The binlogrouter implements a small subset of the MariaDB SELECT syntax as
+  it is mainly used by the replicating slaves to query various parameters. If
+  a field queried by a client is not known to the binlogrouter, the value
+  will be returned back as-is. The following list of functions and variables
   are understood by the binlogrouter and are replaced with actual values:
-  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of\
+  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of
     these return the latest GTID replicated from the master.
-  * `version()` or `@@version`: The version string returned by MaxScale when\
+  * `version()` or `@@version`: The version string returned by MaxScale when
     a client connects to it.
   * `UNIX_TIMESTAMP()`: The current timestamp.
   * `@@version_comment`: Always `pinloki`.
@@ -156,22 +156,22 @@ as binlogrouter only supports GTID based replication.
   * `@@tx_isolation`: Always `REPEATABLE-READ`
   * `@@wait_timeout`: Always `28800`
 * `SET`
-* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should\
+* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should
   start replicating. E.g. `SET @@global.gtid_slave_pos="0-1000-1234,1-1001-5678"`
 * `SHOW VARIABLES LIKE '...'`
-* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`\
-  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`\
-  is not currently supported. In addition, the `LIKE` operator in\
+* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`
+  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`
+  is not currently supported. In addition, the `LIKE` operator in
   binlogrouter only supports exact matches.\
-  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID\
-  coordinates of the binlogrouter. In addition to these, the `server_id`\
+  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID
+  coordinates of the binlogrouter. In addition to these, the `server_id`
   variable will return the configured server ID of the binlogrouter.
 
 ### Configuration Parameters
 
 The binlogrouter is configured similarly to how normal routers are configured in\
-MaxScale. It requires at least one listener where clients can connect to and one\
-server from which the database user information can be retrieved. An example\
+MaxScale. It requires at least one listener where clients can connect to and one
+server from which the database user information can be retrieved. An example
 configuration can be found in the [example](mariadb-maxscale-2208-binlogrouter.md#example) section of this document.
 
 #### `datadir`
@@ -190,7 +190,7 @@ Directory where binary log files are stored.
 * Dynamic: No
 * Default: `1234`
 
-The server ID that MaxScale uses when connecting to the master and when serving\
+The server ID that MaxScale uses when connecting to the master and when serving
 binary logs to the slaves.
 
 #### `net_timeout`
@@ -211,26 +211,26 @@ Network connection and read timeout in seconds for the connection to the master.
 
 Automatically select the master server to replicate from.
 
-When this feature is enabled, the master which binlogrouter will replicate\
+When this feature is enabled, the master which binlogrouter will replicate
 from will be selected from the servers defined by a monitor `cluster=TheMonitor`.\
-Alternatively servers can be listed in `servers`. The servers should be monitored\
-by a monitor. Only servers with the `Master` status are used. If multiple master\
+Alternatively servers can be listed in `servers`. The servers should be monitored
+by a monitor. Only servers with the `Master` status are used. If multiple master
 servers are available, the first available master server will be used.
 
-If a `CHANGE MASTER TO` command is received while `select_master` is on, the\
+If a `CHANGE MASTER TO` command is received while `select_master` is on, the
 command will be honored and `select_master` turned off until the next reboot.\
 This allows the Monitor to perform failover, and more importantly, switchover.\
-It also allows the user to manually redirect the Binlogrouter. The current\
+It also allows the user to manually redirect the Binlogrouter. The current
 master is "sticky", meaning that the same master will be chosen on reboot.
 
-**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is\
-monitoring a binlogrouter. The binlogrouter does not support all the SQL\
-commands that the monitor will send and the rejoin will fail. This restriction\
+**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is
+monitoring a binlogrouter. The binlogrouter does not support all the SQL
+commands that the monitor will send and the rejoin will fail. This restriction
 will be lifted in a future version.
 
 The GTID the replication will start from, will be based on the latest replicated\
-GTID. If no GTID has been replicated, the router will start replication from the\
-start. Manual configuration of the GTID can be done by first configuring the\
+GTID. If no GTID has been replicated, the router will start replication from the
+start. Manual configuration of the GTID can be done by first configuring the
 replication manually with `CHANGE MASTER TO`.
 
 #### `expire_log_duration`
@@ -242,9 +242,9 @@ replication manually with `CHANGE MASTER TO`.
 
 Duration after which a binary log file can be automatically removed.
 
-The duration is measured from the last modification of the log file. Files are\
-purged in the order they were created. The automatic purge works in a similar\
-manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if\
+The duration is measured from the last modification of the log file. Files are
+purged in the order they were created. The automatic purge works in a similar
+manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if
 an eligible file is in active use, i.e. being read by a slave.
 
 #### `expire_log_minimum_files`
@@ -254,7 +254,7 @@ an eligible file is in active use, i.e. being read by a slave.
 * Dynamic: No
 * Default: `2`
 
-The minimum number of log files the automatic purge keeps. At least one file\
+The minimum number of log files the automatic purge keeps. At least one file
 is always kept.
 
 #### `ddl_only`
@@ -265,9 +265,9 @@ is always kept.
 
 When enabled, only DDL events are written to the binary logs. This means that`CREATE`, `ALTER` and `DROP` events are written but `INSERT`, `UPDATE` and`DELETE` events are not.
 
-This mode can be used to keep a record of all the schema changes that occur on a\
-database. As only the DDL events are stored, it becomes very easy to set up an\
-empty server with no data in it by simply pointing it at a binlogrouter instance\
+This mode can be used to keep a record of all the schema changes that occur on a
+database. As only the DDL events are stored, it becomes very easy to set up an
+empty server with no data in it by simply pointing it at a binlogrouter instance
 that has `ddl_only` enabled.
 
 #### `encryption_key_id`
@@ -278,23 +278,23 @@ that has `ddl_only` enabled.
 * Default: `""`
 
 Encryption key ID used to encrypt the binary logs. If configured, an [Encryption\
-Key Manager](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#encryption-key-managers)\
-must also be configured and it must contain the key with the given ID. If the\
-encryption key manager supports versioning, new binary logs will be encrypted\
-using the latest encryption key. Old binlogs will remain encrypted with older\
-key versions and remain readable as long as the key versions used to encrypt\
+Key Manager](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#encryption-key-managers)
+must also be configured and it must contain the key with the given ID. If the
+encryption key manager supports versioning, new binary logs will be encrypted
+using the latest encryption key. Old binlogs will remain encrypted with older
+key versions and remain readable as long as the key versions used to encrypt
 them are available.
 
-Once binary log encryption has been enabled, the encryption key ID cannot be\
-changed and the key must remain available to MaxScale in order for replication\
-to work. If an encryption key is not available or the key manager fails to\
-retrieve it, the replication from the currently selected master server will\
-stop. If the replication is restarted manually, the encryption key retrieval is\
+Once binary log encryption has been enabled, the encryption key ID cannot be
+changed and the key must remain available to MaxScale in order for replication
+to work. If an encryption key is not available or the key manager fails to
+retrieve it, the replication from the currently selected master server will
+stop. If the replication is restarted manually, the encryption key retrieval is
 attempted again.
 
-Re-encryption of binlogs using another encryption key is not possible. However,\
-this is possible if the data is replicated to a second MaxScale server that uses\
-a different encryption key. The same approach can also be used to decrypt\
+Re-encryption of binlogs using another encryption key is not possible. However,
+this is possible if the data is replicated to a second MaxScale server that uses
+a different encryption key. The same approach can also be used to decrypt
 binlogs.
 
 #### `encryption_cipher`
@@ -305,7 +305,7 @@ binlogs.
 * Values: `AES_CBC`, `AES_CTR`, `AES_GCM`
 * Default: `AES_GCM`
 
-The encryption cipher to use. The encryption key size also affects which mode is\
+The encryption cipher to use. The encryption key size also affects which mode is
 used: only 128, 192 and 256 bit encryption keys are currently supported.
 
 Possible values are:
@@ -320,7 +320,7 @@ Possible values are:
 ### New installation
 
 1. Configure and start MaxScale.
-2. If you have not configured `select_master=true` (automatic\
+2. If you have not configured `select_master=true` (automatic
    master selection), issue a `CHANGE MASTER TO` command to binlogrouter.
 
 ```
@@ -342,29 +342,29 @@ SHOW SLAVE STATUS \G
 
 ### Upgrading to version 2.5
 
-Binlogrouter does not read any of the data that a version prior to 2.5\
-has saved. By default binlogrouter will request the replication stream\
-from the blank state (from the start of time), which is basically meant\
-for new systems. If a system is live, the entire replication data probably\
-does not exist, and if it does, it is not necessary for binlogrouter to read\
+Binlogrouter does not read any of the data that a version prior to 2.5
+has saved. By default binlogrouter will request the replication stream
+from the blank state (from the start of time), which is basically meant
+for new systems. If a system is live, the entire replication data probably
+does not exist, and if it does, it is not necessary for binlogrouter to read
 and store all the data.
 
 #### Before you start
 
 * Note that binlogrouter only supports GTID based replication.
-* Make sure that the configured data directory for the new binlogrouter\
+* Make sure that the configured data directory for the new binlogrouter
   is different from the old one, or move old data away.\
   See [datadir](mariadb-maxscale-2208-binlogrouter.md#datadir).
-* If the master contains binlogs from the blank state, and there\
+* If the master contains binlogs from the blank state, and there
   is a large amount of data, consider purging old binlogs.\
   See [Using and Maintaining the Binary Log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log).
 
 #### Deployment
 
-The method described here inflicts the least downtime. Assuming you have\
+The method described here inflicts the least downtime. Assuming you have
 configured version 2.5, and it is ready to go:
 
-1. Redirect each slave that replicates from Binlogrouter to replicate from the\
+1. Redirect each slave that replicates from Binlogrouter to replicate from the
    master.
 
 ```
@@ -387,7 +387,7 @@ master_user=USER,master_password="PASSWORD", master_use_gtid=slave_pos;
 ```
 
 1. Run `maxctrl list servers`. Make sure all your servers are accounted for.\
-   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and\
+   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and
    issue this command to Binlogrouter:
 
 ```
@@ -396,8 +396,8 @@ SET @@global.gtid_slave_pos = "0-1000-1234,1-1001-5678";
 START SLAVE
 ```
 
-**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos\
-if any binlog files have been purged on the master. The server will only stream\
+**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos
+if any binlog files have been purged on the master. The server will only stream
 from the start of time if the first binlog file is present.\
 See [select\_master](mariadb-maxscale-2208-binlogrouter.md#select_master).
 
@@ -415,7 +415,7 @@ SHOW SLAVE STATUS \G
 
 ### Galera cluster
 
-When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2208-binlogrouter.md#select_master) must be\
+When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2208-binlogrouter.md#select_master) must be
 set to true, and the servers must be monitored by the [Galera Monitor](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-galera-monitor.md).\
 Configuring binlogrouter is the same as described above.
 
@@ -480,8 +480,8 @@ port=3306
 
 ### Limitations
 
-* Old-style replication with binlog name and file offset is not supported\
-  and the replication must be started by setting up the GTID to replicate\
+* Old-style replication with binlog name and file offset is not supported
+  and the replication must be started by setting up the GTID to replicate
   from.
 * Only replication from MariaDB servers (including Galera) is supported.
 * Old encrypted binary logs are not re-encrypted with newer key versions ([MXS-4140](https://jira.mariadb.org/browse/MXS-4140))

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-cat.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-cat.md
@@ -6,8 +6,8 @@
 
 The `cat` router is a special router that concatenates result sets.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Configuration
@@ -16,28 +16,28 @@ The router has no special parameters. To use it, define a service with`router=ca
 
 ### Behavior
 
-The order the servers are defined in is the order in which the servers are\
-queried. This means that the results are ordered based on the `servers`\
-parameter of the service. The result will only be completed once all servers\
+The order the servers are defined in is the order in which the servers are
+queried. This means that the results are ordered based on the `servers`
+parameter of the service. The result will only be completed once all servers
 have executed this.
 
-All commands executed via this router will be executed on all servers. This\
-means that an INSERT through the `cat` router will send it to all servers. In\
-the case of commands that do not return resultsets, the response of the last\
-server is sent to the client. This means that if one of the earlier servers\
+All commands executed via this router will be executed on all servers. This
+means that an INSERT through the `cat` router will send it to all servers. In
+the case of commands that do not return resultsets, the response of the last
+server is sent to the client. This means that if one of the earlier servers
 returns a different result, the client will not see it.
 
-As the intended use-case of the router is to mainly reduce multiple result sets\
-into one, it has no mechanisms to prevent writes from being executed on slave\
-servers (which would cause data corruption or replication failure). Take great\
+As the intended use-case of the router is to mainly reduce multiple result sets
+into one, it has no mechanisms to prevent writes from being executed on slave
+servers (which would cause data corruption or replication failure). Take great
 care when performing administrative operations though this router.
 
-If a connection to one of the servers is lost, the client connection will also\
+If a connection to one of the servers is lost, the client connection will also
 be closed.
 
 ### Example
 
-Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-servers.md) tutorial and the\
+Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-servers.md) tutorial and the
 credentials from the [MaxScale Tutorial](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-setting-up-mariadb-maxscale.md).
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-hintrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-hintrouter.md
@@ -8,27 +8,27 @@ HintRouter was introduced in 2.2 and is still beta.
 
 ### Overview
 
-The **HintRouter** module is a simple router intended to operate in conjunction\
-with the NamedServerFilter. The router looks at the hints embedded in a packet\
-buffer and attempts to route the packet according to the hint. The user can also\
-set a default action to be taken when a query has no hints or when the hints\
+The **HintRouter** module is a simple router intended to operate in conjunction
+with the NamedServerFilter. The router looks at the hints embedded in a packet
+buffer and attempts to route the packet according to the hint. The user can also
+set a default action to be taken when a query has no hints or when the hints
 could not be applied.
 
-If a packet has multiple hints attached, the router will read them in order and\
-attempt routing. Any successful routing ends the process and any further hints\
+If a packet has multiple hints attached, the router will read them in order and
+attempt routing. Any successful routing ends the process and any further hints
 are ignored for the packet.
 
 ### Configuration
 
-The HintRouter is a rather simple router and only accepts a few configuration\
+The HintRouter is a rather simple router and only accepts a few configuration
 settings.
 
 ```
 default_action=<master|slave|named|all>
 ```
 
-This setting defines what happens when a query has no routing hint or applying\
-the routing hint(s) fails. If also the default action fails, the routing will\
+This setting defines what happens when a query has no routing hint or applying
+the routing hint(s) fails. If also the default action fails, the routing will
 end in error and the session closes. The different values are:
 
 | Value  | Description                                                                |
@@ -38,40 +38,40 @@ end in error and the session closes. The different values are:
 | named  | Route to a named server. The name is given in the default\_server-setting. |
 | all    | Default value. Route to all connected servers.                             |
 
-Note that setting default action to anything other than `all` means that session\
+Note that setting default action to anything other than `all` means that session
 variable write commands are by default not routed to all backends.
 
 ```
 default_server=<server-name>
 ```
 
-Defines the default backend name if `default_action=named`. `<server-name>` must\
+Defines the default backend name if `default_action=named`. `<server-name>` must
 be a valid backend name.
 
 ```
 max_slaves=<limit>
 ```
 
-`<limit>` should be an integer, -1 by default. Defines how many backend slave\
-servers a session should attempt to connect to. Having less slaves defined in\
-the services and/or less successful connections during session creation is not\
-an error. The router will attempt to distribute slaves evenly between sessions\
-by assigning them in a round robin fashion. The session will always try to\
-connect to a master regardless of this setting, although not finding one is not\
+`<limit>` should be an integer, -1 by default. Defines how many backend slave
+servers a session should attempt to connect to. Having less slaves defined in
+the services and/or less successful connections during session creation is not
+an error. The router will attempt to distribute slaves evenly between sessions
+by assigning them in a round robin fashion. The session will always try to
+connect to a master regardless of this setting, although not finding one is not
 an error.
 
-Negative values activate default mode, in which case this value is set to the\
-number of backends in the service - 1, so that the sessions are connected to all\
+Negative values activate default mode, in which case this value is set to the
+number of backends in the service - 1, so that the sessions are connected to all
 slaves.
 
-If the hints or the `default_action` point to a named server, this setting is\
-probably best left to default to ensure that the specific server is connected to\
-at session creation. The router will not attempt to connect to additional\
+If the hints or the `default_action` point to a named server, this setting is
+probably best left to default to ensure that the specific server is connected to
+at session creation. The router will not attempt to connect to additional
 servers after session creation.
 
 ### Examples
 
-A minimal configuration doesn't require any parameters as all settings have\
+A minimal configuration doesn't require any parameters as all settings have
 reasonable defaults.
 
 ```
@@ -81,7 +81,7 @@ router=hintrouter
 servers=slave1,slave2,slave3
 ```
 
-If packets should be routed to the master server by default and only a few\
+If packets should be routed to the master server by default and only a few
 connections are required, the configuration might be as follows.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-kafkacdc.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-kafkacdc.md
@@ -6,10 +6,10 @@
 
 ### Overview
 
-The KafkaCDC module reads data changes in MariaDB via replication and converts\
+The KafkaCDC module reads data changes in MariaDB via replication and converts
 them into JSON objects that are then streamed to a Kafka broker.
 
-DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the\
+DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the
 following format (example created by `CREATE TABLE test.t1(id INT)`):
 
 ```
@@ -69,10 +69,10 @@ following format (example created by `CREATE TABLE test.t1(id INT)`):
 }
 ```
 
-The `domain`, `server_id` and `sequence` fields contain the GTID that this event\
-belongs to. The `event_number` field is the sequence number of events inside the\
-transaction starting from 1. The `timestamp` field is the UNIX timestamp when\
-the event occurred. The `event_type` field contains the type of the event, one\
+The `domain`, `server_id` and `sequence` fields contain the GTID that this event
+belongs to. The `event_number` field is the sequence number of events inside the
+transaction starting from 1. The `timestamp` field is the UNIX timestamp when
+the event occurred. The `event_type` field contains the type of the event, one
 of:
 
 * `insert`: the event is the data that was added to MariaDB
@@ -80,13 +80,13 @@ of:
 * `update_before`: the event contains the data before an update statement modified it
 * `update_after`: the event contains the data after an update statement modified it
 
-All remaining fields contains data from the table. In the example event this\
+All remaining fields contains data from the table. In the example event this
 would be the fields `id` and `data`.
 
 The sending of these schema objects is optional and can be disabled using`send_schema=false`.
 
-DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that\
-follow the format specified in the DDL event. The objects are in the following\
+DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that
+follow the format specified in the DDL event. The objects are in the following
 format (example created by `INSERT INTO test.t1 VALUES (1)`):
 
 ```
@@ -103,28 +103,28 @@ format (example created by `INSERT INTO test.t1 VALUES (1)`):
 }
 ```
 
-The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These\
+The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These
 contain the table name and schema the event targets.
 
-The router stores table metadata in the MaxScale data directory. The\
-default value is `/var/lib/maxscale/<service name>`. If data for a table\
-is replicated before a DDL event for it is replicated, the CREATE TABLE\
+The router stores table metadata in the MaxScale data directory. The
+default value is `/var/lib/maxscale/<service name>`. If data for a table
+is replicated before a DDL event for it is replicated, the CREATE TABLE
 will be queried from the master server.
 
-During shutdown, the Kafka event queue is flushed. This can take up to 60\
+During shutdown, the Kafka event queue is flushed. This can take up to 60
 seconds if the network is slow or there are network problems.
 
 ### Configuration
 
-* In order for `kafkacdc` to work, the binary logging on the source server must\
-  be configured to use row-based replication and the row image must be set to\
+* In order for `kafkacdc` to work, the binary logging on the source server must
+  be configured to use row-based replication and the row image must be set to
   full by configuring `binlog_format=ROW` and `binlog_row_image=FULL`.
-* The `servers` parameter defines the set of servers where the data is\
-  replicated from. The replication will be done from the first master server\
+* The `servers` parameter defines the set of servers where the data is
+  replicated from. The replication will be done from the first master server
   that is found.
-* The `user` and `password` of the service will be used to connect to the\
+* The `user` and `password` of the service will be used to connect to the
   master. This user requires the `REPLICATION SLAVE` grant.
-* The KafkaCDC service must not be configured to use listeners. If a listener is\
+* The KafkaCDC service must not be configured to use listeners. If a listener is
   configured, all attempts to start a session will fail.
 
 ### Parameters
@@ -135,7 +135,7 @@ seconds if the network is slow or there are network problems.
 * Mandatory: Yes
 * Dynamic: No
 
-The list of Kafka brokers to use in `host:port` format. Multiple values\
+The list of Kafka brokers to use in `host:port` format. Multiple values
 can be separated with commas. This is a mandatory parameter.
 
 #### `topic`
@@ -144,7 +144,7 @@ can be separated with commas. This is a mandatory parameter.
 * Mandatory: Yes
 * Dynamic: No
 
-The Kafka topic where the replicated events will be sent. This is a\
+The Kafka topic where the replicated events will be sent. This is a
 mandatory parameter.
 
 #### `enable_idempotence`
@@ -154,22 +154,22 @@ mandatory parameter.
 * Dynamic: No
 * Default: `false`
 
-Enable idempotent producer mode. This feature requires Kafka version 0.11 or\
+Enable idempotent producer mode. This feature requires Kafka version 0.11 or
 newer to work and is disabled by default.
 
-When enabled, the Kafka producer enters a strict mode which avoids event\
-duplication due to broker outages or other network errors. In HA scenarios where\
-there are more than two MaxScale instances, event duplication can still happen\
+When enabled, the Kafka producer enters a strict mode which avoids event
+duplication due to broker outages or other network errors. In HA scenarios where
+there are more than two MaxScale instances, event duplication can still happen
 as there is no synchronization between the MaxScale instances.
 
-The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),\
+The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),
 describes the parameter as follows:
 
-When set to true, the producer will ensure that messages are successfully\
-produced exactly once and in the original produce order. The following\
-configuration properties are adjusted automatically (if not modified by the\
-user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must\
-be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),\
+When set to true, the producer will ensure that messages are successfully
+produced exactly once and in the original produce order. The following
+configuration properties are adjusted automatically (if not modified by the
+user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must
+be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),
 acks=all, queuing.strategy=fifo.
 
 #### `timeout`
@@ -188,12 +188,12 @@ The connection and read timeout for the replication stream.
 * Dynamic: No
 * Default: `""`
 
-The initial GTID position from where the replication is started. By default the\
-replication is started from the beginning. The value of this parameter is only\
-used if no previously replicated events with GTID positions can be retrieved\
+The initial GTID position from where the replication is started. By default the
+replication is started from the beginning. The value of this parameter is only
+used if no previously replicated events with GTID positions can be retrieved
 from Kafka.
 
-Once the replication has started and a GTID position has been recorded, this\
+Once the replication has started and a GTID position has been recorded, this
 parameter will be ignored. To reset the recorded GTID position, delete the`current_gtid.txt` file located in `/var/lib/maxscale/<SERVICE>/` where`<SERVICE>` is the name of the KafkaCDC service.
 
 #### `server_id`
@@ -203,8 +203,8 @@ parameter will be ignored. To reset the recorded GTID position, delete the`curre
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
-used when replicating from the master in direct replication mode. The default\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
+used when replicating from the master in direct replication mode. The default
 value is 1234. This parameter was added in MaxScale 2.5.7.
 
 #### `match`
@@ -218,13 +218,13 @@ Only include data from tables that match this pattern.
 
 For example, if configured with `match=accounts[.].*`, only data from the`accounts` database is sent to Kafka.
 
-The pattern is matched against the combined database and table name separated by\
-a period. This means that the event for the table `t1` in the `test` database\
-would appear as `test.t1`. The behavior is the same even if the database or the\
-table name contains a period. This means that an event for the `test.table`\
+The pattern is matched against the combined database and table name separated by
+a period. This means that the event for the table `t1` in the `test` database
+would appear as `test.t1`. The behavior is the same even if the database or the
+table name contains a period. This means that an event for the `test.table`
 table in the `my.data` database would appear as `my.data.test.table`.
 
-Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are\
+Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are
 filtered out using the `exclude` parameter.
 
 ```
@@ -249,11 +249,11 @@ exclude=db1 [.](accounts|users)
 
 Exclude data from tables that match this pattern.
 
-For example, if configured with `exclude=mydb[.].*`, all data from the tables in\
+For example, if configured with `exclude=mydb[.].*`, all data from the tables in
 the `mydb` database is not sent to Kafka.
 
-The pattern matching works the same way for both of the `exclude` and `match`\
-parameters. See [match](mariadb-maxscale-2208-kafkacdc.md#match) for an explanation on how the patterns are\
+The pattern matching works the same way for both of the `exclude` and `match`
+parameters. See [match](mariadb-maxscale-2208-kafkacdc.md#match) for an explanation on how the patterns are
 matched against the database and table names.
 
 #### `cooperative_replication`
@@ -263,22 +263,22 @@ matched against the database and table names.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
+Controls whether multiple instances cooperatively replicate from the same
 cluster. This is a boolean parameter and is disabled by default. It was added in\
 MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`), the\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`), the
 replication is only active if the monitor owns the cluster it is monitoring.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID that was delivered\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID that was delivered
 to Kafka.
 
-This means that multiple MaxScale instances can replicate from the same set of\
-servers and the event is only processed once. This feature does not provide\
-exactly-once semantics for the Kafka event delivery. However, it does provide\
-high-availability for the `kafkacdc` instances which allows automated failover\
+This means that multiple MaxScale instances can replicate from the same set of
+servers and the event is only processed once. This feature does not provide
+exactly-once semantics for the Kafka event delivery. However, it does provide
+high-availability for the `kafkacdc` instances which allows automated failover
 between multiple MaxScale instances.
 
 #### `send_schema`
@@ -288,12 +288,12 @@ between multiple MaxScale instances.
 * Dynamic: Yes
 * Default: true
 
-Send JSON schema object into the stream whenever the table schema changes. These\
-events, as described [here](mariadb-maxscale-2208-kafkacdc.md#overview), can be used to detect whenever the\
+Send JSON schema object into the stream whenever the table schema changes. These
+events, as described [here](mariadb-maxscale-2208-kafkacdc.md#overview), can be used to detect whenever the
 format of the data being sent changes.
 
-If this information in these schema change events is not needed or the code that\
-processes the Kafka stream can't handle them, they can be disabled with this\
+If this information in these schema change events is not needed or the code that
+processes the Kafka stream can't handle them, they can be disabled with this
 parameter.
 
 #### `read_gtid_from_kafka`
@@ -303,10 +303,10 @@ parameter.
 * Dynamic: No
 * Default: `true`
 
-On startup, the latest GTID is by default read from the Kafka cluster. This\
+On startup, the latest GTID is by default read from the Kafka cluster. This
 makes it possible to recover the replication position stored by another\
-MaxScale. Sometimes this is not desirable and the GTID should only be read from\
-the local file or started anew. Examples of these are when the GTIDs are reset\
+MaxScale. Sometimes this is not desirable and the GTID should only be read from
+the local file or started anew. Examples of these are when the GTIDs are reset
 or the replication topology has changed.
 
 #### `kafka_ssl`
@@ -316,7 +316,7 @@ or the replication topology has changed.
 * Dynamic: No
 * Default: `false`
 
-Enable SSL for Kafka connections. This is a boolean parameter and is disabled by\
+Enable SSL for Kafka connections. This is a boolean parameter and is disabled by
 default.
 
 #### `kafka_ssl_ca`
@@ -326,7 +326,7 @@ default.
 * Dynamic: No
 * Default: `""`
 
-Path to the certificate authority file in PEM format. If this is not provided,\
+Path to the certificate authority file in PEM format. If this is not provided,
 the default system certificates will be used.
 
 #### `kafka_ssl_cert`
@@ -338,8 +338,8 @@ the default system certificates will be used.
 
 Path to the public certificate in PEM format.
 
-The client must provide a certificate if the Kafka server performs authentication\
-of the client certificates. This feature is enabled by default in Kafka and is\
+The client must provide a certificate if the Kafka server performs authentication
+of the client certificates. This feature is enabled by default in Kafka and is
 controlled by [ssl.endpoint.identification.algorithm](https://kafka.apache.org/documentation/#brokerconfigs_ssl.endpoint.identification.algorithm).
 
 If `kafka_ssl_cert` is provided, `kafka_ssl_key` must also be provided.
@@ -385,8 +385,8 @@ If `kafka_sasl_password` is provided, `kafka_sasl_user` must also be provided.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-The SASL mechanism used. The default value is `PLAIN` which uses plaintext\
-authentication. It is recommended to enable SSL whenever plaintext\
+The SASL mechanism used. The default value is `PLAIN` which uses plaintext
+authentication. It is recommended to enable SSL whenever plaintext
 authentication is used.
 
 Allowed values are:
@@ -400,7 +400,7 @@ Kafka broker.
 
 ### Example Configuration
 
-The following configuration defines the minimal setup for streaming replication\
+The following configuration defines the minimal setup for streaming replication
 events from MariaDB into Kafka as JSON:
 
 ```
@@ -432,8 +432,8 @@ topic=my-cdc-topic
 
 ### Limitations
 
-* The KafkaCDC module provides at-least-once semantics for the generated\
-  events. This means that each replication event is delivered to kafka at least\
+* The KafkaCDC module provides at-least-once semantics for the generated
+  events. This means that each replication event is delivered to kafka at least
   once but there can be duplicate events in case of failures.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-kafkaimporter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-kafkaimporter.md
@@ -7,8 +7,8 @@
 ### Overview
 
 The KafkaImporter module reads messages from Kafka and streams them into a\
-MariaDB server. The messages are inserted into a table designated by either the\
-topic name or the message key (see [table\_name\_in](mariadb-maxscale-2208-kafkaimporter.md#table_name_in) for\
+MariaDB server. The messages are inserted into a table designated by either the
+topic name or the message key (see [table\_name\_in](mariadb-maxscale-2208-kafkaimporter.md#table_name_in) for
 details). By default the table will be automatically created with the following\
 SQL:
 
@@ -19,31 +19,31 @@ CREATE TABLE IF NOT EXISTS my_table (
 );
 ```
 
-The payload of the message is inserted into the `data` field from which the `id`\
-field is calculated. The payload must be a valid JSON object and it must either\
-contain a unique `_id` field or it must not exist or the value must be a JSON\
-null. This is similar to the MongoDB document format where the `_id` field is\
+The payload of the message is inserted into the `data` field from which the `id`
+field is calculated. The payload must be a valid JSON object and it must either
+contain a unique `_id` field or it must not exist or the value must be a JSON
+null. This is similar to the MongoDB document format where the `_id` field is
 the primary key of the document collection.
 
-If a message is read from Kafka and the insertion into the table fails due to a\
-violation of one of the constraints, the message is ignored. Similarly, messages\
-with duplicate `_id` value are also ignored: this is done to avoid inserting the\
-same document multiple times whenever the connection to either Kafka or MariaDB\
+If a message is read from Kafka and the insertion into the table fails due to a
+violation of one of the constraints, the message is ignored. Similarly, messages
+with duplicate `_id` value are also ignored: this is done to avoid inserting the
+same document multiple times whenever the connection to either Kafka or MariaDB
 is lost.
 
-The limitations on the data can be removed by either creating the table before\
-the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`\
-does nothing, or by altering the structure of the existing table. The minimum\
-requirement that must be met is that the table contains the `data` field to\
+The limitations on the data can be removed by either creating the table before
+the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`
+does nothing, or by altering the structure of the existing table. The minimum
+requirement that must be met is that the table contains the `data` field to
 which string values can be inserted into.
 
-The database server where the data is inserted is chosen from the set of servers\
-available to the service. The first server labeled as the Master with the best\
+The database server where the data is inserted is chosen from the set of servers
+available to the service. The first server labeled as the Master with the best
 rank will be chosen. This means that a monitor must be configured for the\
 MariaDB server where the data is to be inserted.
 
-In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 24.08.2\
-the `_id` field is not required to be present. Older versions of MaxScale used\
+In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 24.08.2
+the `_id` field is not required to be present. Older versions of MaxScale used
 the following SQL where the `_id` field was mandatory:
 
 ```
@@ -84,9 +84,9 @@ The comma separated list of topics to subscribe to.
 * Dynamic: Yes
 * Default: `100`
 
-Maximum number of uncommitted records. The KafkaImporter will buffer records\
-into batches and commit them once either enough records are gathered (controlled\
-by this parameter) or when the KafkaImporter goes idle. Any uncommitted records\
+Maximum number of uncommitted records. The KafkaImporter will buffer records
+into batches and commit them once either enough records are gathered (controlled
+by this parameter) or when the KafkaImporter goes idle. Any uncommitted records
 will be read again if a reconnection to either Kafka or MariaDB occurs.
 
 #### `kafka_sasl_mechanism`
@@ -97,7 +97,7 @@ will be read again if a reconnection to either Kafka or MariaDB occurs.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-SASL mechanism to use. The Kafka broker must be configured with the same\
+SASL mechanism to use. The Kafka broker must be configured with the same
 authentication scheme.
 
 #### `kafka_sasl_user`
@@ -116,7 +116,7 @@ SASL username used for authentication. If this parameter is defined,`kafka_sasl_
 * Dynamic: Yes
 * Default: `""`
 
-SASL password for the user. If this parameter is defined, `kafka_sasl_user` must\
+SASL password for the user. If this parameter is defined, `kafka_sasl_user` must
 also be provided.
 
 #### `kafka_ssl`
@@ -135,7 +135,7 @@ Enable SSL for Kafka connections.
 * Dynamic: Yes
 * Default: `""`
 
-SSL Certificate Authority file in PEM format. If this parameter is not\
+SSL Certificate Authority file in PEM format. If this parameter is not
 defined, the system default CA certificate is used.
 
 #### `kafka_ssl_cert`
@@ -169,14 +169,14 @@ The Kafka message part that is used to locate the table to insert the data into.
 Enumeration Values:
 
 * `topic`: The topic named is used as the fully qualified table name.
-* `key`: The message key is used as the fully qualified table name. If the Kafka\
+* `key`: The message key is used as the fully qualified table name. If the Kafka
   message does not have a key, the message is ignored.
 
-For example, all messages with a fully qualified table name of `my_db.my_table`\
-will be inserted into the table `my_table` located in the `my_db` database. If\
-the table or database names have special characters that must be escaped to make\
-them valid identifiers, the name must also contain those escape characters. For\
-example, to insert into a table named `my table` in the database `my database`,\
+For example, all messages with a fully qualified table name of `my_db.my_table`
+will be inserted into the table `my_table` located in the `my_db` database. If
+the table or database names have special characters that must be escaped to make
+them valid identifiers, the name must also contain those escape characters. For
+example, to insert into a table named `my table` in the database `my database`,
 the name would be:
 
 ```
@@ -201,20 +201,20 @@ Timeout for both Kafka and MariaDB network communication.
 
 The storage engine used for tables that are created by the KafkaImporter.
 
-This defines the `ENGINE` table option and must be the name of a valid storage\
-engine in MariaDB. When the storage engine is something other than `InnoDB`, the\
+This defines the `ENGINE` table option and must be the name of a valid storage
+engine in MariaDB. When the storage engine is something other than `InnoDB`, the
 table is created without the generated column and the check constraints:
 
 ```
 CREATE TABLE IF NOT EXISTS my_table (data JSON NOT NULL);
 ```
 
-This is done to avoid conflicts where the custom engine does not support all the\
+This is done to avoid conflicts where the custom engine does not support all the
 features that InnoDB supports.
 
 ### Limitations
 
-* The backend servers used by this service must be MariaDB version 10.2 or\
+* The backend servers used by this service must be MariaDB version 10.2 or
   newer.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-mirror.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-mirror.md
@@ -6,11 +6,11 @@
 
 ### Overview
 
-The `mirror` router is designed for data consistency and database behavior\
-verification during system upgrades. It allows statement duplication to multiple\
+The `mirror` router is designed for data consistency and database behavior
+verification during system upgrades. It allows statement duplication to multiple
 servers in a manner similar to that of the [Tee filter](../mariadb-maxscale-2208--filters/mariadb-maxscale-2208-tee-filter.md) with exporting of collected query metrics.
 
-For each executed query the router exports a JSON object that describes the\
+For each executed query the router exports a JSON object that describes the
 query results and has the following fields:
 
 | Key       | Description                                              |
@@ -21,7 +21,7 @@ query results and has the following fields:
 | query\_id | Query sequence number, starts from 1                     |
 | results   | Array of query result objects                            |
 
-The objects in the `results` array describe an individual query result and have\
+The objects in the `results` array describe an individual query result and have
 the following fields:
 
 | Key      | Description                                |
@@ -41,12 +41,12 @@ the following fields:
 * Mandatory: Yes
 * Dynamic: Yes
 
-The main target from which results are returned to the client. This is a\
+The main target from which results are returned to the client. This is a
 mandatory parameter and must define one of the targets configured in the`targets` parameter of the service.
 
-If the connection to the main target cannot be created or is lost mid-session,\
-the client connection will be closed. Connection failures to other targets are\
-not fatal errors and any open connections to them will be closed. The router\
+If the connection to the main target cannot be created or is lost mid-session,
+the client connection will be closed. Connection failures to other targets are
+not fatal errors and any open connections to them will be closed. The router
 does not create new connections after the initial connections are created.
 
 #### `exporter`
@@ -56,7 +56,7 @@ does not create new connections after the initial connections are created.
 * Dynamic: Yes
 * Values: `log`, `file`, `kafka`
 
-The exporter where the data is exported. This is a mandatory parameter. Possible\
+The exporter where the data is exported. This is a mandatory parameter. Possible
 values are:
 
 * `log`
@@ -64,7 +64,7 @@ values are:
 * `file`
 * Exports metrics to a file. Configured with the [file](mariadb-maxscale-2208-mirror.md#file) parameter.
 * `kafka`
-* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2208-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2208-mirror.md#kafka_topic)\
+* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2208-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2208-mirror.md#kafka_topic)
   parameters.
 
 #### `file`
@@ -74,12 +74,12 @@ values are:
 * Mandatory: No
 * Dynamic: Yes
 
-The output file where the metrics will be written. The file must be writable by\
+The output file where the metrics will be written. The file must be writable by
 the user that is running MaxScale, usually the `maxscale` user.
 
-When the `file` parameter is altered at runtime, the old file is closed before\
-the new file is opened. This makes it a convenient way of rotating the file\
-where the metrics are exported. Note that the file name alteration must change\
+When the `file` parameter is altered at runtime, the old file is closed before
+the new file is opened. This makes it a convenient way of rotating the file
+where the metrics are exported. Note that the file name alteration must change
 the value for it to take effect.
 
 This is a mandatory parameter when configured with `exporter=file`.
@@ -91,7 +91,7 @@ This is a mandatory parameter when configured with `exporter=file`.
 * Mandatory: No
 * Dynamic: Yes
 
-The Kafka broker list. Must be given as a comma-separated list of broker hosts\
+The Kafka broker list. Must be given as a comma-separated list of broker hosts
 with optional ports in `host:port` format.
 
 This is a mandatory parameter when configured with `exporter=kafka`.
@@ -118,12 +118,12 @@ This is a mandatory parameter when configured with `exporter=kafka`.
 What to do when a backend network connection fails. Accepted values are:
 
 * `ignore`
-* Ignore the failing backend if it's not the backend that the `main` parameter\
+* Ignore the failing backend if it's not the backend that the `main` parameter
   points to.
 * `close`
 * Close the client connection when the first backend fails.
 
-This parameter was added in MaxScale 6.0. Older versions always ignored\
+This parameter was added in MaxScale 6.0. Older versions always ignored
 failing backends.
 
 #### `report`
@@ -141,7 +141,7 @@ When to report the result of the queries. Accepted values are:
 * `on_conflict`
 * Only report when one or more backends returns a conflicting result.
 
-This parameter was added in MaxScale 6.0. Older versions always reported the\
+This parameter was added in MaxScale 6.0. Older versions always reported the
 result.
 
 ### Example Configuration
@@ -186,8 +186,8 @@ port=3306
 * Broken network connections are not recreated.
 * Prepared statements are not supported.
 * Contents of non-SQL statements are not added to the exported metrics.
-* Data synchronization in dynamic environments (e.g. when replication is in use)\
-  is not guaranteed. This means that result mismatches can be reported when the\
+* Data synchronization in dynamic environments (e.g. when replication is in use)
+  is not guaranteed. This means that result mismatches can be reported when the
   data is only eventually consistent.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readconnroute.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readconnroute.md
@@ -4,32 +4,32 @@
 
 ## Readconnroute
 
-This document provides an overview of the **readconnroute** router module\
-and its intended use case scenarios. It also displays all router\
+This document provides an overview of the **readconnroute** router module
+and its intended use case scenarios. It also displays all router
 configuration parameters with their descriptions.
 
 ### Overview
 
-The readconnroute router provides simple and lightweight load balancing across a\
+The readconnroute router provides simple and lightweight load balancing across a
 set of servers.
 
-Note that \*_readconnroute_ balances _connections_ and not _statements_. When a\
-client connects, the router selects the server that matches the value of`router_options` and has the least number of connections. Once the connection is\
-opened, it will not be changed for the duration of the session. If the\
-connection between MaxScale and the server breaks, the connection can not be\
-re-established and the client session will be closed. The fact that the server\
+Note that \*_readconnroute_ balances _connections_ and not _statements_. When a
+client connects, the router selects the server that matches the value of`router_options` and has the least number of connections. Once the connection is
+opened, it will not be changed for the duration of the session. If the
+connection between MaxScale and the server breaks, the connection can not be
+re-established and the client session will be closed. The fact that the server
 is fixed when the client connects also means that routing hints are ignored.
 
-Connections from other MaxScale instances or connections done directly on a\
+Connections from other MaxScale instances or connections done directly on a
 database are not taken into account. Only connections done through the same\
 Maxscale instance are taken into account.
 
-**Warning:** `readconnroute` will not prevent writes from being done even if you\
-define `router_options=slave`. The client application is responsible for\
-making sure that it only performs read-only queries in such\
-cases. `readconnroute` is simple by design: it selects a server for each\
-client connection and routes all queries there. If something more complex is\
-required, the [readwritesplit](mariadb-maxscale-2208-readwritesplit.md) router is usually the right\
+**Warning:** `readconnroute` will not prevent writes from being done even if you
+define `router_options=slave`. The client application is responsible for
+making sure that it only performs read-only queries in such
+cases. `readconnroute` is simple by design: it selects a server for each
+client connection and routes all queries there. If something more complex is
+required, the [readwritesplit](mariadb-maxscale-2208-readwritesplit.md) router is usually the right
 choice.
 
 ### Configuration
@@ -44,8 +44,8 @@ For more details about the standard service parameters, refer to the [Configurat
 * Values: `master`, `slave`, `synced`, `running`
 * Default: `running`
 
-**`router_options`** can contain a comma separated list of valid server\
-roles. These roles are used as the valid types of servers the router will\
+**`router_options`** can contain a comma separated list of valid server
+roles. These roles are used as the valid types of servers the router will
 form connections to when new sessions are created.
 
 Examples:
@@ -64,20 +64,20 @@ Here is a list of all possible values for the `router_options`.
 | synced  | A Galera cluster node which is in a synced state with the cluster.                                                                                                                                                     |
 | running | A server that is up and running. All servers that MariaDB MaxScale can connect to are labeled as running.                                                                                                              |
 
-If no `router_options` parameter is configured in the service definition,\
-the router will use the default value of `running`. This means that it will\
-load balance connections across all running servers defined in the `servers`\
+If no `router_options` parameter is configured in the service definition,
+the router will use the default value of `running`. This means that it will
+load balance connections across all running servers defined in the `servers`
 parameter of the service.
 
-When a connection is being created and the candidate server is being chosen, the\
-list of servers is processed in from first entry to last. This means that if two\
-servers with equal rank and number of connections are found, the one that's\
+When a connection is being created and the candidate server is being chosen, the
+list of servers is processed in from first entry to last. This means that if two
+servers with equal rank and number of connections are found, the one that's
 listed first in the _servers_ parameter for the service is chosen.
 
-When using `router_options=slave`, only servers with the `Slave` status are\
-used. If there are no servers with the `Slave` status but there is a `Master`\
-status, it will be used as the fallback server. Note that the use of`router_options=slave` does not prevent writes from being done and the client\
-application is responsible for making sure that no writes are done on a `Slave`\
+When using `router_options=slave`, only servers with the `Slave` status are
+used. If there are no servers with the `Slave` status but there is a `Master`
+status, it will be used as the fallback server. Note that the use of`router_options=slave` does not prevent writes from being done and the client
+application is responsible for making sure that no writes are done on a `Slave`
 server.
 
 #### `master_accept_reads`
@@ -88,8 +88,8 @@ server.
 * Default: true
 
 This option can be used to prevent queries from being sent to the current master.\
-If `router_options` does not contain "master", the readconnroute instance is\
-usually meant for reading. Setting `master_accept_reads=false` excludes the master\
+If `router_options` does not contain "master", the readconnroute instance is
+usually meant for reading. Setting `master_accept_reads=false` excludes the master
 from server selection (and thus from receiving reads).
 
 If `router_options` contains "master", the setting of `master_accept_reads` has no effect.
@@ -103,22 +103,22 @@ By default `master_accept_reads=true`.
 * Dynamic: Yes
 * Default: 0s
 
-The maximum acceptable replication lag. The value is in seconds and is specified\
-as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). The\
+The maximum acceptable replication lag. The value is in seconds and is specified
+as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). The
 default value is `0s`, which means that the lag is ignored.
 
-The replication lag of a server must be less than the configured value in order\
-for it to be used for routing. To configure the router to not allow any lag, use\
+The replication lag of a server must be less than the configured value in order
+for it to be used for routing. To configure the router to not allow any lag, use
 the smallest duration larger than 0, that is, `max_replication_lag=1s`.
 
 ### Examples
 
-The most common use for the readconnroute is to provide either a read or\
-write port for an application. This provides a more lightweight routing\
-solution than the more complex readwritesplit router but requires the\
+The most common use for the readconnroute is to provide either a read or
+write port for an application. This provides a more lightweight routing
+solution than the more complex readwritesplit router but requires the
 application to be able to use distinct write and read ports.
 
-To configure a read-only service that tolerates master failures, we first\
+To configure a read-only service that tolerates master failures, we first
 need to add a new section in to the configuration file.
 
 ```
@@ -129,11 +129,11 @@ servers=slave1,slave2,slave3
 router_options=slave
 ```
 
-Here the `router_options` designates slaves as the only valid server\
-type. With this configuration, the queries are load balanced across the\
+Here the `router_options` designates slaves as the only valid server
+type. With this configuration, the queries are load balanced across the
 slave servers.
 
-For more complex examples of the readconnroute router, take a look at the\
+For more complex examples of the readconnroute router, take a look at the
 examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
 
 ### Router Diagnostics

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md
@@ -4,54 +4,54 @@
 
 ## Readwritesplit
 
-This document provides a short overview of the **readwritesplit** router module\
-and its intended use case scenarios. It also displays all router configuration\
-parameters with their descriptions. A list of current limitations of the module\
+This document provides a short overview of the **readwritesplit** router module
+and its intended use case scenarios. It also displays all router configuration
+parameters with their descriptions. A list of current limitations of the module
 is included and use examples are provided.
 
 ### Overview
 
-The **readwritesplit** router is designed to increase the read-only processing\
-capability of a cluster while maintaining consistency. This is achieved by\
-splitting the query load into read and write queries. Read queries, which do not\
-modify data, are spread across multiple nodes while all write queries will be\
-sent to a single node. For more details on how the load balancing works, refer\
+The **readwritesplit** router is designed to increase the read-only processing
+capability of a cluster while maintaining consistency. This is achieved by
+splitting the query load into read and write queries. Read queries, which do not
+modify data, are spread across multiple nodes while all write queries will be
+sent to a single node. For more details on how the load balancing works, refer
 to [slave\_selection\_criteria](mariadb-maxscale-2208-readwritesplit.md#slave_selection_criteria) and [master\_accept\_reads](mariadb-maxscale-2208-readwritesplit.md#master_accept_reads).
 
-The router is designed to be used with a traditional Master-Slave replication\
-cluster. It automatically detects changes in the master server and will use the\
-current master server of the cluster. With a Galera cluster, one can achieve a\
+The router is designed to be used with a traditional Master-Slave replication
+cluster. It automatically detects changes in the master server and will use the
+current master server of the cluster. With a Galera cluster, one can achieve a
 resilient setup and easy master failover by using one of the Galera nodes as a\
-Write-Master node, where all write queries are routed, and spreading the read\
+Write-Master node, where all write queries are routed, and spreading the read
 load over all the nodes.
 
 ### Interaction with servers in `Maintenance` and `Draining` state
 
-When a server that readwritesplit uses is put into maintenance mode, any ongoing\
-requests are allowed to finish before the connection is closed. If the server\
-that is put into maintenance mode is a master, open transaction are allowed to\
-complete before the connection is closed. Note that this means neither idle\
-session nor long-running transactions will be closed by readwritesplit. To\
+When a server that readwritesplit uses is put into maintenance mode, any ongoing
+requests are allowed to finish before the connection is closed. If the server
+that is put into maintenance mode is a master, open transaction are allowed to
+complete before the connection is closed. Note that this means neither idle
+session nor long-running transactions will be closed by readwritesplit. To
 forcefully close the connections, use the following command:
 
 ```
 maxctrl set server <server> maintenance --force
 ```
 
-If a server is put into the `Draining` state while a connection is open, the\
-connection will be used normally. Whenever a new connection needs to be created,\
-whether that be due to a network error or when a new session being opened, only\
+If a server is put into the `Draining` state while a connection is open, the
+connection will be used normally. Whenever a new connection needs to be created,
+whether that be due to a network error or when a new session being opened, only
 servers that are neither `Draining` nor `Drained` will be used.
 
 ### Configuration
 
-Readwritesplit router-specific settings are specified in the configuration file\
-of MariaDB MaxScale in its specific section. The section can be freely named but\
+Readwritesplit router-specific settings are specified in the configuration file
+of MariaDB MaxScale in its specific section. The section can be freely named but
 the name is used later as a reference in a listener section.
 
 For more details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md).
 
-Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be\
+Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be
 taken into use by new sessions.
 
 ### Parameters
@@ -63,45 +63,45 @@ taken into use by new sessions.
 * Dynamic: Yes
 * Default: 255
 
-`max_slave_connections` sets the maximum number of slaves a router session uses\
-at any moment. The default is to use at most 255 slave connections per client\
-connection. In older versions the default was to use all available slaves with\
+`max_slave_connections` sets the maximum number of slaves a router session uses
+at any moment. The default is to use at most 255 slave connections per client
+connection. In older versions the default was to use all available slaves with
 no limit.
 
 For MaxScale 2.5.12 and newer, the minimum value is 0.
 
-For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions\
-suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that\
-causes the parameter to accept any values but only function when a value greater\
+For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions
+suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that
+causes the parameter to accept any values but only function when a value greater
 than one was given.
 
-Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be\
+Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be
 removed in a future release.
 
-For example, if you have configured MaxScale with one master and three slaves\
-and set `max_slave_connections=2`, for each client connection a connection to\
-the master and two slave connections would be opened. The read query load\
-balancing is then done between these two slaves and writes are sent to the\
+For example, if you have configured MaxScale with one master and three slaves
+and set `max_slave_connections=2`, for each client connection a connection to
+the master and two slave connections would be opened. The read query load
+balancing is then done between these two slaves and writes are sent to the
 master.
 
-By tuning this parameter, you can control how dynamic the load balancing is at\
-the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of\
-possible slave servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more\
-resources but load balancing will almost always give the best single query\
+By tuning this parameter, you can control how dynamic the load balancing is at
+the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of
+possible slave servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more
+resources but load balancing will almost always give the best single query
 response time and performance. Longer sessions are less affected by a high`max_slave_connections` as the relative cost of opening a connection is lower.
 
 **Behavior of `max_slave_connections=0`**
 
-When readwritesplit is configured with `max_slave_connections=0`, readwritesplit\
-will behave slightly differently in that it will route all reads to the current\
-master server. This is a convenient way to force all of the traffic to go to a\
-single node while still being able to leverage the replay and reconnection\
+When readwritesplit is configured with `max_slave_connections=0`, readwritesplit
+will behave slightly differently in that it will route all reads to the current
+master server. This is a convenient way to force all of the traffic to go to a
+single node while still being able to leverage the replay and reconnection
 features of readwritesplit.
 
-In this mode, the behavior of `master_failure_mode=fail_on_write` also changes\
-slightly. If the current `Master` server fails and a read is done when there's\
-no other `Master` server available, the connection will be closed. This is done\
-to prevent an extra slave connection from being opened that would not be closed\
+In this mode, the behavior of `master_failure_mode=fail_on_write` also changes
+slightly. If the current `Master` server fails and a read is done when there's
+no other `Master` server available, the connection will be closed. This is done
+to prevent an extra slave connection from being opened that would not be closed
 if a new `Master` server would arrive.
 
 #### `slave_connections`
@@ -111,17 +111,17 @@ if a new `Master` server would arrive.
 * Dynamic: Yes
 * Default: 255
 
-This parameter controls how many slave connections each new session starts\
+This parameter controls how many slave connections each new session starts
 with. The default value is 255 which is the same as the default value of`max_slave_connections`.
 
-In contrast to `max_slave_connections`, `slave_connections` serves as a\
-soft limit on how many slave connections are created. The number of slave\
-connections can exceed `slave_connections` if the load balancing algorithm\
+In contrast to `max_slave_connections`, `slave_connections` serves as a
+soft limit on how many slave connections are created. The number of slave
+connections can exceed `slave_connections` if the load balancing algorithm
 finds an unconnected slave server better than all other slaves.
 
-Setting this parameter to 1 allows faster connection creation and improved\
-resource usage due to the smaller amount of initial backend\
-connections. It is recommended to use `slave_connections=1` when the\
+Setting this parameter to 1 allows faster connection creation and improved
+resource usage due to the smaller amount of initial backend
+connections. It is recommended to use `slave_connections=1` when the
 lifetime of the client connections is short.
 
 #### `max_slave_replication_lag`
@@ -131,32 +131,32 @@ lifetime of the client connections is short.
 * Dynamic: Yes
 * Default: 0s
 
-Specify how many seconds a slave is allowed to be behind the master. The lag of\
-a slave must be less than the configured value in order for it to be used for\
+Specify how many seconds a slave is allowed to be behind the master. The lag of
+a slave must be less than the configured value in order for it to be used for
 routing. If set to 0 (the default value), the feature is disabled.
 
-In MaxScale 2.5.0, the slave lag must be less than `max_slave_replication_lag`\
-whereas in older versions the slave lag had to be less than or equal to`max_slave_replication_lag`. This means that in MaxScale 2.5.0 it is possible to\
-define, with `max_slave_replication_lag=1`, that all slaves must be up to date\
+In MaxScale 2.5.0, the slave lag must be less than `max_slave_replication_lag`
+whereas in older versions the slave lag had to be less than or equal to`max_slave_replication_lag`. This means that in MaxScale 2.5.0 it is possible to
+define, with `max_slave_replication_lag=1`, that all slaves must be up to date
 in order for them to be used for routing.
 
-Note that this feature does not guarantee that writes done on the master are\
-visible for reads done on the slave. This is mainly due to the method of\
+Note that this feature does not guarantee that writes done on the master are
+visible for reads done on the slave. This is mainly due to the method of
 replication lag measurement. For a feature that guarantees this, refer to [causal\_reads](mariadb-maxscale-2208-readwritesplit.md#causal_reads).
 
-The lag is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the lag is seconds, a lag specified in milliseconds will be rejected, even if\
+The lag is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the lag is seconds, a lag specified in milliseconds will be rejected, even if
 the duration is longer than a second.
 
-The Readwritesplit-router does not detect the replication lag itself. A monitor\
-such as the MariaDB-monitor for a Master/Slave-cluster is required. This option\
-only affects Master-Slave clusters. Galera clusters do not have a concept of\
-slave lag even if the application of write sets might have lag. When a server is\
-disqualified from routing because of replication lag, a warning is logged. Similarly,\
-when the server has caught up enough to be a valid routing target, another warning\
-is logged. These messages are only logged when a query is being routed and the\
+The Readwritesplit-router does not detect the replication lag itself. A monitor
+such as the MariaDB-monitor for a Master/Slave-cluster is required. This option
+only affects Master-Slave clusters. Galera clusters do not have a concept of
+slave lag even if the application of write sets might have lag. When a server is
+disqualified from routing because of replication lag, a warning is logged. Similarly,
+when the server has caught up enough to be a valid routing target, another warning
+is logged. These messages are only logged when a query is being routed and the
 replication state changes.
 
 #### `use_sql_variables_in`
@@ -167,8 +167,8 @@ replication state changes.
 * Values: `master`, `all`
 * Default: `all`
 
-This parameter controls how `SELECT` statements that use SQL user variables are\
-handled. Here is an example of such a query that uses it to return an increasing\
+This parameter controls how `SELECT` statements that use SQL user variables are
+handled. Here is an example of such a query that uses it to return an increasing
 row number for a resultset:
 
 ```
@@ -176,31 +176,31 @@ SET @rownum := 0;
 SELECT @rownum := @rownum + 1 AS rownum, user, host FROM mysql.user;
 ```
 
-By default MaxScale will route both the `SET` and `SELECT` statements to all\
+By default MaxScale will route both the `SET` and `SELECT` statements to all
 nodes. Any future reads of the user variables can also be performed on any node.
 
 The possible values for this parameter are:
 
 * `all` (default)
-* Modifications to user variables inside `SELECT` statements as well as reads\
+* Modifications to user variables inside `SELECT` statements as well as reads
   of user variables are routed to all servers.\
-  Versions before MaxScale 22.08 returned an error if a user variable was\
-  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was\
-  used. MaxScale 22.08 will instead route the query to all servers and discard\
+  Versions before MaxScale 22.08 returned an error if a user variable was
+  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was
+  used. MaxScale 22.08 will instead route the query to all servers and discard
   the extra results.
 * `master`
-* Modifications to user variables inside `SELECT` statements as well as reads\
-  of user variables are routed to the master server. This forces more of the\
-  traffic onto the master server but it reduces the amount of data that is\
-  discarded for any `SELECT` statement that also modifies a user\
-  variable. With this mode, the state of user variables is not deterministic\
-  if they are modified inside of a `SELECT` statement. `SET` statements that\
+* Modifications to user variables inside `SELECT` statements as well as reads
+  of user variables are routed to the master server. This forces more of the
+  traffic onto the master server but it reduces the amount of data that is
+  discarded for any `SELECT` statement that also modifies a user
+  variable. With this mode, the state of user variables is not deterministic
+  if they are modified inside of a `SELECT` statement. `SET` statements that
   modify user variables are still routed to all servers.
 
-DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user\
-variables are still treated as writes and are only routed to the master\
-server. For example, after the following query the value of `@myid` is no longer\
-the same on all servers and the `SELECT` statement can return different values\
+DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user
+variables are still treated as writes and are only routed to the master
+server. For example, after the following query the value of `@myid` is no longer
+the same on all servers and the `SELECT` statement can return different values
 depending where it ends up being executed:
 
 ```
@@ -211,13 +211,13 @@ SELECT @myid; -- Might return 1 or 0
 
 #### `connection_keepalive`
 
-**Note:** This parameter has been moved into the MaxScale core. For the\
-current documentation, read the [connection\_keepalive](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#connection_keepalive)\
+**Note:** This parameter has been moved into the MaxScale core. For the
+current documentation, read the [connection\_keepalive](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#connection_keepalive)
 section in the configuration guide.
 
 Send keepalive pings to backend servers. This feature was introduced in MaxScale\
-2.2.0. The default value is 300 seconds starting with 2.3.2 and for older\
-versions the feature was disabled by default. This parameter was converted into\
+2.2.0. The default value is 300 seconds starting with 2.3.2 and for older
+versions the feature was disabled by default. This parameter was converted into
 a service parameter in MaxScale 2.5.0.
 
 #### `master_reconnection`
@@ -230,26 +230,26 @@ a service parameter in MaxScale 2.5.0.
 Allow the master server to change mid-session. This feature was introduced in\
 MaxScale 2.3.0 and is disabled by default. This feature requires that`disable_sescmd_history` is not used.
 
-When a readwritesplit session starts, it will pick a master server as the\
-current master server of that session. By default, when this master server is\
+When a readwritesplit session starts, it will pick a master server as the
+current master server of that session. By default, when this master server is
 lost or changes to another server, the connection will be closed.
 
-When `master_reconnection` is enabled, readwritesplit can sometimes recover a\
+When `master_reconnection` is enabled, readwritesplit can sometimes recover a
 lost connection to the master server. This largely depends on the value of`master_failure_mode`.
 
-With `master_failure_mode=fail_instantly`, the master server is only allowed to\
-change to another server. This change must happen without a loss of the master\
+With `master_failure_mode=fail_instantly`, the master server is only allowed to
+change to another server. This change must happen without a loss of the master
 server.
 
-With `master_failure_mode=fail_on_write`, the loss of the master server is no\
-longer a fatal error: if a replacement master server appears before any write\
-queries are received, readwritesplit will transparently reconnect to the new\
+With `master_failure_mode=fail_on_write`, the loss of the master server is no
+longer a fatal error: if a replacement master server appears before any write
+queries are received, readwritesplit will transparently reconnect to the new
 master server.
 
-In both cases the change in the master server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet\
+In both cases the change in the master server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet
 been exceeded and the session does not have an open transaction.
 
-The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance\
+The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance
 without any risk to the consistency of the database.
 
 #### `slave_selection_criteria`
@@ -260,17 +260,17 @@ without any risk to the consistency of the database.
 * Values: `LEAST_CURRENT_OPERATIONS`, `ADAPTIVE_ROUTING`, `LEAST_BEHIND_MASTER`, `LEAST_ROUTER_CONNECTIONS`, `LEAST_GLOBAL_CONNECTIONS`
 * Default: `LEAST_CURRENT_OPERATIONS`
 
-This option controls how the readwritesplit router chooses the slaves it\
-connects to and how the load balancing is done. The default behavior is to route\
+This option controls how the readwritesplit router chooses the slaves it
+connects to and how the load balancing is done. The default behavior is to route
 read queries to the slave server with the lowest amount of ongoing queries i.e.`LEAST_CURRENT_OPERATIONS`.
 
-All of the load balancing methods use MaxScale's own accounting. Connections and\
-queries done directly on the database and not through MaxScale are not taken\
-into account by readwritesplit. For example, if server A has 100 queries running\
+All of the load balancing methods use MaxScale's own accounting. Connections and
+queries done directly on the database and not through MaxScale are not taken
+into account by readwritesplit. For example, if server A has 100 queries running
 all of which are routed through MaxScale and server B has 115 queries but only\
-95 of those were routed through MaxScale, server B is considered a better\
-candidate even if the absolute number of active queries on it is higher. This is\
-because MaxScale only tracks the connections and queries routed through the same\
+95 of those were routed through MaxScale, server B is considered a better
+candidate even if the absolute number of active queries on it is higher. This is
+because MaxScale only tracks the connections and queries routed through the same
 process.
 
 The option syntax:
@@ -287,59 +287,59 @@ Where `<criteria>` is one of the following values.
 * `LEAST_GLOBAL_CONNECTIONS`, the slave with least connections from MariaDB MaxScale
 * `LEAST_ROUTER_CONNECTIONS`, the slave with least connections from this service
 
-`LEAST_CURRENT_OPERATIONS` uses the current number of active operations\
-(i.e. SQL queries) as the load balancing metric and it optimizes for maximal\
-query throughput. Each query gets routed to the server with the least active\
-operations which results in faster servers processing more traffic. If two\
-servers have an equal number of active operations, the one that was least\
+`LEAST_CURRENT_OPERATIONS` uses the current number of active operations
+(i.e. SQL queries) as the load balancing metric and it optimizes for maximal
+query throughput. Each query gets routed to the server with the least active
+operations which results in faster servers processing more traffic. If two
+servers have an equal number of active operations, the one that was least
 recently used is chosen.
 
-`ADAPTIVE_ROUTING` uses the server response time and current estimated server\
-load as the load balancing metric. The server that is estimated to finish an\
-additional query first is chosen. A modified average response time for each\
-server is continuously updated to allow slow servers at least some traffic and\
-quickly react to changes in server load conditions. If a server has not received\
-any traffic, the network lag to the server as measured by the monitor is used as\
-the proxy of the true response time. This selection criteria is designed for\
-heterogeneous clusters: servers of differing hardware, differing network\
-distances, or when other loads are running on the servers (including a\
-backup). If the servers are queried by other clients than MaxScale, the load\
+`ADAPTIVE_ROUTING` uses the server response time and current estimated server
+load as the load balancing metric. The server that is estimated to finish an
+additional query first is chosen. A modified average response time for each
+server is continuously updated to allow slow servers at least some traffic and
+quickly react to changes in server load conditions. If a server has not received
+any traffic, the network lag to the server as measured by the monitor is used as
+the proxy of the true response time. This selection criteria is designed for
+heterogeneous clusters: servers of differing hardware, differing network
+distances, or when other loads are running on the servers (including a
+backup). If the servers are queried by other clients than MaxScale, the load
 caused by them is indirectly taken into account.
 
-`LEAST_BEHIND_MASTER` uses the measured replication lag as the load balancing\
-metric. This means that servers that are more up-to-date are favored which\
-increases the likelihood of the data being read being up-to-date. However, this\
-is not as effective as `causal_reads` would be as there's no guarantee that\
-writes done by the same connection will be routed to a server that has\
+`LEAST_BEHIND_MASTER` uses the measured replication lag as the load balancing
+metric. This means that servers that are more up-to-date are favored which
+increases the likelihood of the data being read being up-to-date. However, this
+is not as effective as `causal_reads` would be as there's no guarantee that
+writes done by the same connection will be routed to a server that has
 replicated those changes. The recommended approach is to use`LEAST_CURRENT_OPERATIONS` or `ADAPTIVE_ROUTING` in combination with`causal_reads`
 
-**NOTE**: `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` should not\
-be used, they are legacy options that exist only for backwards\
-compatibility. Using them will result in skewed load balancing as the algorithm\
-uses a metric that's too coarse (number of connections) to load balance\
+**NOTE**: `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` should not
+be used, they are legacy options that exist only for backwards
+compatibility. Using them will result in skewed load balancing as the algorithm
+uses a metric that's too coarse (number of connections) to load balance
 something that's finer (individual SQL queries).
 
-The `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` use the\
-connections from MariaDB MaxScale to the server, not the amount of connections\
+The `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` use the
+connections from MariaDB MaxScale to the server, not the amount of connections
 reported by the server itself.
 
-Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,\
-lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid\
+Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,
+lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid
 values.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#max_sescmd_history)\
+This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#max_sescmd_history)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#disable_sescmd_history)\
+This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#disable_sescmd_history)
 in MaxScale 6.0.
 
 #### `prune_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#prune_sescmd_history)\
+This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#prune_sescmd_history)
 in MaxScale 6.0.
 
 #### `master_accept_reads`
@@ -349,12 +349,12 @@ in MaxScale 6.0.
 * Dynamic: Yes
 * Default: false
 
-**`master_accept_reads`** allows the master server to be used for reads. This is\
-a useful option to enable if you are using a small number of servers and wish to\
+**`master_accept_reads`** allows the master server to be used for reads. This is
+a useful option to enable if you are using a small number of servers and wish to
 use the master for reads as well.
 
-By default, no reads are sent to the master as long as there is a valid slave\
-server available. If no slaves are available, reads are sent to the master\
+By default, no reads are sent to the master as long as there is a valid slave
+server available. If no slaves are available, reads are sent to the master
 regardless of the value of `master_accept_reads`.
 
 ```
@@ -369,18 +369,18 @@ master_accept_reads=true
 * Dynamic: Yes
 * Default: false
 
-This option is disabled by default since MaxScale 2.2.1. In older versions, this\
+This option is disabled by default since MaxScale 2.2.1. In older versions, this
 option was enabled by default.
 
-When a client executes a multi-statement query, it will be treated as if it were\
-a DML statement and routed to the master. If the option is enabled, all queries\
-after a multi-statement query will be routed to the master to guarantee a\
+When a client executes a multi-statement query, it will be treated as if it were
+a DML statement and routed to the master. If the option is enabled, all queries
+after a multi-statement query will be routed to the master to guarantee a
 consistent session state.
 
-If the feature is disabled, queries are routed normally after a multi-statement\
+If the feature is disabled, queries are routed normally after a multi-statement
 query.
 
-**Warning:** Enable the strict mode only if you know that the clients will send\
+**Warning:** Enable the strict mode only if you know that the clients will send
 statements that cause inconsistencies in the session state.
 
 ```
@@ -395,8 +395,8 @@ strict_multi_stmt=true
 * Dynamic: Yes
 * Default: false
 
-Similar to `strict_multi_stmt`, this option allows all queries after a CALL\
-operation on a stored procedure to be routed to the master. This option is\
+Similar to `strict_multi_stmt`, this option allows all queries after a CALL
+operation on a stored procedure to be routed to the master. This option is
 disabled by default and was added in MaxScale 2.1.9.
 
 All warnings and restrictions that apply to `strict_multi_stmt` also apply to`strict_sp_calls`.
@@ -409,10 +409,10 @@ All warnings and restrictions that apply to `strict_multi_stmt` also apply to`st
 * Values: `fail_instantly`, `fail_on_write`, `error_on_write`
 * Default: `fail_instantly`
 
-This option controls how the failure of a master server is handled. By default,\
+This option controls how the failure of a master server is handled. By default,
 the router will close the client connection as soon as the master is lost.
 
-The following table describes the values for this option and how they treat the\
+The following table describes the values for this option and how they treat the
 loss of a master server.
 
 | Value            | Description                                                                                                                     |
@@ -421,22 +421,22 @@ loss of a master server.
 | fail\_on\_write  | The client connection is closed if a write query is received when no master is available.                                       |
 | error\_on\_write | If no master is available and a write query is received, an error is returned stating that the connection is in read-only mode. |
 
-These also apply to new sessions created after the master has failed. This means\
-that in `fail_on_write` or `error_on_write` mode, connections are accepted as\
+These also apply to new sessions created after the master has failed. This means
+that in `fail_on_write` or `error_on_write` mode, connections are accepted as
 long as slave servers are available.
 
-When configured with `fail_on_write` or `error_on_write`, sessions that are idle\
-will not be closed even if all backend connections for that session have\
-failed. This is done in the hopes that before the next query from the idle\
-session arrives, a reconnection to one of the slaves is made. However, this can\
-leave idle connections around unless the client application actively closes\
-them. To prevent this, use the [connection\_timeout](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#connection_timeout)\
+When configured with `fail_on_write` or `error_on_write`, sessions that are idle
+will not be closed even if all backend connections for that session have
+failed. This is done in the hopes that before the next query from the idle
+session arrives, a reconnection to one of the slaves is made. However, this can
+leave idle connections around unless the client application actively closes
+them. To prevent this, use the [connection\_timeout](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#connection_timeout)
 parameter.
 
-**Note:** If `master_failure_mode` is set to `error_on_write` and the connection\
-to the master is lost, by default, clients will not be able to execute write\
-queries without reconnecting to MariaDB MaxScale once a new master is\
-available. If [master\_reconnection](mariadb-maxscale-2208-readwritesplit.md#master_reconnection) is enabled, the\
+**Note:** If `master_failure_mode` is set to `error_on_write` and the connection
+to the master is lost, by default, clients will not be able to execute write
+queries without reconnecting to MariaDB MaxScale once a new master is
+available. If [master\_reconnection](mariadb-maxscale-2208-readwritesplit.md#master_reconnection) is enabled, the
 session can recover if one of the slaves is promoted as the master.
 
 #### `retry_failed_reads`
@@ -449,9 +449,9 @@ session can recover if one of the slaves is promoted as the master.
 This option controls whether autocommit selects are retried in case of failure.\
 This option is enabled by default.
 
-When a simple autocommit select is being executed outside of a transaction and\
-the slave server where the query is being executed fails, readwritesplit can\
-retry the read on a replacement server. This makes the failure of a slave\
+When a simple autocommit select is being executed outside of a transaction and
+the slave server where the query is being executed fails, readwritesplit can
+retry the read on a replacement server. This makes the failure of a slave
 transparent to the client.
 
 #### `delayed_retry`
@@ -461,34 +461,34 @@ transparent to the client.
 * Dynamic: Yes
 * Default: false
 
-Retry queries over a period of time. This parameter takes a boolean value, was\
+Retry queries over a period of time. This parameter takes a boolean value, was
 added in Maxscale 2.3.0 and is disabled by default.
 
-When this feature is enabled, a failure to route a query due to a connection\
-problem will not immediately result in an error. The routing of the query is\
-delayed until either a valid candidate server is available or the retry timeout\
-is reached. If a candidate server becomes available before the timeout is\
-reached, the query is routed normally and no connection error is returned. If no\
-candidates are found and the timeout is exceeded, the router returns to normal\
+When this feature is enabled, a failure to route a query due to a connection
+problem will not immediately result in an error. The routing of the query is
+delayed until either a valid candidate server is available or the retry timeout
+is reached. If a candidate server becomes available before the timeout is
+reached, the query is routed normally and no connection error is returned. If no
+candidates are found and the timeout is exceeded, the router returns to normal
 behavior and returns an error.
 
-When combined with the `master_reconnection` parameter, failures of writes done\
-outside of transactions can be hidden from the client connection. This allows a\
+When combined with the `master_reconnection` parameter, failures of writes done
+outside of transactions can be hidden from the client connection. This allows a
 master to be replaced while writes are being sent.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, `delayed_retry` will no longer attempt to retry a query if it was\
-already sent to the database. If a query is received while a valid target server\
-is not available, the execution of the query is delayed until a valid target is\
-found or the delayed retry timeout is hit. If a query was already sent, it will\
+24.08.1, `delayed_retry` will no longer attempt to retry a query if it was
+already sent to the database. If a query is received while a valid target server
+is not available, the execution of the query is delayed until a valid target is
+found or the delayed retry timeout is hit. If a query was already sent, it will
 not be replayed to prevent duplicate execution of statements.
 
-In older versions of MaxScale, duplicate execution of a statement can occur if\
-the connection to the server is lost or the server crashes but the server comes\
-back up before the timeout for the retrying is exceeded. At this point, if the\
-server managed to read the client's statement, it will be executed. For this\
+In older versions of MaxScale, duplicate execution of a statement can occur if
+the connection to the server is lost or the server crashes but the server comes
+back up before the timeout for the retrying is exceeded. At this point, if the
+server managed to read the client's statement, it will be executed. For this
 reason, it is recommended to only enable `delayed_retry` for older versions of\
-MaxScale when the possibility of duplicate statement execution is an acceptable\
+MaxScale when the possibility of duplicate statement execution is an acceptable
 risk.
 
 #### `delayed_retry_timeout`
@@ -500,10 +500,10 @@ risk.
 
 The duration to wait until an error is returned to the client when`delayed_retry` is enabled. The default value is 10 seconds.
 
-The timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `transaction_replay`
@@ -513,20 +513,20 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Replay interrupted transactions. This parameter was added in MaxScale 2.3.0 and\
-is disabled by default. Enabling this parameter enables both `delayed_retry` and`master_reconnection` and sets `master_failure_mode` to `fail_on_write`, thereby\
+Replay interrupted transactions. This parameter was added in MaxScale 2.3.0 and
+is disabled by default. Enabling this parameter enables both `delayed_retry` and`master_reconnection` and sets `master_failure_mode` to `fail_on_write`, thereby
 overriding any configured values for these parameters.
 
-When the server where the transaction is in progress fails, readwritesplit can\
-migrate the transaction to a replacement server. This can completely hide the\
+When the server where the transaction is in progress fails, readwritesplit can
+migrate the transaction to a replacement server. This can completely hide the
 failure of a master node without any visible effects to the client.
 
 If no replacement node becomes available, the client connection is closed.
 
 To control how long a transaction replay can take, use`transaction_replay_timeout`.
 
-Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2208-readwritesplit.md#transaction-replay-limitations) section for\
-a more detailed explanation of what should and should not be done with\
+Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2208-readwritesplit.md#transaction-replay-limitations) section for
+a more detailed explanation of what should and should not be done with
 transaction replay.
 
 #### `transaction_replay_max_size`
@@ -536,20 +536,20 @@ transaction replay.
 * Dynamic: Yes
 * Default: 1 MiB
 
-The limit on transaction size for transaction replay in bytes. Any transaction\
-that exceeds this limit will not be replayed. The default value is 1 MiB. This\
-limit applies at a session level which means that the total peak memory\
-consumption can be `transaction_replay_max_size` times the number of client\
+The limit on transaction size for transaction replay in bytes. Any transaction
+that exceeds this limit will not be replayed. The default value is 1 MiB. This
+limit applies at a session level which means that the total peak memory
+consumption can be `transaction_replay_max_size` times the number of client
 connections.
 
-The amount of memory needed to store a particular transaction will be slightly\
-larger than the length in bytes of the SQL used in the transaction. If the limit\
+The amount of memory needed to store a particular transaction will be slightly
+larger than the length in bytes of the SQL used in the transaction. If the limit
 is ever exceeded, a message will be logged at the info level.
 
-Starting with MaxScale 6.4.10, the number of times that this limit has been\
+Starting with MaxScale 6.4.10, the number of times that this limit has been
 exceeded is shown in `maxctrl show service` as `trx_max_size_exceeded`.
 
-Read [the configuration guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes)\
+Read [the configuration guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#sizes)
 for more details on size type parameters in MaxScale.
 
 #### `transaction_replay_attempts`
@@ -559,13 +559,13 @@ for more details on size type parameters in MaxScale.
 * Dynamic: Yes
 * Default: 5
 
-The upper limit on how many times a transaction replay is attempted before\
+The upper limit on how many times a transaction replay is attempted before
 giving up. The default value is 5.
 
-A transaction replay failure can happen if the server where the transaction is\
-being replayed fails while the replay is in progress. In practice this parameter\
-controls how many server and network failures a single transaction replay\
-tolerates. If a transaction is replayed successfully, the counter for failed\
+A transaction replay failure can happen if the server where the transaction is
+being replayed fails while the replay is in progress. In practice this parameter
+controls how many server and network failures a single transaction replay
+tolerates. If a transaction is replayed successfully, the counter for failed
 attempts is reset.
 
 #### `transaction_replay_timeout`
@@ -575,30 +575,30 @@ attempts is reset.
 * Dynamic: Yes
 * Default: 0s
 
-The time how long transactions are attempted for. This feature is disabled by\
-default and was added in MaxScale 6.2.1. To explicitly disable this feature, set\
+The time how long transactions are attempted for. This feature is disabled by
+default and was added in MaxScale 6.2.1. To explicitly disable this feature, set
 the value to 0 seconds.
 
-The timeout is [a duration type](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations)\
+The timeout is [a duration type](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations)
 and the value must include a unit for the duration.
 
-When `transaction_replay_timeout` is enabled, the time a transaction replay can\
-take is controlled solely by this parameter. This is a more convenient and\
-predictable method of controlling how long a transaction replay can be attempted\
+When `transaction_replay_timeout` is enabled, the time a transaction replay can
+take is controlled solely by this parameter. This is a more convenient and
+predictable method of controlling how long a transaction replay can be attempted
 before the connection is closed.
 
-If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set\
+If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set
 to the same value.
 
-By default the time how long a transaction can be retried is controlled by`delayed_retry_timeout` and `transaction_replay_attempts`. This can result in a\
-maximum replay time limit of `delayed_retry_timeout` multiplied by`transaction_replay_attempts`, by default this is 50 seconds. The minimum replay\
-time limit can be as low as `transaction_replay_attempts` seconds (5 seconds by\
-default) in cases where the connection fails after it was created. Usually this\
-happens due to problems like the max\_connections limit being hit on the database\
+By default the time how long a transaction can be retried is controlled by`delayed_retry_timeout` and `transaction_replay_attempts`. This can result in a
+maximum replay time limit of `delayed_retry_timeout` multiplied by`transaction_replay_attempts`, by default this is 50 seconds. The minimum replay
+time limit can be as low as `transaction_replay_attempts` seconds (5 seconds by
+default) in cases where the connection fails after it was created. Usually this
+happens due to problems like the max\_connections limit being hit on the database
 server.
 
-With the introduction of `transaction_replay_timeout`, these problems are\
-avoided. Starting with MaxScale 6.2.1, this is the recommended method of\
+With the introduction of `transaction_replay_timeout`, these problems are
+avoided. Starting with MaxScale 6.2.1, this is the recommended method of
 controlling the timeouts for transaction replay.
 
 #### `transaction_replay_retry_on_deadlock`
@@ -608,15 +608,15 @@ controlling the timeouts for transaction replay.
 * Dynamic: Yes
 * Default: false
 
-Enable automatic retrying of transactions that end up in a deadlock. This\
-parameter was added in MaxScale 2.4.6 and the feature is disabled by\
-default. MaxScale versions from 2.4.0 to 2.4.5 always tried to replay deadlocked\
+Enable automatic retrying of transactions that end up in a deadlock. This
+parameter was added in MaxScale 2.4.6 and the feature is disabled by
+default. MaxScale versions from 2.4.0 to 2.4.5 always tried to replay deadlocked
 transactions.
 
-If this feature is enabled and a transaction returns a deadlock error\
-(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),\
-the transaction is automatically retried. If the retrying of the transaction\
-results in another deadlock error, it is retried until it either succeeds or a\
+If this feature is enabled and a transaction returns a deadlock error
+(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),
+the transaction is automatically retried. If the retrying of the transaction
+results in another deadlock error, it is retried until it either succeeds or a
 transaction checksum error is encountered.
 
 #### `transaction_replay_retry_on_mismatch`
@@ -629,8 +629,8 @@ transaction checksum error is encountered.
 Retry transactions that end in checksum mismatch. This parameter was added in\
 MaxScale 6.2.1 is disabled by default.
 
-When enabled, any replayed transactions that end with a checksum mismatch are\
-retried until they either succeeds or one of the transaction replay limits is\
+When enabled, any replayed transactions that end with a checksum mismatch are
+retried until they either succeeds or one of the transaction replay limits is
 reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_replay_attempts`).
 
 #### `transaction_replay_checksum`
@@ -641,30 +641,30 @@ reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_re
 * Values: `full`, `result_only`, `no_insert_id`
 * Default: `full`
 
-Selects which transaction checksum method is used to verify the result of the\
+Selects which transaction checksum method is used to verify the result of the
 replayed transaction.
 
-Note that only `transaction_replay_checksum=full` is guaranteed to retain the\
+Note that only `transaction_replay_checksum=full` is guaranteed to retain the
 consistency of the replayed transaction.
 
 Possible values are:
 
 * `full` (default)
-* All responses from the server are included in the checksum. This retains the\
-  full consistency guarantee of the replayed transaction as it must match\
+* All responses from the server are included in the checksum. This retains the
+  full consistency guarantee of the replayed transaction as it must match
   exactly the one that was already returned to the client.
 * `result_only`
-* Only resultsets and errors are included in the checksum. OK packets\
-  (i.e. successful queries that do not return results) are ignored. This mode\
+* Only resultsets and errors are included in the checksum. OK packets
+  (i.e. successful queries that do not return results) are ignored. This mode
   is intended to be used in cases where the extra information (auto-generated\
-  ID, warnings etc.) returned in the OK packet is not used by the\
+  ID, warnings etc.) returned in the OK packet is not used by the
   application.\
-  This mode is safe to use only if the auto-generated ID is not actually used\
-  by any following queries. An example of such behavior would be a transaction\
+  This mode is safe to use only if the auto-generated ID is not actually used
+  by any following queries. An example of such behavior would be a transaction
   that ends with an `INSERT` into a table with an `AUTO_INCREMENT` field.
 * `no_insert_id`
-* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the\
-  result of the query is not used by any subsequent statement in the\
+* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the
+  result of the query is not used by any subsequent statement in the
   transaction.
 
 #### `optimistic_trx`
@@ -674,21 +674,21 @@ Possible values are:
 * Dynamic: Yes
 * Default: false
 
-Enable optimistic transaction execution. This parameter controls whether normal\
-transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across\
+Enable optimistic transaction execution. This parameter controls whether normal
+transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across
 slaves. This feature is disabled by default and enabling it implicitly enables`transaction_replay`, `delayed_retry` and `master_reconnection` parameters.
 
-When this mode is enabled, all transactions are first attempted on slave\
-servers. If the transaction contains no statements that modify data, it is\
-completed on the slave. If the transaction contains statements that modify data,\
-it is rolled back on the slave server and restarted on the master. The rollback\
-is initiated the moment a data modifying statement is intercepted by\
+When this mode is enabled, all transactions are first attempted on slave
+servers. If the transaction contains no statements that modify data, it is
+completed on the slave. If the transaction contains statements that modify data,
+it is rolled back on the slave server and restarted on the master. The rollback
+is initiated the moment a data modifying statement is intercepted by
 readwritesplit so only read-only statements are executed on slave servers.
 
-As with `transaction_replay` and transactions that are replayed, if the results\
-returned by the master server are not identical to the ones returned by the\
-slave up to the point where the first data modifying statement was executed, the\
-connection is closed. If the execution of ROLLBACK statement on the slave fails,\
+As with `transaction_replay` and transactions that are replayed, if the results
+returned by the master server are not identical to the ones returned by the
+slave up to the point where the first data modifying statement was executed, the
+connection is closed. If the execution of ROLLBACK statement on the slave fails,
 the connection to that slave is closed.
 
 All limitations that apply to `transaction_replay` also apply to`optimistic_trx`.
@@ -704,12 +704,12 @@ All limitations that apply to `transaction_replay` also apply to`optimistic_trx`
 Enable causal reads. This parameter is disabled by default and was introduced in\
 MaxScale 2.3.0.
 
-If a client connection modifies the database and `causal_reads` is enabled, any\
-subsequent reads performed on slave servers will be done in a manner that\
+If a client connection modifies the database and `causal_reads` is enabled, any
+subsequent reads performed on slave servers will be done in a manner that
 prevents replication lag from affecting the results.
 
-The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2208-readwritesplit.md#implementation-of-causal_reads) for more\
-information on what a sync consists of and why minimizing the number of them is\
+The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2208-readwritesplit.md#implementation-of-causal_reads) for more
+information on what a sync consists of and why minimizing the number of them is
 important.
 
 | Mode         | Level of Causality | Latency                                                 |
@@ -720,19 +720,19 @@ important.
 | fast\_global | Service            | None, no sync at all.                                   |
 | universal    | Cluster            | High, one sync per read plus a roundtrip to the master. |
 
-The `fast` and `fast_global` modes should only be used when low latency is more\
-important than proper distribution of reads. These modes should only be used\
-when the workload is mostly read-only with only occasional writes. If used with\
-a mixed or a write-heavy workload, the traffic will end up being routed almost\
+The `fast` and `fast_global` modes should only be used when low latency is more
+important than proper distribution of reads. These modes should only be used
+when the workload is mostly read-only with only occasional writes. If used with
+a mixed or a write-heavy workload, the traffic will end up being routed almost
 exclusively to the master server.
 
-**Note:** This feature requires MariaDB 10.2.16 or newer to function. In\
+**Note:** This feature requires MariaDB 10.2.16 or newer to function. In
 addition to this, the `session_track_system_variables` parameter must include`last_gtid` in its list of tracked system variables.
 
-**Note:** This feature also enables multi-statement execution of SQL in the\
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)\
+**Note:** This feature also enables multi-statement execution of SQL in the
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
-Connector/C. The _Implementation of causal\_reads_ section explains why this is\
+Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.
 
 The possible values for this parameter are:
@@ -740,89 +740,89 @@ The possible values for this parameter are:
 * `none` (default)
 * Read causality is disabled.
 * `local`
-* Writes are locally visible. Writes are guaranteed to be visible only to the\
-  connection that does it. Unrelated modifications done by other connections\
-  are not visible. This mode improves read scalability at the cost of latency\
-  and reduces the overall load placed on the master server without breaking\
+* Writes are locally visible. Writes are guaranteed to be visible only to the
+  connection that does it. Unrelated modifications done by other connections
+  are not visible. This mode improves read scalability at the cost of latency
+  and reduces the overall load placed on the master server without breaking
   causality guarantees.
 * `global`
-* Writes are globally visible. If one connection writes a value, all\
-  connections to the same service will see it. In general this mode is slower\
-  than the `local` mode due to the extra synchronization it has to do. This\
-  guarantees global happens-before ordering of reads when all transactions are\
-  inside a single GTID domain.This mode gives similar benefits as the `local`\
+* Writes are globally visible. If one connection writes a value, all
+  connections to the same service will see it. In general this mode is slower
+  than the `local` mode due to the extra synchronization it has to do. This
+  guarantees global happens-before ordering of reads when all transactions are
+  inside a single GTID domain.This mode gives similar benefits as the `local`
   mode in that it improves read scalability at the cost of latency.\
-  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads\
-  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this\
-  was fixed and all the GTID coordinates are passed alongside all requests\
+  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads
+  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this
+  was fixed and all the GTID coordinates are passed alongside all requests
   which makes multi-domain GTIDs safe to use. However, this does mean that the\
-  GTID coordinates will never be reset: if replication is reset and GTID\
-  coordinates go "backwards", readwritesplit will not consider these as being\
-  newer than the ones already stored. To reset the stored GTID coordinates in\
+  GTID coordinates will never be reset: if replication is reset and GTID
+  coordinates go "backwards", readwritesplit will not consider these as being
+  newer than the ones already stored. To reset the stored GTID coordinates in
   readwritesplit, MaxScale must be restarted.\
-  MaxScale 6.4.11 added the new `reset-gtid` module command to\
+  MaxScale 6.4.11 added the new `reset-gtid` module command to
   readwritesplit. This allows the global GTID state used by`causal_reads=global` to be reset without having to restart MaxScale.
 * `fast`
-* This mode is similar to the `local` mode where it will only affect the\
-  connection that does the write but where the `local` mode waits for a slave\
-  server to catch up, the `fast` mode will only use servers that are known to\
-  have replicated the write. This means that if no slave has replicated the\
-  write, the master where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication\
-  state is only updated by the mariadbmon monitor whenever the servers are\
-  monitored. This means that a smaller `monitor_interval` provides faster\
+* This mode is similar to the `local` mode where it will only affect the
+  connection that does the write but where the `local` mode waits for a slave
+  server to catch up, the `fast` mode will only use servers that are known to
+  have replicated the write. This means that if no slave has replicated the
+  write, the master where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication
+  state is only updated by the mariadbmon monitor whenever the servers are
+  monitored. This means that a smaller `monitor_interval` provides faster
   replication state updates and possibly better overall usage of servers.\
-  This mode is the inverse of the `local` mode in the sense that it improves\
-  read latency at the cost of read scalability while still retaining the\
-  causality guarantees for reads. This functionality can also be considered an\
+  This mode is the inverse of the `local` mode in the sense that it improves
+  read latency at the cost of read scalability while still retaining the
+  causality guarantees for reads. This functionality can also be considered an
   improved version of the functionality that the [CCRFilter](../mariadb-maxscale-2208--filters/mariadb-maxscale-2208-consistent-critical-read-filter.md) module provides.
 * `fast_global`
 * This mode is identical to the `fast` mode except that it uses the global\
-  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`\
-  is ignored in this mode. Currently the replication state is only updated by\
-  the mariadbmon monitor whenever the servers are monitored. This means that a\
-  smaller `monitor_interval` provides faster replication state updates and\
+  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`
+  is ignored in this mode. Currently the replication state is only updated by
+  the mariadbmon monitor whenever the servers are monitored. This means that a
+  smaller `monitor_interval` provides faster replication state updates and
   possibly better overall usage of servers.
 * `universal`
-* The universal mode guarantees that all SELECT statements always see the\
-  latest observable transaction state on a database cluster. The basis of this\
-  is the `@@gtid_binlog_pos` variable which is read from the current primary\
-  server before each read. This guarantees that if a transaction was visible\
-  at the time the read is received by readwritesplit, the transaction is\
-  guaranteed to be complete on the replica server where the read is\
+* The universal mode guarantees that all SELECT statements always see the
+  latest observable transaction state on a database cluster. The basis of this
+  is the `@@gtid_binlog_pos` variable which is read from the current primary
+  server before each read. This guarantees that if a transaction was visible
+  at the time the read is received by readwritesplit, the transaction is
+  guaranteed to be complete on the replica server where the read is
   done. Versions 22.08.16, 23.02.13, 23.08.9, 24.02.5 and older used`@@gtid_current_pos` as the GTID value\
-  ([MXS-5588](https://jira.mariadb.org/browse/MXS-5588)) but this caused\
+  ([MXS-5588](https://jira.mariadb.org/browse/MXS-5588)) but this caused
   problems with Galera clusters.\
-  This mode is the most consistent of all the modes. It provides consistency\
-  regardless of where a write originated from but it comes at the cost of\
-  increased latency. For every read, a round trip to the current master server\
-  is done. This means that the latency of any given SELECT statement increases\
-  by roughly twice the network latency between MaxScale and the database\
-  cluster. In addition, an extra SELECT statement is always executed on the\
+  This mode is the most consistent of all the modes. It provides consistency
+  regardless of where a write originated from but it comes at the cost of
+  increased latency. For every read, a round trip to the current master server
+  is done. This means that the latency of any given SELECT statement increases
+  by roughly twice the network latency between MaxScale and the database
+  cluster. In addition, an extra SELECT statement is always executed on the
   master which places some load on the server.
 
-Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean\
+Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean
 parameter. False values translated to `none` and true values translated to`local`. The use of boolean parameters is deprecated but still accepted in\
 MaxScale 2.5.0.
 
 **Implementation of `causal_reads`**
 
-This feature is based on the `MASTER_GTID_WAIT` function and the tracking of\
-server-side status variables. By tracking the latest GTID that each statement\
-generates, readwritesplit can then perform a synchronization operation with the\
+This feature is based on the `MASTER_GTID_WAIT` function and the tracking of
+server-side status variables. By tracking the latest GTID that each statement
+generates, readwritesplit can then perform a synchronization operation with the
 help of the `MASTER_GTID_WAIT` function.
 
-If the slave has not caught up to the master within the configured time, as\
-specified by [causal\_reads\_timeout](mariadb-maxscale-2208-readwritesplit.md#causal_reads_timeout), it will\
-be retried on the master. In MaxScale 2.3.0 an error was returned to the client\
+If the slave has not caught up to the master within the configured time, as
+specified by [causal\_reads\_timeout](mariadb-maxscale-2208-readwritesplit.md#causal_reads_timeout), it will
+be retried on the master. In MaxScale 2.3.0 an error was returned to the client
 when the slave timed out.
 
-The exception to this rule is the `fast` mode which does not do any\
-synchronization at all. This can be done as any reads that would go to\
+The exception to this rule is the `fast` mode which does not do any
+synchronization at all. This can be done as any reads that would go to
 out-of-date servers will be re-routed to the current master.
 
 **Normal SQL**
 
-A practical example can be given by the following set of SQL commands executed\
+A practical example can be given by the following set of SQL commands executed
 with `autocommit=1`.
 
 ```
@@ -830,17 +830,17 @@ INSERT INTO test.t1 (id) VALUES (1);
 SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-As the statements are not executed inside a transaction, from the load balancer's\
-point of view, the latter statement can be routed to a slave server. The problem\
-with this is that if the value that was inserted on the master has not yet\
-replicated to the server where the SELECT statement is being performed, it can\
+As the statements are not executed inside a transaction, from the load balancer's
+point of view, the latter statement can be routed to a slave server. The problem
+with this is that if the value that was inserted on the master has not yet
+replicated to the server where the SELECT statement is being performed, it can
 appear as if the value we just inserted is not there.
 
-By prefixing these types of SELECT statements with a command that guarantees\
-consistent results for the reads, read scalability can be improved without\
+By prefixing these types of SELECT statements with a command that guarantees
+consistent results for the reads, read scalability can be improved without
 sacrificing consistency.
 
-The set of example SQL above will be translated by MaxScale into the following\
+The set of example SQL above will be translated by MaxScale into the following
 statements.
 
 ```
@@ -854,18 +854,18 @@ SET @maxscale_secret_variable=(
     END); SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-The `SET` command will synchronize the slave to a certain logical point in the\
-replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more\
-details). If the synchronization fails, the query will not run and it will be\
+The `SET` command will synchronize the slave to a certain logical point in the
+replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more
+details). If the synchronization fails, the query will not run and it will be
 retried on the server where the transaction was originally done.
 
 **Prepared Statements**
 
-Binary protocol prepared statements are handled in a different manner. Instead\
-of adding the synchronization SQL into the original SQL query, it is sent as a\
+Binary protocol prepared statements are handled in a different manner. Instead
+of adding the synchronization SQL into the original SQL query, it is sent as a
 separate packet before the prepared statement is executed.
 
-We'll use the same example SQL but use a binary protocol prepared statement for\
+We'll use the same example SQL but use a binary protocol prepared statement for
 the SELECT:
 
 ```
@@ -883,24 +883,24 @@ COM_QUERY:         IF (MASTER_GTID_WAIT('0-3000-8', 10) <> 0) THEN KILL (SELECT 
 COM_STMT_EXECUTE:  ? = 123
 ```
 
-Both the synchronization query and the execution of the prepared statement are\
-sent at the same time. This is done to remove the need to wait for the result of\
-the synchronization query before routing the execution of the prepared\
-statement. This keeps the performance of causal\_reads for prepared statements\
+Both the synchronization query and the execution of the prepared statement are
+sent at the same time. This is done to remove the need to wait for the result of
+the synchronization query before routing the execution of the prepared
+statement. This keeps the performance of causal\_reads for prepared statements
 the same as it is for normal SQL queries.
 
-As a result of this, each time the synchronization query times out, the\
-connection will be killed by the `KILL` statement and readwritesplit will retry\
-the query on the master. This is done to prevent the execution of the prepared\
+As a result of this, each time the synchronization query times out, the
+connection will be killed by the `KILL` statement and readwritesplit will retry
+the query on the master. This is done to prevent the execution of the prepared
 statement that follows the synchronization query from being processed by the\
 MariaDB server.
 
-It is recommend that the session command history is enabled whenever prepared\
-statements are used with `causal_reads`. This allows new connections to be\
+It is recommend that the session command history is enabled whenever prepared
+statements are used with `causal_reads`. This allows new connections to be
 created whenever a causal read times out.
 
-Starting with MaxScale 2.5.17, a failed causal read inside of a read-only\
-transaction started with `START TRANSACTION READ ONLY` will return the following\
+Starting with MaxScale 2.5.17, a failed causal read inside of a read-only
+transaction started with `START TRANSACTION READ ONLY` will return the following
 error:
 
 ```
@@ -909,25 +909,25 @@ SQLSTATE: 25006
 Message:  Causal read timed out while in a read-only transaction, cannot retry command.
 ```
 
-Older versions of MaxScale attempted to retry the command on the current master\
+Older versions of MaxScale attempted to retry the command on the current master
 server which would cause the connection to be closed and a warning to be logged.
 
 **Limitations of Causal Reads**
 
-* This feature does not work with Galera or any other non-standard\
-  replication mechanisms. As Galera does not update the `gtid_slave_pos`\
-  variable when events are replicated via the Galera library, the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)\
-  function used by MaxScale to synchronize reads will wait until the\
-  timeout. With Galera this is not a serious issue as it, by nature, is a\
+* This feature does not work with Galera or any other non-standard
+  replication mechanisms. As Galera does not update the `gtid_slave_pos`
+  variable when events are replicated via the Galera library, the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)
+  function used by MaxScale to synchronize reads will wait until the
+  timeout. With Galera this is not a serious issue as it, by nature, is a
   mostly-synchronous replication mechanism.
-* If the combination of the original SQL statement and the modifications\
-  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),\
+* If the combination of the original SQL statement and the modifications
+  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),
   the causal read will not be attempted and a non-causal read is done instead.\
-  This applies only to text protocol queries as the binary protocol queries use\
+  This applies only to text protocol queries as the binary protocol queries use
   a different synchronization mechanism.
-* SQL like `INSERT ... RETURNING` that commits a transaction and returns a\
+* SQL like `INSERT ... RETURNING` that commits a transaction and returns a
   resultset will only work with causal reads if the connector supports the\
-  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB\
+  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB
   connectors and whether they support the protocol feature.
 
 | Connector         | Supported | Version |
@@ -946,13 +946,13 @@ server which would cause the connection to be closed and a warning to be logged.
 * Dynamic: Yes
 * Default: 10s
 
-The timeout for the slave synchronization done by `causal_reads`. The\
+The timeout for the slave synchronization done by `causal_reads`. The
 default value is 10 seconds.
 
-The timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `lazy_connect`
@@ -962,16 +962,16 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Lazy connection creation causes connections to backend servers to be opened only\
-when they are needed. This reduces the load that is placed on the backend\
-servers when the client connections are short. This parameter is a boolean type\
+Lazy connection creation causes connections to backend servers to be opened only
+when they are needed. This reduces the load that is placed on the backend
+servers when the client connections are short. This parameter is a boolean type
 and is disabled by default.
 
-By default readwritesplit opens as many connections as it can when the session\
-is first opened. This makes the execution of the first query faster when all\
-available connections are already created. When `lazy_connect` is enabled, this\
-initial connection creation is skipped. If the client executes only read\
-queries, no connection to the master is made. If only write queries are made,\
+By default readwritesplit opens as many connections as it can when the session
+is first opened. This makes the execution of the first query faster when all
+available connections are already created. When `lazy_connect` is enabled, this
+initial connection creation is skipped. If the client executes only read
+queries, no connection to the master is made. If only write queries are made,
 only the master connection is used.
 
 #### `reuse_prepared_statements`
@@ -981,22 +981,22 @@ only the master connection is used.
 * Dynamic: Yes
 * Default: false
 
-Reuse identical prepared statements inside the same client connection. This is a\
-boolean parameter and is disabled by default. This feature only applies to\
+Reuse identical prepared statements inside the same client connection. This is a
+boolean parameter and is disabled by default. This feature only applies to
 binary protocol prepared statements.
 
-When this parameter is enabled and the connection prepares an identical prepared\
-statement multiple times, instead of preparing it on the server the existing\
-prepared statement handle is reused. This also means that whenever prepared\
+When this parameter is enabled and the connection prepares an identical prepared
+statement multiple times, instead of preparing it on the server the existing
+prepared statement handle is reused. This also means that whenever prepared
 statements are closed by the client, they will be left open by readwritesplit.
 
-Enabling this feature will increase memory usage of a session. The amount of\
-memory stored per prepared statement is proportional to the length of the\
+Enabling this feature will increase memory usage of a session. The amount of
+memory stored per prepared statement is proportional to the length of the
 prepared SQL statement and the number of parameters the statement has.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a readwritesplit service contains the\
+The `router_diagnostics` output for a readwritesplit service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -1017,48 +1017,48 @@ following fields.
 
 ### Server Ranks
 
-The general rule with server ranks is that primary servers will be used before\
-secondary servers. Readwritesplit is an exception to this rule. The following\
+The general rule with server ranks is that primary servers will be used before
+secondary servers. Readwritesplit is an exception to this rule. The following
 rules govern how readwritesplit behaves with servers that have different ranks.
 
-* Sessions will use the current master server as long as possible. This means\
-  that sessions with a secondary master will not use the primary master as long\
+* Sessions will use the current master server as long as possible. This means
+  that sessions with a secondary master will not use the primary master as long
   as the secondary master is available.
-* All slave connections will use the same rank as the master connection. Any\
+* All slave connections will use the same rank as the master connection. Any
   stale connections with a different rank than the master will be discarded.
-* If no master connection is available and `master_reconnection` is enabled, a\
-  connection to the best master is created. If the new master has a different\
-  priority than existing connections have, the connections with a different rank\
+* If no master connection is available and `master_reconnection` is enabled, a
+  connection to the best master is created. If the new master has a different
+  priority than existing connections have, the connections with a different rank
   will be discarded.
-* If open connections exist, these will be used for routing. This means that if\
-  the master is lost but the session still has slave servers with the same rank,\
+* If open connections exist, these will be used for routing. This means that if
+  the master is lost but the session still has slave servers with the same rank,
   they will remain in use.
 * If no open connections exist, the servers with the best rank will used.
 
 ### Routing hints
 
-The readwritesplit router supports routing hints. For a detailed guide on hint\
-syntax and functionality, please read [this](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-hint-syntax.md)\
+The readwritesplit router supports routing hints. For a detailed guide on hint
+syntax and functionality, please read [this](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-hint-syntax.md)
 document.
 
-**Note**: Routing hints will always have the highest priority when a routing\
-decision is made. This means that it is possible to cause inconsistencies in\
-the session state and the actual data in the database by adding routing hints\
-to DDL/DML statements which are then directed to slave servers. Only use routing\
+**Note**: Routing hints will always have the highest priority when a routing
+decision is made. This means that it is possible to cause inconsistencies in
+the session state and the actual data in the database by adding routing hints
+to DDL/DML statements which are then directed to slave servers. Only use routing
 hints when you are sure that they can cause no harm.
 
-An exception to this rule is `transaction_replay`: when it is enabled, all\
-routing hints inside transaction are ignored. This is done to prevent changes\
-done inside a re-playable transaction from affecting servers outside of the\
-transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed\
+An exception to this rule is `transaction_replay`: when it is enabled, all
+routing hints inside transaction are ignored. This is done to prevent changes
+done inside a re-playable transaction from affecting servers outside of the
+transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed
 routing hints to override the transaction logic.
 
 #### Known Limitations of Routing Hints
 
-* If a `SELECT` statement with a `maxscale route to slave` hint is received\
-  while autocommit is disabled, the query will be routed to a slave server. This\
-  causes some metadata locks to be acquired on the database in question which\
-  will block DDL statements on the server until either the connection is closed\
+* If a `SELECT` statement with a `maxscale route to slave` hint is received
+  while autocommit is disabled, the query will be routed to a slave server. This
+  causes some metadata locks to be acquired on the database in question which
+  will block DDL statements on the server until either the connection is closed
   or autocommit is enabled again.
 
 ### Module Commands
@@ -1067,11 +1067,11 @@ The readwritesplit router implements the following module commands.
 
 #### `reset-gtid`
 
-The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is\
-reverted to an earlier state and the GTIDs recorded in MaxScale are no longer\
+The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is
+reverted to an earlier state and the GTIDs recorded in MaxScale are no longer
 valid.
 
-The first and only argument to the command is the router name. For example, to\
+The first and only argument to the command is the router name. For example, to
 reset the GTID state of a readwritesplit named `My-RW-Router`, the following\
 MaxCtrl command should be used:
 
@@ -1085,12 +1085,12 @@ Examples of the readwritesplit router in use can be found in the [Tutorials](htt
 
 ### Readwritesplit routing decisions
 
-Here is a small explanation which shows what kinds of queries are routed to\
+Here is a small explanation which shows what kinds of queries are routed to
 which type of server.
 
 #### Routing to Master
 
-Routing to master is important for data consistency and because majority of\
+Routing to master is important for data consistency and because majority of
 writes are written to binlog and thus become replicated to slaves.
 
 The following operations are routed to master:
@@ -1111,34 +1111,34 @@ The following operations are routed to master:
 * `@@last_insert_id`
 * `@@identity`
 
-In addition to these, if the **readwritesplit** service is configured with the`max_slave_replication_lag` parameter, and if all slaves suffer from too much\
-replication lag, then statements will be routed to the _Master_. (There might be\
-other similar configuration parameters in the future which limit the number of\
+In addition to these, if the **readwritesplit** service is configured with the`max_slave_replication_lag` parameter, and if all slaves suffer from too much
+replication lag, then statements will be routed to the _Master_. (There might be
+other similar configuration parameters in the future which limit the number of
 statements that will be routed to slaves.)
 
 **Transaction Isolation Level Tracking**
 
-Use of the SERIALIZABLE transaction isolation level with readwritesplit is not\
+Use of the SERIALIZABLE transaction isolation level with readwritesplit is not
 recommended as it somewhat goes against the goals of load balancing.
 
-If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB\
-server, readwritesplit will track the transaction isolation level and lock the\
-session to the master when the isolation level is set to serializable. This\
-retains the correctness of the isolation level which can otherwise cause\
-problems. Once a session is locked to the master, it will not be unlocked. To\
+If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB
+server, readwritesplit will track the transaction isolation level and lock the
+session to the master when the isolation level is set to serializable. This
+retains the correctness of the isolation level which can otherwise cause
+problems. Once a session is locked to the master, it will not be unlocked. To
 reinstate the normal routing behavior, a new connection must be created.
 
-For example, if transaction isolation level tracking cannot be done and an\
-autocommit SELECT is routed to a slave, it no longer behaves in a serializable\
+For example, if transaction isolation level tracking cannot be done and an
+autocommit SELECT is routed to a slave, it no longer behaves in a serializable
 manner. This can also have an effect on the replication in the slave server.
 
 #### Routing to Slaves
 
-The ability to route some statements to slaves is important because it also\
-decreases the load targeted to master. Moreover, it is possible to have multiple\
+The ability to route some statements to slaves is important because it also
+decreases the load targeted to master. Moreover, it is possible to have multiple
 slaves to share the load in contrast to single master.
 
-Queries which can be routed to slaves must be auto committed and belong to one\
+Queries which can be routed to slaves must be auto committed and belong to one
 of the following group:
 
 * Read-only statements (i.e. `SELECT`) that only use read-only built-in functions
@@ -1149,10 +1149,10 @@ The list of supported built-in functions can be found [here](https://github.com/
 
 #### Routing to every session backend
 
-A third class of statements includes those which modify session data, such as\
-session system variables, user-defined variables, the default database, etc. We\
-call them session commands, and they must be replicated as they affect the\
-future results of read and write operations. They must be executed on all\
+A third class of statements includes those which modify session data, such as
+session system variables, user-defined variables, the default database, etc. We
+call them session commands, and they must be replicated as they affect the
+future results of read and write operations. They must be executed on all
 servers that could execute statements on behalf of this client.
 
 Session commands include for example:
@@ -1162,26 +1162,26 @@ Session commands include for example:
 * Binary protocol prepared statements
 * Other miscellaneous commands (COM\_QUIT, COM\_PING etc.)
 
-**NOTE**: if variable assignment is embedded in a write statement it is routed\
-to _Master_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be\
+**NOTE**: if variable assignment is embedded in a write statement it is routed
+to _Master_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be
 routed to _Master_ only.
 
-The router stores all of the executed session commands so that in case of a\
-slave failure, a replacement slave can be chosen and the session command history\
-can be repeated on that new slave. This means that the router stores each\
-executed session command for the duration of the session. Applications that use\
-long-running sessions might cause MariaDB MaxScale to consume a growing amount\
-of memory unless the sessions are closed. This can be solved by adjusting the\
+The router stores all of the executed session commands so that in case of a
+slave failure, a replacement slave can be chosen and the session command history
+can be repeated on that new slave. This means that the router stores each
+executed session command for the duration of the session. Applications that use
+long-running sessions might cause MariaDB MaxScale to consume a growing amount
+of memory unless the sessions are closed. This can be solved by adjusting the
 value of `max_sescmd_history`.
 
 #### Routing to previous target
 
-In the following cases, a query is routed to the same server where the previous\
-query was executed. If no previous target is found, the query is routed to the\
+In the following cases, a query is routed to the same server where the previous
+query was executed. If no previous target is found, the query is routed to the
 current master.
 
-* If a query uses the `FOUND_ROWS()` function, it will be routed to the server\
-  where the last query was executed. This is done with the assumption that a\
+* If a query uses the `FOUND_ROWS()` function, it will be routed to the server
+  where the last query was executed. This is done with the assumption that a
   query with `SQL_CALC_FOUND_ROWS` was previously executed.
 * COM\_STMT\_FETCH\_ROWS will always be routed to the same server where the\
   COM\_STMT\_EXECUTE was routed.
@@ -1196,59 +1196,59 @@ Read queries are routed to the master server in the following situations:
 
 #### Prepares Statement Limitations
 
-If a prepared statement targets a temporary table on the master, the slave\
-servers will fail to execute it. This will cause all slave connections to be\
+If a prepared statement targets a temporary table on the master, the slave
+servers will fail to execute it. This will cause all slave connections to be
 closed (MXS-1816).
 
 #### Transaction Replay Limitations
 
-If the results from the replacement server are not identical when the\
-transaction is replayed, the client connection is closed. This means that any\
-transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot\
+If the results from the replacement server are not identical when the
+transaction is replayed, the client connection is closed. This means that any
+transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot
 be replayed successfully but it will still be attempted.
 
-If a transaction reads data before updating it, the rows should be locked by\
-using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when\
+If a transaction reads data before updating it, the rows should be locked by
+using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when
 multiple transactions are being replayed that modify the same set of rows.
 
-If the connection to the server where the transaction is being executed is\
-lost when the final `COMMIT` is being executed, it is impossible to know\
-whether the transaction was successfully committed. This means that there\
-is a possibility for duplicate transaction execution which can result in\
-data duplication in certain cases. Data duplication can happen if the\
+If the connection to the server where the transaction is being executed is
+lost when the final `COMMIT` is being executed, it is impossible to know
+whether the transaction was successfully committed. This means that there
+is a possibility for duplicate transaction execution which can result in
+data duplication in certain cases. Data duplication can happen if the
 transaction consists of the following statement types:
 
 * INSERT of rows into a table that does not have an auto-increment primary key
 * A "blind update" of one or more rows e.g. `UPDATE t SET c = c + 1 WHERE id = 123`
 * A "blind delete" e.g. `DELETE FROM t LIMIT 100`
 
-This is not an exhaustive list and any operations that do not check the row\
+This is not an exhaustive list and any operations that do not check the row
 contents before performing the operation on them might face this problem.
 
-In all cases the problem of duplicate transaction execution can be avoided by\
-including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that\
-in the case that the transaction fails when it is being committed, the row is\
+In all cases the problem of duplicate transaction execution can be avoided by
+including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that
+in the case that the transaction fails when it is being committed, the row is
 only modified if it matches the expected contents.
 
-Similarly, a connection loss during `COMMIT` can also result in transaction\
-replay failure. This happens due to the same reason as duplicate transaction\
-execution but the retried transaction will not be committed. This can be\
-considered a success case as the transaction replay detected that the results of\
-the two transactions are different. In these cases readwritesplit will abort the\
+Similarly, a connection loss during `COMMIT` can also result in transaction
+replay failure. This happens due to the same reason as duplicate transaction
+execution but the retried transaction will not be committed. This can be
+considered a success case as the transaction replay detected that the results of
+the two transactions are different. In these cases readwritesplit will abort the
 transaction and close the client connection.
 
-Statements that result in an implicit commit do not reset the transaction when\
-transaction\_replay is enabled. This means that if the transaction is replayed,\
-the transaction will be committed twice due to the implicit commit being\
-present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the\
+Statements that result in an implicit commit do not reset the transaction when
+transaction\_replay is enabled. This means that if the transaction is replayed,
+the transaction will be committed twice due to the implicit commit being
+present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the
 transaction to be correctly reset.
 
-Any changes to the session state (e.g. autocommit state, SQL mode) done inside a\
-transaction will remain in effect even if the connection to the server where the\
-transaction is being executed fails. When readwritesplit creates a new\
-connection to a server to replay the transaction, it will first restore the\
-session state by executing all session commands that were executed. This means\
-that if the session state is changed mid-transaction in a way that affects the\
+Any changes to the session state (e.g. autocommit state, SQL mode) done inside a
+transaction will remain in effect even if the connection to the server where the
+transaction is being executed fails. When readwritesplit creates a new
+connection to a server to replay the transaction, it will first restore the
+session state by executing all session commands that were executed. This means
+that if the session state is changed mid-transaction in a way that affects the
 results, transaction replay will fail.
 
 The following partial transaction demonstrates the problem by using [SQL\_MODE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) inside a transaction.
@@ -1261,7 +1261,7 @@ SET SQL_MODE='ANSI_QUOTES'; -- A session command
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-If this transaction has to be replayed the actual SQL that gets executed is the\
+If this transaction has to be replayed the actual SQL that gets executed is the
 following.
 
 ```
@@ -1272,55 +1272,55 @@ SELECT "hello world";       -- Returns an error
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-First the session state is restored by executing all commands that changed the\
+First the session state is restored by executing all commands that changed the
 state after which the actual transaction is replayed. Due to the fact that the\
-SQL\_MODE was changed mid-transaction, one of the queries will now return an\
+SQL\_MODE was changed mid-transaction, one of the queries will now return an
 error instead of the result we expected leading to a transaction replay failure.
 
-In a service-to-service configuration (i.e. a service using another service in\
-its `targets` list ), if the topmost service starts a transaction, all\
-lower-level readwritesplit services will also behave as if a transaction is\
-open. If a connection to a backend database fails during this, it can result in\
-unnecessary transaction replays which in turn can end up with checksum\
-conflicts. The recommended approach is to not use any commands inside a\
+In a service-to-service configuration (i.e. a service using another service in
+its `targets` list ), if the topmost service starts a transaction, all
+lower-level readwritesplit services will also behave as if a transaction is
+open. If a connection to a backend database fails during this, it can result in
+unnecessary transaction replays which in turn can end up with checksum
+conflicts. The recommended approach is to not use any commands inside a
 transaction that would be routed to more than one node.
 
-If the connection to the server where a transaction is being executed is lost\
-while a `ROLLBACK` is being executed, readwritesplit will still attempt to\
-replay the transaction in the hopes that the real response can be delivered to\
-the client. However, this does mean that it is possible that a rolled back\
-transaction which gets replayed ends up with a conflict and is reported as a\
-replay failure when in reality a rolled back transaction could be safely\
+If the connection to the server where a transaction is being executed is lost
+while a `ROLLBACK` is being executed, readwritesplit will still attempt to
+replay the transaction in the hopes that the real response can be delivered to
+the client. However, this does mean that it is possible that a rolled back
+transaction which gets replayed ends up with a conflict and is reported as a
+replay failure when in reality a rolled back transaction could be safely
 ignored.
 
 #### Legacy Configuration
 
-In older versions of MaxScale, routers were configured via the _router\_options_\
+In older versions of MaxScale, routers were configured via the _router\_options_
 parameter. This functionality was deprecated in 2.2 and was removed in 2.3.
 
 #### JDBC Batched Statements
 
-Readwritesplit does not support pipelining of JDBC batched statements. This is\
-caused by the fact that readwritesplit executes the statements one at a time to\
+Readwritesplit does not support pipelining of JDBC batched statements. This is
+caused by the fact that readwritesplit executes the statements one at a time to
 track the state of the response.
 
 **Limitations in multi-statement handling**
 
-When a multi-statement query is executed through the readwritesplit router, it\
-will always be routed to the master. See [strict\_multi\_stmt](mariadb-maxscale-2208-readwritesplit.md#strict_multi_stmt) for more\
+When a multi-statement query is executed through the readwritesplit router, it
+will always be routed to the master. See [strict\_multi\_stmt](mariadb-maxscale-2208-readwritesplit.md#strict_multi_stmt) for more
 details.
 
-If the multi-statement query creates a temporary table, it will not be\
-detected and reads to this table can be routed to slave servers. To\
-prevent this, always execute the temporary table creation as an individual\
+If the multi-statement query creates a temporary table, it will not be
+detected and reads to this table can be routed to slave servers. To
+prevent this, always execute the temporary table creation as an individual
 statement.
 
 **Limitations in client session handling**
 
-Some of the queries that a client sends are routed to all backends instead of\
-just to one. These queries include `USE <db name>` and `SET autocommit=0`, among\
-many others. Readwritesplit sends a copy of these queries to each backend server\
-and forwards the master's reply to the client. Below is a list of MySQL commands\
+Some of the queries that a client sends are routed to all backends instead of
+just to one. These queries include `USE <db name>` and `SET autocommit=0`, among
+many others. Readwritesplit sends a copy of these queries to each backend server
+and forwards the master's reply to the client. Below is a list of MySQL commands
 which are classified as session commands.
 
 ```
@@ -1342,19 +1342,19 @@ SELECT ..INTO variable|OUTFILE|DUMPFILE
 SET autocommit=1|0
 ```
 
-Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were\
+Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were
 not supported and caused the session to be closed.
 
-There is a possibility for misbehavior. If `USE mytable` is executed in one of\
-the slaves and fails, it may be due to replication lag rather than the database\
-not existing. Thus, the same command may produce different result in different\
-backend servers. The slaves which fail to execute a session command will be\
-dropped from the active list of slaves for this session to guarantee a\
-consistent session state across all the servers used by the session. In\
-addition, the server will not be used again for routing for the duration of the\
+There is a possibility for misbehavior. If `USE mytable` is executed in one of
+the slaves and fails, it may be due to replication lag rather than the database
+not existing. Thus, the same command may produce different result in different
+backend servers. The slaves which fail to execute a session command will be
+dropped from the active list of slaves for this session to guarantee a
+consistent session state across all the servers used by the session. In
+addition, the server will not be used again for routing for the duration of the
 session.
 
-The above-mentioned behavior for user variables can be partially controlled with\
+The above-mentioned behavior for user variables can be partially controlled with
 the configuration parameter `use_sql_variables_in`:
 
 ```
@@ -1363,10 +1363,10 @@ use_sql_variables_in=[master|all] (default: all)
 
 **WARNING**
 
-If a SELECT query modifies a user variable when the `use_sql_variables_in`\
-parameter is set to `all`, it will not be routed and the client will receive an\
-error. A log message is written into the log further explaining the reason for\
-the error. Here is an example use of a SELECT query which modifies a user\
+If a SELECT query modifies a user variable when the `use_sql_variables_in`
+parameter is set to `all`, it will not be routed and the client will receive an
+error. A log message is written into the log further explaining the reason for
+the error. Here is an example use of a SELECT query which modifies a user
 variable and how MariaDB MaxScale responds to it.
 
 ```
@@ -1377,7 +1377,7 @@ MySQL [(none)]> SELECT @id := @id + 1 FROM test.t1;
 ERROR 1064 (42000): Routing query to backend failed. See the error log for further details.
 ```
 
-Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user\
+Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user
 variables to the master.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-schemarouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-schemarouter.md
@@ -4,16 +4,16 @@
 
 ## SchemaRouter
 
-The SchemaRouter provides an easy and manageable sharding solution by\
-building a single logical database server from multiple separate ones. Each\
-database is shown to the client and queries targeting unique databases are\
-routed to their respective servers. In addition to providing simple\
-database-based sharding, the schemarouter also enables cross-node\
-session variable usage by routing all queries that modify the session to all\
+The SchemaRouter provides an easy and manageable sharding solution by
+building a single logical database server from multiple separate ones. Each
+database is shown to the client and queries targeting unique databases are
+routed to their respective servers. In addition to providing simple
+database-based sharding, the schemarouter also enables cross-node
+session variable usage by routing all queries that modify the session to all
 nodes.
 
-By default the SchemaRouter assumes that each database and table is only located\
-on one server. If it finds the same database or table on multiple servers, it\
+By default the SchemaRouter assumes that each database and table is only located
+on one server. If it finds the same database or table on multiple servers, it
 will close the session with the following error:
 
 ```
@@ -22,14 +22,14 @@ ERROR 5000 (DUPDB): Error: duplicate tables found on two different shards.
 
 The exception to this rule are the system tables `mysql`, `information_schema`,`performance_schema`, `sys` that are never treated as duplicates.
 
-If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2208-schemarouter.md#ignore_tables_regex) parameter to controls which\
+If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2208-schemarouter.md#ignore_tables_regex) parameter to controls which
 duplicate tables are allowed. To disable the duplicate database detection, use`ignore_tables_regex=.*`.
 
-Schemarouter compares table and database names case-insensitively. This means\
+Schemarouter compares table and database names case-insensitively. This means
 that the tables `test.t1` and `test.T1` are assumed to refer to the same table.
 
-The main limitation of SchemaRouter is that aside from session variable writes\
-and some specific queries, a query can only target one server. This means that\
+The main limitation of SchemaRouter is that aside from session variable writes
+and some specific queries, a query can only target one server. This means that
 queries which depend on results from multiple servers give incorrect results.\
 See [Limitations](mariadb-maxscale-2208-schemarouter.md#limitations) for more information.
 
@@ -37,51 +37,51 @@ From 2.3.0 onwards, SchemaRouter is capable of limited table family sharding.
 
 ### Changes in Version 6
 
-* The `auth_all_servers` parameter is no longer automatically enabled by the\
-  schemarouter. To retain the old behavior that was present in 2.5, explicitly\
+* The `auth_all_servers` parameter is no longer automatically enabled by the
+  schemarouter. To retain the old behavior that was present in 2.5, explicitly
   define `auth_all_servers=true` for all schemarouter services.
 
 ### Routing Logic
 
-* If a command modifies the session state by modifying any session or user\
-  variables, the query is routed to all nodes. These statements include `SET`\
-  statements as well as any other statements that modify the behavior of the\
+* If a command modifies the session state by modifying any session or user
+  variables, the query is routed to all nodes. These statements include `SET`
+  statements as well as any other statements that modify the behavior of the
   client.
-* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers\
-  that contain the database. This same logic applies when a client connects with\
-  a default database: the default database is set only on servers that actually\
+* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers
+  that contain the database. This same logic applies when a client connects with
+  a default database: the default database is set only on servers that actually
   contain it.
-* If a query targets one or more tables that the schemarouter has discovered\
-  during the database mapping phase, the query is only routed if a server is\
-  found that contains all of the tables that the query uses. If no such server\
-  is found, the query is routed to the server that was previously used or to the\
-  first available backend if none have been used. If a query uses a table but\
-  doesn't define the database it is in, it is assumed to be located on the\
+* If a query targets one or more tables that the schemarouter has discovered
+  during the database mapping phase, the query is only routed if a server is
+  found that contains all of the tables that the query uses. If no such server
+  is found, the query is routed to the server that was previously used or to the
+  first available backend if none have been used. If a query uses a table but
+  doesn't define the database it is in, it is assumed to be located on the
   default database of the connection.
-* If a query targets a table or a database that is present on all nodes\
-  (e.g. `information_schema`) and the connection is using a default database,\
-  the query is routed based on the default database. This makes it possible to\
-  control where queries that do match a specific node are routed. If the\
-  connection is not using a default database, the query is routed based solely\
+* If a query targets a table or a database that is present on all nodes
+  (e.g. `information_schema`) and the connection is using a default database,
+  the query is routed based on the default database. This makes it possible to
+  control where queries that do match a specific node are routed. If the
+  connection is not using a default database, the query is routed based solely
   on the tables it contains.
-* If a query uses a table that is unknown to the schemarouter or executes a\
-  command that doesn't target a table, the query is routed to a server contains\
-  the current active default database. If the connection does not have a default\
-  database, the query is routed to the backend that was last used or to the\
-  first available backend if none have been used. If the query contains a\
+* If a query uses a table that is unknown to the schemarouter or executes a
+  command that doesn't target a table, the query is routed to a server contains
+  the current active default database. If the connection does not have a default
+  database, the query is routed to the backend that was last used or to the
+  first available backend if none have been used. If the query contains a
   routing hint that directs it to a server, the query is routed there.
 
-This means that all administrative commands, replication related command as\
-well as certain transaction control statements (XA transaction) are routed to\
-the first available server in certain cases. To avoid problems, use routing\
+This means that all administrative commands, replication related command as
+well as certain transaction control statements (XA transaction) are routed to
+the first available server in certain cases. To avoid problems, use routing
 hints to direct where these statements should go.
 
-* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`\
-  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the\
-  queries to the first available backend. This means that cross-shard\
-  transactions are technically possible but, without external synchronization,\
+* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`
+  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the
+  queries to the first available backend. This means that cross-shard
+  transactions are technically possible but, without external synchronization,
   the transactions are not guaranteed to be globally consistent.
-* `LOAD DATA LOCAL INFILE` commands are routed to the first available server\
+* `LOAD DATA LOCAL INFILE` commands are routed to the first available server
   that contains the tables listed in the query.
 
 #### Custom SQL Commands
@@ -98,24 +98,24 @@ db1.t2   |MyServer1    |
 db2.t1   |MyServer2    |
 ```
 
-The schemarouter will also intercept the `SHOW DATABASES` command and generate\
-it based on its internal data. This means that newly created databases will not\
-show up immediately and will only be visible when the cached data has been\
+The schemarouter will also intercept the `SHOW DATABASES` command and generate
+it based on its internal data. This means that newly created databases will not
+show up immediately and will only be visible when the cached data has been
 updated.
 
 #### Database Mapping
 
-The schemarouter maps each of the servers to know where each database and table\
-is located. As each user has access to a different set of tables and databases,\
-the result is unique to the username and the set of servers that the service\
-uses. These results are cached by the schemarouter. The lifetime of the cached\
+The schemarouter maps each of the servers to know where each database and table
+is located. As each user has access to a different set of tables and databases,
+the result is unique to the username and the set of servers that the service
+uses. These results are cached by the schemarouter. The lifetime of the cached
 result is controlled by the `refresh_interval` parameter.
 
-When a server needs to be mapped, the schemarouter will route a query to each of\
-the servers using the client's credentials. While this query is being executed,\
-all other sessions that would otherwise share the cached result will wait for\
-the update to complete. This waiting functionality was added in MaxScale 2.4.19,\
-older versions did not wait for existing updates to finish and would perform\
+When a server needs to be mapped, the schemarouter will route a query to each of
+the servers using the client's credentials. While this query is being executed,
+all other sessions that would otherwise share the cached result will wait for
+the update to complete. This waiting functionality was added in MaxScale 2.4.19,
+older versions did not wait for existing updates to finish and would perform
 parallel database mapping queries.
 
 ### Configuration
@@ -131,24 +131,24 @@ user=myuser
 password=mypwd
 ```
 
-The module generates the list of databases based on the servers parameter\
-using the connecting client's credentials. The user and password parameters\
-define the credentials that are used to fetch the authentication data from\
-the database servers. The credentials used only require the same grants as\
+The module generates the list of databases based on the servers parameter
+using the connecting client's credentials. The user and password parameters
+define the credentials that are used to fetch the authentication data from
+the database servers. The credentials used only require the same grants as
 mentioned in the configuration documentation.
 
-The list of databases is built by sending a SHOW DATABASES query to all the\
-servers. This requires the user to have at least USAGE and SELECT grants on\
+The list of databases is built by sending a SHOW DATABASES query to all the
+servers. This requires the user to have at least USAGE and SELECT grants on
 the databases that need be sharded.
 
-If you are connecting directly to a database or have different users on some\
-of the servers, you need to get the authentication data from all the\
-servers. You can control this with the `auth_all_servers` parameter. With\
-this parameter, MariaDB MaxScale forms a union of all the users and their\
-grants from all the servers. By default, the schemarouter will fetch the\
+If you are connecting directly to a database or have different users on some
+of the servers, you need to get the authentication data from all the
+servers. You can control this with the `auth_all_servers` parameter. With
+this parameter, MariaDB MaxScale forms a union of all the users and their
+grants from all the servers. By default, the schemarouter will fetch the
 authentication data from all servers.
 
-For example, if two servers have the database `shard` and the following\
+For example, if two servers have the database `shard` and the following
 rights are granted only on one server, all queries targeting the database`shard` would be routed to the server where the grants were given.
 
 ```
@@ -159,9 +159,9 @@ CREATE USER 'john'@'%' IDENTIFIED BY 'password';
 GRANT SELECT,USAGE ON shard.* TO 'john'@'%';
 ```
 
-This would in effect allow the user 'john' to only see the database 'shard'\
+This would in effect allow the user 'john' to only see the database 'shard'
 on this server. Take notice that these grants are matched against MariaDB\
-MaxScale's hostname instead of the client's hostname. Only user\
+MaxScale's hostname instead of the client's hostname. Only user
 authentication uses the client's hostname and all other grants use MariaDB\
 MaxScale's hostname.
 
@@ -174,7 +174,7 @@ MaxScale's hostname.
 * Dynamic: Yes
 * Default: `""`
 
-List of full table names (e.g. db1.t1) to ignore when checking for duplicate\
+List of full table names (e.g. db1.t1) to ignore when checking for duplicate
 tables. By default no tables are ignored.
 
 This parameter was once called `ignore_databases`.
@@ -186,11 +186,11 @@ This parameter was once called `ignore_databases`.
 * Dynamic: No
 * Default: `""`
 
-A [PCRE2 regular expression](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#regular-expressions)\
+A [PCRE2 regular expression](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#regular-expressions)
 that is matched against database names when checking for duplicate databases.\
 By default no tables are ignored.
 
-The following configuration ignores duplicate tables in the databases `db1` and `db2`,\
+The following configuration ignores duplicate tables in the databases `db1` and `db2`,
 and all tables starting with "t" in `db3`.
 
 ```
@@ -207,12 +207,12 @@ This parameter was once called `ignore_databases_regex`.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#max_sescmd_history)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#max_sescmd_history)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#disable_sescmd_history)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#disable_sescmd_history)
 in MaxScale 6.0.
 
 #### `refresh_databases`
@@ -222,11 +222,11 @@ in MaxScale 6.0.
 * Dynamic: No
 * Default: `false`
 
-Enable database map refreshing mid-session. These are triggered by a failure to\
+Enable database map refreshing mid-session. These are triggered by a failure to
 change the database i.e. `USE ...` queries. This feature is disabled by default.
 
-Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0\
-release of MaxScale this parameter now works again but it is disabled by default\
+Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0
+release of MaxScale this parameter now works again but it is disabled by default
 to retain the same behavior as in older releases.
 
 #### `refresh_interval`
@@ -236,26 +236,26 @@ to retain the same behavior as in older releases.
 * Dynamic: Yes
 * Default: `300s`
 
-The minimum interval between database map refreshes in seconds. The default\
+The minimum interval between database map refreshes in seconds. The default
 value is 300 seconds.
 
-The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 ### Table Family Sharding
 
 This functionality was introduced in 2.3.0.
 
-If the same database exists on multiple servers, but the database contains different\
-tables in each server, SchemaRouter is capable of routing queries to the right server,\
+If the same database exists on multiple servers, but the database contains different
+tables in each server, SchemaRouter is capable of routing queries to the right server,
 depending on which table is being addressed.
 
-As an example, suppose the database `db` exists on servers _server1_ and _server2_, but\
-that the database on _server1_ contains the table `tbl1` and on _server2_ contains the\
-table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table\
+As an example, suppose the database `db` exists on servers _server1_ and _server2_, but
+that the database on _server1_ contains the table `tbl1` and on _server2_ contains the
+table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table
 names must be qualified with the database names for table-level sharding to work.\
 Specifically, the query series below is not supported.
 
@@ -266,7 +266,7 @@ SELECT * FROM tbl1; // May be routed to an incorrect backend if using table shar
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a schemarouter service contains the\
+The `router_diagnostics` output for a schemarouter service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -281,46 +281,46 @@ following fields.
 
 ### Limitations
 
-* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the\
-  first explicit database in the query, the current database in use or to the first\
+* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the
+  first explicit database in the query, the current database in use or to the first
   available database, depending on which succeeds.
-* Without a default database, queries that do not use fully qualified table\
-  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will\
-  be routed to the first available server. This includes queries such as explicit\
-  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`\
-  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`\
-  statements that do not directly refer to a table. `CREATE` commands should be\
-  done directly on the node or the router should be equipped with the hint filter\
-  and a routing hint should be used. Queries that modify the session state\
-  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the\
-  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,\
-  otherwise routing hints are required to correctly route the transaction control\
-  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the\
-  routing of transaction control commands to route them to all servers used by the\
+* Without a default database, queries that do not use fully qualified table
+  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will
+  be routed to the first available server. This includes queries such as explicit
+  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`
+  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`
+  statements that do not directly refer to a table. `CREATE` commands should be
+  done directly on the node or the router should be equipped with the hint filter
+  and a routing hint should be used. Queries that modify the session state
+  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the
+  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,
+  otherwise routing hints are required to correctly route the transaction control
+  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the
+  routing of transaction control commands to route them to all servers used by the
   schemarouter.
-* SELECT queries that modify session variables are not supported because uniform results\
-  can not be guaranteed. If such a query is executed, the behavior of the router is\
+* SELECT queries that modify session variables are not supported because uniform results
+  can not be guaranteed. If such a query is executed, the behavior of the router is
   undefined. To work around this limitation, the query must be executed in separate parts.
-* If a query targets a database the SchemaRouter has not mapped to a server, the\
-  query will be routed to the first available server. This possibly returns an\
+* If a query targets a database the SchemaRouter has not mapped to a server, the
+  query will be routed to the first available server. This possibly returns an
   error about database rights instead of a missing database.
-* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the\
+* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the
   correct backend if the statement is known and only requires one backend server. EXECUTE\
-  IMMEDIATE is not supported and is routed to the first available backend and may give\
+  IMMEDIATE is not supported and is routed to the first available backend and may give
   wrong results. Similarly, preparing a statement from a variable (e.g. `PREPARE stmt FROM @a`) is not supported and may be routed wrong.
-* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only\
-  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are\
+* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only
+  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are
   ignored. Starting with MaxScale 22.08, the database names will always be in lowercase.
-* `SHOW TABLES` is routed to the server with the current database. If using\
-  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table\
+* `SHOW TABLES` is routed to the server with the current database. If using
+  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table
   sharding. Use `SHOW SHARDS` to get results from the router itself. Starting with\
   MaxScale 22.08, the database names will always be in lowercase.
-* `USE db1` is routed to the server with `db1`. If the database is divided to multiple\
+* `USE db1` is routed to the server with `db1`. If the database is divided to multiple
   servers, only one server will get the command.
 
 ### Examples
 
-[Here](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-simple-sharding-with-two-servers.md) is a small tutorial on how\
+[Here](../mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-simple-sharding-with-two-servers.md) is a small tutorial on how
 to set up a sharded database.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-smartrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-routers/mariadb-maxscale-2208-smartrouter.md
@@ -6,20 +6,20 @@
 
 ### Overview
 
-SmartRouter is the query router of the SmartQuery framework. Based on the type\
-of the query, each query is routed to the server or cluster that can best\
+SmartRouter is the query router of the SmartQuery framework. Based on the type
+of the query, each query is routed to the server or cluster that can best
 handle it.
 
 For workloads where both transactional and analytical queries are needed,\
-SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into\
-a single entry point in MaxScale. This allows a MaxScale client to freely mix\
-transactional and analytical queries using the same connection. This is known\
+SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into
+a single entry point in MaxScale. This allows a MaxScale client to freely mix
+transactional and analytical queries using the same connection. This is known
 as Hybrid Transactional and Analytical Processing, HTAP.
 
 ### Configuration
 
-SmartRouter is configured as a service that either routes to other MaxScale\
-routers or plain servers. Although one can configure SmartRouter to use a plain\
+SmartRouter is configured as a service that either routes to other MaxScale
+routers or plain servers. Although one can configure SmartRouter to use a plain
 server directly, we refer to the configured "servers" as clusters.
 
 For details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md).
@@ -30,10 +30,10 @@ For details about the standard service parameters, refer to the [Configuration G
 * Mandatory: Yes
 * Dynamic: No
 
-One of the clusters must be designated as the **`master`**. All writes go to the\
+One of the clusters must be designated as the **`master`**. All writes go to the
 master cluster, which for all practical purposes should be a master-slave\
-ReadWriteSplit. This document does not go into details about setting up\
-master-slave clusters, but suffice to say, that when setting up the ColumnStore\
+ReadWriteSplit. This document does not go into details about setting up
+master-slave clusters, but suffice to say, that when setting up the ColumnStore
 servers they should be configured to be slaves of a MariaDB server running an\
 InnoDB engine.\
 The ReadWriteSplit [documentation](mariadb-maxscale-2208-readwritesplit.md) has more on master-slave setup.
@@ -89,8 +89,8 @@ service = SmartQuery
 port = <port>
 ```
 
-Note that the SmartQuery listener listens on a port, while the Row and Column\
-service listeners listen on Unix domain sockets. The reason is that there is a\
+Note that the SmartQuery listener listens on a port, while the Row and Column
+service listeners listen on Unix domain sockets. The reason is that there is a
 significant performance benefit when SmartRouter accesses the services over a\
 Unix domain socket compared to accessing them over a TCP/IP socket.
 
@@ -98,31 +98,31 @@ A complete configuration example can be found at the end of this document.
 
 ### Cluster selection - how queries are routed
 
-SmartRouter keeps track of the performance, or the execution time, of queries to\
+SmartRouter keeps track of the performance, or the execution time, of queries to
 the clusters. Measurements are stored with the canonical of a query as the key.\
-The canonical of a query is the sql with all user-defined constants replaced with\
-question marks. When SmartRouter sees a read-query whose canonical has not been\
-seen before, it will send the query to all clusters. The first response from a\
-cluster will designate that cluster as the best one for that canonical. Also,\
-when the first response is received, the other queries are cancelled. The\
-response is sent to the client once all clusters have responded to the query\
+The canonical of a query is the sql with all user-defined constants replaced with
+question marks. When SmartRouter sees a read-query whose canonical has not been
+seen before, it will send the query to all clusters. The first response from a
+cluster will designate that cluster as the best one for that canonical. Also,
+when the first response is received, the other queries are cancelled. The
+response is sent to the client once all clusters have responded to the query
 or the cancel.
 
-There is obviously overhead when a new canonical is seen. This means that\
-queries after a MaxScale start will be slightly slower than normal. The\
-execution time of a query depends on the database engine, and on the contents\
-of the tables being queried. As a result, MaxScale will periodically re-measure\
+There is obviously overhead when a new canonical is seen. This means that
+queries after a MaxScale start will be slightly slower than normal. The
+execution time of a query depends on the database engine, and on the contents
+of the tables being queried. As a result, MaxScale will periodically re-measure
 queries.
 
-The performance behavior of queries under dynamic conditions, and their effect\
-on different storage engines is being studied at MariaDB. As we learn more, we\
+The performance behavior of queries under dynamic conditions, and their effect
+on different storage engines is being studied at MariaDB. As we learn more, we
 will be able to better categorize queries and move that knowledge into\
 SmartRouter.
 
 ### Limitations
 
 * `LOAD DATA LOCAL INFILE` is not supported.
-* The performance data is not persisted. The measurements will be performed\
+* The performance data is not persisted. The measurements will be performed
   anew after each startup.
 
 ### Complete configuration example

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-automatic-failover-with-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-automatic-failover-with-mariadb-monitor.md
@@ -4,24 +4,24 @@
 
 ## Automatic Failover With MariaDB Monitor
 
-The [MariaDB Monitor](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-mariadb-monitor.md) is not only capable\
-of monitoring the state of a MariaDB master-slave cluster but is also\
-capable of performing _failover_ and _switchover_. In addition, in some\
-circumstances it is capable of _rejoining_ a master that has gone down and\
+The [MariaDB Monitor](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-mariadb-monitor.md) is not only capable
+of monitoring the state of a MariaDB master-slave cluster but is also
+capable of performing _failover_ and _switchover_. In addition, in some
+circumstances it is capable of _rejoining_ a master that has gone down and
 later reappears.
 
-Note that the failover (and switchover and rejoin) functionality is only\
-supported in conjunction with GTID-based replication and initially only\
+Note that the failover (and switchover and rejoin) functionality is only
+supported in conjunction with GTID-based replication and initially only
 for simple topologies, that is, 1 master and several slaves.
 
-The failover, switchover and rejoin functionality are inherent parts of\
-the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin\
+The failover, switchover and rejoin functionality are inherent parts of
+the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin
 are enabled by default.
 
-The following examples have been written with the assumption that there\
-are four servers - `server1`, `server2`, `server3` and `server4` - of\
+The following examples have been written with the assumption that there
+are four servers - `server1`, `server2`, `server3` and `server4` - of
 which `server1` is the initial master and the other servers are slaves.\
-In addition there is a monitor called _TheMonitor_ that monitors those\
+In addition there is a monitor called _TheMonitor_ that monitors those
 servers.
 
 Somewhat simplified, the MaxScale configuration file would look like:
@@ -50,7 +50,7 @@ servers=server1,server2,server3,server4
 
 ## Manual Failover
 
-If everything is in order, the state of the cluster will look something\
+If everything is in order, the state of the cluster will look something
 like this:
 
 ```
@@ -68,7 +68,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If the master now for any reason goes down, then the cluster state will\
+If the master now for any reason goes down, then the cluster state will
 look like this:
 
 ```
@@ -88,7 +88,7 @@ $ maxctrl list servers
 
 Note that the status for `server1` is _Down_.
 
-Since failover is by default _not_ enabled, the failover mechanism must be\
+Since failover is by default _not_ enabled, the failover mechanism must be
 invoked manually:
 
 ```
@@ -103,11 +103,11 @@ There are quite a few arguments, so let's look at each one separately:
 * `failover` is the command we want to invoke, and
 * `TheMonitor` is the first and only argument to that command, the name of the monitor as specified in the configuration file.
 
-The MariaDB Monitor will now autonomously deduce which slave is the most\
-appropriate one to be promoted to master, promote it to master and modify\
+The MariaDB Monitor will now autonomously deduce which slave is the most
+appropriate one to be promoted to master, promote it to master and modify
 the other slaves accordingly.
 
-If we now check the cluster state we will see that one of the remaining\
+If we now check the cluster state we will see that one of the remaining
 slaves has been made into master.
 
 ```
@@ -125,7 +125,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, it will not be rejoined to the cluster, as\
+If `server1` now reappears, it will not be rejoined to the cluster, as
 shown by the following output:
 
 ```
@@ -143,15 +143,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Had `auto_rejoin=true` been specified in the monitor section, then an\
+Had `auto_rejoin=true` been specified in the monitor section, then an
 attempt to rejoin `server1` would have been made.
 
-In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a\
+In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a
 subsequent version a command to that effect will be provided.
 
 ## Automatic Failover
 
-To enable automatic failover, simply add `auto_failover=true` to the\
+To enable automatic failover, simply add `auto_failover=true` to the
 monitor section in the configuration file.
 
 ```
@@ -180,7 +180,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now goes down, failover will automatically be performed and\
+If `server1` now goes down, failover will automatically be performed and
 an existing slave promoted to new master.
 
 ```
@@ -198,12 +198,12 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴────────────────────────┘
 ```
 
-If you are continuously monitoring the server states, you may notice for a\
+If you are continuously monitoring the server states, you may notice for a
 brief period that the state of `server1` is _Down_ and the state of`server2` is still _Slave, Running_.
 
 ## Rejoin
 
-To enable automatic rejoin, simply add `auto_rejoin=true` to the\
+To enable automatic rejoin, simply add `auto_rejoin=true` to the
 monitor section in the configuration file.
 
 ```
@@ -215,7 +215,7 @@ auto_rejoin=true
 ...
 ```
 
-When automatic rejoin is enabled, the MariaDB Monitor will attempt to\
+When automatic rejoin is enabled, the MariaDB Monitor will attempt to
 rejoin a failed master as a slave, if it reappears.
 
 When everything is running fine, the cluster state looks like follows:
@@ -235,8 +235,8 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Assuming `auto_failover=true` has been specified in the configuration\
-file, when `server1` goes down for some reason, failover will be performed\
+Assuming `auto_failover=true` has been specified in the configuration
+file, when `server1` goes down for some reason, failover will be performed
 and we end up with the following cluster state:
 
 ```
@@ -254,15 +254,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, the MariaDB Monitor will detect that and\
+If `server1` now reappears, the MariaDB Monitor will detect that and
 attempt to rejoin the old master as a slave.
 
-Whether rejoining will succeed depends upon the actual state of the old\
-master. For instance, if the old master was modified and the changes had\
-not been replicated to the new master, before the old master went down,\
+Whether rejoining will succeed depends upon the actual state of the old
+master. For instance, if the old master was modified and the changes had
+not been replicated to the new master, before the old master went down,
 then automatic rejoin will not be possible.
 
-If rejoining can be performed, then the cluster state will end up looking\
+If rejoining can be performed, then the cluster state will end up looking
 like:
 
 ```
@@ -282,11 +282,11 @@ $ maxctrl list servers
 
 ## Switchover
 
-Switchover is for cases when you explicitly want to move the master\
+Switchover is for cases when you explicitly want to move the master
 role from one server to another.
 
-If we continue from the cluster state at the end of the previous example\
-and want to make `server1` master again, then we must issue the following\
+If we continue from the cluster state at the end of the previous example
+and want to make `server1` master again, then we must issue the following
 command:
 
 ```
@@ -303,7 +303,7 @@ There are quite a few arguments, so let's look at each one separately:
 * `server1` is the second argument to the command, the name of the server we want to make into _master_, and
 * `server2` is the third argument to the command, the name of the _current master_.
 
-If the command executes successfully, we will end up with the following\
+If the command executes successfully, we will end up with the following
 cluster state:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-avrorouter-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-avrorouter-tutorial.md
@@ -4,12 +4,12 @@
 
 ## Avrorouter Tutorial
 
-This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-avrorouter.md), how to set it up and how it interacts\
+This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-avrorouter.md), how to set it up and how it interacts
 with the binlogrouter.
 
-The first part configures the services and sets them up for the binary log to Avro\
-file conversion. The second part of this tutorial uses the client listener\
-interface for the avrorouter and shows how to communicate with the service\
+The first part configures the services and sets them up for the binary log to Avro
+file conversion. The second part of this tutorial uses the client listener
+interface for the avrorouter and shows how to communicate with the service
 over the network.
 
 ```mermaid
@@ -70,8 +70,8 @@ _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog
 
 ### Preparing the master server
 
-The master server where we will be replicating from needs to have binary logging\
-enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_\
+The master server where we will be replicating from needs to have binary logging
+enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_
 file of the master.
 
 ```
@@ -83,9 +83,9 @@ _You can find out more about replication formats from the_[_MariaDB documentatio
 
 ### Configuring MaxScale
 
-We start by adding two new services into the configuration file. The first\
-service is the binlogrouter service which will read the binary logs from the\
-master server. The second service will read the binlogs as they are streamed\
+We start by adding two new services into the configuration file. The first
+service is the binlogrouter service which will read the binary logs from the
+master server. The second service will read the binlogs as they are streamed
 from the master and convert them into Avro format files.
 
 ```
@@ -121,13 +121,13 @@ protocol=CDC
 port=4001
 ```
 
-The `source` parameter in the _avro-service_ points to the _replication-service_\
-we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog\
-number to start from. With these parameters, the avrorouter will start reading\
+The `source` parameter in the _avro-service_ points to the _replication-service_
+we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog
+number to start from. With these parameters, the avrorouter will start reading
 events from binlog `binlog.000015`.
 
-Note that the _filestem_ and _start\_index_ must point to the file that is the\
-first binlog that the binlogrouter will replicate. For example, if the first\
+Note that the _filestem_ and _start\_index_ must point to the file that is the
+first binlog that the binlogrouter will replicate. For example, if the first
 file you are replicating is `my-binlog-file.001234`, set the parameters to`filestem=my-binlog-file` and `start_index=1234`.
 
 For more information on the avrorouter options, read the [Avrorouter\
@@ -135,31 +135,31 @@ Documentation](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-avrorouter
 
 ## Preparing the data in the master server
 
-Before starting the MaxScale process, we need to make sure that the binary logs\
-of the master server contain the DDL statements that define the table\
-layouts. What this means is that the `CREATE TABLE` statements need to be in the\
+Before starting the MaxScale process, we need to make sure that the binary logs
+of the master server contain the DDL statements that define the table
+layouts. What this means is that the `CREATE TABLE` statements need to be in the
 binary logs before the conversion process is started.
 
-If the binary logs contain data modification events for tables that aren't\
-created in the binary logs, the Avro schema of the table needs to be manually\
+If the binary logs contain data modification events for tables that aren't
+created in the binary logs, the Avro schema of the table needs to be manually
 created. There are multiple ways to do this:
 
-* Dump the database to a slave, configure it to replicate from the master and\
-  point MaxScale to this slave (this is the recommended method as it requires no\
+* Dump the database to a slave, configure it to replicate from the master and
+  point MaxScale to this slave (this is the recommended method as it requires no
   extra steps)
-* Use the [cdc\_schema Go utility](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-avrorouter.md#avro-schema-generator)\
+* Use the [cdc\_schema Go utility](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-avrorouter.md#avro-schema-generator)
   and copy the generated .avsc files to the avrodir
-* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)\
+* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)
   and copy the generated .avsc files to the avrodir
 
-If you used the schema generator scripts, all Avro schema files for tables that\
-are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of\
+If you used the schema generator scripts, all Avro schema files for tables that
+are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of
 the _test.t1_ table would be `test.t1.0000001.avsc`.
 
 ## Starting MariaDB MaxScale
 
-The next step is to start MariaDB MaxScale and set up the binlogrouter. We do\
-that by connecting to the MySQL listener of the _replication\_router_ service and\
+The next step is to start MariaDB MaxScale and set up the binlogrouter. We do
+that by connecting to the MySQL listener of the _replication\_router_ service and
 executing a few commands.
 
 ```
@@ -173,22 +173,22 @@ CHANGE MASTER TO MASTER_HOST='172.18.0.1',
 START SLAVE;
 ```
 
-**NOTE:** GTID replication is not currently supported and file-and-position\
+**NOTE:** GTID replication is not currently supported and file-and-position
 replication must be used.
 
 This will start the replication of binary logs from the master server at\
-172.18.0.1 listening on port 3000. The first file that the binlogrouter\
-replicates is `binlog.000015`. This is the same file that was configured as the\
+172.18.0.1 listening on port 3000. The first file that the binlogrouter
+replicates is `binlog.000015`. This is the same file that was configured as the
 starting file in the avrorouter.
 
 For more details about the SQL commands, refer to the [Binlogrouter](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-binlogrouter.md) documentation.
 
-After the binary log streaming has started, the avrorouter will automatically\
+After the binary log streaming has started, the avrorouter will automatically
 start processing the binlogs.
 
 ## Creating and Processing Data
 
-Next, create a simple test table and populated it with some data by executing\
+Next, create a simple test table and populated it with some data by executing
 the following statements.
 
 ```
@@ -196,21 +196,21 @@ CREATE TABLE test.t1 (id INT);
 INSERT INTO test.t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 ```
 
-To use the _cdc.py_ command line client to connect to the CDC service, we must first\
+To use the _cdc.py_ command line client to connect to the CDC service, we must first
 create a user. This can be done via maxctrl by executing the following command.
 
 ```
 maxctrl call command cdc add_user avro-service maxuser maxpwd
 ```
 
-This will create the _maxuser:maxpwd_ credentials which can then be used to\
+This will create the _maxuser:maxpwd_ credentials which can then be used to
 request a JSON data stream of the `test.t1` table that was created earlier.
 
 ```
 cdc.py -u maxuser -p maxpwd -h 127.0.0.1 -P 4001 test.t1
 ```
 
-The output is a stream of JSON events describing the changes done to the\
+The output is a stream of JSON events describing the changes done to the
 database.
 
 ```
@@ -227,8 +227,8 @@ database.
 {"domain": 0, "server_id": 3000, "sequence": 11, "event_number": 10, "timestamp": 1537429419, "event_type": "insert", "id": 10}
 ```
 
-The first record is always the JSON format schema for the table describing the\
-types and names of the fields. All records that follow it represent the changes\
+The first record is always the JSON format schema for the table describing the
+types and names of the fields. All records that follow it represent the changes
 that have happened on the database.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-servers.md
@@ -4,7 +4,7 @@
 
 ## Configuring Servers
 
-The first step is to define the servers that make up the cluster. These servers\
+The first step is to define the servers that make up the cluster. These servers
 will be used by the services and are monitored by the monitor.
 
 ```
@@ -28,10 +28,10 @@ The `address` and `port` parameters tell where the server is located.
 
 ### Enabling TLS
 
-To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`\
+To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`
 to the server section. To enable server certificate verification, add`ssl_verify_peer_certificate=true`.
 
-The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line\
+The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line
 client.
 
 For more information about TLS, refer to the [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-the-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-the-galera-monitor.md
@@ -20,19 +20,19 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
-This monitor module will assign one node within the Galera Cluster as the\
-current master and other nodes as slave. Only those nodes that are active\
-members of the cluster are considered when making the choice of master node. The\
+This monitor module will assign one node within the Galera Cluster as the
+current master and other nodes as slave. Only those nodes that are active
+members of the cluster are considered when making the choice of master node. The
 master node will be the node with the lowest value of `wsrep_local_index`.
 
 ### Monitor User
 
-The monitor user does not require any special grants to monitor a Galera\
+The monitor user does not require any special grants to monitor a Galera
 cluster. To create a user for the monitor, execute the following SQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-the-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-the-mariadb-monitor.md
@@ -4,7 +4,7 @@
 
 ## Configuring the MariaDB Monitor
 
-This document describes how to configure a MariaDB master-slave cluster monitor\
+This document describes how to configure a MariaDB master-slave cluster monitor
 to be used with MaxScale.
 
 ### Configuring the Monitor
@@ -21,14 +21,14 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
 ### Monitor User
 
-The monitor user requires the REPLICATION CLIENT privileges to do basic\
+The monitor user requires the REPLICATION CLIENT privileges to do basic
 monitoring. To create a user with the proper grants, execute the following SQL.
 
 ```
@@ -36,7 +36,7 @@ CREATE USER 'monitor_user'@'%' IDENTIFIED BY 'my_password';
 GRANT REPLICATION CLIENT ON *.* TO 'monitor_user'@'%';
 ```
 
-**Note:** If the automatic failover of the MariaDB Monitor will used, the user\
+**Note:** If the automatic failover of the MariaDB Monitor will used, the user
 will require additional grants. Execute the following SQL to grant them.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-the-xpand-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-the-xpand-monitor.md
@@ -4,19 +4,19 @@
 
 ## Configuring the Xpand Monitor
 
-This document describes how to configure the Xpand monitor for use\
+This document describes how to configure the Xpand monitor for use
 with a Xpand cluster.
 
 ### Configuring the Monitor
 
-Contrary to the other monitors of MaxScale, the Xpand monitor will\
-autonomously figure out the cluster configuration and for each Xpand\
+Contrary to the other monitors of MaxScale, the Xpand monitor will
+autonomously figure out the cluster configuration and for each Xpand
 node create the corresponding MaxScale server object.
 
-In order to do that, a _sufficient_ number of "bootstrap" server instances\
-must be specified in the MaxScale configuration file for the Xpand\
-monitor to start with. One server instance is in principle sufficient, but\
-if the corresponding node happens to be down when MaxScale starts, the\
+In order to do that, a _sufficient_ number of "bootstrap" server instances
+must be specified in the MaxScale configuration file for the Xpand
+monitor to start with. One server instance is in principle sufficient, but
+if the corresponding node happens to be down when MaxScale starts, the
 monitor will not be able to function.
 
 ```
@@ -33,8 +33,8 @@ port=3306
 protocol=mariadbbackend
 ```
 
-The server configuration is identical with that of any other server, but since\
-these servers are _only_ used for bootstrapping the Xpand monitor it is\
+The server configuration is identical with that of any other server, but since
+these servers are _only_ used for bootstrapping the Xpand monitor it is
 adviceable to use names that clearly will identify them as such.
 
 The actual Xpand monitor configuration looks as follows:
@@ -50,20 +50,20 @@ monitor_interval=2s
 cluster_monitor_interval=60s
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to use for bootstrapping and the username and password to use\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to use for bootstrapping and the username and password to use
 when connecting to the servers.
 
-The `monitor_interval` parameter specifies how frequently the monitor should\
-ping the health check port of each server and the `cluster_monitor_interval`\
-specifies how frequently the monitor should do a complete cluster check, that\
-is, access the `system` tables of the Cluster for checking the Cluster\
-configuration. The default values are `2000` and `60000`, that is, 2 seconds\
+The `monitor_interval` parameter specifies how frequently the monitor should
+ping the health check port of each server and the `cluster_monitor_interval`
+specifies how frequently the monitor should do a complete cluster check, that
+is, access the `system` tables of the Cluster for checking the Cluster
+configuration. The default values are `2000` and `60000`, that is, 2 seconds
 and 1 minute, respectively.
 
-For each detected Xpand node a corresponding MaxScale server object will be\
-created, whose name is `@@<Monitor-Name>:node-<id>, where _Monitor-Name_ is the name of the monitor, in this example`Xpand\` and _id_ is the node id\
-of the Xpand node. So, with a cluster of three nodes, the created servers\
+For each detected Xpand node a corresponding MaxScale server object will be
+created, whose name is `@@<Monitor-Name>:node-<id>, where _Monitor-Name_ is the name of the monitor, in this example`Xpand\` and _id_ is the node id
+of the Xpand node. So, with a cluster of three nodes, the created servers
 might be named like.
 
 ```
@@ -72,9 +72,9 @@ might be named like.
 @@Xpand:node-7`
 ```
 
-Note that as these are created at runtime and may disappear at any moment,\
-depending on changes happening in and made to the Xpand cluster, they\
-should never be referred to directly from service configurations. Instead,\
+Note that as these are created at runtime and may disappear at any moment,
+depending on changes happening in and made to the Xpand cluster, they
+should never be referred to directly from service configurations. Instead,
 services should refer to the monitor, as shown in the following:
 
 ```
@@ -86,9 +86,9 @@ password=service_password
 cluster=Xpand
 ```
 
-Instead of listing the servers of the service explicitly using the `servers`\
-parameter as usually is the case, the service refers to the Xpand monitor\
-using the `cluster` parameter. This will cause the service to use the Xpand\
+Instead of listing the servers of the service explicitly using the `servers`
+parameter as usually is the case, the service refers to the Xpand monitor
+using the `cluster` parameter. This will cause the service to use the Xpand
 nodes that the Xpand monitor discovers at runtime.
 
 For additional details, please consult the monitor [documentation](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-xpand-monitor.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-connection-routing-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-connection-routing-with-mariadb-maxscale.md
@@ -4,8 +4,8 @@
 
 ## Connection Routing with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that has two ports available, one for\
-write connections and another for read connections. The read connections are load-\
+The goal of this tutorial is to configure a system that has two ports available, one for
+write connections and another for read connections. The read connections are load-
 balanced across slave servers.
 
 ### Setting up MariaDB MaxScale
@@ -15,11 +15,11 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring services
 
-We want two services and ports to which the client application can connect. One service\
-routes client connections to the master server, the other load balances between slave\
+We want two services and ports to which the client application can connect. One service
+routes client connections to the master server, the other load balances between slave
 servers. To achieve this, we need to define two services in the configuration file.
 
-Create the following two sections in your configuration file. The section names are the\
+Create the following two sections in your configuration file. The section names are the
 names of the services and should be meaningful. For this tutorial, we use the names_Write-Service_ and _Read-Service_.
 
 ```
@@ -40,18 +40,18 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readconnroute_ for\
+_router_ defines the routing module used. Here we use _readconnroute_ for
 connection-level routing.
 
-A service needs a list of servers to route queries to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers to route queries to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _router\_options_-parameter tells the _readconnroute_-module which servers it should\
-route a client connection to. For the write service we use the _master_-type and for the\
+The _router\_options_-parameter tells the _readconnroute_-module which servers it should
+route a client connection to. For the write service we use the _master_-type and for the
 read service the _slave_-type.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2208-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2208-encrypting-passwords.md).
@@ -59,7 +59,7 @@ For increased security, see [password encryption](mariadb-maxscale-2208-encrypti
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one per service is enough.
 
 ```
@@ -74,13 +74,13 @@ service=Read-Service
 port=3307
 ```
 
-The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set\
+The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set
 it to _Read-Service_.
 
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-encrypting-passwords.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-encrypting-passwords.md
@@ -4,24 +4,24 @@
 
 ## Encrypting Passwords
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
-There are two options for representing the password, either plain text or\
-encrypted passwords may be used. In order to use encrypted passwords a set of\
-keys must be generated that will be used by the encryption and decryption\
+There are two options for representing the password, either plain text or
+encrypted passwords may be used. In order to use encrypted passwords a set of
+keys must be generated that will be used by the encryption and decryption
 process. To generate the keys, use the `maxkeys` command.
 
 ```
 maxkeys
 ```
 
-By default the key file will be generated in `/var/lib/maxscale`. If a different\
-directory is required, it can be given as the first argument to the program. For\
+By default the key file will be generated in `/var/lib/maxscale`. If a different
+directory is required, it can be given as the first argument to the program. For
 more information, see `maxkeys --help`.
 
-Once the keys have been created the `maxpasswd` command can be used to generate\
+Once the keys have been created the `maxpasswd` command can be used to generate
 the encrypted password.
 
 ```
@@ -29,10 +29,10 @@ maxpasswd plainpassword
 96F99AA1315BDC3604B006F427DD9484
 ```
 
-The username and password, either encrypted or plain text, are stored in the\
+The username and password, either encrypted or plain text, are stored in the
 service section using the `user` and `password` parameters.
 
-If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For\
+If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For
 more information, see `maxkeys --help`.
 
 Here is an example configuration that uses an encrypted password.
@@ -47,7 +47,7 @@ user=maxscale
 password=96F99AA1315BDC3604B006F427DD9484
 ```
 
-If the key file is not in the default location, the [datadir](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#datadir) parameter must be\
+If the key file is not in the default location, the [datadir](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#datadir) parameter must be
 set to the directory that contains it.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-mariadb-maxscale-administration-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-mariadb-maxscale-administration-tutorial.md
@@ -4,32 +4,32 @@
 
 ## MariaDB MaxScale Administration Tutorial
 
-The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator\
-to a few of the common administration tasks. This is intended to be an\
-introduction for administrators who are new to MariaDB MaxScale and not a\
+The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator
+to a few of the common administration tasks. This is intended to be an
+introduction for administrators who are new to MariaDB MaxScale and not a
 reference to all the tasks that may be performed.
 
 ### Starting and Stopping MariaDB MaxScale
 
-MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,\
+MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,
 use `systemctl start maxscale`. To stop it, use `systemctl stop maxscale`.
 
 The systemd service file for MaxScale is located in`/lib/systemd/system/maxscale.service`.
 
 #### Additional Options for MaxScale
 
-Additional command line options and other systemd configuration options\
-can be given to MariaDB MaxScale by creating a drop-in file for the\
-service unit file. You can do this with the `systemctl edit maxscale.service`\
-command. For more information about systemd drop-in\
-files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)\
+Additional command line options and other systemd configuration options
+can be given to MariaDB MaxScale by creating a drop-in file for the
+service unit file. You can do this with the `systemctl edit maxscale.service`
+command. For more information about systemd drop-in
+files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)
 and [the systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html).
 
 ### Checking The Status Of The MariaDB MaxScale Services
 
-It is possible to use the maxctrl command to obtain statistics about the\
-services that are running within MaxScale. The maxctrl command `list services`\
-will give very basic information regarding services. This command may be either\
+It is possible to use the maxctrl command to obtain statistics about the
+services that are running within MaxScale. The maxctrl command `list services`
+will give very basic information regarding services. This command may be either
 run in interactive mode or passed on the maxctrl command line.
 
 ```
@@ -49,16 +49,16 @@ $ maxctrl list services
 └────────────────────────┴────────────────┴─────────────┴───────────────────┴────────────────────────────────────┘
 ```
 
-Network listeners count as a user of the service, therefore there will always be\
-one user per network port in which the service listens. More details can be\
+Network listeners count as a user of the service, therefore there will always be
+one user per network port in which the service listens. More details can be
 obtained by using the "show service" command.
 
 ### What Clients Are Connected To MariaDB MaxScale
 
-To determine what client are currently connected to MariaDB MaxScale, you can\
-use the `list sessions` command within maxctrl. This will give you IP address\
-and the ID of the session for that connection. As with any maxctrl\
-command this can be passed on the command line or typed interactively in\
+To determine what client are currently connected to MariaDB MaxScale, you can
+use the `list sessions` command within maxctrl. This will give you IP address
+and the ID of the session for that connection. As with any maxctrl
+command this can be passed on the command line or typed interactively in
 maxctrl.
 
 ```
@@ -73,28 +73,28 @@ $ maxctrl list sessions
 ### Rotating the Log File
 
 MariaDB MaxScale logs messages of different priority into a single log file.\
-With the exception if error messages that are always logged, whether messages of\
-a particular priority should be logged or not can be enabled via the maxctrl\
-interface or in the configuration file. By default, MaxScale keeps on writing to\
-the same log file. To prevent the file from growing indefinitely, the\
+With the exception if error messages that are always logged, whether messages of
+a particular priority should be logged or not can be enabled via the maxctrl
+interface or in the configuration file. By default, MaxScale keeps on writing to
+the same log file. To prevent the file from growing indefinitely, the
 administrator must take action.
 
-The name of the log file is maxscale.log. When the log is rotated, MaxScale\
+The name of the log file is maxscale.log. When the log is rotated, MaxScale
 closes the current log file and opens a new one using the same name.
 
-Log file rotation is achieved by use of the `rotate logs` command\
+Log file rotation is achieved by use of the `rotate logs` command
 in maxctrl.
 
 ```
 maxctrl rotate logs
 ```
 
-As there currently is only the maxscale log, that is the only one that will be\
+As there currently is only the maxscale log, that is the only one that will be
 rotated.
 
-This may be integrated into the Linux _logrotate_ mechanism by adding a\
-configuration file to the /etc/logrotate.d directory. If we assume we want to\
-rotate the log files once per month and wish to keep 5 log files worth of\
+This may be integrated into the Linux _logrotate_ mechanism by adding a
+configuration file to the /etc/logrotate.d directory. If we assume we want to
+rotate the log files once per month and wish to keep 5 log files worth of
 history, the configuration file would look as follows.
 
 ```
@@ -113,7 +113,7 @@ endscript
 }
 ```
 
-MariaDB MaxScale will also rotate all of its log files if it receives the USR1\
+MariaDB MaxScale will also rotate all of its log files if it receives the USR1
 signal. Using this the logrotate configuration script can be rewritten as
 
 ```
@@ -129,41 +129,41 @@ endscript
 }
 ```
 
-In older versions MaxScale renamed the log file, behavior which is not fully\
-compliant with the assumptions of logrotate and may lead to issues, depending on\
-the used logrotate configuration file. From version 2.1 onward, MaxScale will\
-not itself rename the log file, but when the log is rotated, MaxScale will\
-simply close and reopen the same log file. That will make the behavior fully\
+In older versions MaxScale renamed the log file, behavior which is not fully
+compliant with the assumptions of logrotate and may lead to issues, depending on
+the used logrotate configuration file. From version 2.1 onward, MaxScale will
+not itself rename the log file, but when the log is rotated, MaxScale will
+simply close and reopen the same log file. That will make the behavior fully
 compliant with logrotate.
 
 ### Taking Objects Temporarily Out of Use
 
 #### Putting Servers into Maintenance
 
-MariaDB MaxScale supports the concept of maintenance mode for servers within a\
-cluster. This allows for planned, temporary removal of a database from the\
+MariaDB MaxScale supports the concept of maintenance mode for servers within a
+cluster. This allows for planned, temporary removal of a database from the
 cluster without the need to change the MariaDB MaxScale configuration.
 
 ```
 maxctrl set server db-server-3 maintenance
 ```
 
-To achieve this, you can use the `set server` command in maxctrl to set the\
-maintenance mode flag for the server. This may be done interactively within\
+To achieve this, you can use the `set server` command in maxctrl to set the
+maintenance mode flag for the server. This may be done interactively within
 maxctrl or by passing the command on the command line.
 
-This will cause MariaDB MaxScale to stop routing any new requests to the server,\
-however if there are currently requests executing on the server these will not\
-be interrupted. Connections to servers in maintenance mode are closed as soon as\
-the next request arrives. To close them immediately, use the `--force` option\
+This will cause MariaDB MaxScale to stop routing any new requests to the server,
+however if there are currently requests executing on the server these will not
+be interrupted. Connections to servers in maintenance mode are closed as soon as
+the next request arrives. To close them immediately, use the `--force` option
 for `maxctrl set server`.
 
 ```
 maxctrl clear server db-server-3 maintenance
 ```
 
-Clearing the maintenance mode for a server will bring it back into use. If\
-multiple MariaDB MaxScale instances are configured to use the node then\
+Clearing the maintenance mode for a server will bring it back into use. If
+multiple MariaDB MaxScale instances are configured to use the node then
 maintenance mode must be set within each MariaDB MaxScale instance.
 
 ### Stopping and Starting Services
@@ -172,16 +172,16 @@ maintenance mode must be set within each MariaDB MaxScale instance.
 maxctrl stop service db-service
 ```
 
-Services can be stopped to temporarily halt their use. Stopping a service will\
-cause it to stop accepting new connections until it is started. New connections\
-are not refused if the service is stopped and are queued instead. This means\
+Services can be stopped to temporarily halt their use. Stopping a service will
+cause it to stop accepting new connections until it is started. New connections
+are not refused if the service is stopped and are queued instead. This means
 that connecting clients will wait until the service is started again.
 
 ```
 maxctrl start service db-service
 ```
 
-Starting a service will cause it to accept all queued connections that were\
+Starting a service will cause it to accept all queued connections that were
 created while it was stopped.
 
 #### Stopping and Starting Monitors
@@ -190,35 +190,35 @@ created while it was stopped.
 maxctrl stop monitor db-monitor
 ```
 
-Stopping a monitor will cause it to stop monitoring the state of the servers\
-assigned to it. This is useful when the state of the servers is assigned\
+Stopping a monitor will cause it to stop monitoring the state of the servers
+assigned to it. This is useful when the state of the servers is assigned
 manually with `maxctrl set server`.
 
 ```
 maxctrl start monitor db-monitor
 ```
 
-Starting a monitor will make it resume monitoring of the servers. Any manually\
+Starting a monitor will make it resume monitoring of the servers. Any manually
 assigned states will be overwritten by the monitor.
 
 ### Runtime Configuration Modification
 
-The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,\
+The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,
 modify or destroy objects (servers, services, monitors etc.) inside\
-MaxScale. The exact syntax for each of the commands and any additional options\
+MaxScale. The exact syntax for each of the commands and any additional options
 that they take can be seen with `maxctrl --help <command>`.
 
-Not all parameters can be modified at runtime. Refer to the module documentation\
-for more information on which parameters can be modified at runtime. If a\
-parameter cannot be modified at runtime, the object can be destroyed and\
+Not all parameters can be modified at runtime. Refer to the module documentation
+for more information on which parameters can be modified at runtime. If a
+parameter cannot be modified at runtime, the object can be destroyed and
 recreated in order to change it.
 
-All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime\
-persist through restarts. Any changes done to objects in the main configuration\
+All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime
+persist through restarts. Any changes done to objects in the main configuration
 file are ignored if a persisted entry is found for it.
 
-For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete\
-configuration for the object. To remove all runtime changes for all objects,\
+For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete
+configuration for the object. To remove all runtime changes for all objects,
 remove all files found in `/var/lib/maxscale/maxscale.cnf.d`.
 
 #### Core Parameter Configuration
@@ -229,7 +229,7 @@ Modify global MaxScale parameters:
 maxctrl alter maxscale auth_connect_timeout 5s
 ```
 
-Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) for a full list\
+Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) for a full list
 of parameters that can be modified at runtime.
 
 #### Managing Servers
@@ -252,8 +252,8 @@ maxctrl alter server db-server-1 port 3307
 maxctrl destroy server db-server-1
 ```
 
-A server can only be destroyed if it is not used by any services or monitors. To\
-automatically remove the server from the services and monitors that use it, use\
+A server can only be destroyed if it is not used by any services or monitors. To
+automatically remove the server from the services and monitors that use it, use
 the `--force` flag.
 
 **Drain a Server**
@@ -262,9 +262,9 @@ the `--force` flag.
 maxctrl set server db-server-1 drain
 ```
 
-When a server is set into the `drain` state, no new connections to it are\
-created. Unlike to the `maintenance` state which immediately stops all new\
-requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them\
+When a server is set into the `drain` state, no new connections to it are
+created. Unlike to the `maintenance` state which immediately stops all new
+requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them
 in order to be gracefully closed once the client disconnects.
 
 To remove the `drain` state, use `clear server` command:
@@ -273,7 +273,7 @@ To remove the `drain` state, use `clear server` command:
 maxctrl clear server db-server-1 drain
 ```
 
-Servers with the `Master` state cannot be drained. To drain them, first perform\
+Servers with the `Master` state cannot be drained. To drain them, first perform
 a switchover to another node and then drain the server.
 
 #### Managing Monitors
@@ -308,7 +308,7 @@ maxctrl unlink monitor db-monitor db-server-1
 maxctrl destroy monitor db-monitor
 ```
 
-A monitor can only be destroyed if it is not monitoring any servers. To\
+A monitor can only be destroyed if it is not monitoring any servers. To
 automatically remove the servers from the monitor, use the `--force` flag.
 
 #### Managing Services
@@ -331,7 +331,7 @@ maxctrl alter service db-service user new-db-user
 maxctrl link service db-service db-server1
 ```
 
-Any servers added to services will only be used by new sessions. Existing\
+Any servers added to services will only be used by new sessions. Existing
 sessions will use the servers that were available when they connected.
 
 **Remove Servers from a Service**
@@ -340,8 +340,8 @@ sessions will use the servers that were available when they connected.
 maxctrl unlink service db-service db-server1
 ```
 
-Similarly to adding servers, removing servers from a service will only affect\
-new sessions. Existing sessions keep using the servers even if they are removed\
+Similarly to adding servers, removing servers from a service will only affect
+new sessions. Existing sessions keep using the servers even if they are removed
 from a service.
 
 **Change the Filters of a Service**
@@ -350,9 +350,9 @@ from a service.
 maxctrl alter service-filters my-regexfilter my-qlafilter
 ```
 
-The order of the filters is significant: the first filter will be the first to\
-receive the query. The new set of filters will only be used by new\
-sessions. Existing sessions will keep using the filters that were configured\
+The order of the filters is significant: the first filter will be the first to
+receive the query. The new set of filters will only be used by new
+sessions. Existing sessions will keep using the filters that were configured
 when they connected.
 
 **Destroy a Service**
@@ -361,9 +361,9 @@ when they connected.
 maxctrl destroy service db-service
 ```
 
-The service can only be destroyed if it uses no servers or clusters and has no\
-listeners associated with it. To force destruction of a service even if it does\
-use servers or has listeners, use the `--force` flag. This will also destroy any\
+The service can only be destroyed if it uses no servers or clusters and has no
+listeners associated with it. To force destruction of a service even if it does
+use servers or has listeners, use the `--force` flag. This will also destroy any
 listeners associated with the service.
 
 #### Managing Filters
@@ -380,11 +380,11 @@ maxctrl create filter regexfilter match=ENGINE=MyISAM replace=ENGINE=InnoDB
 maxctrl destroy filter my-regexfilter
 ```
 
-A filter can only be destroyed if it is not used by any services. To\
-automatically remove the filter from all services using it, use the `--force`\
+A filter can only be destroyed if it is not used by any services. To
+automatically remove the filter from all services using it, use the `--force`
 flag.
 
-Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters\
+Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters
 of a filter, destroy it and recreate it with the modified parameters.
 
 #### Managing Listeners
@@ -401,16 +401,16 @@ maxctrl create listener db-listener db-service 4006
 maxctrl destroy listener db-listener
 ```
 
-Destroying a listener will close the network socket and stop it from accepting\
-new connections. Existing connections that were created through it will keep\
+Destroying a listener will close the network socket and stop it from accepting
+new connections. Existing connections that were created through it will keep
 displaying it as the originating listener.
 
-Listeners cannot be moved from one service to another. In order to do this, the\
+Listeners cannot be moved from one service to another. In order to do this, the
 listener must be destroyed and then recreated with the new service.
 
 ### Managing MaxCtrl and REST API Users
 
-MaxCtrl uses the same credentials as the MaxScale REST API. These users can be\
+MaxCtrl uses the same credentials as the MaxScale REST API. These users can be
 managed via MaxCtrl.
 
 #### Create a New MaxCtrl User
@@ -419,14 +419,14 @@ managed via MaxCtrl.
 maxctrl create user basic-user basic-password
 ```
 
-By default new users are only allowed to read data. To make the account an\
+By default new users are only allowed to read data. To make the account an
 administrative account, add the `--type=admin` option to the command:
 
 ```
 maxctrl create user admin-user admin-password --type=admin
 ```
 
-Administrative accounts are allowed to use all MaxCtrl commands and modify any\
+Administrative accounts are allowed to use all MaxCtrl commands and modify any
 parts of MaxScale.
 
 #### Change the Password of an Existing User

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-maxscale-and-xpand-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-maxscale-and-xpand-tutorial.md
@@ -4,25 +4,25 @@
 
 ## MaxScale and Xpand Tutorial
 
-Since version 2.4, MaxScale has built-in support for Xpand. This\
-tutorial explains how to setup MaxScale in front of a Xpand\
+Since version 2.4, MaxScale has built-in support for Xpand. This
+tutorial explains how to setup MaxScale in front of a Xpand
 cluster.
 
-There is no Xpand specific router, but both the [readconnroute](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readconnroute.md) and\
-the [readwritesplit](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md) routers can be\
+There is no Xpand specific router, but both the [readconnroute](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readconnroute.md) and
+the [readwritesplit](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md) routers can be
 used.
 
 ### Xpand and Readconnroute
 
-With _readconnroute_ you get simple connection based routing, where\
-each new connection is created (by default) to the Xpand node with\
-the least amount of existing connections. That is, with readconnroute\
-the behaviour will be very similar to the behaviour when [HAProxy](https://www.haproxy.org) is used as the Xpand load\
+With _readconnroute_ you get simple connection based routing, where
+each new connection is created (by default) to the Xpand node with
+the least amount of existing connections. That is, with readconnroute
+the behaviour will be very similar to the behaviour when [HAProxy](https://www.haproxy.org) is used as the Xpand load
 balancer.
 
 #### Bootstrap servers
 
-The Xpand monitor is capable of autonomously figuring out the cluster\
+The Xpand monitor is capable of autonomously figuring out the cluster
 configuration, but in order to get going there must be at least one_server_-section referring to a node in the Xpand cluster.
 
 ```
@@ -33,9 +33,9 @@ port=3306
 protocol=MySQLBackend
 ```
 
-That server definition will be used by the monitor in order to connect\
-to the Xpand cluster. There can be more than one such "bootstrap"\
-definition to cater for the case that the node used as a bootstrap\
+That server definition will be used by the monitor in order to connect
+to the Xpand cluster. There can be more than one such "bootstrap"
+definition to cater for the case that the node used as a bootstrap
 server is down when MaxScale starts.
 
 **NOTE** These bootstrap servers should _only_ be referred to from the\
@@ -43,7 +43,7 @@ Xpand monitor configuration, but _never_ from a service.
 
 #### Monitor
 
-In the Xpand monitor section, the bootstrap servers are referred to\
+In the Xpand monitor section, the bootstrap servers are referred to
 in the same way as "ordinary" servers are referred to in other monitors.
 
 ```
@@ -64,19 +64,19 @@ GRANT SELECT ON system.nodeinfo TO 'maxscale-monitor'@'maxscalehost';
 GRANT SELECT ON system.softfailed_nodes TO 'maxscale-monitor'@'maxscalehost';
 ```
 
-In case the same user is used both for the monitor and the service (see below),\
+In case the same user is used both for the monitor and the service (see below),
 then the user must be given the grants required by the service as well.
 
-The bootstrap servers are only used for connecting to the Xpand\
-cluster; thereafter the Xpand monitor will dynamically find out the\
+The bootstrap servers are only used for connecting to the Xpand
+cluster; thereafter the Xpand monitor will dynamically find out the
 cluster configuration.
 
-The discovered cluster configuration will be stored (the ips and ports\
-of the Xpand nodes) and upon subsequent restarts the Xpand\
-monitor will use that information if the bootstrap servers happen to\
+The discovered cluster configuration will be stored (the ips and ports
+of the Xpand nodes) and upon subsequent restarts the Xpand
+monitor will use that information if the bootstrap servers happen to
 be unavailable.
 
-With the configuration above `maxctrl list servers` might output\
+With the configuration above `maxctrl list servers` might output
 the following:
 
 ```
@@ -95,7 +95,7 @@ the following:
 
 All servers whose name start with `@@` have been detected dynamically.
 
-Note that the address `10.2.224.101` appears twice; once for`Bootstrap-1` and another time for `@@Xpand:node-6`. The Xpand\
+Note that the address `10.2.224.101` appears twice; once for`Bootstrap-1` and another time for `@@Xpand:node-6`. The Xpand
 monitor will create a dynamic server instance for _all_ nodes in the\
 Xpand cluster; also for the ones used in bootstrap server sections.
 
@@ -120,22 +120,22 @@ GRANT SELECT ON system.users TO 'maxscale-service'@'maxscalehost';
 GRANT SELECT ON system.user_acl TO 'maxscale-service'@'maxscalehost';
 ```
 
-In case the same user is used both for the monitor (see above) and the service,\
+In case the same user is used both for the monitor (see above) and the service,
 then the user must be given the grants required by the monitor as well.
 
-Note that the service does _not_ list any specific servers, but\
+Note that the service does _not_ list any specific servers, but
 instead refers, using the argument `cluster`, to the Xpand monitor.
 
-In practice this means that the service will use the servers of the\
-monitor named `Xpand` and in the case of a Xpand monitor those\
-servers will be the ones that the monitor has detected\
-dynamically. That is, when setup like this, the service will\
-automatically adjust to any changes taking place in the Xpand\
+In practice this means that the service will use the servers of the
+monitor named `Xpand` and in the case of a Xpand monitor those
+servers will be the ones that the monitor has detected
+dynamically. That is, when setup like this, the service will
+automatically adjust to any changes taking place in the Xpand
 cluster.
 
-**NOTE** There is no need to specify any `router_options`, but the\
+**NOTE** There is no need to specify any `router_options`, but the
 default `router_options=running` provides the desired behaviour.\
-In particular do **not** specify `router_options=master` as that will\
+In particular do **not** specify `router_options=master` as that will
 cause only a _single_ node to be used.
 
 #### Listener
@@ -152,22 +152,22 @@ port=4008
 
 ### Xpand and Readwritesplit
 
-The primary purpose of the router _readwritesplit_ is to split\
+The primary purpose of the router _readwritesplit_ is to split
 statements between one master and multiple slaves. In the case of\
-Xpand, all servers will be masters, but _readwritesplit_ may still\
+Xpand, all servers will be masters, but _readwritesplit_ may still
 be the right choice.
 
-Namely, as _readwritesplit_ is transaction aware and capable of\
-replaying transactions, it can be used for hiding certain events\
+Namely, as _readwritesplit_ is transaction aware and capable of
+replaying transactions, it can be used for hiding certain events
 taking place in Xpand from the clients that use it.
 
-For instance, whenever a node is removed from or added to a Xpand\
-cluster there will be a _group change_, which is visible to a client\
-as a transaction rollback. However, if _readwritesplit_ is used and\
-transaction replay is enabled, then MaxScale may be able to hide the\
+For instance, whenever a node is removed from or added to a Xpand
+cluster there will be a _group change_, which is visible to a client
+as a transaction rollback. However, if _readwritesplit_ is used and
+transaction replay is enabled, then MaxScale may be able to hide the
 group change so that the client only detects a slight delay.
 
-Apart from the service section, the configuration when using_readwritesplit_ is identical to the _readconnroute_ configuration\
+Apart from the service section, the configuration when using_readwritesplit_ is identical to the _readconnroute_ configuration
 described above.
 
 #### Service
@@ -185,20 +185,20 @@ transaction_replay=true
 slave_selection_criteria=LEAST_GLOBAL_CONNECTIONS
 ```
 
-With this configuration, subject to the boundary conditions of\
-transaction replaying, a client will neither notice group change\
-events nor the disappearance of the very node the client is connected\
-to. In that latter case, MaxScale will simply connect to another node\
-and replay the current transaction (if one is active). For detailed\
-information about the transaction replay functionality, please refer\
+With this configuration, subject to the boundary conditions of
+transaction replaying, a client will neither notice group change
+events nor the disappearance of the very node the client is connected
+to. In that latter case, MaxScale will simply connect to another node
+and replay the current transaction (if one is active). For detailed
+information about the transaction replay functionality, please refer
 to the _readwritesplit_[documentation](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md#transaction_replay).
 
-**NOTE** It is vital to have`slave_selection_criteria=LEAST_GLOBAL_CONNECTIONS`, as otherwise\
-connections will **not** be distributed evenly across all Xpand\
+**NOTE** It is vital to have`slave_selection_criteria=LEAST_GLOBAL_CONNECTIONS`, as otherwise
+connections will **not** be distributed evenly across all Xpand
 nodes.
 
-As a rule of thumb, use _readwritesplit_ if it is important that\
-changes taking place in the cluster configuration are hidden from the\
+As a rule of thumb, use _readwritesplit_ if it is important that
+changes taking place in the cluster configuration are hidden from the
 applications, otherwise use _readconnroute_.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-read-write-splitting-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-read-write-splitting-with-mariadb-maxscale.md
@@ -4,8 +4,8 @@
 
 ## Read-Write Splitting with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that appears to the client as a single\
-database. MariaDB MaxScale will split the statements such that write statements are sent\
+The goal of this tutorial is to configure a system that appears to the client as a single
+database. MariaDB MaxScale will split the statements such that write statements are sent
 to the master server and read statements are balanced across the slave servers.
 
 ### Setting up MariaDB MaxScale
@@ -15,9 +15,9 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring the service
 
-After configuring the servers and the monitor, we create a read-write-splitter service\
-configuration. Create the following section in your configuration file. The section name\
-is also the name of the service and should be meaningful. For this tutorial, we use the\
+After configuring the servers and the monitor, we create a read-write-splitter service
+configuration. Create the following section in your configuration file. The section name
+is also the name of the service and should be meaningful. For this tutorial, we use the
 name _Splitter-Service_.
 
 ```
@@ -29,14 +29,14 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readwritesplit_ for\
+_router_ defines the routing module used. Here we use _readwritesplit_ for
 query-level read-write-splitting.
 
-A service needs a list of servers where queries will be routed to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers where queries will be routed to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2208-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2208-encrypting-passwords.md).
@@ -44,7 +44,7 @@ For increased security, see [password encryption](mariadb-maxscale-2208-encrypti
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one is enough.
 
 ```
@@ -59,7 +59,7 @@ The _service_ parameter tells which service the listener connects to. For the_Sp
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-rest-api-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-rest-api-tutorial.md
@@ -4,23 +4,23 @@
 
 ## REST API Tutorial
 
-This tutorial is a quick overview of what the MaxScale REST API offers, how it\
-can be used to inspect the state of MaxScale and how to use it to modify the\
-runtime configuration of MaxScale. The tutorial uses the `curl` command line\
+This tutorial is a quick overview of what the MaxScale REST API offers, how it
+can be used to inspect the state of MaxScale and how to use it to modify the
+runtime configuration of MaxScale. The tutorial uses the `curl` command line
 client to demonstrate how the API is used.
 
 ### Configuration and Hardening
 
-The MaxScale REST API listens on port 8989 on the local host. The `admin_port`\
-and `admin_host` parameters control which port and address the REST API listens\
-on. Note that for security reasons the API only listens for local connections\
-with the default configuration. It is critical that the default credentials are\
-changed and TLS/SSL encryption is configured before exposing the REST API to a\
+The MaxScale REST API listens on port 8989 on the local host. The `admin_port`
+and `admin_host` parameters control which port and address the REST API listens
+on. Note that for security reasons the API only listens for local connections
+with the default configuration. It is critical that the default credentials are
+changed and TLS/SSL encryption is configured before exposing the REST API to a
 network.
 
-The default user for the REST API is `admin` and the password is `mariadb`. The\
-easiest way to secure the REST API is to use the `maxctrl` command line client\
-to create a new admin user and delete the default one. To do this, run the\
+The default user for the REST API is `admin` and the password is `mariadb`. The
+easiest way to secure the REST API is to use the `maxctrl` command line client
+to create a new admin user and delete the default one. To do this, run the
 following commands:
 
 ```
@@ -28,13 +28,13 @@ maxctrl create user my_user my_password --type=admin
 maxctrl destroy user admin
 ```
 
-This will create the user `my_user` with the password `my_password` that is an\
-administrative account. After this account is created, the default `admin`\
+This will create the user `my_user` with the password `my_password` that is an
+administrative account. After this account is created, the default `admin`
 account is removed with the next command.
 
-The next step is to enable TLS encryption. To do this, you need a CA\
-certificate, a private key and a public certificate file all in PEM format. Add\
-the following three parameters under the `[maxscale]` section of the MaxScale\
+The next step is to enable TLS encryption. To do this, you need a CA
+certificate, a private key and a public certificate file all in PEM format. Add
+the following three parameters under the `[maxscale]` section of the MaxScale
 configuration file and restart MaxScale.
 
 ```
@@ -43,15 +43,15 @@ admin_ssl_cert=/certs/server-cert.pem
 admin_ssl_ca_cert=/certs/ca-cert.pem
 ```
 
-Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our\
-server certificates are self-signed so the `--tls-verify-server-cert=false`\
+Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our
+server certificates are self-signed so the `--tls-verify-server-cert=false`
 option is required.
 
 ```
 maxctrl --user=my_user --password=my_password --secure --tls-ca-cert=/certs/ca-cert.pem --tls-verify-server-cert=false show maxscale
 ```
 
-If no errors are raised, this means that the communication via the REST API is\
+If no errors are raised, this means that the communication via the REST API is
 now secure and can be used across networks.
 
 ### Requesting Data
@@ -59,8 +59,8 @@ now secure and can be used across networks.
 **Note:** For the sake of brevity, the rest of this tutorial will omit the\
 TLS/SSL options from the `curl` command line. For more information, refer to the`curl` manpage.
 
-The most basic task to do with the REST API is to see whether MaxScale is up and\
-running. To do this, we do a HTTP request on the root resource (the `-i` option\
+The most basic task to do with the REST API is to see whether MaxScale is up and
+running. To do this, we do a HTTP request on the root resource (the `-i` option
 shows the HTTP headers).
 
 `curl -i 127.0.0.1:8989/v1/`
@@ -74,7 +74,7 @@ ETag: "0"
 Date: Mon, 04 Mar 19 08:29:41 GMT
 ```
 
-To query a resource collection endpoint, append it to the URL. The `/v1/filters/`\
+To query a resource collection endpoint, append it to the URL. The `/v1/filters/`
 endpoint shows the list of filters configured in MaxScale. This is a _resource collection_ endpoint: it contains the list of all resources of a particular type.
 
 `curl 127.0.0.1:8989/v1/filters`
@@ -149,17 +149,17 @@ endpoint shows the list of filters configured in MaxScale. This is a _resource c
 }
 ```
 
-The `data` holds the actual list of resources: the `Hint` and `Logger`\
-filters. Each object has the `id` field which is the unique name of that\
+The `data` holds the actual list of resources: the `Hint` and `Logger`
+filters. Each object has the `id` field which is the unique name of that
 object. It is the same as the section name in `maxscale.cnf`.
 
-Each resource in the list has a `relationships` object. This shows the\
-relationship links between resources. In our example, the `Hint` filter is used\
-by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in\
+Each resource in the list has a `relationships` object. This shows the
+relationship links between resources. In our example, the `Hint` filter is used
+by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in
 use.
 
-To request an individual resource, we add the object name to the resource\
-collection URL. For example, if we want to get only the `Logger` filter we\
+To request an individual resource, we add the object name to the resource
+collection URL. For example, if we want to get only the `Logger` filter we
 execute the following command.
 
 `curl 127.0.0.1:8989/v1/filters/Logger`
@@ -208,18 +208,18 @@ execute the following command.
 }
 ```
 
-Note that this time the `data` member holds an object instead of an array of\
-objects. All other parts of the response are similar to what was shown in the\
+Note that this time the `data` member holds an object instead of an array of
+objects. All other parts of the response are similar to what was shown in the
 previous example.
 
 ### Creating Objects
 
-One of the uses of the REST API is to create new objects in MaxScale at\
-runtime. This allows new servers, services, filters, monitor and listeners to be\
+One of the uses of the REST API is to create new objects in MaxScale at
+runtime. This allows new servers, services, filters, monitor and listeners to be
 created without restarting MaxScale.
 
-For example, to create a new server in MaxScale the JSON definition of a server\
-must be sent to the REST API at the `/v1/servers/` endpoint. The request body\
+For example, to create a new server in MaxScale the JSON definition of a server
+must be sent to the REST API at the `/v1/servers/` endpoint. The request body
 defines the server name as well as the parameters for it.
 
 To create objects with `curl`, first write the JSON definition into a file.
@@ -245,9 +245,9 @@ To send the data, use the following command.
 curl -X POST -d @new_server.txt 127.0.0.1:8989/v1/servers
 ```
 
-The `-d` option takes a file name prefixed with a `@` as an argument. Here we\
-have `@new_server.txt` which is the name of the file where the JSON definition\
-was stored. The `-X` option defines the HTTP verb to use and to create a new\
+The `-d` option takes a file name prefixed with a `@` as an argument. Here we
+have `@new_server.txt` which is the name of the file where the JSON definition
+was stored. The `-X` option defines the HTTP verb to use and to create a new
 object we must use the POST verb.
 
 To verify the data request the newly created object.
@@ -258,18 +258,18 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Modifying Data
 
-The easiest way to modify an object is to first request it, store the result in\
+The easiest way to modify an object is to first request it, store the result in
 a file, edit it and then send the updated object back to the REST API.
 
-Let's say we want to modify the port that the server we created earlier listens\
+Let's say we want to modify the port that the server we created earlier listens
 on. First we request the current object and store the result in a file.
 
 ```
 curl 127.0.0.1:8989/v1/servers/server1 > server1.txt
 ```
 
-After that we edit the file and change the port from 3003 to 3306. Next the\
-modified JSON object is sent to the REST API as a PATCH command. To do this,\
+After that we edit the file and change the port from 3003 to 3306. Next the
+modified JSON object is sent to the REST API as a PATCH command. To do this,
 execute the following command.
 
 ```
@@ -284,12 +284,12 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Object Relationships
 
-To continue with our previous example, we add the updated server to a\
-service. To do this, the `relationships` object of the server must be modified\
+To continue with our previous example, we add the updated server to a
+service. To do this, the `relationships` object of the server must be modified
 to include the service we want to add the server to.
 
-To define a relationship between a server and a service, the `data` member must\
-have the `relationships` field and it must contain an object with the `services`\
+To define a relationship between a server and a service, the `data` member must
+have the `relationships` field and it must contain an object with the `services`
 field (some fields omitted for brevity).
 
 ```
@@ -312,13 +312,13 @@ field (some fields omitted for brevity).
 }
 ```
 
-The `data.relationships.services.data` field contains a list of objects that\
-define the `id` and `type` fields. The id is the name of the object (a service\
-or a monitor for servers) and the type tells which type it is. Only `services`\
+The `data.relationships.services.data` field contains a list of objects that
+define the `id` and `type` fields. The id is the name of the object (a service
+or a monitor for servers) and the type tells which type it is. Only `services`
 type objects should be present in the `services` object.
 
-In our example we are linking the `server1` server to the `RW-Split-Router`\
-service. As was seen with the previous example, the easiest way to do this is to\
+In our example we are linking the `server1` server to the `RW-Split-Router`
+service. As was seen with the previous example, the easiest way to do this is to
 store the result, edit it and then send it back with a HTTP PATCH.
 
 If we want to remove a server from _all_ services and monitors, we can set the`data` member of the `services` and `monitors` relationships to an empty array:
@@ -338,39 +338,39 @@ If we want to remove a server from _all_ services and monitors, we can set the`d
 }
 ```
 
-This is useful if you want to delete the server which can only be done if it has\
+This is useful if you want to delete the server which can only be done if it has
 no relationships to other objects.
 
 ### Deleting Objects
 
-To delete an object, simply execute a HTTP DELETE request on the resource you\
-want to delete. For example, to delete the `server1` server, execute the\
+To delete an object, simply execute a HTTP DELETE request on the resource you
+want to delete. For example, to delete the `server1` server, execute the
 following command.
 
 ```
 curl -X DELETE 127.0.0.1:8989/v1/servers/server1
 ```
 
-In order to delete an object, it must not have any relationships to other\
+In order to delete an object, it must not have any relationships to other
 objects.
 
 ### Further Reading
 
 The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../../../../../en/mariadb-maxscale-2208-maxscale-rest-api/).
 
-The `maxctrl` command line client is self-documenting and the `maxctrl help`\
-command is a good tool for exploring the various commands that are available in\
-it. The `maxctrl api get` command can be useful way to explore the REST API as\
+The `maxctrl` command line client is self-documenting and the `maxctrl help`
+command is a good tool for exploring the various commands that are available in
+it. The `maxctrl api get` command can be useful way to explore the REST API as
 it provides a way to easily extract values out of the JSON data generated by the\
 REST API.
 
-There is a multitude of REST API clients readily available and most of them are\
-far more convenient to use than `curl`. We recommend investigating what you need\
-and how you intend to either integrate or use the MaxScale REST API. Most modern\
-languages either have a built-in HTTP library or there exists a de facto\
+There is a multitude of REST API clients readily available and most of them are
+far more convenient to use than `curl`. We recommend investigating what you need
+and how you intend to either integrate or use the MaxScale REST API. Most modern
+languages either have a built-in HTTP library or there exists a de facto
 standard library.
 
-The MaxScale REST API follows the JSON API specification and there exist\
+The MaxScale REST API follows the JSON API specification and there exist
 libraries that are built specifically for these sorts of APIs
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-setting-up-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-setting-up-mariadb-maxscale.md
@@ -7,26 +7,26 @@
 This document is designed as a quick introduction to setting up MariaDB MaxScale.
 
 The installation and configuration of the MariaDB Server is not covered in this document.\
-See the following MariaDB documentation articles for more information on setting up a\
-master-slave-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)\
+See the following MariaDB documentation articles for more information on setting up a
+master-slave-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)
 and [Getting Started With MariaDB Galera Cluster](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster)\
 .
 
-This tutorial assumes that one of the standard MaxScale binary distributions is used and\
+This tutorial assumes that one of the standard MaxScale binary distributions is used and
 that MaxScale is installed using default options.
 
 Building from source code in GitHub is covered in [Building from Source](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-building-mariadb-maxscale-from-source-code.md).
 
 ### Installing MaxScale
 
-The precise installation process varies from one distribution to another. Details on\
+The precise installation process varies from one distribution to another. Details on
 package installation can be found in the [Installation Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-installation-guide.md).
 
 ### Creating a user account for MaxScale
 
-MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve\
-user authentication information from the backend databases. Create a special user\
-account for this purpose by executing the following SQL commands on the master server of\
+MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve
+user authentication information from the backend databases. Create a special user
+account for this purpose by executing the following SQL commands on the master server of
 your database cluster. The following tutorials will use these credentials.
 
 ```
@@ -45,12 +45,12 @@ MariaDB versions 10.2.2 to 10.2.10 also require `GRANT SELECT ON mysql.* TO 'max
 
 ### Creating client user accounts
 
-Because MariaDB MaxScale sits between the clients and the backend databases, the backend\
-databases will see all clients as if they were connecting from MaxScale's address. This\
+Because MariaDB MaxScale sits between the clients and the backend databases, the backend
+databases will see all clients as if they were connecting from MaxScale's address. This
 usually means that two sets of grants for each user are required.
 
-For example, assume that the user _'jdoe'@'client-host'_ exists and MaxScale is located at\_maxscale-host\_. If _'jdoe'@'client-host'_ needs to be able to connect through MaxScale,\
-another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the\
+For example, assume that the user _'jdoe'@'client-host'_ exists and MaxScale is located at\_maxscale-host\_. If _'jdoe'@'client-host'_ needs to be able to connect through MaxScale,
+another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the
 same password and similar grants as _'jdoe'@'client-host'_.
 
 The quickest way to do this is to first create the new user:
@@ -77,18 +77,18 @@ Then copy the same grants to the `'jdoe'@'maxscale-host'` user.
 GRANT SELECT, INSERT, UPDATE, DELETE ON *.* TO 'jdoe'@'maxscale-host';
 ```
 
-An alternative to generating two separate accounts is to use one account with a wildcard\
-host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than\
+An alternative to generating two separate accounts is to use one account with a wildcard
+host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than
 having specific user accounts as it allows access from all hosts.
 
 ### Creating the configuration file
 
-MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is\
+MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is
 provided with the MaxScale installation.
 
-A global _maxscale_ section is included in every MaxScale configuration file. This section\
-sets the values of various global parameters, such as the number of threads MaxScale uses\
-to handle client requests. To set thread count to the number of available cpu cores, set\
+A global _maxscale_ section is included in every MaxScale configuration file. This section
+sets the values of various global parameters, such as the number of threads MaxScale uses
+to handle client requests. To set thread count to the number of available cpu cores, set
 the following.
 
 ```
@@ -98,7 +98,7 @@ threads=auto
 
 ### Configuring the servers
 
-Read the [Configuring Servers](mariadb-maxscale-2208-configuring-servers.md) mini-tutorial for server\
+Read the [Configuring Servers](mariadb-maxscale-2208-configuring-servers.md) mini-tutorial for server
 configuration instructions.
 
 ### Configuring the monitor
@@ -115,7 +115,7 @@ For a simple connection based setup, read the [Connection Routing Tutorial](mari
 
 ### Starting MaxScale
 
-After configuration is complete, MariaDB MaxScale is ready to start. For systems that\
+After configuration is complete, MariaDB MaxScale is ready to start. For systems that
 use systemd, use the _systemctl_ command.
 
 ```
@@ -128,13 +128,13 @@ For older SysV systems, use the _service_ command.
 sudo service maxscale start
 ```
 
-If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see\
+If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see
 if any errors are detected in the configuration file.
 
 ### Checking MaxScale status with MaxCtrl
 
-The _maxctrl_-command can be used to confirm that MaxScale is running and the services,\
-listeners and servers have been correctly configured. The following shows expected output\
+The _maxctrl_-command can be used to confirm that MaxScale is running and the services,
+listeners and servers have been correctly configured. The following shows expected output
 when using a read-write-splitting configuration.
 
 ```
@@ -167,7 +167,7 @@ when using a read-write-splitting configuration.
 └───────────────────┴──────┴──────┴─────────┘
 ```
 
-MariaDB MaxScale is now ready to start accepting client connections and route queries to\
+MariaDB MaxScale is now ready to start accepting client connections and route queries to
 the backend cluster.
 
 More options can be found in the [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/),[readwritesplit module documentation](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md) and [readconnroute module documentation](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readconnroute.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-using-maxgui-tutorial.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-This tutorial is an overview of what the MaxGUI offers as an alternative\
+This tutorial is an overview of what the MaxGUI offers as an alternative
 solution to [MaxCtrl](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-maxctrl.md).
 
 ## Dashboard
@@ -14,11 +14,11 @@ solution to [MaxCtrl](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-m
 ### Annotation
 
 1. [MaxScale object](https://mariadb.com/kb/en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#objects). i.e.\
-   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate\
+   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate
    to its detail page)
 2. Create a new MaxScale object.
 3. Dashboard Tab Navigation.
-4. Search Input. This can be used as a quick way to search for a keyword in\
+4. Search Input. This can be used as a quick way to search for a keyword in
    tables.
 5. Dashboard graphs. Refresh interval is 10 seconds.
 
@@ -32,43 +32,43 @@ solution to [MaxCtrl](../mariadb-maxscale-2208-reference/mariadb-maxscale-2208-m
 
 ### Create a new MaxScale object
 
-Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating\
+Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating
 a new object.
 
 ### View Replication Status
 
-The replication status of a server monitored by [MariaDB-Monitor](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-mariadb-monitor.md) can be viewed by mousing over\
+The replication status of a server monitored by [MariaDB-Monitor](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-mariadb-monitor.md) can be viewed by mousing over
 the server name. A tooltip will be displayed with the following information:\
 replication\_state, seconds\_behind\_master, slave\_io\_running, slave\_sql\_running.
 
 ## Detail
 
-This page shows information on each MaxScale object and allow to edit its\
-parameter, relationships and perform other manipulation operations. Most of the\
+This page shows information on each MaxScale object and allow to edit its
+parameter, relationships and perform other manipulation operations. Most of the
 control buttons will be shown on the mouseover event. Below is a screenshot of a\
-Monitor Detail page, other Detail pages also have a similar layout structure so\
+Monitor Detail page, other Detail pages also have a similar layout structure so
 this is used for illustration purpose.
 
 ### Annotation
 
-1. Settings option. Clicking on the gear icon will show icons allowing to do\
+1. Settings option. Clicking on the gear icon will show icons allowing to do
    different operations depending on the type of the Detail page.
 
 * Monitor Detail page, there are icons to Stop, Start, and Destroy monitor.
 * Service Detail page, there are icons to Stop, Start, and Destroy service.
-* Server Detail page, there are icons to Set maintenance mode, Clear server\
+* Server Detail page, there are icons to Set maintenance mode, Clear server
   state, Drain and Delete server.
-* Filter and Listener Detail page, there is a delete icon to delete the\
+* Filter and Listener Detail page, there is a delete icon to delete the
   object.
 
-1. Switchover button. This button is shown on the mouseover event allowing to\
+1. Switchover button. This button is shown on the mouseover event allowing to
    swap the running primary server with a designated secondary server.
-2. Edit parameters button. This button is shown on the mouseover event allowing\
-   to edit the MaxScale object's parameter. Clicking on it will enable editable\
+2. Edit parameters button. This button is shown on the mouseover event allowing
+   to edit the MaxScale object's parameter. Clicking on it will enable editable
    mode on the table. After finishing editing the parameters, simply click the\
    Done Editing button.
-3. A Detail page has tables showing "Relationship" between other MaxScale\
-   object. This "unlink" icon is shown on the mouseover event allowing to\
+3. A Detail page has tables showing "Relationship" between other MaxScale
+   object. This "unlink" icon is shown on the mouseover event allowing to
    remove the relationship between two objects.
 4. This button is used to link other MaxScale objects to the relationship.
 
@@ -82,12 +82,12 @@ This page visualizes MaxScale configuration as shown in the figure below.
 
 #### Annotation
 
-1. A MaxScale object (a node graph). The position of the node in the graph can\
+1. A MaxScale object (a node graph). The position of the node in the graph can
    be changed by dragging and dropping it.
-2. Anchor link. The detail page of each MaxScale object can be accessed by\
+2. Anchor link. The detail page of each MaxScale object can be accessed by
    clicking on the name of the node.
-3. Filter visualization button. By default, if the number of filters used by a\
-   service is larger than 3, filter nodes aren't visualized as shown in the\
+3. Filter visualization button. By default, if the number of filters used by a
+   service is larger than 3, filter nodes aren't visualized as shown in the
    figure. Clicking this button will visualize them.
 4. Hide filter visualization button.
 5. Refresh rate dropdown. The frequency with which the data is refreshed.
@@ -96,40 +96,40 @@ This page visualizes MaxScale configuration as shown in the figure below.
 ### Clusters
 
 This page shows all monitor clusters using [mariadbmon](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-mariadb-monitor.md) module in a card-like view.\
-Clicking on the card will visualize the cluster into a tree graph as shown in\
+Clicking on the card will visualize the cluster into a tree graph as shown in
 the figure below.
 
 #### Annotation
 
-1. Drag a secondary server on top of a primary server to promote the secondary\
+1. Drag a secondary server on top of a primary server to promote the secondary
    server as the new primary server.
-2. Server manipulation operations button. Showing a dropdown with the following\
+2. Server manipulation operations button. Showing a dropdown with the following
    operations:
 
 * Set maintenance mode: Setting a server to a maintenance mode.
 * Clear server state: Clear current server state.
 * Drain server: Drain the server of connections.
 
-1. Quick access to query editor button. Opening the `Query Editor` page for\
-   this server. If the connection is already created for that server, it'll use\
-   it. Otherwise, it creates a blank worksheet and shows a connection dialog to\
+1. Quick access to query editor button. Opening the `Query Editor` page for
+   this server. If the connection is already created for that server, it'll use
+   it. Otherwise, it creates a blank worksheet and shows a connection dialog to
    connect to that server.
-2. Carousel navigation button. Viewing more information about the server in the\
+2. Carousel navigation button. Viewing more information about the server in the
    next slide.
 3. Collapse the carousel.
-4. Anchor link of the server. Opening the detail page of the server in a new\
+4. Anchor link of the server. Opening the detail page of the server in a new
    tab.
 5. Collapse its children nodes.
-6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be\
+6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be
    manually rejoined by dragging it on top of the primary server.
-7. Monitor manipulation operations button. Showing a dropdown with the\
+7. Monitor manipulation operations button. Showing a dropdown with the
    following operations:
 
 * Stop monitor.
 * Start monitor.
 * Reset Replication.
 * Release Locks.
-* Master failover. Manually performing a master failover. This option is\
+* Master failover. Manually performing a master failover. This option is
   visible only when the `auto_failover` parameter is disabled.
 
 1. Refresh rate dropdown. The frequency with which the data is refreshed.
@@ -141,11 +141,11 @@ This page shows and allows editing of MaxScale parameters.
 
 ### Annotation
 
-1. Edit parameters button. This button is shown on the mouseover event allowing\
-   to edit the MaxScale parameter. Clicking on it will enable editable mode on\
+1. Edit parameters button. This button is shown on the mouseover event allowing
+   to edit the MaxScale parameter. Clicking on it will enable editable mode on
    the table..
 2. Editable parameters are visible as it's illustrated in the screenshot.
-3. After finishing editing the parameters, simply click the Done Editing\
+3. After finishing editing the parameters, simply click the Done Editing
    button.
 
 ## Logs Archive
@@ -163,72 +163,72 @@ A SQL editor tool to run queries and perform other SQL operations.
 
 ### Annotation
 
-1. Worksheet tab navigation. Each worksheet is bound to a connection, so\
+1. Worksheet tab navigation. Each worksheet is bound to a connection, so
    sessions querying within a worksheet is not yet supported.
 2. Add a new worksheet button.
-3. Connection manager dropdown. With this dropdown, you can create a new\
-   connection or change the connection for the current active worksheet. A new\
-   connection can be created by selecting the last option in the dropdown\
-   labeled as `New connection`. Once a connection is created, it automatically\
+3. Connection manager dropdown. With this dropdown, you can create a new
+   connection or change the connection for the current active worksheet. A new
+   connection can be created by selecting the last option in the dropdown
+   labeled as `New connection`. Once a connection is created, it automatically
    binds the connection to the current active worksheet.
 4. Active database dropdown. Right-click on the database name and click`Use database` option to quickly change the default (current) database
-5. Schemas sidebar. Showing available schemas on the current connection. As\
-   shown in the figure above, these items can be explored to show tables,\
+5. Schemas sidebar. Showing available schemas on the current connection. As
+   shown in the figure above, these items can be explored to show tables,
    stored procedures, columns, and triggers within the schema.
 6. Schemas sidebar object.
 
-* Each object has its own context menu providing different options. e.g. For\
-  the table object as shown in the figure above, it has options to`Preview Data (top 1000)` and `View Details`. The query result for these\
-  options is shown in the `Data Preview` result tab which is annotated as\
-  number 12. The context menu can be shown by right-clicking on the object\
+* Each object has its own context menu providing different options. e.g. For
+  the table object as shown in the figure above, it has options to`Preview Data (top 1000)` and `View Details`. The query result for these
+  options is shown in the `Data Preview` result tab which is annotated as
+  number 12. The context menu can be shown by right-clicking on the object
   or clicking on the three dots icon placed on the right side of the object.
-* Quick access to the `Preview Data (top 1000)` context menu option. For a\
+* Quick access to the `Preview Data (top 1000)` context menu option. For a
   table object, its preview data can also be seen by clicking on its name.
-* Quick overview tooltip. Each object has its own tooltip providing an\
+* Quick overview tooltip. Each object has its own tooltip providing an
   overview of the object.
 
 1. Refresh schema objects button. After deleting or creating schema object, the`Schemas sidebar` needs to be manually refreshed.
 2. Collapse the `Schemas sidebar` button.
-3. SQL editor. The editor is powered by [Monaco editor](https://microsoft.github.io/monaco-editor/) which means its\
-   functionalities are similar to VS code. Available commands can be seen by\
-   pressing F1 while the cursor is active on the editor. This is an intention\
-   to prevent conflict between the browser's shortcut keys and the SQL\
-   editor's. This also means the editor shortcut key commands are valid only\
+3. SQL editor. The editor is powered by [Monaco editor](https://microsoft.github.io/monaco-editor/) which means its
+   functionalities are similar to VS code. Available commands can be seen by
+   pressing F1 while the cursor is active on the editor. This is an intention
+   to prevent conflict between the browser's shortcut keys and the SQL
+   editor's. This also means the editor shortcut key commands are valid only
    when the cursor is active on the `SQL editor` with an exception for the`Run all statements`, `Run selected statements` and`Save statements to favorite` commands.
-4. Query Results. Showing the query results of queries written in the SQL\
+4. Query Results. Showing the query results of queries written in the SQL
    editor.
 5. Data Preview. Showing the query results of `Preview Data (top 1000)` and`View Details` options of the schema sidebar context menu.
 6. History/Snippets. Showing query history and snippet queries.
 7. Result tab navigation. Navigating between SQL queries results.
-8. Filter query history logs. The query history is divided into two types of\
-   logs The `User query logs` contains logs for queries written in the`SQL editor` while the `Action logs` contains logs for auto-generated SQL,\
+8. Filter query history logs. The query history is divided into two types of
+   logs The `User query logs` contains logs for queries written in the`SQL editor` while the `Action logs` contains logs for auto-generated SQL,
    such as `Preview Data (top 1000)`, `View Details`, `Drop Table` and`Truncate Table`.
-9. Export query result button. Exporting as `json`, `csv` with a custom\
+9. Export query result button. Exporting as `json`, `csv` with a custom
    delimiter.
 10. Filter query result columns dropdown. Selecting columns to be visible.
 11. Vertical query result button. Switching to vertical mode.
-12. Run button. Running the queries written in the `SQL editor`. Alternatively,\
-    pressing `Ctrl/CMD+Shift+Enter` to `Run all statements` or `Ctrl/CMD+Enter`\
+12. Run button. Running the queries written in the `SQL editor`. Alternatively,
+    pressing `Ctrl/CMD+Shift+Enter` to `Run all statements` or `Ctrl/CMD+Enter`
     to `Run selected statements`.
-13. Visualize query result button. Visualizing a query result into a line,\
+13. Visualize query result button. Visualizing a query result into a line,
     scatter, vertical bar, and horizontal bar graph.
 14. Create a query snippet from the queries written in the `SQL editor`.\
     Alternatively, press `Ctrl/CMD+D`.
 15. Open Script button.
-16. Save Script button. This writes content into the opened file. This only\
-    works on Chrome or any browsers based on Chromium served over a secure\
+16. Save Script button. This writes content into the opened file. This only
+    works on Chrome or any browsers based on Chromium served over a secure
     connection (https)
 17. Save Script As button. Save the content as a new file.
-18. [sql\_select\_limit](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables#sql_select_limit)\
+18. [sql\_select\_limit](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables#sql_select_limit)
     input. Changing the maximum number of rows to return from SELECT statements.
 19. Add a new session button.
-20. Query Editor settings button. Open `Query configuration` dialog to change\
+20. Query Editor settings button. Open `Query configuration` dialog to change
     the value of `Max rows` (sql\_select\_limit),`Query history retention period (in days)`,`Show confirmation before executing the statements` and`Show system schemas`.
 21. Maximize Query Editor window.
 
 ## How to kill a session
 
-A session can be killed easily on the "Current Sessions" table which can be\
+A session can be killed easily on the "Current Sessions" table which can be
 found on the [Dashboard](mariadb-maxscale-2208-using-maxgui-tutorial.md#dashboard), Server detail, and Service detail page.
 
 ### Annotation

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-14-to-20.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-14-to-20.md
@@ -11,17 +11,17 @@ For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog](../
 
 ### Installation
 
-Before starting the upgrade, we **strongly** recommend you back up your current\
+Before starting the upgrade, we **strongly** recommend you back up your current
 configuration file.
 
 ### MaxAdmin
 
-The default way the communication between MaxAdmin and MariaDB MaxScale is\
+The default way the communication between MaxAdmin and MariaDB MaxScale is
 handled has been changed from an internet socket to a Unix domain socket.\
 The former alternative is still available but has been _deprecated_.
 
 If no arguments are given to MaxAdmin, it will attempt to connect to\
-MariaDB MaxScale using a Unix domain socket. After the upgrade you will\
+MariaDB MaxScale using a Unix domain socket. After the upgrade you will
 need to provide at least one internet socket related flag - `-h`, `-P`,`-u` or `-p` - to force MaxAdmin to use the internet socket approach.
 
 E.g.
@@ -33,8 +33,8 @@ user@host $ maxadmin -u admin
 ### MySQL Monitor
 
 The MySQL Monitor now assigns the stale state to the master server by default.\
-In addition to this, the slave servers receive the stale slave state when they\
-lose the connection to the master. This should not cause changes in behavior\
+In addition to this, the slave servers receive the stale slave state when they
+lose the connection to the master. This should not cause changes in behavior
 but the output of MaxAdmin will show new states when replication is broken.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -11,40 +11,40 @@ For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog]
 
 ### Installation
 
-Before starting the upgrade, we **strongly** recommend you back up your current\
+Before starting the upgrade, we **strongly** recommend you back up your current
 configuration file.
 
 ### IPv6 Support
 
-MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to\
-was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,\
+MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to
+was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,
 add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)\
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files
 
-The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The\
+The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The
 default location for the log file is _/var/log/maxscale/maxscale.log_.
 
-Rotating the log files will cause MaxScale to reopen the file instead of\
+Rotating the log files will cause MaxScale to reopen the file instead of
 renaming them. This makes the MaxScale logging facility _logrotate_ compatible.
 
 ### ReadWriteSplit
 
-The `disable_sescmd_history` option is now enabled by default. This means that\
-slaves will not be recovered mid-session even if a replacement slave is\
-available. To enable the legacy behavior, add the `disable_sescmd_history=true`\
+The `disable_sescmd_history` option is now enabled by default. This means that
+slaves will not be recovered mid-session even if a replacement slave is
+available. To enable the legacy behavior, add the `disable_sescmd_history=true`
 parameter to the service definition.
 
 ### Persistent Connections
 
-The MariaDB session state is reset in MaxScale 2.1 for persistent\
-connections. This means that any modifications to the session state (default\
-database, user variable etc.) will not survive if the connection is put into the\
+The MariaDB session state is reset in MaxScale 2.1 for persistent
+connections. This means that any modifications to the session state (default
+database, user variable etc.) will not survive if the connection is put into the
 connection pool. For most users, this is the expected behavior.
 
 ### User Data Cache
@@ -53,15 +53,15 @@ The location of the MariaDB user data cache was moved from`/var/cache/maxscale/<
 
 ### Galeramon Monitoring Algorithm
 
-Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with\
+Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with
 multiple MaxScales but it also causes slower changes of the master node.
 
-To enable the legacy behavior, add `root_node_as_master=false` to the Galera\
+To enable the legacy behavior, add `root_node_as_master=false` to the Galera
 monitor configuration.
 
 ### MaxAdmin Editing Mode
 
-The default editing mode was changed from _vim_ to _emacs_ mode. To start\
+The default editing mode was changed from _vim_ to _emacs_ mode. To start
 maxadmin in the legacy mode, use the `-i` option.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-21-to-22.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-21-to-22.md
@@ -9,31 +9,31 @@ This document describes possible issues upgrading MariaDB MaxScale from version\
 
 For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
 
-Before starting the upgrade, we recommend you back up your current configuration\
+Before starting the upgrade, we recommend you back up your current configuration
 file.
 
 #### Administrative Users
 
-The file format for the administrative users used by MaxScale has been\
-changed. Old style files are automatically upgraded and a backup of the old file is\
+The file format for the administrative users used by MaxScale has been
+changed. Old style files are automatically upgraded and a backup of the old file is
 stored in `/var/lib/maxscale/passwd.backup`.
 
 #### Regular Expression Parameters
 
-Modules may now use a built-in regular expression string parameter type instead\
-of a normal string when accepting patterns. The modules that use the new regex\
-parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the\
+Modules may now use a built-in regular expression string parameter type instead
+of a normal string when accepting patterns. The modules that use the new regex
+parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the
 string in slashes, e.g. `match=/^select/` defines the pattern `^select`.
 
 #### Binlog Server
 
-Binlog server automatically accepts GTID connection from MariaDB 10 slave servers\
+Binlog server automatically accepts GTID connection from MariaDB 10 slave servers
 by saving all incoming GTIDs into a SQLite map database.
 
 #### MaxCtrl Included in Main Package
 
-In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2\
-it is in the main `maxscale` package. If you have a previous installation\
+In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2
+it is in the main `maxscale` package. If you have a previous installation
 of MaxCtrl, please remove it before upgrading to MaxScale 2.2.2.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-22-to-23.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-22-to-23.md
@@ -7,37 +7,37 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.2 to 2.3.
 
-For more information about MariaDB MaxScale 2.3, please refer\
+For more information about MariaDB MaxScale 2.3, please refer
 to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
 
-Before starting the upgrade, we recommend you back up your current\
+Before starting the upgrade, we recommend you back up your current
 configuration file.
 
 ### Increased Memory Use
 
-Starting with MaxScale 2.3.0 up to 40% of the memory can be used for\
-caching parsed queries. The most noticeable change is that it improves\
-performance in almost all cases where queries need to be parsed. Most of\
+Starting with MaxScale 2.3.0 up to 40% of the memory can be used for
+caching parsed queries. The most noticeable change is that it improves
+performance in almost all cases where queries need to be parsed. Most of
 the time this happens when the readwritesplit router or filters are used.
 
-The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total\
-memory to 1GB, add `query_classifier_cache_size=1G` to your\
+The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total
+memory to 1GB, add `query_classifier_cache_size=1G` to your
 configuration. To disable it, set the value to `0`.
 
-In addition to the aforementioned query classifier caching, the\
-readwritesplit session command history is enabled by default in 2.3 but is\
-limited to a maximum of 50 commands after which the history is\
-disabled. This is unlikely to show in any metrics but it contributes to\
+In addition to the aforementioned query classifier caching, the
+readwritesplit session command history is enabled by default in 2.3 but is
+limited to a maximum of 50 commands after which the history is
+disabled. This is unlikely to show in any metrics but it contributes to
 the increased memory foorprint of MaxScale.
 
 ### Unknown Global Parameters
 
-All unknown parameters are now treated as errors. Check your configuration for\
+All unknown parameters are now treated as errors. Check your configuration for
 errors if MaxScale fails to start after upgrading to 2.3.1.
 
 ### `passwd` is deprecated
 
-In the configuration file, passwords for monitors and services should be\
+In the configuration file, passwords for monitors and services should be
 specified using `password`; the support for the deprecated`passwd` will be removed in the future. That is, the following
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-23-to-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-23-to-24.md
@@ -7,20 +7,20 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.3 to 2.4.
 
-For more information about MariaDB MaxScale 2.4, please refer\
+For more information about MariaDB MaxScale 2.4, please refer
 to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
 
-Before starting the upgrade, we recommend you back up your current\
+Before starting the upgrade, we recommend you back up your current
 configuration file.
 
 ### Section Names
 
 #### Reserved Names
 
-Section and object names starting with `@@` are now reserved for\
+Section and object names starting with `@@` are now reserved for
 internal use by MaxScale.
 
-In case such names have been used, they must manually be changed\
+In case such names have been used, they must manually be changed
 in all configuration files of MaxScale, before MaxScale 2.4 is started.
 
 Those files are:
@@ -31,7 +31,7 @@ Those files are:
 
 #### Whitespace in Names
 
-Whitespace in section names that was deprecated in MaxScale 2.2 will now be\
+Whitespace in section names that was deprecated in MaxScale 2.2 will now be
 rejected, which will cause the startup of MaxScale to fail.
 
 To prevent that, section names like
@@ -58,11 +58,11 @@ servers=MyServer
 
 ### Durations
 
-Durations can now be specified using one of the suffixes `h`, `m`, `s`\
-and `ms` for specifying durations in hours, minutes, seconds and\
+Durations can now be specified using one of the suffixes `h`, `m`, `s`
+and `ms` for specifying durations in hours, minutes, seconds and
 milliseconds, respectively.
 
-_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,\
+_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,
 so it is advisable to add suffixes to durations. For instance,
 
 ```
@@ -72,12 +72,12 @@ some_param=60000ms
 
 ### Improved Admin User Encryption
 
-MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a\
+MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a
 user to use the better hashing algorithm, either recreate the user or use the`maxctrl alter user` command.
 
 ### MariaDB-Monitor
 
-The following settings have been removed and cause a startup error\
+The following settings have been removed and cause a startup error
 if defined:
 
 * `mysql51_replication`
@@ -86,16 +86,16 @@ if defined:
 
 ### ReadWriteSplit
 
-* If multiple masters are available for a readwritesplit service, the one with\
+* If multiple masters are available for a readwritesplit service, the one with
   the lowest connection count is selected.
-* If a master server is placed into maintenance mode, all open transactions are\
-  allowed to gracefully finish before the session is closed. To forcefully close\
+* If a master server is placed into maintenance mode, all open transactions are
+  allowed to gracefully finish before the session is closed. To forcefully close
   the connections, use the `--force` option for `maxctrl set server`.
-* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the\
+* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the
   overall load on the system when connections are rapidly opened and closed.
-* Transaction replays now have a limit on how many times a replay is\
+* Transaction replays now have a limit on how many times a replay is
   attempted. The default values is five attempts and is controlled by the`transaction_replay_attempts` parameter.
-* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the\
+* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the
   transaction is automatically retried.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -9,39 +9,39 @@ MaxScale from version 2.4 to 2.5.
 
 For more information about MaxScale 2.5, refer to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
 
-Before starting the upgrade, any existing configuration files should be\
+Before starting the upgrade, any existing configuration files should be
 backed up.
 
 ### MaxAdmin
 
 The deprecated MaxAdmin interface has been removed in 2.5.0 in favor of the REST\
-API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can\
+API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can
 no longer be used.
 
 ### Authentication
 
-The credentials used by services now require additional grants. For a full list\
+The credentials used by services now require additional grants. For a full list
 of required grants, refer to the [protocol documentation](../../../../../en/mariadb-maxscale-2208-maxscale-2208-authentication-modules/#required-grants).
 
 ### MariaDB-Monitor
 
-The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in\
+The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in
 a later version.
 
 #### Password encryption
 
-The encrypted passwords feature has been updated to be more secure. Users are\
-recommended to generate a new encryption key and re-encrypt their passwords\
+The encrypted passwords feature has been updated to be more secure. Users are
+recommended to generate a new encryption key and re-encrypt their passwords
 using the `maxkeys` and `maxpasswd` utilities. Old passwords still work.
 
 ### Default Server State
 
-The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally\
+The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally
 used before they were monitored.
 
 ### Columnstore Monitor
 
-It is now mandatory to specify in the configuration what version the\
+It is now mandatory to specify in the configuration what version the
 monitored Columnstore cluster is.
 
 ```
@@ -52,20 +52,20 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-columnstore-monitor.md#master-selection)\
+Please see the [documentation](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-columnstore-monitor.md#master-selection)
 for details.
 
 ### New binlog router
 
-The binlog router delivered with MaxScale 2.5 is completely new and\
-not 100% backward compatible with the binlog router delivered with\
-earlier MaxScale versions. If you use the binlog router, carefully\
-assess whether the functionality provided by the new one fulfills\
+The binlog router delivered with MaxScale 2.5 is completely new and
+not 100% backward compatible with the binlog router delivered with
+earlier MaxScale versions. If you use the binlog router, carefully
+assess whether the functionality provided by the new one fulfills
 your requirements, before upgrading MaxScale.
 
 ### Tee Filter
 
-The tee filter parameter `service` has been deprecated in favor of the `target`\
+The tee filter parameter `service` has been deprecated in favor of the `target`
 parameter. All usages of `service` can be replaced with `target`.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-25-to-6.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-25-to-6.md
@@ -4,27 +4,27 @@
 
 ## Upgrading MariaDB MaxScale from 2.5 to 6
 
-This document describes possible issues when upgrading MariaDB MaxScale from\
+This document describes possible issues when upgrading MariaDB MaxScale from
 version 2.5 to 6.
 
-Note that the versioning scheme has changed and that version 6 immediately\
-follows version 2.5. Effectively, the non-changing `2.`-prefix has been dropped\
-and henceforth at a major release, the _major_, instead of the _minor_ version\
-number, will be bumped. This change also affects how maintenance releases are\
-versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was\
+Note that the versioning scheme has changed and that version 6 immediately
+follows version 2.5. Effectively, the non-changing `2.`-prefix has been dropped
+and henceforth at a major release, the _major_, instead of the _minor_ version
+number, will be bumped. This change also affects how maintenance releases are
+versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was
 followed by the maintenance release 2.5.2. 6.1, the first GA version of MaxScale\
 6, will be followed by the maintenance release 6.2.
 
 For more information about MaxScale 6, refer to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
 
-Before starting the upgrade, any existing configuration files should be backed\
+Before starting the upgrade, any existing configuration files should be backed
 up.
 
 ### Duration Type Parameters
 
 Using duration type parameters without an explicit suffix has been deprecated in\
 MaxScale 2.4. In MaxScale 6 they are no longer allowed when used with the REST\
-API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that\
+API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that
 use a duration type parameter must explicitly specify the suffix of the unit.
 
 For example, the following command:
@@ -39,8 +39,8 @@ should be replaced with:
 maxctrl alter service My-Service connection_keepalive 30000ms
 ```
 
-Duration type parameters can still be defined in the configuration file without\
-an explicit suffix but this behavior is deprecated. The recommended approach is\
+Duration type parameters can still be defined in the configuration file without
+an explicit suffix but this behavior is deprecated. The recommended approach is
 to add explicit suffixes to all duration type parameters when upgrading to\
 MaxScale 6.
 
@@ -62,16 +62,16 @@ The following deprecated core parameters have been removed:
 
 The deprecated aliases for the schemarouter parameters `ignore_databases` and`ignore_databases_regex` have been removed. They can be replaced with`ignore_tables` and `ignore_tables_regex`.
 
-In addition, the `preferred_server` parameter that was deprecated in 2.5 has\
+In addition, the `preferred_server` parameter that was deprecated in 2.5 has
 also been removed.
 
 ### Session Command History
 
-The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`\
-have been made into generic service parameters that are shared between all\
+The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`
+have been made into generic service parameters that are shared between all
 routers that support it.
 
-The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it\
+The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it
 being enabled or are not affected by it.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-6-to-2208.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-6-to-2208.md
@@ -4,19 +4,19 @@
 
 ## Upgrading MariaDB MaxScale from 6 to 22.08
 
-This document describes possible issues when upgrading MariaDB MaxScale from\
+This document describes possible issues when upgrading MariaDB MaxScale from
 version 6 to 22.08.
 
 For more information about MaxScale 22.08, refer to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
 
-Before starting the upgrade, any existing configuration files should be backed\
+Before starting the upgrade, any existing configuration files should be backed
 up.
 
 ## Removed Features
 
-* The support for legacy encryption keys generated with `maxkeys` from pre-2.5\
-  versions has been removed. This feature was deprecated in MaxScale 2.5 when\
-  the new key storage format was introduced. To migrate to the new key storage\
+* The support for legacy encryption keys generated with `maxkeys` from pre-2.5
+  versions has been removed. This feature was deprecated in MaxScale 2.5 when
+  the new key storage format was introduced. To migrate to the new key storage
   format, create a new key file with `maxkeys` and re-encrypt the passwords with`maxpasswd`.
 * The deprecated Database Firewall filter has been removed.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale.md
@@ -6,31 +6,31 @@
 
 For more information about what has changed, please refer to the ChangeLog and to the [release notes](https://mariadb.com/kb/Release-Notes/).
 
-Before starting the upgrade, any existing configuration files should\
+Before starting the upgrade, any existing configuration files should
 be backed up.
 
 ## Upgrading MariaDB MaxScale from 21.06 to 22.08
 
 ### Removed Features
 
-* The support for legacy encryption keys generated with `maxkeys` from pre-2.5\
-  versions has been removed. This feature was deprecated in MaxScale 2.5 when\
-  the new key storage format was introduced. To migrate to the new key storage\
+* The support for legacy encryption keys generated with `maxkeys` from pre-2.5
+  versions has been removed. This feature was deprecated in MaxScale 2.5 when
+  the new key storage format was introduced. To migrate to the new key storage
   format, create a new key file with `maxkeys` and re-encrypt the passwords with`maxpasswd`.
 * The deprecated Database Firewall filter has been removed.
 
 ## Upgrading MariaDB MaxScale from 2.5 to 21.06
 
-**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have\
-been released as 6.4.16 in June, was released as 21.06.16. The purpose of this\
-change is to make the versioning scheme used by all MaxScale series\
+**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have
+been released as 6.4.16 in June, was released as 21.06.16. The purpose of this
+change is to make the versioning scheme used by all MaxScale series
 identical. 21.06 denotes the year and month when the first 6 release was made.
 
 ### Duration Type Parameters
 
 Using duration type parameters without an explicit suffix has been deprecated in\
 MaxScale 2.4. In MaxScale 6 they are no longer allowed when used with the REST\
-API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that\
+API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that
 use a duration type parameter must explicitly specify the suffix of the unit.
 
 For example, the following command:
@@ -45,8 +45,8 @@ should be replaced with:
 maxctrl alter service My-Service connection_keepalive 30000ms
 ```
 
-Duration type parameters can still be defined in the configuration file without\
-an explicit suffix but this behavior is deprecated. The recommended approach is\
+Duration type parameters can still be defined in the configuration file without
+an explicit suffix but this behavior is deprecated. The recommended approach is
 to add explicit suffixes to all duration type parameters when upgrading to\
 MaxScale 6.
 
@@ -68,22 +68,22 @@ The following deprecated core parameters have been removed:
 
 The deprecated aliases for the schemarouter parameters `ignore_databases` and`ignore_databases_regex` have been removed. They can be replaced with`ignore_tables` and `ignore_tables_regex`.
 
-In addition, the `preferred_server` parameter that was deprecated in 2.5 has\
+In addition, the `preferred_server` parameter that was deprecated in 2.5 has
 also been removed.
 
 #### `mariadbmon`
 
-* MariaDBMonitor settings `ignore_external_masters`, `detect_replication_lagdetect_standalone_master`, `detect_stale_master` and `detect_stale_slave`\
-  have been removed. The first two were ineffective, the latter three are\
+* MariaDBMonitor settings `ignore_external_masters`, `detect_replication_lagdetect_standalone_master`, `detect_stale_master` and `detect_stale_slave`
+  have been removed. The first two were ineffective, the latter three are
   replaced by `master_conditions` and `slave_conditions`.
 
 ### Session Command History
 
-The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`\
-have been made into generic service parameters that are shared between all\
+The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`
+have been made into generic service parameters that are shared between all
 routers that support it.
 
-The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it\
+The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it
 being enabled or are not affected by it.
 
 ## Upgrading MariaDB MaxScale from 2.4 to 2.5
@@ -91,33 +91,33 @@ being enabled or are not affected by it.
 ### MaxAdmin
 
 The deprecated MaxAdmin interface has been removed in 2.5.0 in favor of the REST\
-API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can\
+API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can
 no longer be used.
 
 ### Authentication
 
-The credentials used by services now require additional grants. For a full list\
+The credentials used by services now require additional grants. For a full list
 of required grants, refer to the [protocol documentation](https://mariadb.com/kb/en/mariadb-maxscale-2208-maxscale-2208-authentication-modules/#required-grants).
 
 ### MariaDB-Monitor
 
-The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in\
+The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in
 a later version.
 
 #### Password encryption
 
-The encrypted passwords feature has been updated to be more secure. Users are\
-recommended to generate a new encryption key and re-encrypt their passwords\
+The encrypted passwords feature has been updated to be more secure. Users are
+recommended to generate a new encryption key and re-encrypt their passwords
 using the `maxkeys` and `maxpasswd` utilities. Old passwords still work.
 
 ### Default Server State
 
-The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally\
+The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally
 used before they were monitored.
 
 ### Columnstore Monitor
 
-It is now mandatory to specify in the configuration what version the\
+It is now mandatory to specify in the configuration what version the
 monitored Columnstore cluster is.
 
 ```
@@ -128,20 +128,20 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-columnstore-monitor.md#master-selection)\
+Please see the [documentation](../mariadb-maxscale-2208-monitors/mariadb-maxscale-2208-columnstore-monitor.md#master-selection)
 for details.
 
 ### New binlog router
 
-The binlog router delivered with MaxScale 2.5 is completely new and\
-not 100% backward compatible with the binlog router delivered with\
-earlier MaxScale versions. If you use the binlog router, carefully\
-assess whether the functionality provided by the new one fulfills\
+The binlog router delivered with MaxScale 2.5 is completely new and
+not 100% backward compatible with the binlog router delivered with
+earlier MaxScale versions. If you use the binlog router, carefully
+assess whether the functionality provided by the new one fulfills
 your requirements, before upgrading MaxScale.
 
 ### Tee Filter
 
-The tee filter parameter `service` has been deprecated in favor of the `target`\
+The tee filter parameter `service` has been deprecated in favor of the `target`
 parameter. All usages of `service` can be replaced with `target`.
 
 ## Upgrading MariaDB MaxScale from 2.3 to 2.4
@@ -150,10 +150,10 @@ parameter. All usages of `service` can be replaced with `target`.
 
 #### Reserved Names
 
-Section and object names starting with `@@` are now reserved for\
+Section and object names starting with `@@` are now reserved for
 internal use by MaxScale.
 
-In case such names have been used, they must manually be changed\
+In case such names have been used, they must manually be changed
 in all configuration files of MaxScale, before MaxScale 2.4 is started.
 
 Those files are:
@@ -164,7 +164,7 @@ Those files are:
 
 #### Whitespace in Names
 
-Whitespace in section names that was deprecated in MaxScale 2.2 will now be\
+Whitespace in section names that was deprecated in MaxScale 2.2 will now be
 rejected, which will cause the startup of MaxScale to fail.
 
 To prevent that, section names like
@@ -191,11 +191,11 @@ servers=MyServer
 
 ### Durations
 
-Durations can now be specified using one of the suffixes `h`, `m`, `s`\
-and `ms` for specifying durations in hours, minutes, seconds and\
+Durations can now be specified using one of the suffixes `h`, `m`, `s`
+and `ms` for specifying durations in hours, minutes, seconds and
 milliseconds, respectively.
 
-_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,\
+_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,
 so it is advisable to add suffixes to durations. For instance,
 
 ```
@@ -205,12 +205,12 @@ some_param=60000ms
 
 ### Improved Admin User Encryption
 
-MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a\
+MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a
 user to use the better hashing algorithm, either recreate the user or use the`maxctrl alter user` command.
 
 ### MariaDB-Monitor
 
-The following settings have been removed and cause a startup error\
+The following settings have been removed and cause a startup error
 if defined:
 
 * `mysql51_replication`
@@ -219,45 +219,45 @@ if defined:
 
 ### ReadWriteSplit
 
-* If multiple masters are available for a readwritesplit service, the one with\
+* If multiple masters are available for a readwritesplit service, the one with
   the lowest connection count is selected.
-* If a master server is placed into maintenance mode, all open transactions are\
-  allowed to gracefully finish before the session is closed. To forcefully close\
+* If a master server is placed into maintenance mode, all open transactions are
+  allowed to gracefully finish before the session is closed. To forcefully close
   the connections, use the `--force` option for `maxctrl set server`.
-* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the\
+* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the
   overall load on the system when connections are rapidly opened and closed.
-* Transaction replays now have a limit on how many times a replay is\
+* Transaction replays now have a limit on how many times a replay is
   attempted. The default values is five attempts and is controlled by the`transaction_replay_attempts` parameter.
-* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the\
+* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the
   transaction is automatically retried.
 
 ## Upgrading MariaDB MaxScale from 2.2 to 2.3
 
 ### Increased Memory Use
 
-Starting with MaxScale 2.3.0 up to 40% of the memory can be used for\
-caching parsed queries. The most noticeable change is that it improves\
-performance in almost all cases where queries need to be parsed. Most of\
+Starting with MaxScale 2.3.0 up to 40% of the memory can be used for
+caching parsed queries. The most noticeable change is that it improves
+performance in almost all cases where queries need to be parsed. Most of
 the time this happens when the readwritesplit router or filters are used.
 
-The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total\
-memory to 1GB, add `query_classifier_cache_size=1G` to your\
+The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total
+memory to 1GB, add `query_classifier_cache_size=1G` to your
 configuration. To disable it, set the value to `0`.
 
-In addition to the aforementioned query classifier caching, the\
-readwritesplit session command history is enabled by default in 2.3 but is\
-limited to a maximum of 50 commands after which the history is\
-disabled. This is unlikely to show in any metrics but it contributes to\
+In addition to the aforementioned query classifier caching, the
+readwritesplit session command history is enabled by default in 2.3 but is
+limited to a maximum of 50 commands after which the history is
+disabled. This is unlikely to show in any metrics but it contributes to
 the increased memory foorprint of MaxScale.
 
 ### Unknown Global Parameters
 
-All unknown parameters are now treated as errors. Check your configuration for\
+All unknown parameters are now treated as errors. Check your configuration for
 errors if MaxScale fails to start after upgrading to 2.3.1.
 
 ### `passwd` is deprecated
 
-In the configuration file, passwords for monitors and services should be\
+In the configuration file, passwords for monitors and services should be
 specified using `password`; the support for the deprecated`passwd` will be removed in the future. That is, the following
 
 ```
@@ -294,61 +294,61 @@ Authenticator options are now only used with listeners.
 
 #### Administrative Users
 
-The file format for the administrative users used by MaxScale has been\
-changed. Old style files are automatically upgraded and a backup of the old file is\
+The file format for the administrative users used by MaxScale has been
+changed. Old style files are automatically upgraded and a backup of the old file is
 stored in `/var/lib/maxscale/passwd.backup`.
 
 #### Regular Expression Parameters
 
-Modules may now use a built-in regular expression string parameter type instead\
-of a normal string when accepting patterns. The modules that use the new regex\
-parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the\
+Modules may now use a built-in regular expression string parameter type instead
+of a normal string when accepting patterns. The modules that use the new regex
+parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the
 string in slashes, e.g. `match=/^select/` defines the pattern `^select`.
 
 #### Binlog Server
 
-Binlog server automatically accepts GTID connection from MariaDB 10 slave servers\
+Binlog server automatically accepts GTID connection from MariaDB 10 slave servers
 by saving all incoming GTIDs into a SQLite map database.
 
 #### MaxCtrl Included in Main Package
 
-In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2\
-it is in the main `maxscale` package. If you have a previous installation\
+In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2
+it is in the main `maxscale` package. If you have a previous installation
 of MaxCtrl, please remove it before upgrading to MaxScale 2.2.2.
 
 ## Upgrading MariaDB MaxScale from 2.0 to 2.1
 
 ### IPv6 Support
 
-MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to\
-was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,\
+MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to
+was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,
 add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)\
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files
 
-The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The\
+The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The
 default location for the log file is _/var/log/maxscale/maxscale.log_.
 
-Rotating the log files will cause MaxScale to reopen the file instead of\
+Rotating the log files will cause MaxScale to reopen the file instead of
 renaming them. This makes the MaxScale logging facility _logrotate_ compatible.
 
 ### ReadWriteSplit
 
-The `disable_sescmd_history` option is now enabled by default. This means that\
-slaves will not be recovered mid-session even if a replacement slave is\
-available. To enable the legacy behavior, add the `disable_sescmd_history=true`\
+The `disable_sescmd_history` option is now enabled by default. This means that
+slaves will not be recovered mid-session even if a replacement slave is
+available. To enable the legacy behavior, add the `disable_sescmd_history=true`
 parameter to the service definition.
 
 ### Persistent Connections
 
-The MariaDB session state is reset in MaxScale 2.1 for persistent\
-connections. This means that any modifications to the session state (default\
-database, user variable etc.) will not survive if the connection is put into the\
+The MariaDB session state is reset in MaxScale 2.1 for persistent
+connections. This means that any modifications to the session state (default
+database, user variable etc.) will not survive if the connection is put into the
 connection pool. For most users, this is the expected behavior.
 
 ### User Data Cache
@@ -357,27 +357,27 @@ The location of the MariaDB user data cache was moved from`/var/cache/maxscale/<
 
 ### Galeramon Monitoring Algorithm
 
-Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with\
+Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with
 multiple MaxScales but it also causes slower changes of the master node.
 
-To enable the legacy behavior, add `root_node_as_master=false` to the Galera\
+To enable the legacy behavior, add `root_node_as_master=false` to the Galera
 monitor configuration.
 
 ### MaxAdmin Editing Mode
 
-The default editing mode was changed from _vim_ to _emacs_ mode. To start\
+The default editing mode was changed from _vim_ to _emacs_ mode. To start
 maxadmin in the legacy mode, use the `-i` option.
 
 ## Upgrading MariaDB MaxScale from 1.4 to 2.0
 
 ### MaxAdmin
 
-The default way the communication between MaxAdmin and MariaDB MaxScale is\
+The default way the communication between MaxAdmin and MariaDB MaxScale is
 handled has been changed from an internet socket to a Unix domain socket.\
 The former alternative is still available but has been _deprecated_.
 
 If no arguments are given to MaxAdmin, it will attempt to connect to\
-MariaDB MaxScale using a Unix domain socket. After the upgrade you will\
+MariaDB MaxScale using a Unix domain socket. After the upgrade you will
 need to provide at least one internet socket related flag - `-h`, `-P`,`-u` or `-p` - to force MaxAdmin to use the internet socket approach.
 
 E.g.
@@ -389,16 +389,16 @@ user@host $ maxadmin -u admin
 ### MySQL Monitor
 
 The MySQL Monitor now assigns the stale state to the master server by default.\
-In addition to this, the slave servers receive the stale slave state when they\
-lose the connection to the master. This should not cause changes in behavior\
+In addition to this, the slave servers receive the stale slave state when they
+lose the connection to the master. This should not cause changes in behavior
 but the output of MaxAdmin will show new states when replication is broken.
 
 ## Upgrading MaxScale from 1.3 to 1.4
 
 ### Service user permissions
 
-The service users now also need SELECT privileges on mysql.tables\_priv. This is\
-required for the resolution of table level grants. To grant SELECT privileges\
+The service users now also need SELECT privileges on mysql.tables\_priv. This is
+required for the resolution of table level grants. To grant SELECT privileges
 for the service user, replace the user and hostname in the following example.
 
 ```
@@ -413,8 +413,8 @@ For more information about how to do this, please read the installation guide:[M
 
 ### SSL
 
-The SSL configuration parameters are now a part of the listeners. If a service\
-used the old style SSL configuration parameters, the values should be moved to\
+The SSL configuration parameters are now a part of the listeners. If a service
+used the old style SSL configuration parameters, the values should be moved to
 the listener which is associated with that service.
 
 Here is an example of an old style configuration.
@@ -459,23 +459,23 @@ ssl_ca_cert=/home/user/certs/ca.pem
 ssl_version=TLSv12
 ```
 
-Please also note that the `enabled` SSL mode is no longer supported due to\
-the inherent security issues with allowing SSL and non-SSL connections on\
-the same port. In addition to this, SSLv3 is no longer supported due to\
+Please also note that the `enabled` SSL mode is no longer supported due to
+the inherent security issues with allowing SSL and non-SSL connections on
+the same port. In addition to this, SSLv3 is no longer supported due to
 vulnerabilities found in it.
 
 ## Upgrading MaxScale from 1.2 to 1.3
 
 ### Binlog Router
 
-The master server details are now provided with a **master.ini** file located in\
-the binlog directory and it can be changed using a CHANGE MASTER TO command issued\
+The master server details are now provided with a **master.ini** file located in
+the binlog directory and it can be changed using a CHANGE MASTER TO command issued
 via a MySQL connection to MaxScale.
 
-This file, properly filled, is now mandatory and without it the binlog router\
+This file, properly filled, is now mandatory and without it the binlog router
 cannot connect to the master database.
 
-Before starting binlog router after MaxScale 1.3 upgrade, please add relevant\
+Before starting binlog router after MaxScale 1.3 upgrade, please add relevant
 information to _master.ini_, example:
 
 ```
@@ -487,26 +487,26 @@ master_password=somepass
 filestem=repl-bin
 ```
 
-Additionally, the option `servers=masterdb` in the service definition is no\
+Additionally, the option `servers=masterdb` in the service definition is no
 longer required.
 
 ## Upgrading MaxScale from 1.1 to 1.2
 
-This document describes upgrading MaxScale from version 1.1.1 to 1.2 and\
-the major differences in the new version compared to the old version. The\
-major changes can be found in the `Changelog.txt` file in the installation\
+This document describes upgrading MaxScale from version 1.1.1 to 1.2 and
+the major differences in the new version compared to the old version. The
+major changes can be found in the `Changelog.txt` file in the installation
 directory and the official release notes in the `ReleaseNotes.txt` file.
 
 ### Installation
 
 Upgrading MaxScale will copy the `MaxScale.cnf` file in`/usr/local/mariadb-maxscale/etc/` to `/etc/` and renamed to `maxscale.cnf`.\
-Binary log files are not automatically copied and should be manually moved\
+Binary log files are not automatically copied and should be manually moved
 from `/usr/local/mariadb-maxscale` to `/var/lib/maxscale/`.
 
 ### File location changes
 
-MaxScale 1.2 follows the [FHS-standard](https://www.pathname.com/fhs/) and\
-installs to `/usr/` and `/var/` subfolders. Here are the major changes and\
+MaxScale 1.2 follows the [FHS-standard](https://www.pathname.com/fhs/) and
+installs to `/usr/` and `/var/` subfolders. Here are the major changes and
 file locations.
 
 * Configuration files are located in `/etc/` and use lowercase letters: `/etc/maxscale.cnf`
@@ -518,26 +518,26 @@ file locations.
 
 ### Running MaxScale without root permissions
 
-MaxScale can run as a non-root user with the 1.2 version. RPM and DEB\
-packages install the `maxscale` user and `maxscale` group which are used\
-by the init scripts and systemd configuration files. If you are installing\
-from a binary tarball, you can run the `postinst` script included in it to\
+MaxScale can run as a non-root user with the 1.2 version. RPM and DEB
+packages install the `maxscale` user and `maxscale` group which are used
+by the init scripts and systemd configuration files. If you are installing
+from a binary tarball, you can run the `postinst` script included in it to
 manually create these groups.
 
 ## Upgrading MaxScale from 1.0 to 1.1
 
-This document describes upgrading MaxScale from version 1.0.5 to 1.1.0 and\
-the major differences in the new version compared to the old version. The\
-major changes can be found in the `Changelog.txt` file in the installation\
+This document describes upgrading MaxScale from version 1.0.5 to 1.1.0 and
+the major differences in the new version compared to the old version. The
+major changes can be found in the `Changelog.txt` file in the installation
 directory and the official release notes in the `ReleaseNotes.txt` file.
 
 ### Installation
 
-If you are installing MaxScale from a RPM package, we recommend you back\
-up your configuration and log files and that you remove the old installation\
-of MaxScale completely. If you choose to upgrade MaxScale instead of removing\
-it and re-installing it afterwards, the init scripts in `/etc/init.d` folder\
-will be missing. This is due to the RPM packaging system but the script can\
+If you are installing MaxScale from a RPM package, we recommend you back
+up your configuration and log files and that you remove the old installation
+of MaxScale completely. If you choose to upgrade MaxScale instead of removing
+it and re-installing it afterwards, the init scripts in `/etc/init.d` folder
+will be missing. This is due to the RPM packaging system but the script can
 be re-installed by running the `postinst` script found in the`/usr/local/mariadb-maxscale` folder.
 
 ```
@@ -546,14 +546,14 @@ cd /usr/local/mariadb-maxscale
 ./postinst
 ```
 
-The 1.1.0 version of MaxScale installs into `/usr/local/mariadb-maxscale`\
-instead of `/usr/local/skysql/maxscale`. This will cause external references\
-to MaxScale's home directory to stop working so remember to update all\
+The 1.1.0 version of MaxScale installs into `/usr/local/mariadb-maxscale`
+instead of `/usr/local/skysql/maxscale`. This will cause external references
+to MaxScale's home directory to stop working so remember to update all
 paths with the new version.
 
 ### MaxAdmin changes
 
-The MaxAdmin client's default password in MaxScale 1.1.0 is `mariadb`\
+The MaxAdmin client's default password in MaxScale 1.1.0 is `mariadb`
 instead of `skysql`.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-about-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-about-mariadb-maxscale.md
@@ -1,48 +1,48 @@
 # About MariaDB MaxScale
 
-**MariaDB MaxScale** is a database proxy that forwards database statements to\
+**MariaDB MaxScale** is a database proxy that forwards database statements to
 one or more database servers.
 
-The forwarding is performed using rules based on the semantic understanding of\
-the database statements and on the roles of the servers within the backend\
+The forwarding is performed using rules based on the semantic understanding of
+the database statements and on the roles of the servers within the backend
 cluster of databases.
 
-MariaDB MaxScale is designed to provide, transparently to applications, load\
-balancing and high availability functionality. MariaDB MaxScale has a scalable\
-and flexible architecture, with plugin components to support different protocols\
+MariaDB MaxScale is designed to provide, transparently to applications, load
+balancing and high availability functionality. MariaDB MaxScale has a scalable
+and flexible architecture, with plugin components to support different protocols
 and routing approaches.
 
 MariaDB MaxScale makes extensive use of the asynchronous I/O capabilities of the\
-Linux operating system, combined with a fixed number of worker threads. _epoll_\
-is used to provide the event driven framework for the input and output via\
+Linux operating system, combined with a fixed number of worker threads. _epoll_
+is used to provide the event driven framework for the input and output via
 sockets.
 
-Many of the services provided by MariaDB MaxScale are implemented as external\
-shared object modules loaded at runtime. These modules support a fixed\
-interface, communicating the entry points via a structure consisting of a set of\
-function pointers. This structure is called the "module object". Additional\
+Many of the services provided by MariaDB MaxScale are implemented as external
+shared object modules loaded at runtime. These modules support a fixed
+interface, communicating the entry points via a structure consisting of a set of
+function pointers. This structure is called the "module object". Additional
 modules can be created to work with MariaDB MaxScale.
 
-Commonly used module types are _protocol_, _router_ and _filter_. Protocol\
-modules implement the communication between clients and MariaDB MaxScale, and\
-between MariaDB MaxScale and backend servers. Routers inspect the queries from\
-clients and decide the target backend. The decisions are usually based on\
-routing rules and backend server status. Filters work on data as it passes\
-through MariaDB MaxScale. Filter are often used for logging queries or modifying\
+Commonly used module types are _protocol_, _router_ and _filter_. Protocol
+modules implement the communication between clients and MariaDB MaxScale, and
+between MariaDB MaxScale and backend servers. Routers inspect the queries from
+clients and decide the target backend. The decisions are usually based on
+routing rules and backend server status. Filters work on data as it passes
+through MariaDB MaxScale. Filter are often used for logging queries or modifying
 server responses.
 
-A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,\
+A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,
 issues and communicate with the MariaDB MaxScale community. Send email to [maxscale@googlegroups.com](mailto:maxscale@googlegroups.com) or use the [forum](https://groups.google.com/forum/#!forum/maxscale) interface.
 
 Bugs can be reported in the MariaDB Jira [jira.mariadb.org](https://jira.mariadb.org)
 
 ### Installing MariaDB MaxScale
 
-Information about installing MariaDB MaxScale, either from a repository or by\
+Information about installing MariaDB MaxScale, either from a repository or by
 building from source code, is included in the [MariaDB MaxScale Installation\
 Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-installation-guide.md).
 
-The same guide also provides basic information on running MariaDB MaxScale. More\
+The same guide also provides basic information on running MariaDB MaxScale. More
 detailed information about configuring MariaDB MaxScale can be found in the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md
@@ -1,42 +1,42 @@
 # Limitations and Known Issues within MariaDB MaxScale
 
-This document lists known issues and limitations in MariaDB MaxScale and its\
-plugins. Since limitations are related to specific plugins, this document is\
+This document lists known issues and limitations in MariaDB MaxScale and its
+plugins. Since limitations are related to specific plugins, this document is
 divided into several sections.
 
 ### Configuration limitations
 
-In versions 2.1.2 and earlier, the configuration files are limited to 1024\
+In versions 2.1.2 and earlier, the configuration files are limited to 1024
 characters per line. This limitation was increased to 16384 characters in\
 MaxScale 2.1.3. MaxScale 2.3.0 increased this limit to 16777216 characters.
 
-In versions 2.2.12 and earlier, the section names in the configuration files\
-were limited to 49 characters. This limitation was increased to 1023 characters\
+In versions 2.2.12 and earlier, the section names in the configuration files
+were limited to 49 characters. This limitation was increased to 1023 characters
 in MaxScale 2.2.13.
 
 #### Multiple MaxScales on same server
 
-Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to\
-the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale\
-instances to listen on the same network port if the directories used by both\
-instances are completely separate and there are no conflicts which can cause\
-unexpected splitting of connections. This will only happen if users explicitly\
-tell MaxScale to ignore the default directories and will not happen in normal\
+Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to
+the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale
+instances to listen on the same network port if the directories used by both
+instances are completely separate and there are no conflicts which can cause
+unexpected splitting of connections. This will only happen if users explicitly
+tell MaxScale to ignore the default directories and will not happen in normal
 use.
 
 ### Security limitations
 
 #### MariaDB 10.2
 
-The parser of MaxScale correctly parses `WITH` statements, but fails to\
+The parser of MaxScale correctly parses `WITH` statements, but fails to
 collect columns, functions and tables used in the `SELECT` defining the`WITH` clause.
 
-Consequently, the database firewall will **not** block `WITH` statements\
+Consequently, the database firewall will **not** block `WITH` statements
 where the `SELECT` of the `WITH` clause refers to forbidden columns.
 
 ### MariaDB Default Values
 
-MaxScale assumes that certain configuration parameters in MariaDB are set to\
+MaxScale assumes that certain configuration parameters in MariaDB are set to
 their default values. These include but are not limited to:
 
 * `autocommit`: Autocommit is enabled for all new connections.
@@ -51,38 +51,38 @@ require query classification, a custom parser is used to detect them. Currently\
 the only situation in which this parser is used is when a `readconnroute`\
 service uses the `cache` filter.
 
-The custom parser detects a subset of the full SQL syntax used to start\
-transactions. This means that more complex statements will not be fully parsed\
-and will cause the transaction state to not match the real state on the\
-database. For example, `SET @my_var = (SELECT 1), autocommit = 0` is not parsed\
+The custom parser detects a subset of the full SQL syntax used to start
+transactions. This means that more complex statements will not be fully parsed
+and will cause the transaction state to not match the real state on the
+database. For example, `SET @my_var = (SELECT 1), autocommit = 0` is not parsed
 by the custom parser and causes the autocommit modification to not be noticed.
 
 #### XA Transactions
 
-MaxScale will treat statements executed after `XA START` and before `XA END` as\
-if they were executed in a normal read-write transaction started with `START TRANSACTION`. This means that only XA transactions in the ACTIVE state will be\
+MaxScale will treat statements executed after `XA START` and before `XA END` as
+if they were executed in a normal read-write transaction started with `START TRANSACTION`. This means that only XA transactions in the ACTIVE state will be
 routed as transactions and all statements after `XA END` are routed normally.
 
-XA transactions and normal transactions are mutually exclusive in MariaDB. This\
-means that a `START TRANSACTION` command will fail if the connection already has\
-an open XA transaction. MaxScale currently only inspects the SQL and deduces the\
-transaction state from that. If a transaction fails to start due to an open XA\
-transaction, the state in MaxScale and in MariaDB can be different and MaxScale\
-will keep routing statements as if they were inside of a transaction. However,\
+XA transactions and normal transactions are mutually exclusive in MariaDB. This
+means that a `START TRANSACTION` command will fail if the connection already has
+an open XA transaction. MaxScale currently only inspects the SQL and deduces the
+transaction state from that. If a transaction fails to start due to an open XA
+transaction, the state in MaxScale and in MariaDB can be different and MaxScale
+will keep routing statements as if they were inside of a transaction. However,
 as this is an unlikely scenario, usually no action needs to be taken.
 
 ### Prepared Statements
 
-For its proper functioning, MaxScale needs in general to be aware of the\
-transaction state and _autocommit_ mode. In order to be that, MaxScale\
+For its proper functioning, MaxScale needs in general to be aware of the
+transaction state and _autocommit_ mode. In order to be that, MaxScale
 parses statements going through it.
 
-However, if a transaction is committed or rolled back, or the autocommit\
-mode is changed using a prepared statement, MaxScale will miss that and its\
-internal state will be incorrect, until the transaction state or autocommit\
+However, if a transaction is committed or rolled back, or the autocommit
+mode is changed using a prepared statement, MaxScale will miss that and its
+internal state will be incorrect, until the transaction state or autocommit
 mode is changed using an explicit statement.
 
-For instance, after the following sequence of commands, MaxScale will still\
+For instance, after the following sequence of commands, MaxScale will still
 think _autocommit_ is on:
 
 ```
@@ -91,7 +91,7 @@ PREPARE hide_autocommit FROM "set autocommit=0"
 EXECUTE hide_autocommit
 ```
 
-To ensure that MaxScale functions properly, do not commit or rollback a\
+To ensure that MaxScale functions properly, do not commit or rollback a
 transaction or change the autocommit mode using a prepared statement.
 
 ### Protocol limitations
@@ -99,65 +99,65 @@ transaction or change the autocommit mode using a prepared statement.
 #### Limitations with MySQL/MariaDB Protocol support (MariaDBClient)
 
 * Compression is not included in the server handshake.
-* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept\
-  it. If the ID matches a MaxScale session ID, it will be closed by sending\
-  modified `KILL` commands of the same type to all backend server to which the\
-  session in question is connected to. This results in behavior that is similar\
-  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,\
+* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept
+  it. If the ID matches a MaxScale session ID, it will be closed by sending
+  modified `KILL` commands of the same type to all backend server to which the
+  session in question is connected to. This results in behavior that is similar
+  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,
   all connections with a matching username will be closed instead.
-* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type\
-  statements. If a query by a query ID is to be killed, it needs to be done\
+* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type
+  statements. If a query by a query ID is to be killed, it needs to be done
   directly on the backend databases.
 * Any `KILL` commands executed using a prepared statement are ignored by\
-  MaxScale. If any are executed, it is highly likely that the wrong connection\
+  MaxScale. If any are executed, it is highly likely that the wrong connection
   ends up being killed.
-* If a `KILL` connection kills a session that is connected to a readwritesplit\
-  service that has `transaction_replay` or `delayed_retry` enabled, it is\
-  possible that the query is retried even if the connection is killed. To avoid\
+* If a `KILL` connection kills a session that is connected to a readwritesplit
+  service that has `transaction_replay` or `delayed_retry` enabled, it is
+  possible that the query is retried even if the connection is killed. To avoid
   this, use `KILL QUERY` instead.
-* A `KILL` on one service can cause a connection from another service to be\
+* A `KILL` on one service can cause a connection from another service to be
   closed even if it uses a different protocol.
-* The change user command (COM\_CHANGE\_USER) only works with standard\
+* The change user command (COM\_CHANGE\_USER) only works with standard
   authentication.
-* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session\
-  ends up in an inconsistent state. This can happen if the password of the\
-  target user is changed and MaxScale uses old user account data when processing\
-  the change user. In such a situation, MaxScale and server will disagree on the\
+* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session
+  ends up in an inconsistent state. This can happen if the password of the
+  target user is changed and MaxScale uses old user account data when processing
+  the change user. In such a situation, MaxScale and server will disagree on the
   current user. This can affect e.g. reconnections.
 
 ### Authenticator limitations
 
 #### Limitations in the MySQL authenticator (MariaDBAuth)
 
-* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use\
+* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use
   a new authentication protocol which does not support pre-4.1 style passwords.
 * When users have different passwords based on the host from which they connect\
-  MariaDB MaxScale is unable to determine which password it should use to connect\
-  to the backend database. This results in failed connections and unusable\
+  MariaDB MaxScale is unable to determine which password it should use to connect
+  to the backend database. This results in failed connections and unusable
   usernames in MariaDB MaxScale.
 
 ### Filter limitations
 
 #### Tee filter limitations (tee)
 
-The Tee filter does not support binary protocol prepared statements. The\
-execution of a prepared statements through a service that uses the tee filter is\
-not guaranteed to succeed on the service where the filter branches to as it does\
+The Tee filter does not support binary protocol prepared statements. The
+execution of a prepared statements through a service that uses the tee filter is
+not guaranteed to succeed on the service where the filter branches to as it does
 on the original service.
 
-This possibility exists due to the fact that the binary protocol prepared\
-statements are identified by a server-generated ID. The ID sent to the client\
-from the main service is not guaranteed to be the same that is sent by the\
+This possibility exists due to the fact that the binary protocol prepared
+statements are identified by a server-generated ID. The ID sent to the client
+from the main service is not guaranteed to be the same that is sent by the
 branch service.
 
 ### Monitor limitations
 
-A server can only be monitored by one monitor. Two or more monitors monitoring\
+A server can only be monitored by one monitor. Two or more monitors monitoring
 the same server is considered an error.
 
 #### Limitations with Galera Cluster Monitoring (galeramon)
 
-The default master selection is based only on MIN(wsrep\_local\_index). This\
+The default master selection is based only on MIN(wsrep\_local\_index). This
 can be influenced with the server priority mechanic described in the [Galera Monitor](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-galera-monitor.md) manual.
 
 ### Router limitations
@@ -166,38 +166,38 @@ Refer to individual router documentation for a list of their limitations.
 
 ## ETL Limitations
 
-The ETL feature in MaxScale always uses the MariaDB Connector/ODBC driver to\
-perform the data loading into MariaDB. The recommended minimum version of the\
-connector is 3.1.18. Older versions of the driver suffer from problems that may\
-manifest as crashes or memory leaks. The driver must be installed on the system\
+The ETL feature in MaxScale always uses the MariaDB Connector/ODBC driver to
+perform the data loading into MariaDB. The recommended minimum version of the
+connector is 3.1.18. Older versions of the driver suffer from problems that may
+manifest as crashes or memory leaks. The driver must be installed on the system
 in order for the ETL feature to work.
 
-The data loading into MariaDB is done with `autocommit`, `unique_checks` and`foreign_key_checks` disabled inside of a single transaction. This is done to\
-leverage the optimizations done for InnoDB that allows faster insertions into\
-empty tables. When loading data into MariaDB versions 10.5 or older, this can\
+The data loading into MariaDB is done with `autocommit`, `unique_checks` and`foreign_key_checks` disabled inside of a single transaction. This is done to
+leverage the optimizations done for InnoDB that allows faster insertions into
+empty tables. When loading data into MariaDB versions 10.5 or older, this can
 translate into long rollback times in case the ETL operation fails.
 
 ### ETL Limitations with PostgreSQL as the Source
 
-For ETL operations that migrate data from PostgreSQL, we recommend using the\
-official PostgreSQL ODBC driver. Use of other PostgreSQL ODBC drivers is\
-possible but not recommended: correct configuration of the driver is necessary\
+For ETL operations that migrate data from PostgreSQL, we recommend using the
+official PostgreSQL ODBC driver. Use of other PostgreSQL ODBC drivers is
+possible but not recommended: correct configuration of the driver is necessary
 to prevent the driver from consuming too much memory.
 
 #### Limitations in Automatic SQL Generation
 
 * Triggers on tables are not migrated automatically.
-* Check constraints are defined using the native PostgreSQL\
+* Check constraints are defined using the native PostgreSQL
   syntax. Incompatibilities must be manually fixed.
 * All indexes specific to PostgreSQL will be converted into normal indexes in\
   MariaDB.
-* The `GEOMETRY` type is assumed to be the type provided by PostGIS. It is\
+* The `GEOMETRY` type is assumed to be the type provided by PostGIS. It is
   converted into a MariaDB `GEOMETRY` type and is extracted using `ST_AsText`.
 
 ### ETL Limitations with Generic ODBC Targets
 
-It is the responsibility of the end-user to correctly configure the ODBC\
-driver. Some drivers read the whole resultset into memory by default which will\
+It is the responsibility of the end-user to correctly configure the ODBC
+driver. Some drivers read the whole resultset into memory by default which will
 result in MaxScale running out of memory
 
 * ETL operations that operate on more than one catalog are not supported.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md
@@ -3,45 +3,45 @@
 This document describes general MySQL protocol authentication in MaxScale. For\
 REST-api authentication, see the [configuration guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md) and the [REST-api guide](../mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md).
 
-Similar to the MariaDB Server, MaxScale uses authentication plugins to implement\
-different authentication schemes for incoming clients. The same plugins also\
-handle authenticating the clients to backend servers. The authentication plugins\
+Similar to the MariaDB Server, MaxScale uses authentication plugins to implement
+different authentication schemes for incoming clients. The same plugins also
+handle authenticating the clients to backend servers. The authentication plugins
 available in MaxScale are [standard MySQL password](mariadb-maxscale-2302-mysql-authenticator.md),[GSSAPI](mariadb-maxscale-2302-gssapi-client-authenticator.md) and [pluggable authentication modules (PAM)](mariadb-maxscale-2302-pam-authenticator.md).
 
-Most of the authentication processing is performed on the protocol level, before\
-handing it over to one of the plugins. This shared part is described in this\
+Most of the authentication processing is performed on the protocol level, before
+handing it over to one of the plugins. This shared part is described in this
 document. For information on an individual plugin, see its documentation.
 
 ### User account management
 
-Every MaxScale service with a MariaDB protocol listener requires knowledge of\
-the user accounts defined on the backend databases. The service maintains this\
+Every MaxScale service with a MariaDB protocol listener requires knowledge of
+the user accounts defined on the backend databases. The service maintains this
 information in an internal component called the _user account manager_ (UAM).\
-The UAM queries relevant data from the _mysql_-database of the backends and\
-stores it. Typically, only the current primary server is queried, as all servers\
-are assumed to have the same users. The service settings _user_ and _password_\
+The UAM queries relevant data from the _mysql_-database of the backends and
+stores it. Typically, only the current primary server is queried, as all servers
+are assumed to have the same users. The service settings _user_ and _password_
 define the credentials used when fetching user accounts.
 
-The service uses the stored data when authenticating clients, checking their\
-passwords and database access rights. This results in an authentication process\
-very similar to the MariaDB Server itself. Unauthorized users are generally\
-detected already at the MaxScale level instead of the backend servers. This may\
+The service uses the stored data when authenticating clients, checking their
+passwords and database access rights. This results in an authentication process
+very similar to the MariaDB Server itself. Unauthorized users are generally
+detected already at the MaxScale level instead of the backend servers. This may
 not apply in some cases, for example if MaxScale is using old user account data.
 
-If authentication fails, the UAM updates its data from a backend. MaxScale may\
-attempt authenticating the client again with the refreshed data without\
-communicating the first failure to the client. This transparent user data update\
+If authentication fails, the UAM updates its data from a backend. MaxScale may
+attempt authenticating the client again with the refreshed data without
+communicating the first failure to the client. This transparent user data update
 does not always work, in which case the client should try to log in again.
 
-As the UAM is shared between all listeners of a service, its settings are\
-defined in the service configuration. For more information, search the [configuration guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)\
-for _users\_refresh\_time_, _users\_refresh\_interval_ and_auth\_all\_servers_. Other settings which affect how the UAM connects to backends\
-are the global settings _auth\_connect\_timeout_ and _local\_address_, and\
+As the UAM is shared between all listeners of a service, its settings are
+defined in the service configuration. For more information, search the [configuration guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)
+for _users\_refresh\_time_, _users\_refresh\_interval_ and_auth\_all\_servers_. Other settings which affect how the UAM connects to backends
+are the global settings _auth\_connect\_timeout_ and _local\_address_, and
 the various server-level ssl-settings.
 
 #### Required grants
 
-To properly fetch user account information, the MaxScale service user must be\
+To properly fetch user account information, the MaxScale service user must be
 able to read from various tables in the _mysql_-database: _user_, _db_,_tables\_priv_, _columns\_priv_, _procs\_priv_, _proxies\_priv_ and _roles\_mapping_.\
 The user should also have the _SHOW DATABASES_-grant.
 
@@ -66,23 +66,23 @@ GRANT ALL ON infinidb_vtable.* TO 'maxscale'@'maxscalehost';
 ### Limitations and troubleshooting
 
 When a client logs in to MaxScale, MaxScale sees the client's IP address. When\
-MaxScale then connects the client to backends (using the client's username and\
+MaxScale then connects the client to backends (using the client's username and
 password), the backends see the connection coming from the IP address of\
-MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this\
-is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),\
+MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this
+is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),
 authentication to backends will fail.
 
 There are two primary ways to deal with this:
 
-1. Duplicate user accounts. For every user account with a restricted hostname an\
+1. Duplicate user accounts. For every user account with a restricted hostname an
    equivalent user account for MaxScale is added (`'alice'@'maxscale-ip'`).
 2. Use [proxy protocol](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#proxy_protocol).
 
-Option 1 limits the passwords for user accounts with shared usernames. Such\
+Option 1 limits the passwords for user accounts with shared usernames. Such
 accounts must use the same password since they will effectively share the\
 MaxScale-to-backend user account. Option 2 requires server support.
 
-See [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)\
+See [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 for additional information on how to solve authentication issues.
 
 #### Wildcard database grants
@@ -90,14 +90,14 @@ for additional information on how to solve authentication issues.
 MaxScale supports wildcards `_` and `%` for database-level grants. As with\
 MariaDB Server, `grant select on test_.* to 'alice'@'%';` gives access to _test\__ as well as _test1_, _test2_ and so on. If the GRANT command escapes the
 wildcard (`grant select on` test\_`.* to 'alice'@'%';`) both MaxScale and the\
-MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`\
+MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`
 are only interpreted as wildcards when the grant is to a database:`grant select on` test\_`.t1 to 'alice'@'%';` only grants access to the_test\_.t1_-table, not to _test1.t1_.
 
 ### Authenticator options
 
-The listener configuration defines authentication options which only affect the\
-listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an\
-individual authentication plugin or the authentication as a whole. The latter\
+The listener configuration defines authentication options which only affect the
+listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an
+individual authentication plugin or the authentication as a whole. The latter
 are explained below. Multiple options can be given as a comma-separated list.
 
 ```
@@ -111,20 +111,20 @@ authenticator_options=skip_authentication=true,lower_case_table_names=1
 * Dynamic: No
 * Default: `false`
 
-If enabled, MaxScale will not check the\
+If enabled, MaxScale will not check the
 passwords of incoming clients and just assumes that they are correct.\
-Wrong passwords are instead detected when MaxScale tries to authenticate to the\
+Wrong passwords are instead detected when MaxScale tries to authenticate to the
 backend servers.
 
-This setting is mainly meant for failure tolerance in situations where the\
-password check is performed outside of MaxScale. If, for example, MaxScale\
-cannot use an LDAP-server but the backend databases can, enabling this setting\
-allows clients to log in. Even with this setting enabled, a user account\
+This setting is mainly meant for failure tolerance in situations where the
+password check is performed outside of MaxScale. If, for example, MaxScale
+cannot use an LDAP-server but the backend databases can, enabling this setting
+allows clients to log in. Even with this setting enabled, a user account
 matching the incoming client username and IP must exist on the backends for\
 MaxScale to accept the client.
 
 This setting is incompatible with standard MariaDB/MySQL authentication plugin\
-(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to\
+(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to
 backend servers using standard authentication.
 
 ```
@@ -138,12 +138,12 @@ authenticator_options=skip_authentication=true
 * Dynamic: No
 * Default: `true`
 
-If disabled, MaxScale does not require that a\
+If disabled, MaxScale does not require that a
 valid user account entry for incoming clients exists on the backends.\
-Specifically, only the client username needs to match a user account,\
+Specifically, only the client username needs to match a user account,
 hostname/IP is ignored.
 
-This setting may be used to force clients to connect through MaxScale. Normally,\
+This setting may be used to force clients to connect through MaxScale. Normally,
 creating the user _jdoe@%_ will allow the user _jdoe_ to connect from any\
 IP-address. By disabling _match\_host_ and replacing the user with _jdoe@maxscale-IP_, the user can still connect from any client IP but will be
 forced to go through MaxScale.
@@ -159,29 +159,29 @@ authenticator_options=match_host=false
 * Dynamic: No
 * Default: `0`
 
-Controls database name matching for authentication\
-when an incoming client logs in to a non-empty database. The setting functions\
-similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)\
+Controls database name matching for authentication
+when an incoming client logs in to a non-empty database. The setting functions
+similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)
 and should be set to the value used by the backends.
 
 The setting accepts the values 0, 1 or 2:
 
 * `0`: case-sensitive matching (default)
-* `1`: convert the requested database name to lower case before using case-insensitive\
+* `1`: convert the requested database name to lower case before using case-insensitive
   matching. Assumes that database names on the server are stored in lower case.
 * `2`: use case-insensitive matching.
 
-_true_ and _false_ are also accepted for backwards compatibility. These map to 1\
+_true_ and _false_ are also accepted for backwards compatibility. These map to 1
 and 0, respectively.
 
-The identifier names are converted using an ASCII-only function. This means that\
+The identifier names are converted using an ASCII-only function. This means that
 non-ASCII characters will retain their case-sensitivity.
 
-Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior\
-of `lower_case_table_names=1` is identical with how the MariaDB server\
-behaves. In older releases the comparisons were done in a case-sensitive manner\
-after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes\
-it a safe alternative to use when a mix of older and newer MaxScale versions is\
+Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior
+of `lower_case_table_names=1` is identical with how the MariaDB server
+behaves. In older releases the comparisons were done in a case-sensitive manner
+after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes
+it a safe alternative to use when a mix of older and newer MaxScale versions is
 being used.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-ed25519-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-ed25519-authenticator.md
@@ -1,19 +1,19 @@
 # Ed25519 Authenticato
 
-Ed25519 is a highly secure authentication method based on public key\
+Ed25519 is a highly secure authentication method based on public key
 cryptography. It is used with the auth\_ed25519-plugin of MariaDB Server.
 
-When a client authenticates via ed25519, MaxScale first sends them a random\
-message. The client signs the message using their password as private key and\
-sends the signature back. MaxScale then checks the signature using the public\
-key fetched from the _mysql.user_-table. The client password or an equivalent\
+When a client authenticates via ed25519, MaxScale first sends them a random
+message. The client signs the message using their password as private key and
+sends the signature back. MaxScale then checks the signature using the public
+key fetched from the _mysql.user_-table. The client password or an equivalent
 token is never exposed. For more information, see [server documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-ed25519).
 
-The security of this authentication scheme presents a problem for a proxy such\
-as MaxScale since MaxScale needs to log in to backend servers on behalf of the\
-client. Since each server will generate their own random messages, MaxScale\
-cannot simply forward the original signature. Either the real password is\
-required, or a different authentication scheme must be used between MaxScale\
+The security of this authentication scheme presents a problem for a proxy such
+as MaxScale since MaxScale needs to log in to backend servers on behalf of the
+client. Since each server will generate their own random messages, MaxScale
+cannot simply forward the original signature. Either the real password is
+required, or a different authentication scheme must be used between MaxScale
 and backends. The MaxScale ed25519auth-plugin supports both alternatives.
 
 ### Configuration
@@ -28,17 +28,17 @@ service=Read-Write-Service
 authenticator=ed25519auth
 ```
 
-MaxScale will now authenticate incoming clients with ed25519 if their user\
-account has _plugin_ set to "ed25519" in the _mysql.user_-table. However,\
-routing queries will fail since MaxScale cannot authenticate to backends. To\
-continue, either use a mapping file or enable sha256-mode. Sha256-mode is\
+MaxScale will now authenticate incoming clients with ed25519 if their user
+account has _plugin_ set to "ed25519" in the _mysql.user_-table. However,
+routing queries will fail since MaxScale cannot authenticate to backends. To
+continue, either use a mapping file or enable sha256-mode. Sha256-mode is
 enabled with the following settings.
 
 #### `ed_mode`
 
 This setting defines the authentication mode used. Two values are supported:
 
-* `ed25519` (default) Digital signature based authentication. Requires mapping\
+* `ed25519` (default) Digital signature based authentication. Requires mapping
   for backend support.
 * `sha256` Authenticate client with caching\_sha2\_password-plugin instead.\
   Requires either SSL or configured RSA-keys.
@@ -49,7 +49,7 @@ authenticator_options=ed_mode=sha256
 
 #### `ed_rsa_privkey_path` and `ed_rsa_pubkey_path`
 
-Defines the RSA-keys used for encrypting the client password if SSL is not in\
+Defines the RSA-keys used for encrypting the client password if SSL is not in
 use. Should point to files with the private and public keys.
 
 ```
@@ -60,13 +60,13 @@ authenticator_options=ed_mode=sha256,
 
 ### Using a mapping file
 
-To enable MaxScale to authenticate to backends,[user mapping](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#user_mapping_file)\
+To enable MaxScale to authenticate to backends,[user mapping](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#user_mapping_file)
 can be used. The mapping and backend passwords are given in a json-file.\
-The client can map to an identical username or to another user, and the backend\
+The client can map to an identical username or to another user, and the backend
 authentication scheme can be something else than ed25519.
 
-The following example maps user "alpha" to "beta" and MaxScale then uses\
-standard authentication to log into backends as "beta". User "alpha"\
+The following example maps user "alpha" to "beta" and MaxScale then uses
+standard authentication to log into backends as "beta". User "alpha"
 authenticates to MaxScale using whatever method configured in the server.\
 User "gamma" does not map to another user, just the password is given.
 
@@ -112,16 +112,16 @@ user_mapping_file=/home/joe/mapping.json
 
 ### Using sha256-authentication
 
-The mapping-based solution requires the DBA to maintain a file with user\
+The mapping-based solution requires the DBA to maintain a file with user
 passwords, which has security and upkeep implications. To avoid this,\
-MaxScale can instead use the caching\_sha2\_password-plugin to authenticate\
-the client. This authentication scheme transmits the client password to MaxScale\
-in full, allowing MaxScale to log into backends using ed25519. MaxScale\
-effectively lies to the client about its authentication plugin and then uses\
-the correct plugin with the backends. Enable sha256-authentication by setting\
+MaxScale can instead use the caching\_sha2\_password-plugin to authenticate
+the client. This authentication scheme transmits the client password to MaxScale
+in full, allowing MaxScale to log into backends using ed25519. MaxScale
+effectively lies to the client about its authentication plugin and then uses
+the correct plugin with the backends. Enable sha256-authentication by setting
 authentication option _ed\_mode_ to "sha256".
 
-sha256-authentication is best used with encrypted connections. The example\
+sha256-authentication is best used with encrypted connections. The example
 below shows a listener configured for sha256-mode and SSL.
 
 ```
@@ -139,9 +139,9 @@ ssl_ca=/tmp/myCA.pem
 
 If SSL is not in use, caching\_sha2\_password transmits the password using\
 RSA-encryption. In this case, MaxScale needs the public and private RSA-keys.\
-MaxScale sends the public key to the client if they don't already have it and\
-the client uses it to encrypt the password. MaxScale then uses the private key\
-to decrypt the password. The example below shows a listener configured for\
+MaxScale sends the public key to the client if they don't already have it and
+the client uses it to encrypt the password. MaxScale then uses the private key
+to decrypt the password. The example below shows a listener configured for
 sha256-mode without SSL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-gssapi-client-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-gssapi-client-authenticator.md
@@ -1,24 +1,24 @@
 # GSSAPI Client Authenticator
 
-GSSAPI is an authentication protocol that is commonly implemented with Kerberos\
-on Unix or Active Directory on Windows. This document describes GSSAPI\
+GSSAPI is an authentication protocol that is commonly implemented with Kerberos
+on Unix or Active Directory on Windows. This document describes GSSAPI
 authentication in MaxScale. The authentication module name in MaxScale is_GSSAPIAuth_.
 
 ### Preparing the GSSAPI system
 
-For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short\
+For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short
 guide on how to set up Kerberos for MaxScale.
 
-The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB\
-documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)\
+The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB
+documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)
 is a good example on how to set it up.
 
-The next step is to copy the keytab file from the server where MariaDB is\
-installed to the server where MaxScale is located. The keytab file must be\
-placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an\
+The next step is to copy the keytab file from the server where MariaDB is
+installed to the server where MaxScale is located. The keytab file must be
+placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an
 authenticator option.
 
-The location of the keytab file can be changed with the KRB5\_KTNAME environment\
+The location of the keytab file can be changed with the KRB5\_KTNAME environment
 variable: [keytab\_def.html](https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html)
 
 To take GSSAPI authentication into use, add the following to the listener.
@@ -39,10 +39,10 @@ The principal name should be the same as on the MariaDB servers.
 * Dynamic: No
 * Default: `mariadb/localhost.localdomain`
 
-The service principal name to send to the client. This parameter is a string\
+The service principal name to send to the client. This parameter is a string
 parameter which is used by the client to request the token.
 
-This parameter _must_ be the same as the principal name that the backend MariaDB\
+This parameter _must_ be the same as the principal name that the backend MariaDB
 server uses.
 
 #### `gssapi_keytab_path`
@@ -52,10 +52,10 @@ server uses.
 * Dynamic: No
 * Default: Kerberos Default
 
-Keytab file location. This should be an absolute path to the file containing the\
-keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that\
+Keytab file location. This should be an absolute path to the file containing the
+keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that
 multiple listeners with GSSAPIAuth will override each other. If using multiple\
-GSSAPI authenticators, either do not set this option or use the same value for\
+GSSAPI authenticators, either do not set this option or use the same value for
 all listeners.
 
 ```
@@ -64,23 +64,23 @@ authenticator_options=principal_name=mymariadb@EXAMPLE.COM,gssapi_keytab_path=/h
 
 ### Implementation details
 
-Read the [Authentication Modules](mariadb-maxscale-2302-authentication-modules.md) document for more\
+Read the [Authentication Modules](mariadb-maxscale-2302-authentication-modules.md) document for more
 details on how authentication modules work in MaxScale.
 
 #### GSSAPI authentication
 
-The GSSAPI plugin authentication starts when the database server sends the\
-service principal name in the AuthSwitchRequest packet. The principal name will\
+The GSSAPI plugin authentication starts when the database server sends the
+service principal name in the AuthSwitchRequest packet. The principal name will
 usually be in the form `service@REALM.COM`.
 
-The client searches its local cache for a token for the service or may request\
-it from the GSSAPI server. If found, the client sends the token to the database\
-server. The database server verifies the authenticity of the token using its\
+The client searches its local cache for a token for the service or may request
+it from the GSSAPI server. If found, the client sends the token to the database
+server. The database server verifies the authenticity of the token using its
 keytab file and sends the final OK packet to the client.
 
 ### Building the module
 
-The GSSAPI authenticator modules require the GSSAPI development libraries\
+The GSSAPI authenticator modules require the GSSAPI development libraries
 (krb5-devel on CentOS 7).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-mysql-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-mysql-authenticator.md
@@ -1,12 +1,12 @@
 # MariaDB/MySQL Authenticator
 
-The _MariaDBAuth_-module implements the client and backend authentication for the\
-server plugin _mysql\_native\_password_. This is the default authentication\
+The _MariaDBAuth_-module implements the client and backend authentication for the
+server plugin _mysql\_native\_password_. This is the default authentication
 plugin used by both MariaDB and MySQL.
 
 ### Authenticator options
 
-The following settings may be given in the _authenticator\_options_ of the\
+The following settings may be given in the _authenticator\_options_ of the
 listener.
 
 #### `log_password_mismatch`
@@ -16,10 +16,10 @@ listener.
 * Dynamic: No
 * Default: `false`
 
-The service setting _log\_auth\_warnings_ must\
-also be enabled for this setting to have effect. When both settings are enabled,\
-password hashes are logged if a client gives a wrong password. This feature may\
-be useful when diagnosing authentication issues. It should only be enabled on a\
+The service setting _log\_auth\_warnings_ must
+also be enabled for this setting to have effect. When both settings are enabled,
+password hashes are logged if a client gives a wrong password. This feature may
+be useful when diagnosing authentication issues. It should only be enabled on a
 secure system as the logging of password hashes may be a security risk.
 
 #### `cache_dir`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-pam-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-pam-authenticator.md
@@ -1,15 +1,15 @@
 # PAM Authenticator
 
 Pluggable authentication module (PAM) is a general purpose authentication API.\
-An application using PAM can authenticate a user without knowledge about the\
-underlying authentication implementation. The actual authentication scheme is\
-defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be\
-quite elaborate. MaxScale supports a very limited form of the PAM protocol,\
+An application using PAM can authenticate a user without knowledge about the
+underlying authentication implementation. The actual authentication scheme is
+defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be
+quite elaborate. MaxScale supports a very limited form of the PAM protocol,
 which this document details.
 
 ### Configuration
 
-The MaxScale PAM module requires little configuration. All that is required\
+The MaxScale PAM module requires little configuration. All that is required
 is to change the listener authenticator module to "PAMAuth".
 
 ```
@@ -25,14 +25,14 @@ address=123.456.789.10
 port=12345
 ```
 
-MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_\
-set to "pam" in the _mysql.user_-table. The PAM service name of a user is read\
-from the _authetication\_string_-column. The matching PAM service in the\
-operating system PAM config is used for authenticating the user. If the\_authetication\_string\_ for a user is empty, the fallback service "mysql" is\
+MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_
+set to "pam" in the _mysql.user_-table. The PAM service name of a user is read
+from the _authetication\_string_-column. The matching PAM service in the
+operating system PAM config is used for authenticating the user. If the\_authetication\_string\_ for a user is empty, the fallback service "mysql" is
 used.
 
-PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)\
-for more information. A simple service definition used for testing this module\
+PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)
+for more information. A simple service definition used for testing this module
 is below.
 
 ```
@@ -48,8 +48,8 @@ account         required        pam_unix.so
 * Default: `false`
 
 If enabled, MaxScale communicates with the client as if using [mysql\_clear\_password](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/1-connecting/connection#mysql_clear_password-plugin).\
-This setting has no effect on MaxScale-to-backend communication, which adapts to\
-either "dialog" or "mysql\_clear\_password", depending on which one the backend\
+This setting has no effect on MaxScale-to-backend communication, which adapts to
+either "dialog" or "mysql\_clear\_password", depending on which one the backend
 suggests. This setting is meant to be used with the similarly named MariaDB\
 Server setting.
 
@@ -74,11 +74,11 @@ This setting defines the authentication mode used. Two values are supported:
 authenticator_options=pam_mode=password_2FA
 ```
 
-If set to "password\_2FA", any users authenticating via PAM will be asked two\
-passwords ("Password" and "Verification code") during login. MaxScale uses the\
+If set to "password\_2FA", any users authenticating via PAM will be asked two
+passwords ("Password" and "Verification code") during login. MaxScale uses the
 normal password when either the local PAM api or a backend asks for "Password".\
-MaxScale answers any other password prompt (e.g. "Verification code") with the\
-second password. See [the limitations section](mariadb-maxscale-2302-pam-authenticator.md#implementation-details-and-limitations)\
+MaxScale answers any other password prompt (e.g. "Verification code") with the
+second password. See [the limitations section](mariadb-maxscale-2302-pam-authenticator.md#implementation-details-and-limitations)
 for more details. Two-factor mode is incompatible with\_pam\_use\_cleartext\_plugin\_.
 
 #### `pam_backend_mapping`
@@ -89,7 +89,7 @@ for more details. Two-factor mode is incompatible with\_pam\_use\_cleartext\_plu
 * Values: `none`, `mariadb`
 * Default: `none`
 
-Defines backend authentication mapping, i.e. switch of authentication method\
+Defines backend authentication mapping, i.e. switch of authentication method
 between client-to-MaxScale and MaxScale-to-backend. Supported values:
 
 * `none` No mapping
@@ -99,28 +99,28 @@ between client-to-MaxScale and MaxScale-to-backend. Supported values:
 authenticator_options=pam_backend_mapping=mariadb
 ```
 
-If set to "mariadb", MaxScale will authenticate clients to backends using\
+If set to "mariadb", MaxScale will authenticate clients to backends using
 standard MariaDB authentication. Authentication to MaxScale itself still uses\
-PAM. MaxScale asks the local PAM system if the client username was mapped\
-to another username during authentication, and use the mapped username when\
-logging in to backends. Passwords for the mapped users can be given in a file,\
-see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to\
-authenticate without a password. Because of this, normal PAM users and mapped\
+PAM. MaxScale asks the local PAM system if the client username was mapped
+to another username during authentication, and use the mapped username when
+logging in to backends. Passwords for the mapped users can be given in a file,
+see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to
+authenticate without a password. Because of this, normal PAM users and mapped
 users cannot be used on the same listener.
 
-Because the client still needs to authenticate to MaxScale normally, an\
-anonymous user may be required. If the backends do not allow such a user, one\
+Because the client still needs to authenticate to MaxScale normally, an
+anonymous user may be required. If the backends do not allow such a user, one
 can be manually added using the service setting [user\_accounts\_file](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#user_accounts_file).
 
-To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be\
-installed separately. It is included in recent MariaDB Server packages and can\
-also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)\
-for more information on how to configure the module. If the goal is to only map\
-users from PAM to MariaDB in MaxScale, then configuring user mapping\
+To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be
+installed separately. It is included in recent MariaDB Server packages and can
+also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)
+for more information on how to configure the module. If the goal is to only map
+users from PAM to MariaDB in MaxScale, then configuring user mapping
 on just the machine running MaxScale is enough.
 
-Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#user_mapping_file),\
-as it is easier to configure. `pam_backend_mapping` should only be used when\
+Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#user_mapping_file),
+as it is easier to configure. `pam_backend_mapping` should only be used when
 the user mapping needs to be defined by pam.
 
 #### `pam_mapped_pw_file`
@@ -130,19 +130,19 @@ the user mapping needs to be defined by pam.
 * Dynamic: No
 * Default: None
 
-Path to a json-text file with user passwords. Default value is empty, which\
+Path to a json-text file with user passwords. Default value is empty, which
 disables the feature.
 
 ```
 authenticator_options=pam_mapped_pw_file=/home/root/passwords.json,pam_backend_mapping=mariadb
 ```
 
-This feature only works together with `pam_backend_mapping=mariadb`. The file is\
-only read during listener creation (typically MaxScale start) or when a listener\
-is modified during runtime. The file should contain passwords for the mapped\
-users. When a client is authenticating, MaxScale searches the password data for a\
-matching username. If one is found, MaxScale uses the supplied password when\
-logging in to backends. Otherwise, MaxScale tries to authenticate without a\
+This feature only works together with `pam_backend_mapping=mariadb`. The file is
+only read during listener creation (typically MaxScale start) or when a listener
+is modified during runtime. The file should contain passwords for the mapped
+users. When a client is authenticating, MaxScale searches the password data for a
+matching username. If one is found, MaxScale uses the supplied password when
+logging in to backends. Otherwise, MaxScale tries to authenticate without a
 password.
 
 One array, "users\_and\_passwords", is read from the file. Each array element in the array must define the following fields:
@@ -169,105 +169,105 @@ An example file is below.
 
 ### Anonymous user mapping
 
-When backend authenticator mapping is not in use\
-(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator\
+When backend authenticator mapping is not in use
+(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator
 supports a limited version of [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
 It requires less configuration but is also less accurate than proper mapping.\
 Anonymous mapping is enabled in MaxScale if the following user exists:
 
 * Empty username (e.g. `''@'%'` or `''@'myhost.com'`)
 * `plugin = 'pam'`
-* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one\
+* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one
   row with `GRANT PROXY ON ...`)
 
-When the authenticator detects such users, anonymous account mapping is enabled\
-for the hosts of the anonymous users. To verify this, enable the info log\
-(`log_info=1` in MaxScale config file). When a client is logging in using the\
-anonymous user account, MaxScale will log a message starting with "Found\
+When the authenticator detects such users, anonymous account mapping is enabled
+for the hosts of the anonymous users. To verify this, enable the info log
+(`log_info=1` in MaxScale config file). When a client is logging in using the
+anonymous user account, MaxScale will log a message starting with "Found
 matching anonymous user ...".
 
-When mapping is on, the MaxScale PAM authenticator does not require client\
-accounts to exist in the `mysql.user`-table received from the backend. MaxScale\
-only requires that the hostname of the incoming client matches the host field of\
-one of the anonymous users (comparison performed using `LIKE`). If a match is\
-found, MaxScale attempts to authenticate the client to the local machine with\
-the username and password supplied. The PAM service used for authentication is\
-read from the `authentication_string`-field of the anonymous user. If\
-authentication was successful, MaxScale then uses the username and password to\
+When mapping is on, the MaxScale PAM authenticator does not require client
+accounts to exist in the `mysql.user`-table received from the backend. MaxScale
+only requires that the hostname of the incoming client matches the host field of
+one of the anonymous users (comparison performed using `LIKE`). If a match is
+found, MaxScale attempts to authenticate the client to the local machine with
+the username and password supplied. The PAM service used for authentication is
+read from the `authentication_string`-field of the anonymous user. If
+authentication was successful, MaxScale then uses the username and password to
 log to the backends.
 
-Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2302-pam-authenticator.md#configuration). This means,\
-that if a user is found and the authentication fails, anonymous authentication\
-is not attempted even when it could use a different PAM service with a different\
+Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2302-pam-authenticator.md#configuration). This means,
+that if a user is found and the authentication fails, anonymous authentication
+is not attempted even when it could use a different PAM service with a different
 outcome.
 
-Setting up PAM group mapping for the MariaDB server is a more involved process\
+Setting up PAM group mapping for the MariaDB server is a more involved process
 as the server requires details on which Unix user or group is mapped to which\
-MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)\
-for more details. Performing all the steps in the guide also on the MaxScale\
-machine is not required, as the MaxScale PAM plugin only checks that the client\
-host matches an anonymous user and that the client (with the username and\
-password it provided) can log into the local PAM configuration. If using normal\
-password authentication, simply generating the Unix user and password should be\
+MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)
+for more details. Performing all the steps in the guide also on the MaxScale
+machine is not required, as the MaxScale PAM plugin only checks that the client
+host matches an anonymous user and that the client (with the username and
+password it provided) can log into the local PAM configuration. If using normal
+password authentication, simply generating the Unix user and password should be
 enough.
 
 ### Implementation details and limitations
 
 The general PAM authentication scheme is difficult for a proxy such as MaxScale.\
-An application using the PAM interface needs to define a _conversation function_\
-to allow the OS PAM modules to communicate with the client, possibly exchanging\
-multiple messages. This works when a client logs in to a normal server, but not\
+An application using the PAM interface needs to define a _conversation function_
+to allow the OS PAM modules to communicate with the client, possibly exchanging
+multiple messages. This works when a client logs in to a normal server, but not
 with MaxScale since it needs to autonomously log into multiple backends. For\
-MaxScale to successfully log into the servers, the messages and answers need to\
-be predefined. The passwords given to MaxScale need to work as is when MaxScale\
+MaxScale to successfully log into the servers, the messages and answers need to
+be predefined. The passwords given to MaxScale need to work as is when MaxScale
 logs into the backends. This requirement prevents the use of one-time passwords.
 
-The MaxScale PAM authentication module supports two password modes. In normal\
+The MaxScale PAM authentication module supports two password modes. In normal
 mode, client authentication begins with MaxScale sending an\
-AuthSwitchRequest packet. In addition to the command, the packet contains the\
-client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)\
-and the message "Password: ". In the next packet, the client should send the\
-password, which MaxScale will forward to the PAM api running on the local\
-machine. If the password is correct, an OK packet is sent to the client. If the\
-local PAM api asks for additional credentials as is typical in two-factor\
-authentication schemes, authentication fails. Informational messages such as\
-password expiration notifications are allowed. These are simply printed to the\
+AuthSwitchRequest packet. In addition to the command, the packet contains the
+client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)
+and the message "Password: ". In the next packet, the client should send the
+password, which MaxScale will forward to the PAM api running on the local
+machine. If the password is correct, an OK packet is sent to the client. If the
+local PAM api asks for additional credentials as is typical in two-factor
+authentication schemes, authentication fails. Informational messages such as
+password expiration notifications are allowed. These are simply printed to the
 log.
 
-On the backend side, MaxScale expects the servers to act as MaxScale did towards\
-the client. The servers should send an AuthSwitchRequest packet as defined\
-above, MaxScale responds with the password received by the client authenticator\
-and finally backend replies with OK. Informational messages from backends are\
+On the backend side, MaxScale expects the servers to act as MaxScale did towards
+the client. The servers should send an AuthSwitchRequest packet as defined
+above, MaxScale responds with the password received by the client authenticator
+and finally backend replies with OK. Informational messages from backends are
 only printed to the info-log.
 
 #### Two-factor authentication support
 
-MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the\
-client to log in to the local PAM api as well as all the backends, the code must\
-be reusable. This prevents the use of any kind of centrally checked one-use\
-codes. Time-based codes work, assuming the backends are checking the codes\
+MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the
+client to log in to the local PAM api as well as all the backends, the code must
+be reusable. This prevents the use of any kind of centrally checked one-use
+codes. Time-based codes work, assuming the backends are checking the codes
 independently of each other. Automatic reconnection features (e.g.\
-readwritesplit-router) will not work, as the code has likely changed since\
+readwritesplit-router) will not work, as the code has likely changed since
 original authentication.
 
-Optionally, the PAM configuration on the backend servers can be weakened such\
-that the servers only asks for the normal password. This way, MaxScale will\
-check the 2FA-code of the incoming client, while MaxScale logs into the backends\
+Optionally, the PAM configuration on the backend servers can be weakened such
+that the servers only asks for the normal password. This way, MaxScale will
+check the 2FA-code of the incoming client, while MaxScale logs into the backends
 using only the password.
 
-Due to technical reasons, MaxScale does not forward the password prompts from\
+Due to technical reasons, MaxScale does not forward the password prompts from
 the PAM api to the client. MaxScale will always ask for "Password" and\
-"Verification code", even if the PAM api asks for other items. This prevents the\
+"Verification code", even if the PAM api asks for other items. This prevents the
 use of authentication schemes where a specific question must be answered (e.g.\
-"Input code Nr. 5"). This is not a significant limitation, as such schemes would\
+"Input code Nr. 5"). This is not a significant limitation, as such schemes would
 not work with backend servers anyway.
 
 ### Test tool
 
-MaxScale binary directory contains the _test\_pam\_login_-executable. This simple\
-program asks for a username, password and PAM service and then uses the given\
-credentials to login to the given service. _test\_pam\_login_ uses the same code\
-as MaxScale itself to communicate with the OS PAM interface and may be useful\
+MaxScale binary directory contains the _test\_pam\_login_-executable. This simple
+program asks for a username, password and PAM service and then uses the given
+credentials to login to the given service. _test\_pam\_login_ uses the same code
+as MaxScale itself to communicate with the OS PAM interface and may be useful
 for diagnosing PAM login issues.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-connectors/mariadb-maxscale-2302-maxscale-cdc-connector.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-connectors/mariadb-maxscale-2302-maxscale-cdc-connector.md
@@ -4,29 +4,29 @@ The C++ connector for the [MariaDB MaxScale](https://mariadb.com/products/techno
 
 ### Usage
 
-The CDC connector is a single-file connector which allows it to be relatively\
+The CDC connector is a single-file connector which allows it to be relatively
 easily embedded into existing applications.
 
-To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
+To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
 and install the `maxscale-cdc-connector` package.
 
 ### API Overview
 
-A CDC connection object is prepared by instantiating the `CDC::Connection`\
-class. To create the actual connection, call the `CDC::Connection::connect`\
+A CDC connection object is prepared by instantiating the `CDC::Connection`
+class. To create the actual connection, call the `CDC::Connection::connect`
 method of the class.
 
-After the connection has been created, call the `CDC::Connection::read` method\
-to get a row of data. The `CDC::Row::length` method tells how many values a row\
-has and `CDC::Row::value` is used to access that value. The field name of a\
-value can be extracted with the `CDC::Row::key` method and the current GTID of a\
+After the connection has been created, call the `CDC::Connection::read` method
+to get a row of data. The `CDC::Row::length` method tells how many values a row
+has and `CDC::Row::value` is used to access that value. The field name of a
+value can be extracted with the `CDC::Row::key` method and the current GTID of a
 row of data is retrieved with the `CDC::Row::gtid` method.
 
 To close the connection, destroy the instantiated object.
 
 ### Examples
 
-The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)\
+The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)
 that demonstrates basic usage of the MaxScale CDC Connector.
 
 ### Dependencies
@@ -65,7 +65,7 @@ sudo zypper install -y libjansson-devel openssl-devel cmake make gcc-c++ git
 
 ### Building and Packaging
 
-To build and package the connector as a library, follow MaxScale build\
+To build and package the connector as a library, follow MaxScale build
 instructions with the exception of adding `-DTARGET_COMPONENT=devel` to the\
 CMake call.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-design-documents/mariadb-maxscale-2302-mariadb-maxscale-plugin-development-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-design-documents/mariadb-maxscale-2302-mariadb-maxscale-plugin-development-guide.md
@@ -1,91 +1,91 @@
 # MariaDB MaxScale plugin development guide
 
-This document and the attached example code explain prospective plugin\
-developers the MariaDB MaxScale plugin API and also present and explain some\
-best practices and possible pitfalls in module development. We predict that_filters_ and _routers_ are the module types developers are most likely to work\
+This document and the attached example code explain prospective plugin
+developers the MariaDB MaxScale plugin API and also present and explain some
+best practices and possible pitfalls in module development. We predict that_filters_ and _routers_ are the module types developers are most likely to work
 on, so the APIs of these two are discussed in detail.
 
 ### Introduction
 
-MariaDB MaxScale is designed to be an extensible program. Much, if not most, of\
-the actual processing is done by plugin modules. Plugins receive network data,\
-process it and relay it to its destination. The MaxScale core loads plugins,\
-manages client sessions and threads and, most importantly, offers a selection of\
-functions for the plugins to call upon. This collection of functions is called\
+MariaDB MaxScale is designed to be an extensible program. Much, if not most, of
+the actual processing is done by plugin modules. Plugins receive network data,
+process it and relay it to its destination. The MaxScale core loads plugins,
+manages client sessions and threads and, most importantly, offers a selection of
+functions for the plugins to call upon. This collection of functions is called
 the _MaxScale Public Interface_ or just **MPI** for short.
 
-The plugin modules are shared libraries (.so-files) implementing a set of\
-interface functions, the plugin API. Different plugin types have different APIs,\
-although there are similarities. The MPI is a set of C and C++ header files,\
-from which the module code includes the ones required. MariaDB MaxScale is\
-written in C/C++ and the plugin API is in pure C. Although it is possible\
-to write plugins in any language capable of exposing a C interface and\
-dynamically binding to the core program, in this document we assume plugin\
+The plugin modules are shared libraries (.so-files) implementing a set of
+interface functions, the plugin API. Different plugin types have different APIs,
+although there are similarities. The MPI is a set of C and C++ header files,
+from which the module code includes the ones required. MariaDB MaxScale is
+written in C/C++ and the plugin API is in pure C. Although it is possible
+to write plugins in any language capable of exposing a C interface and
+dynamically binding to the core program, in this document we assume plugin
 modules are written in C++.
 
 The _RoundRobinRouter_ is a practical example of a simple router plugin. The\
 RoundRobinRouter is compiled, installed and ran in [section\
-5.1](mariadb-maxscale-2302-mariadb-maxscale-plugin-development-guide.md#hands-on-example:-roundrobinrouter). The source for the router is located\
+5.1](mariadb-maxscale-2302-mariadb-maxscale-plugin-development-guide.md#hands-on-example:-roundrobinrouter). The source for the router is located
 in the `examples`-folder.
 
 ### Module categories
 
-This section lists all the module types and summarises their core tasks. The\
+This section lists all the module types and summarises their core tasks. The
 modules are listed in the order a client packet would typically travel through.\
-For more information about a particular module type, see the corresponding\
-folder in `MaxScale/Documentation/`, located in the main MariaDB MaxScale\
+For more information about a particular module type, see the corresponding
+folder in `MaxScale/Documentation/`, located in the main MariaDB MaxScale
 repository.
 
 **Protocol** modules implement I/O between clients and MaxScale, and between\
-MaxScale and backend servers. Protocol modules read and write to socket\
-descriptors using raw I/O functions provided by the MPI, and implement\
+MaxScale and backend servers. Protocol modules read and write to socket
+descriptors using raw I/O functions provided by the MPI, and implement
 protocol-specific I/O functions to be used through a common interface. The\
-Protocol module API is defined in `protocol.h`. Currently, the only implemented\
+Protocol module API is defined in `protocol.h`. Currently, the only implemented
 database protocol is _MySQL_.
 
-**Authenticator** modules retrieve user account information from the backend\
+**Authenticator** modules retrieve user account information from the backend
 databases, store it and use it to authenticate connecting clients. MariaDB\
-MaxScale includes authenticators for MySQL (normal and GSSApi). The\
+MaxScale includes authenticators for MySQL (normal and GSSApi). The
 authenticator API is defined in `authenticator.h`.
 
-**Filter** modules process data from clients before routing. A data buffer may\
-travel through multiple filters before arriving in a router. For a data buffer\
-going from a backend to the client, the router receives it first and the\
-filters receive it in reverse order. MaxScale includes a healthly selection of\
+**Filter** modules process data from clients before routing. A data buffer may
+travel through multiple filters before arriving in a router. For a data buffer
+going from a backend to the client, the router receives it first and the
+filters receive it in reverse order. MaxScale includes a healthly selection of
 filters ranging from logging, overwriting query data and caching. The filter\
 API is defined in `filter.h`.
 
-**Router** modules route packets from the last filter in the filter chain to\
-backends and reply data from backends to the last filter. The routing decisions\
-may be based on a variety of conditions; typically packet contents and backend\
-status are the most significant factors. Routers are often used for load\
+**Router** modules route packets from the last filter in the filter chain to
+backends and reply data from backends to the last filter. The routing decisions
+may be based on a variety of conditions; typically packet contents and backend
+status are the most significant factors. Routers are often used for load
 balancing, dividing clients and even individual queries between backends.\
-Routers use protocol functions to write to backends, making them somewhat\
+Routers use protocol functions to write to backends, making them somewhat
 protocol-agnostic. The router API is defined in `router.h`.
 
-**Monitor** modules do not process data flowing through MariaDB MaxScale, but\
-support the other modules in their operation by updating the status of the\
-backend servers. Monitors are ran in their own threads to minimize\
-interference to the worker threads. They periodically connect to all their\
+**Monitor** modules do not process data flowing through MariaDB MaxScale, but
+support the other modules in their operation by updating the status of the
+backend servers. Monitors are ran in their own threads to minimize
+interference to the worker threads. They periodically connect to all their
 assigned backends, query their status and write the results in global structs.\
 The monitor API is defined in `monitor.h`.
 
 ### Common definitions and headers
 
-Generally, most type definitions, macros and functions exposed by the MPI to be\
-used by modules are prefixed with **MXS**. This should avoid name collisions\
+Generally, most type definitions, macros and functions exposed by the MPI to be
+used by modules are prefixed with **MXS**. This should avoid name collisions
 in the case a module includes many symbols from the MPI.
 
 Every compilation unit in a module should begin with `#define MXS_MODULE_NAME "<name>"`. This definition will be used by log macros for clarity, prepending`<name>` to every log message. Next, the module should`#include <maxscale/cppdefs.h>` (for C++) or `#include <maxscale/cdefs.h>` (for\
-C). These headers contain compilation environment dependent definitions and\
-global constants, and include some generally useful headers. Including one of\
+C). These headers contain compilation environment dependent definitions and
+global constants, and include some generally useful headers. Including one of
 them first in every source file enables later global redefinitions across all\
-MaxScale modules. If your module is composed of multiple source files, the above\
-should be placed to a common header file included in the beginning of the source\
-files. The file with the module API definition should also include the header\
+MaxScale modules. If your module is composed of multiple source files, the above
+should be placed to a common header file included in the beginning of the source
+files. The file with the module API definition should also include the header
 for the module type, e.g. `filter.h`.
 
-Other common MPI header files required by most modules are listed in the table\
+Other common MPI header files required by most modules are listed in the table
 below.
 
 | Header       | Contents                            |
@@ -103,73 +103,73 @@ below.
 
 #### Module information container
 
-A module must implement the `MXS_CREATE_MODULE()`-function, which returns a\
-pointer to a `MXS_MODULE`-structure. This function is called by the module\
-loader during program startup. `MXS_MODULE` (type defined in `modinfo.h`)\
-contains function pointers to further module entrypoints, miscellaneous\
-information about the module and the configuration parameters accepted by the\
-module. This function must be exported without C++ name mangling, so in C++ code\
+A module must implement the `MXS_CREATE_MODULE()`-function, which returns a
+pointer to a `MXS_MODULE`-structure. This function is called by the module
+loader during program startup. `MXS_MODULE` (type defined in `modinfo.h`)
+contains function pointers to further module entrypoints, miscellaneous
+information about the module and the configuration parameters accepted by the
+module. This function must be exported without C++ name mangling, so in C++ code
 it should be defined `extern "C"`.
 
-The information container describes the module in general and is constructed\
-once during program execution. A module may have multiple _instances_ with\
-different values for configuration parameters. For example, a filter module can\
-be used with two different configurations in different services (or even in the\
-same service). In this case the loader uses the same module information\
+The information container describes the module in general and is constructed
+once during program execution. A module may have multiple _instances_ with
+different values for configuration parameters. For example, a filter module can
+be used with two different configurations in different services (or even in the
+same service). In this case the loader uses the same module information
 container for both but creates two module instances.
 
 The MariaDB MaxScale configuration file `maxscale.cnf` is parsed by the core.\
-The core also checks that all the defined parameters are of the correct type for\
-the module. For this, the `MXS_MODULE`-structure includes a list of parameters\
-accepted by the module, defining parameter names, types and default values. In\
-the actual module code, parameter values should be extracted using functions\
+The core also checks that all the defined parameters are of the correct type for
+the module. For this, the `MXS_MODULE`-structure includes a list of parameters
+accepted by the module, defining parameter names, types and default values. In
+the actual module code, parameter values should be extracted using functions
 defined in `config.h`.
 
 ### Module API
 
 #### Overview
 
-This section explains some general concepts encountered when implementing a\
-module API. For more detailed information, see the module specific subsection,\
+This section explains some general concepts encountered when implementing a
+module API. For more detailed information, see the module specific subsection,
 header files or the doxygen documentation.
 
-Modules with configuration data define an _INSTANCE_ object, which is created by\
-the module code in a `createInstance`-function or equivalent. The instance\
-creation function is called during MaxScale startup, usually when creating\
-services. MaxScale core holds the module instance data in the`SERVICE`-structure (or other higher level construct) and gives it as a\
-parameter when calling functions from the module in question. The instance\
-structure should contain all non-client-specific information required by the\
-functions of the module. The core does not know what the object contains (since\
-it is defined by the module itself), nor will it modify the pointer or the\
+Modules with configuration data define an _INSTANCE_ object, which is created by
+the module code in a `createInstance`-function or equivalent. The instance
+creation function is called during MaxScale startup, usually when creating
+services. MaxScale core holds the module instance data in the`SERVICE`-structure (or other higher level construct) and gives it as a
+parameter when calling functions from the module in question. The instance
+structure should contain all non-client-specific information required by the
+functions of the module. The core does not know what the object contains (since
+it is defined by the module itself), nor will it modify the pointer or the
 referenced object in any way.
 
-Modules dealing with client-specific data require a _SESSION_ object for every\
-client. As with the instance data, the definition of the module session\
+Modules dealing with client-specific data require a _SESSION_ object for every
+client. As with the instance data, the definition of the module session
 structure is up to the module writer and MaxScale treats it as an opaque type.\
-Usually the session contains status indicators and any resources required by the\
-client. MaxScale core has its own `MXS_SESSION` object, which tracks a variety\
-of client related information. The `MXS_SESSION` is given as a parameter to\
-module-specific session creation functions and is required for several typical\
+Usually the session contains status indicators and any resources required by the
+client. MaxScale core has its own `MXS_SESSION` object, which tracks a variety
+of client related information. The `MXS_SESSION` is given as a parameter to
+module-specific session creation functions and is required for several typical
 operations such as connecting to backends.
 
-Descriptor control blocks (`DCB`), are generalized I/O descriptor types. DCBs\
-store the file descriptor, state, remote address, username, session, and other\
-data. DCBs are created whenever a new socket is created. Typically this happens\
-when a new client connects or MaxScale connects the client session to backend\
-servers. The module writer should use DCB handling functions provided by the MPI\
-to manage connections instead of calling general networking libraries. This\
-ensures that I/O is handled asynchronously by epoll. In general, module code\
-should avoid blocking I/O, _sleep_, _yield_ or other potentially costly\
+Descriptor control blocks (`DCB`), are generalized I/O descriptor types. DCBs
+store the file descriptor, state, remote address, username, session, and other
+data. DCBs are created whenever a new socket is created. Typically this happens
+when a new client connects or MaxScale connects the client session to backend
+servers. The module writer should use DCB handling functions provided by the MPI
+to manage connections instead of calling general networking libraries. This
+ensures that I/O is handled asynchronously by epoll. In general, module code
+should avoid blocking I/O, _sleep_, _yield_ or other potentially costly
 operations, as the same thread is typically used for many client sessions.
 
-Network data such as client queries and backend replies are held in a buffer\
-container called `GWBUF`. Multiple GWBUFs can form a linked list with type\
-information and properties in each GWBUF-node. Each node includes a pointer to a\
-reference counted shared buffer (`SHARED_BUF`), which finally points to a slice\
-of the actual data. In effect, multiple GWBUF-chains can share some data while\
-keeping some parts private. This construction is meant to minimize the need for\
-data copying and makes it easy to append more data to partially received data\
-packets. Plugin writers should use the MPI to manipulate GWBUFs. For more\
+Network data such as client queries and backend replies are held in a buffer
+container called `GWBUF`. Multiple GWBUFs can form a linked list with type
+information and properties in each GWBUF-node. Each node includes a pointer to a
+reference counted shared buffer (`SHARED_BUF`), which finally points to a slice
+of the actual data. In effect, multiple GWBUF-chains can share some data while
+keeping some parts private. This construction is meant to minimize the need for
+data copying and makes it easy to append more data to partially received data
+packets. Plugin writers should use the MPI to manipulate GWBUFs. For more
 information on the GWBUF, see [Filter and Router](mariadb-maxscale-2302-mariadb-maxscale-plugin-development-guide.md#filter-and-router).
 
 #### General module management
@@ -181,21 +181,21 @@ int thread_init()
 void thread_finish()
 ```
 
-These four functions are present in all `MXS_MODULE` structs and are not part of\
-the API of any individual module type. `process_init` and `process_finish` are\
+These four functions are present in all `MXS_MODULE` structs and are not part of
+the API of any individual module type. `process_init` and `process_finish` are
 called by the module loader right after loading a module and just before\
-MaxScale terminates, respectively. Usually, these can be set to null in`MXS_MODULE` unless the module needs some general initializations before\
-creating any instances. `thread_init` and `thread_finish` are thread-specific\
+MaxScale terminates, respectively. Usually, these can be set to null in`MXS_MODULE` unless the module needs some general initializations before
+creating any instances. `thread_init` and `thread_finish` are thread-specific
 equivalents.
 
 ```
 void diagnostics(INSTANCE *instance, DCB *dcb)
 ```
 
-A diagnostics printing routine is present in nearly all module types, although\
-with varying signatures. This entrypoint should print various statistics and\
-status information about the module instance `instance` in string form. The\
-target of the printing is the given DCB, and printing should be implemented by\
+A diagnostics printing routine is present in nearly all module types, although
+with varying signatures. This entrypoint should print various statistics and
+status information about the module instance `instance` in string form. The
+target of the printing is the given DCB, and printing should be implemented by
 calling `dcb_printf`.
 
 #### Protocol
@@ -217,19 +217,19 @@ int32_t connlimit(struct dcb *, int limit)
 ```
 
 Protocol modules are laborous to implement due to their low level nature. Each\
-DCB maintains pointers to the correct protocol functions to be used with it,\
+DCB maintains pointers to the correct protocol functions to be used with it,
 allowing the DCB to be used in a protocol-independent manner.
 
-`read`, `write_ready`, `error` and `hangup` are _epoll_ handlers for their\
-respective events. `write` implements writing and is usually called in a router\
-module. `accept` is a listener socker handler. `connect` is used during session\
+`read`, `write_ready`, `error` and `hangup` are _epoll_ handlers for their
+respective events. `write` implements writing and is usually called in a router
+module. `accept` is a listener socker handler. `connect` is used during session
 creation when connecting to backend servers. `listen` creates a listener socket.`close` closes a DCB created by `accept`, `connect` or `listen`.
 
-In the ideal case modules other than the protocol modules themselves should not\
-be protocol-specific. This is currently difficult to achieve, since many actions\
-in the modules are dependent on protocol-speficic details. In the future,\
-protocol modules may be expanded to implement a generic query parsing and\
-information API, allowing filters and routers to be used with different SQL\
+In the ideal case modules other than the protocol modules themselves should not
+be protocol-specific. This is currently difficult to achieve, since many actions
+in the modules are dependent on protocol-speficic details. In the future,
+protocol modules may be expanded to implement a generic query parsing and
+information API, allowing filters and routers to be used with different SQL
 variants.
 
 #### Authenticator
@@ -249,14 +249,14 @@ int reauthenticate(struct dcb *, const char *user, uint8_t *token,
                    uint8_t *output, size_t output_len);
 ```
 
-Authenticators must communicate with the client or the backends and implement\
-authentication. The authenticators can be divided to client and backend modules,\
-although the two types are linked and must be used together. Authenticators are\
+Authenticators must communicate with the client or the backends and implement
+authentication. The authenticators can be divided to client and backend modules,
+although the two types are linked and must be used together. Authenticators are
 also dependent on the protocol modules.
 
 #### Filter and Router
 
-Filter and router APIs are nearly identical and are presented together. Since\
+Filter and router APIs are nearly identical and are presented together. Since
 these are the modules most likely to be implemented by plugin developers, their\
 APIs are discussed in more detail.
 
@@ -265,10 +265,10 @@ INSTANCE* createInstance(SERVICE* service, char** options)
 void destroyInstance(INSTANCE* instance)
 ```
 
-`createInstance` should read the `options` and initialize an instance object for\
-use with `service`. Often, simply saving the configuration values to fields is\
-enough. `destroyInstance` is called when the service using the module is\
-deallocated. It should free any resources claimed by the instance. All sessions\
+`createInstance` should read the `options` and initialize an instance object for
+use with `service`. Often, simply saving the configuration values to fields is
+enough. `destroyInstance` is called when the service using the module is
+deallocated. It should free any resources claimed by the instance. All sessions
 created by this instance should be closed before calling the destructor.
 
 ```
@@ -277,11 +277,11 @@ void closeSession(INSTANCE* instance, SESSION* session)
 void freeSession(INSTANCE* instance, SESSION* session)
 ```
 
-These functions manage sessions. `newSession` should allocate a router or filter\
-session attached to the client session represented by `mxs_session`. MaxScale\
-will pass the returned pointer to all the API entrypoints that process user data\
-for the particular client. `closeSession` should close connections the session\
-has opened and release any resources specific to the served client. The_SESSION_ structure allocated in `newSession` should not be deallocated by`closeSession` but in `freeSession`. These two are called in succession\
+These functions manage sessions. `newSession` should allocate a router or filter
+session attached to the client session represented by `mxs_session`. MaxScale
+will pass the returned pointer to all the API entrypoints that process user data
+for the particular client. `closeSession` should close connections the session
+has opened and release any resources specific to the served client. The_SESSION_ structure allocated in `newSession` should not be deallocated by`closeSession` but in `freeSession`. These two are called in succession
 by the core.
 
 ```
@@ -290,55 +290,55 @@ clientReply(INSTANCE* instance, SESSION session, GWBUF* queue, const mxs::ReplyR
 uint64_t getCapabilities(INSTANCE* instance)
 ```
 
-`routeQuery` is called for client requests which should be routed to backends,\
-and `clientReply` for backend reply packets which should be routed to the\
-client. For some modules, MaxScale itself is the backend. For filters, these can\
+`routeQuery` is called for client requests which should be routed to backends,
+and `clientReply` for backend reply packets which should be routed to the
+client. For some modules, MaxScale itself is the backend. For filters, these can
 be NULL, in which case the filter will be skipped for that packet type.
 
-`routeQuery` is often the most complicated function in a router, as it\
-implements the routing logic. It typically considers the client request `queue`,\
-the router settings in `instance` and the session state in `session` when making\
-a routing decision. For filters as well, `routeQuery` typically implements the\
-main logic, although the routing target is constant. For router modules,`routeQuery` should send data forward with `dcb->func.write()`. Filters should\
+`routeQuery` is often the most complicated function in a router, as it
+implements the routing logic. It typically considers the client request `queue`,
+the router settings in `instance` and the session state in `session` when making
+a routing decision. For filters as well, `routeQuery` typically implements the
+main logic, although the routing target is constant. For router modules,`routeQuery` should send data forward with `dcb->func.write()`. Filters should
 directly call `routeQuery` for the next filter or router in the chain.
 
-`clientReply` processes data flowing from backend back to client. For routers,\
-this function is often much simpler than `routeQuery`, since there is only one\
-client to route to. Depending on the router, some packets may not be routed to\
+`clientReply` processes data flowing from backend back to client. For routers,
+this function is often much simpler than `routeQuery`, since there is only one
+client to route to. Depending on the router, some packets may not be routed to
 the client. For example, if a client query was routed to multiple backends,\
 MaxScale will receive multiple replies while the client only expects one.\
-Routers should pass the reply packet to the last filter in the chain (reversed\
-order) using the function `mxs_route_reply`. Filters should call the`clientReply` of the previous filter in the chain. There is no need for filters\
-to worry about being the first filter in the chain, as this is handled\
+Routers should pass the reply packet to the last filter in the chain (reversed
+order) using the function `mxs_route_reply`. Filters should call the`clientReply` of the previous filter in the chain. There is no need for filters
+to worry about being the first filter in the chain, as this is handled
 transparently by the session creation routine.
 
-Application data is not always received in complete packets from the network\
-stack. How partial packets are handled by the receiving protocol module depends\
-on the attached filters and the router, communicated by their`getCapabilities`-functions. `getCapabilities` should return a bitfield\
-resulting from ORring the individual capabilities. `routing.hh` lists the allowed\
+Application data is not always received in complete packets from the network
+stack. How partial packets are handled by the receiving protocol module depends
+on the attached filters and the router, communicated by their`getCapabilities`-functions. `getCapabilities` should return a bitfield
+resulting from ORring the individual capabilities. `routing.hh` lists the allowed
 capability flags.
 
-If a router or filter sets no capabilities, `routeQuery` or `clientReply` may be\
-called to route partial packets. If the routing logic does not require any\
-information on the contents of the packets or even tracking the number of\
-packets, this may be fine. For many cases though, receiving a data packet in a\
-complete GWBUF chain or in one contiguous GWBUF is required. The former can be\
-requested by `getCapabilities` returning _RCAP\_TYPE\_STMT_, the latter by_RCAP\_TYPE\_CONTIGUOUS_. Separate settings exist for queries and replies. For\
-replies, an additional value, _RCAP\_TYPE\_RESULTSET\_OUTPUT_ is defined. This\
+If a router or filter sets no capabilities, `routeQuery` or `clientReply` may be
+called to route partial packets. If the routing logic does not require any
+information on the contents of the packets or even tracking the number of
+packets, this may be fine. For many cases though, receiving a data packet in a
+complete GWBUF chain or in one contiguous GWBUF is required. The former can be
+requested by `getCapabilities` returning _RCAP\_TYPE\_STMT_, the latter by_RCAP\_TYPE\_CONTIGUOUS_. Separate settings exist for queries and replies. For
+replies, an additional value, _RCAP\_TYPE\_RESULTSET\_OUTPUT_ is defined. This
 requests the protocol module to gather partial results into one result set.\
-Enforcing complete packets will delay processing, since the protocol module will\
-have to wait for the entire data packet to arrive before sending it down the\
+Enforcing complete packets will delay processing, since the protocol module will
+have to wait for the entire data packet to arrive before sending it down the
 processing chain.
 
 ```
 bool handleError(INSTANCE* instance, SESSION* session, GWBUF* errmsgbuf, mxs::Endpoint* problem, const mxs::Reply& reply);
 ```
 
-This router-only entrypoint is called if a network error occurs in one of the\
-backend server connections in use by the session. When the entrypoint is called,\
-the router should try to continue the session if possible. If the session can\
-continue operating normally, the function should return `true`. If the router\
-cannot continue routing queries, for example due to a complete cluster outage,\
+This router-only entrypoint is called if a network error occurs in one of the
+backend server connections in use by the session. When the entrypoint is called,
+the router should try to continue the session if possible. If the session can
+continue operating normally, the function should return `true`. If the router
+cannot continue routing queries, for example due to a complete cluster outage,
 the function should return `false` which will cause the whole session to close.
 
 #### Monitor
@@ -349,12 +349,12 @@ void stopMonitor(MXS_MONITOR *monitor)
 void diagnostics(DCB *, const MXS_MONITOR *)
 ```
 
-Monitor modules typically run a repeated monitor routine with a used defined\
-interval. The `MXS_MONITOR` is a standard monitor definition used for all\
-monitors and contains a void pointer for storing module specific data.`startMonitor` should create a new thread for itself using functions in the MPI\
-and have it regularly run a monitor loop. In the beginning of every monitor\
-loop, the monitor should lock the `SERVER`-structures of its servers. This\
-prevents any administrative action from interfering with the monitor during its\
+Monitor modules typically run a repeated monitor routine with a used defined
+interval. The `MXS_MONITOR` is a standard monitor definition used for all
+monitors and contains a void pointer for storing module specific data.`startMonitor` should create a new thread for itself using functions in the MPI
+and have it regularly run a monitor loop. In the beginning of every monitor
+loop, the monitor should lock the `SERVER`-structures of its servers. This
+prevents any administrative action from interfering with the monitor during its
 pass.
 
 ### Compiling, installing and running
@@ -364,32 +364,32 @@ The requirements for compiling a module are:_The public headers (MPI)_ A compati
 * Libraries required by the public headers
 
 Some of the public header files themselves include headers from other libraries.\
-These libraries need to be installed and it may be required to point out their\
+These libraries need to be installed and it may be required to point out their
 location to gcc. Some of the more commonly required libraries are:
 
 * _MySQL Connector-C_, used by the MySQL protocol module
 * _pcre2 regular expressions_ (libpcre2-dev), used for example by the header`modutil.h`
 
-After all dependencies are accounted for, the module should compile with a\
+After all dependencies are accounted for, the module should compile with a
 command similar to
 
 ```
 gcc -I /usr/local/include/mariadb -shared -fPIC -g -o libmymodule.so mymodule.cpp
 ```
 
-Large modules composed of several source files and using additional libraries\
-may require a more complicated compilation scheme, but that is outside the scope\
-of this document. The result of compiling a plugin should be a single shared\
+Large modules composed of several source files and using additional libraries
+may require a more complicated compilation scheme, but that is outside the scope
+of this document. The result of compiling a plugin should be a single shared
 library file.
 
-The compiled .so-file needs to be copied to the MaxScale library folder, which\
-is `/usr/local/lib/maxscale` by default. MaxScale expects the filename to be`lib<name>.so`, where `<name>` must match the module name given in the\
+The compiled .so-file needs to be copied to the MaxScale library folder, which
+is `/usr/local/lib/maxscale` by default. MaxScale expects the filename to be`lib<name>.so`, where `<name>` must match the module name given in the
 configuration file.
 
 #### Hands-on example: RoundRobinRouter
 
-In this example, the RoundRobinRouter is compiled, installed and tested. The\
-software environment this section was written and tested is listed below. Any\
+In this example, the RoundRobinRouter is compiled, installed and tested. The
+software environment this section was written and tested is listed below. Any
 recent Linux setup should be applicable.
 
 * Linux Mint 18
@@ -400,14 +400,14 @@ recent Linux setup should be applicable.
 * MaxScale plugin development headers (in `usr/include/maxscale`)
 
 **Step 1** Compile RoundRobinRouter with `$gcc -I /usr/local/include/mariadb -shared -fPIC -g -o libroundrobinrouter.so roundrobinrouter.cpp`.\
-Assuming all headers were found, the shared library `libroundrobinrouter.so`\
+Assuming all headers were found, the shared library `libroundrobinrouter.so`
 is produced.
 
 **Step 2** Copy the compiled module to the MaxScale module directory: `$sudo cp libroundrobinrouter.so /usr/local/lib/maxscale`.
 
-**Step 3** Modify the MaxScale configuration file to use the RoundRobinRouter as\
-a router. Example service and listener definitions are below. The _servers_\
-and _write\_backend_-lines should be configured according to the actual backend\
+**Step 3** Modify the MaxScale configuration file to use the RoundRobinRouter as
+a router. Example service and listener definitions are below. The _servers_
+and _write\_backend_-lines should be configured according to the actual backend
 configuration.
 
 ```
@@ -537,7 +537,7 @@ maxctrl
 MaxScale> call command roundrobinrouter test_command "one" 0
 ```
 
-The result of the `test_command "one" 0` is printed to the terminal MaxScale is\
+The result of the `test_command "one" 0` is printed to the terminal MaxScale is
 running in:
 
 ```
@@ -549,22 +549,22 @@ Argument 1: type 'boolean' value 'false'
 
 ### Summary and conclusion
 
-Plugins offer a way to extend MariaDB MaxScale whenever the standard modules are\
-found insufficient. The plugins need only implement a set API, can be\
-independently compiled and installation is simply a file copy with some\
+Plugins offer a way to extend MariaDB MaxScale whenever the standard modules are
+found insufficient. The plugins need only implement a set API, can be
+independently compiled and installation is simply a file copy with some
 configuration file modifications.
 
-Out of the different plugin types, filters are the easiest to implement. They\
-work independently and have few requirements. Protocol and authenticator modules\
-require indepth knowledge of the database protocol they implement. Router module\
+Out of the different plugin types, filters are the easiest to implement. They
+work independently and have few requirements. Protocol and authenticator modules
+require indepth knowledge of the database protocol they implement. Router module
 complexity depends on the routing logic requirements.
 
-The provided RoundRobinRouter example code should serve as a valid starting\
-point for both filters and routers. Studying the MaxScale Public Interface\
-headers to get a general idea of what services the core provides for plugins,\
+The provided RoundRobinRouter example code should serve as a valid starting
+point for both filters and routers. Studying the MaxScale Public Interface
+headers to get a general idea of what services the core provides for plugins,
 is also highly recommended.
 
-Lastly, MariaDB MaxScale is an open-source project, so code contributions can be\
+Lastly, MariaDB MaxScale is an open-source project, so code contributions can be
 accepted if they fulfill the [requirements](https://github.com/mariadb-corporation/MaxScale/wiki/Contributing).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-binlog-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-binlog-filter.md
@@ -4,22 +4,22 @@ This filter was introduced in MariaDB MaxScale 2.3.0.
 
 ### Overview
 
-The `binlogfilter` can be combined with a `binlogrouter` service to selectively\
+The `binlogfilter` can be combined with a `binlogrouter` service to selectively
 replicate the binary log events to replica servers.
 
-The filter uses two settings, _match_ and _exclude_, to determine which events\
-are replicated. If a binlog event does not match or is excluded, the event is\
-replaced with an empty data event. The empty event is always 35 bytes which\
+The filter uses two settings, _match_ and _exclude_, to determine which events
+are replicated. If a binlog event does not match or is excluded, the event is
+replaced with an empty data event. The empty event is always 35 bytes which
 translates to a space reduction in most cases.
 
-When statement-based replication is used, any query events that are filtered out\
-are replaced with a SQL comment. This causes the query event to do nothing and\
-thus the event will not modify the contents of the database. The GTID position\
-of the replicating database will still advance which means that downstream\
+When statement-based replication is used, any query events that are filtered out
+are replaced with a SQL comment. This causes the query event to do nothing and
+thus the event will not modify the contents of the database. The GTID position
+of the replicating database will still advance which means that downstream
 servers replicating from it keep functioning correctly.
 
-The filter works with both row based and statement based replication but we\
-recommend using row based replication with the binlogfilter. This guarantees\
+The filter works with both row based and statement based replication but we
+recommend using row based replication with the binlogfilter. This guarantees
 that there are no ambiguities in the event filtering.
 
 ### Configuration
@@ -42,18 +42,18 @@ Include queries that match the regex. See next entry, `exclude`, for more inform
 
 Exclude queries that match the regex.
 
-If neither `match` nor `exclude` are defined, the filter does nothing and all events\
-are replicated. This filter does not accept regular expression options as a separate\
-setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for\
+If neither `match` nor `exclude` are defined, the filter does nothing and all events
+are replicated. This filter does not accept regular expression options as a separate
+setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for
 more information.
 
-The two settings are matched against the database and table name concatenated\
-with a period. For example, the string the patterns are matched against for the\
+The two settings are matched against the database and table name concatenated
+with a period. For example, the string the patterns are matched against for the
 database `test` and table `t1` is `test.t1`.
 
-For statement based replication, the pattern is matched against all the tables\
-in the statements. If any of the tables matches the _match_ pattern, the event\
-is replicated. If any of the tables matches the _exclude_ pattern, the event is\
+For statement based replication, the pattern is matched against all the tables
+in the statements. If any of the tables matches the _match_ pattern, the event
+is replicated. If any of the tables matches the _exclude_ pattern, the event is
 not replicated.
 
 #### `rewrite_src`
@@ -73,28 +73,28 @@ See the next entry, `rewrite_dest`, for more information.
 * Default: None
 
 `rewrite_src` and `rewrite_dest` control the statement rewriting of the binlogfilter.\
-The `rewrite_src` setting is a PCRE2 regular expression that is matched against\
-the default database and the SQL of statement based replication events (query\
+The `rewrite_src` setting is a PCRE2 regular expression that is matched against
+the default database and the SQL of statement based replication events (query
 events). `rewrite_dest` is the replacement string which supports the normal\
-PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,\
+PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,
 etc.).
 
 Both `rewrite_src` and `rewrite_dest` must be defined to enable statement rewriting.
 
-When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)\
-must be used. The filter will disallow replication for all replicas that attempt\
+When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)
+must be used. The filter will disallow replication for all replicas that attempt
 to replicate with traditional file-and-position based replication.
 
-The replacement is done both on the default database as well as the SQL\
-statement in the query event. This means that great care must be taken when\
-defining the rewriting rules. To prevent accidental modification of the SQL into\
-a form that is no longer valid, use database and table names that never occur in\
+The replacement is done both on the default database as well as the SQL
+statement in the query event. This means that great care must be taken when
+defining the rewriting rules. To prevent accidental modification of the SQL into
+a form that is no longer valid, use database and table names that never occur in
 the inserted data and is never used as a constant value.
 
 ### Example Configuration
 
-With the following configuration, only events belonging to database `customers`\
-are replicated. In addition to this, events for the table `orders` are excluded\
+With the following configuration, only events belonging to database `customers`
+are replicated. In addition to this, events for the table `orders` are excluded
 and thus are not replicated.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache.md
@@ -4,34 +4,34 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-From MaxScale version 2.2.11 onwards, the cache filter is no longer\
-considered experimental. The following changes to the default behaviour\
+From MaxScale version 2.2.11 onwards, the cache filter is no longer
+considered experimental. The following changes to the default behaviour
 have also been made:
 
 * The default value of `cached_data` is now `thread_specific` (used to be`shared`).
 * The default value of `selects` is now `assume_cacheable` (used to be`verify_cacheable`).
 
 The cache filter is a simple cache that is capable of caching the result of\
-SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,\
+SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,
 without the queries being routed to any server.
 
 By _default_ the cache will be used and populated in the following circumstances:
 
 * There is no explicit transaction active, that is, autocommit is used,
 * there is an explicitly read-only transaction (that is,`START TRANSACTION READ ONLY`) active, or
-* there is a transaction active and no statement that modifies the database\
+* there is a transaction active and no statement that modifies the database
   has been performed.
 
-In practice, the last bullet point basically means that if a transaction has\
+In practice, the last bullet point basically means that if a transaction has
 been started with `BEGIN`, `START TRANSACTION` or `START TRANSACTION READ WRITE`, then the cache will be used and populated until the first `UPDATE`,`INSERT` or `DELETE` statement is encountered.
 
-That is, in default mode the cache effectively causes the system to behave\
-as if the _isolation level_ would be `READ COMMITTED`, irrespective of what\
+That is, in default mode the cache effectively causes the system to behave
+as if the _isolation level_ would be `READ COMMITTED`, irrespective of what
 the isolation level of the backends actually is.
 
 The default behaviour can be altered using the configuration parameter [cache\_in\_transactions](mariadb-maxscale-2302-cache.md#cache_in_transactions).
 
-By default it is assumed that all `SELECT` statements are cacheable, which\
+By default it is assumed that all `SELECT` statements are cacheable, which
 means that also statements like `SELECT LOCALTIME` are cached. Please check [selects](mariadb-maxscale-2302-cache.md#selects) for how to change the default behaviour.
 
 ### Limitations
@@ -50,34 +50,34 @@ Multi-statements are always sent to the backend and their result is**not** cache
 
 The cache is **not** aware of grants.
 
-The implication is that unless the cache has been explicitly configured\
-who the caching should apply to, the presence of the cache may provide\
+The implication is that unless the cache has been explicitly configured
+who the caching should apply to, the presence of the cache may provide
 a user with access to data he should not have access to.
 
 Please read the section [Security](mariadb-maxscale-2302-cache.md#security-1) for more detailed information.
 
-However, from 2.5 onwards it is possible to configure the cache to cache\
-the data of each user separately, which effectively means that there can\
-be no unintended sharing. Please see [users](mariadb-maxscale-2302-cache.md#users) for how to change\
+However, from 2.5 onwards it is possible to configure the cache to cache
+the data of each user separately, which effectively means that there can
+be no unintended sharing. Please see [users](mariadb-maxscale-2302-cache.md#users) for how to change
 the default behaviour.
 
 #### `information_schema`
 
-When [invalidation](mariadb-maxscale-2302-cache.md#invalidation) is enabled, SELECTs targeting tables\
-in `information_schema` are not cached. The reason is that as the content\
-of the tables changes as the side-effect of something else, the cache would\
+When [invalidation](mariadb-maxscale-2302-cache.md#invalidation) is enabled, SELECTs targeting tables
+in `information_schema` are not cached. The reason is that as the content
+of the tables changes as the side-effect of something else, the cache would
 not know when to invalidate the cache-entries.
 
 ### Invalidation
 
-Since MaxScale 2.5, the cache is capable of invalidating entries in the\
-cache when a modification (UPDATE, INSERT or DELETE) that may affect those\
+Since MaxScale 2.5, the cache is capable of invalidating entries in the
+cache when a modification (UPDATE, INSERT or DELETE) that may affect those
 entries is made.
 
-The cache invalidation works on the table-level, that is, a modification\
-made to a particular table will cause all cache entries that refer to that\
-table to be invalidated, irrespective of whether the modification actually\
-has an impact on the cache entries or not. For instance, suppose the result\
+The cache invalidation works on the table-level, that is, a modification
+made to a particular table will cause all cache entries that refer to that
+table to be invalidated, irrespective of whether the modification actually
+has an impact on the cache entries or not. For instance, suppose the result
 of the following SELECT has been cached
 
 ```
@@ -90,55 +90,55 @@ An insert like
 INSERT INTO t SET a=42;
 ```
 
-will cause the cache entry containing the result of that SELECT to be\
+will cause the cache entry containing the result of that SELECT to be
 invalidated even if the INSERT actually does not affect it. Please see [invalidate](mariadb-maxscale-2302-cache.md#invalidate) for how to enable the invalidation.
 
-When invalidation has been enabled MaxScale must be able to completely\
-parse a SELECT statement for its results to be stored in the cache. The\
-reason is that in order to be able to invalidate cache entries, MaxScale\
-must know what tables a SELECT statement depends upon. Consequently, if\
-(and only if) invalidation has been enabled and MaxScale fails to parse a\
+When invalidation has been enabled MaxScale must be able to completely
+parse a SELECT statement for its results to be stored in the cache. The
+reason is that in order to be able to invalidate cache entries, MaxScale
+must know what tables a SELECT statement depends upon. Consequently, if
+(and only if) invalidation has been enabled and MaxScale fails to parse a
 statement, the result of that particular statement will not be cached.
 
 When invalidation has been enabled, MaxScale will also parse all UPDATE,\
-INSERT and DELETE statements, in order to find out what tables are\
-modified. If that parsing fails, MaxScale will _by default_ clear the\
-entire cache. The reason is that unless MaxScale can completely parse\
-the statement it cannot know what tables are modified and hence not what\
-cache entries should be invalidated. Consequently, to prevent stale data\
-from being returned, the entire cache is cleared. The default behaviour\
+INSERT and DELETE statements, in order to find out what tables are
+modified. If that parsing fails, MaxScale will _by default_ clear the
+entire cache. The reason is that unless MaxScale can completely parse
+the statement it cannot know what tables are modified and hence not what
+cache entries should be invalidated. Consequently, to prevent stale data
+from being returned, the entire cache is cleared. The default behaviour
 can be changed using the configuration parameter [clear\_cache\_on\_parse\_errors](mariadb-maxscale-2302-cache.md#clear_cache_on_parse_errors).
 
-Note that what threading approach is used has a big impact on the\
-invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2302-cache.md#threads-users-and-invalidation)\
+Note that what threading approach is used has a big impact on the
+invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2302-cache.md#threads-users-and-invalidation)
 for how the threading approach affects the invalidation.
 
-Note also that since the invalidation may not, depending on how the\
-cache has been configured, be visible to all sessions of all users, it\
+Note also that since the invalidation may not, depending on how the
+cache has been configured, be visible to all sessions of all users, it
 is still important to configure a reasonable [soft](mariadb-maxscale-2302-cache.md#soft_ttl) and [hard](mariadb-maxscale-2302-cache.md#hard_ttl) TTL.
 
 #### Best Efforts
 
-The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the\
-cache in all circumstances reflects the state in the actual database,\
-would require that the operations involving the cache and the MariaDB\
+The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the
+cache in all circumstances reflects the state in the actual database,
+would require that the operations involving the cache and the MariaDB
 server are synchronized, which would cause an unacceptable overhead.
 
 What _best efforts_ means in this context is best illustrated using an example.
 
-Suppose a client executes the statement `SELECT * FROM tbl` and that the result\
-is cached. Next time that or any other client executes the same statement, the\
-result is returned from the cache and the MariaDB server will not be accessed\
+Suppose a client executes the statement `SELECT * FROM tbl` and that the result
+is cached. Next time that or any other client executes the same statement, the
+result is returned from the cache and the MariaDB server will not be accessed
 at all.
 
-If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the\
-cached value for the `SELECT` statement above and all other statements that are\
-dependent upon `tbl` will be invalidated. That is, the next time someone executes\
+If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the
+cached value for the `SELECT` statement above and all other statements that are
+dependent upon `tbl` will be invalidated. That is, the next time someone executes
 the statement `SELECT * FROM tbl` the result will again be fetched from the\
 MariaDB server and stored to the cache.
 
-However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`\
-at the same time someone else executes the `INSERT ...` statement. A possible\
+However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`
+at the same time someone else executes the `INSERT ...` statement. A possible
 chain of events is as follows:
 
 ```
@@ -149,7 +149,7 @@ MaxScale -> DB                                   SELECT COUNT(*) FROM tbl
 MaxScale -> DB        INSERT ...
 ```
 
-That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of\
+That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of
 each other, the events may be re-ordered as far as the cache is concerned.
 
 ```
@@ -157,16 +157,16 @@ MaxScale -> Cache     Delete invalidated values
 MaxScale -> Cache                                Store result and invalidation key
 ```
 
-That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the\
+That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the
 situation _before_ the insert and will thus not be correct.
 
-The stale result will be returned until the value has reached its _time-to-live_\
+The stale result will be returned until the value has reached its _time-to-live_
 or its invalidation is caused by some update operation.
 
 ### Configuration
 
-The cache is simple to add to any existing service. However, some experimentation\
-may be required in order to find the configuration settings that provide\
+The cache is simple to add to any existing service. However, some experimentation
+may be required in order to find the configuration settings that provide
 the maximum benefit.
 
 ```
@@ -184,21 +184,21 @@ type=service
 filters=Cache
 ```
 
-Each configured cache filter uses a storage of its own. That is, if there\
-are two services, each configured with a specific cache filter, then,\
-even if queries target the very same servers the cached data will not\
+Each configured cache filter uses a storage of its own. That is, if there
+are two services, each configured with a specific cache filter, then,
+even if queries target the very same servers the cached data will not
 be shared.
 
-Two services can use the same cache filter, but then either the services\
-should use the very same servers _or_ a completely different set of servers,\
-where the used table names are different. Otherwise there can be unintended\
+Two services can use the same cache filter, but then either the services
+should use the very same servers _or_ a completely different set of servers,
+where the used table names are different. Otherwise there can be unintended
 sharing.
 
 #### Filter Parameters
 
 The cache filter has no mandatory parameters but a range of optional ones.\
-Note that it is advisable to specify `max_size` to prevent the cache from\
-using up all memory there is, in case there is very little overlap among the\
+Note that it is advisable to specify `max_size` to prevent the cache from
+using up all memory there is, in case there is very little overlap among the
 queries.
 
 **`storage`**
@@ -208,8 +208,8 @@ queries.
 * Dynamic: No
 * Default: `storage_inmemory`
 
-The name of the module that provides the storage for the cache. That\
-module will be loaded and provided with the value of `storage_options` as\
+The name of the module that provides the storage for the cache. That
+module will be loaded and provided with the value of `storage_options` as
 argument. For instance:
 
 ```
@@ -227,11 +227,11 @@ See [Storage](mariadb-maxscale-2302-cache.md#storage-1) for what storage modules
 
 **NOTE** Deprecated in 23.02.
 
-A string that is provided verbatim to the storage module specified in `storage`,\
-when the module is loaded. Note that the needed arguments and their format depend\
+A string that is provided verbatim to the storage module specified in `storage`,
+when the module is loaded. Note that the needed arguments and their format depend
 upon the specific module.
 
-From 23.02 onwards, the storage module configuration should be provided using\
+From 23.02 onwards, the storage module configuration should be provided using
 nested parameters.
 
 **`hard_ttl`**
@@ -241,8 +241,8 @@ nested parameters.
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Hard time to live_; the maximum amount of time the cached\
-result is used before it is discarded and the result is fetched from the\
+_Hard time to live_; the maximum amount of time the cached
+result is used before it is discarded and the result is fetched from the
 backend (and cached). See also [soft\_ttl](mariadb-maxscale-2302-cache.md#soft_ttl).
 
 ```
@@ -256,21 +256,21 @@ hard_ttl=60s
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Soft time to live_; the amount of time - in seconds - the cached result is\
-used before it is refreshed from the server. When `soft_ttl` has passed, the\
+_Soft time to live_; the amount of time - in seconds - the cached result is
+used before it is refreshed from the server. When `soft_ttl` has passed, the
 result will be refreshed when the _first_ client requests the value.
 
-However, as long as [hard\_ttl](mariadb-maxscale-2302-cache.md#hard_ttl) has not passed, _all_ other clients\
-requesting the same value will use the result from the cache while it is being\
-fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`\
-has passed, even if several clients request the same value at the same time,\
+However, as long as [hard\_ttl](mariadb-maxscale-2302-cache.md#hard_ttl) has not passed, _all_ other clients
+requesting the same value will use the result from the cache while it is being
+fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`
+has passed, even if several clients request the same value at the same time,
 there will be just one request to the backend.
 
 ```
 soft_ttl=60s
 ```
 
-If the value of `soft_ttl` is larger than `hard_ttl` it will be adjusted\
+If the value of `soft_ttl` is larger than `hard_ttl` it will be adjusted
 down to the same value.
 
 **`max_resultset_rows`**
@@ -280,7 +280,7 @@ down to the same value.
 * Dynamic: No
 * Default: `0` (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 stored in the cache. A resultset larger than this, will not be stored.
 
 ```
@@ -295,14 +295,14 @@ max_resultset_rows=1000
 * Default: `0` (no limit)
 
 Specifies the maximum size of a resultset, for it to be stored in the cache.\
-A resultset larger than this, will not be stored. The size can be specified\
+A resultset larger than this, will not be stored. The size can be specified
 as described [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#sizes).
 
 ```
 max_resultset_size=128Ki
 ```
 
-Note that the value of `max_resultset_size` should not be larger than the\
+Note that the value of `max_resultset_size` should not be larger than the
 value of `max_size`.
 
 **`max_count`**
@@ -312,12 +312,12 @@ value of `max_size`.
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum number of items the cache may contain. If the limit has been\
+The maximum number of items the cache may contain. If the limit has been
 reached and a new item should be stored, then an older item will be evicted.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
-is used, then the total number of cached items is #threads \* the value\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
+is used, then the total number of cached items is #threads \* the value
 of `max_count`.
 
 ```
@@ -331,11 +331,11 @@ max_count=1000
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum size the cache may occupy. If the limit has been reached and a new\
+The maximum size the cache may occupy. If the limit has been reached and a new
 item should be stored, then some older item(s) will be evicted to make space.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
 is used, then the total size is #threads \* the value of `max_size`.
 
 ```
@@ -349,15 +349,15 @@ max_size=100Mi
 * Dynamic: Yes
 * Default: `""` (no rules)
 
-Specifies the path of the file where the caching rules are stored. A relative\
+Specifies the path of the file where the caching rules are stored. A relative
 path is interpreted relative to the _data directory_ of MariaDB MaxScale.
 
 ```
 rules=/path/to/rules-file
 ```
 
-Note that the rules will be reloaded, and applied if different, every time\
-a dynamic configuration change is made. Thus, to cause a reloading of the\
+Note that the rules will be reloaded, and applied if different, every time
+a dynamic configuration change is made. Thus, to cause a reloading of the
 rules, alter the rules parameter to the same value it has.
 
 ```
@@ -372,22 +372,22 @@ maxctrl alter filter MyCache rules='/path/to/rules-file'
 * Values: `shared`, `thread_specific`
 * Default: `thread_specific`
 
-An enumeration option specifying how data is shared between threads. The\
+An enumeration option specifying how data is shared between threads. The
 allowed values are:
 
-* `shared`: The cached data is shared between threads. On the one hand\
-  it implies that there will be synchronization between threads, on\
+* `shared`: The cached data is shared between threads. On the one hand
+  it implies that there will be synchronization between threads, on
   the other hand that all threads will use data fetched by any thread.
-* `thread_specific`: The cached data is specific to a thread. On the\
-  one hand it implies that no synchronization is needed between threads,\
-  on the other hand that the very same data may be fetched and stored\
+* `thread_specific`: The cached data is specific to a thread. On the
+  one hand it implies that no synchronization is needed between threads,
+  on the other hand that the very same data may be fetched and stored
   multiple times.
 
 ```
 cached_data=shared
 ```
 
-Default is `thread_specific`. See `max_count` and `max_size` what implication\
+Default is `thread_specific`. See `max_count` and `max_size` what implication
 changing this setting to `shared` has.
 
 **`selects`**
@@ -398,35 +398,35 @@ changing this setting to `shared` has.
 * Values: `assume_cacheable`, `verify_cacheable`
 * Default: `assume_cacheable`
 
-An enumeration option specifying what approach the cache should take with\
+An enumeration option specifying what approach the cache should take with
 respect to `SELECT` statements. The allowed values are:
 
-* `assume_cacheable`: The cache can assume that all `SELECT` statements,\
+* `assume_cacheable`: The cache can assume that all `SELECT` statements,
   without exceptions, are cacheable.
-* `verify_cacheable`: The cache can not assume that all `SELECT`\
+* `verify_cacheable`: The cache can not assume that all `SELECT`
   statements are cacheable, but must verify that.
 
 ```
 selects=verify_cacheable
 ```
 
-Default is `assume_cacheable`. In this case, all `SELECT` statements are\
-assumed to be cacheable and will be parsed _only_ if some specific rule\
+Default is `assume_cacheable`. In this case, all `SELECT` statements are
+assumed to be cacheable and will be parsed _only_ if some specific rule
 requires that.
 
-If `verify_cacheable` is specified, then all `SELECT` statements will be\
-parsed and only those that are safe for caching - e.g. do _not_ call any\
-non-cacheable functions or access any non-cacheable variables - will be\
+If `verify_cacheable` is specified, then all `SELECT` statements will be
+parsed and only those that are safe for caching - e.g. do _not_ call any
+non-cacheable functions or access any non-cacheable variables - will be
 subject to caching.
 
-If `verify_cacheable` has been specified, the cache will not be used in\
+If `verify_cacheable` has been specified, the cache will not be used in
 the following circumstances:
 
 * The `SELECT` uses any of the following functions: `BENCHMARK`,`CONNECTION_ID`, `CONVERT_TZ`, `CURDATE`, `CURRENT_DATE`, `CURRENT_TIMESTAMP`,`CURTIME`, `DATABASE`, `ENCRYPT`, `FOUND_ROWS`, `GET_LOCK`, `IS_FREE_LOCK`,`IS_USED_LOCK`, `LAST_INSERT_ID`, `LOAD_FILE`, `LOCALTIME`, `LOCALTIMESTAMP`,`MASTER_POS_WAIT`, `NOW`, `RAND`, `RELEASE_LOCK`, `SESSION_USER`, `SLEEP`,`SYSDATE`, `SYSTEM_USER`, `UNIX_TIMESTAMP`, `USER`, `UUID`, `UUID_SHORT`.
 * The `SELECT` accesses any of the following fields: `CURRENT_DATE`,`CURRENT_TIMESTAMP`, `LOCALTIME`, `LOCALTIMESTAMP`
 * The `SELECT` uses system or user variables.
 
-Note that parsing all `SELECT` statements carries a performance\
+Note that parsing all `SELECT` statements carries a performance
 cost. Please read [performance](mariadb-maxscale-2302-cache.md#performance) for more details.
 
 **`cache_in_transactions`**
@@ -437,21 +437,21 @@ cost. Please read [performance](mariadb-maxscale-2302-cache.md#performance) for 
 * Values: `never`, `read_only_transactions`, `all_transactions`
 * Default: `all_transactions`
 
-An enumeration option specifying how the cache should behave when there\
+An enumeration option specifying how the cache should behave when there
 are active transactions:
 
-* `never`: When there is an active transaction, no data will be returned\
+* `never`: When there is an active transaction, no data will be returned
   from the cache, but all requests will always be sent to the backend.\
   The cache will be populated inside explicitly read-only transactions.\
-  Inside transactions that are not explicitly read-only, the cache will\
+  Inside transactions that are not explicitly read-only, the cache will
   be populated until the first non-SELECT statement.
-* `read_only_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be populated, but not used\
+* `read_only_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be populated, but not used
   until the first non-SELECT statement.
-* `all_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be used and populated until the\
+* `all_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be used and populated until the
   first non-SELECT statement.
 
 ```
@@ -460,7 +460,7 @@ cache_in_transactions=never
 
 Default is `all_transactions`.
 
-The values `read_only_transactions` and `all_transactions` have roughly the\
+The values `read_only_transactions` and `all_transactions` have roughly the
 same effect as changing the isolation level of the backend to `read_committed`.
 
 **`debug`**
@@ -470,8 +470,8 @@ same effect as changing the isolation level of the backend to `read_committed`.
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the cache\
-can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the cache
+can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -500,9 +500,9 @@ Specifies whether the cache is initially enabled or disabled.
 enabled=false
 ```
 
-The value affects the initial state of the MaxScale user\
-variables using which the behaviour of the cache can be modified\
-at runtime. Please see [Runtime Configuration](mariadb-maxscale-2302-cache.md#runtime-configuration)\
+The value affects the initial state of the MaxScale user
+variables using which the behaviour of the cache can be modified
+at runtime. Please see [Runtime Configuration](mariadb-maxscale-2302-cache.md#runtime-configuration)
 for details.
 
 **`invalidate`**
@@ -513,7 +513,7 @@ for details.
 * Values: `never`, `current`
 * Default: `never`
 
-An enumeration option specifying how the cache should invalidate\
+An enumeration option specifying how the cache should invalidate
 cache entries.
 
 ```
@@ -524,18 +524,18 @@ cache entries.
   not.
 ```
 
-The effect of `current` depends upon the value of `cached_data`. If the value\
-is `shared`, that is, all threads share the same cache, then the effect of an\
+The effect of `current` depends upon the value of `cached_data`. If the value
+is `shared`, that is, all threads share the same cache, then the effect of an
 invalidation is immediately visible to all sessions, as there is just one cache.\
-However, if the value is `thread_specific`, then an invalidation will affect only\
+However, if the value is `thread_specific`, then an invalidation will affect only
 the cache that the session happens to be using.
 
-If it is important and _sufficient_ that an application immediately sees a change\
-that it itself has caused, then a combination of `invalidate=current`\
+If it is important and _sufficient_ that an application immediately sees a change
+that it itself has caused, then a combination of `invalidate=current`
 and `cached_data=thread_specific` can be used.
 
-If it is important that an application _immediately_ sees all changes, irrespective\
-of who has caused them, then a combination of `invalidate=current`\
+If it is important that an application _immediately_ sees all changes, irrespective
+of who has caused them, then a combination of `invalidate=current`
 and `cached_data=shared` _must_ be used.
 
 **`clear_cache_on_parse_errors`**
@@ -545,18 +545,18 @@ and `cached_data=shared` _must_ be used.
 * Dynamic: No
 * Default: `true`
 
-This boolean option specifies how the cache should behave in case of\
+This boolean option specifies how the cache should behave in case of
 parsing errors when invalidation has been enabled.
 
-* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE\
+* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE
   statement then all cached data will be cleared.
-* `false`: A failure to parse an UPDATE/INSERT/DELETE statement\
+* `false`: A failure to parse an UPDATE/INSERT/DELETE statement
   is ignored and no invalidation will take place due that statement.
 
 The default value is `true`.
 
-Changing the value to `false` may mean that stale data is returned from\
-the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement\
+Changing the value to `false` may mean that stale data is returned from
+the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement
 affects entries in the cache.
 
 **`users`**
@@ -567,7 +567,7 @@ affects entries in the cache.
 * Values: `mixed`, `isolated`
 * Default: `mixed`
 
-An enumeration option specifying how the cache should cache data for\
+An enumeration option specifying how the cache should cache data for
 different users.
 
 ```
@@ -578,11 +578,11 @@ different users.
   no unintended sharing.
 ```
 
-Note that if `isolated` has been specified, then each user will\
-conceptually have a cache of his own, which is populated\
-independently from each other. That is, if two users make the\
-same query, then the data will be fetched twice and also stored\
-twice. So, a `isolated` cache will in general use more memory and\
+Note that if `isolated` has been specified, then each user will
+conceptually have a cache of his own, which is populated
+independently from each other. That is, if two users make the
+same query, then the data will be fetched twice and also stored
+twice. So, a `isolated` cache will in general use more memory and
 cause more traffic to the backend compared to a `mixed` cache.
 
 **`timeout`**
@@ -592,7 +592,7 @@ cause more traffic to the backend compared to a `mixed` cache.
 * Dynamic: No
 * Default: `5s`
 
-The _timeout_ used when performing operations to distributed storages\
+The _timeout_ used when performing operations to distributed storages
 such as _redis_ or _memcached_.
 
 ```
@@ -601,19 +601,19 @@ timeout=7000ms
 
 #### Runtime Configuration
 
-The cache filter can be configured at runtime by executing SQL commands. If\
-there is more than one cache filter in a service, only the first cache filter\
-will be able to process the variables. The remaining filters will not see them\
+The cache filter can be configured at runtime by executing SQL commands. If
+there is more than one cache filter in a service, only the first cache filter
+will be able to process the variables. The remaining filters will not see them
 and thus configuring them at runtime is not possible.
 
 **`@maxscale.cache.populate`**
 
-Using the variable `@maxscale.cache.populate` it is possible to specify at\
-runtime whether the cache should be populated or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.populate` it is possible to specify at
+runtime whether the cache should be populated or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be populated.
 
 ```
@@ -623,10 +623,10 @@ SET @maxscale.cache.populate=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-In the example above, the first `SELECT` will always be sent to the\
-server and the result will be cached, provided the actual cache rules\
-specifies that it should be. The second `SELECT` may be served from the\
-cache, depending on the value of `@maxscale.cache.use` (and the cache\
+In the example above, the first `SELECT` will always be sent to the
+server and the result will be cached, provided the actual cache rules
+specifies that it should be. The second `SELECT` may be served from the
+cache, depending on the value of `@maxscale.cache.use` (and the cache
 rules).
 
 The value of `@maxscale.cache.populate` can be queried
@@ -639,12 +639,12 @@ but only _after_ it has been explicitly set once.
 
 **`@maxscale.cache.use`**
 
-Using the variable `@maxscale.cache.use` it is possible to specify at\
-runtime whether the cache should be used or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.use` it is possible to specify at
+runtime whether the cache should be used or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be used.
 
 ```
@@ -654,15 +654,15 @@ SET @maxscale.cache.use=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-The first `SELECT` will be served from the cache, providing the rules\
-specify that the statement should be cached, the cache indeed contains\
+The first `SELECT` will be served from the cache, providing the rules
+specify that the statement should be cached, the cache indeed contains
 the result and the date is not stale (as specified by the _TTL_).
 
-If the data is stale, the `SELECT` will be sent to the server **and**\
+If the data is stale, the `SELECT` will be sent to the server **and**
 the cache entry will be updated, irrespective of the value of`@maxscale.cache.populate`.
 
-If `@maxscale.cache.use` is `true` but the result is not found in the\
-cache, and the result is subsequently fetched from the server, the\
+If `@maxscale.cache.use` is `true` but the result is not found in the
+cache, and the result is subsequently fetched from the server, the
 result will **not** be added to the cache, unless`@maxscale.cache.populate` is also `true`.
 
 The value of `@maxscale.cache.use` can be queried
@@ -675,12 +675,12 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.soft_ttl`**
 
-Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime\
-to specify _in seconds_ what _soft ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `soft_ttl`. That is,\
+Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime
+to specify _in seconds_ what _soft ttl_ should be applied. Its initial
+value is the value of the configuration parameter `soft_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _soft ttl_ should be applied.
 
 ```
@@ -690,13 +690,13 @@ SET @maxscale.cache.soft_ttl=60;
 SELECT c, d FROM important;
 ```
 
-When data is `SELECT`ed from the unimportant table `unimportant`, the data\
-will be returned from the cache provided it is no older than 10 minutes,\
-but when data is `SELECT`ed from the important table `important`, the\
+When data is `SELECT`ed from the unimportant table `unimportant`, the data
+will be returned from the cache provided it is no older than 10 minutes,
+but when data is `SELECT`ed from the important table `important`, the
 data will be returned from the cache provided it is no older than 1 minute.
 
-Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`\
-in the sense that if the former is less that the latter, then _soft ttl_\
+Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`
+in the sense that if the former is less that the latter, then _soft ttl_
 will, when used, be adjusted down to the value of _hard ttl_.
 
 The value of `@maxscale.cache.soft_ttl` can be queried
@@ -709,16 +709,16 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.hard_ttl`**
 
-Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime\
-to specify _in seconds_ what _hard ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `hard_ttl`. That is,\
+Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime
+to specify _in seconds_ what _hard ttl_ should be applied. Its initial
+value is the value of the configuration parameter `hard_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _hard ttl_ should be applied.
 
-Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,\
-is important to ensure that the former is at least as large as the latter\
+Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,
+is important to ensure that the former is at least as large as the latter
 and for best overall performance that it is larger.
 
 ```
@@ -738,11 +738,11 @@ but only after it has explicitly been set once.
 
 **Client Driven Caching**
 
-With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible\
+With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible
 to make the caching completely client driven.
 
-Provide no `rules` file, which means that _all_ `SELECT` statements are\
-subject to caching and that all users receive data from the cache. Set\
+Provide no `rules` file, which means that _all_ `SELECT` statements are
+subject to caching and that all users receive data from the cache. Set
 the startup mode of the cache to _disabled_.
 
 ```
@@ -762,10 +762,10 @@ SELECT e, f FROM tbl3;
 SET @maxscale.cache.populate=FALSE;
 ```
 
-Note that those `SELECT`s must return something in order for the\
+Note that those `SELECT`s must return something in order for the
 statement to be _marked_ for caching.
 
-After this, the value of `@maxscale.cache.use` will decide whether\
+After this, the value of `@maxscale.cache.use` will decide whether
 or not the cache is considered.
 
 ```
@@ -774,12 +774,12 @@ SELECT a, b FROM tbl1;
 SET @maxscale.cache.use=FALSE;
 ```
 
-With `@maxscale.cache.use` being `true`, the cache is considered\
-and the result returned from there, if not stale. If it is stale,\
+With `@maxscale.cache.use` being `true`, the cache is considered
+and the result returned from there, if not stale. If it is stale,
 the result is fetched from the server and the cached entry is updated.
 
-By setting a very long _TTL_ it is possible to prevent the cache\
-from ever considering an entry to be stale and instead manually\
+By setting a very long _TTL_ it is possible to prevent the cache
+from ever considering an entry to be stale and instead manually
 cause the cache to be updated when needed.
 
 ```
@@ -791,8 +791,8 @@ SET @maxscale.cache.populate=FALSE;
 
 ### Threads, Users and Invalidation
 
-What caching approach is used and how different users are treated\
-has a significant impact on the behaviour of the cache. In the\
+What caching approach is used and how different users are treated
+has a significant impact on the behaviour of the cache. In the
 following the implication of different combinations is explained.
 
 | cached\_data/users | mixed                                                                                                                          | isolated                                                                                                                        |
@@ -802,14 +802,14 @@ following the implication of different combinations is explained.
 
 #### Invalidation
 
-Invalidation takes place only in the current cache, so how _visible_\
+Invalidation takes place only in the current cache, so how _visible_
 the invalidation is, depends upon the configuration value of`cached_data`.
 
 **`cached_data=thread_specific`**
 
-The invalidation is visible only to the sessions that are handled by\
-the same worker thread where the invalidation occurred. Sessions of the\
-same or other users that are handled by different worker threads will\
+The invalidation is visible only to the sessions that are handled by
+the same worker thread where the invalidation occurred. Sessions of the
+same or other users that are handled by different worker threads will
 not see the new value before the TTL causes the value to be refreshed.
 
 **`cache_data=shared`**
@@ -820,8 +820,8 @@ The invalidation is immediately visible to all sessions of all users.
 
 The caching rules are expressed as a JSON object or as an array of JSON objects.
 
-There are two decisions to be made regarding the caching; in what circumstances\
-should data be stored to the cache and in what circumstances should the data in\
+There are two decisions to be made regarding the caching; in what circumstances
+should data be stored to the cache and in what circumstances should the data in
 the cache be used.
 
 Expressed in JSON this looks as follows
@@ -845,9 +845,9 @@ or, in case an array is used, as
 ]
 ```
 
-The `store` field specifies in what circumstances data should be stored to\
-the cache and the `use` field specifies in what circumstances the data in\
-the cache should be used. In both cases, the value is a JSON array containing\
+The `store` field specifies in what circumstances data should be stored to
+the cache and the `use` field specifies in what circumstances the data in
+the cache should be used. In both cases, the value is a JSON array containing
 objects.
 
 If an array of rule objects is specified, then, when looking for a rule that\
@@ -857,14 +857,14 @@ deciding whether data in the cache should be used.
 
 #### When to Store
 
-By default, if no rules file have been provided or if the `store` field is\
-missing from the object, the results of all queries will be stored to the\
-cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter\
+By default, if no rules file have been provided or if the `store` field is
+missing from the object, the results of all queries will be stored to the
+cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter
 parameters.
 
-By providing a `store` field in the JSON object, the decision whether to\
-store the result of a particular query to the cache can be controlled in\
-a more detailed manner. The decision to cache the results of a query can\
+By providing a `store` field in the JSON object, the decision whether to
+store the result of a particular query to the cache can be controlled in
+a more detailed manner. The decision to cache the results of a query can
 depend upon
 
 * the database,
@@ -888,21 +888,21 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`\
+If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`
 or `unlike`, then _value_ is interpreted as a _pcre2_ regular expression.\
-Note though that if _attribute_ is `database`, `table` or `column`, then\
-the string is interpreted as a name, where a dot `.` denotes qualification\
+Note though that if _attribute_ is `database`, `table` or `column`, then
+the string is interpreted as a name, where a dot `.` denotes qualification
 or scoping.
 
-The objects in the `store` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `store` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 result of the query in question will be stored to the cache.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then the result of the query is not stored to the cache.
 
-Note that as the query itself is used as the key, although the following\
+Note that as the query itself is used as the key, although the following
 queries
 
 ```
@@ -916,7 +916,7 @@ USE db1;
 SELECT * FROM tbl
 ```
 
-target the same table and produce the same results, they will be cached\
+target the same table and produce the same results, they will be cached
 separately. The same holds for queries like
 
 ```
@@ -929,13 +929,13 @@ and
 SELECT * FROM tbl WHERE b = 3 AND a = 2;
 ```
 
-as well. Although they conceptually are identical, there will be two\
+as well. Although they conceptually are identical, there will be two
 cache entries.
 
-Note that if a column has been specified in a rule, then a statement\
+Note that if a column has been specified in a rule, then a statement
 will match _irrespective_ of where that particular column appears.\
-For instance, if a rule specifies that the result of statements referring\
-to the column _a_ should be cached, then the following statement will\
+For instance, if a rule specifies that the result of statements referring
+to the column _a_ should be cached, then the following statement will
 match
 
 ```
@@ -950,7 +950,7 @@ SELECT b FROM tbl WHERE a > 5;
 
 **Qualified Names**
 
-When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,\
+When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,
 dot (`.`) denotes qualification or scope.
 
 In practice that means that if _attribute_ is `database` then _value_ may\
@@ -959,20 +959,20 @@ dot, used for separating the database and table names respectively, and\
 if _attribute_ is `column` then _value_ may contain one or two dots, used\
 for separating table and column names, or database, table and column names.
 
-Note that if a qualified name is used as a _value_, then all parts of the\
-name must be available for a match. Currently Maria DB MaxScale may not\
-always be capable of deducing in what table a particular column is. If\
-that is the case, then a value like `tbl.field` may not necessarily\
+Note that if a qualified name is used as a _value_, then all parts of the
+name must be available for a match. Currently Maria DB MaxScale may not
+always be capable of deducing in what table a particular column is. If
+that is the case, then a value like `tbl.field` may not necessarily
 be a match even if the field is `field` and the table actually is `tbl`.
 
 **Implication of the default database**
 
-If the rules concerns the `database`, then only if the statement refers\
+If the rules concerns the `database`, then only if the statement refers
 to _no_ specific database, will the default database be considered.
 
 **Regexp Matching**
 
-The string used for matching the regular expression contains as much\
+The string used for matching the regular expression contains as much
 information as there is available. For instance, in a situation like
 
 ```
@@ -1012,8 +1012,8 @@ Cache all queries _not_ targeting a particular table
 }
 ```
 
-That will exclude queries targeting table _tbl1_ irrespective of which\
-database it is in. To exclude a table in a particular database, specify\
+That will exclude queries targeting table _tbl1_ irrespective of which
+database it is in. To exclude a table in a particular database, specify
 the table name using a qualified name.
 
 ```
@@ -1042,16 +1042,16 @@ Cache all queries containing a WHERE clause
 }
 ```
 
-Note that will actually cause all queries that contain WHERE anywhere,\
+Note that will actually cause all queries that contain WHERE anywhere,
 to be cached.
 
 #### When to Use
 
-By default, if no rules file have been provided or if the `use` field is\
+By default, if no rules file have been provided or if the `use` field is
 missing from the object, all users may be returned data from the cache.
 
-By providing a `use` field in the JSON object, the decision whether to use\
-data from the cache can be controlled in a more detailed manner. The decision\
+By providing a `use` field in the JSON object, the decision whether to use
+data from the cache can be controlled in a more detailed manner. The decision
 to use data from the cache can depend upon
 
 * the user.
@@ -1072,7 +1072,7 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account\
+If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account
 string, that is, `%` means indicates wildcard, but if _op_ is `like` or`unlike` it is simply assumed _value_ is a pcre2 regular expression.
 
 For instance, the following are equivalent:
@@ -1091,26 +1091,26 @@ For instance, the following are equivalent:
 }
 ```
 
-Note that if _op_ is `=` or `!=` then the usual assumptions apply,\
-that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_\
-or _unlike_ is used, then no assumptions apply, but the string is\
+Note that if _op_ is `=` or `!=` then the usual assumptions apply,
+that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_
+or _unlike_ is used, then no assumptions apply, but the string is
 used verbatim as a regular expression.
 
-The objects in the `use` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `use` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 data in the cache will be used, subject to the value of `ttl`.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then data in the cache will not be used.
 
-Note that `use` is relevant only if the query is subject to caching,\
-that is, if all queries are cached or if a query matches a particular\
+Note that `use` is relevant only if the query is subject to caching,
+that is, if all queries are cached or if a query matches a particular
 rule in the `store` array.
 
 **Examples**
 
-Use data from the cache for all users except `admin` (actually `'admin'@'%'`),\
+Use data from the cache for all users except `admin` (actually `'admin'@'%'`),
 regardless of what host the `admin` user comes from.
 
 ```
@@ -1127,15 +1127,15 @@ regardless of what host the `admin` user comes from.
 
 ### Security
 
-As the cache is not aware of grants, unless the cache has been explicitly\
-configured who the caching should apply to, the presence of the cache\
+As the cache is not aware of grants, unless the cache has been explicitly
+configured who the caching should apply to, the presence of the cache
 may provide a user with access to data he should not have access to.\
 Note that the following applies _only_ if `users=mixed` has been configured.\
-If `users=isolated` has been configured, then there can never be any\
+If `users=isolated` has been configured, then there can never be any
 unintended sharing between users.
 
-Suppose there is a table `access` that the user _alice_ has access to,\
-but the user _bob_ does not. If _bob_ tries to access the table, he will\
+Suppose there is a table `access` that the user _alice_ has access to,
+but the user _bob_ does not. If _bob_ tries to access the table, he will
 get an error as reply:
 
 ```
@@ -1143,8 +1143,8 @@ MySQL [testdb]> select * from access;
 ERROR 1142 (42000): SELECT command denied to user 'bob'@'localhost' for table 'access'
 ```
 
-If we now setup caching for the table, using the simplest possible rules\
-file, _bob_ will get access to data from the table, provided he executes\
+If we now setup caching for the table, using the simplest possible rules
+file, _bob_ will get access to data from the table, provided he executes
 a select identical with one _alice_ has executed.
 
 For instance, suppose the rules look as follows:
@@ -1161,7 +1161,7 @@ For instance, suppose the rules look as follows:
 }
 ```
 
-If _alice_ now queries the table, she will get the result, which also will\
+If _alice_ now queries the table, she will get the result, which also will
 be cached:
 
 ```
@@ -1173,7 +1173,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-If _bob_ now executes the very same query, and the result is still in the\
+If _bob_ now executes the very same query, and the result is still in the
 cache, it will be returned to him.
 
 ```
@@ -1193,7 +1193,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-That can be prevented, by explicitly declaring in the rules that the caching\
+That can be prevented, by explicitly declaring in the rules that the caching
 should be applied to _alice_ only.
 
 ```
@@ -1215,24 +1215,24 @@ should be applied to _alice_ only.
 }
 ```
 
-With these rules in place, _bob_ is again denied access, since queries\
+With these rules in place, _bob_ is again denied access, since queries
 targeting the table `access` will in his case not be served from the cache.
 
 ### Storage
 
 There are two types of storages that can be used; _local_ and _shared_.
 
-The only _local_ storage implementation is `storage_inmemory` that simply\
-stores the cache values in memory. The storage is not persistent and is\
-destroyed when MaxScale terminates. Since the storage exists in the MaxScale\
+The only _local_ storage implementation is `storage_inmemory` that simply
+stores the cache values in memory. The storage is not persistent and is
+destroyed when MaxScale terminates. Since the storage exists in the MaxScale
 process, it is very fast and provides almost always a performance benefit.
 
-Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)\
+Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)
 and [redis](https://redis.io/) respectively.
 
 The shared storages are accessed across the network and consequently it is _not_ self-evident that their use will provide any performance benefit.
-Namely, irrespective of whether the data is fetched from the cache or from\
-the server there will be a network hop and often that network hop is, as far\
+Namely, irrespective of whether the data is fetched from the cache or from
+the server there will be a network hop and often that network hop is, as far
 as the performance goes, what costs the most.
 
 The presence of a shared cache _may_ provide a performance benefit
@@ -1241,12 +1241,12 @@ The presence of a shared cache _may_ provide a performance benefit
 * if the used SELECT statements are heavy (that is, take a significant amount of time) to process for the database server, or
 * if the presence of the cache reduces the overall load of an otherwise overloaded database server.
 
-As a general rule a _shared_ storage should not be used without first\
+As a general rule a _shared_ storage should not be used without first
 assessing its value using a realistic workload.
 
 #### `storage_inmemory`
 
-This simple storage module uses the standard memory allocator for storing\
+This simple storage module uses the standard memory allocator for storing
 the cached data.
 
 ```
@@ -1257,12 +1257,12 @@ This storage module takes no arguments.
 
 #### `storage_memcached`
 
-This storage module uses [memcached](https://memcached.org/) for storing the\
+This storage module uses [memcached](https://memcached.org/) for storing the
 cached data.
 
-Multiple MaxScale instances can share the same memcached server and items\
+Multiple MaxScale instances can share the same memcached server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
@@ -1286,18 +1286,18 @@ If no port is provided, then the default port `11211` will be used.
 * Dynamic: No
 * Default: 1Mi
 
-By default, the maximum size of a value stored to memcached is 1MiB, but that\
-can be configured to something else, in which case this parameter should be\
+By default, the maximum size of a value stored to memcached is 1MiB, but that
+can be configured to something else, in which case this parameter should be
 set accordingly.
 
-The value of `max_value_size` will be used for capping `max_resultset_size`,\
-that is, if memcached has been configured to allow larger values than 1MiB\
-but `max_value_size` has not been set accordingly, only resultsets up to 1MiB\
+The value of `max_value_size` will be used for capping `max_resultset_size`,
+that is, if memcached has been configured to allow larger values than 1MiB
+but `max_value_size` has not been set accordingly, only resultsets up to 1MiB
 in size will be cached.
 
 **Example**
 
-From MaxScale 23.02 onwards, the storage configuration should be provided\
+From MaxScale 23.02 onwards, the storage configuration should be provided
 as nested parameters.
 
 ```
@@ -1309,7 +1309,7 @@ storage_memcached.server=192.168.1.31
 storage_memcached.max_value_size=10M
 ```
 
-Although _deprecated_ in 23.02, the configuration can also be provided\
+Although _deprecated_ in 23.02, the configuration can also be provided
 using `storage_options`:
 
 ```
@@ -1323,39 +1323,39 @@ storage_options="server=192.168.1.31,max_value_size=10M"
 
 **Security**
 
-_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and\
-the memcached server is encrypted. Consequently, _anybody_ with access to the\
+_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and
+the memcached server is encrypted. Consequently, _anybody_ with access to the
 memcached server or to the network have access to the cached data.
 
 #### `storage_redis`
 
-This storage module uses [redis](https://redis.io/) for storing the\
+This storage module uses [redis](https://redis.io/) for storing the
 cached data.
 
-Note that Redis should be configured with no idle timeout or with a timeout that\
-is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which\
+Note that Redis should be configured with no idle timeout or with a timeout that
+is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which
 will hurt both the functionality and the performance.
 
-Multiple MaxScale instances can share the same redis server and items\
+Multiple MaxScale instances can share the same redis server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
 storage=storage_redis
 ```
 
-If `storage_redis` cannot connect to the Redis server, caching will silently\
-be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2302-cache.md#timeout)\
+If `storage_redis` cannot connect to the Redis server, caching will silently
+be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2302-cache.md#timeout)
 interval.
 
-If a timeout error occurs during an operation, reconnecting will be attempted\
-after a delay, which will be an increasing multiple of `timeout`. For example,\
-if `timeout` is the default 5 seconds, then reconnection attempts will first\
-be made after 10 seconds, then after 15 seconds, then 20 and so on. However,\
-once 60 seconds have been reached, the delay will no longer be increased but\
-the delay will stay at one minute. Note that each time a reconnection attempt\
-is made, unless the reason for the timeout has disappeared, the client will be\
+If a timeout error occurs during an operation, reconnecting will be attempted
+after a delay, which will be an increasing multiple of `timeout`. For example,
+if `timeout` is the default 5 seconds, then reconnection attempts will first
+be made after 10 seconds, then after 15 seconds, then 20 and so on. However,
+once 60 seconds have been reached, the delay will no longer be increased but
+the delay will stay at one minute. Note that each time a reconnection attempt
+is made, unless the reason for the timeout has disappeared, the client will be
 stalled for `timeout` seconds.
 
 `storage_redis` has the following parameters:
@@ -1402,7 +1402,7 @@ Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
 * Dynamic: No
 * Default: `""`
 
-The SSL client certificate that MaxScale should use with the Redis\
+The SSL client certificate that MaxScale should use with the Redis
 server. The certificate must match the key defined in `ssl_key`.
 
 Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
@@ -1425,7 +1425,7 @@ Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
 * Dynamic: No
 * Default: `""`
 
-The Certificate Authority (CA) certificate for the CA that signed the\
+The Certificate Authority (CA) certificate for the CA that signed the
 certificate specified with `ssl_cert`.
 
 Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
@@ -1444,16 +1444,16 @@ then both _username_ and _password_ must be provided.
 
 **SSL**
 
-If `ssl_key`, `ssl_cert` and `ssl_ca` are provided, then SSL/TLS will be used\
+If `ssl_key`, `ssl_cert` and `ssl_ca` are provided, then SSL/TLS will be used
 in the communication with the Redis server, if `ssl` is set to `true`.
 
-Note that the SSL/TLS support is only available in Redis from version 6\
-onwards and that the support is not by default built into Redis, but has\
+Note that the SSL/TLS support is only available in Redis from version 6
+onwards and that the support is not by default built into Redis, but has
 to be specifically enabled at compile time as explained [here](https://redis.io/docs/management/security/encryption/).
 
 **Example**
 
-From MaxScale 23.02 onwards, the storage configuration should be provided\
+From MaxScale 23.02 onwards, the storage configuration should be provided
 as nested parameters.
 
 ```
@@ -1466,7 +1466,7 @@ storage_redis.username=hello
 storage_redis.password=world
 ```
 
-Although _deprecated_ in 23.02, the configuration can also be provided\
+Although _deprecated_ in 23.02, the configuration can also be provided
 using `storage_options`:
 
 ```
@@ -1480,12 +1480,12 @@ storage_options="server=192.168.1.31,username=hello,password=world"
 
 **Invalidation**
 
-`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2302-cache.md#best-efforts)\
-are of greater significance since also the communication between the cache and the\
+`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2302-cache.md#best-efforts)
+are of greater significance since also the communication between the cache and the
 cache storage is asynchronous and takes place over the network.
 
-_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation\
-mode), redis must be flushed as otherwise there will be entries in the cache that\
+_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation
+mode), redis must be flushed as otherwise there will be entries in the cache that
 will not be affected by the invalidation.
 
 ```
@@ -1494,15 +1494,15 @@ $ redis-cli flushall
 
 **Security**
 
-The data in the redis server is _not_ encrypted. Consequently, _anybody_ with\
+The data in the redis server is _not_ encrypted. Consequently, _anybody_ with
 access to the redis server has access to the cached data.
 
-Unless [SSL](mariadb-maxscale-2302-cache.md#ssl) has been enabled, _anybody_ with access to the network has\
+Unless [SSL](mariadb-maxscale-2302-cache.md#ssl) has been enabled, _anybody_ with access to the network has
 access to the cached data.
 
 ### Example
 
-In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size\
+In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size
 of the cached data is `50` mebibytes. The rules for the cache are in the file`cache_rules.json`.
 
 #### Configuration
@@ -1542,16 +1542,16 @@ The rules specify that the data of the table `sbtest` should be cached.
 
 ### Performance
 
-When the cache filter was introduced, the most significant factor affecting\
+When the cache filter was introduced, the most significant factor affecting
 the performance of the cache was whether the statements needed to be parsed.\
-Initially, all statements were parsed in order to exclude `SELECT` statements\
-that use non-cacheable functions, access non-cacheable variables or refer\
-to system or user variables. Later, the default value of the `selects` parameter\
+Initially, all statements were parsed in order to exclude `SELECT` statements
+that use non-cacheable functions, access non-cacheable variables or refer
+to system or user variables. Later, the default value of the `selects` parameter
 was changed to `assume_cacheable`, to maximize the default performance.
 
-With the default configuration, the cache itself will not cause the statements\
-to be parsed. However, even with `assume_cacheable` configured, a rule referring\
-specifically to a _database_, _table_ or _column_ will still cause the\
+With the default configuration, the cache itself will not cause the statements
+to be parsed. However, even with `assume_cacheable` configured, a rule referring
+specifically to a _database_, _table_ or _column_ will still cause the
 statement to be parsed.
 
 For instance, a simple rule like
@@ -1586,15 +1586,15 @@ If the rule is instead expressed using a regular expression
 
 then the statement will not be parsed.
 
-However, when the [query classifier cache](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#query_classifier_cache_size)\
-was introduced, the parsing cost was significantly reduced and\
-currently the cost for parsing and regular expression matching\
+However, when the [query classifier cache](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#query_classifier_cache_size)
+was introduced, the parsing cost was significantly reduced and
+currently the cost for parsing and regular expression matching
 is roughly the same.
 
-In the following is a table with numbers giving a rough picture\
+In the following is a table with numbers giving a rough picture
 of the relative cost of different approaches.
 
-In the table, _regexp match_ means that the cacheable statements\
+In the table, _regexp match_ means that the cacheable statements
 were picked out using a rule like
 
 ```
@@ -1605,7 +1605,7 @@ were picked out using a rule like
 }
 ```
 
-while _exact match_ means that the cacheable statements were picked out using a\
+while _exact match_ means that the cacheable statements were picked out using a
 rule like
 
 ```
@@ -1618,12 +1618,12 @@ rule like
 
 The exact match rule requires all statements to be parsed.
 
-As the purpose of the test is to illustrate the overhead of\
-different approaches, the rules were formulated so that\
+As the purpose of the test is to illustrate the overhead of
+different approaches, the rules were formulated so that
 all SELECT statements would match.
 
 Note that these figures were obtained by running sysbench,\
-MaxScale and the server in the same computer, so they are\
+MaxScale and the server in the same computer, so they are
 only indicative.
 
 | selects           | Rule         | qps |
@@ -1637,18 +1637,18 @@ only indicative.
 
 For comparison, without caching, the qps is `33`.
 
-As can be seen, due to the query classifier cache there is\
+As can be seen, due to the query classifier cache there is
 no difference between exact and regex based matching.
 
 #### Summary
 
 For maximum performance:
 
-* Arrange the situation so that the default `selects=assume_cacheable`\
+* Arrange the situation so that the default `selects=assume_cacheable`
   can be used, and use no rules.
 
-Otherwise it is mostly a personal preference whether exact or regex\
-based rules are used. However, one should always test with real data\
+Otherwise it is mostly a personal preference whether exact or regex
+based rules are used. However, one should always test with real data
 and real queries before choosing one over the other.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-comment-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-comment-filter.md
@@ -2,8 +2,8 @@
 
 ### Overview
 
-With the _comment_ filter it is possible to define comments that are\
-injected before the actual statements. These comments appear as sql\
+With the _comment_ filter it is possible to define comments that are
+injected before the actual statements. These comments appear as sql
 comments when they are received by the server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-consistent-critical-read-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-consistent-critical-read-filter.md
@@ -4,41 +4,41 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Consistent Critical Read (CCR) filter allows consistent critical reads to be\
+The Consistent Critical Read (CCR) filter allows consistent critical reads to be
 done through MaxScale while still allowing scaleout of non-critical reads.
 
-When the filter detects a statement that would modify the database, it attaches\
-a routing hint to all following statements done by that connection. This routing\
-hint guides the routing module to route the statement to the primary server where\
-data is guaranteed to be in an up-to-date state. Writes from one session do not,\
+When the filter detects a statement that would modify the database, it attaches
+a routing hint to all following statements done by that connection. This routing
+hint guides the routing module to route the statement to the primary server where
+data is guaranteed to be in an up-to-date state. Writes from one session do not,
 by default, propagate to other sessions.
 
-_Note:_ This filter does not work with prepared statements. Only text protocol\
+_Note:_ This filter does not work with prepared statements. Only text protocol
 queries are handled by this filter.
 
 #### Controlling the Filter with SQL Comments
 
-The triggering of the filter can be limited further by adding MaxScale supported\
-comments to queries and/or by using regular expressions. The query comments take\
-precedence: if a comment is found it is obeyed even if a regular expression\
+The triggering of the filter can be limited further by adding MaxScale supported
+comments to queries and/or by using regular expressions. The query comments take
+precedence: if a comment is found it is obeyed even if a regular expression
 parameter might give a different result. Even a comment cannot cause a\
-SELECT-query to trigger the filter. Such a comment is considered an error and\
+SELECT-query to trigger the filter. Such a comment is considered an error and
 ignored.
 
-The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-hint-syntax.md)\
-and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a\
-query has a MaxScale supported comment line which defines the parameter `ccr`,\
-that comment is caught by the CCR-filter. Parameter values `match` and `ignore`\
-are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)\
+The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-hint-syntax.md)
+and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a
+query has a MaxScale supported comment line which defines the parameter `ccr`,
+that comment is caught by the CCR-filter. Parameter values `match` and `ignore`
+are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)
 on receiving the write query. For example, the query
 
 ```
 INSERT INTO departments VALUES ('d1234', 'NewDepartment'); -- maxscale ccr=ignore
 ```
 
-would normally cause the filter to trigger, but does not because of the\
-comment. The `match`-comment typically has no effect, since write queries by\
-default trigger the filter anyway. It can be used to override an ignore-type\
+would normally cause the filter to trigger, but does not because of the
+comment. The `match`-comment typically has no effect, since write queries by
+default trigger the filter anyway. It can be used to override an ignore-type
 regular expression that would otherwise prevent triggering.
 
 ### Filter Parameters
@@ -52,19 +52,19 @@ The CCR filter has no mandatory parameters.
 * Dynamic: Yes
 * Default: `60s`
 
-The time window during which queries are routed to the primary. The duration\
-can be specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations)\
+The time window during which queries are routed to the primary. The duration
+can be specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations)
 but the value will always be rounded to the nearest second.\
-If no explicit unit has been specified, the value is interpreted as seconds\
+If no explicit unit has been specified, the value is interpreted as seconds
 in MaxScale 2.4. In subsequent versions a value without a unit may be rejected.\
 The default value for this parameter is 60 seconds.
 
-When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new\
-data modifying SQL statement is processed within the time window, the timer is\
+When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new
+data modifying SQL statement is processed within the time window, the timer is
 reset to the value of _time_.
 
-Enabling this parameter in combination with the _count_ parameter causes both\
-the time window and number of queries to be inspected. If either of the two\
+Enabling this parameter in combination with the _count_ parameter causes both
+the time window and number of queries to be inspected. If either of the two
 conditions are met, the query is re-routed to the primary.
 
 #### `count`
@@ -77,10 +77,10 @@ conditions are met, the query is re-routed to the primary.
 The number of SQL statements to route to primary after detecting a data modifying\
 SQL statement. This feature is disabled by default.
 
-After processing a data modifying SQL statement, a counter is set to the value\
-of _count_ and all statements are routed to the primary. Each executed statement\
-after a data modifying SQL statement cause the counter to be decremented. Once\
-the counter reaches zero, the statements are routed normally. If a new data\
+After processing a data modifying SQL statement, a counter is set to the value
+of _count_ and all statements are routed to the primary. Each executed statement
+after a data modifying SQL statement cause the counter to be decremented. Once
+the counter reaches zero, the statements are routed normally. If a new data
 modifying SQL statement is processed, the counter is reset to the value of_count_.
 
 #### `match`, `ignore`
@@ -90,9 +90,9 @@ modifying SQL statement is processed, the counter is reset to the value of_count
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
-control which statements trigger statement re-routing. Only non-SELECT statements are\
-inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works\
+These [regular expression settings](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+control which statements trigger statement re-routing. Only non-SELECT statements are
+inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works
 similarly.
 
 ```
@@ -118,16 +118,16 @@ Regular expression options for `match` and `ignore`.
 * Dynamic: Yes
 * Default: `false`
 
-`global` is a boolean parameter that when enabled causes writes from one\
-connection to propagate to all other connections. This can be used to work\
-around cases where one connection writes data and another reads it, expecting\
+`global` is a boolean parameter that when enabled causes writes from one
+connection to propagate to all other connections. This can be used to work
+around cases where one connection writes data and another reads it, expecting
 the write done by the other connection to be visible.
 
 This parameter only works with the `time` parameter. The use of `global` and`count` at the same time is not allowed and will be treated as an error.
 
 ### Example Configuration
 
-Here is a minimal filter configuration for the CCRFilter which should solve most\
+Here is a minimal filter configuration for the CCRFilter which should solve most
 problems with critical reads after writes.
 
 ```
@@ -137,13 +137,13 @@ module=ccrfilter
 time=5
 ```
 
-With this configuration, whenever a connection does a write, all subsequent\
+With this configuration, whenever a connection does a write, all subsequent
 reads done by that connection will be forced to the primary for 5 seconds.
 
-This prevents read scaling until the modifications have been replicated to the\
-replicas. For best performance, the value of _time_ should be slightly greater\
-than the actual replication lag between the primary and its replicas. If the number\
-of critical read statements is known, the _count_ parameter could be used to\
+This prevents read scaling until the modifications have been replicated to the
+replicas. For best performance, the value of _time_ should be slightly greater
+than the actual replication lag between the primary and its replicas. If the number
+of critical read statements is known, the _count_ parameter could be used to
 control the number reads that are sent to the primary.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-hintfilter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-hintfilter.md
@@ -4,14 +4,14 @@ This filter adds routing hints to a service. The filter has no parameters.
 
 ## Hint Syntax
 
-**Note:** If a query has more than one comment only the first comment is\
-processed. Always place any MaxScale related comments first before any other\
+**Note:** If a query has more than one comment only the first comment is
+processed. Always place any MaxScale related comments first before any other
 comments that might appear in the query.
 
 ### Comments and comment types
 
-The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and\
-they need to be enabled by passing the `--comments` or `-c` option to it. Most,\
+The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and
+they need to be enabled by passing the `--comments` or `-c` option to it. Most,
 if not all, connectors keep all comments intact in executed queries.
 
 ```
@@ -19,10 +19,10 @@ if not all, connectors keep all comments intact in executed queries.
 mariadb --comments -u my-user -psecret -e "SELECT @@hostname -- maxscale route to server db1"
 ```
 
-For comment types, use either `--` (notice the whitespace after the double\
+For comment types, use either `--` (notice the whitespace after the double
 hyphen) or `#` after the semicolon or `/* ... */` before the semicolon.
 
-Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character\
+Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character
 after the start tag or before the end tag but adding the whitespace is advised.
 
 ### Hint body
@@ -33,12 +33,12 @@ All hints must start with the `maxscale` tag.
 -- maxscale <hint body>
 ```
 
-The hints have two types, ones that define a server type and others that contain\
+The hints have two types, ones that define a server type and others that contain
 name-value pairs.
 
 #### Routing destination hints
 
-These hints will instruct the router to route a query to a certain type of a\
+These hints will instruct the router to route a query to a certain type of a
 server.
 
 ```
@@ -51,8 +51,8 @@ server.
 -- maxscale route to master
 ```
 
-A `master` value in a routing hint will route the query to a primary server. This\
-can be used to direct read queries to a primary server for a up-to-date result\
+A `master` value in a routing hint will route the query to a primary server. This
+can be used to direct read queries to a primary server for a up-to-date result
 with no replication lag.
 
 **Route to replica**
@@ -61,8 +61,8 @@ with no replication lag.
 -- maxscale route to slave
 ```
 
-A `slave` value will route the query to a replica server. Please note that the\
-hints will override any decisions taken by the routers which means that it is\
+A `slave` value will route the query to a replica server. Please note that the
+hints will override any decisions taken by the routers which means that it is
 possible to force writes to a replica server.
 
 **Route to named server**
@@ -71,7 +71,7 @@ possible to force writes to a replica server.
 -- maxscale route to server <server name>
 ```
 
-A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in\
+A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in
 maxscale.cnf. If the server is not used by the service, the hint is ignored.
 
 **Route to last used server**
@@ -80,8 +80,8 @@ maxscale.cnf. If the server is not used by the service, the hint is ignored.
 -- maxscale route to last
 ```
 
-A `last` value will route the query to the server that processed the last\
-query. This hint can be used to force certain queries to be grouped to the same\
+A `last` value will route the query to the server that processed the last
+query. This hint can be used to force certain queries to be grouped to the same
 server.
 
 **Name-value hints**
@@ -90,13 +90,13 @@ server.
 -- maxscale <param>=<value>
 ```
 
-These control the behavior and affect the routing decisions made by the\
-router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower\
+These control the behavior and affect the routing decisions made by the
+router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower
 replication lag than this parameter's value.
 
 ### Hint stack
 
-Hints can be either single-use hints, which makes them affect only one query, or\
+Hints can be either single-use hints, which makes them affect only one query, or
 named hints, which can be pushed on and off a stack of active hints.
 
 Defining named hints:
@@ -123,7 +123,7 @@ You can define and activate a hint in a single command using the following:
 -- maxscale <hint name> begin <hint content>
 ```
 
-You can also push anonymous hints onto the stack which are only used as long as\
+You can also push anonymous hints onto the stack which are only used as long as
 they are on the stack:
 
 ```
@@ -132,14 +132,14 @@ they are on the stack:
 
 ## Prepared Statements
 
-The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared\
+The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared
 statements.
 
 ### Binary Protocol
 
-With binary protocol prepared statements, a routing hint in the prepared\
-statement is applied to the execution of the statement but not the preparation\
-of it. The preparation of the statement is routed normally and is sent to all\
+With binary protocol prepared statements, a routing hint in the prepared
+statement is applied to the execution of the statement but not the preparation
+of it. The preparation of the statement is routed normally and is sent to all
 servers.
 
 For example, when the following prepared statement is prepared with the MariaDB\
@@ -165,13 +165,13 @@ Support for direct execution of prepared statements was added in MaxScale\
 
 ### Text Protocol
 
-Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL\
-commands) behave differently. If a `PREPARE` command has a routing hint, it will\
-be routed according to the routing hint. Any subsequent `EXECUTE` command will\
-not be affected by the routing hint in the `PREPARE` statement. This means they\
+Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL
+commands) behave differently. If a `PREPARE` command has a routing hint, it will
+be routed according to the routing hint. Any subsequent `EXECUTE` command will
+not be affected by the routing hint in the `PREPARE` statement. This means they
 must have their own routing hints.
 
-The following example is the recommended method of executing text protocol\
+The following example is the recommended method of executing text protocol
 prepared statements with hints:
 
 ```
@@ -185,7 +185,7 @@ The `PREPARE` is routed normally and will be routed to all servers. The`EXECUTE`
 
 ### Routing `SELECT` queries to primary
 
-In this example, MariaDB MaxScale is configured with the readwritesplit router\
+In this example, MariaDB MaxScale is configured with the readwritesplit router
 and the hint filter.
 
 ```
@@ -202,9 +202,9 @@ type=filter
 module=hintfilter
 ```
 
-Behind MariaDB MaxScale is a primary server and a replica server. If there is\
-replication lag between the primary and the replica, read queries sent to the replica\
-might return old data. To guarantee up-to-date data, we can add a routing hint\
+Behind MariaDB MaxScale is a primary server and a replica server. If there is
+replication lag between the primary and the replica, read queries sent to the replica
+might return old data. To guarantee up-to-date data, we can add a routing hint
 to the query.
 
 ```
@@ -212,9 +212,9 @@ INSERT INTO table1 VALUES ("John","Doe",1);
 SELECT * FROM table1; -- maxscale route to master
 ```
 
-The first INSERT query will be routed to the primary. The following SELECT query\
-would normally be routed to the replica but with the added routing hint it will be\
-routed to the primary. This way we can do an INSERT and a SELECT right after it\
+The first INSERT query will be routed to the primary. The following SELECT query
+would normally be routed to the replica but with the added routing hint it will be
+routed to the primary. This way we can do an INSERT and a SELECT right after it
 and still get up-to-date data.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-lua-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-lua-filter.md
@@ -2,34 +2,34 @@
 
 The luafilter is a filter that calls a set of functions in a Lua script.
 
-Read the [Lua language documentation](https://www.lua.org/docs.html) for\
+Read the [Lua language documentation](https://www.lua.org/docs.html) for
 information on how to write Lua scripts.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Filter Parameters
 
-The luafilter has two parameters. They control which scripts will be called by\
-the filter. Both parameters are optional but at least one should be defined. If\
-both `global_script` and `session_script` are defined, the entry points in both\
+The luafilter has two parameters. They control which scripts will be called by
+the filter. Both parameters are optional but at least one should be defined. If
+both `global_script` and `session_script` are defined, the entry points in both
 scripts will be called.
 
 #### `global_script`
 
-The global Lua script. The parameter value is a path to a readable Lua script\
+The global Lua script. The parameter value is a path to a readable Lua script
 which will be executed.
 
-This script will always be called with the same global Lua state and it can be\
+This script will always be called with the same global Lua state and it can be
 used to build a global view of the whole service.
 
 #### `session_script`
 
-The session level Lua script. The parameter value is a path to a readable Lua\
+The session level Lua script. The parameter value is a path to a readable Lua
 script which will be executed once for each session.
 
-Each session will have its own Lua state meaning that each session can have a\
+Each session will have its own Lua state meaning that each session can have a
 unique Lua environment. Use this script to do session specific tasks.
 
 ### Lua Script Calling Convention
@@ -37,38 +37,38 @@ unique Lua environment. Use this script to do session specific tasks.
 The entry points for the Lua script expect the following signatures:
 
 * `nil createInstance(name)` - global script only, called when the script is first loaded
-  * When the global script is loaded, it first executes on a global level\
-    before the luafilter calls the createInstance function in the Lua script\
+  * When the global script is loaded, it first executes on a global level
+    before the luafilter calls the createInstance function in the Lua script
     with the filter's name as its argument.
 * `nil newSession(string, string)` - new session is created
-  * After the session script is loaded, the newSession function in the Lua\
-    scripts is called. The first parameter is the username of the client and\
+  * After the session script is loaded, the newSession function in the Lua
+    scripts is called. The first parameter is the username of the client and
     the second parameter is the client's network address.
 * `nil closeSession()` - session is closed
   * The `closeSession` function in the Lua scripts will be called.
 * `(nil | bool | string) routeQuery(string)` - query is being routed
-  * The Luafilter calls the `routeQuery` functions of both the session and the\
-    global script. The query is passed as a string parameter to the\
-    routeQuery Lua function and the return values of the session specific\
-    function, if any were returned, are interpreted. If the first value is\
-    bool, it is interpreted as a decision whether to route the query or to\
-    send an error packet to the client. If it is a string, the current query\
-    is replaced with the return value and the query will be routed. If nil is\
+  * The Luafilter calls the `routeQuery` functions of both the session and the
+    global script. The query is passed as a string parameter to the
+    routeQuery Lua function and the return values of the session specific
+    function, if any were returned, are interpreted. If the first value is
+    bool, it is interpreted as a decision whether to route the query or to
+    send an error packet to the client. If it is a string, the current query
+    is replaced with the return value and the query will be routed. If nil is
     returned, the query is routed normally.
 * `nil clientReply(string)` - reply to a query is being routed
   * This function is called with the name of the server that returned the response.
 * `string diagnostic()` - global script only, print diagnostic information
-  * If the Lua function returns a string that is valid JSON, it will be\
-    decoded as JSON and displayed as such in the REST API. If the object does\
+  * If the Lua function returns a string that is valid JSON, it will be
+    decoded as JSON and displayed as such in the REST API. If the object does
     not decode into JSON, it will be stored as a JSON string.
 
-These functions, if found in the script, will be called whenever a call to the\
+These functions, if found in the script, will be called whenever a call to the
 matching entry point is made.
 
 **Script Template**
 
-Here is a script template that can be used to try out the luafilter. Copy it\
-into a file and add `global_script=<path to script>` into the filter\
+Here is a script template that can be used to try out the luafilter. Copy it
+into a file and add `global_script=<path to script>` into the filter
 configuration. Make sure the file is readable by the `maxscale` user.
 
 ```
@@ -99,23 +99,23 @@ end
 
 #### Functions Exposed by the Luafilter
 
-The luafilter exposes the following functions that can be called inside the Lua\
+The luafilter exposes the following functions that can be called inside the Lua
 script API endpoints.
 
 * `string mxs_get_type_mask()`
-* Returns the type of the current query being executed as a string. The values\
-  are the string versions of the query types defined in query\_classifier.h\
+* Returns the type of the current query being executed as a string. The values
+  are the string versions of the query types defined in query\_classifier.h
   are separated by vertical bars (`|`).\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_operation()`
-* Returns the current operation type as a string. The values are defined in\
+* Returns the current operation type as a string. The values are defined in
   query\_classifier.h.\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_canonical()`
 * Returns the canonical version of a query by replacing all user-defined constant values with question marks.\
   This function can only be called from the `routeQuery` entry point.
 * `number mxs_get_session_id()`
-* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return\
+* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return
   the value 0.
 * `string mxs_get_db()`
 * Returns the current default database used by the connection.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-masking.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-masking.md
@@ -4,15 +4,15 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-With the _masking_ filter it is possible to obfuscate the returned\
+With the _masking_ filter it is possible to obfuscate the returned
 value of a particular column.
 
-For instance, suppose there is a table _person_ that, among other\
-columns, contains the column _ssn_ where the social security number\
+For instance, suppose there is a table _person_ that, among other
+columns, contains the column _ssn_ where the social security number
 of a person is stored.
 
-With the masking filter it is possible to specify that when the _ssn_\
-field is queried, a masked value is returned unless the user making\
+With the masking filter it is possible to specify that when the _ssn_
+field is queried, a masked value is returned unless the user making
 the query is a specific one. That is, when making the query
 
 ```
@@ -41,44 +41,44 @@ the _ssn_ would be masked, as in
 ...
 ```
 
-Note that the masking filter should be viewed as a best-effort solution\
-intended for protecting against accidental misuse rather than malicious\
+Note that the masking filter should be viewed as a best-effort solution
+intended for protecting against accidental misuse rather than malicious
 attacks.
 
 ### Security
 
-From MaxScale 2.3 onwards, the masking filter will reject statements\
+From MaxScale 2.3 onwards, the masking filter will reject statements
 that use functions in conjunction with columns that should be masked.\
-Allowing function usage provides a way for circumventing the masking,\
+Allowing function usage provides a way for circumventing the masking,
 unless a firewall filter is separately configured and installed.
 
-Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2302-masking.md#prevent_function_usage)\
+Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2302-masking.md#prevent_function_usage)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will check the\
-definition of user variables and reject statements that define a user\
+From MaxScale 2.3.5 onwards, the masking filter will check the
+definition of user variables and reject statements that define a user
 variable using a statement that refers to columns that should be masked.
 
-Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2302-masking.md#check_user_variables)\
+Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2302-masking.md#check_user_variables)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine unions\
-and if the second or subsequent SELECT refer to columns that should\
+From MaxScale 2.3.5 onwards, the masking filter will examine unions
+and if the second or subsequent SELECT refer to columns that should
 be masked, the statement will be rejected.
 
-Please see the configuration parameter [check\_unions](mariadb-maxscale-2302-masking.md#check_unions)\
+Please see the configuration parameter [check\_unions](mariadb-maxscale-2302-masking.md#check_unions)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine subqueries\
-and if a subquery refers to columns that should be masked, the statement\
+From MaxScale 2.3.5 onwards, the masking filter will examine subqueries
+and if a subquery refers to columns that should be masked, the statement
 will be rejected.
 
-Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2302-masking.md#check_subqueries)\
+Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2302-masking.md#check_subqueries)
 for how to change the default behaviour.
 
-Note that in order to ensure that it is not possible to get access to\
-masked data, the privileges of the users should be minimized. For instance,\
-if a user can create tables and perform inserts, he or she can execute\
+Note that in order to ensure that it is not possible to get access to
+masked data, the privileges of the users should be minimized. For instance,
+if a user can create tables and perform inserts, he or she can execute
 something like
 
 ```
@@ -89,16 +89,16 @@ SELECT revealed_ssn FROM cheat;
 
 to get access to the cleartext version of a masked field `ssn`.
 
-From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that\
+From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that
 cannot be fully parsed.
 
-Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2302-masking.md#require_fully_parsed)\
+Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2302-masking.md#require_fully_parsed)
 for how to change the default behaviour.
 
-From MaxScale 2.3.7 onwards, the masking filter will treat any strings\
+From MaxScale 2.3.7 onwards, the masking filter will treat any strings
 passed to functions as if they were fields. The reason is that as the\
-MaxScale query classifier is not aware of whether `ANSI_QUOTES` is\
-enabled or not, it is possible to bypass the masking by turning that\
+MaxScale query classifier is not aware of whether `ANSI_QUOTES` is
+enabled or not, it is possible to bypass the masking by turning that
 option on.
 
 ```
@@ -106,32 +106,32 @@ mysql> set @@sql_mode = 'ANSI_QUOTES';
 mysql> select concat("ssn") from managers;
 ```
 
-Before this change, the content of the field `ssn` would have been\
+Before this change, the content of the field `ssn` would have been
 returned in clear text even if the column should have been masked.
 
-Note that this change will mean that there may be false positives\
-if `ANSI_QUOTES` is not enabled and a string argument happens to\
+Note that this change will mean that there may be false positives
+if `ANSI_QUOTES` is not enabled and a string argument happens to
 be the same as the name of a field to be masked.
 
 Please see the configuration parameter\
-\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)\
+\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)
 for how to change the default behaviour.
 
 ### Limitations
 
-The masking filter can _only_ be used for masking columns of the following\
-types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no\
+The masking filter can _only_ be used for masking columns of the following
+types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no
 masking will be performed.
 
-Currently, the masking filter can only work on packets whose payload is less\
-than 16MB. If the masking filter encounters a packet whose payload is exactly\
-that, thus indicating a situation where the payload is delivered in multiple\
-packets, the value of the parameter `large_payloads` specifies how the masking\
+Currently, the masking filter can only work on packets whose payload is less
+than 16MB. If the masking filter encounters a packet whose payload is exactly
+that, thus indicating a situation where the payload is delivered in multiple
+packets, the value of the parameter `large_payloads` specifies how the masking
 filter should handle the situation.
 
 ### Configuration
 
-The masking filter is taken into use with the following kind of\
+The masking filter is taken into use with the following kind of
 configuration setup.
 
 ```
@@ -157,7 +157,7 @@ The masking filter has one mandatory parameter - `rules`.
 * Dynamic: Yes
 
 Specifies the path of the file where the masking rules are stored.\
-A relative path is interpreted relative to the _module configuration directory_\
+A relative path is interpreted relative to the _module configuration directory_
 of MariaDB MaxScale. The default module configuration directory is_/etc/maxscale.modules.d_.
 
 ```
@@ -172,8 +172,8 @@ rules=/path/to/rules-file
 * Values: `never`, `always`
 * Default: `never`
 
-With this optional parameter the masking filter can be instructed to log\
-a warning if a masking rule matches a column that is not of one of the\
+With this optional parameter the masking filter can be instructed to log
+a warning if a masking rule matches a column that is not of one of the
 allowed types.
 
 ```
@@ -188,17 +188,17 @@ warn_type_mismatch=always
 * Values: `ignore`, `abort`
 * Default: `abort`
 
-This optional parameter specifies how the masking filter should treat\
-payloads larger than `16MB`, that is, payloads that are delivered in\
+This optional parameter specifies how the masking filter should treat
+payloads larger than `16MB`, that is, payloads that are delivered in
 multiple MySQL protocol packets.
 
-The values that can be used are `ignore`, which means that columns in\
-such payloads are not masked, and `abort`, which means that if such\
-payloads are encountered, the client connection is closed. The default\
+The values that can be used are `ignore`, which means that columns in
+such payloads are not masked, and `abort`, which means that if such
+payloads are encountered, the client connection is closed. The default
 is `abort`.
 
-Note that the aborting behaviour is applied only to resultsets that\
-contain columns that should be masked. There are _no_ limitations on\
+Note that the aborting behaviour is applied only to resultsets that
+contain columns that should be masked. There are _no_ limitations on
 resultsets that do not contain such columns.
 
 ```
@@ -212,23 +212,23 @@ large_payload=ignore
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should behave\
-if a column that should be masked, is used in conjunction with some\
-function. As the masking filter works _only_ on the basis of the\
-information in the returned result-set, if the name of a column is\
-not present in the result-set, then the masking filter cannot mask a\
-value. This means that the masking filter basically can be bypassed\
+This optional parameter specifies how the masking filter should behave
+if a column that should be masked, is used in conjunction with some
+function. As the masking filter works _only_ on the basis of the
+information in the returned result-set, if the name of a column is
+not present in the result-set, then the masking filter cannot mask a
+value. This means that the masking filter basically can be bypassed
 with a query like:
 
 ```
 SELECT CONCAT(masked_column) FROM tbl;
 ```
 
-If the value of `prevent_function_usage` is `true`, then all\
-statements that contain functions referring to masked columns will\
-be rejected. As that means that also queries using potentially\
-harmless functions, such as `LENGTH(masked_column)`, are rejected\
-as well, this feature can be turned off. In that case, the firewall\
+If the value of `prevent_function_usage` is `true`, then all
+statements that contain functions referring to masked columns will
+be rejected. As that means that also queries using potentially
+harmless functions, such as `LENGTH(masked_column)`, are rejected
+as well, this feature can be turned off. In that case, the firewall
 filter should be setup to allow or reject the use of certain functions.
 
 ```
@@ -242,19 +242,19 @@ prevent_function_usage=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
-behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a\
+This optional parameter specifies how the masking filter should
+behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a
 statement that cannot be fully parsed,
 
-If true, then statements that cannot be fully parsed (due to a\
+If true, then statements that cannot be fully parsed (due to a
 parser limitation) will be blocked.
 
 ```
 require_fully_parsed=false
 ```
 
-Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered\
-less effective, as it with a statement that can not be fully parsed may be\
+Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered
+less effective, as it with a statement that can not be fully parsed may be
 possible to bypass the protection that they are intended to provide.
 
 **`treat_string_arg_as_field`**
@@ -264,9 +264,9 @@ possible to bypass the protection that they are intended to provide.
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should treat\
-strings used as arguments to functions. If true, they will be handled\
-as fields, which will cause fields to be masked even if `ANSI_QUOTES` has\
+This optional parameter specifies how the masking filter should treat
+strings used as arguments to functions. If true, they will be handled
+as fields, which will cause fields to be masked even if `ANSI_QUOTES` has
 been enabled and `"` is used instead of backtick.
 
 ```
@@ -280,7 +280,7 @@ treat_string_arg_as_field=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to user variables. If true, then a statement like
 
 ```
@@ -300,7 +300,7 @@ check_user_variables=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to UNIONs. If true, then a statement like
 
 ```
@@ -320,7 +320,7 @@ check_unions=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to subqueries. If true, then a statement like
 
 ```
@@ -337,7 +337,7 @@ check_subqueries=false
 
 The masking rules are expressed as a JSON object.
 
-The top-level object is expected to contain a key `rules` whose\
+The top-level object is expected to contain a key `rules` whose
 value is an array of rule objects.
 
 ```
@@ -346,8 +346,8 @@ value is an array of rule objects.
 }
 ```
 
-Each rule in the rules array is a JSON object, expected to\
-contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two\
+Each rule in the rules array is a JSON object, expected to
+contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two
 latter ones optional.
 
 ```
@@ -365,15 +365,15 @@ latter ones optional.
 
 #### `replace`
 
-The value of this key is an object that specifies the column\
-whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The\
+The value of this key is an object that specifies the column
+whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The
 value of these keys must be a string.
 
-If only `column` is specified, then a column with that name\
-matches irrespective of the table and database. If `table`\
-is specified, then the column matches only if it is in a table\
-with the specified name, and if `database` is specified when\
-the column matches only if it is in a database with the\
+If only `column` is specified, then a column with that name
+matches irrespective of the table and database. If `table`
+is specified, then the column matches only if it is in a table
+with the specified name, and if `database` is specified when
+the column matches only if it is in a database with the
 specified name.
 
 ```
@@ -393,10 +393,10 @@ specified name.
 }
 ```
 
-**NOTE** If a rule contains a table/database then if the resultset\
-does _not_ contain table/database information, it will always be\
-considered a match if the column matches. For instance, given the\
-rule above, if there is a table `person2`, also containing an `ssn`\
+**NOTE** If a rule contains a table/database then if the resultset
+does _not_ contain table/database information, it will always be
+considered a match if the column matches. For instance, given the
+rule above, if there is a table `person2`, also containing an `ssn`
 field, then a query like
 
 ```
@@ -409,24 +409,24 @@ will not return masked values, but a query like
 SELECT ssn FROM person UNION SELECT ssn FROM person2;
 ```
 
-will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is\
+will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is
 observed even with a nonsensical query like
 
 ```
 SELECT ssn FROM person2 UNION SELECT ssn FROM person2;
 ```
 
-even if nothing from `person2` should be masked. The reason is that\
-as the resultset contains no table information, the values must be\
-masked if the column name matches, as otherwise the masking could\
+even if nothing from `person2` should be masked. The reason is that
+as the resultset contains no table information, the values must be
+masked if the column name matches, as otherwise the masking could
 easily be circumvented with a query like
 
 ```
 SELECT ssn FROM person UNION SELECT ssn FROM person;
 ```
 
-The optional key `match` makes partial replacement of the original\
-value possible: only the matched part would be replaced\
+The optional key `match` makes partial replacement of the original
+value possible: only the matched part would be replaced
 with the fill character.\
 The `match` value must be a valid pcre2 regular expression.
 
@@ -442,14 +442,14 @@ The `match` value must be a valid pcre2 regular expression.
 
 #### `obfuscate`
 
-The obfuscate rule allows the obfuscation of the value\
+The obfuscate rule allows the obfuscation of the value
 by passing it through an obfuscation algorithm.\
 Current solution uses a non-reversible obfuscation approach.
 
-However, note that although it is in principle impossible to obtain the\
-original value from the obfuscated one, if the range of possible original\
-values is limited, it is straightforward to figure out the possible\
-original values by running all possible values through the obfuscation\
+However, note that although it is in principle impossible to obtain the
+original value from the obfuscated one, if the range of possible original
+values is limited, it is straightforward to figure out the possible
+original values by running all possible values through the obfuscation
 algorithm and then comparing the results.
 
 The minimal configuration is:
@@ -474,20 +474,20 @@ SELECT name from db1.tbl1;`
 
 #### `with`
 
-The value of this key is an object that specifies what the value of the matched\
-column should be replaced with for the `replace` rule. Currently, the object\
+The value of this key is an object that specifies what the value of the matched
+column should be replaced with for the `replace` rule. Currently, the object
 is expected to contain either the key `value` or the key `fill`.\
 The value of both must be a string with length greater than zero.\
 If both keys are specified, `value` takes precedence.\
 If `fill` is not specified, the default `X` is used as its value.
 
-If `value` is specified, then its value is used to replace the actual value\
-verbatim and the length of the specified value must match the actual returned\
+If `value` is specified, then its value is used to replace the actual value
+verbatim and the length of the specified value must match the actual returned
 value (from the server) exactly. If the lengths do not match, the value of`fill` is used to mask the actual value.
 
-When the value of `fill` (fill-value) is used for masking the returned value,\
-the fill-value is used as many times as necessary to match the length of the\
-return value. If required, only a part of the fill-value may be used in the end\
+When the value of `fill` (fill-value) is used for masking the returned value,
+the fill-value is used as many times as necessary to match the length of the
+return value. If required, only a part of the fill-value may be used in the end
 of the mask value to get the lengths to match.
 
 ```
@@ -530,8 +530,8 @@ of the mask value to get the lengths to match.
 
 #### `applies_to`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is applied to. Each string\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is applied to. Each string
 should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -547,13 +547,13 @@ should be a MariaDB account string, that is, `%` is a wildcard.
 }
 ```
 
-If this key is not specified, then the masking is performed for all\
+If this key is not specified, then the masking is performed for all
 users, except the ones exempted using the key `exempted`.
 
 #### `exempted`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is _not_ applied to. Each\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is _not_ applied to. Each
 string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -571,14 +571,14 @@ string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-module-commands.md) documentation for details\
+Read [Module Commands](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-module-commands.md) documentation for details
 about module commands.
 
 The masking filter supports the following module commands.
 
 #### `reload`
 
-Reload the rules from the rules file. The new rules are taken into use\
+Reload the rules from the rules file. The new rules are taken into use
 only if the loading succeeds without any errors.
 
 ```
@@ -590,8 +590,8 @@ MariaDB MaxScale configuration file.
 
 ### Example
 
-In the following we configure a masking filter _MyMasking_ that should always log a\
-warning if a masking rule matches a column that is of a type that cannot be masked,\
+In the following we configure a masking filter _MyMasking_ that should always log a
+warning if a masking rule matches a column that is of a type that cannot be masked,
 and that should abort the client connection if a resultset package is larger than\
 16MB. The rules for the masking filter are in the file `masking_rules.json`.
 
@@ -613,9 +613,9 @@ filters=MyMasking
 
 #### `masking_rules.json`
 
-The rules specify that the data of a column whose name is `ssn`, should\
-be replaced with the string _012345-ABCD_. If the length of the data is\
-not exactly the same as the length of the replacement value, then the\
+The rules specify that the data of a column whose name is `ssn`, should
+be replaced with the string _012345-ABCD_. If the length of the data is
+not exactly the same as the length of the replacement value, then the
 data should be replaced with as many _X_ characters as needed.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-maxrows.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-maxrows.md
@@ -4,11 +4,11 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Maxrows filter is capable of restricting the amount of rows that a SELECT,\
+The Maxrows filter is capable of restricting the amount of rows that a SELECT,
 a prepared statement or stored procedure could return to the client application.
 
-If a resultset from a backend server has more rows than the configured limit\
-or the resultset size exceeds the configured size,\
+If a resultset from a backend server has more rows than the configured limit
+or the resultset size exceeds the configured size,
 an empty result will be sent to the client.
 
 ### Configuration
@@ -38,7 +38,7 @@ Optional parameters are:
 * Dynamic: Yes
 * Default: (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 returned to the user.
 
 If a resultset is larger than this an empty result will be sent instead.
@@ -54,8 +54,8 @@ max_resultset_rows=1000
 * Dynamic: Yes
 * Default: `64Ki`
 
-Specifies the maximum size a resultset can have in order\
-to be sent to the client. A resultset larger than this, will\
+Specifies the maximum size a resultset can have in order
+to be sent to the client. A resultset larger than this, will
 not be sent: an empty resultset will be sent instead.
 
 ```
@@ -70,7 +70,7 @@ max_resultset_size=128Ki
 * Values: `empty`, `error`, `ok`
 * Default: `empty`
 
-Specifies what the filter sends to the client when the\
+Specifies what the filter sends to the client when the
 rows or size limit is hit, possible values:
 
 * an empty result set
@@ -91,8 +91,8 @@ ERROR 1415 (0A000): Row limit/size exceeded for query: select * from test.t4
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the Maxrows\
-filter can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the Maxrows
+filter can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -107,7 +107,7 @@ debug=2
 
 ### Example Configuration
 
-Here is an example of filter configuration where the maximum number of returned\
+Here is an example of filter configuration where the maximum number of returned
 rows is 10000 and maximum allowed resultset size is 256KB
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-named-server-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-named-server-filter.md
@@ -2,25 +2,25 @@
 
 ### Overview
 
-The **namedserverfilter** is a MariaDB MaxScale filter module able to route\
-queries to servers based on regular expression (regex) matches. Since it is a\
+The **namedserverfilter** is a MariaDB MaxScale filter module able to route
+queries to servers based on regular expression (regex) matches. Since it is a
 filter instead of a router, the NamedServerFilter only sets routing suggestions.\
-It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the\
-data packets. This filter uses the _PCRE2_ library for regular expression\
+It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the
+data packets. This filter uses the _PCRE2_ library for regular expression
 matching.
 
 ### Configuration
 
-The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of\
-the modes may be used for a given filter instance. The legacy mode is meant for\
-backwards compatibility and allows only one regular expression and one server\
-name in the configuration. In indexed mode, up to 25 regex-server pairs are\
+The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of
+the modes may be used for a given filter instance. The legacy mode is meant for
+backwards compatibility and allows only one regular expression and one server
+name in the configuration. In indexed mode, up to 25 regex-server pairs are
 allowed in the form _match01_ - _target01_, _match02_ - _target02_ and so on.\
-Also, in indexed mode, the server names (targets) may contain a list of names or\
+Also, in indexed mode, the server names (targets) may contain a list of names or
 special tags `->master` or `->slave`.
 
-All parameters except the deprecated `match` and `target` parameters can\
-be modified at runtime. Any modifications to the filter configuration will\
+All parameters except the deprecated `match` and `target` parameters can
+be modified at runtime. Any modifications to the filter configuration will
 only affect sessions created after the change has completed.
 
 Below is a configuration example for the filter in indexed-mode. The legacy mode\
@@ -61,10 +61,10 @@ NamedServerFilter requires at least one _matchXY_ - _targetXY_ pair.
 * Dynamic: Yes
 * Default: None
 
-_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#regular-expressions)\
+_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#regular-expressions)
 against which the incoming SQL query is matched. _XY_ must be a number in the range\
-01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is\
-defined, the other must be defined as well. If a query matches the pattern, the filter\
+01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is
+defined, the other must be defined as well. If a query matches the pattern, the filter
 attaches a routing hint defined by the _target_-setting to the query. The _options_-parameter affects how the patterns are compiled.
 
 ```
@@ -80,7 +80,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-[Regular expression options](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Regular expression options](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 for `matchXY`.
 
 #### `targetXY`
@@ -99,8 +99,8 @@ accordingly. The target can be one of the following:
 * `->slave` (adds a `HINT_ROUTE_TO_SLAVE` hint)
 * `->all` (adds a `HINT_ROUTE_TO_ALL` hint)
 
-The support for service names was added in MaxScale 6.3.2. Older\
-versions of MaxScale did not accept service names in the `target`\
+The support for service names was added in MaxScale 6.3.2. Older
+versions of MaxScale did not accept service names in the `target`
 parameters.
 
 ```
@@ -114,9 +114,9 @@ target01=MyServer2
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines an IP address or mask which a connecting\
-client's IP address is matched against. Only sessions whose address matches this\
-setting will have this filter active and performing the regex matching. Traffic\
+This optional parameter defines an IP address or mask which a connecting
+client's IP address is matched against. Only sessions whose address matches this
+setting will have this filter active and performing the regex matching. Traffic
 from other client IPs is simply left as is and routed straight through.
 
 ```
@@ -133,7 +133,7 @@ source=192.168.10.%
 
 Note that using `source=%` to match any IP is not allowed.
 
-Since MaxScale 2.3 it's also possible to specify multiple addresses separated\
+Since MaxScale 2.3 it's also possible to specify multiple addresses separated
 by comma. Incoming client connections are subsequently checked against each.
 
 ```
@@ -147,9 +147,9 @@ source=192.168.21.3,192.168.10.%
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines a username the connecting client username is\
-matched against. Only sessions that are connected using this username will have\
-the match and routing hints applied to them. Traffic from other users is simply\
+This optional parameter defines a username the connecting client username is
+matched against. Only sessions that are connected using this username will have
+the match and routing hints applied to them. Traffic from other users is simply
 left as is and routed straight through.
 
 ```
@@ -160,30 +160,30 @@ user=john
 
 The maximum number of accepted _match_ - _target_ pairs is 25.
 
-In the configuration file, the indexed match and target settings may be in any order\
-and may skip numbers. During SQL-query matching, however, the regexes are tested\
-in ascending order: match01, match02, match03 and so on. As soon as a match is\
-found for a given query, the routing hints are written and the packet is\
-forwarded to the next filter or router. Any remaining match regexes are\
-ignored. This means the _match_ - _target_ pairs should be indexed in priority\
-order, or, if priority is not a factor, in order of decreasing match\
+In the configuration file, the indexed match and target settings may be in any order
+and may skip numbers. During SQL-query matching, however, the regexes are tested
+in ascending order: match01, match02, match03 and so on. As soon as a match is
+found for a given query, the routing hints are written and the packet is
+forwarded to the next filter or router. Any remaining match regexes are
+ignored. This means the _match_ - _target_ pairs should be indexed in priority
+order, or, if priority is not a factor, in order of decreasing match
 probability.
 
-Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching\
-the prepared sql against the _match_-parameters. If a match is found, the\
-routing hints are attached to any execution of that prepared statement. Text-\
-mode prepared statements are not supported in this way. To divert them, use\
+Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching
+the prepared sql against the _match_-parameters. If a match is found, the
+routing hints are attached to any execution of that prepared statement. Text-
+mode prepared statements are not supported in this way. To divert them, use
 regular expressions which match the specific "EXECUTE"-query.
 
 ### Examples
 
 #### Example 1 - Route queries targeting a specific table to a server
 
-This will route all queries matching the regular expression `*from *users` to\
+This will route all queries matching the regular expression `*from *users` to
 the server named _server2_. The filter will ignore character case in queries.
 
-A query like `SELECT * FROM users` would be routed to server2 where as a query\
-like `SELECT * FROM accounts` would be routed according to the normal rules of\
+A query like `SELECT * FROM users` would be routed to server2 where as a query
+like `SELECT * FROM accounts` would be routed according to the normal rules of
 the router.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-query-log-all-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-query-log-all-filter.md
@@ -31,13 +31,13 @@ filters=MyLogFilter
 
 ### Log Rotation
 
-The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`\
-command. This will cause the log files to be reopened when the next message is\
+The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`
+command. This will cause the log files to be reopened when the next message is
 written to the file. This applies to both unified and session type logging.
 
 ### Filter Parameters
 
-The QLA filter has one mandatory parameter, `filebase`, and a number of optional\
+The QLA filter has one mandatory parameter, `filebase`, and a number of optional
 parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 
 #### `filebase`
@@ -46,7 +46,7 @@ parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 * Mandatory: Yes
 * Dynamic: No
 
-The basename of the output file created for each session. A session index is\
+The basename of the output file created for each session. A session index is
 added to the filename for each written session file. For unified log files,_.unified_ is appended.
 
 ```
@@ -105,7 +105,7 @@ Limit logging to sessions with this client source address.
 * Mandatory: No
 * Dynamic: Yes
 
-Only log queries from users that match this pattern. If the `user` parameter is\
+Only log queries from users that match this pattern. If the `user` parameter is
 used, the value of `user_match` is ignored.
 
 Here is an example pattern that matches the users `alice` and `bob`:
@@ -120,7 +120,7 @@ user_match=/(^alice$)|(^bob$)/
 * Mandatory: No
 * Dynamic: Yes
 
-Exclude all queries from users that match this pattern. If the `user` parameter\
+Exclude all queries from users that match this pattern. If the `user` parameter
 is used, the value of `user_exclude` is ignored.
 
 Here is an example pattern that excludes the users `alice` and `bob`:
@@ -135,10 +135,10 @@ user_exclude=/(^alice$)|(^bob$)/
 * Mandatory: No
 * Dynamic: Yes
 
-Only log queries from hosts that match this pattern. If the `source` parameter\
+Only log queries from hosts that match this pattern. If the `source` parameter
 is used, the value of `source_match` is ignored.
 
-Here is an example pattern that matches the loopback interface as well as the\
+Here is an example pattern that matches the loopback interface as well as the
 address `192.168.0.109`:
 
 ```
@@ -151,10 +151,10 @@ source_match=/(^127[.]0[.]0[.]1)|(^192[.]168[.]0[.]109)/
 * Mandatory: No
 * Dynamic: Yes
 
-Exclude all queries from hosts that match this pattern. If the `source`\
+Exclude all queries from hosts that match this pattern. If the `source`
 parameter is used, the value of `source_exclude` is ignored.
 
-Here is an example pattern that excludes the loopback interface as well as the\
+Here is an example pattern that excludes the loopback interface as well as the
 address `192.168.0.109`:
 
 ```
@@ -205,14 +205,14 @@ Type of data to log in the log files.
 | error\_msg         | Error message from the server (if any) (v6.2)           |
 | server             | The server where the query was routed (if any) (v22.08) |
 
-The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,\
+The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,
 but can be specified to another unit using _duration\_unit_.
 
 The log entry is written when the last reply from the server is received.\
-Prior to version 6.2 the entry was written when the query was received from\
+Prior to version 6.2 the entry was written when the query was received from
 the client, or if _reply\_time_ was specified, on first reply from the server.
 
-**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_\
+**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_
 is set the error message may contain user defined constants. For example:
 
 ```
@@ -240,7 +240,7 @@ This option is available as of MaxScale version 6.2.
 * Dynamic: Yes
 * Default: `false`
 
-When this option is true the canonical form of the query is logged. In the\
+When this option is true the canonical form of the query is logged. In the
 canonical form all user defined constants are replaced with question marks.\
 This option is available as of MaxScale version 6.2.
 
@@ -267,7 +267,7 @@ Flush log files after every write.
 * Dynamic: Yes
 * Default: `","`
 
-Defines the separator string between elements of\
+Defines the separator string between elements of
 log entries. The value should be enclosed in quotes.
 
 #### `newline_replacement`
@@ -277,19 +277,19 @@ log entries. The value should be enclosed in quotes.
 * Dynamic: Yes
 * Default: `" "`
 
-Default value is `" "` (one space). SQL-queries may include line breaks, which, if\
-printed directly to the log, may break automatic parsing. This parameter defines\
-what should be written in the place of a newline sequence (\r, \n or \r\n). If\
-this is set as the empty string, then newlines are not replaced and printed as\
+Default value is `" "` (one space). SQL-queries may include line breaks, which, if
+printed directly to the log, may break automatic parsing. This parameter defines
+what should be written in the place of a newline sequence (\r, \n or \r\n). If
+this is set as the empty string, then newlines are not replaced and printed as
 is to the output. The value should be enclosed in quotes.
 
 ### Examples
 
 #### Example 1 - Query without primary key
 
-Imagine you have observed an issue with a particular table and you want to\
-determine if there are queries that are accessing that table but not using the\
-primary key of the table. Let's assume the table name is PRODUCTS and the\
+Imagine you have observed an issue with a particular table and you want to
+determine if there are queries that are accessing that table but not using the
+primary key of the table. Let's assume the table name is PRODUCTS and the
 primary key is called PRODUCT\_ID. Add a filter with the following definition:
 
 ```
@@ -309,7 +309,7 @@ password=mypasswd
 filters=ProductsSelectLogger
 ```
 
-The result of using this filter with the service used by the application would\
+The result of using this filter with the service used by the application would
 be a log file of all select queries querying PRODUCTS without using the\
 PRODUCT\_ID primary key in the predicates of the query. Executing `SELECT * FROM PRODUCTS` would log the following into `/var/logs/qla/SelectProducts`:
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-regex-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-regex-filter.md
@@ -4,13 +4,13 @@
 
 ### Overview
 
-The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite\
-query content using regular expression matches and text substitution. The\
+The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite
+query content using regular expression matches and text substitution. The
 regular expressions use the [PCRE2 syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html).
 
-PCRE2 library uses a different syntax than POSIX to refer to capture\
-groups in the replacement string. The main difference is the usage of the dollar\
-character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)\
+PCRE2 library uses a different syntax than POSIX to refer to capture
+groups in the replacement string. The main difference is the usage of the dollar
+character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)
 chapter in the PCRE2 manual.
 
 ### Configuration
@@ -66,7 +66,7 @@ The _options_-parameter affects how the patterns are compiled as [usual](../mari
 * Mandatory: Yes
 * Dynamic: Yes
 
-This is the text that should replace the part of the SQL-query matching the\
+This is the text that should replace the part of the SQL-query matching the
 pattern defined in _match_.
 
 ```
@@ -80,9 +80,9 @@ replace=ENGINE =
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
-the address from which the client connection to MariaDB MaxScale\
-originates. Only sessions that originate from this address will have the match\
+The optional source parameter defines an address that is used to match against
+the address from which the client connection to MariaDB MaxScale
+originates. Only sessions that originate from this address will have the match
 and replacement applied to them.
 
 ```
@@ -96,9 +96,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will have the match and\
+The optional user parameter defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will have the match and
 replacement applied to them.
 
 ```
@@ -112,9 +112,9 @@ user=john
 * Dynamic: Yes
 * Default: None
 
-The optional log\_file parameter defines a log file in which the filter writes\
-all queries that are not matched and matching queries with their replacement\
-queries. All sessions will log to this file so this should only be used for\
+The optional log\_file parameter defines a log file in which the filter writes
+all queries that are not matched and matching queries with their replacement
+queries. All sessions will log to this file so this should only be used for
 diagnostic purposes.
 
 ```
@@ -128,10 +128,10 @@ log_file=/tmp/regexfilter.log
 * Dynamic: Yes
 * Default: None
 
-The optional log\_trace parameter toggles the logging of non-matching and\
+The optional log\_trace parameter toggles the logging of non-matching and
 matching queries with their replacements into the log file on the _info_ level.\
-This is the preferred method of diagnosing the matching of queries since the log\
-level can be changed at runtime. For more details about logging levels and\
+This is the preferred method of diagnosing the matching of queries since the log
+level can be changed at runtime. For more details about logging levels and
 session specific logging, please read the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#global-settings).
 
 ```
@@ -142,10 +142,10 @@ log_trace=true
 
 #### Example 1 - Replace MySQL 5.1 create table syntax with that for later versions
 
-MySQL 5.1 used the parameter TYPE = to set the storage engine that should be\
-used for a table. In later versions this changed to be ENGINE =. Imagine you\
-have an application that you can not change for some reason, but you wish to\
-migrate to a newer version of MySQL. The regexfilter can be used to transform\
+MySQL 5.1 used the parameter TYPE = to set the storage engine that should be
+used for a table. In later versions this changed to be ENGINE =. Imagine you
+have an application that you can not change for some reason, but you wish to
+migrate to a newer version of MySQL. The regexfilter can be used to transform
 the create table statements into the form that could be used by MySQL 5.5
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-rewrite-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-rewrite-filter.md
@@ -3,8 +3,8 @@
 ### Overview
 
 The rewrite filter allows modification of sql queries on the fly.\
-Reasons for modifying queries can be to rewrite a query for performance,\
-or to change a specific query when the client query is incorrect and\
+Reasons for modifying queries can be to rewrite a query for performance,
+or to change a specific query when the client query is incorrect and
 cannot be changed in a timely manner.
 
 The examples will use Rewrite Filter file format. See below.
@@ -19,7 +19,7 @@ Rewriter native syntax uses placeholders to grab and replace parts of text.
 
 The syntax for a plain placeholder is `@{N}` where N is a positive integer.
 
-The syntax for a placeholder regex is `@{N:regex}`. It allows more control\
+The syntax for a placeholder regex is `@{N:regex}`. It allows more control
 when needed.
 
 The below is a valid entry in rf format. For demonstration, all options are set.\
@@ -53,23 +53,23 @@ For a match, the two `@{2}` text grabs must be equal.
 
 The match template is used to match against the sql to be rewritten.
 
-The match template can be partial `from mytable`. But the actual underlying\
-regex match is always for the whole sql. If the match template does not\
-start or end with a placeholder, placeholders are automatically added so\
-that the above becomes `@{1}from mytable@{2}`. The automatically added\
+The match template can be partial `from mytable`. But the actual underlying
+regex match is always for the whole sql. If the match template does not
+start or end with a placeholder, placeholders are automatically added so
+that the above becomes `@{1}from mytable@{2}`. The automatically added
 placeholders cannot be used in the replace template.
 
-Matching the whole input also means that Native syntax does not support\
-(and is not intended to support) scan and replace. Only the first occurrence\
+Matching the whole input also means that Native syntax does not support
+(and is not intended to support) scan and replace. Only the first occurrence
 of the above `from mytable` can be modified in the replace template.\
-However, one can selectively choose to modify e.g. the first through\
+However, one can selectively choose to modify e.g. the first through
 third occurrence of `from mytable` by writing`from mytable @{1} from mytable @{2} from mytable @{3}`.
 
 For scan and replace use a different regex\_grammar (see below).
 
 **Replace template**
 
-The replace template uses the placeholders from the match template to\
+The replace template uses the placeholders from the match template to
 rewrite sql.
 
 ```
@@ -85,11 +85,11 @@ Input: select count(distinct author) from books where entity != "AI"
 Rewritten: select count(*) from (select distinct author from books where entity != "AI") as t123
 ```
 
-An important option for smooth matching is `ignore_whitespace`, which\
-is on (true) by default. It creates the match regex in such a way that\
-the amount and kind of whitespace does not affect matching. However,\
-to make `ignore_whitespace` always work, it is important to add\
-whitespace where allowed. If "id=42" is in the match template then\
+An important option for smooth matching is `ignore_whitespace`, which
+is on (true) by default. It creates the match regex in such a way that
+the amount and kind of whitespace does not affect matching. However,
+to make `ignore_whitespace` always work, it is important to add
+whitespace where allowed. If "id=42" is in the match template then
 only the exact "id=42" can match. But if "id = 42" is used, and`ignore_whitespace` is on, both "id=42" and "id = 42" will match.
 
 Another example, and what not to do:
@@ -106,7 +106,7 @@ Input: select name from mytable where id=42
 Rewritten: select name from mytable force index (myindex) where id=42
 ```
 
-That works, but because the match lacks specific detail about the\
+That works, but because the match lacks specific detail about the
 expected sql, things are likely to break. In this case`show indexes from my_table` would no longer work.
 
 The minimum detail in this case could be:
@@ -119,22 +119,22 @@ The minimum detail in this case could be:
 select @{2} from mytable force index (myindex)
 ```
 
-but if more detail is known, like something specific in the where clause,\
+but if more detail is known, like something specific in the where clause,
 that too should be added.
 
 **Placeholder Regex**
 
 Syntax: @{N:regex}
 
-In a placeholder regex the character `}` must be escaped to `\}`\
-(for literal matching). Plain parenthesis "()" indicate capturing\
+In a placeholder regex the character `}` must be escaped to `\}`
+(for literal matching). Plain parenthesis "()" indicate capturing
 groups, which are internally used by the Native grammar.\
 Thus plain parentheses in a placeholder regex will break matching.\
 However, non-capturing groups can be used: e.g. `@{1:(:?Jane|Joe)}`.\
 To match a literal parenthesis use an escape, e.g. `\(`.
 
 Suppose an application is misbehaving after an upgrade and a quick fix is needed.\
-This query `select zip from address_book where str_id = "AZ-124"` is correct,\
+This query `select zip from address_book where str_id = "AZ-124"` is correct,
 but if the id is an integer the where clause should be `id = 1234`.
 
 ```
@@ -155,7 +155,7 @@ For scan and replace the regex\_grammar must be set to something else than\
 Native. An example will illustrate the usage.
 
 Replace all occurrences of "wrong\_table\_name" with "correct\_table\_name".\
-Further, if the replacement was made then replace all occurrences\
+Further, if the replacement was made then replace all occurrences
 of wrong\_column\_name with correct\_column\_name.
 
 ```
@@ -260,7 +260,7 @@ Ignore whitespace differences in the match template and input sql.
 * Type: boolean
 * Default: false
 
-If a template matches and the replacement is done, continue to the\
+If a template matches and the replacement is done, continue to the
 next template and apply it to the result of the previous rewrite.
 
 **`what_if`**
@@ -268,7 +268,7 @@ next template and apply it to the result of the previous rewrite.
 * Type: boolean
 * Default: false
 
-Do not make the replacement, only log what would have\
+Do not make the replacement, only log what would have
 been replaced (NOTICE level).
 
 ### Rewrite file format
@@ -284,12 +284,12 @@ match template
 replace template
 ```
 
-The character `#` starts a single line comment when it is the\
+The character `#` starts a single line comment when it is the
 first character on a line.
 
 Empty lines are ignored.
 
-The rf format does not need any additional escaping to what the basic\
+The rf format does not need any additional escaping to what the basic
 format requires (see Placeholder Regex).
 
 Options are specified as follows:
@@ -300,11 +300,11 @@ case_sensitive: true
 
 The colon must stick to the option name.
 
-The separators `%` and `%%` must be the exact content of\
+The separators `%` and `%%` must be the exact content of
 their respective separator lines.
 
-The templates can span multiple lines. Whitespace does not\
-matter as long as `ignore_whitespace = true`. Always use space\
+The templates can span multiple lines. Whitespace does not
+matter as long as `ignore_whitespace = true`. Always use space
 where space is allowed to maximize the utility of`ignore_whitespace`.
 
 Example
@@ -324,10 +324,10 @@ and @{3} in (select user from approved_users)
 ### Json file format
 
 The json file format is harder to read and edit manually.\
-It will be needed if support for editing of rewrite templates\
+It will be needed if support for editing of rewrite templates
 is added to the GUI.
 
-All double quotes and escape characters have to be escaped in json,\
+All double quotes and escape characters have to be escaped in json,
 i.e '"' and '\\'.
 
 The same example as above is:
@@ -347,7 +347,7 @@ and @{3} in (select user from approved_users)"
 
 ### Reload template file
 
-The configuration is re-read if any dynamic value is updated\
+The configuration is re-read if any dynamic value is updated
 even if the value does not change.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-tee-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-tee-filter.md
@@ -3,17 +3,17 @@
 ### Overview
 
 The tee filter is a "plumbing" fitting in the MariaDB MaxScale filter toolkit.\
-It can be used in a filter pipeline of a service to make copies of requests from\
+It can be used in a filter pipeline of a service to make copies of requests from
 the client and send the copies to another service within MariaDB MaxScale.
 
-**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a\
-service which uses a tee filter will require a grant for the loopback address,\
+**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a
+service which uses a tee filter will require a grant for the loopback address,
 i.e. `127.0.0.1`.
 
 ### Configuration
 
-The configuration block for the TEE filter requires the minimal filter\
-parameters in its section within the MaxScale configuration file. The service to\
+The configuration block for the TEE filter requires the minimal filter
+parameters in its section within the MaxScale configuration file. The service to
 send the duplicates to must be defined.
 
 ```
@@ -33,7 +33,7 @@ filters=DataMartFilter
 
 ### Filter Parameters
 
-The tee filter requires a mandatory parameter to define the service to replicate\
+The tee filter requires a mandatory parameter to define the service to replicate
 statements to and accepts a number of optional parameters.
 
 #### `target`
@@ -43,8 +43,8 @@ statements to and accepts a number of optional parameters.
 * Dynamic: Yes
 * Default: none
 
-The target where the filter will duplicate all queries. The target can be either\
-a service or a server. The duplicate connection that is created to this target\
+The target where the filter will duplicate all queries. The target can be either
+a service or a server. The duplicate connection that is created to this target
 will be referred to as the "branch target" in this document.
 
 #### `service`
@@ -54,8 +54,8 @@ will be referred to as the "branch target" in this document.
 * Dynamic: Yes
 * Default: none
 
-The service where the filter will duplicate all queries. This parameter is\
-deprecated in favor of the `target` parameter and will be removed in a future\
+The service where the filter will duplicate all queries. This parameter is
+deprecated in favor of the `target` parameter and will be removed in a future
 release. Both `target` and `service` cannot be defined.
 
 #### `match`
@@ -105,7 +105,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
+The optional source parameter defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be replicated.
 
@@ -120,8 +120,8 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a user name that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
+The optional user parameter defines a user name that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
 sessions that are connected using this username are replicated.
 
 ```
@@ -135,63 +135,63 @@ user=john
 * Dynamic: Yes
 * Default: `false`
 
-Enable synchronous routing mode. When configured with `sync=true`, the filter\
-will queue new queries until the response from both the main and the branch\
-target has been received. This means that for `n` executed queries, `n - 1`\
-queries are guaranteed to be synchronized. Adding one extra statement\
-(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL\
+Enable synchronous routing mode. When configured with `sync=true`, the filter
+will queue new queries until the response from both the main and the branch
+target has been received. This means that for `n` executed queries, `n - 1`
+queries are guaranteed to be synchronized. Adding one extra statement
+(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL
 statements have been successfully executed on both targets.
 
-In the synchronous routing mode, a failure of the branch target will cause the\
+In the synchronous routing mode, a failure of the branch target will cause the
 client session to be closed.
 
 ### Limitations
 
-* All statements that are executed on the branch target are done in an\
-  asynchronous manner. This means that when the client receives the response\
-  there is no guarantee that the statement has completed on the branch\
-  target. The `sync` feature provides some synchronization guarantees that can\
+* All statements that are executed on the branch target are done in an
+  asynchronous manner. This means that when the client receives the response
+  there is no guarantee that the statement has completed on the branch
+  target. The `sync` feature provides some synchronization guarantees that can
   be used to verify successful execution on both targets.
-* Any errors on the branch target will cause the connection to it to be\
-  closed. If `target` is a service, it is up to the router to decide whether the\
-  connection is closed. For direct connections to servers, any network errors\
-  cause the connection to be closed. When the connection is closed, no new\
+* Any errors on the branch target will cause the connection to it to be
+  closed. If `target` is a service, it is up to the router to decide whether the
+  connection is closed. For direct connections to servers, any network errors
+  cause the connection to be closed. When the connection is closed, no new
   queries will be routed to the branch target.
 
-With `sync=true`, a failure of the branch target will cause the whole session\
+With `sync=true`, a failure of the branch target will cause the whole session
 to be closed.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-module-commands.md) documentation for
 details about module commands.
 
 The tee filter supports the following module commands.
 
 #### `tee disable [FILTER]`
 
-This command disables a tee filter instance. A disabled tee filter will not send\
+This command disables a tee filter instance. A disabled tee filter will not send
 any queries to the target service.
 
 #### `tee enable [FILTER]`
 
-Enable a disabled tee filter. This resumes the sending of queries to the target\
+Enable a disabled tee filter. This resumes the sending of queries to the target
 service.
 
 ### Examples
 
 #### Example 1 - Replicate all inserts into the orders table
 
-Assume an order processing system that has a table called orders. You also have\
-another database server, the datamart server, that requires all inserts into\
+Assume an order processing system that has a table called orders. You also have
+another database server, the datamart server, that requires all inserts into
 orders to be replicated to it. Deletes and updates are not, however, required.
 
-Set up a service in MariaDB MaxScale, called Orders, to communicate with the\
-order processing system with the tee filter applied to it. Also set up a service\
-to talk to the datamart server, using the DataMart service. The tee filter would\
+Set up a service in MariaDB MaxScale, called Orders, to communicate with the
+order processing system with the tee filter applied to it. Also set up a service
+to talk to the datamart server, using the DataMart service. The tee filter would
 have as its service entry the DataMart service, by adding a match parameter of\
-"insert into orders" would then result in all requests being sent to the order\
-processing system, and insert statements that include the orders table being\
+"insert into orders" would then result in all requests being sent to the order
+processing system, and insert statements that include the orders table being
 additionally sent to the datamart server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-throttle.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-throttle.md
@@ -4,13 +4,13 @@ This filter was added in MariaDB MaxScale 2.3
 
 ### Overview
 
-The throttle filter is used to limit the maximum query frequency (QPS - queries\
-per second) of a database session to a configurable value. The main use cases\
-are to prevent a rogue session (client side error) and a DoS attack from\
+The throttle filter is used to limit the maximum query frequency (QPS - queries
+per second) of a database session to a configurable value. The main use cases
+are to prevent a rogue session (client side error) and a DoS attack from
 overloading the system.
 
-The throttling is dynamic. The query frequency is not limited to an absolute\
-value. Depending on the configuration the throttle will allow some amount of\
+The throttling is dynamic. The query frequency is not limited to an absolute
+value. Depending on the configuration the throttle will allow some amount of
 high frequency queries, or especially short bursts with no frequency limitation.
 
 ### Configuration
@@ -31,27 +31,27 @@ filters = Throttle
 ```
 
 This configuration states that the query frequency will be throttled to around\
-500 qps, and that the time limit a query is allowed to stay at the maximum\
-frequency is 60 seconds. All values involving time are configured in\
-milliseconds. With the basic configuration the throttling will be nearly\
-immediate, i.e. a session will only be allowed very short bursts of high\
+500 qps, and that the time limit a query is allowed to stay at the maximum
+frequency is 60 seconds. All values involving time are configured in
+milliseconds. With the basic configuration the throttling will be nearly
+immediate, i.e. a session will only be allowed very short bursts of high
 frequency querying.
 
-When a session has been continuously throttled for `throttling_duration`\
-milliseconds, or 60 seconds in this example, MaxScale will disconnect the\
+When a session has been continuously throttled for `throttling_duration`
+milliseconds, or 60 seconds in this example, MaxScale will disconnect the
 session.
 
 #### Allowing high frequency bursts
 
-The two parameters `max_qps` and `sampling_duration` together define how a\
+The two parameters `max_qps` and `sampling_duration` together define how a
 session is throttled.
 
-Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not\
-an instantaneous measure, but one could say it has a granularity of 10 seconds,\
-we see that over the 10 seconds 10\*400 = 4000 queries are allowed before\
+Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not
+an instantaneous measure, but one could say it has a granularity of 10 seconds,
+we see that over the 10 seconds 10\*400 = 4000 queries are allowed before
 throttling kicks in.
 
-With these values, a fresh session can start off with a speed of 2000 qps, and\
+With these values, a fresh session can start off with a speed of 2000 qps, and
 maintain that speed for 2 seconds before throttling starts.
 
 If the client continues to query at high speed and throttling duration is set to\
@@ -67,8 +67,8 @@ If the client continues to query at high speed and throttling duration is set to
 
 Maximum queries per second.
 
-This is the frequency to which a session will be limited over a given time\
-period. QPS is not measured as an instantaneous value but over a configurable\
+This is the frequency to which a session will be limited over a given time
+period. QPS is not measured as an instantaneous value but over a configurable
 sampling duration (see `sampling_duration`).
 
 **`throttling_duration`**
@@ -77,7 +77,7 @@ sampling duration (see `sampling_duration`).
 * Mandatory: Yes
 * Dynamic: Yes
 
-This defines how long a session is allowed to be throttled before MaxScale\
+This defines how long a session is allowed to be throttled before MaxScale
 disconnects the session.
 
 #### `sampling_duration`
@@ -87,11 +87,11 @@ disconnects the session.
 * Dynamic: Yes
 * Default: 250ms
 
-Sampling duration defines the window of time over which QPS is measured. This\
-parameter directly affects the amount of time that high frequency queries are\
+Sampling duration defines the window of time over which QPS is measured. This
+parameter directly affects the amount of time that high frequency queries are
 allowed before throttling kicks in.
 
-The lower this value is, the more strict throttling becomes. Conversely, the\
+The lower this value is, the more strict throttling becomes. Conversely, the
 longer this time is, the longer bursts of high frequency querying is allowed.
 
 #### `continuous_duration`
@@ -101,8 +101,8 @@ longer this time is, the longer bursts of high frequency querying is allowed.
 * Dynamic: Yes
 * Default: 2s
 
-This value defines what continuous throttling means. Continuous throttling\
-starts as soon as the filter throttles the frequency. Continuous throttling ends\
+This value defines what continuous throttling means. Continuous throttling
+starts as soon as the filter throttles the frequency. Continuous throttling ends
 when no throttling has been performed in the past `continuous_duration` time.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-top-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-top-filter.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-The top filter is a filter module for MariaDB MaxScale that monitors every SQL\
-statement that passes through the filter. It measures the duration of that\
-statement, the time between the statement being sent and the first result being\
-returned. The top N times are kept, along with the SQL text itself and a list\
-sorted on the execution times of the query is written to a file upon closure of\
+The top filter is a filter module for MariaDB MaxScale that monitors every SQL
+statement that passes through the filter. It measures the duration of that
+statement, the time between the statement being sent and the first result being
+returned. The top N times are kept, along with the SQL text itself and a list
+sorted on the execution times of the query is written to a file upon closure of
 the client session.
 
 ### Configuration
@@ -29,7 +29,7 @@ filters=MyLogFilter
 
 #### Filter Parameters
 
-The top filter has one mandatory parameter, `filebase`, and a number of optional\
+The top filter has one mandatory parameter, `filebase`, and a number of optional
 parameters.
 
 **`filebase`**
@@ -38,15 +38,15 @@ parameters.
 * Mandatory: Yes
 * Dynamic: Yes
 
-The basename of the output file created for each session. The session ID is\
+The basename of the output file created for each session. The session ID is
 added to the filename for each file written. This is a mandatory parameter.
 
 ```
 filebase=/tmp/SqlQueryLog
 ```
 
-The filebase may also be set as the filter, the mechanism to set the filebase\
-via the filter option is superseded by the parameter. If both are set the\
+The filebase may also be set as the filter, the mechanism to set the filebase
+via the filter option is superseded by the parameter. If both are set the
 parameter setting will be used and the filter option ignored.
 
 **`count`**
@@ -69,7 +69,7 @@ count=30
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Limits](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 the queries logged by the filter.
 
 ```
@@ -85,7 +85,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Limits](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 the queries logged by the filter.
 
 **`options`**
@@ -96,7 +96,7 @@ the queries logged by the filter.
 * Values: `ignorecase`, `case`, `extended`
 * Default: `case`
 
-[Regular expression options](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Regular expression options](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 for `match` and `exclude`.
 
 **`source`**
@@ -106,7 +106,7 @@ for `match` and `exclude`.
 * Dynamic: Yes
 * Default: None
 
-Defines an address that is used to match against\
+Defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be logged.
 
@@ -121,9 +121,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-Defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will result in results being\
+Defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will result in results being
 generated.
 
 ```
@@ -134,8 +134,8 @@ user=john
 
 #### Example 1 - Heavily Contended Table
 
-You have an order system and believe the updates of the PRODUCTS table is\
-causing some performance issues for the rest of your application. You would like\
+You have an order system and believe the updates of the PRODUCTS table is
+causing some performance issues for the rest of your application. You would like
 to know which of the many updates in your application is causing the issue.
 
 Add a filter with the following definition:
@@ -150,12 +150,12 @@ exclude=UPDATE.*PRODUCTS_STOCK.*WHERE
 filebase=/var/logs/top/ProductsUpdate
 ```
 
-Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table\
+Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table
 from being included in the report.
 
 #### Example 2 - One Application Server is Slow
 
-One of your applications servers is slower than the rest, you believe it is\
+One of your applications servers is slower than the rest, you believe it is
 related to database access but you are not sure what is taking the time.
 
 Add a filter with the following definition:
@@ -169,7 +169,7 @@ source=192.168.0.32
 filebase=/var/logs/top/SlowAppServer
 ```
 
-In order to produce a comparison with an unaffected application server you can\
+In order to produce a comparison with an unaffected application server you can
 also add a second filter as a control.
 
 ```
@@ -194,14 +194,14 @@ password=mypasswd
 filters=SlowAppServer | ControlAppServer
 ```
 
-You will then have two sets of logs files written, one which profiles the top 20\
-queries of the slow application server and another that gives you the top 20\
-queries of your control application server. These two sets of files can then be\
+You will then have two sets of logs files written, one which profiles the top 20
+queries of the slow application server and another that gives you the top 20
+queries of your control application server. These two sets of files can then be
 compared to determine what if anything is different between the two.
 
 ### Output Report
 
-The following is an example report for a number of fictitious queries executed\
+The following is an example report for a number of fictitious queries executed
 against the employees example database available for MySQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-transaction-performance-monitoring-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-transaction-performance-monitoring-filter.md
@@ -1,21 +1,21 @@
 # Transaction Performance Monitoring Filter
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Overview
 
-The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale\
+The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale
 that monitors every SQL statement that passes through the filter.\
 The filter groups a series of SQL statements into a transaction by detecting\
-'commit' or 'rollback' statements. It logs all committed transactions with necessary\
-information, such as timestamp, client, SQL statements, latency, etc., which\
+'commit' or 'rollback' statements. It logs all committed transactions with necessary
+information, such as timestamp, client, SQL statements, latency, etc., which
 can be used later for transaction performance analysis.
 
 ### Configuration
 
-The configuration block for the TPM filter requires the minimal filter\
+The configuration block for the TPM filter requires the minimal filter
 options in it's section within the maxscale.cnf file, stored in /etc/maxscale.cnf.
 
 ```
@@ -51,9 +51,9 @@ filename=/tmp/SqlQueryLog
 
 #### Source
 
-The optional `source` parameter defines an address that is used\
-to match against the address from which the client connection\
-to MaxScale originates. Only sessions that originate from this\
+The optional `source` parameter defines an address that is used
+to match against the address from which the client connection
+to MaxScale originates. Only sessions that originate from this
 address will be logged.
 
 ```
@@ -62,9 +62,9 @@ source=127.0.0.1
 
 #### User
 
-The optional `user` parameter defines a user name that is used\
+The optional `user` parameter defines a user name that is used
 to match against the user from which the client connection to\
-MaxScale originates. Only sessions that are connected using\
+MaxScale originates. Only sessions that are connected using
 this username are logged.
 
 ```
@@ -73,7 +73,7 @@ user=john
 
 #### Delimiter
 
-The optional `delimiter` parameter defines a delimiter that is used to\
+The optional `delimiter` parameter defines a delimiter that is used to
 distinguish columns in the log. The default delimiter is **`:::`**.
 
 ```
@@ -82,7 +82,7 @@ delimiter=:::
 
 #### Query\_delimiter
 
-The optional `query_delimiter` defines a delimiter that is used to\
+The optional `query_delimiter` defines a delimiter that is used to
 distinguish different SQL statements in a transaction.\
 The default query delimiter is **`@@@`**.
 
@@ -92,9 +92,9 @@ query_delimiter=@@@
 
 #### Named\_pipe
 
-**`named_pipe`** is the path to a named pipe, which TPM filter uses to\
+**`named_pipe`** is the path to a named pipe, which TPM filter uses to
 communicate with 3rd-party applications (e.g., [DBSeer](https://dbseer.org)).\
-Logging is enabled when the router receives the character '1' and logging is\
+Logging is enabled when the router receives the character '1' and logging is
 disabled when the router receives the character '0' from this named pipe.\
 The default named pipe is **`/tmp/tpmfilter`** and logging is **disabled** by default.
 
@@ -124,7 +124,7 @@ For each transaction, the TPM filter prints its log in the following format:
 
 #### Example 1 - Log Transactions for Performance Analysis
 
-You want to log every transaction with its SQL statements and latency\
+You want to log every transaction with its SQL statements and latency
 for future transaction performance analysis.
 
 Add a filter with the following definition:
@@ -147,7 +147,7 @@ password=mypasswd
 filters=PerformanceLogger
 ```
 
-After the filter reads the character '1' from its named pipe, the following\
+After the filter reads the character '1' from its named pipe, the following
 is an example log that is generated from the above TPM filter with the above configuration:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-building-mariadb-maxscale-from-source-code.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-building-mariadb-maxscale-from-source-code.md
@@ -1,6 +1,6 @@
 # Building MariaDB MaxScale from Source Code
 
-MariaDB MaxScale can be built on any system that meets the requirements. The main\
+MariaDB MaxScale can be built on any system that meets the requirements. The main
 requirements are as follows:
 
 * CMake version 3.16 or later (Packaging requires CMake 3.25.1 or later)
@@ -22,7 +22,7 @@ requirements are as follows:
 * libssh
 * pcre2
 
-This is the minimum set of requirements that must be met to build the MaxScale\
+This is the minimum set of requirements that must be met to build the MaxScale
 core package. Some modules in MaxScale require optional extra dependencies.
 
 * libuuid (binlogrouter)
@@ -33,9 +33,9 @@ core package. Some modules in MaxScale require optional extra dependencies.
 * memcached (storage\_memcached for the cache filter)
 * hiredis (storage\_redis for the cache filter)
 
-Some of these dependencies are not available on all operating systems and are\
-downloaded automatically during the build step. To skip the building of modules\
-that need automatic downloading of the dependencies, use `-DBUNDLE=N` when\
+Some of these dependencies are not available on all operating systems and are
+downloaded automatically during the build step. To skip the building of modules
+that need automatic downloading of the dependencies, use `-DBUNDLE=N` when
 configuring CMake.
 
 ### Quickstart
@@ -61,7 +61,7 @@ For a definitive list of packages, consult the [install\_build\_deps.sh](https:/
 
 The tests and other parts of the build can be controlled via CMake arguments.
 
-Here is a small table with the names of the most common parameters and what\
+Here is a small table with the names of the most common parameters and what
 they control. These should all be given as parameters to the -D switch in _NAME_=_VALUE_ format (e.g. `-DBUILD_TESTS=Y`).
 
 | Argument Name          | Explanation                                                                                                                                                                |
@@ -73,25 +73,25 @@ they control. These should all be given as parameters to the -D switch in _NAME_
 | TARGET\_COMPONENT      | Which component to install, default is the 'core' package. Other targets are 'experimental', which installs experimental packages and 'all' which installs all components. |
 | TARBALL                | Build tar.gz packages, requires PACKAGE=Y                                                                                                                                  |
 
-**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a\
+**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a
 list of the CMake variables.
 
 ### Running unit tests
 
-To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,\
+To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,
 compile and then run the `make test` command.
 
 ## Building MariaDB MaxScale packages
 
-If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation\
-and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your\
+If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation
+and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your
 system.
 
-To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create\
+To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create
 a _maxscale-x.y.z.tar.gz_ file where _x.y.z_ is the version number.
 
-Some Debian and Ubuntu systems suffer from a bug where `make package` fails\
-with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to\
+Some Debian and Ubuntu systems suffer from a bug where `make package` fails
+with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to
 the LD\_LIBRARY\_PATH environment variable.
 
 ```
@@ -101,14 +101,14 @@ LD_LIBRARY_PATH=$PWD/server/core/ make package
 
 ### Installing optional components
 
-The MaxScale build system is split into multiple components. The main component\
-is the `core` MaxScale package which contains MaxScale and all the modules. This\
-is the default component that is build, installed and packaged. There is also\
-the `experimental` component that contains all experimental modules which are\
-not considered as part of the core MaxScale package and are either alpha or beta\
+The MaxScale build system is split into multiple components. The main component
+is the `core` MaxScale package which contains MaxScale and all the modules. This
+is the default component that is build, installed and packaged. There is also
+the `experimental` component that contains all experimental modules which are
+not considered as part of the core MaxScale package and are either alpha or beta
 quality modules.
 
-To build the experimental modules along with the MaxScale core components,\
+To build the experimental modules along with the MaxScale core components,
 invoke CMake with `-DTARGET_COMPONENT=core,experimental`.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-installing-mariadb-maxscale-using-a-tarball.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-installing-mariadb-maxscale-using-a-tarball.md
@@ -1,6 +1,6 @@
 # Installing MariaDB MaxScale using a tarball
 
-MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`\
+MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`
 identifies the operating system, e.g. `maxscale-2.5.6.centos.7.tar.gz`.
 
 In order to use the tarball, the following libraries are required:
@@ -13,12 +13,12 @@ In order to use the tarball, the following libraries are required:
 * unixODBC
 
 The tarball has been built with the assumption that it will be installed in `/usr/local`.\
-However, it is possible to install it in any directory, but in that case MariaDB MaxScale\
+However, it is possible to install it in any directory, but in that case MariaDB MaxScale
 must be invoked with a flag.
 
 ### Installing as root in `/usr/local`
 
-If you have root access to the system you probably want to install MariaDB MaxScale under\
+If you have root access to the system you probably want to install MariaDB MaxScale under
 the user and group `maxscale`.
 
 The required steps are as follows:
@@ -33,14 +33,14 @@ $ cd maxscale
 $ sudo chown -R maxscale var
 ```
 
-Creating the symbolic link is necessary, since MariaDB MaxScale has been built\
+Creating the symbolic link is necessary, since MariaDB MaxScale has been built
 with the assumption that the plugin directory is `/usr/local/maxscale/lib/maxscale`.
 
 The symbolic link also makes it easy to switch between different versions of\
 MariaDB MaxScale that have been installed side by side in `/usr/local`;\
 just make the symbolic link point to another installation.
 
-In addition, the first time you install MariaDB MaxScale from a tarball\
+In addition, the first time you install MariaDB MaxScale from a tarball
 you need to create the following directories:
 
 ```
@@ -69,14 +69,14 @@ When the configuration file has been created, MariaDB MaxScale can be started.
 $ sudo bin/maxscale --user=maxscale -d
 ```
 
-The `-d` flag causes maxscale _not_ to turn itself into a daemon,\
+The `-d` flag causes maxscale _not_ to turn itself into a daemon,
 which is advisable the first time MariaDB MaxScale is started, as it makes it easier to spot problems.
 
 If you want to place the configuration file somewhere else but in `/etc`\
 you can invoke MariaDB MaxScale with the `--config` flag,\
 for instance, `--config=/usr/local/maxscale/etc/maxscale.cnf`.
 
-Note also that if you want to keep _everything_ under `/usr/local/maxscale`\
+Note also that if you want to keep _everything_ under `/usr/local/maxscale`
 you can invoke MariaDB MaxScale using the flag `--basedir`.
 
 ```
@@ -104,12 +104,12 @@ $ cd maxscale-x.y.z.OS
 $ bin/maxscale -d --basedir=.
 ```
 
-With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`\
-directories are found. Unless it is specified, MariaDB MaxScale assumes\
-the `lib` directory is found in `/usr/local/maxscale`,\
+With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`
+directories are found. Unless it is specified, MariaDB MaxScale assumes
+the `lib` directory is found in `/usr/local/maxscale`,
 and the `var` and `etc` directories in `/`.
 
-It is also possible to specify the directories and the location of\
+It is also possible to specify the directories and the location of
 the configuration file individually. Invoke MaxScale like
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md
@@ -1,8 +1,8 @@
 # MaxScale Configuration Guide
 
-This document describes how to configure MariaDB MaxScale and presents some\
-possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,\
-and consists of an event processing core with various support functions and\
+This document describes how to configure MariaDB MaxScale and presents some
+possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,
+and consists of an event processing core with various support functions and
 plugin modules that tailor the behavior of the program.
 
 ## Concepts
@@ -22,9 +22,9 @@ plugin modules that tailor the behavior of the program.
 
 #### Server
 
-A server represents an individual database server to which a client can be\
-connected via MariaDB MaxScale. The status of a server varies during the lifetime\
-of the server and typically the status is updated by some monitor. However, it\
+A server represents an individual database server to which a client can be
+connected via MariaDB MaxScale. The status of a server varies during the lifetime
+of the server and typically the status is updated by some monitor. However, it
 is also possible to update the status of a server manually.
 
 | Status                   | Description                                                                                                                                                                                                                                                                                                               |
@@ -43,55 +43,55 @@ For more information on how to manually set these states via MaxCtrl, read the [
 
 #### Monitor
 
-A monitor module is capable of monitoring the state of a particular kind\
+A monitor module is capable of monitoring the state of a particular kind
 of cluster and making that state available to the routers of MaxScale.
 
-Examples of monitor modules are `mariadbmon` that is capable of monitoring\
-a regular primary-replica cluster and in addition of performing both _switchover_\
-and _failover_, `galeramon` that is capable of monitoring a Galera cluster,\
+Examples of monitor modules are `mariadbmon` that is capable of monitoring
+a regular primary-replica cluster and in addition of performing both _switchover_
+and _failover_, `galeramon` that is capable of monitoring a Galera cluster,
 and `csmon` that is capable of monitoring a Columnstore cluster.
 
-Monitor modules have sections of their own in the MaxScale configuration\
+Monitor modules have sections of their own in the MaxScale configuration
 file.
 
 #### Filter
 
-A filter module resides in front of routers in the request processing chain\
-of MaxScale. That is, a filter will see a request before it reaches the router\
-and before a response is sent back to the client. This allows filters to\
+A filter module resides in front of routers in the request processing chain
+of MaxScale. That is, a filter will see a request before it reaches the router
+and before a response is sent back to the client. This allows filters to
 reject, handle, alter or log information about a request.
 
 Examples of filters `cache` that provides query caching according to rules,`regexfilter` that can rewrite requests according to regular expressions, and`qlafilter` that logs information about requests.
 
-Filters have sections of their own in the MaxScale configuration file that are\
+Filters have sections of their own in the MaxScale configuration file that are
 referred to from _services_.
 
 #### Router
 
-A router module is capable of routing requests to backend servers according to\
-the characteristics of a request and/or the algorithm the router\
+A router module is capable of routing requests to backend servers according to
+the characteristics of a request and/or the algorithm the router
 implements. Examples of routers are `readconnroute` that provides _connection routing_, that is, the server is chosen according to specified rules when the
-session is created and all requests are subsequently routed to that server,\
-and `readwritesplit` that provides _statement routing_, that is, each\
+session is created and all requests are subsequently routed to that server,
+and `readwritesplit` that provides _statement routing_, that is, each
 individual request is routed to the most appropriate server.
 
-Routers do not have sections of their own in the MaxScale configuration file,\
+Routers do not have sections of their own in the MaxScale configuration file,
 but are referred to from _services_.
 
 #### Service
 
-A service abstracts a set of databases and makes them appear as a single one\
-to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular\
-way. If the service uses filters, then all requests will be pre-processed in\
+A service abstracts a set of databases and makes them appear as a single one
+to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular
+way. If the service uses filters, then all requests will be pre-processed in
 some way before they reach the router.
 
 Services have sections of their own in the MaxScale configuration file.
 
 #### Listener
 
-A listener defines a port MaxScale listens on. Connection requests arriving on\
-that port will be forwarded to the service the listener is associated with. A\
-listener may be associated with a single service, but several listeners may be\
+A listener defines a port MaxScale listens on. Connection requests arriving on
+that port will be forwarded to the service the listener is associated with. A
+listener may be associated with a single service, but several listeners may be
 associated with the same service.
 
 Listeners have sections of their own in the MaxScale configuration file.
@@ -103,33 +103,33 @@ The administration of MaxScale can be divided in two parts:
 * Writing the MaxScale configuration file, which is described in the following [section](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#configuration).
 * Performing runtime modifications using [MaxCtrl](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md)
 
-For detailed information about _MaxCtrl_ please refer to the specific\
+For detailed information about _MaxCtrl_ please refer to the specific
 documentation referred to above. In the following it will only be explained how\
 MaxCtrl relate to each other, as far as user credentials go.
 
-**Note**: By default all runtime configuration changes are saved on disk and\
-loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details\
+**Note**: By default all runtime configuration changes are saved on disk and
+loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details
 on how it works and how to disable it.
 
 MaxCtrl can connect using TCP/IP sockets. When connecting with MaxCtrl using\
-TCP/IP sockets, the user and password must be provided and are checked against a\
+TCP/IP sockets, the user and password must be provided and are checked against a
 separate user credentials database. By default, that database contains the user`admin` whose password is `mariadb`.
 
-Note that if MaxCtrl is invoked without explicitly providing a user and password\
-then it will by default use `admin` and `mariadb`. That means that when the\
+Note that if MaxCtrl is invoked without explicitly providing a user and password
+then it will by default use `admin` and `mariadb`. That means that when the
 default user is removed, the credentials must always be provided.
 
 ### Administration audit file
 
-The REST API calls to MaxScale can be logged\
+The REST API calls to MaxScale can be logged
 by enabling [admin\_audit](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#admin_audit).
 
-For more detail see the admin audit configuration values `admin_audit`,`admin_audit_file` and `admin_audit_exclude_methods` below\
+For more detail see the admin audit configuration values `admin_audit`,`admin_audit_file` and `admin_audit_exclude_methods` below
 and [Administration Tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-mariadb-maxscale-administration-tutorial.md#administration-audit-file).
 
 ### Static Configuration Parameters
 
-The following list of global configuration parameters can **NOT** be changed at\
+The following list of global configuration parameters can **NOT** be changed at
 runtime and can only be defined in a configuration file:
 
 * `admin_auth`
@@ -171,35 +171,35 @@ runtime and can only be defined in a configuration file:
 * `substitute_variables`
 * `threads_max`
 
-All other parameters that relate to objects can be altered at runtime or can be\
+All other parameters that relate to objects can be altered at runtime or can be
 changed by destroying and recreating the object in question.
 
 ## Configuration
 
-MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If\
-the command line argument `--configdir=<path>` is given, `maxscale.cnf` is\
-searched for in _\<path>_ instead. If the argument `--config=<file>` is given,\
+MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If
+the command line argument `--configdir=<path>` is given, `maxscale.cnf` is
+searched for in _\<path>_ instead. If the argument `--config=<file>` is given,
 configuration is read from the file _\<file>_.
 
-MaxScale also looks for a directory with the same name as the configuration\
-file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale\
+MaxScale also looks for a directory with the same name as the configuration
+file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale
 recursively reads all files with the ".cnf" suffix in the directory hierarchy.\
 Other files are ignored.
 
-After loading normal configuration files, MaxScale reads runtime-generated\
+After loading normal configuration files, MaxScale reads runtime-generated
 configuration files, if any, from the [persisted configuration files directory](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#persistdir).
 
 Different configuration sections can be arranged with little restrictions.\
-Global path settings such as `logdir`, `piddir` and `datadir` are only read from\
-the main configuration file. Other global settings are also best left in the\
-main file to ensure they are read before other configuration sections are\
+Global path settings such as `logdir`, `piddir` and `datadir` are only read from
+the main configuration file. Other global settings are also best left in the
+main file to ensure they are read before other configuration sections are
 parsed.
 
 The configuration file format used is [INI](https://en.wikipedia.org/wiki/INI_file), similar to the\
-MariaDB Server. The files contain sections and each section can contain multiple\
+MariaDB Server. The files contain sections and each section can contain multiple
 key-value pairs.
 
-Comments are defined by prefixing a row with a hash (#). Trailing comments are\
+Comments are defined by prefixing a row with a hash (#). Trailing comments are
 not supported.
 
 ```
@@ -207,8 +207,8 @@ not supported.
 some_parameter=123
 ```
 
-A parameter can be defined on multiple lines as shown below. A value spread over\
-multiple lines is simply concatenated. The additional lines of the value\
+A parameter can be defined on multiple lines as shown below. A value spread over
+multiple lines is simply concatenated. The additional lines of the value
 definition need to have at least one whitespace character in the beginning.
 
 ```
@@ -224,24 +224,24 @@ servers=server1,
 
 Section names may not contain whitespace and must not start with the characters`@@`.
 
-As the object names are used to form URLs in the MaxScale REST API, they must be\
+As the object names are used to form URLs in the MaxScale REST API, they must be
 safe for use in URLs. This means that only alphanumeric characters (i.e. `a-zA-Z` and `0-9`) and the special characters `_.~-` can be used.
 
 ### Dynamic Configuration
 
 By default all changes done at runtime via the MaxScale GUI, MaxCtrl or the REST\
-API will be saved on disk, inside the [persistdir](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#persistdir) directory. The\
-changes done at runtime will override the configuration found in the static\
+API will be saved on disk, inside the [persistdir](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#persistdir) directory. The
+changes done at runtime will override the configuration found in the static
 configuration files for that particular object.
 
-This means that if an object that is found in `/etc/maxscale.cnf` is modified at\
-runtime, all future changes to it must also be done at runtime. Any\
-modifications done to `/etc/maxscale.cnf` after a runtime change has been made\
+This means that if an object that is found in `/etc/maxscale.cnf` is modified at
+runtime, all future changes to it must also be done at runtime. Any
+modifications done to `/etc/maxscale.cnf` after a runtime change has been made
 are ignored for that object.
 
-To prevent the saving of runtime changes and to make all runtime changes\
-volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`\
-section. This will make MaxScale behave like the MariaDB server does: any\
+To prevent the saving of runtime changes and to make all runtime changes
+volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`
+section. This will make MaxScale behave like the MariaDB server does: any
 changes done with `SET GLOBAL` statements are lost if the process is restarted.
 
 ### Special Parameter Types
@@ -249,16 +249,16 @@ changes done with `SET GLOBAL` statements are lost if the process is restarted.
 #### Booleans
 
 Boolean type parameters interpret the values `true`, `yes`, `on` and `1` as\_true\_ values and `false`, `no`, `off` and `0` as _false_ values. Starting with\
-MaxScale 23.02, the REST API also accepts the same boolean values for boolean\
+MaxScale 23.02, the REST API also accepts the same boolean values for boolean
 type parameters.
 
 #### Sizes
 
-Where _specifically noted_, a number denoting a size can be suffixed by a subset\
-of the IEC binary prefixes or the SI prefixes. In the former case the number\
-will be interpreted as a certain multiple of 1024 and in the latter case as a\
-certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`\
-and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,\
+Where _specifically noted_, a number denoting a size can be suffixed by a subset
+of the IEC binary prefixes or the SI prefixes. In the former case the number
+will be interpreted as a certain multiple of 1024 and in the latter case as a
+certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`
+and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,
 the matching is case insensitive.
 
 For instance, the following entries
@@ -283,8 +283,8 @@ max_size=1T
 
 #### Durations
 
-A number denoting a duration can be suffixed by one of the case-insensitive\
-suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,\
+A number denoting a duration can be suffixed by one of the case-insensitive
+suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,
 minutes, seconds and milliseconds, respectively.
 
 For instance, the following entries
@@ -299,79 +299,79 @@ soft_ttl=3600000ms
 
 are equivalent.
 
-Note that if an explicit unit is not specified, then it is specific to the\
-configuration parameter whether the duration is interpreted as seconds or\
+Note that if an explicit unit is not specified, then it is specific to the
+configuration parameter whether the duration is interpreted as seconds or
 milliseconds.
 
 _Not_ providing an explicit unit has been deprecated in MaxScale 2.4.
 
 #### Regular Expressions
 
-Many modules have settings which accept a regular expression. In most cases, these\
+Many modules have settings which accept a regular expression. In most cases, these
 settings are named either _match_ or _exclude_, and are used to filter users or queries.\
-MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching\
+MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching
 regular expressions.
 
-When writing a regular expression (regex) type parameter to a MaxScale configuration file,\
-the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This\
-clarifies where the pattern begins and ends, even if it includes whitespace. Without\
-slashes the configuration loader trims the pattern from the ends. The slashes are removed\
-before compiling the pattern. For backwards compatibility, the slashes are not yet\
-mandatory. Omitting them is, however, deprecated and will be rejected in a future release\
-of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_\
-accept parameters in this type of regular expression form. Some other modules may not\
+When writing a regular expression (regex) type parameter to a MaxScale configuration file,
+the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This
+clarifies where the pattern begins and ends, even if it includes whitespace. Without
+slashes the configuration loader trims the pattern from the ends. The slashes are removed
+before compiling the pattern. For backwards compatibility, the slashes are not yet
+mandatory. Omitting them is, however, deprecated and will be rejected in a future release
+of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_
+accept parameters in this type of regular expression form. Some other modules may not
 handle the slashes yet correctly.
 
-PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses\
-regular expressions simply, only checking whether the pattern and subject match at some\
-point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to\
-accept any query with the text "SELECT" somewhere within. To force the pattern to only\
+PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses
+regular expressions simply, only checking whether the pattern and subject match at some
+point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to
+accept any query with the text "SELECT" somewhere within. To force the pattern to only
 match at the beginning of the query, set `match=/^SELECT/`. To only match the end, set`match=/SELECT$/`.
 
-Modules which accept regular expression parameters also often accept options which affect\
-how the patterns are compiled. Typically, this setting is called _options_ and accepts\
+Modules which accept regular expression parameters also often accept options which affect
+how the patterns are compiled. Typically, this setting is called _options_ and accepts
 values such as `ignorecase`, `case` and `extended`.
 
-* `ignorecase`: Causes the regular expression matcher to ignore letter case, and\
+* `ignorecase`: Causes the regular expression matcher to ignore letter case, and
   is often on by default. When enabled, `/SELECT/` would match both `SELECT` and`select`.
-* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this\
+* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this
   is not the same as the extended regular expression syntax that for example`grep -E` uses.
-* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not\
+* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not
   match `select`.
 
-These settings can also be defined in the pattern itself, so they can be\
-used even in modules without pattern compilation settings. The pattern\
-settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)\
+These settings can also be defined in the pattern itself, so they can be
+used even in modules without pattern compilation settings. The pattern
+settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)
 for more information.
 
 **Standard regular expression settings for filters**
 
-Many filters use the settings _match_, _exclude_ and _options_. Since these settings are\
-used in a similar way across these filters, the settings are explained here. The\
-documentation of the filters link here and describe any exceptions to this\
+Many filters use the settings _match_, _exclude_ and _options_. Since these settings are
+used in a similar way across these filters, the settings are explained here. The
+documentation of the filters link here and describe any exceptions to this
 generalized explanation.
 
-These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the\
+These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the
 patterns are compiled. _options_ works as explained above, accepting the values`ignorecase`, `case` and `extended`, with `ignorecase` being the default.
 
-The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is\
+The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is
 not defined, all queries are considered to match.
 
 If _exclude_ is defined, the filter only acts on queries not matching that pattern. If\_exclude\_ is not defined, nothing is excluded.
 
 If both are defined, the query needs to match _match_ but not match _exclude_.
 
-Even if a filter does not act on a query, the query is not lost. The query is simply\
+Even if a filter does not act on a query, the query is not lost. The query is simply
 passed on to the next module in the processing chain as if the filter was not there.
 
 #### Enumerations
 
-Enumeration type parameters have a pre-defined set of accepted values. For types\
-declared as `enum`, only one value is accepted. For `enum_mask` types, multiple\
+Enumeration type parameters have a pre-defined set of accepted values. For types
+declared as `enum`, only one value is accepted. For `enum_mask` types, multiple
 values can be defined by separating them with commas. All enumeration values in\
 MaxScale are case-sensitive.
 
-For example the `router_options` parameter in the `readconnroute` router is a\
+For example the `router_options` parameter in the `readconnroute` router is a
 mask type enumeration:
 
 ```
@@ -380,7 +380,7 @@ router_options=master,slave
 
 #### Path Lists
 
-A `pathlist` type parameter expects one or more filesystem paths separated by\
+A `pathlist` type parameter expects one or more filesystem paths separated by
 colons. The value must not include space between the separators.
 
 Here is an example path list parameter that points to `/tmp/something.log` and`/var/log/maxscale/maxscale.log`:
@@ -391,8 +391,8 @@ path_list_parameter=/tmp/something.log:/var/log/maxscale/maxscale.log
 
 ### Global Settings
 
-The global settings, in a section named `[MaxScale]`, allow various parameters\
-that affect MariaDB MaxScale as a whole to be tuned. This section must be\
+The global settings, in a section named `[MaxScale]`, allow various parameters
+that affect MariaDB MaxScale as a whole to be tuned. This section must be
 defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 
 #### `core_file`
@@ -401,9 +401,9 @@ defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 * Default: true
 * Dynamic: No
 
-This parameter specifies whether a core file should be generated if MaxScale\
-crashes. The default is `true` although usually a core file is not needed,\
-as MaxScale is capable of logging the full stack trace of all threads\
+This parameter specifies whether a core file should be generated if MaxScale
+crashes. The default is `true` although usually a core file is not needed,
+as MaxScale is capable of logging the full stack trace of all threads
 when it crashes.
 
 #### `auto_tune`
@@ -414,7 +414,7 @@ when it crashes.
 * Mandatory: No
 * Dynamic: No
 
-An _auto tunable_ parameter is a parameter whose value can be derived from a\
+An _auto tunable_ parameter is a parameter whose value can be derived from a
 particular server variable. With this parameter it can be specified whether`all` or a specific set of parameters should automatically be set.
 
 The current auto tunable parameters are:
@@ -424,13 +424,13 @@ The current auto tunable parameters are:
 | [connection\_keepalive](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#connection_keepalive)                                | 80% of the smallest [wait\_timeout](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#wait_timeout) value of the servers used by the service |
 | [wait\_timeout](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#wait_timeout) | The smallest [wait\_timeout](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#wait_timeout) value of the servers used by the service        |
 
-The values of the server variables are collected by monitors, which means that\
-if the servers of a service are not monitored by a monitor, then the parameters\
+The values of the server variables are collected by monitors, which means that
+if the servers of a service are not monitored by a monitor, then the parameters
 of that service will not be auto tuned.
 
-Note that even if `auto_tune` is set to `all`, the auto tunable parameters\
+Note that even if `auto_tune` is set to `all`, the auto tunable parameters
 can still be set in the configuration file and modified with _maxctrl_.\
-However, the specified value will be overwritten at the next auto tuning\
+However, the specified value will be overwritten at the next auto tuning
 round, but only if the servers of the service are monitored by a monitor.
 
 #### `threads`
@@ -440,20 +440,20 @@ round, but only if the servers of the service are monitored by a monitor.
 * Dynamic: No
 * Default: `auto`
 
-This parameter controls the number of worker threads that are handling the\
-events coming from the kernel. The default is `auto` which uses as many threads\
-as there are CPU cores. MaxScale versions older than 6 used one thread by\
+This parameter controls the number of worker threads that are handling the
+events coming from the kernel. The default is `auto` which uses as many threads
+as there are CPU cores. MaxScale versions older than 6 used one thread by
 default.
 
-You can explicitly enable automatic configuration of this value by setting the\
-value to `auto`. This way MariaDB MaxScale will detect the number of available\
+You can explicitly enable automatic configuration of this value by setting the
+value to `auto`. This way MariaDB MaxScale will detect the number of available
 processors and set the amount of threads to be equal to that number.
 
-Note that if MaxScale is running in a container where the CPU resources\
-have been limited, the use of `auto` may cause MaxScale to use more resources\
-than what is available. In such a situation `auto` should not be used, but instead\
-an explicit number that corresponds to the amount of CPU resources available in\
-the container. As a rule of thumb, an appropriate value for `threads` is the\_vCPU\_ of the container rounded up to the nearest integer. For instance, if\
+Note that if MaxScale is running in a container where the CPU resources
+have been limited, the use of `auto` may cause MaxScale to use more resources
+than what is available. In such a situation `auto` should not be used, but instead
+an explicit number that corresponds to the amount of CPU resources available in
+the container. As a rule of thumb, an appropriate value for `threads` is the\_vCPU\_ of the container rounded up to the nearest integer. For instance, if
 the _vCPU_ of the container is `0.5` then `1` is an appropriate value for`threads`, if the _vCPU_ is `2.3` then `3` is.
 
 The maximum value for `threads` is specified by [threads\_max](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#threads_max).
@@ -470,7 +470,7 @@ From 23.02 onwards it is possible to change the number threads at runtime.\
 Please see [Threads](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#threads-1) for more details.
 
 Additional threads will be created to execute other internal services within\
-MariaDB MaxScale. This setting is used to configure the number of threads that\
+MariaDB MaxScale. This setting is used to configure the number of threads that
 will be used to manage the user connections.
 
 #### `threads_max`
@@ -479,11 +479,11 @@ will be used to manage the user connections.
 * Default: 256
 * Dynamic: No
 
-This parameter specifies the hard limit for the number of worker threads,\
+This parameter specifies the hard limit for the number of worker threads,
 which is specified using [threads](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#threads).
 
-At startup, if the value of `threads` is larger than that of `threads_max`,\
-the value of `threads` will be reduced to that. At runtime, an attempt to\
+At startup, if the value of `threads` is larger than that of `threads_max`,
+the value of `threads` will be reduced to that. At runtime, an attempt to
 increase the value of `threads` beyond that of `threads_max` is an error.
 
 #### `rebalance_period`
@@ -493,19 +493,19 @@ increase the value of `threads` beyond that of `threads_max` is an error.
 * Dynamic: Yes
 * Default: `0s`
 
-This duration parameter controls how often the load of the worker threads\
-should be checked. The default value is 0, which means that no checks and\
+This duration parameter controls how often the load of the worker threads
+should be checked. The default value is 0, which means that no checks and
 no rebalancing will be performed.
 
 ```
 rebalance_period=10s
 ```
 
-Note that the value of `rebalance_period` should not be smaller than the\
+Note that the value of `rebalance_period` should not be smaller than the
 value of `rebalance_window` whose default value is 10.
 
-If the value of `rebalance_period` is significantly shorter than that\
-of `rebalance_window`, it may lead to oscillation where work is constantly\
+If the value of `rebalance_period` is significantly shorter than that
+of `rebalance_window`, it may lead to oscillation where work is constantly
 moved from one thread to another.
 
 #### `rebalance_threshold`
@@ -515,21 +515,21 @@ moved from one thread to another.
 * Dynamic: Yes
 * Default: `20`
 
-This integer parameter controls at which point MaxScale should start\
+This integer parameter controls at which point MaxScale should start
 moving work from one worker thread to another.
 
 If the difference in load between the thread with the maximum load and\
 the thread with the minimum load is larger than the value of this parameter,\
 then work will be moved from the former to the latter.
 
-Although the load of a thread can vary between 0 and 100, the value of this\
+Although the load of a thread can vary between 0 and 100, the value of this
 parameter must be between 5 and 100.
 
 ```
 rebalance_threshold=15
 ```
 
-Note that rebalancing will not be performed unless `rebalance_period`\
+Note that rebalancing will not be performed unless `rebalance_period`
 has been specified.
 
 #### `rebalance_window`
@@ -539,11 +539,11 @@ has been specified.
 * Dynamic: Yes
 * Default: `10`
 
-This integer parameter controls how many seconds of load should be\
-taken into account when deciding whether work should be moved from\
+This integer parameter controls how many seconds of load should be
+taken into account when deciding whether work should be moved from
 one thread to another.
 
-The default value is 10, which means that the load during the last 10\
+The default value is 10, which means that the load during the last 10
 seconds is considered when deciding whether work should be moved.
 
 The minimum value is 1 and the maximum 60.
@@ -555,8 +555,8 @@ The minimum value is 1 and the maximum 60.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether reverse domain name lookups are made to convert\
-client IP addresses to hostnames. If enabled, client IP addresses will not be\
+This parameter controls whether reverse domain name lookups are made to convert
+client IP addresses to hostnames. If enabled, client IP addresses will not be
 resolved to hostnames during authentication or for the REST API even if requested.
 
 If you have database users that use a hostname in the host part of the user\
@@ -572,8 +572,8 @@ an IP address.
 * Dynamic: Yes
 * Default: `10s`
 
-Duration, default 10s. This setting defines the connection timeout when\
-attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same\
+Duration, default 10s. This setting defines the connection timeout when
+attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same
 value is also used for read and write timeouts. Increasing this value causes\
 MaxScale to wait longer for a response from a server before user fetching fails.\
 Other servers may then be attempted.
@@ -582,10 +582,10 @@ Other servers may then be attempted.
 auth_connect_timeout=10s
 ```
 
-The value is given as [a duration](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,\
-the value is interpreted as seconds. In subsequent versions a value without a\
-unit may be rejected. Since the granularity of the timeout is seconds, a timeout\
-specified in milliseconds will be rejected even if the given value is longer\
+The value is given as [a duration](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,
+the value is interpreted as seconds. In subsequent versions a value without a
+unit may be rejected. Since the granularity of the timeout is seconds, a timeout
+specified in milliseconds will be rejected even if the given value is longer
 than a second.
 
 #### `auth_read_timeout`
@@ -603,14 +603,14 @@ Deprecated and ignored as of MaxScale 2.5.0. See _auth\_connect\_timeout_ above.
 * Dynamic: No
 * Default: `1`
 
-The number of times an interrupted internal query will be retried. The default\
-is to retry the query once. This feature was added in MaxScale 2.1.10 and was\
+The number of times an interrupted internal query will be retried. The default
+is to retry the query once. This feature was added in MaxScale 2.1.10 and was
 disabled by default until MaxScale 2.3.0.
 
-An interrupted query is any query that is interrupted by a network\
-error. Connection timeouts are included in network errors and thus is it\
-advisable to make sure that the value of `query_retry_timeout` is set to an\
-adequate value. Internal queries are only used to retrieve authentication data\
+An interrupted query is any query that is interrupted by a network
+error. Connection timeouts are included in network errors and thus is it
+advisable to make sure that the value of `query_retry_timeout` is set to an
+adequate value. Internal queries are only used to retrieve authentication data
 and monitor the servers.
 
 #### `query_retry_timeout`
@@ -620,16 +620,16 @@ and monitor the servers.
 * Dynamic: Yes
 * Default: `10s`
 
-The total timeout in seconds for any retried queries. The default value is 5\
+The total timeout in seconds for any retried queries. The default value is 5
 seconds.
 
-An interrupted query is retried for either the configured amount of attempts or\
+An interrupted query is retried for either the configured amount of attempts or
 until the configured timeout is reached.
 
-The value is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `passive`
@@ -639,11 +639,11 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `false`
 
-Controls whether MaxScale is a passive node in a cluster of multiple MaxScale\
+Controls whether MaxScale is a passive node in a cluster of multiple MaxScale
 instances.
 
-This parameter is intended to be used with multiple MaxScale instances that use\
-failover functionality to manipulate the cluster in some form. Passive nodes\
+This parameter is intended to be used with multiple MaxScale instances that use
+failover functionality to manipulate the cluster in some form. Passive nodes
 only observe the clusters being monitored and take no direct actions.
 
 The following functionality is disabled when passive mode is enabled:
@@ -652,8 +652,8 @@ The following functionality is disabled when passive mode is enabled:
 * Automatic rejoin in the `mariadbmon` module
 * Launching of monitor scripts
 
-**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and\
-route any traffic sent to it. The **only** operations affected by the passive\
+**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and
+route any traffic sent to it. The **only** operations affected by the passive
 mode are the ones listed above.
 
 #### `ms_timestamp`
@@ -663,7 +663,7 @@ mode are the ones listed above.
 * Dynamic: Yes
 * Default: `false`
 
-Enable or disable the high precision timestamps in logfiles. Enabling this adds\
+Enable or disable the high precision timestamps in logfiles. Enabling this adds
 millisecond precision to all logfile timestamps.
 
 #### `skip_permission_checks`
@@ -673,13 +673,13 @@ millisecond precision to all logfile timestamps.
 * Dynamic: Yes
 * Default: `false`
 
-Skip service and monitor user permission checks. This is useful when you know\
+Skip service and monitor user permission checks. This is useful when you know
 the permissions are OK and you want to speed up the startup process.
 
-It is recommended to not disable the permission checks so that any missing\
-privileges are detected when maxscale is starting up. If you are experiencing a\
-slow startup of MaxScale due to large amounts of connection timeouts when\
-permissions are checked, disabling the permission checks could speed up the\
+It is recommended to not disable the permission checks so that any missing
+privileges are detected when maxscale is starting up. If you are experiencing a
+slow startup of MaxScale due to large amounts of connection timeouts when
+permissions are checked, disabling the permission checks could speed up the
 startup process.
 
 ```
@@ -693,10 +693,10 @@ skip_permission_checks=true
 * Dynamic: Yes
 * Default: `false`
 
-Log messages to the system journal. This logs messages using the native SystemD\
+Log messages to the system journal. This logs messages using the native SystemD
 journal interface. The logs can be viewed with `journalctl`.
 
-MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be\
+MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be
 logged twice: once into the system journal and once into MaxScale's own logfile.
 
 #### `maxlog`
@@ -717,8 +717,8 @@ Log messages to MariaDB MaxScale's log file. The name of the log file is`maxscal
 
 Log messages whose syslog priority is _warning_.
 
-MaxScale logs warning level messages whenever a condition is encountered that\
-the user should be notified of but does not require immediate action or it\
+MaxScale logs warning level messages whenever a condition is encountered that
+the user should be notified of but does not require immediate action or it
 indicates a minor problem.
 
 #### `log_notice`
@@ -730,8 +730,8 @@ indicates a minor problem.
 
 Log messages whose syslog priority is _notice_.
 
-These messages contain information that is helpful for the user and they usually\
-do not indicate a problem. These are logged whenever something worth nothing\
+These messages contain information that is helpful for the user and they usually
+do not indicate a problem. These are logged whenever something worth nothing
 happens in either MaxScale or in the servers it monitors.
 
 #### `log_info`
@@ -744,10 +744,10 @@ happens in either MaxScale or in the servers it monitors.
 Log messages whose syslog priority is _info_.
 
 These messages provide detailed information about the internal workings of\
-MariaDB MaxScale. These messages should only be enabled when there is a need to\
-inspect the internal logic of MaxScale. A common use-case is to see why a\
-particular query was handled in a certain way. Almost all modules log some\
-messages on the info level and this can be very helpful when trying to solve\
+MariaDB MaxScale. These messages should only be enabled when there is a need to
+inspect the internal logic of MaxScale. A common use-case is to see why a
+particular query was handled in a certain way. Almost all modules log some
+messages on the info level and this can be very helpful when trying to solve
 routing related problems.
 
 #### `log_debug`
@@ -759,11 +759,11 @@ routing related problems.
 
 Log messages whose syslog priority is _debug_.
 
-These messages are intended for development purposes and are disabled by\
+These messages are intended for development purposes and are disabled by
 default. These are rarely useful outside of debugging core MaxScale issues.
 
-**Note:** If MariaDB MaxScale has been built in release mode, then debug\
-messages are excluded from the build and this setting will not have any\
+**Note:** If MariaDB MaxScale has been built in release mode, then debug
+messages are excluded from the build and this setting will not have any
 effect. If an attempt to enable these is made, a warning is logged.
 
 #### `log_warn_super_user`
@@ -773,10 +773,10 @@ effect. If an attempt to enable these is made, a warning is logged.
 * Dynamic: No
 * Default: `false`
 
-When enabled, a warning is logged whenever a client with SUPER-privilege\
-successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The\
-setting is intended for diagnosing situations where a client interferes with a\
-primary server switchover. Super-users bypass the _read\_only_-flag which\
+When enabled, a warning is logged whenever a client with SUPER-privilege
+successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The
+setting is intended for diagnosing situations where a client interferes with a
+primary server switchover. Super-users bypass the _read\_only_-flag which
 switchover uses to block writes to the primary.
 
 #### `log_augmentation`
@@ -786,9 +786,9 @@ switchover uses to block writes to the primary.
 * Dynamic: Yes
 * Default: `0`
 
-Enable or disable the augmentation of messages. If this is enabled, then each\
-logged message is appended with the name of the function where the message was\
-logged. This is primarily for development purposes and hence is disabled by\
+Enable or disable the augmentation of messages. If this is enabled, then each
+logged message is appended with the name of the function where the message was
+logged. This is primarily for development purposes and hence is disabled by
 default.
 
 ```
@@ -806,10 +806,10 @@ To disable the augmentation use the value 0 and to enable it use the value 1.
 * Dynamic: Yes
 * Default: `10, 1000ms, 10000ms`
 
-It is possible that a particular error (or warning) is logged over and over\
-again, if the cause for the error persistently remains. To prevent the log from\
-flooding, it is possible to specify how many times a particular error may be\
-logged within a time period, before the logging of that error is suppressed for\
+It is possible that a particular error (or warning) is logged over and over
+again, if the cause for the error persistently remains. To prevent the log from
+flooding, it is possible to specify how many times a particular error may be
+logged within a time period, before the logging of that error is suppressed for
 a while.
 
 ```
@@ -825,18 +825,18 @@ log_throttling=8, 2s, 15000ms
 In the example above, the logging of a particular error will be suppressed for\
 15 seconds if the error has been logged 8 times in 2 seconds.
 
-The default is `10, 1000ms, 10000ms`, which means that if the same error is\
-logged 10 times in one second, the logging of that error is suppressed for the\
+The default is `10, 1000ms, 10000ms`, which means that if the same error is
+logged 10 times in one second, the logging of that error is suppressed for the
 following 10 seconds.
 
-Whenever an error message that is being throttled is logged within the\
-triggering window (the second argument), the suppression window is\
-extended. This continues until there is a pause in the messages that is longer\
+Whenever an error message that is being throttled is logged within the
+triggering window (the second argument), the suppression window is
+extended. This continues until there is a pause in the messages that is longer
 than the triggering window.
 
-For example, with the default configuration the messages must pause for at least\
-one second in order for the throttling to eventually stop. This mechanism\
-prevents long-lasting error conditions from slowly filling up the log with short\
+For example, with the default configuration the messages must pause for at least
+one second in order for the throttling to eventually stop. This mechanism
+prevents long-lasting error conditions from slowly filling up the log with short
 bursts of messages.
 
 To disable log throttling, add an entry with an empty value
@@ -851,8 +851,8 @@ or one where any of the integers is 0.
 log_throttling=0, 0, 0
 ```
 
-The durations can be specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In\
+The durations can be specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In
 subsequent versions a value without a unit may be rejected.
 
 Note that _notice_, _info_ and _debug_ messages are never throttled.
@@ -864,7 +864,7 @@ Note that _notice_, _info_ and _debug_ messages are never throttled.
 * Dynamic: No
 * Default: `/var/log/maxscale`
 
-Set the directory where the logfiles are stored. The folder needs to be both\
+Set the directory where the logfiles are stored. The folder needs to be both
 readable and writable by the user running MariaDB MaxScale.
 
 ```
@@ -879,10 +879,10 @@ logdir=/var/log/maxscale/
 * Default: `/var/lib/maxscale`
 
 Set the directory where the data files used by MariaDB MaxScale are stored.\
-Modules can write to this directory and for example the binlogrouter uses this\
+Modules can write to this directory and for example the binlogrouter uses this
 folder as the default location for storing binary logs.
 
-This is also the directory where the password encryption key is read from that\
+This is also the directory where the password encryption key is read from that
 is generated by `maxkeys`.
 
 ```
@@ -896,10 +896,10 @@ datadir=/var/lib/maxscale/
 * Dynamic: No
 * Default: `""`
 
-The location where the `.secrets` file is read from. If `secretsdir` is not\
+The location where the `.secrets` file is read from. If `secretsdir` is not
 defined, the file is read from [datadir](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#datadir).
 
-This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6\
+This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6
 and 24.02.2.
 
 #### `libdir`
@@ -909,12 +909,12 @@ and 24.02.2.
 * Dynamic: No
 * Default: OS Dependent
 
-Set the directory where MariaDB MaxScale looks for modules. The library\
-directory is the only directory that MariaDB MaxScale uses when it searches for\
-modules. If you have custom modules for MariaDB MaxScale, make sure you have\
+Set the directory where MariaDB MaxScale looks for modules. The library
+directory is the only directory that MariaDB MaxScale uses when it searches for
+modules. If you have custom modules for MariaDB MaxScale, make sure you have
 them in this folder.
 
-The default value depends on the operating system. For RHEL versions the value\
+The default value depends on the operating system. For RHEL versions the value
 is `/usr/lib64/maxscale/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/`
 
 ```
@@ -930,14 +930,14 @@ libdir=/usr/lib64/maxscale/
 
 Sets the directory where static data assets are loaded.
 
-The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI\
-files have been manually moved somewhere else, this path must be configured to\
+The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI
+files have been manually moved somewhere else, this path must be configured to
 point to the parent directory of the `gui/` subdirectory.
 
-The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path\
-resolves to outside of this directory are not served by the MaxScale GUI: this\
+The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path
+resolves to outside of this directory are not served by the MaxScale GUI: this
 is done to prevent other files from being accessible via the MaxScale REST\
-API. This means that path to the GUI source directory can contain symbolic links\
+API. This means that path to the GUI source directory can contain symbolic links
 but all parts after the `/gui/` directory must reside inside it.
 
 #### `cachedir`
@@ -960,7 +960,7 @@ cachedir=/var/cache/maxscale/
 * Dynamic: No
 * Default: `/var/run/maxscale`
 
-Configure the directory for the PID file for MariaDB MaxScale. This file\
+Configure the directory for the PID file for MariaDB MaxScale. This file
 contains the Process ID for the running MariaDB MaxScale process.
 
 ```
@@ -974,8 +974,8 @@ piddir=/var/run/maxscale/
 * Dynamic: No
 * Default: `/usr/bin`
 
-Configure the directory where the executable files reside. All internal\
-processes which are launched will use this directory to look for executable\
+Configure the directory where the executable files reside. All internal
+processes which are launched will use this directory to look for executable
 files.
 
 ```
@@ -989,13 +989,13 @@ execdir=/usr/bin/
 * Dynamic: No
 * Default: OS Dependent
 
-Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C\
-used in MaxScale can use this directory to load authentication plugins. The\
-versions of the plugins must be binary compatible with the connector version\
+Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C
+used in MaxScale can use this directory to load authentication plugins. The
+versions of the plugins must be binary compatible with the connector version
 that MaxScale was built with.
 
-Starting with version 6.2.0, the plugins are bundled with MaxScale and the\
-default value now points to the bundled plugins. The location where the plugins\
+Starting with version 6.2.0, the plugins are bundled with MaxScale and the
+default value now points to the bundled plugins. The location where the plugins
 are stored depends on the operating system. For RHEL versions the value is`/usr/lib64/maxscale/plugin/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/plugin/`.
 
 Older versions of MaxScale used `/usr/lib/mysql/plugin/` as the default value.
@@ -1011,10 +1011,10 @@ connector_plugindir=/usr/lib64/maxscale/plugin/
 * Dynamic: No
 * Default: `/var/lib/maxscale/maxscale.cnf.d/`
 
-Configure the directory where persisted configurations are stored. When a new\
-object is created via MaxCtrl, it will be stored in this directory. Do not use\
-this directory for normal configuration files, use _/etc/maxscale.cnf.d/_\
-instead. The user MaxScale is running as must be able to write into this\
+Configure the directory where persisted configurations are stored. When a new
+object is created via MaxCtrl, it will be stored in this directory. Do not use
+this directory for normal configuration files, use _/etc/maxscale.cnf.d/_
+instead. The user MaxScale is running as must be able to write into this
 directory.
 
 ```
@@ -1028,16 +1028,16 @@ persistdir=/var/lib/maxscale/maxscale.cnf.d/
 * Dynamic: No
 * Default: `/etc/maxscale.modules.d/`
 
-Configure the directory where module configurations are stored. Path arguments\
-are resolved relative to this directory. This directory should be used to store\
+Configure the directory where module configurations are stored. Path arguments
+are resolved relative to this directory. This directory should be used to store
 module specific configurations.
 
-Any configuration parameter that is not an absolute path will be interpreted as\
-a relative path. The relative paths use the module configuration directory as\
+Any configuration parameter that is not an absolute path will be interpreted as
+a relative path. The relative paths use the module configuration directory as
 the working directory.
 
-For example, the configuration parameter `file=my_file.txt` would be interpreted\
-as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would\
+For example, the configuration parameter `file=my_file.txt` would be interpreted
+as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would
 be interpreted as `/home/user/my_file.txt`.
 
 ```
@@ -1051,7 +1051,7 @@ module_configdir=/etc/maxscale.modules.d/
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will\
+Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will
 look for the errmsg.sys file installed with MariaDB MaxScale from this folder.
 
 ```
@@ -1065,8 +1065,8 @@ language=/var/lib/maxscale/
 * Dynamic: No
 * Default: `qc_sqlite`
 
-The module used by MariaDB MaxScale for query classification. The information\
-provided by this module is used by MariaDB MaxScale when deciding where a\
+The module used by MariaDB MaxScale for query classification. The information
+provided by this module is used by MariaDB MaxScale when deciding where a
 particular statement should be sent. The default query classifier is\_qc\_sqlite\_.
 
 #### `query_classifier_cache_size`
@@ -1077,20 +1077,20 @@ particular statement should be sent. The default query classifier is\_qc\_sqlite
 * Default: System Dependent
 
 Specifies the maximum size of the query classifier cache. The default limit is\
-15% of total system memory starting with MaxScale 2.3.7. In older versions the\
+15% of total system memory starting with MaxScale 2.3.7. In older versions the
 default limit was 40% of total system memory. This feature was added in MaxScale\
 2.3.0.
 
-When the query classifier cache has been enabled, MaxScale will, after a\
-statement has been parsed, store the classification result using the\
+When the query classifier cache has been enabled, MaxScale will, after a
+statement has been parsed, store the classification result using the
 canonicalized version of the statement as the key.
 
-If the classification result for a statement is needed, MaxScale will first\
-canonicalize the statement and check whether the result can be found in the\
-cache. If it can, the statement will not be parsed at all but the cached result\
+If the classification result for a statement is needed, MaxScale will first
+canonicalize the statement and check whether the result can be found in the
+cache. If it can, the statement will not be parsed at all but the cached result
 is used.
 
-The configuration parameter takes one integer that specifies the maximum size of\
+The configuration parameter takes one integer that specifies the maximum size of
 the cache. The size of the cache can be specified as explained [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#sizes).
 
 ```
@@ -1098,17 +1098,17 @@ the cache. The size of the cache can be specified as explained [here](mariadb-ma
 query_classifier_cache_size=1MB
 ```
 
-Note that MaxScale uses a separate cache for each worker thread. To obtain the\
-amount of memory available for each thread, divide the cache size with the value\
-of `threads`. If statements are evicted from the cache (visible in the\
+Note that MaxScale uses a separate cache for each worker thread. To obtain the
+amount of memory available for each thread, divide the cache size with the value
+of `threads`. If statements are evicted from the cache (visible in the
 diagnostic output), consider increasing the cache size.
 
-Note also that limit is not a hard limit, but an approximate one. Namely, although\
-the memory needed for storing the canonicalized statement and the classification\
-result is correctly accounted for, there is additional overhead whose size is not\
+Note also that limit is not a hard limit, but an approximate one. Namely, although
+the memory needed for storing the canonicalized statement and the classification
+result is correctly accounted for, there is additional overhead whose size is not
 exactly known and over which we do not have direct control.
 
-Using `maxctrl show threads` it is possible to check what the actual size of\
+Using `maxctrl show threads` it is possible to check what the actual size of
 the cache is and to see performance statistics.
 
 | Key                | Meaning                                                                                                                 |
@@ -1126,7 +1126,7 @@ the cache is and to see performance statistics.
 * Dynamic: No
 * Default: `""`
 
-Arguments for the query classifier. What arguments are accepted depends on the\
+Arguments for the query classifier. What arguments are accepted depends on the
 particular query classifier being used. The default query classifier -_qc\_sqlite_ - supports the following arguments:
 
 **`log_unrecognized_statements`**
@@ -1134,9 +1134,9 @@ particular query classifier being used. The default query classifier -_qc\_sqlit
 An integer argument taking the following values:
 
 * 0: Nothing is logged. This is the default.
-* 1: Statements that cannot be parsed completely are logged. They may have been\
+* 1: Statements that cannot be parsed completely are logged. They may have been
   partially parsed, or classified based on keyword matching.
-* 2: Statements that cannot even be partially parsed are logged. They may have\
+* 2: Statements that cannot even be partially parsed are logged. They may have
   been classified based on keyword matching.
 * 3: Statements that cannot even be classified by keyword matching are logged.
 
@@ -1145,8 +1145,8 @@ query_classifier=qc_sqlite
 query_classifier_args=log_unrecognized_statements=1
 ```
 
-This will log all statements that cannot be parsed completely. This may be\
-useful if you suspect that MariaDB MaxScale routes statements to the wrong\
+This will log all statements that cannot be parsed completely. This may be
+useful if you suspect that MariaDB MaxScale routes statements to the wrong
 server (e.g. to a replica instead of to a primary).
 
 #### `substitute_variables`
@@ -1156,15 +1156,15 @@ server (e.g. to a replica instead of to a primary).
 * Dynamic: No
 * Default: `false`
 
-Enable or disable the substitution of environment variables in the MaxScale\
-configuration file. If the substitution of variables is enabled and a\
+Enable or disable the substitution of environment variables in the MaxScale
+configuration file. If the substitution of variables is enabled and a
 configuration line like
 
 ```
 some_parameter=$SOME_VALUE
 ```
 
-is encountered, then `$SOME_VALUE` will be replaced with the actual value\
+is encountered, then `$SOME_VALUE` will be replaced with the actual value
 of the environment variable `SOME_VALUE`. Note: _Variable substitution will be made only if '$' is the first character of the value._ _Everything_ following '$' is interpreted as the name of the environment
 variable.
 
@@ -1174,9 +1174,9 @@ variable.
 substitute_variables=true
 ```
 
-The setting of `substitute_variables` will have an effect on all parameters\
-in the all other sections, irrespective of where the `[maxscale]` section\
-is placed in the configuration file. However, in the `[maxscale]` section,\
+The setting of `substitute_variables` will have an effect on all parameters
+in the all other sections, irrespective of where the `[maxscale]` section
+is placed in the configuration file. However, in the `[maxscale]` section,
 to ensure that substitution will take place, place the`substitute_variables=true` line first.
 
 #### `sql_mode`
@@ -1187,7 +1187,7 @@ to ensure that substitution will take place, place the`substitute_variables=true
 * Values: `default`, `oracle`
 * Default: `default`
 
-Specifies whether the query classifier parser should initially expect _MariaDB_\
+Specifies whether the query classifier parser should initially expect _MariaDB_
 or _PL/SQL_ kind of SQL.
 
 The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`oracle` : The parser expects PL/SQL.
@@ -1196,7 +1196,7 @@ The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`orac
 sql_mode=oracle
 ```
 
-**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume\
+**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume
 that `autocommit` initially is off.
 
 At runtime, MariaDB MaxScale will recognize statements like
@@ -1213,12 +1213,12 @@ set sql_mode=default;
 
 and change mode accordingly.
 
-**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also\
-behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave\
+**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also
+behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave
 as if `autocommit` had been turned on.
 
-Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of\
-the server, so the value of `sql_mode` should reflect the sql mode used\
+Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of
+the server, so the value of `sql_mode` should reflect the sql mode used
 when the server is started.
 
 #### `local_address`
@@ -1230,8 +1230,8 @@ when the server is started.
 
 What specific local address/interface to use when connecting to servers.
 
-This can be used for ensuring that MaxScale uses a particular interface\
-when connecting to servers, in case the computer MaxScale is running on\
+This can be used for ensuring that MaxScale uses a particular interface
+when connecting to servers, in case the computer MaxScale is running on
 has multiple interfaces.
 
 ```
@@ -1245,27 +1245,27 @@ local_address=192.168.1.254
 * Dynamic: Yes
 * Default: `30s`
 
-How often, in seconds, MaxScale at most may refresh the users from the\
+How often, in seconds, MaxScale at most may refresh the users from the
 backend server.
 
-MaxScale will at startup load the users from the backend server, but if\
-the authentication of a user fails, MaxScale assumes it is because a new\
-user has been created and will thus refresh the users. By default, MaxScale\
-will do that at most once per 30 seconds and with this configuration option\
-that can be changed. A value of 0 allows infinite refreshes and a negative\
+MaxScale will at startup load the users from the backend server, but if
+the authentication of a user fails, MaxScale assumes it is because a new
+user has been created and will thus refresh the users. By default, MaxScale
+will do that at most once per 30 seconds and with this configuration option
+that can be changed. A value of 0 allows infinite refreshes and a negative
 value disables the refreshing entirely.
 
 ```
 users_refresh_time=120s
 ```
 
-The value is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds\
+In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds
 but, due to a bug, the default value was 0 which allowed infinite refreshes.
 
 #### `users_refresh_interval`
@@ -1275,12 +1275,12 @@ but, due to a bug, the default value was 0 which allowed infinite refreshes.
 * Dynamic: Yes
 * Default: `0s`
 
-How often, in seconds, MaxScale will automatically refresh the users from the\
+How often, in seconds, MaxScale will automatically refresh the users from the
 backend server.
 
-This configuration is used to periodically refresh the backend users, making sure\
-they are up to date. The default value for this setting is 0, meaning the users\
-are not periodically refreshed. However, they can still be refreshed in case of\
+This configuration is used to periodically refresh the backend users, making sure
+they are up to date. The default value for this setting is 0, meaning the users
+are not periodically refreshed. However, they can still be refreshed in case of
 failed authentication depending on `users_refresh_time`.
 
 ```
@@ -1294,13 +1294,13 @@ users_refresh_interval=2h
 * Dynamic: Yes
 * Default: `0`
 
-How many statements MaxScale should store for each session. This is for\
-debugging purposes, as in case of problems it is often of value to be able\
-to find out exactly what statements were sent before a particular\
+How many statements MaxScale should store for each session. This is for
+debugging purposes, as in case of problems it is often of value to be able
+to find out exactly what statements were sent before a particular
 problem turned up.
 
-**Note:** See also `dump_last_statements` using which the actual dumping\
-of the statements is enabled. Unless both of the parameters are defined,\
+**Note:** See also `dump_last_statements` using which the actual dumping
+of the statements is enabled. Unless both of the parameters are defined,
 the statement dumping mechanism doesn't work.
 
 ```
@@ -1315,10 +1315,10 @@ retain_last_statements=20
 * Values: `on_close`, `on_error`, `never`
 * Default: `never`
 
-With this configuration item it is specified in what circumstances MaxScale\
-should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never\
-logged, with `on_error` they are logged if the client closes the connection\
-improperly, and with `on_close` they are always logged when a client session\
+With this configuration item it is specified in what circumstances MaxScale
+should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never
+logged, with `on_error` they are logged if the client closes the connection
+improperly, and with `on_close` they are always logged when a client session
 is closed.
 
 ```
@@ -1326,7 +1326,7 @@ dump_last_statements=on_error
 ```
 
 Note that you need to specify with `retain_last_statements` how many statements\
-MaxScale should retain for each session. Unless it has been set to another value\
+MaxScale should retain for each session. Unless it has been set to another value
 than `0`, this configuration setting will not have an effect.
 
 #### `session_trace`
@@ -1336,8 +1336,8 @@ than `0`, this configuration setting will not have an effect.
 * Dynamic: Yes
 * Default: `0`
 
-How many log entries are stored in the session specific trace log. This log is\
-written to disk when a session ends abnormally and can be used for debugging\
+How many log entries are stored in the session specific trace log. This log is
+written to disk when a session ends abnormally and can be used for debugging
 purposes. Currently the session trace log is written to the log in the following situations:
 
 * When MaxScale receives a fatal signal and is about to crash.
@@ -1345,8 +1345,8 @@ purposes. Currently the session trace log is written to the log in the following
 * If the session is not closed gracefully (i.e. client doesn't send a COM\_QUIT packet)
 * Whenever readwritesplit receives a response that is was not expecting.
 
-It would be good to enable this if a session is disconnected and the log is not\
-detailed enough. In this case the info log might reveal the true cause of why\
+It would be good to enable this if a session is disconnected and the log is not
+detailed enough. In this case the info log might reveal the true cause of why
 the connection was closed.
 
 ```
@@ -1358,9 +1358,9 @@ Default is `0`.
 The session trace log is also exposed by REST API and is shown with`maxctrl show sessions`.
 
 The order in which the session trace messages are logged into the log changed in\
-MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal\
-log order" of older events coming first and newer events appearing later in the\
-file. Older versions of MaxScale logged the trace dump in the reverse order with\
+MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal
+log order" of older events coming first and newer events appearing later in the
+file. Older versions of MaxScale logged the trace dump in the reverse order with
 the newest messages first and oldest ones last.
 
 #### `session_trace_match`
@@ -1370,17 +1370,17 @@ the newest messages first and oldest ones last.
 * Dynamic: Yes
 * Default: None
 
-If both `session_trace` and `session_trace_match` are defined, and a trace log\
-entry of a session matches the regular expression, the trace log is written to\
+If both `session_trace` and `session_trace_match` are defined, and a trace log
+entry of a session matches the regular expression, the trace log is written to
 disk. The check for the match is done when the session is stopping.
 
-The most effective way to debug MaxScale related issues is to turn on `log_info`\
-and observe the events written into the MaxScale log. The only problem with this\
-approach is that it can cause a severe performance bottleneck and can easily\
-fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged\
+The most effective way to debug MaxScale related issues is to turn on `log_info`
+and observe the events written into the MaxScale log. The only problem with this
+approach is that it can cause a severe performance bottleneck and can easily
+fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged
 can be filtered to only what is needed.
 
-For example, the following configuration would only log the trace log messages\
+For example, the following configuration would only log the trace log messages
 from sessions that execute SQL queries with syntax errors:
 
 ```
@@ -1388,10 +1388,10 @@ session_trace=1000
 session_trace_match=/You have an error in your SQL syntax/
 ```
 
-This could be used to easily identify which applications execute the queries\
-without having to gather the info level log output from all the sessions that\
-connect to MaxScale. For every session that ends up logging a syntax error\
-message, the last 1000 lines of log output done by that session is written into\
+This could be used to easily identify which applications execute the queries
+without having to gather the info level log output from all the sessions that
+connect to MaxScale. For every session that ends up logging a syntax error
+message, the last 1000 lines of log output done by that session is written into
 the MaxScale log.
 
 #### `writeq_high_water`
@@ -1401,20 +1401,20 @@ the MaxScale log.
 * Dynamic: Yes
 * Default: `65536`
 
-High water mark for network write buffer. When the size of the outbound network\
-buffer in MaxScale for a single connection exceeds this value, network traffic\
-throttling for that connection is started. The parameter accepts [size type\
+High water mark for network write buffer. When the size of the outbound network
+buffer in MaxScale for a single connection exceeds this value, network traffic
+throttling for that connection is started. The parameter accepts [size type
 values](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#sizes). The default value was 16777216 bytes before 22.08.4.
 
-More specifically, if the client side write queue is above this value, it will\
-block traffic coming from backend servers. If the backend side write queue is\
+More specifically, if the client side write queue is above this value, it will
+block traffic coming from backend servers. If the backend side write queue is
 above this value, it will block traffic from client.
 
-The buffer that this parameter controls is the buffer internal to MaxScale and\
-is not the kernel TCP send buffer. This means that the total amount of buffered\
+The buffer that this parameter controls is the buffer internal to MaxScale and
+is not the kernel TCP send buffer. This means that the total amount of buffered
 data is determined by both the kernel TCP buffers and the value of`writeq_high_water`.
 
-Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value\
+Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value
 to 0.
 
 #### `writeq_low_water`
@@ -1424,13 +1424,13 @@ to 0.
 * Dynamic: Yes
 * Default: `1024`
 
-Low water mark for network write buffer. Once the traffic throttling is enabled,\
-it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#sizes). The\
+Low water mark for network write buffer. Once the traffic throttling is enabled,
+it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#sizes). The
 default value was 8192 bytes before 22.08.4.
 
 The value of `writeq_high_water` must always be greater than the value of`writeq_low_water`.
 
-Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value\
+Network throttling is only enabled when both `writeq_high_water` and`writeq_low_water` have a non-zero value. To disable throttling, set the value
 to 0.
 
 #### `persist_runtime_changes`
@@ -1441,10 +1441,10 @@ to 0.
 
 Persist changes done at runtime. This parameter was added in MaxScale 22.08.0.
 
-When `persist_runtime_changes` is enabled, runtime configuration changes done\
-with the GUI, MaxCtrl or via the REST API cause a new configuration file to be\
-saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is\
-enabled, these files will be applied on top of any existing values found in\
+When `persist_runtime_changes` is enabled, runtime configuration changes done
+with the GUI, MaxCtrl or via the REST API cause a new configuration file to be
+saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is
+enabled, these files will be applied on top of any existing values found in
 static configuration files whenever MaxScale is starting up.
 
 #### `load_persisted_configs`
@@ -1457,11 +1457,11 @@ static configuration files whenever MaxScale is starting up.
 Load persisted runtime changes on startup. This parameter was added in MaxScale\
 2.3.6.
 
-All runtime configuration changes are persisted in generated configuration files\
-located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on\
-startup after main configuration files have been read. To make runtime\
-configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores\
-the current runtime state of MaxScale. This makes problem analysis easier if an\
+All runtime configuration changes are persisted in generated configuration files
+located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on
+startup after main configuration files have been read. To make runtime
+configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores
+the current runtime state of MaxScale. This makes problem analysis easier if an
 unexpected outage happens.
 
 #### `max_auth_errors_until_block`
@@ -1471,14 +1471,14 @@ unexpected outage happens.
 * Dynamic: Yes
 * Default: `10`
 
-The maximum number of authentication failures that are tolerated before a host\
-is temporarily blocked. The default value is 10 failures. After a host is\
-blocked, connections from it are rejected for 60 seconds. To disable this\
+The maximum number of authentication failures that are tolerated before a host
+is temporarily blocked. The default value is 10 failures. After a host is
+blocked, connections from it are rejected for 60 seconds. To disable this
 feature, set the value to 0.
 
-Note that the configured value is not a hard limit. The number of tolerated\
-failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the\
-configured value of this parameter and `threads` is the number of configured\
+Note that the configured value is not a hard limit. The number of tolerated
+failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the
+configured value of this parameter and `threads` is the number of configured
 threads.
 
 #### `debug`
@@ -1488,16 +1488,16 @@ threads.
 * Dynamic: No
 * Default: `""`
 
-Define debug options from the --debug command line option. Either the command\
-line option or the parameter should be used, not both. The debug options are\
+Define debug options from the --debug command line option. Either the command
+line option or the parameter should be used, not both. The debug options are
 only for testing purposes and are not to be used in production.
 
 #### REST API Configuration
 
-The MaxScale REST API is an HTTP interface that provides JSON format data\
+The MaxScale REST API is an HTTP interface that provides JSON format data
 intended to be consumed by monitoring applications and visualization tools.
 
-The following options must be defined under the `[maxscale]` section in the\
+The following options must be defined under the `[maxscale]` section in the
 configuration file.
 
 #### `admin_host`
@@ -1526,8 +1526,8 @@ The port where the REST API listens on. The default value is port 8989.
 * Dynamic: No
 * Default: `true`
 
-Enable REST API authentication using HTTP Basic Access\
-authentication. This is not a secure method of authentication without HTTPS but\
+Enable REST API authentication using HTTP Basic Access
+authentication. This is not a secure method of authentication without HTTPS but
 it does add a small layer of security.
 
 For more information, read the [REST API documentation](../mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md).
@@ -1541,7 +1541,7 @@ For more information, read the [REST API documentation](../mariadb-maxscale-23-0
 
 The path to the TLS private key in PEM format for the admin interface.
 
-If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin\
+If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin
 interface will use encrypted HTTPS instead of plain HTTP.
 
 #### `admin_ssl_cert`
@@ -1551,7 +1551,7 @@ interface will use encrypted HTTPS instead of plain HTTP.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS public certificate in PEM format. See `admin_ssl_key`\
+The path to the TLS public certificate in PEM format. See `admin_ssl_key`
 documentation for more details.
 
 #### `admin_ssl_ca_cert`
@@ -1565,11 +1565,11 @@ Deprecated since MariaDB MaxScale 22.08. See `admin_ssl_ca`.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS CA certificate in PEM format. If defined, the client\
-certificate, if provided, will be validated against it. This parameter is\
+The path to the TLS CA certificate in PEM format. If defined, the client
+certificate, if provided, will be validated against it. This parameter is
 optional starting with MaxScale 2.3.19.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,
 which is still accepted as an alias for `admin_ssl_ca`.
 
 #### `admin_ssl_version`
@@ -1580,7 +1580,7 @@ which is still accepted as an alias for `admin_ssl_ca`.
 * Values: `MAX`, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`, `TLSv10`, `TLSv11`, `TLSv12`, `TLSv13`
 * Default: `MAX`
 
-This parameter controls the enabled TLS versions in the REST API. Accepted\
+This parameter controls the enabled TLS versions in the REST API. Accepted
 values are:
 
 * `TLSv10`
@@ -1589,7 +1589,7 @@ values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -1597,19 +1597,19 @@ releases accept also the following alias values:
 * `TLSv1.2`
 * `TLSv1.3` (not supported on OpenSSL 1.0)
 
-The default value is `MAX` which negotiates the highest level of encryption that\
-both the client and server support. The list of supported TLS versions depends\
+The default value is `MAX` which negotiates the highest level of encryption that
+both the client and server support. The list of supported TLS versions depends
 on the operating system and what TLS versions the GnuTLS library supports.
 
 For example, to enable only TLSv1.1 and TLSv1.3, use`admin_ssl_version=TLSv1.1,TLSv1.3`.
 
 This parameter was added in MaxScale 2.5.7.
 
-Older versions of MaxScale interpreted `admin_ssl_version` as the minimum\
+Older versions of MaxScale interpreted `admin_ssl_version` as the minimum
 allowed TLS version. In those versions, `admin_ssl_version=TLSv1.2` allowed both\
-TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2\
-and all newer versions, the value is a enumeration of accepted TLS protocol\
-versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To\
+TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2
+and all newer versions, the value is a enumeration of accepted TLS protocol
+versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To
 retain the old behavior, specify all the accepted values with`admin_ssl_version=TLSv1.2,TLSv1.3`
 
 #### `admin_enabled`
@@ -1619,7 +1619,7 @@ retain the old behavior, specify all the accepted values with`admin_ssl_version=
 * Dynamic: No
 * Default: `true`
 
-Enable or disable the admin interface. This allows the admin interface to\
+Enable or disable the admin interface. This allows the admin interface to
 be completely disabled to prevent access to it.
 
 #### `admin_gui`
@@ -1632,9 +1632,9 @@ be completely disabled to prevent access to it.
 Enable or disable the admin graphical user interface.
 
 MaxScale provides a GUI for administrative operations via the REST API. When the\
-GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will\
-serve the GUI. When disabled, the REST API will respond with a 200 OK to the\
-request. By disabling the GUI, the root resource can be used as a low overhead\
+GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will
+serve the GUI. When disabled, the REST API will respond with a 200 OK to the
+request. By disabling the GUI, the root resource can be used as a low overhead
 health check.
 
 #### `admin_secure_gui`
@@ -1646,10 +1646,10 @@ health check.
 
 Whether to serve the GUI only over secure HTTPS connections.
 
-To be secure by default, the GUI is only served over HTTPS connections as\
+To be secure by default, the GUI is only served over HTTPS connections as
 it uses a token authentication scheme. This also controls whether the`/auth` endpoint requires an encrypted connection.
 
-To allow use of the GUI without having to configure TLS certificates for\
+To allow use of the GUI without having to configure TLS certificates for
 the MaxScale REST API, set this parameter to false.
 
 #### `admin_log_auth_failures`
@@ -1668,17 +1668,17 @@ Log authentication failures for the admin interface.
 * Dynamic: No
 * Default: `""`
 
-Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings\
-accept a PAM service name which is used during authentication if normal authentication\
+Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings
+accept a PAM service name which is used during authentication if normal authentication
 fails. `admin_pam_readwrite_service` should accept users who can do any\
-MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only\
-do read operations. Because REST-API does not support back and forth communication between\
-the client and MaxScale, the PAM services must be simple. They should only ask for the\
+MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only
+do read operations. Because REST-API does not support back and forth communication between
+the client and MaxScale, the PAM services must be simple. They should only ask for the
 password and nothing else.
 
-If only `admin_pam_readwrite_service` is configured, both read and write operations can be\
-authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read\
-operations can be authenticated by PAM. If both are set, the service used is determined by\
+If only `admin_pam_readwrite_service` is configured, both read and write operations can be
+authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read
+operations can be authenticated by PAM. If both are set, the service used is determined by
 the requested operation. Leave or set both empty to disable PAM for REST-API.
 
 #### `admin_jwt_algorithm`
@@ -1692,46 +1692,46 @@ the requested operation. Leave or set both empty to disable PAM for REST-API.
 The signature algorithm used by the MaxScale REST API when generating JSON Web\
 Tokens.
 
-For more information about the tokens and how they work, refer to [the REST API\
+For more information about the tokens and how they work, refer to [the REST API
 documentation](../mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md).
 
-If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale\
-will generate a random encryption key on startup and use that to sign the\
+If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale
+will generate a random encryption key on startup and use that to sign the
 messages. The symmetric key can also be retrieved from an if the `admin_jwt_key` parameter is defined.
 
-If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must\
-contain a private key and a public certificate of the correct type. If the wrong\
+If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must
+contain a private key and a public certificate of the correct type. If the wrong
 key type, key length or elliptic curve is used, MaxScale will refuse to start.
 
-Asymmetric key algorithms make it possible for the clients of the REST API to\
+Asymmetric key algorithms make it possible for the clients of the REST API to
 validate that the token was indeed generated by the correct entity.
 
-Symmetric algorithms make it easy to share the same tokens between\
-multiple MaxScale instances as the shared secret can be stored in a key\
+Symmetric algorithms make it easy to share the same tokens between
+multiple MaxScale instances as the shared secret can be stored in a key
 management system.
 
 The possible values for this parameter are:
 
 * `auto`
-* MaxScale will attempt to detect the best algorithm to use for\
+* MaxScale will attempt to detect the best algorithm to use for
   signatures. The algorithm used depends on the private key type: RSA keys use`PS256`, EC keys use the `ES256`, `ES384` or `ES512` depending on the curve,\
-  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot\
+  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot
   auto-detect the key type, it falls back to `HS256` as the default algorithm.
 * `HS256`, `HS384` or `HS512`
 * [HMAC with SHA-2\
-  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct\
+  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct
   size.
 * `RS256`, `RS384` or `RS512`
 * [Digital Signature with\
-  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires\
+  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires
   at least a 2048-bit RSA key.
 * `PS256`, `PS384` or `PS512`
 * [Digital Signature with\
-  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires\
+  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires
   at least a 2048-bit RSA key.
 * `ES256`, `ES384` or `ES512`
 * [Digital Signature with\
-  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires\
+  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires
   an EC key with the correct curve: P-256 for `ES256`, P-384 for `ES384` and\
   P-512 for `ES512`.
 * `ED25519` or `ED448`
@@ -1746,15 +1746,15 @@ The possible values for this parameter are:
 * Dynamic: No
 * Default: `""`
 
-The ID for the encryption key used to sign the JSON Web Tokens. If configured,\
-an [Encryption Key Manager](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured\
-and it must contain the key with the given ID. If no key is defined, MaxScale\
-will use a random encryption key whenever a symmetric signature algorithm is\
+The ID for the encryption key used to sign the JSON Web Tokens. If configured,
+an [Encryption Key Manager](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured
+and it must contain the key with the given ID. If no key is defined, MaxScale
+will use a random encryption key whenever a symmetric signature algorithm is
 used.
 
-Currently, the encryption key is only read on startup. This means that the\
+Currently, the encryption key is only read on startup. This means that the
 tokens will be signed by the latest key version that is available on startup:\
-rotating the encryption key in the key management system will not cause the JWTs\
+rotating the encryption key in the key management system will not cause the JWTs
 to be signed with newer versions of the key.
 
 #### `admin_jwt_max_age`
@@ -1766,11 +1766,11 @@ to be signed with newer versions of the key.
 
 The maximum lifetime of a token generated by the `/auth` endpoint.
 
-If a client requests for a token with a lifetime that exceeds the configured\
-value, the token lifetime is silently truncated to this value. This can be used\
+If a client requests for a token with a lifetime that exceeds the configured
+value, the token lifetime is silently truncated to this value. This can be used
 to control the maximum length of a MaxGUI session.
 
-This also acts as the effective maximum age of any database connection created\
+This also acts as the effective maximum age of any database connection created
 from the `/sql` endpoint.
 
 #### `admin_oidc_url`
@@ -1782,14 +1782,14 @@ from the `/sql` endpoint.
 
 The URL to a OpenID Connect server that is used for JWT validation.
 
-If defined, any tokens signed by this server are accepted as valid bearer tokens\
-for the MaxScale REST API. The `"sub"` field of the token is assumed to be the\
-username of an administrative user in MaxScale and the `"account"` claim is\
-assumed to be the type of the user: `"admin"` for administrative users with full\
+If defined, any tokens signed by this server are accepted as valid bearer tokens
+for the MaxScale REST API. The `"sub"` field of the token is assumed to be the
+username of an administrative user in MaxScale and the `"account"` claim is
+assumed to be the type of the user: `"admin"` for administrative users with full
 access to the REST-API and `"basic"` for users with read-only access to the\
 REST-API. This means that all users must be first created with `maxctrl create user` before the tokens are accepted if the OIDC provider is not able to add the`"account"` claim.
 
-If this URL is changed at runtime, the new certificates will not be\
+If this URL is changed at runtime, the new certificates will not be
 fetched until a `maxctrl reload tls` command is executed.
 
 #### `admin_verify_url`
@@ -1801,19 +1801,19 @@ fetched until a `maxctrl reload tls` command is executed.
 
 URL to a server to which the REST API token verification is delegated.
 
-If the URL is defined, any tokens passed to the REST API will be validated by\
-doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client\
+If the URL is defined, any tokens passed to the REST API will be validated by
+doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client
 and the custom `X-Referrer-Method` header is set to the HTTP method being used\
 (PUT, GET etc.).
 
-**Note**: When `admin_verify_url` is used and the remote server cannot\
-be accessed, all REST API access that uses tokens will be disabled. The\
-only way to use the REST API with tokens is to remove `admin_verify_url`\
-from the configuration which requires restarting MaxScale. The REST API\
-still accepts HTTP Basic Access authentication even if the remote server\
+**Note**: When `admin_verify_url` is used and the remote server cannot
+be accessed, all REST API access that uses tokens will be disabled. The
+only way to use the REST API with tokens is to remove `admin_verify_url`
+from the configuration which requires restarting MaxScale. The REST API
+still accepts HTTP Basic Access authentication even if the remote server
 cannot be reached.
 
-By delegating the authentication and authorization of the REST API to an\
+By delegating the authentication and authorization of the REST API to an
 external server, users can implement custom access control systems for the\
 MaxScale REST API.
 
@@ -1835,8 +1835,8 @@ Enable logging of incoming REST API calls.
 
 The file where the REST API auditing information is logged.
 
-If a non-default value is used, the directory where the file resides must\
-exist. For example, with `/var/log/maxscale/audit_files/audit.csv`, the\
+If a non-default value is used, the directory where the file resides must
+exist. For example, with `/var/log/maxscale/audit_files/audit.csv`, the
 directory `/var/log/maxscale/audit_files` must exist.
 
 #### `admin_audit_exclude_methods`
@@ -1850,9 +1850,9 @@ directory `/var/log/maxscale/audit_files` must exist.
 List of comma separated HTTP methods to exclude from logging\
 Currently MaxScale does not use `CONNECT` or `TRACE`.
 
-Resetting to log all methods can be done in the configuration file by\
+Resetting to log all methods can be done in the configuration file by
 writing `admin_audit_exclude_methods=` or at runtime with`maxctrl alter maxscale admin_audit_exclude_methods=`.\
-Remember that once a runtime change has been made, the entry for that\
+Remember that once a runtime change has been made, the entry for that
 setting is ignored in the main configuration file (usually maxscale.cnf).
 
 #### `config_sync_cluster`
@@ -1862,10 +1862,10 @@ setting is ignored in the main configuration file (usually maxscale.cnf).
 * Dynamic: Yes
 * Default: None
 
-This parameter controls which cluster (i.e. monitor) is used to synchronize\
+This parameter controls which cluster (i.e. monitor) is used to synchronize
 configuration changes between MaxScale instances. The first server labeled`Master` will be used for the synchronization.
 
-By default configuration synchronization is not enabled and it must be\
+By default configuration synchronization is not enabled and it must be
 explicitly enabled by defining a monitor name for `config_sync_cluster`.
 
 When `config_sync_cluster` is defined, `config_sync_user` and`config_sync_password` must also be defined.
@@ -1880,8 +1880,8 @@ Synchronization](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#c
 * Dynamic: Yes
 * Default: None
 
-The username for the account that is used to synchronize configuration changes\
-across MaxScale instances. Both this parameter and `config_sync_password` are\
+The username for the account that is used to synchronize configuration changes
+across MaxScale instances. Both this parameter and `config_sync_password` are
 required if `config_sync_cluster` is configured.
 
 This account must have the following grants:
@@ -1890,7 +1890,7 @@ This account must have the following grants:
 GRANT SELECT, INSERT, UPDATE, CREATE ON `mysql`.`maxscale_config`
 ```
 
-The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`\
+The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`
 grant is not needed by the user configured in `config_sync_user`. The following\
 SQL is used to create the table.
 
@@ -1904,7 +1904,7 @@ CREATE TABLE IF NOT EXISTS mysql.maxscale_config(
 ) ENGINE=InnoDB;
 ```
 
-If the database where the table is created is changed with `config_sync_db`, the\
+If the database where the table is created is changed with `config_sync_db`, the
 grants must be adjusted to target that database instead.
 
 #### `config_sync_password`
@@ -1914,8 +1914,8 @@ grants must be adjusted to target that database instead.
 * Dynamic: Yes
 * Default: None
 
-The password for `config_sync_user`. Both this parameter and `config_sync_user`\
-are required if `config_sync_cluster` is configured. This password can\
+The password for `config_sync_user`. Both this parameter and `config_sync_user`
+are required if `config_sync_cluster` is configured. This password can
 optionally be encrypted using `maxpasswd`.
 
 #### `config_sync_db`
@@ -1925,13 +1925,13 @@ optionally be encrypted using `maxpasswd`.
 * Dynamic: No
 * Default: `mysql`
 
-The database where the `maxscale_config` table is created. By default the table\
-is created in the `mysql` database. This parameter was added in MaxScale\
+The database where the `maxscale_config` table is created. By default the table
+is created in the `mysql` database. This parameter was added in MaxScale
 versions 6.4.6 and 22.08.5.
 
-As tables in the `mysql` database cannot have triggers on them, the database\
+As tables in the `mysql` database cannot have triggers on them, the database
 must be changed to a user-created one in order to create triggers on the table.\
-An example use-case for triggers on this table is to track all configuration\
+An example use-case for triggers on this table is to track all configuration
 changes done to MaxScale by inserting them into a separate table.
 
 #### `config_sync_interval`
@@ -1943,9 +1943,9 @@ changes done to MaxScale by inserting them into a separate table.
 
 How often to synchronize the configuration with the cluster.
 
-As the synchronization involves selecting the configuration version from the\
-database, this value should not be set to an unreasonably low value. The default\
-value of 5 second should provide a good compromise between responsiveness and\
+As the synchronization involves selecting the configuration version from the
+database, this value should not be set to an unreasonably low value. The default
+value of 5 second should provide a good compromise between responsiveness and
 how much load it places on the database.
 
 #### `config_sync_timeout`
@@ -1955,8 +1955,8 @@ how much load it places on the database.
 * Dynamic: Yes
 * Default: `10s`
 
-Timeout for all SQL operations done during the configuration synchronization. If\
-an operation exceeds this timeout, the configuration change is treated as failed\
+Timeout for all SQL operations done during the configuration synchronization. If
+an operation exceeds this timeout, the configuration change is treated as failed
 and an error is reported to the client that did the change.
 
 #### `key_manager`
@@ -1971,13 +1971,13 @@ The encryption key manager to use. The available encryption key managers are:
 * `none` - No key manager, encryption keys are not available.
 * `file` - [File-based key manager](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#file-based-key-manager)
 * `kmip` - [KMIP key manager](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#kmip-key-manager)
-* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This\
-  key manager is only included on systems with GCC 9 or newer which\
+* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This
+  key manager is only included on systems with GCC 9 or newer which
   means it cannot be used on Ubuntu 18.04.
 
-Refer to the [Encryption Key Managers](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for\
-more information on how to configure the key managers. The key managers each\
-have their configuration in their own namespace and must have their name as a\
+Refer to the [Encryption Key Managers](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for
+more information on how to configure the key managers. The key managers each
+have their configuration in their own namespace and must have their name as a
 prefix.
 
 For example to configure the `file` key manager, the following must be used:
@@ -1989,16 +1989,16 @@ file.keyfile=/path/to/keyfile
 
 ### Events
 
-MaxScale logs warnings and errors for various reasons and often it is self-\
-evident and generally applicable whether some occurrence should warrant a\
+MaxScale logs warnings and errors for various reasons and often it is self-
+evident and generally applicable whether some occurrence should warrant a
 warning or an error, or perhaps just an info-level message.
 
-However, there are events whose seriousness is not self-evident. For\
-instance, in some environments an authentication failure may simply indicate\
-that someone has made a typo, while in some other environment that can only\
+However, there are events whose seriousness is not self-evident. For
+instance, in some environments an authentication failure may simply indicate
+that someone has made a typo, while in some other environment that can only
 happen in case there has been a security breech.
 
-To handle events like these, MaxScale defines _events_ whose logging\
+To handle events like these, MaxScale defines _events_ whose logging
 facility and level can be controlled by the administrator. Given an event`X`, its facility and level are controlled in the following manner:
 
 ```
@@ -2006,21 +2006,21 @@ event.X.facility=LOG_LOCAL0
 event.X.level=LOG_ERR
 ```
 
-The above means that if event _X_ occurs, then that is logged using the\
+The above means that if event _X_ occurs, then that is logged using the
 facility `LOG_LOCAL0` and the level `LOG_ERR`.
 
-The valid values of facility`are the facility values reported by`man\
+The valid values of facility`are the facility values reported by`man
 syslog`, e.g.`LOG\_AUTH`,`LOG\_LOCAL0`and`LOG\_USER`. Likewise, the valid values for`level`are the ones also reported by`man syslog`, e.g.`LOG\_WARNING`,`LOG\_ERR`and`LOG\_CRIT\`.
 
-Note that MaxScale does not act upon the level, that is, even if the level\
-of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut\
+Note that MaxScale does not act upon the level, that is, even if the level
+of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut
 down if that event occurs.
 
 The default facility is `LOG_USER` and the default level is `LOG_WARNING`.
 
-Note that you may also have to configure `rsyslog` to ensure that the\
-event can be logged to the intended log file. For instance, if the facility\
-is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line\
+Note that you may also have to configure `rsyslog` to ensure that the
+event can be logged to the intended log file. For instance, if the facility
+is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line
 like
 
 ```
@@ -2042,22 +2042,22 @@ event.authentication_failure.level=LOG_CRIT
 
 ### Service
 
-A service represents the database service that MariaDB MaxScale offers to the\
-clients. In general a service consists of a set of backend database servers and\
-a routing algorithm that determines how MariaDB MaxScale decides to send\
+A service represents the database service that MariaDB MaxScale offers to the
+clients. In general a service consists of a set of backend database servers and
+a routing algorithm that determines how MariaDB MaxScale decides to send
 statements or route connections to those backend servers.
 
-A service may be considered as a virtual database server that MariaDB MaxScale\
+A service may be considered as a virtual database server that MariaDB MaxScale
 makes available to its clients.
 
 Several different services may be defined using the same set of backend servers.\
-For example a connection based routing service might be used by clients that\
-already performed internal read/write splitting, whilst a different statement\
-based router may be used by clients that are not written with this functionality\
-in place. Both sets of applications could access the same data in the same\
+For example a connection based routing service might be used by clients that
+already performed internal read/write splitting, whilst a different statement
+based router may be used by clients that are not written with this functionality
+in place. Both sets of applications could access the same data in the same
 databases.
 
-A service is identified by a service name, which is the name of the\
+A service is identified by a service name, which is the name of the
 configuration file section and a type parameter of service.
 
 ```
@@ -2065,9 +2065,9 @@ configuration file section and a type parameter of service.
 type=service
 ```
 
-In order for MariaDB MaxScale to forward any requests it must have at least one\
-service defined within the configuration file. The definition of a service alone\
-is not enough to allow MariaDB MaxScale to forward requests however, the service\
+In order for MariaDB MaxScale to forward any requests it must have at least one
+service defined within the configuration file. The definition of a service alone
+is not enough to allow MariaDB MaxScale to forward requests however, the service
 is merely present to link together the other configuration elements.
 
 #### `router`
@@ -2076,15 +2076,15 @@ is merely present to link together the other configuration elements.
 * Mandatory: Yes
 * Dynamic: No
 
-The router parameter of a service defines the name of the router module that\
+The router parameter of a service defines the name of the router module that
 will be used to implement the routing algorithm between the client of MariaDB\
-MaxScale and the backend databases. Additionally routers may also be passed a\
-comma separated list of options that are used to control the behavior of the\
-routing algorithm. The two parameters that control the routing choice are router\
-and router\_options. The router options are specific to a particular router and\
-are used to modify the behavior of the router. The read connection router can be\
-passed options of `master`, `slave` or `synced`, an example of configuring a service\
-to use this router and limiting the choice of servers to those in `slave` state\
+MaxScale and the backend databases. Additionally routers may also be passed a
+comma separated list of options that are used to control the behavior of the
+routing algorithm. The two parameters that control the routing choice are router
+and router\_options. The router options are specific to a particular router and
+are used to modify the behavior of the router. The read connection router can be
+passed options of `master`, `slave` or `synced`, an example of configuring a service
+to use this router and limiting the choice of servers to those in `slave` state
 would be as follows.
 
 ```
@@ -2092,7 +2092,7 @@ router=readconnroute
 router_options=slave
 ```
 
-To change the router to connect on to servers in the `master` state as well as\
+To change the router to connect on to servers in the `master` state as well as
 slave servers, the router options can be modified to include the `master` state.
 
 ```
@@ -2100,7 +2100,7 @@ router=readconnroute
 router_options=master,slave
 ```
 
-A more complete description of router options and what is available for a given\
+A more complete description of router options and what is available for a given
 router is included with the documentation of the router itself.
 
 #### `filters`
@@ -2110,17 +2110,17 @@ router is included with the documentation of the router itself.
 * Dynamic: Yes
 * Default: None
 
-The filters option allow a set of filters to be defined for a service; requests\
-from the client are passed through these filters before being sent to the router\
-for dispatch to the backend server. The filters parameter takes one or more\
-filter names, as defined within the filter definition section of the\
+The filters option allow a set of filters to be defined for a service; requests
+from the client are passed through these filters before being sent to the router
+for dispatch to the backend server. The filters parameter takes one or more
+filter names, as defined within the filter definition section of the
 configuration file. Multiple filters are separated using the | character.
 
 ```
 filters=counter | QLA
 ```
 
-The requests pass through the filters from left to right in the order defined in\
+The requests pass through the filters from left to right in the order defined in
 the configuration parameter.
 
 #### `targets`
@@ -2130,7 +2130,7 @@ the configuration parameter.
 * Dynamic: Yes
 * Default: None
 
-The `targets` parameter is a comma separated list of server and/or service names\
+The `targets` parameter is a comma separated list of server and/or service names
 that comprise the routing targets of the service. This parameter was added in\
 MaxScale 2.5.0.
 
@@ -2138,9 +2138,9 @@ MaxScale 2.5.0.
 targets=My-Service,server2
 ```
 
-This parameter allows nested service configurations to be defined without having\
-to configure listeners for all services. For example, one use-case is to use\
-multiple readwritesplit services behind a schemarouter service to have both the\
+This parameter allows nested service configurations to be defined without having
+to configure listeners for all services. For example, one use-case is to use
+multiple readwritesplit services behind a schemarouter service to have both the
 sharding of schemarouter with the high-availability of readwritesplit.
 
 **NOTE:** The `targets` parameter is mutually exclusive with the `cluster` and`servers` parameters.
@@ -2152,8 +2152,8 @@ sharding of schemarouter with the high-availability of readwritesplit.
 * Dynamic: Yes
 * Default: None
 
-The servers parameter in a service definition provides a comma separated list of\
-the backend servers that comprise the service. The server names are those used\
+The servers parameter in a service definition provides a comma separated list of
+the backend servers that comprise the service. The server names are those used
 in the name section of a block with a type parameter of server (see below).
 
 ```
@@ -2169,7 +2169,7 @@ servers=server1,server2,server3
 * Dynamic: Yes
 * Default: None
 
-The servers the service uses are defined by the monitor specified as value\
+The servers the service uses are defined by the monitor specified as value
 of this configuration parameter.
 
 ```
@@ -2184,7 +2184,7 @@ cluster=TheMonitor
 * Mandatory: Yes
 * Dynamic: Yes
 
-This setting defines the _user_ the service uses to fetch user account\
+This setting defines the _user_ the service uses to fetch user account
 information from backends. A _password_ is specified using [password](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#password).
 
 ```
@@ -2192,8 +2192,8 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
 #### `password`
@@ -2202,9 +2202,9 @@ regarding user account management and client authentication.
 * Mandatory: Yes
 * Dynamic: Yes
 
-This settings defines the _password_ the service uses to fetch user account\
-information from backends. The _password_ may be either a plain text password or\
-an [encrypted password](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified\
+This settings defines the _password_ the service uses to fetch user account
+information from backends. The _password_ may be either a plain text password or
+an [encrypted password](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified
 using [user](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#user).
 
 ```
@@ -2212,8 +2212,8 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
 #### `enable_root_user`
@@ -2237,7 +2237,7 @@ Deprecated and ignored.
 * Dynamic: No
 * Default: None
 
-This parameter sets a custom version string that is sent in the MySQL Handshake\
+This parameter sets a custom version string that is sent in the MySQL Handshake
 from MariaDB MaxScale to clients.
 
 Example:
@@ -2246,13 +2246,13 @@ Example:
 version_string=10.11.2-MariaDB-RWsplit
 ```
 
-If not set, MaxScale will attempt to use a version string from the\
-backend databases by selecting the version string of the database with\
+If not set, MaxScale will attempt to use a version string from the
+backend databases by selecting the version string of the database with
 the lowest version number. If the selected version is from the MariaDB\
 10 series, a `5.5.5-` prefix will be added to it similarly to how the\
 MariaDB 10 series versions added it.
 
-If MaxScale has not been able to connect to a single database and the\
+If MaxScale has not been able to connect to a single database and the
 versions are unknown, the default value of `5.5.5-10.4.32 <MaxScale version>-maxscale` is used where `<MaxScale version>` is the version of\
 MaxScale.
 
@@ -2263,11 +2263,11 @@ MaxScale.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether only a single server or all of the servers are\
+This parameter controls whether only a single server or all of the servers are
 used when loading the users from the backend servers.
 
-By default MaxScale uses the first server labeled as `Master` as the source of\
-the authentication data. When this option is enabled, the authentication data is\
+By default MaxScale uses the first server labeled as `Master` as the source of
+the authentication data. When this option is enabled, the authentication data is
 loaded from all the servers and combined into one big data set.
 
 #### `strip_db_esc`
@@ -2282,12 +2282,12 @@ names when loading user grants from a backend server. When enabled, a grant\
 such as `grant select on` test\_`.* to 'user'@'%';` is read as `grant select on` test\_`.* to 'user'@'%';`
 
 This setting has no effect on database-level grants fetched from a MariaDB\
-Server. The database names of a MariaDB Server are compared using the LIKE\
-operator to properly handle wildcards and escaped wildcards. This setting may\
-affect database names in table and column level grants, although these typically\
+Server. The database names of a MariaDB Server are compared using the LIKE
+operator to properly handle wildcards and escaped wildcards. This setting may
+affect database names in table and column level grants, although these typically
 do not contain backlashes.
 
-Some visual database management tools automatically escape some characters and\
+Some visual database management tools automatically escape some characters and
 this might cause conflicts when MaxScale tries to authenticate users.
 
 #### `log_auth_warnings`
@@ -2297,8 +2297,8 @@ this might cause conflicts when MaxScale tries to authenticate users.
 * Dynamic: Yes
 * Default: `true`
 
-Enable or disable the logging of authentication failures and warnings. If\
-enabled, messages about failed authentication attempts will be logged with\
+Enable or disable the logging of authentication failures and warnings. If
+enabled, messages about failed authentication attempts will be logged with
 details about who tried to connect to MariaDB MaxScale and from where.
 
 #### `log_warning`
@@ -2308,10 +2308,10 @@ details about who tried to connect to MariaDB MaxScale and from where.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log warning messages even if the global\
+When enabled, this allows a service to log warning messages even if the global
 log level configuration disables them.
 
-Note that disabling the service level logging does not override the global\
+Note that disabling the service level logging does not override the global
 logging configuration: with `log_warning=false` in the service and`log_warning=true` globally, warnings will still be logged for all services.
 
 #### `log_notice`
@@ -2321,7 +2321,7 @@ logging configuration: with `log_warning=false` in the service and`log_warning=t
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log notice messages even if the global\
+When enabled, this allows a service to log notice messages even if the global
 log level configuration disables them.
 
 #### `log_info`
@@ -2331,7 +2331,7 @@ log level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log info messages even if the global log\
+When enabled, this allows a service to log info messages even if the global log
 level configuration disables them.
 
 #### `log_debug`
@@ -2341,10 +2341,10 @@ level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log debug messages even if the global log\
+When enabled, this allows a service to log debug messages even if the global log
 level configuration disables them.
 
-Debug messages are only enabled for debug builds. Enabling `log_debug` in a\
+Debug messages are only enabled for debug builds. Enabling `log_debug` in a
 release build does nothing.
 
 #### `connection_timeout`
@@ -2356,35 +2356,35 @@ release build does nothing.
 * Auto tune: [Yes](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#auto_tune)
 
 The connection\_timeout parameter is used to disconnect sessions to MariaDB\
-MaxScale that have been idle for too long. The session timeouts are disabled by\
-default. To enable them, define the timeout in seconds in the service's\
-configuration section. A value of zero is interpreted as no timeout, the same\
+MaxScale that have been idle for too long. The session timeouts are disabled by
+default. To enable them, define the timeout in seconds in the service's
+configuration section. A value of zero is interpreted as no timeout, the same
 as if the parameter is not defined.
 
-The value is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `connection_timeout` for those is not used.
 
-The value of `connection_timeout` should be lower than the lowest `wait_timeout`\
-value on the backend servers. This way idle clients are disconnected by MaxScale\
-before the backend servers have to close them. Any client-side idle timeouts\
-(e.g. maximum lifetime for connection pools) should be lower than both`connection_timeout` and `wait_timeout`. This way the client application will\
-end up closing the connection itself which most of the time results in better\
+The value of `connection_timeout` should be lower than the lowest `wait_timeout`
+value on the backend servers. This way idle clients are disconnected by MaxScale
+before the backend servers have to close them. Any client-side idle timeouts
+(e.g. maximum lifetime for connection pools) should be lower than both`connection_timeout` and `wait_timeout`. This way the client application will
+end up closing the connection itself which most of the time results in better
 and more helpful error messages.
 
-**Warning:** If a connection is idle for longer than the configured connection\
+**Warning:** If a connection is idle for longer than the configured connection
 timeout, it will be forcefully disconnected and a warning will be logged in the\
 MaxScale log file.
 
-In MaxScale versions 6.2.0 and older, if long-running operations (e.g. `ALTER TABLE`) were performed, MaxScale would close the connections if they look longer\
+In MaxScale versions 6.2.0 and older, if long-running operations (e.g. `ALTER TABLE`) were performed, MaxScale would close the connections if they look longer
 than `connection_timeout` seconds to execute\
-([MXS-3893](https://jira.mariadb.org/browse/MXS-3893)). In MaxScale 6.2.1 this\
+([MXS-3893](https://jira.mariadb.org/browse/MXS-3893)). In MaxScale 6.2.1 this
 has been fixed and the active operations are now correctly tracked.
 
 Example:
@@ -2401,13 +2401,13 @@ connection_timeout=300s
 * Dynamic: Yes
 * Default: `0`
 
-The maximum number of simultaneous connections MaxScale should permit to this\
-service. If the parameter is zero or is omitted, there is no limit. Any attempt\
-to make more connections after the limit is reached will result in a "Too many\
+The maximum number of simultaneous connections MaxScale should permit to this
+service. If the parameter is zero or is omitted, there is no limit. Any attempt
+to make more connections after the limit is reached will result in a "Too many
 connections" error being returned.
 
-**Warning**: In MaxScale 2.5, it is possible that the number of concurrent\
-connections temporarily exceeds the value of `max_connections`. This has been\
+**Warning**: In MaxScale 2.5, it is possible that the number of concurrent
+connections temporarily exceeds the value of `max_connections`. This has been
 fixed in MaxScale 6.
 
 Example:
@@ -2425,19 +2425,19 @@ max_connections=100
 * Default: `false`
 
 Enable transaction state tracking by offloading it to the backend servers.\
-Getting the transaction state from the server will be more accurate for stored\
-procedures or multi-statement SQL that modifies the transaction state\
+Getting the transaction state from the server will be more accurate for stored
+procedures or multi-statement SQL that modifies the transaction state
 non-atomically.
 
-In general, it is better to avoid using this type of SQL as tracking the\
-transaction state via the server responses is not compatible with features such\
-as `transaction_replay` in readwritesplit. `session_track_trx_state` should only\
-be enabled if the default transaction tracking done by MaxScale does not produce\
+In general, it is better to avoid using this type of SQL as tracking the
+transaction state via the server responses is not compatible with features such
+as `transaction_replay` in readwritesplit. `session_track_trx_state` should only
+be enabled if the default transaction tracking done by MaxScale does not produce
 the desired outcome.
 
-This is only supported by MariaDB versions 10.3 or newer. The following must be\
-configured in the MariaDB server in order for this feature to work. Not\
-configuring the MariaDB server with it can result in the transaction state being\
+This is only supported by MariaDB versions 10.3 or newer. The following must be
+configured in the MariaDB server in order for this feature to work. Not
+configuring the MariaDB server with it can result in the transaction state being
 wrong in MaxScale which can result in data inconsistency.
 
 ```
@@ -2454,12 +2454,12 @@ session_track_transaction_info = CHARACTERISTICS
 
 How many statements MaxScale should store for each session of this service.\
 This overrides the value of the global setting with the same name. If`retain_last_statements` has been specified in the global section of the\
-MaxScale configuration file, then if it has _not_ been explicitly specified\
-for the service, the global value holds, otherwise the service specific\
-value rules. That is, it is possible to enable the setting globally and\
+MaxScale configuration file, then if it has _not_ been explicitly specified
+for the service, the global value holds, otherwise the service specific
+value rules. That is, it is possible to enable the setting globally and
 turn it off for a specific service, or just enable it for specific services.
 
-The value of this parameter can be changed at runtime using `maxctrl` and the\
+The value of this parameter can be changed at runtime using `maxctrl` and the
 new value will take effect for sessions created thereafter.
 
 ```
@@ -2474,38 +2474,38 @@ maxctrl alter service MyService retain_last_statements 5
 * Default: `300s`
 * Auto tune: [Yes](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#auto_tune)
 
-Keep idle connections alive by sending pings to backend servers. This feature\
-was introduced in MaxScale 2.5.0 where it was changed from a\
-readwritesplit-specific feature to a generic service feature. The default value\
+Keep idle connections alive by sending pings to backend servers. This feature
+was introduced in MaxScale 2.5.0 where it was changed from a
+readwritesplit-specific feature to a generic service feature. The default value
 for this parameter is 300 seconds. To disable this feature, set the value to 0.
 
-The keepalive interval is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no\
+The keepalive interval is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no
 explicit unit is provided, the value is interpreted as seconds in MaxScale\
-2.5. In subsequent versions a value without a unit may be rejected. Note that\
-since the granularity of the keepalive is seconds, a keepalive specified in\
+2.5. In subsequent versions a value without a unit may be rejected. Note that
+since the granularity of the keepalive is seconds, a keepalive specified in
 milliseconds will be rejected, even if the duration is longer than a second.
 
-The parameter value is the interval in seconds between each keepalive ping. A\
-keepalive ping will be sent to a backend server if the connection has been idle\
+The parameter value is the interval in seconds between each keepalive ping. A
+keepalive ping will be sent to a backend server if the connection has been idle
 for longer than the configured keepalive interval.
 
-Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client\
-has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings\
+Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client
+has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings
 regardless of the client state.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `connection_keepalive` for those is not used.
 
-If the value of `connection_keepalive` is changed at runtime, the change in the\
+If the value of `connection_keepalive` is changed at runtime, the change in the
 value takes effect immediately.
 
-As the connection keepalive pings must be done only when there's no ongoing\
-query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that\
-rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the\
+As the connection keepalive pings must be done only when there's no ongoing
+query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that
+rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the
 performance will be the same with or without `connection_keepalive`.
 
-If you want to avoid the performance cost and you don't need the connection\
+If you want to avoid the performance cost and you don't need the connection
 keepalive feature, you can disable it with `connection_keepalive=0s`.
 
 #### `force_connection_keepalive`
@@ -2515,16 +2515,16 @@ keepalive feature, you can disable it with `connection_keepalive=0s`.
 * Dynamic: Yes
 * Default: `false`
 
-By default, connection keepalive pings are only sent if the client is either\
-executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are\
-unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can\
-be used to emulate the pre-2.5.21 behavior if long-lived application connections\
+By default, connection keepalive pings are only sent if the client is either
+executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are
+unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can
+be used to emulate the pre-2.5.21 behavior if long-lived application connections
 rely on the old unconditional keepalive pings.
 
 _Note:_ if `force_connection_keepalive` is enabled and `connection_keepalive` in\
-MaxScale is set to a lower value than the `wait_timeout` on the database, the\
-client idle timeouts that `wait_timeout` control are no longer effective. This\
-happens because MaxScale unconditionally sends the pings which make the client\
+MaxScale is set to a lower value than the `wait_timeout` on the database, the
+client idle timeouts that `wait_timeout` control are no longer effective. This
+happens because MaxScale unconditionally sends the pings which make the client
 behave like it is not idle and thus the connections will never be killed due to`wait_timeout`.
 
 #### `net_write_timeout`
@@ -2534,17 +2534,17 @@ behave like it is not idle and thus the connections will never be killed due to`
 * Dynamic: Yes
 * Default: `0s`
 
-This parameter controls how long a network write to the client can stay\
+This parameter controls how long a network write to the client can stay
 buffered. This feature is disabled by default.
 
-When `net_write_timeout` is configured and data is buffered on the client\
-network connection, if the time since the last successful network write exceeds\
+When `net_write_timeout` is configured and data is buffered on the client
+network connection, if the time since the last successful network write exceeds
 the configured limit, the client connection will be disconnected.
 
-The value is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `max_sescmd_history`
@@ -2554,45 +2554,45 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `50`
 
-`max_sescmd_history` sets a limit on how many distinct session commands are\
-stored in the session command history. When the history limit is exceeded, the\
-history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server\
+`max_sescmd_history` sets a limit on how many distinct session commands are
+stored in the session command history. When the history limit is exceeded, the
+history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server
 reconnections are no longer possible.
 
-The required history size can be estimated by counting the total number of\
-session state modifying commands (e.g `SET NAMES`) that are used by a\
-client. Note that connectors usually add some commands that aren't visible to\
-the application developer which means a safety margin should be added. A good\
-rule of thumb is to count the expected number of statements and double that\
-number. The default value of 50 is a value that'll work for most applications\
+The required history size can be estimated by counting the total number of
+session state modifying commands (e.g `SET NAMES`) that are used by a
+client. Note that connectors usually add some commands that aren't visible to
+the application developer which means a safety margin should be added. A good
+rule of thumb is to count the expected number of statements and double that
+number. The default value of 50 is a value that'll work for most applications
 that do not rely heavily on user variables.
 
-Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4\
-and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol\
-prepared statements opened by the client are also kept open by MaxScale and are\
+Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4
+and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol
+prepared statements opened by the client are also kept open by MaxScale and are
 restored whenever a reconnection to a server happens. The limits imposed by`max_sescmd_history` apply to other text protocol commands e.g. `SET NAMES`.\
-Note that text protocol prepared statements count as text protocol commands and\
-are thus potentially pruned when history pruning happens. If an application uses\
+Note that text protocol prepared statements count as text protocol commands and
+are thus potentially pruned when history pruning happens. If an application uses
 a lot of `PREPARE stmt FROM <sql>` commands, it is recommended that the value of`max_sescmd_history` is increased accordingly.
 
-In older versions of MaxScale, binary protocol prepared statements were limited\
-by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this\
-caused problems when the binary protocol prepared statement were pruned while\
-they were still open from the client's point of view. In older versions, the\
-recommended value of `max_sescmd_history` is the number of state modifying\
-commands plus the maximum number of open prepared statements that any application\
+In older versions of MaxScale, binary protocol prepared statements were limited
+by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this
+caused problems when the binary protocol prepared statement were pruned while
+they were still open from the client's point of view. In older versions, the
+recommended value of `max_sescmd_history` is the number of state modifying
+commands plus the maximum number of open prepared statements that any application
 may use.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
-In addition to limiting the number of commands to store, it also acts as a hard\
-limit on the number of packets that may be queued up on a backend before it is\
-closed. Packets are queued while the TCP socket is being opened and when\
-prepared statements are being prepared. In certain rare cases, a slow server may\
-fall behind and not catch up to the rest of the cluster and a backlog of packets\
-forms. In these cases, if more than `max_sescmd_history` packets are queued, the\
+In addition to limiting the number of commands to store, it also acts as a hard
+limit on the number of packets that may be queued up on a backend before it is
+closed. Packets are queued while the TCP socket is being opened and when
+prepared statements are being prepared. In certain rare cases, a slow server may
+fall behind and not catch up to the rest of the cluster and a backlog of packets
+forms. In these cases, if more than `max_sescmd_history` packets are queued, the
 connection to the server is closed.
 
 #### `prune_sescmd_history`
@@ -2602,37 +2602,37 @@ connection to the server is closed.
 * Dynamic: Yes
 * Default: `true`
 
-This option enables pruning of the session command history when it exceeds the\
-value configured in `max_sescmd_history`. When this option is enabled, only a\
-set number of statements are stored in the history. This limits the per-session\
+This option enables pruning of the session command history when it exceeds the
+value configured in `max_sescmd_history`. When this option is enabled, only a
+set number of statements are stored in the history. This limits the per-session
 memory use while still allowing safe reconnections.
 
-This parameter is intended to be used with pooled connections that remain in use\
-for a very long time. Most connection pool implementations do not reset the\
-session state and instead re-initialize it with new values. This causes the\
-session command history to grow at roughly a constant rate for the lifetime of\
+This parameter is intended to be used with pooled connections that remain in use
+for a very long time. Most connection pool implementations do not reset the
+session state and instead re-initialize it with new values. This causes the
+session command history to grow at roughly a constant rate for the lifetime of
 the pooled connection.
 
-Each client-side session that uses a pooled connection only executes a finite\
-amount of session commands. By retaining a shorter history that encompasses all\
-session commands the individual clients execute, the session state of a pooled\
+Each client-side session that uses a pooled connection only executes a finite
+amount of session commands. By retaining a shorter history that encompasses all
+session commands the individual clients execute, the session state of a pooled
 connection can be accurately recreated on another server.
 
-When the session command history pruning is enabled, there is a theoretical\
-possibility that upon server reconnection the session states of the connections\
-are inconsistent. This can only happen if the length of the stored history is\
-shorter than the list of relevant statements that affect the session state. In\
-practice the default value of 50 session commands is a fairly reasonable value\
+When the session command history pruning is enabled, there is a theoretical
+possibility that upon server reconnection the session states of the connections
+are inconsistent. This can only happen if the length of the stored history is
+shorter than the list of relevant statements that affect the session state. In
+practice the default value of 50 session commands is a fairly reasonable value
 and the risk of inconsistent session state is relatively low.
 
-In case the default history length is too short for safe pruning, set the value\
-of `max_sescmd_history` to the total number of commands that affect the session\
-state plus a safety margin of 10. The safety margin reserves some extra space\
-for new commands that might be executed due to changes in the client side\
+In case the default history length is too short for safe pruning, set the value
+of `max_sescmd_history` to the total number of commands that affect the session
+state plus a safety margin of 10. The safety margin reserves some extra space
+for new commands that might be executed due to changes in the client side
 application.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `disable_sescmd_history`
@@ -2642,17 +2642,17 @@ history. Currently only `readwritesplit` and `schemarouter` support it.
 * Dynamic: Yes
 * Default: `false`
 
-This option disables the session command history. This way no history is stored\
-and if a replica server fails, the router will not try to replace the failed\
-replica. Disabling session command history will allow long-lived connections\
+This option disables the session command history. This way no history is stored
+and if a replica server fails, the router will not try to replace the failed
+replica. Disabling session command history will allow long-lived connections
 without causing a constant growth in the memory consumption.
 
-This parameter should only be used when either the memory footprint must be as\
-small as possible or when the pruning of the session command history is not\
+This parameter should only be used when either the memory footprint must be as
+small as possible or when the pruning of the session command history is not
 acceptable.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `user_accounts_file`
@@ -2669,25 +2669,25 @@ Default value is empty, which disables the feature.
 user_accounts_file=/home/root/users.json
 ```
 
-In addition to querying the backends, MaxScale can read users from a file. This\
-feature is useful when backends have limitations on the type of users that can\
-be created, or if MaxScale needs to allow users to log in even\
-when backends are down (e.g. binlog router). The users read from the file are\
-only present on MaxScale, so logging into backends can still fail. The format of\
-the file is protocol-specific. The following only applies to MariaDB-protocol,\
+In addition to querying the backends, MaxScale can read users from a file. This
+feature is useful when backends have limitations on the type of users that can
+be created, or if MaxScale needs to allow users to log in even
+when backends are down (e.g. binlog router). The users read from the file are
+only present on MaxScale, so logging into backends can still fail. The format of
+the file is protocol-specific. The following only applies to MariaDB-protocol,
 which is also the only protocol supporting this feature.
 
-The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which\
-contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at\
-least the string fields _user_ and _host_, which define the user account to add\
+The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which
+contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at
+least the string fields _user_ and _host_, which define the user account to add
 or modify.
 
-The elements in the _user_-array may contain the following additional fields. If\
+The elements in the _user_-array may contain the following additional fields. If
 a field is not defined, it is assumed either empty (string) or false (boolean).
 
 * password: String. Password hash, similar to the equivalent column on server.
 * plugin: String. Authentication plugin used by client, similar to server.
-* authentication\_string: String. Additional authentication info, similar to\
+* authentication\_string: String. Additional authentication info, similar to
   server.
 * default\_role: String. Default role of user, similar to server.
 * super\_priv: Boolean. True if user has SUPER grant.
@@ -2697,17 +2697,17 @@ a field is not defined, it is assumed either empty (string) or false (boolean).
 
 The elements in the _db_-array must contain the following additional field:
 
-* db: String. Database which the user can access. Can contain % and \_\
+* db: String. Database which the user can access. Can contain % and \_
   wildcards.
 
-The elements in the _roles\_mapping_-array must contain the following additional\
+The elements in the _roles\_mapping_-array must contain the following additional
 field:
 
 * role: String. Role the user can access.
 
 When users are read from both servers and the file, the server takes priority.\
 That is, if user `'joe'@'%'` is defined on both, the file-version is discarded.\
-The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant\
+The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant
 and role lists.
 
 An example users file is below.
@@ -2766,9 +2766,9 @@ Defines when _user\_accounts\_file_ is read. The value is an enum, either\
 read from a server. The file contents are then added to the server-based data.\
 If reading from server fails (e.g. servers are down), the file is ignored.
 
-"file\_only\_always" means that users are not read from the servers at all and the\
-file contents is all that matters. The state of the servers is ignored. This\
-mode can be useful with the binlog router, as it allows clients to log in and\
+"file\_only\_always" means that users are not read from the servers at all and the
+file contents is all that matters. The state of the servers is ignored. This
+mode can be useful with the binlog router, as it allows clients to log in and
 fetch binary logs from MaxScale even when backend servers are down.
 
 ```
@@ -2782,36 +2782,36 @@ user_accounts_file_usage=file_only_always
 * Dynamic: Yes
 * Default: `-1s`
 
-Normally, MaxScale only pools backend connections when\
-a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections\
+Normally, MaxScale only pools backend connections when
+a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections
 instead of creating new connections to backends. If connection sharing is enabled,\
-MaxScale can pool backend connections also from running sessions, and\
-re-attach a pooled connection when a session is doing a query. This effectively\
+MaxScale can pool backend connections also from running sessions, and
+re-attach a pooled connection when a session is doing a query. This effectively
 allows multiple sessions to share backend connections.
 
-_idle\_session\_pool\_time_ defines the amount of time a session must be idle\
-before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in\
+_idle\_session\_pool\_time_ defines the amount of time a session must be idle
+before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in
 seconds or milliseconds.
 
-This feature has a significant drawback: when a backend connection is reused, it\
-needs to be restored to the correct state. This means reauthenticating and\
-replaying session commands. This can add a significant delay before the\
-connection is actually ready for a query. If the session command history size\
-exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for\
+This feature has a significant drawback: when a backend connection is reused, it
+needs to be restored to the correct state. This means reauthenticating and
+replaying session commands. This can add a significant delay before the
+connection is actually ready for a query. If the session command history size
+exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for
 the session.
 
-This feature should only be used when limiting the backend connection count is\
-a priority, even at the cost of query delay and throughput. This feature only\
+This feature should only be used when limiting the backend connection count is
+a priority, even at the cost of query delay and throughput. This feature only
 works when the following server settings are also set in MaxScale configuration:
 
 1. [max\_routing\_connections](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#max_routing_connections)
 2. [persistpoolmax](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#persistpoolmax)
 3. [persistmaxtime](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#persistmaxtime)
 
-Since reusing a backend connection is an expensive operation, MaxScale only\
-pools connections when another session requires them. _idle\_session\_pool\_time_\
-thus effectively limits the frequency at which a connection can be moved from\
-one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to\
+Since reusing a backend connection is an expensive operation, MaxScale only
+pools connections when another session requires them. _idle\_session\_pool\_time_
+thus effectively limits the frequency at which a connection can be moved from
+one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to
 move connections as soon as possible.
 
 ```
@@ -2823,57 +2823,57 @@ See below for more information on configuring connection sharing.
 **Details, limitations and suggestions for connection sharing**
 
 As noted above, when a connection is pooled and reused its state is lost.\
-Although session variables and prepared statements are restored by replaying\
+Although session variables and prepared statements are restored by replaying
 session commands, some state information cannot be transferred.
 
-The most common such state is a transaction. When a transaction is on,\
+The most common such state is a transaction. When a transaction is on,
 connection sharing is disabled for that session until the transaction completes.\
-Other similar situations may not be properly detected, and it's the\
-responsibility of the user to avoid introducing such state to the session when\
+Other similar situations may not be properly detected, and it's the
+responsibility of the user to avoid introducing such state to the session when
 using connection sharing. This means that the following should not be used:
 
-* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that\
+* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that
   introduces state into the connection.
-* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector\
+* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector
   must be used instead of the variable.
 * Stored procedures that cause session level side-effects.
 
-Several settings affect connection sharing and its effectiveness. Reusing a\
-connection is an expensive operation so its frequency should be minimized. The\
+Several settings affect connection sharing and its effectiveness. Reusing a
+connection is an expensive operation so its frequency should be minimized. The
 important configuration settings in addition to _idle\_session\_pool\_time_ are\
 MaxScale server settings [persistpoolmax](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#persistpoolmax),[persistmaxtime](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#persistmaxtime) and [max\_routing\_connections](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#max_routing_connections).\
-The service settings [max\_sescmd\_history](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These\
+The service settings [max\_sescmd\_history](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These
 settings should be tuned according to the use case.
 
-_persistpoolmax_ limits how many connections can be kept in a pool for a given\
-server. If the pool is full, no more connections are detached from sessions even\
-if they are idle and required. The pool size should be large enough to contain\
+_persistpoolmax_ limits how many connections can be kept in a pool for a given
+server. If the pool is full, no more connections are detached from sessions even
+if they are idle and required. The pool size should be large enough to contain
 any connections being transferred between sessions, but not be greater than _max\_routing\_connections_. Using the value of _max\_routing\_connections_ is a
 reasonable starting point.
 
-_persistmaxtime_ limits the time a connection may stay in the pool. This should\
-be high enough so that pooled connections are not unnecessarily closed. Cleaning\
+_persistmaxtime_ limits the time a connection may stay in the pool. This should
+be high enough so that pooled connections are not unnecessarily closed. Cleaning
 up clearly unneeded connections from the pool may be useful when _max\_routing\_connections_ is restrictively tuned. Because each MaxScale routing
-thread has its own connection pool, one thread can monopolize access to a\
-server. For example, if the pool of thread 1 has 100 connections to _ServerA_\
-with `max_routing_connections=100`, other threads can no longer connect to the\
-server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as\
-it would cause unneeded connections in the pool to be closed faster. Such\
-connection slots then become available to other routing threads. Reducing the\
-number of [routing threads](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool\
-fragmentation. This may reduce overall throughput, though. When using connection\
+thread has its own connection pool, one thread can monopolize access to a
+server. For example, if the pool of thread 1 has 100 connections to _ServerA_
+with `max_routing_connections=100`, other threads can no longer connect to the
+server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as
+it would cause unneeded connections in the pool to be closed faster. Such
+connection slots then become available to other routing threads. Reducing the
+number of [routing threads](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool
+fragmentation. This may reduce overall throughput, though. When using connection
 sharing, backend connections are only in the pool momentarily. Consequently,_persistmaxtime_ can be set quite low, e.g. 10s.
 
-If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is\
-disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find\
-a backend connection. This can be avoided with _prune\_sescmd\_history_. However,\
-pruning means that old session commands will not be replayed when a pooled\
-connection is reused. If the pruned commands are important\
+If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is
+disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find
+a backend connection. This can be avoided with _prune\_sescmd\_history_. However,
+pruning means that old session commands will not be replayed when a pooled
+connection is reused. If the pruned commands are important
 (e.g. statement preparations), the session may fail later on.
 
 If the number of clients actively running queries is greater than _max\_routing\_connections_, query throughput will suffer as clients will need to
-take turns. In this situation, it's imperative to minimize the number of\
-backend connections a single session uses. The settings to achieve this depend\
+take turns. In this situation, it's imperative to minimize the number of
+backend connections a single session uses. The settings to achieve this depend
 on the router. For ReadWriteSplit the following should be used:
 
 ```
@@ -2882,12 +2882,12 @@ lazy_connect=1
 transaction_replay=true
 ```
 
-The above settings mean that MaxScale can process roughly\
-(_number of replica servers_ X _max\_routing\_connections_) read queries\
-simultaneously. Write queries will still need to take turns as there is only one\
+The above settings mean that MaxScale can process roughly
+(_number of replica servers_ X _max\_routing\_connections_) read queries
+simultaneously. Write queries will still need to take turns as there is only one
 primary server.
 
-The following configuration snippet shows example server and service\
+The following configuration snippet shows example server and service
 configurations for connection sharing with ReadWriteSplit.
 
 ```
@@ -2914,11 +2914,11 @@ lazy_connect=1
 * Dynamic: Yes
 * Default: `60s`
 
-When connection sharing (as described above) is on, clients\
-may have to wait for their turn to use a backend connection. If too much time\
-passes without a connection becoming available, MaxScale returns an error to\
-the client, usually also ending the session. _multiplex\_timeout_ sets this\
-timeout. Increase it if queries are failing with "Timed out when waiting for a\
+When connection sharing (as described above) is on, clients
+may have to wait for their turn to use a backend connection. If too much time
+passes without a connection becoming available, MaxScale returns an error to
+the client, usually also ending the session. _multiplex\_timeout_ sets this
+timeout. Increase it if queries are failing with "Timed out when waiting for a
 connection". Decrease it if failing early is preferable to stalling.
 
 ```
@@ -2927,10 +2927,10 @@ multiplex_timeout=33s
 
 ### Server
 
-Server sections define the backend database servers MaxScale uses. A server is\
-identified by its section name in the configuration file. The only mandatory\
-parameter of a server is _type_, but _address_ and _port_ are also usually\
-defined. A server may be a member of one or more services. A server may only be\
+Server sections define the backend database servers MaxScale uses. A server is
+identified by its section name in the configuration file. The only mandatory
+parameter of a server is _type_, but _address_ and _port_ are also usually
+defined. A server may be a member of one or more services. A server may only be
 monitored by at most one monitor.
 
 ```
@@ -2947,7 +2947,7 @@ port=3000
 * Dynamic: Yes
 * Default: `""`
 
-The IP-address or hostname of the machine running the database server. MaxScale\
+The IP-address or hostname of the machine running the database server. MaxScale
 uses this address to connect to the server.
 
 Either _address_ or _socket_ must be defined, but not both.
@@ -2959,7 +2959,7 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: `3306`
 
-The port the backend server listens on for incoming connections. MaxScale uses\
+The port the backend server listens on for incoming connections. MaxScale uses
 this port to connect to the server.
 
 #### `socket`
@@ -2969,7 +2969,7 @@ this port to connect to the server.
 * Dynamic: Yes
 * Default: `""`
 
-The absolute path to a UNIX domain socket the MariaDB server is listening\
+The absolute path to a UNIX domain socket the MariaDB server is listening
 on.
 
 Either _address_ or _socket_ must be defined, but not both.
@@ -2981,9 +2981,9 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitorpasswd](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -2998,9 +2998,9 @@ monitorpw=mymonitorpasswd
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitoruser](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitoruser](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -3008,7 +3008,7 @@ monitoruser=mymonitoruser
 monitorpw=mymonitorpasswd
 ```
 
-`monitorpw` may be either a plain text password or an encrypted password. See\
+`monitorpw` may be either a plain text password or an encrypted password. See
 the section [encrypting passwords](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encrypting-passwords) for more information.
 
 #### `extra_port`
@@ -3018,19 +3018,19 @@ the section [encrypting passwords](mariadb-maxscale-2302-mariadb-maxscale-config
 * Dynamic: Yes
 * Default: `0`
 
-An alternative port used for administrative connections to the server. If this\
-setting is defined, MaxScale uses it for monitoring the server and to fetch user\
+An alternative port used for administrative connections to the server. If this
+setting is defined, MaxScale uses it for monitoring the server and to fetch user
 accounts. Client sessions will still use the normal port.
 
-Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on\
-the backend server has been reached. Extra-port connections have their own\
-connection limit, which is one by default. This needs to be increased to allow\
+Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on
+the backend server has been reached. Extra-port connections have their own
+connection limit, which is one by default. This needs to be increased to allow
 both monitor and user account manager to connect.
 
-If the connection to the extra-port fails due to connection number limit or if\
+If the connection to the extra-port fails due to connection number limit or if
 the port is not open on the server, normal port is used.
 
-For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)\
+For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)
 and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables#extra_max_connections).
 
 #### `persistpoolmax`
@@ -3041,15 +3041,15 @@ and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-
 * Default: `0`
 
 Sets the size of the server connection pool. Disabled by default. When enabled,\
-MaxScale places unused connections to the server to a pool and reuses them\
-later. Connections typically become unused when a session closes. If the size of\
+MaxScale places unused connections to the server to a pool and reuses them
+later. Connections typically become unused when a session closes. If the size of
 the pool reaches _persistpoolmax_, unused connections are closed instead.
 
-Every routing thread has its own pool. As of version 6.3.0, MaxScale will round\
+Every routing thread has its own pool. As of version 6.3.0, MaxScale will round
 up _persistpoolmax_ so that every thread has an equal size pool.
 
-When a MariaDB-protocol connection is taken from the pool to be used in a new\
-session, the state of the connection is dependent on the router. ReadWriteSplit\
+When a MariaDB-protocol connection is taken from the pool to be used in a new
+session, the state of the connection is dependent on the router. ReadWriteSplit
 restores the connection to match the session state. Other routers do not.
 
 #### `persistmaxtime`
@@ -3059,15 +3059,15 @@ restores the connection to match the session state. Other routers do not.
 * Dynamic: Yes
 * Default: `0s`
 
-The `persistmaxtime` parameter defaults to zero but can be set to a duration as\
-documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is\
-interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a\
-unit may be rejected. Note that since the granularity of the parameter is\
-seconds, a value specified in milliseconds will be rejected, even if the\
+The `persistmaxtime` parameter defaults to zero but can be set to a duration as
+documented [here](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is
+interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a
+unit may be rejected. Note that since the granularity of the parameter is
+seconds, a value specified in milliseconds will be rejected, even if the
 duration is longer than a second.
 
-A DCB placed in the persistent pool for a server will only be reused if the\
-elapsed time since it joined the pool is less than the given value. Otherwise,\
+A DCB placed in the persistent pool for a server will only be reused if the
+elapsed time since it joined the pool is less than the given value. Otherwise,
 the DCB will be discarded and the connection closed.
 
 #### `max_routing_connections`
@@ -3077,18 +3077,18 @@ the DCB will be discarded and the connection closed.
 * Dynamic: Yes
 * Default: `0`
 
-Maximum number of routing connections to this server. Connections held in a pool\
-also count towards this maximum. Does not limit monitor connections or user\
+Maximum number of routing connections to this server. Connections held in a pool
+also count towards this maximum. Does not limit monitor connections or user
 account fetching. A value of 0 (default) means no limit.
 
-Since every client session can generate a connection to a server, the server may\
-run out of memory when the number of clients is high enough. This setting limits\
-server memory use caused by MaxScale. The effect depends on if the service\
-setting [idle\_session\_pool\_time](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection\
+Since every client session can generate a connection to a server, the server may
+run out of memory when the number of clients is high enough. This setting limits
+server memory use caused by MaxScale. The effect depends on if the service
+setting [idle\_session\_pool\_time](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection
 sharing, is enabled or not.
 
 If connection sharing is not on, _max\_routing\_connections_ simply sets a limit.\
-Any sessions attempting to exceed this limit will fail to connect to the\
+Any sessions attempting to exceed this limit will fail to connect to the
 backend. The client can still connect to MaxScale, but queries will fail.
 
 If connection sharing is on, sessions exceeding the limit will be put on hold\
@@ -3106,37 +3106,37 @@ max_routing_connections=1234
 * Dynamic: Yes
 * Default: `false`
 
-If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-header when connecting client sessions to the server. The header contains the\
-original client IP address and port, as seen by MaxScale. The server will then\
-read the header and perform authentication as if the connection originated from\
-this address instead of MaxScale's IP address. With this feature, the user\
-accounts on the backend server can be simplified to only contain the actual\
+If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+header when connecting client sessions to the server. The header contains the
+original client IP address and port, as seen by MaxScale. The server will then
+read the header and perform authentication as if the connection originated from
+this address instead of MaxScale's IP address. With this feature, the user
+accounts on the backend server can be simplified to only contain the actual
 client hosts and not the MaxScale host.
 
-**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy\
-protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#proxy_protocol_networks) in MaxScale. This also needs\
-to be done whenever one MaxScale may connect to another Maxscale and the\
+**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy
+protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#proxy_protocol_networks) in MaxScale. This also needs
+to be done whenever one MaxScale may connect to another Maxscale and the
 connecting MaxScale has `proxy_protocol` enabled.
 
-PROXY protocol will be supported by MariaDB 10.3, which this feature has been\
-tested with. To use it, enable the PROXY protocol in MaxScale for every\
-compatible server and configure the MariaDB servers themselves to accept the\
-protocol headers from MaxScale's IP address. On the server side, the protocol\
-should be enabled only for trusted IPs, as it allows the sender to spoof the\
-connection origin. If a proxy header is sent to a server not expecting it, the\
-connection will fail. Usually PROXY protocol should be enabled for every\
+PROXY protocol will be supported by MariaDB 10.3, which this feature has been
+tested with. To use it, enable the PROXY protocol in MaxScale for every
+compatible server and configure the MariaDB servers themselves to accept the
+protocol headers from MaxScale's IP address. On the server side, the protocol
+should be enabled only for trusted IPs, as it allows the sender to spoof the
+connection origin. If a proxy header is sent to a server not expecting it, the
+connection will fail. Usually PROXY protocol should be enabled for every
 server in a cluster, as they typically have similar grants.
 
-Other SQL-servers may support PROXY protocol as well, but the implementation may\
-be highly restricting. Strict adherence to the protocol requires that the\
-backend server does not allow mixing of un-proxied and proxied connections from\
-a given IP. MaxScale requires normal connections to backends for monitoring and\
-authentication data queries, which would be blocked. To bypass this restriction,\
-the server monitor needs to be disabled and the service listener needs to be\
+Other SQL-servers may support PROXY protocol as well, but the implementation may
+be highly restricting. Strict adherence to the protocol requires that the
+backend server does not allow mixing of un-proxied and proxied connections from
+a given IP. MaxScale requires normal connections to backends for monitoring and
+authentication data queries, which would be blocked. To bypass this restriction,
+the server monitor needs to be disabled and the service listener needs to be
 configured to disregard authentication errors (`skip_authentication=true`).\
-Server states also need to be set manually in MaxCtrl. These steps are _not_\
-required for MariaDB 10.3, since its implementation is more flexible and allows\
+Server states also need to be set manually in MaxCtrl. These steps are _not_
+required for MariaDB 10.3, since its implementation is more flexible and allows
 both PROXY-headered and headerless connections from a proxy-enabled IP.
 
 #### `disk_space_threshold`
@@ -3146,30 +3146,30 @@ both PROXY-headered and headerless connections from a proxy-enabled IP.
 * Dynamic: No
 * Default: None
 
-This parameter specifies how full a disk may be, before MaxScale should start\
-logging warnings or take other actions (e.g. perform a switchover). This\
+This parameter specifies how full a disk may be, before MaxScale should start
+logging warnings or take other actions (e.g. perform a switchover). This
 functionality will only work with MariaDB server versions 10.1.32, 10.2.14 and\
 10.3.6 onwards, if the `DISKS` _information schema plugin_ has been installed.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-A limit is specified as a path followed by a colon and a percentage specifying\
+A limit is specified as a path followed by a colon and a percentage specifying
 how full the corresponding disk may be, before action is taken. E.g. an entry like
 
 ```
 /data:80
 ```
 
-specifies that the disk that has been mounted on `/data` may be used until 80%\
-of the total space has been consumed. Multiple entries can be specified by\
-separating them by a comma. If the path is specified using `*`, then the limit\
-applies to all disks. However, the value of `*` is only applied if there is not\
+specifies that the disk that has been mounted on `/data` may be used until 80%
+of the total space has been consumed. Multiple entries can be specified by
+separating them by a comma. If the path is specified using `*`, then the limit
+applies to all disks. However, the value of `*` is only applied if there is not
 an exact match.
 
-Note that if a particular disk has been mounted on several paths, only one path\
-need to be specified. If several are specified, then the one with the smallest\
+Note that if a particular disk has been mounted on several paths, only one path
+need to be specified. If several are specified, then the one with the smallest
 percentage will be applied.
 
 Examples:
@@ -3181,7 +3181,7 @@ disk_space_threshold=/data1:80,/data2:60,*:90
 ```
 
 The last line means that the disk mounted at `/data1` may be used up to\
-80%, the disk mounted at `/data2` may be used up to 60% and all other disks\
+80%, the disk mounted at `/data2` may be used up to 60% and all other disks
 mounted at any paths may be used up until 90% of maximum capacity, before\
 MaxScale starts to warn to take action.
 
@@ -3198,7 +3198,7 @@ Note that the path to be used, is one of the paths returned by:
 ...
 ```
 
-There is no default value, but this parameter must be explicitly specified\
+There is no default value, but this parameter must be explicitly specified
 if the disk space situation should be monitored.
 
 #### `rank`
@@ -3209,20 +3209,20 @@ if the disk space situation should be monitored.
 * Values: `primary`, `secondary`
 * Default: `primary`
 
-This parameter controls the order in which servers are used. Valid values for\
+This parameter controls the order in which servers are used. Valid values for
 this parameter are `primary` and `secondary`. The default value is`primary`.
 
-This behavior depends on the router implementation but the general rule of thumb\
+This behavior depends on the router implementation but the general rule of thumb
 is that primary servers will be used before secondary servers.
 
-Readconnroute will always use primary servers before secondary servers as long\
+Readconnroute will always use primary servers before secondary servers as long
 as they match the configured server type.
 
-Readwritesplit will pick servers that have the same rank as the current\
-primary. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md)\
+Readwritesplit will pick servers that have the same rank as the current
+primary. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md)
 for a detailed description of the behavior.
 
-The following example server configuration demonstrates how `rank` can be used\
+The following example server configuration demonstrates how `rank` can be used
 to exclude `DR-site` servers from routing.
 
 ```
@@ -3247,7 +3247,7 @@ address=192.168.0.22
 rank=secondary
 ```
 
-The `main-site-primary` and `main-site-replica` servers will be used as long as\
+The `main-site-primary` and `main-site-replica` servers will be used as long as
 they are available. When they are no longer available, the `DR-site-primary` and`DR-site-replica` will be used.
 
 #### `priority`
@@ -3257,11 +3257,11 @@ they are available. When they are no longer available, the `DR-site-primary` and
 * Dynamic: Yes
 * Default: 0
 
-Server priority. Currently only used by galeramon to choose the order in which\
-nodes are selected as the current primary server. Refer to the [Server Priorities](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-galera-monitor.md#interaction-with-server-priorities)\
+Server priority. Currently only used by galeramon to choose the order in which
+nodes are selected as the current primary server. Refer to the [Server Priorities](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-galera-monitor.md#interaction-with-server-priorities)
 section of the galeramon documentation for more information on how to use it.
 
-Starting with MaxScale 2.5.21, this parameter also accepts negative values. In\
+Starting with MaxScale 2.5.21, this parameter also accepts negative values. In
 older versions, the parameter only accepted non-negative values.
 
 #### `replication_custom_options`
@@ -3271,33 +3271,33 @@ older versions, the parameter only accepted non-negative values.
 * Dynamic: Yes
 
 Server-specific custom string added to "CHANGE MASTER TO"-commands sent by\
-MariaDB Monitor. Overrides `replication_custom_options` setting set in\
-the monitor. This setting affects the server where the command is ran at, not\
-the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-\
-command to server A telling it to replicate from server B, the setting value\
+MariaDB Monitor. Overrides `replication_custom_options` setting set in
+the monitor. This setting affects the server where the command is ran at, not
+the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-
+command to server A telling it to replicate from server B, the setting value
 from MaxScale configuration for server A would be used.
 
-See [MariaDB Monitor documentation](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md#replication_custom_options)\
+See [MariaDB Monitor documentation](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md#replication_custom_options)
 for more information.
 
 ### Monitor
 
-Monitor sections are used to define the monitoring module that watches a set of\
+Monitor sections are used to define the monitoring module that watches a set of
 servers. Each server can only be monitored by one monitor.
 
 Common monitor parameters [can be found here](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-common-monitor-parameters.md).
 
 ### Listener
 
-A listener defines a port MaxScale listens on for incoming connections. Accepted\
-connections are linked with a MaxScale service. Multiple listeners can feed the\
-same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface\
+A listener defines a port MaxScale listens on for incoming connections. Accepted
+connections are linked with a MaxScale service. Multiple listeners can feed the
+same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface
 only. _socket_ is also optional and is used for Unix socket connections.
 
-The network socket where the listener listens may have a backlog of\
+The network socket where the listener listens may have a backlog of
 connections. The size of this backlog is controlled by the\_net.ipv4.tcp\_max\_syn\_backlog\_ and _net.core.somaxconn_ kernel parameters.
 
-Increasing the size of the backlog by modifying the kernel parameters helps with\
+Increasing the size of the backlog by modifying the kernel parameters helps with
 sudden connection spikes and rejected connections. For more information see [listen(2)](https://man7.org/linux/man-pages/man2/listen.2.html).
 
 ```
@@ -3313,7 +3313,7 @@ port=3006
 * Mandatory: Yes
 * Dynamic: No
 
-The service to which the listener is associated. This is the name of a service\
+The service to which the listener is associated. This is the name of a service
 that is defined elsewhere in the configuration file.
 
 #### `protocol`
@@ -3326,11 +3326,11 @@ that is defined elsewhere in the configuration file.
 The name of the protocol module used for communication between the client and\
 MaxScale. The same protocol is also used for backend communication.
 
-Usually this does not need to be defined as the default protocol is the MariaDB\
+Usually this does not need to be defined as the default protocol is the MariaDB
 network protocol that is used by SQL connections.
 
-For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL\
-protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-nosql-protocol-module.md) module\
+For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL
+protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-nosql-protocol-module.md) module
 documentation.
 
 #### `address`
@@ -3340,8 +3340,8 @@ documentation.
 * Dynamic: No
 * Default: `"::"`
 
-This sets the address the listening socket is bound to. The address may be\
-specified as an IP address in 'dot notation' or as a hostname. If left undefined\
+This sets the address the listening socket is bound to. The address may be
+specified as an IP address in 'dot notation' or as a hostname. If left undefined
 the listener will bind to all network interfaces.
 
 #### `port`
@@ -3351,7 +3351,7 @@ the listener will bind to all network interfaces.
 * Dynamic: No
 * Default: `0`
 
-The port the listener listens on. If left undefined a default port for the\
+The port the listener listens on. If left undefined a default port for the
 protocol is used.
 
 #### `socket`
@@ -3361,10 +3361,10 @@ protocol is used.
 * Dynamic: No
 * Default: `""`
 
-If defined, the listener uses Unix domain sockets to listen for incoming\
+If defined, the listener uses Unix domain sockets to listen for incoming
 connections. The parameter value is the name of the socket to use.
 
-If you want to use both network ports and UNIX domain sockets with a service,\
+If you want to use both network ports and UNIX domain sockets with a service,
 define two separate listeners that connect to the same service.
 
 #### `authenticator`
@@ -3374,8 +3374,8 @@ define two separate listeners that connect to the same service.
 * Dynamic: No
 * Default: `""`
 
-The authenticator module to use. Each protocol module defines a default\
-authentication module, which is used if the setting is left undefined._MariaDBClient_-protocol supports multiple authenticators and they can be used\
+The authenticator module to use. Each protocol module defines a default
+authentication module, which is used if the setting is left undefined._MariaDBClient_-protocol supports multiple authenticators and they can be used
 simultaneously by giving a comma-separated list e.g.`authenticator=PAMAuth,mariadbauth,gssapiauth`
 
 #### `authenticator_options`
@@ -3385,8 +3385,8 @@ simultaneously by giving a comma-separated list e.g.`authenticator=PAMAuth,maria
 * Dynamic: No
 * Default: `""`
 
-This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of\
-this parameter should be a comma-separated list of key-value pairs. See\
+This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of
+this parameter should be a comma-separated list of key-value pairs. See
 authenticator specific documentation for more details.
 
 #### `sql_mode`
@@ -3402,33 +3402,33 @@ If both are used this setting will override the global setting for this listener
 
 #### `proxy_protocol_networks`
 
-Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-when connecting. The proxy header contains the original client IP-address and\
+Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+when connecting. The proxy header contains the original client IP-address and
 port, and MaxScale will use that information in its internal bookkeeping.\
-This means the client is authenticated as if it was connecting from the host\
-in the proxy header. If proxy protocol is also enabled in MaxScale server\
-settings, MaxScale will relay the original client address and port to\
+This means the client is authenticated as if it was connecting from the host
+in the proxy header. If proxy protocol is also enabled in MaxScale server
+settings, MaxScale will relay the original client address and port to
 the server. See [server settings](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#proxy_protocol) for more information.
 
-This setting may be useful if a compatible load balancer is relaying client\
-connections to MaxScale. If proxy headers are used, both MaxScale and the\
+This setting may be useful if a compatible load balancer is relaying client
+connections to MaxScale. If proxy headers are used, both MaxScale and the
 backends will know where the client originally came from.
 
-The `proxy_protocol_networks`-setting works similarly to the equivalent setting\
+The `proxy_protocol_networks`-setting works similarly to the equivalent setting
 in [MariaDB Server](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/server-client-software/client-libraries/proxy-protocol-support).\
 The value can be a single IP or subnetwork, or a comma-separated list of them.\
-Subnetworks are given in CIDR-format, e.g. "192.168.0.0/16". "\*" is a valid\
-value, allowing anyone to send the header. "localhost" allows proxy headers\
+Subnetworks are given in CIDR-format, e.g. "192.168.0.0/16". "\*" is a valid
+value, allowing anyone to send the header. "localhost" allows proxy headers
 from domain socket connections.
 
-Only trusted IPs should be added to the list, as the proxy header may affect\
+Only trusted IPs should be added to the list, as the proxy header may affect
 authentication results.
 
 ```
 proxy_protocol_networks=192.168.0.1,198.168.0.0/16
 ```
 
-Similar to MariaDB Server, MaxScale will also accept normal connections even\
+Similar to MariaDB Server, MaxScale will also accept normal connections even
 if `proxy_protocol_networks` is configured for the listener.
 
 #### `connection_init_sql_file`
@@ -3438,10 +3438,10 @@ if `proxy_protocol_networks` is configured for the listener.
 * Dynamic: Yes
 * Default: `""`
 
-Path to a text file with sql queries. Any sessions created from the listener\
-will send the contents of the file to backends after authentication. Each\
-non-empty line in the file is interpreted as a query. Each query must succeed\
-for the backend connection to be usable for client queries. The queries should\
+Path to a text file with sql queries. Any sessions created from the listener
+will send the contents of the file to backends after authentication. Each
+non-empty line in the file is interpreted as a query. Each query must succeed
+for the backend connection to be usable for client queries. The queries should
 not return any data.
 
 ```
@@ -3462,28 +3462,28 @@ set @myvar2 = 4;
 * Dynamic: Yes
 * Default: `""`
 
-Path to a json-text file with user and group mapping, as well as server\
-credentials. Only affects MariaDB-protocol based listeners. Default value is\
+Path to a json-text file with user and group mapping, as well as server
+credentials. Only affects MariaDB-protocol based listeners. Default value is
 empty, which disables the feature.
 
 ```
 user_mapping_file=/home/root/mapping.json
 ```
 
-Should not be used together with [PAM Authenticator](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-pam-authenticator.md)\
-settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite\
-the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on\
+Should not be used together with [PAM Authenticator](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-pam-authenticator.md)
+settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite
+the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on
 backends and map them to backend users.
 
 This file functions very similar to [PAM-based mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
-Both user-to-user and group-to-user mappings can be defined. Also, the password\
-and authentication plugin for the mapped users can be added. The file is only\
-read during listener creation (typically MaxScale start) or when a listener is\
-modified during runtime. When a client logs into MaxScale, their username is\
+Both user-to-user and group-to-user mappings can be defined. Also, the password
+and authentication plugin for the mapped users can be added. The file is only
+read during listener creation (typically MaxScale start) or when a listener is
+modified during runtime. When a client logs into MaxScale, their username is
 searched from the mapping data. If the name matches either a name mapping or a\
-Linux group mapping, the username is replaced by the mapped name. The mapped\
-name is then used when logging into backends. If the file also contains\
-credentials for the mapped user, then those are used. Otherwise, MaxScale tries\
+Linux group mapping, the username is replaced by the mapped name. The mapped
+name is then used when logging into backends. If the file also contains
+credentials for the mapped user, then those are used. Otherwise, MaxScale tries
 to log in with an empty password and default MariaDB authentication.
 
 Three arrays are read from the file: _user\_map_, _group\_map_ and\_server\_credentials\_, none of which are mandatory.
@@ -3498,25 +3498,25 @@ Each array element in the _group\_map_-array must define the following fields:
 * original\_group: String. Incoming client Linux group.
 * mapped\_user: String. Username the client is mapped to.
 
-Each array element in the _server\_credentials_-array can define the following\
+Each array element in the _server\_credentials_-array can define the following
 fields:
 
 * mapped\_user: String. The mapped username this password is for.
-* password: String. Backend server password. Can be encrypted with\
+* password: String. Backend server password. Can be encrypted with
   maxpasswd.
-* plugin: String, optional. Authentication plugin to use. Must be enabled on\
-  the listener. Defaults to empty, which results in standard MariaDB\
+* plugin: String, optional. Authentication plugin to use. Must be enabled on
+  the listener. Defaults to empty, which results in standard MariaDB
   authentication.
 
-When a client successfully logs into MaxScale, MaxScale first searches for\
-name-based mapping. The incoming client does not need to be a Linux user for\
-name-based mapping to take place. If the name is not found, MaxScale checks if\
-the client is a Linux user with a group membership matching an element in the\
-group mapping array. If the client is a member of more than 100 groups, this\
+When a client successfully logs into MaxScale, MaxScale first searches for
+name-based mapping. The incoming client does not need to be a Linux user for
+name-based mapping to take place. If the name is not found, MaxScale checks if
+the client is a Linux user with a group membership matching an element in the
+group mapping array. If the client is a member of more than 100 groups, this
 check may fail.
 
-If a mapping is found, MaxScale searches the credentials array for a matching\
-username, and uses the password and plugin listed. The plugin need not be the\
+If a mapping is found, MaxScale searches the credentials array for a matching
+username, and uses the password and plugin listed. The plugin need not be the
 same as the one the original user used. Currently, "mysql\_native\_password" and\
 "pam" are supported as mapped plugins.
 
@@ -3557,18 +3557,18 @@ An example mapping file is below.
 
 ## Available Protocols
 
-The protocols supported by MariaDB MaxScale are implemented as external modules\
+The protocols supported by MariaDB MaxScale are implemented as external modules
 that are loaded dynamically into the MariaDB MaxScale core. They allow MariaDB\
-MaxScale to communicate in various protocols both on the client side and the\
-backend side. Each of the protocols can be either a client protocol or a backend\
-protocol. Client protocols are used for client-MariaDB MaxScale communication\
+MaxScale to communicate in various protocols both on the client side and the
+backend side. Each of the protocols can be either a client protocol or a backend
+protocol. Client protocols are used for client-MariaDB MaxScale communication
 and backend protocols are for MariaDB MaxScale-database communication.
 
 ### `MariaDBClient`
 
-This is the implementation of the MySQL-protocol. When defined for a listener,\
+This is the implementation of the MySQL-protocol. When defined for a listener,
 the listener will accept MySQL-connections from clients, assign them to a\
-MaxScale service and route the queries from the client to backend servers. Any\
+MaxScale service and route the queries from the client to backend servers. Any
 backends used by the service should be MariaDB/MySQL-servers or compatible.
 
 ### `CDC`
@@ -3577,42 +3577,42 @@ See [Change Data Capture Protocol](../mariadb-maxscale-23-02-protocols/mariadb-m
 
 ## TLS/SSL encryption
 
-This section describes configuration parameters for both servers and listeners\
-that control the TLS/SSL encryption method and the various certificate files\
+This section describes configuration parameters for both servers and listeners
+that control the TLS/SSL encryption method and the various certificate files
 involved in it.
 
 To enable TLS/SSL for a listener, you must set the `ssl` parameter to`true` and provide at least the `ssl_cert` and `ssl_key` parameters.
 
-To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification\
+To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification
 enabled, the `ssl_cert` and `ssl_key` parameters must also be defined.
 
 Custom CA certificates can be defined with the `ssl_ca` parameter.
 
-After this, MaxScale connections between the server and/or the client will be\
-encrypted. Note that the database must also be configured to use TLS/SSL\
+After this, MaxScale connections between the server and/or the client will be
+encrypted. Note that the database must also be configured to use TLS/SSL
 connections if backend connection encryption is used.
 
-**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on\
+**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on
 the same port.
 
-If TLS encryption is enabled for a listener, any unencrypted connections to it\
-will be rejected. MaxScale does this to improve security by preventing\
+If TLS encryption is enabled for a listener, any unencrypted connections to it
+will be rejected. MaxScale does this to improve security by preventing
 accidental creation of unencrypted connections.
 
-The separation of secure and insecure connections differs from the MariaDB\
+The separation of secure and insecure connections differs from the MariaDB
 server which allows both secure and insecure connections on the same port. As\
-MaxScale is the gateway through which all connections go, in order to guarantee\
-a more secure system MaxScale enforces a stricter security policy than what the\
+MaxScale is the gateway through which all connections go, in order to guarantee
+a more secure system MaxScale enforces a stricter security policy than what the
 server does.
 
-TLS encryption must be enabled for listeners when they are created. For servers,\
+TLS encryption must be enabled for listeners when they are created. For servers,
 the TLS can be enabled after creation but it cannot be disabled or altered.
 
 Starting with MaxScale 2.5.20, if the TLS certificate given to MaxScale has the\
-X509v3 extended key usage information, MaxScale will check it and refuse to use\
-a certificate with the wrong usage. This means that a certificate with only\
-clientAuth can only be used with servers and a certificate with only serverAuth\
-can only be used with listeners. In order to use the same certificate for both\
+X509v3 extended key usage information, MaxScale will check it and refuse to use
+a certificate with the wrong usage. This means that a certificate with only
+clientAuth can only be used with servers and a certificate with only serverAuth
+can only be used with listeners. In order to use the same certificate for both
 listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 #### `ssl`
@@ -3624,12 +3624,12 @@ listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 This enables SSL connections when set to true. The legacy values `required` and`disabled` were removed in MaxScale 6.0.
 
-If enabled, the certificate files mentioned above must also be\
+If enabled, the certificate files mentioned above must also be
 supplied. MaxScale connections to will then be encrypted with TLS/SSL.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require\
-ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created\
+24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require
+ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created
 with `REQUIRE SSL` or `REQUIRE X509`.
 
 #### `ssl_key`
@@ -3639,8 +3639,8 @@ with `REQUIRE SSL` or `REQUIRE X509`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client private key MaxScale should use. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client private key MaxScale should use. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_cert`
@@ -3650,9 +3650,9 @@ parameter for listeners but an optional parameter for servers.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client certificate MaxScale should use with the server. The\
-certificate must match the key defined in `ssl_key`. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client certificate MaxScale should use with the server. The
+certificate must match the key defined in `ssl_key`. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_ca_cert`
@@ -3666,13 +3666,13 @@ Deprecated since MariaDB MaxScale 22.08. See `ssl_ca`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the Certificate Authority (CA) certificate for the CA that signed the\
-certificate referred to in the previous parameter. It will be used to verify\
-that the certificate is valid. This is a required parameter for both listeners\
+A string giving a file path that identifies an existing readable file. The file
+must be the Certificate Authority (CA) certificate for the CA that signed the
+certificate referred to in the previous parameter. It will be used to verify
+that the certificate is valid. This is a required parameter for both listeners
 and servers. The CA certificate can consist of a certificate chain.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,
 which is still accepted as an alias for `ssl_ca`.
 
 #### `ssl_version`
@@ -3691,7 +3691,7 @@ This parameter controls the allowed TLS version. Accepted values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -3703,18 +3703,18 @@ The default setting (MAX) allows all supported versions. MaxScale supports\
 TLSv1.0, TLSv1.1, TLSv1.2 and TLSv1.3 depending on the OpenSSL library version.\
 TLSv1.0 and TLSv1.1 are considered deprecated and should not be used, so setting`ssl_version=TLSv1.2,TLSv1.3` or `ssl_version=TLSv1.3` is recommended.
 
-In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this\
-setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would\
+In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this
+setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would
 only enable TLSv12. The interpretation changed in MaxScale versions 6.4.14,\
-22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while\
-allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`\
+22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while
+allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`
 enabled both TLSv1.2 and TLSv1.3.
 
 The interpretation changed again in MaxScale versions 6.4.16, 22.08.13,\
-23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an\
-enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior\
-from the previous releases where the newer versions were automatically enabled,\
-the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)\
+23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an
+enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior
+from the previous releases where the newer versions were automatically enabled,
+the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)
 parameter works.
 
 #### `ssl_cipher`
@@ -3724,8 +3724,8 @@ parameter works.
 * Dynamic: Yes
 * Default: `""`
 
-Set the list of TLS ciphers. By default, no explicit ciphers are defined and the\
-system defaults are used. Note that this parameter does not modify TLSv1.3\
+Set the list of TLS ciphers. By default, no explicit ciphers are defined and the
+system defaults are used. Note that this parameter does not modify TLSv1.3
 ciphers.
 
 #### `ssl_cert_verify_depth`
@@ -3735,8 +3735,8 @@ ciphers.
 * Dynamic: Yes
 * Default: `9`
 
-The maximum length of the certificate authority chain that will be accepted. The\
-default value is 9, same as the OpenSSL default. The configured value must be\
+The maximum length of the certificate authority chain that will be accepted. The
+default value is 9, same as the OpenSSL default. The configured value must be
 larger than 0.
 
 #### `ssl_verify_peer_certificate`
@@ -3746,11 +3746,11 @@ larger than 0.
 * Dynamic: Yes
 * Default: `false`
 
-Peer certificate verification. This functionality is disabled by default. In\
+Peer certificate verification. This functionality is disabled by default. In
 versions prior to 2.3.17 the feature was enabled by default.
 
-When this feature is enabled, the peer must send a certificate. The certificate\
-sent by the peer is verified against the configured Certificate Authority to\
+When this feature is enabled, the peer must send a certificate. The certificate
+sent by the peer is verified against the configured Certificate Authority to
 make sure the peer is who they claim to be. For listeners, this behaves as if`REQUIRE X509` was defined for all users. For servers, this behaves like the`--ssl-verify-server-cert` command line option for the `mysql` client.
 
 #### `ssl_verify_peer_host`
@@ -3762,10 +3762,10 @@ make sure the peer is who they claim to be. For listeners, this behaves as if`RE
 
 Peer host verification.
 
-When this feature is enabled, the peer hostname or IP is verified against the\
-certificate that is sent by the peer. If the IP address or the hostname does not\
-match the one in the certificate returned by the peer, the connection will be\
-closed. If the peer does not provide a certificate, the host verification is not\
+When this feature is enabled, the peer hostname or IP is verified against the
+certificate that is sent by the peer. If the IP address or the hostname does not
+match the one in the certificate returned by the peer, the connection will be
+closed. If the peer does not provide a certificate, the host verification is not
 done. To require peer certificates, use `ssl_verify_peer_certificate`.
 
 #### `ssl_crl`
@@ -3775,8 +3775,8 @@ done. To require peer certificates, use `ssl_verify_peer_certificate`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be a Certificate Revocation List in the PEM format that defines the revoked\
+A string giving a file path that identifies an existing readable file. The file
+must be a Certificate Revocation List in the PEM format that defines the revoked
 certificates. This parameter is only accepted by listeners.
 
 **Example SSL enabled server configuration**
@@ -3792,7 +3792,7 @@ ssl_key=/usr/local/mariadb/maxscale/ssl/key.max-client.pem
 ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
-This example configuration requires all connections to this server to be\
+This example configuration requires all connections to this server to be
 encrypted with SSL. The paths to the certificate files and the Certificate\
 Authority file are also provided.
 
@@ -3810,18 +3810,18 @@ ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
 This example configuration requires all connections to be encrypted with\
-SSL. The paths to the certificate files and the Certificate Authority file are\
+SSL. The paths to the certificate files and the Certificate Authority file are
 also provided.
 
 ## Module Types
 
 ### Routing Modules
 
-The main task of MariaDB MaxScale is to accept database connections from client\
-applications and route the connections or the statements sent over those\
+The main task of MariaDB MaxScale is to accept database connections from client
+applications and route the connections or the statements sent over those
 connections to the various services supported by MariaDB MaxScale.
 
-Currently a number of routing modules are available, these are designed for a\
+Currently a number of routing modules are available, these are designed for a
 range of different needs.
 
 Connection based load balancing:
@@ -3842,18 +3842,18 @@ Binary log server:
 
 ### Monitor Modules
 
-Monitor modules are used by MariaDB MaxScale to internally monitor the state of\
-the backend databases in order to set the server flags for each of those\
-servers. The router modules then use these flags to determine if the particular\
-server is a suitable destination for routing connections for particular query\
+Monitor modules are used by MariaDB MaxScale to internally monitor the state of
+the backend databases in order to set the server flags for each of those
+servers. The router modules then use these flags to determine if the particular
+server is a suitable destination for routing connections for particular query
 classifications. The monitors are run within separate threads of MariaDB\
 MaxScale and do not affect MariaDB MaxScale's routing performance.
 
 * [MariaDB Monitor](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md)
 * [Galera Monitor](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-galera-monitor.md)
 
-The use of monitors in MaxScale is not absolutely mandatory: it is possible to\
-run MariaDB MaxScale without a monitor module. In this case an external\
+The use of monitors in MaxScale is not absolutely mandatory: it is possible to
+run MariaDB MaxScale without a monitor module. In this case an external
 monitoring system must the status of each server via MaxCtrl or the REST\
 API. **Only do this if you know what you are doing.**
 
@@ -3887,10 +3887,10 @@ flowchart LR
 _A client's query passes through the router session's QLA and Regex filters on its way to the backend server, with QLA also logging the query._
 
 Filters provide a means to manipulate or process requests as they pass through\
-MariaDB MaxScale between the client side protocol and the query router. A full\
+MariaDB MaxScale between the client side protocol and the query router. A full
 explanation of each filter's functionality can be found in its documentation.
 
-The [Filter Tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-filters.md) document shows how you\
+The [Filter Tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-filters.md) document shows how you
 can add a filter to a service and combine multiple filters in one service.
 
 * [Query Log All (QLA) Filter](../mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-query-log-all-filter.md)
@@ -3903,8 +3903,8 @@ can add a filter to a service and combine multiple filters in one service.
 
 Passwords stored in the maxscale.cnf file may optionally be encrypted for added security.\
 This is done by creation of an encryption key on installation of MariaDB MaxScale.\
-Encryption keys may be created manually by executing the maxkeys utility with the argument\
-of the filename to store the key. The default location MariaDB MaxScale stores\
+Encryption keys may be created manually by executing the maxkeys utility with the argument
+of the filename to store the key. The default location MariaDB MaxScale stores
 the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES CBC encryption.
 
 ```
@@ -3912,16 +3912,16 @@ the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES C
 maxkeys /var/lib/maxscale/
 ```
 
-Changing the encryption key for MariaDB MaxScale will invalidate any currently\
+Changing the encryption key for MariaDB MaxScale will invalidate any currently
 encrypted keys stored in the maxscale.cnf file.
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
 ### Creating Encrypted Passwords
 
-Encrypted passwords are created by executing the maxpasswd command with the location\
+Encrypted passwords are created by executing the maxpasswd command with the location
 of the .secrets file and the password you require to encrypt as an argument.
 
 ```
@@ -3930,9 +3930,9 @@ maxpasswd /var/lib/maxscale/ MaxScalePw001
 61DD955512C39A4A8BC4BB1E5F116705
 ```
 
-The output of the maxpasswd command is a hexadecimal string, this should be inserted\
+The output of the maxpasswd command is a hexadecimal string, this should be inserted
 into the maxscale.cnf file in place of the ordinary, plain text, password.\
-MariaDB MaxScale will determine this as an encrypted password and automatically decrypt\
+MariaDB MaxScale will determine this as an encrypted password and automatically decrypt
 it before sending it the database server.
 
 ```
@@ -3946,7 +3946,7 @@ password=61DD955512C39A4A8BC4BB1E5F116705
 
 ## Runtime Configuration Changes
 
-Read the following documents for different methods of altering the MaxScale\
+Read the following documents for different methods of altering the MaxScale
 configuration at runtime.
 
 * MaxCtrl
@@ -3957,88 +3957,88 @@ configuration at runtime.
 * [alter](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md#alter)
 * [REST API](../mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md) documentation
 
-All changes to the configuration done via MaxCtrl are persisted as individual\
-configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these\
-files will override any configurations found in the main configuration file or\
+All changes to the configuration done via MaxCtrl are persisted as individual
+configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these
+files will override any configurations found in the main configuration file or
 any auxiliary configuration files.
 
-Refer to the [Dynamic Configuration](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more\
+Refer to the [Dynamic Configuration](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more
 details on how this mechanism works and how to disable it.
 
 ### Configuration Synchronization
 
-The configuration synchronization mechanism is intended for synchronizing\
-configuration changes done on one MaxScale to all other MaxScales. This is done\
+The configuration synchronization mechanism is intended for synchronizing
+configuration changes done on one MaxScale to all other MaxScales. This is done
 by propagating the changes via the database cluster used by Maxscale.
 
-When configuring configuration synchronization for the first time, the same\
-static configuration files should be used on all MaxScale instances that use the\
+When configuring configuration synchronization for the first time, the same
+static configuration files should be used on all MaxScale instances that use the
 same cluster: the value of `config_sync_cluster` must be the same on all\
-MaxScale instances and the cluster (i.e. the monitor) pointed by it and its\
+MaxScale instances and the cluster (i.e. the monitor) pointed by it and its
 servers must be the same in every configuration.
 
-Whenever the MaxScale configuration is modified at runtime, the latest\
-configuration is stored in the database cluster in the `mysql.maxscale_config`\
-table. The table is created when the first modification to the configuration is\
+Whenever the MaxScale configuration is modified at runtime, the latest
+configuration is stored in the database cluster in the `mysql.maxscale_config`
+table. The table is created when the first modification to the configuration is
 done. A local copy of the configuration is stored in the data directory to allow\
-MaxScale to function even if a connection to the cluster cannot be made. By\
+MaxScale to function even if a connection to the cluster cannot be made. By
 default this file is stored at `/var/lib/maxscale/maxscale-config.json`.
 
-Whenever MaxScale starts up, it checks if a local version of this configuration\
-exists. If it does and it is a valid cached configuration, the static\
-configuration file as well as any other generated configuration files are\
-ignored. The exception is the `[maxscale]` section of the main static\
+Whenever MaxScale starts up, it checks if a local version of this configuration
+exists. If it does and it is a valid cached configuration, the static
+configuration file as well as any other generated configuration files are
+ignored. The exception is the `[maxscale]` section of the main static
 configuration file which is always read.
 
-Each configuration has a version number with the initial configuration being\
-version 0. Each time the configuration is modified, the version number is\
-incremented. This version number is used to detect when MaxScale needs to update\
+Each configuration has a version number with the initial configuration being
+version 0. Each time the configuration is modified, the version number is
+incremented. This version number is used to detect when MaxScale needs to update
 its configuration.
 
 #### Error Handling in Configuration Synchronization
 
-When doing a configuration change on the local MaxScale, if the configuration\
-change completes on MaxScale but fails to be committed to the database, MaxScale\
+When doing a configuration change on the local MaxScale, if the configuration
+change completes on MaxScale but fails to be committed to the database, MaxScale
 will attempt to revert the local configuration change. If this attempt fails,\
 MaxScale will discard the cached configuration and abort the process.
 
-When synchronizing with the cluster, if MaxScale fails to apply a configuration\
-retrieved from the cluster, it attempts to revert the configuration to the\
-previous version. If successful, the failed configuration update is ignored. If\
-the configuration update that fails cannot be reverted, the MaxScale\
-configuration will be in an indeterminate state. When this happens, MaxScale\
+When synchronizing with the cluster, if MaxScale fails to apply a configuration
+retrieved from the cluster, it attempts to revert the configuration to the
+previous version. If successful, the failed configuration update is ignored. If
+the configuration update that fails cannot be reverted, the MaxScale
+configuration will be in an indeterminate state. When this happens, MaxScale
 will discard the cached configuration and abort the process.
 
-When loading a locally cached configuration during startup, if any errors are\
-found in the cached configuration, it is discarded and the MaxScale process will\
-attempt to restart by exiting with code 75 from the main process. If MaxScale is\
+When loading a locally cached configuration during startup, if any errors are
+found in the cached configuration, it is discarded and the MaxScale process will
+attempt to restart by exiting with code 75 from the main process. If MaxScale is
 being used as a SystemD service, this will automatically trigger a restart of\
 MaxScale and no further actions are needed.
 
-The most common reason for a failed configuration update is missing files. For\
-example, if a configuration update adds encrypted connections to a server and\
-the TLS certificates it uses were not copied over to all MaxScale nodes before\
-the change was done, the operation will fail on all nodes that do not have these\
+The most common reason for a failed configuration update is missing files. For
+example, if a configuration update adds encrypted connections to a server and
+the TLS certificates it uses were not copied over to all MaxScale nodes before
+the change was done, the operation will fail on all nodes that do not have these
 files.
 
-If the synchronization of the configuration change fails at the step when the\
-database transaction is being committed, the new configuration can be\
-momentarily visible to the local MaxScale. This means the changes are not\
-guaranteed to be atomic on the local MaxScale but are atomic from the cluster's\
+If the synchronization of the configuration change fails at the step when the
+database transaction is being committed, the new configuration can be
+momentarily visible to the local MaxScale. This means the changes are not
+guaranteed to be atomic on the local MaxScale but are atomic from the cluster's
 point of view.
 
 #### Synchronization of Encrypted Passwords
 
-Starting with MaxScale 6.4.9, any passwords that are transmitted by the\
-configuration synchronization are encrypted if password encryption has been\
-enabled in MaxScale. This means that all MaxScale nodes in the same\
-configuration cluster must be configured to use password encryption and they\
+Starting with MaxScale 6.4.9, any passwords that are transmitted by the
+configuration synchronization are encrypted if password encryption has been
+enabled in MaxScale. This means that all MaxScale nodes in the same
+configuration cluster must be configured to use password encryption and they
 need to all use the same encryption keys that were created with `maxkeys`.
 
 #### Managing Configuration Synchronization
 
-The output of `maxctrl show maxscale` contains the `Config Sync` field with\
-information about the current configuration state of the local Maxscale as well\
+The output of `maxctrl show maxscale` contains the `Config Sync` field with
+information about the current configuration state of the local Maxscale as well
 as the state of any other nodes using this cluster.
 
 ```
@@ -4056,17 +4056,17 @@ as the state of any other nodes using this cluster.
 ├──────────────┼─────────────────────────────────────────────────────────────┤
 ```
 
-The `version` field is the logical configuration version and the `origin` is the\
-node that originates the latest configuration change. The `checksum` field is\
+The `version` field is the logical configuration version and the `origin` is the
+node that originates the latest configuration change. The `checksum` field is
 the checksum of the logical configuration and can be used to compare whether two\
-Maxscale instances are in the same configuration state. The `nodes` field\
-contains the status of each MaxScale instance mapped to the hostname of the\
-server. This field is updated whenever MaxScale reads the configuration from the\
-cluster and can thus be used to detect which MaxScales have updated their\
+Maxscale instances are in the same configuration state. The `nodes` field
+contains the status of each MaxScale instance mapped to the hostname of the
+server. This field is updated whenever MaxScale reads the configuration from the
+cluster and can thus be used to detect which MaxScales have updated their
 configuration.
 
-The `mysql.maxscale_config` table where the configuration changes are stored\
-must not be modified manually. The only case when the table should be modified\
+The `mysql.maxscale_config` table where the configuration changes are stored
+must not be modified manually. The only case when the table should be modified
 is when resetting the configuration synchronization.
 
 To reset the configuration synchronization:
@@ -4076,71 +4076,71 @@ To reset the configuration synchronization:
 3. Drop the `mysql.maxscale_config` table
 4. Start all MaxScale instances
 
-To disable configuration synchronization, remove `config_sync_cluster` from the\
-configuration file or set it to an empty string: `config_sync_cluster=""`. This\
+To disable configuration synchronization, remove `config_sync_cluster` from the
+configuration file or set it to an empty string: `config_sync_cluster=""`. This
 can be done at runtime with MaxCtrl by passing an empty string to`config_sync_cluster`:
 
 ```
 maxctrl alter maxscale config_sync_cluster ""
 ```
 
-If MaxScale cannot create a connection to the database cluster, configuration\
-changes are not possible until communication with the database is possible. To\
-override this behavior and force the changes to be done, use the `--skip-sync`\
-option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any\
-updates done with `--skip-sync` will overwritten by changes coming from the\
+If MaxScale cannot create a connection to the database cluster, configuration
+changes are not possible until communication with the database is possible. To
+override this behavior and force the changes to be done, use the `--skip-sync`
+option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any
+updates done with `--skip-sync` will overwritten by changes coming from the
 cluster.
 
 #### Limitations in Configuration Synchronization
 
-Only the MaxScale configuration is synchronized. Any external files (TLS\
-certificates, configuration files for modules or data generated by MaxScale) are\
-not synchronized. For example, the rule files for the cache filter must be\
+Only the MaxScale configuration is synchronized. Any external files (TLS
+certificates, configuration files for modules or data generated by MaxScale) are
+not synchronized. For example, the rule files for the cache filter must be
 synchronized separately if the filter itself is modified.
 
-Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers\
-and modifications to the administrative users will be synchronized. In older\
-versions servers had to be put into maintenance mode and users had to be\
+Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers
+and modifications to the administrative users will be synchronized. In older
+versions servers had to be put into maintenance mode and users had to be
 modified separately on each MaxScale.
 
-* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not\
+* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not
   synchronized.
-* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`\
-  option will not export the cluster configuration and instead exports only the\
-  static configuration files. To start a new MaxScale based off of a clustered\
-  configuration, copy the static configuration files as well as the JSON\
-  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale\
+* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`
+  option will not export the cluster configuration and instead exports only the
+  static configuration files. To start a new MaxScale based off of a clustered
+  configuration, copy the static configuration files as well as the JSON
+  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale
   instance.
 
 ### Backing Up Configuration Changes
 
-The combination of configuration files can be done either manually\
-(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line\
+The combination of configuration files can be done either manually
+(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line
 option. See `maxscale --help` for more information about how to use the`--export-config` flag.
 
-For example, to export the current runtime configuration, run the following\
+For example, to export the current runtime configuration, run the following
 command.
 
 ```
 maxscale --export-config=/tmp/maxscale.cnf.combined
 ```
 
-This will create the `/tmp/maxscale.cnf.combined` file and write the current\
-configuration into the it. This allows new MaxScale instances to be easily set\
-up without requiring copying of all runtime configuration files. The user\
-executing the command must be able to read all MaxScale configuration files as\
+This will create the `/tmp/maxscale.cnf.combined` file and write the current
+configuration into the it. This allows new MaxScale instances to be easily set
+up without requiring copying of all runtime configuration files. The user
+executing the command must be able to read all MaxScale configuration files as
 well as create and write the provided filename.
 
 ## Encryption Key Managers
 
-The encryption key managers are how MaxScale retrieves symmetric encryption keys\
-from a key management system. Some parts of MaxScale require the `key_manager`\
-to be configured in order to work. The key manager that is used is selected with\
-the [key\_manager](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is\
+The encryption key managers are how MaxScale retrieves symmetric encryption keys
+from a key management system. Some parts of MaxScale require the `key_manager`
+to be configured in order to work. The key manager that is used is selected with
+the [key\_manager](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is
 configured by placing the parameters in the `[maxscale]` section.
 
-The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key\
-management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration\
+The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key
+management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration
 files.
 
 ### File-based Key Manager
@@ -4148,13 +4148,13 @@ files.
 The encryption keys are stored in a text file stored on a local filesystem.
 
 The file uses the same format as the MariaDB server [File Key Management\
-Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file\
-consisting of an encryption key ID number and the hex-encoded encryption key\
+Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file
+consisting of an encryption key ID number and the hex-encoded encryption key
 separated by a semicolon. Read [Creating the Key\
-File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)\
+File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)
 for more details on how to create the file.
 
-For example, to configure encryption for the `nosqlprotocol` shared credentials\
+For example, to configure encryption for the `nosqlprotocol` shared credentials
 using the file-based encryption key:
 
 1. Create the key file with `(echo -n '1;' ; openssl rand -hex 32) | cat > /var/lib/maxscale/encryption.key`
@@ -4191,9 +4191,9 @@ nosqlprotocol.authentication_password=my_password
 * Mandatory: Yes
 * Dynamic: Yes
 
-Path to the file that contains the encryption keys. The user MaxScale runs as\
-(almost always `maxscale`) must be able to read this file. Encryption keys are\
-read from disk only during startup or when any global MaxScale parameter is\
+Path to the file that contains the encryption keys. The user MaxScale runs as
+(almost always `maxscale`) must be able to read this file. Encryption keys are
+read from disk only during startup or when any global MaxScale parameter is
 modified at runtime.
 
 ### KMIP Key Manager
@@ -4205,7 +4205,7 @@ The KMIP key manager has been verified to work with the PyKMIP server.
 #### Limitations
 
 * Key versioning is not supported
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the KMIP server.
 
 #### Parameters
@@ -4252,17 +4252,17 @@ The CA certificate to use. By default the system default certificates are used.
 
 ### HashiCorp Vault Key Manager
 
-Encryption keys are read from a local or remote Vault server using the secret\
-engine included in the Vault. This key manager supports versioned keys. Only\
+Encryption keys are read from a local or remote Vault server using the secret
+engine included in the Vault. This key manager supports versioned keys. Only
 version 2 key-value stores are supported.
 
 The encryption keys use the same format as the MariaDB [HashiCorp Vault Key\
 Management Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/hashicorp-key-management-plugin):\
-The key-value secret for each encryption key ID must contain the field `data`\
-which must contain a hex-encoded string that is either 32, 48 or 64 characters\
+The key-value secret for each encryption key ID must contain the field `data`
+which must contain a hex-encoded string that is either 32, 48 or 64 characters
 long.
 
-An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit\
+An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit
 encryption key using `openssl` and stores it using the key ID `1`:
 
 ```
@@ -4282,7 +4282,7 @@ version            1
 
 #### Limitations
 
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the Vault server.
 
 #### Parameters
@@ -4293,7 +4293,7 @@ version            1
 * Mandatory: Yes
 * Dynamic: Yes
 
-The authentication token used to connect to the Vault server. This can be\
+The authentication token used to connect to the Vault server. This can be
 encrypted using `maxpasswd`, similar to how other passwords are encrypted.
 
 **`vault.host`**
@@ -4326,7 +4326,7 @@ The CA certificate to use. By default the system default certificates are used.
 * Default: true
 * Dynamic: Yes
 
-Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating\
+Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating
 with the Vault server.
 
 **`vault.mount`**
@@ -4335,7 +4335,7 @@ with the Vault server.
 * Default: `secret`
 * Dynamic: Yes
 
-The Key-Value mount where the secret is stored. By default the `secret` mount is\
+The Key-Value mount where the secret is stored. By default the `secret` mount is
 used which is present by default in most Vault installations.
 
 **`vault.timeout`**
@@ -4348,30 +4348,30 @@ The connection and request timeout used with the Vault server.
 
 ## Threads
 
-For routing, MaxScale uses asynchronous I/O and a fixed number of threads\
+For routing, MaxScale uses asynchronous I/O and a fixed number of threads
 (aka _routing workers_), whose number up until 23.02 was fixed at startup.\
-From 23.02 onwards the number of threads can be altered at runtime, which\
-is convenient, for instance, if MaxScale is running in a container whose\
+From 23.02 onwards the number of threads can be altered at runtime, which
+is convenient, for instance, if MaxScale is running in a container whose
 properties are changed during the lifetime of the container.
 
 A thread can be in three different states:
 
-* **Active**: The thread is routing client traffic and is listening\
+* **Active**: The thread is routing client traffic and is listening
   for new connections.
-* **Draining**: The thread is routing client traffic but is **not**\
+* **Draining**: The thread is routing client traffic but is **not**
   listening for new connections.
-* **Dormant**: The thread is not routing client traffic (all sessions\
-  have ended), and is not listening for new connections, and is waiting\
+* **Dormant**: The thread is not routing client traffic (all sessions
+  have ended), and is not listening for new connections, and is waiting
   to be terminated.
 
-All threads start as _Active_ and may become _Draining_ if the number of\
-threads is reduced. A draining thread will eventually become _Dormant_,\
+All threads start as _Active_ and may become _Draining_ if the number of
+threads is reduced. A draining thread will eventually become _Dormant_,
 unless the number of threads is increased while the thread is still _Draining_.
 
-Note that it is not possible to terminate a specific thread, but it is only\
-possible to specify the _number_ of threads that MaxScale should use, and\
-that the threads will be terminated from the end. This has implications\
-if the number of threads is reduced by more than 1, as a _Dormant_ thread\
+Note that it is not possible to terminate a specific thread, but it is only
+possible to specify the _number_ of threads that MaxScale should use, and
+that the threads will be terminated from the end. This has implications
+if the number of threads is reduced by more than 1, as a _Dormant_ thread
 will not be terminated before it is the last thread.
 
 In the following, MaxScale has been started with `threads=4`.
@@ -4400,8 +4400,8 @@ $ bin/maxctrl show threads
 ...
 ```
 
-we will see that the threads 2 and 3 are now _Draining_. The reason is\
-that threads 2 and 3 still handle client sessions. If some client sessions\
+we will see that the threads 2 and 3 are now _Draining_. The reason is
+that threads 2 and 3 still handle client sessions. If some client sessions
 now end, the situation may become like
 
 ```
@@ -4413,13 +4413,13 @@ now end, the situation may become like
 ...
 ```
 
-That is, thread 2 is _Dormant_ and thread 3 is _Draining_. All client sessions\
-that were handled by thread 2 have ended and the thread is ready to be\
-terminated. However, as thread 3 is still _Draining_, thread 2 will not be\
+That is, thread 2 is _Dormant_ and thread 3 is _Draining_. All client sessions
+that were handled by thread 2 have ended and the thread is ready to be
+terminated. However, as thread 3 is still _Draining_, thread 2 will not be
 terminated but stay _Dormant_.
 
-If the sessions handled by thread 3 end, then it will become _Dormant_ at\
-which point first thread 3 will be terminatad and immediately after that\
+If the sessions handled by thread 3 end, then it will become _Dormant_ at
+which point first thread 3 will be terminatad and immediately after that
 thread 2.
 
 ```
@@ -4444,7 +4444,7 @@ $ bin/maxctrl show threads
 ...
 ```
 
-that is, the number of threads was 4 but has been reduced to 2, and while\
+that is, the number of threads was 4 but has been reduced to 2, and while
 thread 2 has become drained it stays as _Dormant_ since thread 3 is still _Draining_, it is possible to make thread 2 _Active_ again by increasing the
 number of threads to 3.
 
@@ -4474,8 +4474,8 @@ $ bin/maxctrl show threads
 
 ## Error Reporting
 
-MariaDB MaxScale is designed to be executed as a service, therefore all error\
-reports, including configuration errors, are written to the MariaDB MaxScale\
+MariaDB MaxScale is designed to be executed as a service, therefore all error
+reports, including configuration errors, are written to the MariaDB MaxScale
 error log file. By default, MariaDB MaxScale will log to a file in`/var/log/maxscale` and the system log.
 
 ## Limitations
@@ -4484,31 +4484,31 @@ The current limitations of MaxScale are listed in the [Limitations](../mariadb-m
 
 ## Performance Optimization
 
-* Tune `query_classifier_cache_size` to allow maximal use of the query\
-  classifier cache. Increase the value and/or system memory until the set of\
-  unique SQL patterns fits into memory. By default at most 15% of the system\
-  memory is used for this cache. To detect if the SQL statements fit into\
-  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to\
-  see how many evictions take place. If it keeps increasing, increase the size\
-  of the query classifier cache. Using the query classifier cache with a CPU\
-  bound workload gives a roughly 20% improvement in performance compared to when\
+* Tune `query_classifier_cache_size` to allow maximal use of the query
+  classifier cache. Increase the value and/or system memory until the set of
+  unique SQL patterns fits into memory. By default at most 15% of the system
+  memory is used for this cache. To detect if the SQL statements fit into
+  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to
+  see how many evictions take place. If it keeps increasing, increase the size
+  of the query classifier cache. Using the query classifier cache with a CPU
+  bound workload gives a roughly 20% improvement in performance compared to when
   it is turned off.
-* A faster CPU with more CPU cores is better. This is true for most applications\
+* A faster CPU with more CPU cores is better. This is true for most applications
   but especially for MaxScale as it is mostly limited by the speed of the\
   CPU. Using `threads=auto` is recommended (the default starting with MaxScale\
   6\).
-* Network throughput between the client, MaxScale and the database nodes governs\
-  how much traffic can be handled. The client-to-MaxScale network is likely to\
-  be saturated first: having multiple MaxScales in front of the cluster is an\
+* Network throughput between the client, MaxScale and the database nodes governs
+  how much traffic can be handled. The client-to-MaxScale network is likely to
+  be saturated first: having multiple MaxScales in front of the cluster is an
   easy way of solving this problem.
-* Certain MaxScale modules store data on disk. A faster disk improves their\
-  performance but depending on the module, this might not be a big enough of a\
-  problem to worry about. Filters like the `qlafilter` that write information to\
+* Certain MaxScale modules store data on disk. A faster disk improves their
+  performance but depending on the module, this might not be a big enough of a
+  problem to worry about. Filters like the `qlafilter` that write information to
   disk for every SQL query can cause performance bottlenecks.
 
 ### MaxScale Diagnostics using MaxCtrl
 
-From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with\
+From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with
 information about the system MaxScale is running on. The fields are:
 
 | Field                                   | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -4527,34 +4527,34 @@ In addition there is an `os` object that contains what the Linux command `uname`
 
 **`threads`**
 
-If `threads` has not been specified at all in the MaxScale configuration file,\
-or if its value is `auto`, then MaxScale will use as many routing threads as\
-there are physical cores on the machine. This is the right choice, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
+If `threads` has not been specified at all in the MaxScale configuration file,
+or if its value is `auto`, then MaxScale will use as many routing threads as
+there are physical cores on the machine. This is the right choice, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
 in any way.
 
-However, if the number of cores available to MaxScale have been restricted or\
-if MaxScale is running in a container whose CPU quota and period have been\
-limited, then it will lead to MaxScale using more routing threads than what\
+However, if the number of cores available to MaxScale have been restricted or
+if MaxScale is running in a container whose CPU quota and period have been
+limited, then it will lead to MaxScale using more routing threads than what
 is appropriate in the environment where it is running.
 
-If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`\
-should be specified explicitly in the MaxScale configuration file and its value\
-should be that of `machine.cores_virtual` rounded up to the nearest integer. If\
+If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`
+should be specified explicitly in the MaxScale configuration file and its value
+should be that of `machine.cores_virtual` rounded up to the nearest integer. If
 that value is `1` it may be beneficial to check whether `2` gives better performance.
 
 **`query_classifier_cache_size`**
 
-If `query_classifier_cache_size` has not been specified in the MaxScale\
-configuration file, then MaxScale will use at most 15% of the amount of physical\
-memory in the machine for the cache. This is a good starting point, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
-in any way. Note that the amount specifies how much memory the cache at maximum\
+If `query_classifier_cache_size` has not been specified in the MaxScale
+configuration file, then MaxScale will use at most 15% of the amount of physical
+memory in the machine for the cache. This is a good starting point, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
+in any way. Note that the amount specifies how much memory the cache at maximum
 is allowed to use, not what would immediately be allocated for the cache.
 
-However, if the amount of memory available to MaxScale has been restricted,\
-which may be the case if MaxScale is running in a container, this may cause the\
-cache to grow beyond what is available, which will lead to a crash or MaxScale\
+However, if the amount of memory available to MaxScale has been restricted,
+which may be the case if MaxScale is running in a container, this may cause the
+cache to grow beyond what is available, which will lead to a crash or MaxScale
 being killed.
 
 If the value of `machine.memory_available` is less than that of`machine.memory_physical`, then `query_classifier_cache_size` should be explicitly\
@@ -4593,7 +4593,7 @@ $ maxctrl show maxscale
 As can be seen, `maxscale.threads` is larger than `machine.cores_virtual` and thus,`threads=4` should explicitly be specified in the MaxScale configuration file.
 
 `maxscale.query_classifier_cache_size` is the default 15% of `machine.memory_physical`\
-but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be\
+but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be
 added to the configuration file.
 
 ```
@@ -4605,12 +4605,12 @@ query_classifier_cache_size=3100000000
 
 ## Troubleshooting
 
-For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)\
+For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 article on the MariaDB documentation.
 
 ### Systemd Watchdog
 
-If MaxScale is running as a systemd service, the systemd Watchdog will be\
+If MaxScale is running as a systemd service, the systemd Watchdog will be
 enabled by default. To configure it, change the `WatchdogSec` option in the\
 Service section of the maxscale systemd configuration file located in`/lib/systemd/system/maxscale.service`:
 
@@ -4618,8 +4618,8 @@ Service section of the maxscale systemd configuration file located in`/lib/syste
 WatchdogSec=30s
 ```
 
-It is not recommended to use a watchdog timeout less than 30 seconds. When\
-enabled MaxScale will check that all threads are running and notify systemd\
+It is not recommended to use a watchdog timeout less than 30 seconds. When
+enabled MaxScale will check that all threads are running and notify systemd
 with a "keep-alive ping".
 
 Systemd reference: [systemd.service.html](https://www.freedesktop.org/software/systemd/man/systemd.service.html)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-installation-guide.md
@@ -1,14 +1,14 @@
 # MariaDB MaxScale Installation Guide
 
-We recommend to install MaxScale on a separate server, to ensure that there\
-can be no competition of resources between MaxScale and a MariaDB Server that\
+We recommend to install MaxScale on a separate server, to ensure that there
+can be no competition of resources between MaxScale and a MariaDB Server that
 it manages.
 
 ### Install MariaDB MaxScale From MariaDB Repositories
 
-The recommended approach is to use [the MariaDB package\
-repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
-to install MaxScale. After enabling the repository by following the\
+The recommended approach is to use [the MariaDB package
+repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
+to install MaxScale. After enabling the repository by following the
 instructions, MaxScale can be installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install maxscale`.
@@ -17,9 +17,9 @@ instructions, MaxScale can be installed with the following commands.
 
 ### Install MariaDB MaxScale From a RPM/DEB Package
 
-Download the correct MaxScale package for your CPU architecture and operating\
-system from [the MariaDB Downloads\
-page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be\
+Download the correct MaxScale package for your CPU architecture and operating
+system from [the MariaDB Downloads
+page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be
 installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install /path/to/maxscale-*.rpm`
@@ -29,7 +29,7 @@ installed with the following commands.
 ### Install MariaDB MaxScale Using a Tarball
 
 MaxScale can also be installed using a tarball.\
-That may be required if you are using a Linux distribution for which there\
+That may be required if you are using a Linux distribution for which there
 exist no installation package or if you want to install many different\
 MaxScale versions side by side. For instructions on how to do that, please refer to [Install MariaDB MaxScale using a Tarball](mariadb-maxscale-2302-installing-mariadb-maxscale-using-a-tarball.md).
 
@@ -42,20 +42,20 @@ To do this, refer to the separate document [Building MariaDB MaxScale from Sourc
 
 #### Memory allocation behavior
 
-MaxScale assumes that memory allocations always succeed and in general does\
-not check for memory allocation failures. This assumption is compatible with\
-the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)\
+MaxScale assumes that memory allocations always succeed and in general does
+not check for memory allocation failures. This assumption is compatible with
+the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)
 having the value `0`, which is also the default on most systems.
 
-With `vm.overcommit_memory` being `0`, memory _allocations_ made by an\
-application never fail, but instead the application may be killed by the\
-so-called OOM (out-of-memory) killer if, by the time the application\
-actually attempts to _use_ the allocated memory, there is not available\
+With `vm.overcommit_memory` being `0`, memory _allocations_ made by an
+application never fail, but instead the application may be killed by the
+so-called OOM (out-of-memory) killer if, by the time the application
+actually attempts to _use_ the allocated memory, there is not available
 free memory on the system.
 
-If the value is `2`, then a memory allocation made by an application may\
-fail and unless the application is prepared for that possibility, it will\
-likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory\
+If the value is `2`, then a memory allocation made by an application may
+fail and unless the application is prepared for that possibility, it will
+likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory
 allocation failures, it will crash in this situation.
 
 The current value of `vm.overcommit_memory` can be checked with
@@ -72,36 +72,36 @@ cat /proc/sys/vm/overcommit_memory
 
 ### Configuring MariaDB MaxScale
 
-[The MaxScale Tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-setting-up-mariadb-maxscale.md) covers the first\
-steps in configuring your MariaDB MaxScale installation. Follow this tutorial\
+[The MaxScale Tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-setting-up-mariadb-maxscale.md) covers the first
+steps in configuring your MariaDB MaxScale installation. Follow this tutorial
 to learn how to configure and start using MaxScale.
 
-For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md) and the module specific documents\
+For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md) and the module specific documents
 listed in the [Documentation Contents](../mariadb-maxscale-2302-contents.md).
 
 ### Encrypting Passwords
 
-Read the [Encrypting Passwords](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encrypting-passwords)\
-section of the configuration guide to set up password encryption for the\
+Read the [Encrypting Passwords](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encrypting-passwords)
+section of the configuration guide to set up password encryption for the
 configuration file.
 
 ### Administration Of MariaDB MaxScale
 
 There are various administration tasks that may be done with MariaDB MaxScale.\
-A command line tools is available, [maxctrl](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md), that will\
+A command line tools is available, [maxctrl](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md), that will
 interact with a running MariaDB MaxScale and allow the status of MariaDB\
-MaxScale to be monitored and give some control of the MariaDB MaxScale\
+MaxScale to be monitored and give some control of the MariaDB MaxScale
 functionality.
 
-[The administration tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-mariadb-maxscale-administration-tutorial.md)\
+[The administration tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-mariadb-maxscale-administration-tutorial.md)
 covers the common administration tasks that need to be done with MariaDB MaxScale.
 
 ### Copying or Backing Up MaxScale
 
-The main configuration file for MaxScale is in `/etc/maxscale.cnf` and\
+The main configuration file for MaxScale is in `/etc/maxscale.cnf` and
 additional user-created configuration files are in`/etc/maxscale.cnf.d/`. Objects created or modified at runtime are stored in`/var/lib/maxscale/maxscale.cnf.d/`. Some modules also store internal data in`/var/lib/maxscale/` named after the module or the configuration object.
 
-The simplest way to back up the configuration and runtime data of a MaxScale\
+The simplest way to back up the configuration and runtime data of a MaxScale
 installation is to create an archive from the following files and directories:
 
 * `/etc/maxscale.cnf`
@@ -114,7 +114,7 @@ This can be done with the following command:
 tar -caf maxscale-backup.tar.gz /etc/maxscale.cnf /etc/maxscale.cnf.d/ /var/lib/maxscale/
 ```
 
-If MaxScale is configured to store data in custom locations, these should be\
+If MaxScale is configured to store data in custom locations, these should be
 included in the backup as well.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-maxgui-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-maxgui-guide.md
@@ -6,27 +6,27 @@ _MaxGUI_ is a browser-based interface for MaxScale REST-API and query execution.
 
 ## Enabling MaxGUI
 
-To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale\
+To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale
 configuration file. Once enabled, MaxGUI will be available on port 8989:`http://127.0.0.1:8989/`
 
 ### Securing the GUI
 
 To make MaxGUI secure, set `admin_secure_gui=true` and configure both the`admin_ssl_key` and `admin_ssl_cert` parameters.
 
-See [Configuration Guide](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-rest-api-tutorial.md)\
+See [Configuration Guide](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-rest-api-tutorial.md)
 for instructions on how to harden your MaxScale installation for production use.
 
 ## Authentication
 
-MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`\
+MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`
 with `mariadb` as the password.
 
-Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the\
-authentication method for persisting the user's session. If the _Remember me_\
-checkbox is ticked, the session will persist for 24 hours. Otherwise, the\
+Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the
+authentication method for persisting the user's session. If the _Remember me_
+checkbox is ticked, the session will persist for 24 hours. Otherwise, the
 session will expire as soon as MaxGUI is closed.
 
-To log out, simply click the username section in the top right corner of the\
+To log out, simply click the username section in the top right corner of the
 page header to access the logout menu.
 
 ## Pages
@@ -40,7 +40,7 @@ By default, the refresh interval is 10 seconds.
 
 ### Detail
 
-This page shows information on each [MaxScale object](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#objects) and allow to edit its\
+This page shows information on each [MaxScale object](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#objects) and allow to edit its
 parameter, relationships and perform other manipulation operations.
 
 Access this page by clicking on the MaxScale object name on the [dashboard page](mariadb-maxscale-2302-mariadb-maxscale-maxgui-guide.md#dashboard)
@@ -50,8 +50,8 @@ Access this page by clicking on the MaxScale object name on the [dashboard page]
 This page visualizes MaxScale configuration and clusters.
 
 * Configuration: Visualizing MaxScale configuration.
-* Cluster: Visualizing a replication cluster into a tree graph and provides\
-  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the\
+* Cluster: Visualizing a replication cluster into a tree graph and provides
+  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the
   moment, it supports only servers monitored by Monitor using [mariadbmon](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md) module.
 
 Access this page by clicking the graph icon on the sidebar navigation.
@@ -64,25 +64,25 @@ Access this page by clicking the gear icon on the sidebar navigation.
 
 ### Logs Archive
 
-Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar\
+Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar
 navigation.
 
 ### Workspace
 
-The "Workspace" page offers a versatile set of tools for effectively managing\
+The "Workspace" page offers a versatile set of tools for effectively managing
 data and database interactions. It includes the following key tasks:
 
 #### 1. Run Queries
 
-Execute queries on various servers, services, or listeners to retrieve data and\
-perform database operations. Visualize query results using different graph\
-types such as line, bar, or scatter graphs. Export query results in formats\
+Execute queries on various servers, services, or listeners to retrieve data and
+perform database operations. Visualize query results using different graph
+types such as line, bar, or scatter graphs. Export query results in formats
 like CSV or JSON for further analysis and sharing.
 
 #### 2. Data Migration
 
-The "Data Migration" feature facilitates seamless transitions from PostgreSQL\
-to MariaDB. Transfer data and database structures between the two systems while\
+The "Data Migration" feature facilitates seamless transitions from PostgreSQL
+to MariaDB. Transfer data and database structures between the two systems while
 ensuring data integrity and consistency throughout the process.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-common-monitor-parameters.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-common-monitor-parameters.md
@@ -1,6 +1,6 @@
 # Common Monitor Parameters
 
-This document settings supported by all monitors. These should be defined\
+This document settings supported by all monitors. These should be defined
 in the monitor section of the configuration file.
 
 ### Parameters
@@ -19,7 +19,7 @@ The monitor module this monitor should use. Typically `mariadbmon` or`galeramon`
 * Mandatory: Yes
 * Dynamic: Yes
 
-Username used by the monitor to connect to the backend servers. If a server defines\
+Username used by the monitor to connect to the backend servers. If a server defines
 the `monitoruser` parameter, that value will be used instead.
 
 #### `password`
@@ -28,10 +28,10 @@ the `monitoruser` parameter, that value will be used instead.
 * Mandatory: Yes
 * Dynamic: Yes
 
-Password for the user defined with the `user` parameter. If a server defines\
+Password for the user defined with the `user` parameter. If a server defines
 the `monitorpw` parameter, that value will be used instead.
 
-**Note:** In older versions of MaxScale this parameter was called `passwd`. The\
+**Note:** In older versions of MaxScale this parameter was called `passwd`. The
 use of `passwd` was deprecated in MaxScale 2.3.0.
 
 #### `servers`
@@ -53,17 +53,17 @@ servers=MyServer1,MyServer2
 * Dynamic: Yes
 * Default: `2s`
 
-Defines how often the monitor updates the status of the servers. Choose a lower\
+Defines how often the monitor updates the status of the servers. Choose a lower
 value if servers should be queried more often. The smallest possible value is\
-100 milliseconds. If querying the servers takes longer than `monitor_interval`,\
+100 milliseconds. If querying the servers takes longer than `monitor_interval`,
 the effective update rate is reduced.
 
 ```
 monitor_interval=2s
 ```
 
-The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.
 
 #### `backend_connect_timeout`
@@ -74,10 +74,10 @@ versions a value without a unit may be rejected.
 * Default: `3s`
 
 This parameter controls the timeout for connecting to a monitored server.\
-The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -92,10 +92,10 @@ backend_connect_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for writing to a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 seconds.
 
 ```
@@ -110,10 +110,10 @@ backend_write_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for reading from a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -127,9 +127,9 @@ backend_read_timeout=3s
 * Dynamic: Yes
 * Default: `1`
 
-This parameter defines the maximum times a backend connection is attempted every\
-monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds\
-to perform. If none of the attempts are successful, the backend is considered to\
+This parameter defines the maximum times a backend connection is attempted every
+monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds
+to perform. If none of the attempts are successful, the backend is considered to
 be unreachable and down.
 
 ```
@@ -147,18 +147,18 @@ This parameter duplicates the `disk_space_threshold`[server parameter](../mariad
 If the parameter has _not_ been specified for a server, then the one specified\
 for the monitor is applied.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-That is, if the disk configuration is the same on all servers monitored by\
-the monitor, it is sufficient (and more convenient) to specify the disk\
-space threshold in the monitor section, but if the disk configuration is\
-different on all or some servers, then the disk space threshold can be\
+That is, if the disk configuration is the same on all servers monitored by
+the monitor, it is sufficient (and more convenient) to specify the disk
+space threshold in the monitor section, but if the disk configuration is
+different on all or some servers, then the disk space threshold can be
 specified individually for each server.
 
-For example, suppose `server1`, `server2` and `server3` are identical\
-in all respects. In that case we can specify `disk_space_threshold`\
+For example, suppose `server1`, `server2` and `server3` are identical
+in all respects. In that case we can specify `disk_space_threshold`
 in the monitor.
 
 ```
@@ -181,8 +181,8 @@ disk_space_threshold=/data:80
 ...
 ```
 
-However, if the servers are heterogeneous with the disk used for the\
-data directory mounted on different paths, then the disk space threshold\
+However, if the servers are heterogeneous with the disk used for the
+data directory mounted on different paths, then the disk space threshold
 must be specified separately for each server.
 
 ```
@@ -207,8 +207,8 @@ servers=server1,server2,server3
 ...
 ```
 
-If _most_ of the servers have the data directory disk mounted on\
-the same path, then the disk space threshold can be specified on\
+If _most_ of the servers have the data directory disk mounted on
+the same path, then the disk space threshold can be specified on
 the monitor and separately on the server with a different setup.
 
 ```
@@ -232,7 +232,7 @@ disk_space_threshold=/data:80
 ...
 ```
 
-Above, `server1` has the disk used for the data directory mounted\
+Above, `server1` has the disk used for the data directory mounted
 at `/DbData` while both `server2` and `server3` have it mounted on`/data` and thus the setting in the monitor covers them both.
 
 #### `disk_space_check_interval`
@@ -242,15 +242,15 @@ at `/DbData` while both `server2` and `server3` have it mounted on`/data` and th
 * Dynamic: Yes
 * Default: `0s`
 
-With this parameter it can be specified the minimum amount of time\
-between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+With this parameter it can be specified the minimum amount of time
+between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.\
-The default value is 0, which means that by default the disk space\
+The default value is 0, which means that by default the disk space
 will not be checked.
 
-Note that as the checking is made as part of the regular monitor interval\
-cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,\
+Note that as the checking is made as part of the regular monitor interval
+cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,
 the checking will still take place at `monitor_interval` intervals.
 
 #### `script`
@@ -260,9 +260,9 @@ the checking will still take place at `monitor_interval` intervals.
 * Dynamic: Yes
 * Default: None
 
-This command will be executed on a server state change. The parameter should\
-be an absolute path to a command or the command should be in the executable\
-path. The user running MaxScale should have execution rights to the file itself\
+This command will be executed on a server state change. The parameter should
+be an absolute path to a command or the command should be in the executable
+path. The user running MaxScale should have execution rights to the file itself
 and the directory it resides in. The script may have placeholders which\
 MaxScale will substitute with useful information when launching the script.
 
@@ -276,15 +276,15 @@ The placeholders and their substitution results are:
 * `$MASTERLIST` -> list of IPs and ports of all primary servers
 * `$SYNCEDLIST` -> list of IPs and ports of all synced Galera nodes
 * `$PARENT` -> IP and port of the parent of the server which initiated the event.\
-  For primary-replica setups, this will be the primary if the initiating server is a\
+  For primary-replica setups, this will be the primary if the initiating server is a
   replica.
-* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who\
-  initiated the event. For primary-replica setups, this will be a list of replica\
+* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who
+  initiated the event. For primary-replica setups, this will be a list of replica
   servers if the initiating server is a primary.
 
-The expanded variable value can be an empty string if no servers match the\
-variable's requirements. For example, if no primaries are available `$MASTERLIST`\
-will expand into an empty string. The list-type substitutions will only contain\
+The expanded variable value can be an empty string if no servers match the
+variable's requirements. For example, if no primaries are available `$MASTERLIST`
+will expand into an empty string. The list-type substitutions will only contain
 servers monitored by the current monitor.
 
 ```
@@ -299,17 +299,17 @@ The above script could be executed as:
 
 See section [Script example](mariadb-maxscale-2302-common-monitor-parameters.md#script-example) below for an example script.
 
-Any output by the executed script will be logged into the MaxScale log. Each\
+Any output by the executed script will be logged into the MaxScale log. Each
 outputted line will be logged as a separate log message.
 
-The log level on which the messages are logged depends on the format of the\
-messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the\
-corresponding level. If the message is not prefixed with one of the keywords,\
-the message will be logged on the notice level. Whitespace before, after or\
-between the keyword and the colon is ignored and the matching is\
+The log level on which the messages are logged depends on the format of the
+messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the
+corresponding level. If the message is not prefixed with one of the keywords,
+the message will be logged on the notice level. Whitespace before, after or
+between the keyword and the colon is ignored and the matching is
 case-insensitive.
 
-Currently, the script must not execute any of the following MaxCtrl\
+Currently, the script must not execute any of the following MaxCtrl
 calls as they cause a deadlock:
 
 * `alter monitor` to the monitor executing the script
@@ -323,14 +323,14 @@ calls as they cause a deadlock:
 * Dynamic: Yes
 * Default: `90s`
 
-The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If the script execution exceeds the configured timeout, it is stopped by sending\
-a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be\
+If the script execution exceeds the configured timeout, it is stopped by sending
+a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be
 sent to it once the execution time is greater than twice the configured timeout.
 
 #### `events`
@@ -341,15 +341,15 @@ sent to it once the execution time is greater than twice the configured timeout.
 * Values: `master_down`, `master_up`, `slave_down`, `slave_up`, `server_down`, `server_up`, `lost_master`, `lost_slave`, `new_master`, `new_slave`
 * Default: All events
 
-A list of event names which cause the script to be executed. If this option is\
-not defined, all events cause the script to be executed. The list must contain a\
+A list of event names which cause the script to be executed. If this option is
+not defined, all events cause the script to be executed. The list must contain a
 comma separated list of event names.
 
 ```
 events=master_down,slave_down
 ```
 
-The following table contains all the possible event types and their\
+The following table contains all the possible event types and their
 descriptions.
 
 | Event Name   | Description                                  |
@@ -372,38 +372,38 @@ descriptions.
 * Dynamic: Yes
 * Default: `28800s`
 
-The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the max age is seconds, a max age specified in milliseconds will be rejected,\
+The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the max age is seconds, a max age specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-When the monitor starts, it reads any stored journal files. If the journal file\
-is older than the value of _journal\_max\_age_, it will be removed and the monitor\
+When the monitor starts, it reads any stored journal files. If the journal file
+is older than the value of _journal\_max\_age_, it will be removed and the monitor
 starts with no prior knowledge of the servers.
 
 ### Monitor Crash Safety
 
-Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the\
-latest server states. This change makes the monitors crash-safe when options\
-that introduce states are used. It also allows the monitors to retain stateful\
+Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the
+latest server states. This change makes the monitors crash-safe when options
+that introduce states are used. It also allows the monitors to retain stateful
 information when MaxScale is restarted.
 
-For MySQL monitor, options that introduce states into the monitoring process are\
-the `detect_stale_master` and `detect_stale_slave` options, both of which are\
-enabled by default. Galeramon has the `disable_master_failback` parameter which\
+For MySQL monitor, options that introduce states into the monitoring process are
+the `detect_stale_master` and `detect_stale_slave` options, both of which are
+enabled by default. Galeramon has the `disable_master_failback` parameter which
 introduces a state.
 
-The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the\
-name of the monitor section in the configuration file. If MaxScale crashes or is\
-shut down in an uncontrolled fashion, the journal will be read when MaxScale is\
-started. To skip the recovery process, manually delete the journal file before\
+The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the
+name of the monitor section in the configuration file. If MaxScale crashes or is
+shut down in an uncontrolled fashion, the journal will be read when MaxScale is
+started. To skip the recovery process, manually delete the journal file before
 starting MaxScale.
 
 ### Script example
 
-Below is an example monitor configuration which launches a script with all\
-supported substitutions. The example script reads the results and prints it to\
+Below is an example monitor configuration which launches a script with all
+supported substitutions. The example script reads the results and prints it to
 file and sends it as email.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-galera-monitor.md
@@ -2,39 +2,39 @@
 
 ### Overview
 
-The Galera Monitor is a monitoring module for MaxScale that monitors a Galera\
-cluster. It detects whether nodes are a part of the cluster and if they are in\
-sync with the rest of the cluster. It can also assign primary and replica roles\
-inside MaxScale, allowing Galera clusters to be used with modules designed for\
+The Galera Monitor is a monitoring module for MaxScale that monitors a Galera
+cluster. It detects whether nodes are a part of the cluster and if they are in
+sync with the rest of the cluster. It can also assign primary and replica roles
+inside MaxScale, allowing Galera clusters to be used with modules designed for
 traditional primary-replica clusters.
 
-By default, the Galera Monitor will choose the node with the lowest`wsrep_local_index` value as the primary. This will mean that two MaxScales\
+By default, the Galera Monitor will choose the node with the lowest`wsrep_local_index` value as the primary. This will mean that two MaxScales
 running on different servers will choose the same server as the primary.
 
 #### WSREP Variables and Their Effects
 
-The following WSREP variables are inspected by galeramon to see whether a node is\
-usable. If the node is not usable, it loses the `Master` and `Slave` labels and\
+The following WSREP variables are inspected by galeramon to see whether a node is
+usable. If the node is not usable, it loses the `Master` and `Slave` labels and
 will be in the `Running` state.
 
-* If `wsrep_ready=0`, the WSREP system is not yet ready and the Galera node\
+* If `wsrep_ready=0`, the WSREP system is not yet ready and the Galera node
   cannot accept queries.
-* If `wsrep_desync=1` is set, the node is desynced and is not participating in\
+* If `wsrep_desync=1` is set, the node is desynced and is not participating in
   the Galera replication.
-* If `wsrep_reject_queries=[ALL|ALL_KILL]` is set, queries are refused and the\
+* If `wsrep_reject_queries=[ALL|ALL_KILL]` is set, queries are refused and the
   node is unusable.
-* With `wsrep_sst_donor_rejects_queries=1`, donor nodes reject\
-  queries. Galeramon treats this the same as if `wsrep_reject_queries=ALL` was\
+* With `wsrep_sst_donor_rejects_queries=1`, donor nodes reject
+  queries. Galeramon treats this the same as if `wsrep_reject_queries=ALL` was
   set.
-* If `wsrep_local_state` is not 4 (or 2 with `available_when_donor=true`), the\
+* If `wsrep_local_state` is not 4 (or 2 with `available_when_donor=true`), the
   node is not in the correct state and is not used.
 
 #### Galera clusters and replicas replicating from it
 
-MaxScale 2.4.0 added support for replicas replicating off of Galera nodes. If a\
-non-Galera server monitored by galeramon is replicating from a Galera node also\
-monitored by galeramon, it will be assigned the `Slave, Running` status as long\
-as the replication works. This allows read-scaleout with Galera servers without\
+MaxScale 2.4.0 added support for replicas replicating off of Galera nodes. If a
+non-Galera server monitored by galeramon is replicating from a Galera node also
+monitored by galeramon, it will be assigned the `Slave, Running` status as long
+as the replication works. This allows read-scaleout with Galera servers without
 increasing the size of the Galera cluster.
 
 ### Required Grants
@@ -60,7 +60,7 @@ GRANT SUPER ON *.* TO 'maxscale'@'maxscalehost';
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers. The user requires the\
 REPLICATION CLIENT privilege to successfully monitor the state of the servers.
 
@@ -87,10 +87,10 @@ These are optional parameters specific to the Galera Monitor.
 * Default: false
 * Dynamic: Yes
 
-If a node marked as primary inside MaxScale happens to fail and the primary\
-status is assigned to another node MaxScale will normally return the primary\
-status to the original node after it comes back up. With this option enabled, if\
-the primary status is assigned to a new node it will not be reassigned to the\
+If a node marked as primary inside MaxScale happens to fail and the primary
+status is assigned to another node MaxScale will normally return the primary
+status to the original node after it comes back up. With this option enabled, if
+the primary status is assigned to a new node it will not be reassigned to the
 original node for as long as the new primary node is running. In this case the`Master Stickiness` status bit is set which will be visible in the`maxctrl list servers` output.
 
 #### `available_when_donor`
@@ -100,16 +100,16 @@ original node for as long as the new primary node is running. In this case the`M
 * Dynamic: Yes
 
 This option allows Galera nodes to be used normally when they are donors in an\
-SST operation when the SST method is non-blocking\
+SST operation when the SST method is non-blocking
 (e.g. `wsrep_sst_method=mariadb-backup`).
 
-Normally when an SST is performed, both participating nodes lose their `Synced`,`Master` or `Slave` statuses. When this option is enabled, the donor is treated as\
-if it was a normal member of the cluster (i.e. `wsrep_local_state = 4`). This is\
-especially useful if the cluster drops down to one node and an SST is required\
+Normally when an SST is performed, both participating nodes lose their `Synced`,`Master` or `Slave` statuses. When this option is enabled, the donor is treated as
+if it was a normal member of the cluster (i.e. `wsrep_local_state = 4`). This is
+especially useful if the cluster drops down to one node and an SST is required
 to increase the cluster size.
 
-The current list of non-blocking SST\
-methods are `xtrabackup`, `xtrabackup-v2` and `mariadb-backup`. Read the [wsrep\_sst\_method](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables)\
+The current list of non-blocking SST
+methods are `xtrabackup`, `xtrabackup-v2` and `mariadb-backup`. Read the [wsrep\_sst\_method](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables)
 documentation for more details.
 
 #### `disable_master_role_setting`
@@ -118,8 +118,8 @@ documentation for more details.
 * Default: false
 * Dynamic: Yes
 
-This disables the assignment of primary and replica roles to the Galera cluster\
-nodes. If this option is enabled, Synced is the only status assigned by this\
+This disables the assignment of primary and replica roles to the Galera cluster
+nodes. If this option is enabled, Synced is the only status assigned by this
 monitor.
 
 #### `use_priority`
@@ -128,8 +128,8 @@ monitor.
 * Default: false
 * Dynamic: Yes
 
-Enable interaction with server priorities. This will allow the monitor to\
-deterministically pick the write node for the monitored Galera cluster and will\
+Enable interaction with server priorities. This will allow the monitor to
+deterministically pick the write node for the monitored Galera cluster and will
 allow for controlled node replacement.
 
 #### `root_node_as_master`
@@ -138,27 +138,27 @@ allow for controlled node replacement.
 * Default: false
 * Dynamic: Yes
 
-This option controls whether the write primary Galera node requires a_wsrep\_local\_index_ value of 0. This option was introduced in MaxScale 2.1.0 and\
-it is disabled by default in versions 2.1.5 and newer. In versions 2.1.4 and\
+This option controls whether the write primary Galera node requires a_wsrep\_local\_index_ value of 0. This option was introduced in MaxScale 2.1.0 and
+it is disabled by default in versions 2.1.5 and newer. In versions 2.1.4 and
 older, the option was enabled by default.
 
-A Galera cluster will always have a node which has a _wsrep\_local\_index_ value\
-of 0. Based on this information, multiple MaxScale instances can always pick the\
+A Galera cluster will always have a node which has a _wsrep\_local\_index_ value
+of 0. Based on this information, multiple MaxScale instances can always pick the
 same node for writes.
 
 If the `root_node_as_master` option is disabled for galeramon, the node with the\
 lowest index will always be chosen as the primary. If it is enabled, only the\
 node with a _wsrep\_local\_index_ value of 0 can be chosen as the primary.
 
-This parameter can work with `disable_master_failback` but using them together\
-is not advisable: the intention of `root_node_as_master` is to make sure that\
-all MaxScale instances that are configured to use the same Galera cluster will\
-send writes to the same node. If `disable_master_failback` is enabled, this is\
-no longer true if the Galera cluster reorganizes itself in a way that a\
-different node gets the node index 0, writes would still be going to the old\
-node that previously had the node index 0. A restart of one of the MaxScales or\
-a new MaxScale joining the cluster will cause writes to be sent to the wrong\
-node, thus resulting in an increasing the rate of deadlock errors and\
+This parameter can work with `disable_master_failback` but using them together
+is not advisable: the intention of `root_node_as_master` is to make sure that
+all MaxScale instances that are configured to use the same Galera cluster will
+send writes to the same node. If `disable_master_failback` is enabled, this is
+no longer true if the Galera cluster reorganizes itself in a way that a
+different node gets the node index 0, writes would still be going to the old
+node that previously had the node index 0. A restart of one of the MaxScales or
+a new MaxScale joining the cluster will cause writes to be sent to the wrong
+node, thus resulting in an increasing the rate of deadlock errors and
 sub-optimal performance.
 
 #### `set_donor_nodes`
@@ -167,12 +167,12 @@ sub-optimal performance.
 * Default: false
 * Dynamic: Yes
 
-This option controls whether the global variable _wsrep\_sst\_donor_ should be set\
+This option controls whether the global variable _wsrep\_sst\_donor_ should be set
 in each cluster node with _slave' status_.\
-The variable contains a list of replica servers, automatically sorted, with\
+The variable contains a list of replica servers, automatically sorted, with
 possible primary candidates at its end.
 
-The sorting is based either on _wsrep\_local\_index_ or node server _priority_\
+The sorting is based either on _wsrep\_local\_index_ or node server _priority_
 depending on the value of _use\_priority_ option.\
 If no server has _priority_ defined the sorting switches to _wsrep\_local\_index_.\
 Node names are collected by fetching the result of the variable _wsrep\_node\_name_.
@@ -184,24 +184,24 @@ SET GLOBAL wsrep_sst_donor = "galera001,galera000"
 ```
 
 **Note**:\
-in order to set the global variable _wsrep\_sst\_donor_, proper privileges are\
+in order to set the global variable _wsrep\_sst\_donor_, proper privileges are
 required for the monitor user that connects to cluster nodes.\
 This option is disabled by default and was introduced in MaxScale 2.1.0.
 
 ### Interaction with Server Priorities
 
-If the `use_priority` option is set and a server is configured with the`priority=<int>` parameter, galeramon will use that as the basis on which the\
-primary node is chosen. This requires the `disable_master_role_setting` to be\
-undefined or disabled. The server with the lowest positive value of _priority_\
-will be chosen as the primary node when a replacement Galera node is promoted to\
-a primary server inside MaxScale. If all candidate servers have the same\
-priority, the order of the servers in the `servers` parameter dictates which is\
+If the `use_priority` option is set and a server is configured with the`priority=<int>` parameter, galeramon will use that as the basis on which the
+primary node is chosen. This requires the `disable_master_role_setting` to be
+undefined or disabled. The server with the lowest positive value of _priority_
+will be chosen as the primary node when a replacement Galera node is promoted to
+a primary server inside MaxScale. If all candidate servers have the same
+priority, the order of the servers in the `servers` parameter dictates which is
 chosen as the primary.
 
-Nodes with a negative value (_priority_ < 0) will never be chosen as the\
-primary. This allows you to mark some servers as permanent replicas by assigning a\
-non-positive value into _priority_. Nodes with the default priority of 0 are\
-only selected if no nodes with higher priority are present and the normal node\
+Nodes with a negative value (_priority_ < 0) will never be chosen as the
+primary. This allows you to mark some servers as permanent replicas by assigning a
+non-positive value into _priority_. Nodes with the default priority of 0 are
+only selected if no nodes with higher priority are present and the normal node
 selection rules apply to them (i.e. selection is based on `wsrep_local_index`).
 
 Here is an example.
@@ -232,13 +232,13 @@ port=3306
 priority=-1
 ```
 
-In this example `node-1` is always used as the primary if available. If `node-1`\
-is not available, then the next node with the highest priority rank is used. In\
-this case it would be `node-3`. If both `node-1` and `node-3` were down, then`node-2` would be used. Because `node-4` has a value of -1 in _priority_, it\
-will never be the primary. Nodes without _priority_ parameter are considered as\
+In this example `node-1` is always used as the primary if available. If `node-1`
+is not available, then the next node with the highest priority rank is used. In
+this case it would be `node-3`. If both `node-1` and `node-3` were down, then`node-2` would be used. Because `node-4` has a value of -1 in _priority_, it
+will never be the primary. Nodes without _priority_ parameter are considered as
 having a priority of 0 and will be used only if all nodes with a positive_priority_ value are not available.
 
-With priority ranks you can control the order in which MaxScale chooses the\
+With priority ranks you can control the order in which MaxScale chooses the
 primary node. This will allow for a controlled failure and replacement of nodes.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-MariaDB Monitor monitors a Primary-Replica replication cluster. It probes the\
-state of the backends and assigns server roles such as primary and replica, which\
-are used by the routers when deciding where to route a query. It can also modify\
-the replication cluster by performing failover, switchover and rejoin. Backend\
-server versions older than MariaDB/MySQL 5.5 are not supported. Failover and\
+MariaDB Monitor monitors a Primary-Replica replication cluster. It probes the
+state of the backends and assigns server roles such as primary and replica, which
+are used by the routers when deciding where to route a query. It can also modify
+the replication cluster by performing failover, switchover and rejoin. Backend
+server versions older than MariaDB/MySQL 5.5 are not supported. Failover and
 other similar operations require MariaDB 10.0.2 or later.
 
 Up until MariaDB MaxScale 2.2.0, this monitor was called _MySQL Monitor_.
@@ -41,7 +41,7 @@ set), then the FILE-grant is required with MariaDB Server versions 10.4.7,\
 GRANT FILE ON *.* TO 'maxscale'@'maxscalehost';
 ```
 
-MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it\
+MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it
 allows the monitor to log in even if server connection limit has been reached.
 
 ```
@@ -50,7 +50,7 @@ GRANT CONNECTION ADMIN ON *.* TO 'maxscale'@'maxscalehost';
 
 #### Cluster Manipulation Grants
 
-If [cluster manipulation operations](mariadb-maxscale-2302-mariadb-monitor.md#cluster-manipulation-operations) are used,\
+If [cluster manipulation operations](mariadb-maxscale-2302-mariadb-monitor.md#cluster-manipulation-operations) are used,
 the following additional grants are required:
 
 ```
@@ -58,7 +58,7 @@ GRANT SUPER, RELOAD, PROCESS, SHOW DATABASES, EVENT ON *.* TO 'maxscale'@'maxsca
 GRANT SELECT ON mysql.user TO 'maxscale'@'maxscalehost';
 ```
 
-As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of\
+As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of
 its former sub-privileges. These must be given separately.
 
 ```
@@ -76,59 +76,59 @@ GRANT REPLICATION SLAVE ON *.* TO 'replication'@'replicationhost';
 
 ### Primary selection
 
-Only one backend can be primary at any given time. A primary must be running\
-(successfully connected to by the monitor) and its _read\_only_-setting must be\
-off. A primary may not be replicating from another server in the monitored\
-cluster unless the primary is part of a multiprimary group. Primary selection\
-prefers to select the server with the most replicas, possibly in multiple\
-replication layers. Only replicas reachable by a chain of running relays or\
-directly connected to the primary count. When multiple servers are tied for\
-primary status, the server which appears earlier in the `servers`-setting of the\
+Only one backend can be primary at any given time. A primary must be running
+(successfully connected to by the monitor) and its _read\_only_-setting must be
+off. A primary may not be replicating from another server in the monitored
+cluster unless the primary is part of a multiprimary group. Primary selection
+prefers to select the server with the most replicas, possibly in multiple
+replication layers. Only replicas reachable by a chain of running relays or
+directly connected to the primary count. When multiple servers are tied for
+primary status, the server which appears earlier in the `servers`-setting of the
 monitor is selected.
 
-Servers in a cyclical replication topology (multiprimary group) are interpreted\
-as having all the servers in the group as replicas. Even from a multiprimary group\
+Servers in a cyclical replication topology (multiprimary group) are interpreted
+as having all the servers in the group as replicas. Even from a multiprimary group
 only one server is selected as the overall primary.
 
-After a primary has been selected, the monitor prefers to stick with the choice\
-even if other potential primaries with more replica servers are available. Only if\
-the current primary is clearly unsuitable does the monitor try to select another\
+After a primary has been selected, the monitor prefers to stick with the choice
+even if other potential primaries with more replica servers are available. Only if
+the current primary is clearly unsuitable does the monitor try to select another
 primary. An existing primary turns invalid if:
 
 1. It is unwritable (read\_only is on).
-2. It has been down for more than failcount monitor passes and has no running\
-   replicas. Running replicas behind a downed relay count. A replica in this\
-   context is any server with at least a partially running replication connection\
-   (either io or sql thread is running). The replicas must also be down for more\
+2. It has been down for more than failcount monitor passes and has no running
+   replicas. Running replicas behind a downed relay count. A replica in this
+   context is any server with at least a partially running replication connection
+   (either io or sql thread is running). The replicas must also be down for more
    than failcount monitor passes to allow new master selection.
-3. It did not previously replicate from another server in the cluster but it\
+3. It did not previously replicate from another server in the cluster but it
    is now replicating.
-4. It was previously part of a multiprimary group but is no longer, or the\
+4. It was previously part of a multiprimary group but is no longer, or the
    multiprimary group is replicating from a server not in the group.
 
-Cases 1 and 2 cover the situations in which the DBA, an external script or even\
-another MaxScale has modified the cluster such that the old primary can no longer\
-act as primary. Cases 3 and 4 are less severe. In these cases the topology has\
-changed significantly and the primary should be re-selected, although the old\
+Cases 1 and 2 cover the situations in which the DBA, an external script or even
+another MaxScale has modified the cluster such that the old primary can no longer
+act as primary. Cases 3 and 4 are less severe. In these cases the topology has
+changed significantly and the primary should be re-selected, although the old
 primary may still be the best choice.
 
-The primary change described above is different from failover and switchover\
+The primary change described above is different from failover and switchover
 described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2302-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
-A primary change only modifies the server roles inside MaxScale but does not\
+A primary change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a primary change on their own.
 
-As a general rule, it's best to avoid situations where the cluster has multiple\
+As a general rule, it's best to avoid situations where the cluster has multiple
 standalone servers, separate primary-replica pairs or separate multiprimary groups.\
-Due to primary invalidation rule 2, a standalone primary can easily lose the\
-primary status to another valid primary if it goes down. The new primary probably\
-does not have the same data as the previous one. Non-standalone primaries are less\
-vulnerable, as a single running replica or multiprimary group member will keep the\
+Due to primary invalidation rule 2, a standalone primary can easily lose the
+primary status to another valid primary if it goes down. The new primary probably
+does not have the same data as the previous one. Non-standalone primaries are less
+vulnerable, as a single running replica or multiprimary group member will keep the
 primary valid even when down.
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers.
 
 ```
@@ -142,8 +142,8 @@ password=mypwd
 
 From MaxScale 2.2.1 onwards, the module name is `mariadbmon` instead of`mysqlmon`. The old name can still be used.
 
-The grants required by `user` depend on which monitor features are used. A full\
-list of the grants can be found in the [Required Grants](mariadb-maxscale-2302-mariadb-monitor.md#required-grants)\
+The grants required by `user` depend on which monitor features are used. A full
+list of the grants can be found in the [Required Grants](mariadb-maxscale-2302-mariadb-monitor.md#required-grants)
 section.
 
 ### Common Monitor Parameters
@@ -152,9 +152,9 @@ For a list of optional parameters that all monitors support, read the [Monitor C
 
 ### MariaDB Monitor optional parameters
 
-These are optional parameters specific to the MariaDB Monitor. Failover,\
-switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2302-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are\
-described in the [Rebuild server-section](mariadb-maxscale-2302-mariadb-monitor.md#rebuild-server). ColumnStore\
+These are optional parameters specific to the MariaDB Monitor. Failover,
+switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2302-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are
+described in the [Rebuild server-section](mariadb-maxscale-2302-mariadb-monitor.md#rebuild-server). ColumnStore
 parameters are described in the [ColumnStore commands-section](mariadb-maxscale-2302-mariadb-monitor.md#settings).
 
 #### `assume_unique_hostnames`
@@ -164,31 +164,31 @@ parameters are described in the [ColumnStore commands-section](mariadb-maxscale-
 * Dynamic: Yes
 * Default: `true`
 
-When active, the monitor assumes that server hostnames and\
-ports are consistent between the server definitions in the MaxScale\
-configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers\
-themselves. Specifically, the monitor assumes that if server A is replicating\
-from server B, then A must have a replica connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this\
-is not the case, e.g. an IP is used in the server while a hostname is given in\
-the file, the monitor may misinterpret the topology. In MaxScale 2.4.1, the\
-monitor attempts name resolution on the addresses if a simple string comparison\
-does not find a match. Using exact matching addresses is, however, more\
+When active, the monitor assumes that server hostnames and
+ports are consistent between the server definitions in the MaxScale
+configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers
+themselves. Specifically, the monitor assumes that if server A is replicating
+from server B, then A must have a replica connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this
+is not the case, e.g. an IP is used in the server while a hostname is given in
+the file, the monitor may misinterpret the topology. In MaxScale 2.4.1, the
+monitor attempts name resolution on the addresses if a simple string comparison
+does not find a match. Using exact matching addresses is, however, more
 reliable.
 
-This setting must be ON to use any cluster operation features such as failover\
-or switchover, because MaxScale uses the addresses and ports in the\
+This setting must be ON to use any cluster operation features such as failover
+or switchover, because MaxScale uses the addresses and ports in the
 configuration file when issuing "CHANGE MASTER TO"-commands.
 
-If the network configuration is such that the addresses MaxScale uses to connect\
-to backends are different from the ones the servers use to connect to each\
-other, `assume_unique_hostnames` should be set to OFF. In this mode, MaxScale\
-uses server id:s it queries from the servers and the `Master_Server_Id` fields\
-of the replica connections to deduce which server is replicating from which. This\
-is not perfect though, since MaxScale doesn't know the id:s of servers it has\
-never connected to (e.g. server has been down since MaxScale was started). Also,\
-the `Master_Server_Id`-field may have an incorrect value if the replica connection\
-has not been established. MaxScale will only trust the value if the monitor has\
-seen the replica connection IO thread connected at least once. If this is not the\
+If the network configuration is such that the addresses MaxScale uses to connect
+to backends are different from the ones the servers use to connect to each
+other, `assume_unique_hostnames` should be set to OFF. In this mode, MaxScale
+uses server id:s it queries from the servers and the `Master_Server_Id` fields
+of the replica connections to deduce which server is replicating from which. This
+is not perfect though, since MaxScale doesn't know the id:s of servers it has
+never connected to (e.g. server has been down since MaxScale was started). Also,
+the `Master_Server_Id`-field may have an incorrect value if the replica connection
+has not been established. MaxScale will only trust the value if the monitor has
+seen the replica connection IO thread connected at least once. If this is not the
 case, the replica connection is ignored.
 
 #### `master_conditions`
@@ -201,9 +201,9 @@ case, the replica connection is ignored.
 
 Designate additional conditions for\_Master\_-status, i.e qualified for read and write queries.
 
-Normally, if a suitable primary candidate server is found as described in [Primary selection](mariadb-maxscale-2302-mariadb-monitor.md#primary-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a primary server. This\
+Normally, if a suitable primary candidate server is found as described in [Primary selection](mariadb-maxscale-2302-mariadb-monitor.md#primary-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a primary server. This
 setting is an enum\_mask, allowing multiple conditions to be set simultaneously.\
-Conditions 2, 3 and 4 refer to replica servers. If combined, a single replica must\
+Conditions 2, 3 and 4 refer to replica servers. If combined, a single replica must
 fulfill all of the given conditions for the primary to be viable.
 
 If the primary candidate fails _master\_conditions_ but fulfills\_slave\_conditions\_, it may be designated _Slave_ instead.
@@ -211,24 +211,24 @@ If the primary candidate fails _master\_conditions_ but fulfills\_slave\_conditi
 The available conditions are:
 
 1. none : No additional conditions
-2. connecting\_slave : At least one immediate replica (not behind relay) is\
+2. connecting\_slave : At least one immediate replica (not behind relay) is
    attempting to replicate or is replicating from the primary (Slave\_IO\_Running is\
-   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A replica with incorrect\
-   replication credentials does not count. If the replica is currently down, results\
+   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A replica with incorrect
+   replication credentials does not count. If the replica is currently down, results
    from the last successful monitor tick are used.
-3. connected\_slave : Same as above, with the difference that the replication\
-   connection must be up (Slave\_IO\_Running is 'Yes'). If the replica is currently\
+3. connected\_slave : Same as above, with the difference that the replication
+   connection must be up (Slave\_IO\_Running is 'Yes'). If the replica is currently
    down, results from the last successful monitor tick are used.
-4. running\_slave : Same as connecting\_slave, with the addition that the\
+4. running\_slave : Same as connecting\_slave, with the addition that the
    replica must also be Running.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2302-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate primary is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2302-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate primary is selected also by the
    primary MaxScale.
 
-The default value of this setting is`master_requirements=primary_monitor_master` to ensure that both monitors use\
+The default value of this setting is`master_requirements=primary_monitor_master` to ensure that both monitors use
 the same primary server when cooperating.
 
-For example, to require that the primary must have a replica which is both\
+For example, to require that the primary must have a replica which is both
 connected and running, set
 
 ```
@@ -243,29 +243,29 @@ master_conditions=connected_slave,running_slave
 * Values: `none`, `linked_master`, `running_master`, `writable_master`, `primary_monitor_master`
 * Default: `none`
 
-Designate additional conditions for _Slave_-status,\
+Designate additional conditions for _Slave_-status,
 i.e qualified for read queries.
 
-Normally, a server is _Slave_ if it is at least attempting to replicate from the\
+Normally, a server is _Slave_ if it is at least attempting to replicate from the
 primary candidate or a relay (Slave\_IO\_Running is 'Yes' or 'Connecting',\
-Slave\_SQL\_Running is 'Yes', valid replication credentials). The primary candidate\
-does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a replica\
-server. This setting is an enum\_mask, allowing multiple conditions to be set\
+Slave\_SQL\_Running is 'Yes', valid replication credentials). The primary candidate
+does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a replica
+server. This setting is an enum\_mask, allowing multiple conditions to be set
 simultaneously.
 
 The available conditions are:
 
 1. none : No additional conditions. This is the default value.
-2. linked\_master : The replica must be connected to the primary (Slave\_IO\_Running\
-   and Slave\_SQL\_Running are 'Yes') and the primary must be Running. The same\
+2. linked\_master : The replica must be connected to the primary (Slave\_IO\_Running
+   and Slave\_SQL\_Running are 'Yes') and the primary must be Running. The same
    applies to any relays between the replica and the primary.
 3. running\_master : The primary must be running. Relays may be down.
 4. writable\_master : The primary must be writable, i.e. labeled Master.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2302-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate primary is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2302-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate primary is selected also by the
    primary MaxScale.
 
-For example, to require that the primary server of the cluster must be running\
+For example, to require that the primary server of the cluster must be running
 and writable for any servers to have _Slave_-status, set
 
 ```
@@ -279,8 +279,8 @@ slave_conditions=running_master,writable_master
 * Dynamic: Yes
 * Default: `5`
 
-Number of consecutive monitor passes a primary server must be down before it is\
-considered failed. If automatic failover is enabled (`auto_failover=true`), it\
+Number of consecutive monitor passes a primary server must be down before it is
+considered failed. If automatic failover is enabled (`auto_failover=true`), it
 may be performed at this time. A value of 0 or 1 enables immediate failover.
 
 If automatic failover is not possible, the monitor will try to\
@@ -289,8 +289,8 @@ for more details. Changing the primary may break replication as queries could be
 routed to a server without previous events. To prevent this, avoid having\
 multiple valid primary servers in the cluster.
 
-The worst-case delay between the primary failure and the start of the failover\
-can be estimated by summing up the timeout values and `monitor_interval` and\
+The worst-case delay between the primary failure and the start of the failover
+can be estimated by summing up the timeout values and `monitor_interval` and
 multiplying that by `failcount`:
 
 ```
@@ -304,19 +304,19 @@ multiplying that by `failcount`:
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-disable the _read\_only_-flag on the primary when seen. The flag is\
-checked every monitor tick. The monitor user requires the SUPER-privilege for\
+If set to ON, the monitor attempts to
+disable the _read\_only_-flag on the primary when seen. The flag is
+checked every monitor tick. The monitor user requires the SUPER-privilege for
 this feature to work.
 
-Typically, the primary server should never be in read-only-mode. Such a situation\
-may arise due to misconfiguration or accident, or perhaps if MaxScale crashed\
+Typically, the primary server should never be in read-only-mode. Such a situation
+may arise due to misconfiguration or accident, or perhaps if MaxScale crashed
 during switchover.
 
-When this feature is enabled, setting the primary manually to _read\_only_ will no\
-longer cause the monitor to search for another primary. The primary will instead\
-for a moment lose its \[Master]-status (no writes), until the monitor again\
-enables writes on the primary. When starting from scratch, the monitor still\
+When this feature is enabled, setting the primary manually to _read\_only_ will no
+longer cause the monitor to search for another primary. The primary will instead
+for a moment lose its \[Master]-status (no writes), until the monitor again
+enables writes on the primary. When starting from scratch, the monitor still
 prefers to select a writable server as primary if possible.
 
 #### `enforce_read_only_slaves`
@@ -326,18 +326,18 @@ prefers to select a writable server as primary if possible.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-enable the _read\_only_-flag on any writable replica server. The flag is checked\
-every monitor tick. The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this\
+If set to ON, the monitor attempts to
+enable the _read\_only_-flag on any writable replica server. The flag is checked
+every monitor tick. The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this
 feature to work. While the _read\_only_-flag is ON, only users with the\
-SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If\
-temporary write access is required, this feature should be disabled before\
-attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly\
+SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If
+temporary write access is required, this feature should be disabled before
+attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly
 re-enable it.
 
-_read\_only_ won't be enabled on the master server, even if it has\
-lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2302-mariadb-monitor.md#master_conditions) and is\
+_read\_only_ won't be enabled on the master server, even if it has
+lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2302-mariadb-monitor.md#master_conditions) and is
 marked \[Slave].
 
 #### `enforce_read_only_servers`
@@ -347,12 +347,12 @@ marked \[Slave].
 * Dynamic: Yes
 * Default: `false`
 
-Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2302-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in\
+Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2302-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in
 maintenance (a superset of the servers altered by _enforce\_read\_only\_slaves_).
 
-The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid\
-primary or primary candidate, _read\_only_ is not set on any server as it is\
+The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid
+primary or primary candidate, _read\_only_ is not set on any server as it is
 unclear which servers should be altered.
 
 #### `maintenance_on_low_disk_space`
@@ -362,16 +362,16 @@ unclear which servers should be altered.
 * Dynamic: Yes
 * Default: `true`
 
-If a running server that is not the primary\
+If a running server that is not the primary
 or a relay primary is out of disk space the server is set to maintenance mode.\
-Such servers are not used for router sessions and are ignored when performing a\
-failover or other cluster modification operation. See the general monitor\
-parameters [disk\_space\_threshold](mariadb-maxscale-2302-common-monitor-parameters.md#disk_space_threshold) and [disk\_space\_check\_interval](mariadb-maxscale-2302-common-monitor-parameters.md#disk_space_check_interval)\
+Such servers are not used for router sessions and are ignored when performing a
+failover or other cluster modification operation. See the general monitor
+parameters [disk\_space\_threshold](mariadb-maxscale-2302-common-monitor-parameters.md#disk_space_threshold) and [disk\_space\_check\_interval](mariadb-maxscale-2302-common-monitor-parameters.md#disk_space_check_interval)
 on how to enable disk space monitoring.
 
-Once a server has been put to maintenance mode, the disk space situation\
-of that server is no longer updated. The server will not be taken out of\
-maintenance mode even if more disk space becomes available. The maintenance\
+Once a server has been put to maintenance mode, the disk space situation
+of that server is no longer updated. The server will not be taken out of
+maintenance mode even if more disk space becomes available. The maintenance
 flag must be removed manually:
 
 ```
@@ -386,22 +386,22 @@ maxctrl clear server server2 Maint
 * Values: `none`, `majority_of_all`, `majority_of_running`
 * Default: `none`
 
-Using this setting is recommended when multiple MaxScales are monitoring the\
-same backend cluster. When enabled, the monitor attempts to acquire exclusive\
-locks on the backend servers. The monitor considers itself the primary monitor\
-if it has a majority of locks. The majority can be either over all configured\
-servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2302-mariadb-monitor.md#cooperative-monitoring)\
+Using this setting is recommended when multiple MaxScales are monitoring the
+same backend cluster. When enabled, the monitor attempts to acquire exclusive
+locks on the backend servers. The monitor considers itself the primary monitor
+if it has a majority of locks. The majority can be either over all configured
+servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2302-mariadb-monitor.md#cooperative-monitoring)
 for more details on how this feature works and which value to use.
 
 Allowed values:
 
 1. `none` Default value, no locking.
-2. `majority_of_all` Primary monitor requires a majority of locks, even counting\
+2. `majority_of_all` Primary monitor requires a majority of locks, even counting
    servers which are \[Down].
 3. `majority_of_running` Primary monitor requires a majority of locks over\
    \[Running] servers.
 
-This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has\
+This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has
 acquired the locks. Generally, it's best not to mix cooperative monitoring with\_passive\_. Either set `passive=false` or do not set it at all.
 
 #### `script_max_replication_lag`
@@ -411,55 +411,55 @@ acquired the locks. Generally, it's best not to mix cooperative monitoring with\
 * Dynamic: Yes
 * Default: `-1`
 
-Defines a replication lag limit in seconds for\
-launching the monitor script configured in the _script_-parameter. If the\
+Defines a replication lag limit in seconds for
+launching the monitor script configured in the _script_-parameter. If the
 replication lag of a server goes above this limit, the script is ran with the\
-$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the\
+$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
-Negative values disable this feature. For more information on monitor scripts,\
+Negative values disable this feature. For more information on monitor scripts,
 see [general monitor documentation](https://mariadb.com/kb/en/node:mariadb-maxscale-2302-common-monitor-parameters#script).
 
 ### Cluster manipulation operations
 
-Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster\
+Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster
 modification. The operations implemented are:
 
 * [failover](mariadb-maxscale-2302-mariadb-monitor.md#failover), which replaces a failed primary with a replica
 * [switchover](mariadb-maxscale-2302-mariadb-monitor.md#switchover), which swaps a running primary with a replica
 * [async-switchover](mariadb-maxscale-2302-mariadb-monitor.md#queued-switchover), which schedules a switchover and returns
 * [rejoin](mariadb-maxscale-2302-mariadb-monitor.md#rejoin), which directs servers to replicate from the primary
-* [reset-replication](mariadb-maxscale-2302-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and\
+* [reset-replication](mariadb-maxscale-2302-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
-See [operation details](mariadb-maxscale-2302-mariadb-monitor.md#operation-details) for more information on the\
+See [operation details](mariadb-maxscale-2302-mariadb-monitor.md#operation-details) for more information on the
 implementation of the commands.
 
-The cluster operations require that the monitor user (`user`) has the following\
+The cluster operations require that the monitor user (`user`) has the following
 privileges:
 
-* SUPER, to modify replica connections, set globals such as read\_only and kill\
+* SUPER, to modify replica connections, set globals such as read\_only and kill
   connections from other super-users
-* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list\
+* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list
   replica connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
 * SHOW DATABASES and EVENT, to list and modify server events
 * SELECT on mysql.user, to see which users have SUPER
 
-A list of the grants can be found in the [Required Grants](mariadb-maxscale-2302-mariadb-monitor.md#required-grants)\
+A list of the grants can be found in the [Required Grants](mariadb-maxscale-2302-mariadb-monitor.md#required-grants)
 section.
 
-The privilege system was changed in MariaDB Server 10.5. The effects of this on\
-the MaxScale monitor user are minor, as the SUPER-privilege contains many of the\
-required privileges and is still required to kill connections from other\
+The privilege system was changed in MariaDB Server 10.5. The effects of this on
+the MaxScale monitor user are minor, as the SUPER-privilege contains many of the
+required privileges and is still required to kill connections from other
 super-users.
 
-In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required\
+In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required
 grants. The monitor requires:
 
 * READ\_ONLY ADMIN, to set read\_only
-* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication\
+* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication
   connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
@@ -468,19 +468,19 @@ grants. The monitor requires:
 * CONNECTION ADMIN, to kill connections
 * SELECT on mysql.user, to see which users have SUPER
 
-In addition, the monitor needs to know which username and password a\
+In addition, the monitor needs to know which username and password a
 replica should use when starting replication. These are given in`replication_user` and `replication_password`.
 
-The user can define files with SQL statements which are executed on any server\
+The user can define files with SQL statements which are executed on any server
 being demoted or promoted by cluster manipulation commands. See the sections on`promotion_sql_file` and `demotion_sql_file` for more information.
 
-The monitor can manipulate scheduled server events when promoting or demoting a\
+The monitor can manipulate scheduled server events when promoting or demoting a
 server. See the section on `handle_events` for more information.
 
-All cluster operations can be activated manually through MaxCtrl. See\
+All cluster operations can be activated manually through MaxCtrl. See
 section [Manual activation](mariadb-maxscale-2302-mariadb-monitor.md#manual-activation) for more details.
 
-See [Limitations and requirements](mariadb-maxscale-2302-mariadb-monitor.md#limitations-and-requirements) for\
+See [Limitations and requirements](mariadb-maxscale-2302-mariadb-monitor.md#limitations-and-requirements) for
 information on possible issues with failover and switchover.
 
 #### Operation details
@@ -491,22 +491,22 @@ information on possible issues with failover and switchover.
 call command mariadbmon failover MONITOR
 ```
 
-**Failover** replaces a failed primary with a running replica. It does the\
+**Failover** replaces a failed primary with a running replica. It does the
 following:
 
-1. Select the most up-to-date replica of the old primary to be the new primary. The\
+1. Select the most up-to-date replica of the old primary to be the new primary. The
    selection criteria is as follows in descending priority:
 2. gtid\_IO\_pos (latest event in relay log)
 3. gtid\_current\_pos (most processed events)
 4. log\_slave\_updates is on
 5. disk space is not low
-6. If the new primary has unprocessed relay log items, cancel and try again\
+6. If the new primary has unprocessed relay log items, cancel and try again
    later.
 7. Prepare the new primary:
-8. Remove the replica connection the new primary used to replicate from the\
+8. Remove the replica connection the new primary used to replicate from the
    old primary.
 9. Disable the read\_only-flag.
-10. Enable scheduled server events (if event handling is on). Only events\
+10. Enable scheduled server events (if event handling is on). Only events
     that were enabled on the old primary are enabled.
 11. Run the commands in `promotion_sql_file`.
 12. Start replication from external primary if one existed.
@@ -516,7 +516,7 @@ following:
 16. START SLAVE
 17. Check that all replicas are replicating.
 
-Failover is considered successful if steps 1 to 3 succeed, as the cluster then\
+Failover is considered successful if steps 1 to 3 succeed, as the cluster then
 has at least a valid primary server.
 
 **Switchover**
@@ -525,23 +525,23 @@ has at least a valid primary server.
 call command mariadbmon switchover MONITOR [NEW_PRIMARY] [OLD_PRIMARY]
 ```
 
-**Switchover** swaps a running primary with a running replica. It does the\
+**Switchover** swaps a running primary with a running replica. It does the
 following:
 
 1. Prepare the old primary for demotion:
 2. Stop any external replication.
-3. Kill connections from super-users since read\_only does not affect\
+3. Kill connections from super-users since read\_only does not affect
    them.
 4. Enable the read\_only-flag to stop writes.
 5. Disable scheduled server events (if event handling is on).
 6. Run the commands in `demotion_sql_file`.
 7. Flush the binary log (FLUSH LOGS) so that all events are on disk.
 8. Wait for the new primary to catch up with the old primary.
-9. Promote new primary and redirect replicas as in failover steps 3 and 4. Also\
+9. Promote new primary and redirect replicas as in failover steps 3 and 4. Also
    redirect the demoted old primary.
 10. Check that all replicas are replicating.
 
-Similar to failover, switchover is considered successful if the new primary was\
+Similar to failover, switchover is considered successful if the new primary was
 successfully promoted.
 
 **Rejoin**
@@ -550,8 +550,8 @@ successfully promoted.
 call command mariadbmon rejoin MONITOR OLD_PRIMARY
 ```
 
-**Rejoin** joins a standalone server to the cluster or redirects a replica\
-replicating from a server other than the primary. A standalone server is joined\
+**Rejoin** joins a standalone server to the cluster or redirects a replica
+replicating from a server other than the primary. A standalone server is joined
 by:
 
 1. Run the commands in `demotion_sql_file`.
@@ -568,9 +568,9 @@ STOP SLAVE, RESET SLAVE, CHANGE MASTER TO and START SLAVE commands.
 maxctrl call command mariadbmon reset-replication MONITOR [NEW_PRIMARY]
 ```
 
-**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets\
-gtid:s. This destructive command is meant for situations where the gtid:s in the\
-cluster are out of sync while the actual data is known to be in sync. The\
+**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets
+gtid:s. This destructive command is meant for situations where the gtid:s in the
+cluster are out of sync while the actual data is known to be in sync. The
 operation proceeds as follows:
 
 1. Reset gtid:s and delete binary logs on all servers:
@@ -578,38 +578,38 @@ operation proceeds as follows:
 3. Enable the read\_only-flag.
 4. Disable scheduled server events (if event handling is on).
 5. Delete binary logs (RESET MASTER).
-6. Set the sequence number of gtid\_slave\_pos to zero. This also affects\
+6. Set the sequence number of gtid\_slave\_pos to zero. This also affects
    gtid\_current\_pos.
 7. Prepare new primary:
 8. Disable the read\_only-flag.
-9. Enable scheduled server events (if event handling is on). Events are\
-   only enabled if the cluster had a primary server when starting the\
-   reset-replication operation. Only events that were enabled on the previous\
+9. Enable scheduled server events (if event handling is on). Events are
+   only enabled if the cluster had a primary server when starting the
+   reset-replication operation. Only events that were enabled on the previous
    primary are enabled on the new.
-10. Direct other servers to replicate from the new primary as in the other\
+10. Direct other servers to replicate from the new primary as in the other
     operations.
 
 #### Manual activation
 
 Cluster operations can be activated manually through the REST API or MaxCtrl.\
-The commands are only performed when MaxScale is in active mode. The commands\
-generally match their automatic versions. The exception is _rejoin_, in which\
-the manual command allows rejoining even when the joining server has empty\
-gtid:s. This rule allows the user to force a rejoin on a server without binary\
+The commands are only performed when MaxScale is in active mode. The commands
+generally match their automatic versions. The exception is _rejoin_, in which
+the manual command allows rejoining even when the joining server has empty
+gtid:s. This rule allows the user to force a rejoin on a server without binary
 logs.
 
-All commands require the monitor instance name as the first parameter. Failover\
-selects the new primary server automatically and does not require additional\
+All commands require the monitor instance name as the first parameter. Failover
+selects the new primary server automatically and does not require additional
 parameters. Rejoin requires the name of the joining server as second parameter.\
 Replication reset accepts the name of the new primary server as second parameter.\
 If not given, the current primary is selected.
 
-Switchover takes one to three parameters. If only the monitor name is given,\
-switchover will autoselect both the replica to promote and the current primary as\
-the server to be demoted. If two parameters are given, the second parameter is\
-interpreted as the replica to promote. If three parameters are given, the third\
-parameter is interpreted as the current primary. The user-given current primary is\
-compared to the primary server currently deduced by the monitor and if the two\
+Switchover takes one to three parameters. If only the monitor name is given,
+switchover will autoselect both the replica to promote and the current primary as
+the server to be demoted. If two parameters are given, the second parameter is
+interpreted as the replica to promote. If three parameters are given, the third
+parameter is interpreted as the current primary. The user-given current primary is
+compared to the primary server currently deduced by the monitor and if the two
 are unequal, an error is given.
 
 Example commands are below:
@@ -624,29 +624,29 @@ call command mariadbmon switchover MyMonitor NewPrimaryServ
 call command mariadbmon switchover MyMonitor NewPrimaryServ OldPrimaryServ
 ```
 
-The commands follow the standard module command syntax. All require the monitor\
-configuration name (MyMonitor) as the first parameter. For switchover, the\
-last two parameters define the server to promote (NewPrimaryServ) and the server\
-to demote (OldPrimaryServ). For rejoin, the server to join (OldPrimaryServ) is\
+The commands follow the standard module command syntax. All require the monitor
+configuration name (MyMonitor) as the first parameter. For switchover, the
+last two parameters define the server to promote (NewPrimaryServ) and the server
+to demote (OldPrimaryServ). For rejoin, the server to join (OldPrimaryServ) is
 required. Replication reset requires the server to promote (NewPrimaryServ).
 
-It is safe to perform manual operations even with automatic failover, switchover\
-or rejoin enabled since automatic operations cannot happen simultaneously\
+It is safe to perform manual operations even with automatic failover, switchover
+or rejoin enabled since automatic operations cannot happen simultaneously
 with manual ones.
 
-When a cluster modification is initiated via the REST-API, the URL path is of the\
+When a cluster modification is initiated via the REST-API, the URL path is of the
 form:
 
 ```
 /v1/maxscale/modules/mariadbmon/<operation>?<monitor-instance>&<server-param1>&<server-param2>
 ```
 
-* `<operation>` is the name of the command: failover, switchover, rejoin\
+* `<operation>` is the name of the command: failover, switchover, rejoin
   or reset-replication.
-* `<monitor-instance>` is the monitor section name from the MaxScale\
+* `<monitor-instance>` is the monitor section name from the MaxScale
   configuration file.
-* `<server-param1>` and `<server-param2>` are server parameters as described\
-  above for MaxCtrl. Only switchover accepts both, failover doesn't need any\
+* `<server-param1>` and `<server-param2>` are server parameters as described
+  above for MaxCtrl. Only switchover accepts both, failover doesn't need any
   and both rejoin and reset-replication accept one.
 
 Given a MaxScale configuration file like
@@ -659,7 +659,7 @@ servers=server1, server2, server3, server 4
 ...
 ```
 
-with the assumption that `server2` is the current primary, then the URL\
+with the assumption that `server2` is the current primary, then the URL
 path for making `server4` the new primary would be:
 
 ```
@@ -676,9 +676,9 @@ Example REST-API paths for other commands are listed below.
 
 **Queued switchover**
 
-Most cluster modification commands wait until the operation either succeeds or\
-fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the\
-module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,\
+Most cluster modification commands wait until the operation either succeeds or
+fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the
+module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,
 whether queued or not.
 
 ```
@@ -695,125 +695,125 @@ maxctrl call command mariadbmon fetch-cmd-result Cluster1
 
 #### Automatic activation
 
-Failover can activate automatically if `auto_failover` is on. The activation\
+Failover can activate automatically if `auto_failover` is on. The activation
 begins when the primary has been down at least `failcount` monitor iterations.\
-Before modifying the cluster, the monitor checks that all prerequisites for the\
-failover are fulfilled. If the cluster does not seem ready, an error is printed\
+Before modifying the cluster, the monitor checks that all prerequisites for the
+failover are fulfilled. If the cluster does not seem ready, an error is printed
 and the cluster is rechecked during the next monitor iteration.
 
-Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the primary\
-server is low on disk space but otherwise the operating logic is quite similar\
+Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the primary
+server is low on disk space but otherwise the operating logic is quite similar
 to automatic failover.
 
-Rejoin stands for starting replication on a standalone server or redirecting a\
-replica replicating from the wrong primary (any server that is not the cluster\
-primary). The rejoined servers are directed to replicate from the current cluster\
-primary server, forcing the replication topology to a 1-primary-N-replicas\
+Rejoin stands for starting replication on a standalone server or redirecting a
+replica replicating from the wrong primary (any server that is not the cluster
+primary). The rejoined servers are directed to replicate from the current cluster
+primary server, forcing the replication topology to a 1-primary-N-replicas
 configuration.
 
-A server is categorized as standalone if the server has no replica connections,\
-not even stopped ones. A server is replicating from the wrong primary if the\
-replica IO thread is connected but the primary server id seen by the replica does not\
-match the cluster primary id. Alternatively, the IO thread may be stopped or\
-connecting but the primary server host or port information differs from the\
-cluster primary info. These criteria mean that a STOP SLAVE does not yet set a\
+A server is categorized as standalone if the server has no replica connections,
+not even stopped ones. A server is replicating from the wrong primary if the
+replica IO thread is connected but the primary server id seen by the replica does not
+match the cluster primary id. Alternatively, the IO thread may be stopped or
+connecting but the primary server host or port information differs from the
+cluster primary info. These criteria mean that a STOP SLAVE does not yet set a
 replica as standalone.
 
-With `auto_rejoin` active, the monitor will try to rejoin any servers matching\
-the above requirements. Rejoin does not obey `failcount` and will attempt to\
-rejoin any valid servers immediately. When activating rejoin manually, the\
+With `auto_rejoin` active, the monitor will try to rejoin any servers matching
+the above requirements. Rejoin does not obey `failcount` and will attempt to
+rejoin any valid servers immediately. When activating rejoin manually, the
 user-designated server must fulfill the same requirements.
 
 #### Limitations and requirements
 
-Switchover and failover are meant for simple topologies (one primary and\
-several replicas). Using these commands with complicated topologies\
-(multiple primaries, relays, circular replication) may give unpredictable results\
+Switchover and failover are meant for simple topologies (one primary and
+several replicas). Using these commands with complicated topologies
+(multiple primaries, relays, circular replication) may give unpredictable results
 and should be tested before use on a production system.
 
-Switchover and failover only understand simple topologies. They will not work if\
+Switchover and failover only understand simple topologies. They will not work if
 the cluster has multiple primaries, relay primaries, or if the topology is circular.\
-The server cluster is assumed to be well-behaving with no significant\
-replication lag (within `failover_timeout`/`switchover_timeout`) and all\
+The server cluster is assumed to be well-behaving with no significant
+replication lag (within `failover_timeout`/`switchover_timeout`) and all
 commands that modify the cluster (such as "STOP SLAVE", "CHANGE MASTER",\
-"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`\
+"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`
 and `backend_write_timeout`).
 
-The backends must all use GTID-based replication, and the domain id should not\
-change during a switchover or failover. Replicas should not have extra\
+The backends must all use GTID-based replication, and the domain id should not
+change during a switchover or failover. Replicas should not have extra
 local events so that GTIDs are compatible across the cluster.
 
-Failover cannot be performed if MaxScale was started only after the primary\
-server went down. This is because MaxScale needs reliable information on the\
-gtid domain of the cluster and the replication topology in general to properly\
+Failover cannot be performed if MaxScale was started only after the primary
+server went down. This is because MaxScale needs reliable information on the
+gtid domain of the cluster and the replication topology in general to properly
 select the new primary. `enforce_simple_topology=1` relaxes this requirement.
 
-Failover may lose events. If a primary goes down before sending new events to at\
-least one replica, those events are lost when a new primary is chosen. If the old\
-primary comes back online, the other servers have likely moved on with a\
+Failover may lose events. If a primary goes down before sending new events to at
+least one replica, those events are lost when a new primary is chosen. If the old
+primary comes back online, the other servers have likely moved on with a
 diverging history and the old primary can no longer join the replication cluster.
 
 To reduce the chance of losing data, use [semisynchronous replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication).\
-In semisynchronous mode, the primary waits for a replica to receive an event before\
-returning an acknowledgement to the client. This does not yet guarantee a clean\
-failover. If the primary fails after preparing a transaction but before receiving\
-replica acknowledgement, it will still commit the prepared transaction as part of\
-its crash recovery. If the replicas never saw this transaction, the\
-old primary has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
+In semisynchronous mode, the primary waits for a replica to receive an event before
+returning an acknowledgement to the client. This does not yet guarantee a clean
+failover. If the primary fails after preparing a transaction but before receiving
+replica acknowledgement, it will still commit the prepared transaction as part of
+its crash recovery. If the replicas never saw this transaction, the
+old primary has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
 for more information. This situation is much less likely in MariaDB Server\
-10.6.2 and later, as the improved crash recovery logic will delete such\
+10.6.2 and later, as the improved crash recovery logic will delete such
 transactions.
 
-Even a controlled shutdown of the primary may lose events. The server does not by\
-default wait for all data to be replicated to the replicas when shutting down and\
-instead simply closes all connections. Before shutting down the primary with the\
-intention of having a replica promoted, run _switchover_ first to ensure that all\
+Even a controlled shutdown of the primary may lose events. The server does not by
+default wait for all data to be replicated to the replicas when shutting down and
+instead simply closes all connections. Before shutting down the primary with the
+intention of having a replica promoted, run _switchover_ first to ensure that all
 data is replicated. For more information on server shutdown, see [Binary Log Dump Threads and the Shutdown Process](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-threads).
 
-Switchover requires that the cluster is "frozen" for the duration of the\
-operation. This means that no data modifying statements such as INSERT or UPDATE\
-are executed and the GTID position of the primary server is stable. When\
-switchover begins, the monitor sets the global _read\_only_ flag on the old\
+Switchover requires that the cluster is "frozen" for the duration of the
+operation. This means that no data modifying statements such as INSERT or UPDATE
+are executed and the GTID position of the primary server is stable. When
+switchover begins, the monitor sets the global _read\_only_ flag on the old
 primary backend to stop any updates. _read\_only_ does not affect users with the\
-SUPER-privilege so any such user can issue writes during a switchover. These\
-writes have a high chance of breaking replication, because the write may not be\
-replicated to all replicas before they switch to the new primary. To prevent this,\
-any users who commonly do updates should NOT have the SUPER-privilege. For even\
+SUPER-privilege so any such user can issue writes during a switchover. These
+writes have a high chance of breaking replication, because the write may not be
+replicated to all replicas before they switch to the new primary. To prevent this,
+any users who commonly do updates should NOT have the SUPER-privilege. For even
 more security, the only SUPER-user session during a switchover should be the\
-MaxScale monitor user. This also applies to users running scheduled server\
-events. Although the monitor by default disables events on the master, an\
-event may already be executing. If the event definer has SUPER-privilege, the\
+MaxScale monitor user. This also applies to users running scheduled server
+events. Although the monitor by default disables events on the master, an
+event may already be executing. If the event definer has SUPER-privilege, the
 event can write to the database even through _read\_only_.
 
-When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest\
-of the cluster. If the current cluster primary does not have binary logs from the\
-moment the rejoining server lost connection, the rejoining server cannot\
-continue replication. This is an issue if the primary has changed and\
+When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest
+of the cluster. If the current cluster primary does not have binary logs from the
+moment the rejoining server lost connection, the rejoining server cannot
+continue replication. This is an issue if the primary has changed and
 the new primary does not have _log\_slave\_updates_ on.
 
-If an automatic cluster operation such as auto-failover or auto-rejoin fails,\
-all cluster modifying operations are disabled for `failcount` monitor iterations,\
-after which the operation may be retried. Similar logic applies if the cluster is\
+If an automatic cluster operation such as auto-failover or auto-rejoin fails,
+all cluster modifying operations are disabled for `failcount` monitor iterations,
+after which the operation may be retried. Similar logic applies if the cluster is
 unsuitable for such operations, e.g. replication is not using GTID.
 
 #### External primary support
 
-The monitor detects if a server in the cluster is replicating from an external\
-primary (a server that is not monitored by the monitor). If the replicating\
-server is the cluster primary server, then the cluster itself is considered to\
+The monitor detects if a server in the cluster is replicating from an external
+primary (a server that is not monitored by the monitor). If the replicating
+server is the cluster primary server, then the cluster itself is considered to
 have an external primary.
 
-If a failover/switchover happens, the new primary server is set to replicate from\
-the cluster external primary server. The username and password for the replication\
-are defined in `replication_user` and `replication_password`. The address and\
-port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster\
-primary server. In the case of switchover, the old primary also stops replicating\
+If a failover/switchover happens, the new primary server is set to replicate from
+the cluster external primary server. The username and password for the replication
+are defined in `replication_user` and `replication_password`. The address and
+port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster
+primary server. In the case of switchover, the old primary also stops replicating
 from the external server to preserve the topology.
 
-After failover the new primary is replicating from the external primary. If the\
-failed old primary comes back online, it is also replicating from the external\
-server. To normalize the situation, either have _auto\_rejoin_ on or manually\
-execute a rejoin. This will redirect the old primary to the current cluster\
+After failover the new primary is replicating from the external primary. If the
+failed old primary comes back online, it is also replicating from the external
+server. To normalize the situation, either have _auto\_rejoin_ on or manually
+execute a rejoin. This will redirect the old primary to the current cluster
 primary.
 
 #### Configuration parameters
@@ -825,18 +825,18 @@ primary.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic primary failover. When automatic failover is enabled, MaxScale\
-will elect a new primary server for the cluster if the old primary goes down. A\
-server is assumed _Down_ if it cannot be connected to, even if this is caused by\
+Enable automatic primary failover. When automatic failover is enabled, MaxScale
+will elect a new primary server for the cluster if the old primary goes down. A
+server is assumed _Down_ if it cannot be connected to, even if this is caused by
 incorrect credentials. Failover triggers if the primary stays down for [failcount](mariadb-maxscale-2302-mariadb-monitor.md#failcount) monitor intervals. Failover will not take place if\
 MaxScale is set [passive](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#passive).
 
-As failover alters replication, it requires more privileges than normal\
+As failover alters replication, it requires more privileges than normal
 monitoring. See [here](mariadb-maxscale-2302-mariadb-monitor.md#cluster-manipulation-grants) for a list of grants.
 
-Failover is designed to be used with simple primary-replica topologies. More\
-complicated topologies, such as multilayered or circular replication, are not\
-guaranteed to always work correctly. Test before using failover with such\
+Failover is designed to be used with simple primary-replica topologies. More
+complicated topologies, such as multilayered or circular replication, are not
+guaranteed to always work correctly. Test before using failover with such
 setups.
 
 **`auto_rejoin`**
@@ -846,20 +846,20 @@ setups.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic joining of servers to the cluster. When enabled, MaxScale will\
-attempt to direct servers to replicate from the current cluster primary if they\
-are not currently doing so. Replication will be started on any standalone\
+Enable automatic joining of servers to the cluster. When enabled, MaxScale will
+attempt to direct servers to replicate from the current cluster primary if they
+are not currently doing so. Replication will be started on any standalone
 servers. Servers that are replicating from another server will be redirected.\
-This effectively enforces a 1-primary-N-replicas topology. The current primary\
-itself is not redirected, so it can continue to replicate from an external\
-primary. Rejoin is also not performed on any server that is replicating from\
-multiple sources, as this indicates a complicated topology (this rule is\
+This effectively enforces a 1-primary-N-replicas topology. The current primary
+itself is not redirected, so it can continue to replicate from an external
+primary. Rejoin is also not performed on any server that is replicating from
+multiple sources, as this indicates a complicated topology (this rule is
 overridden by [enforce\_simple\_topology](mariadb-maxscale-2302-mariadb-monitor.md#enforce_simple_topology)).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2302-mariadb-monitor.md#auto_failover) to redirect\
-the former primary when it comes back online. Sometimes this kind of rejoin will\
-fail as the old primary may have transactions that were never replicated to the\
-current one. See [limitations](mariadb-maxscale-2302-mariadb-monitor.md#limitations-and-requirements) for more\
+This feature is often paired with [auto\_failover](mariadb-maxscale-2302-mariadb-monitor.md#auto_failover) to redirect
+the former primary when it comes back online. Sometimes this kind of rejoin will
+fail as the old primary may have transactions that were never replicated to the
+current one. See [limitations](mariadb-maxscale-2302-mariadb-monitor.md#limitations-and-requirements) for more
 information.
 
 As an example, consider the following series of events:
@@ -869,9 +869,9 @@ As an example, consider the following series of events:
 3. Replica A comes back
 4. Old primary comes back
 
-Replica A is still trying to replicate from the downed primary, since it wasn't\
-online during failover. If _auto\_rejoin_ is on, Replica A will quickly be\
-redirected to Replica B, the current primary. The old primary will also rejoin the\
+Replica A is still trying to replicate from the downed primary, since it wasn't
+online during failover. If _auto\_rejoin_ is on, Replica A will quickly be
+redirected to Replica B, the current primary. The old primary will also rejoin the
 cluster if possible.
 
 **`switchover_on_low_disk_space`**
@@ -904,18 +904,18 @@ switchover_on_low_disk_space=true
 * Default: `false`
 
 This setting tells the monitor to assume that the servers should be arranged in a\
-1-primary-N-replicas topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual\
+1-primary-N-replicas topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual
 settings.
 
-By default, mariadbmon will not rejoin servers with more than one replication\
-stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the\
-cluster and any extra replication sources will be removed. This is done to make\
+By default, mariadbmon will not rejoin servers with more than one replication
+stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the
+cluster and any extra replication sources will be removed. This is done to make
 automated failover with multi-source external replication possible.
 
-This setting also allows the monitor to perform a failover to a cluster where the primary\
-server has not been seen \[Running]. This is usually the case when the primary goes down\
-before MaxScale is started. When using this feature, the monitor will guess the GTID\
-domain id of the primary from the replicas. For reliable results, the GTID:s of the cluster\
+This setting also allows the monitor to perform a failover to a cluster where the primary
+server has not been seen \[Running]. This is usually the case when the primary goes down
+before MaxScale is started. When using this feature, the monitor will guess the GTID
+domain id of the primary from the replicas. For reliable results, the GTID:s of the cluster
 should be simple.
 
 ```
@@ -929,19 +929,19 @@ enforce_simple_topology=true
 * Dynamic: Yes
 * Default: None
 
-The username and password of the replication user. These are given as the values\
-for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is\
+The username and password of the replication user. These are given as the values
+for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is
 executed.
 
-Both `replication_user` and `replication_password` parameters must be defined if\
-a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication\
+Both `replication_user` and `replication_password` parameters must be defined if
+a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication
 user.
 
-The credentials used for replication must have the `REPLICATION SLAVE`\
+The credentials used for replication must have the `REPLICATION SLAVE`
 privilege.
 
-`replication_password` uses the same encryption scheme as other password\
-parameters. If password encryption is in use, `replication_password` must be\
+`replication_password` uses the same encryption scheme as other password
+parameters. If password encryption is in use, `replication_password` must be
 encrypted with the same key to avoid erroneous decryption.
 
 **`replication_master_ssl`**
@@ -951,25 +951,25 @@ encrypted with the same key to avoid erroneous decryption.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable\
-encryption for the replication stream. This setting should only be enabled if the backend\
-servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication\
+If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable
+encryption for the replication stream. This setting should only be enabled if the backend
+servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication
 user should require an encrypted connection (`e.g. ALTER USER repl@'%' REQUIRE SSL;`).
 
-If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing\
+If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing
 settings when redirecting a replica connection.
 
 **`replication_custom_options`**
 
 Type: string
 
-A custom string added to "CHANGE MASTER TO"-commands sent by the monitor\
-whenever setting up replication (e.g. during switchover). Useful for defining\
-ssl certificates or other specialized replication options. MaxScale does not\
-check the contents of the string, so care should be taken to ensure that\
-only valid options are set and that the contents do not interfere with\
-the options MaxScale sets on its own (e.g. MASTER\_HOST). This setting can\
-also be configured for an individual server. If configured for both\
+A custom string added to "CHANGE MASTER TO"-commands sent by the monitor
+whenever setting up replication (e.g. during switchover). Useful for defining
+ssl certificates or other specialized replication options. MaxScale does not
+check the contents of the string, so care should be taken to ensure that
+only valid options are set and that the contents do not interfere with
+the options MaxScale sets on its own (e.g. MASTER\_HOST). This setting can
+also be configured for an individual server. If configured for both
 the monitor and a server, the server setting takes priority.
 
 ```
@@ -986,19 +986,19 @@ replication_custom_options=MASTER_SSL_CERT = '/tmp/certs/client-cert.pem',
 * Dynamic: Yes
 * Default: `90s`
 
-Time limit for failover and switchover operations. The default\
-values are 90 seconds for both. `switchover_timeout` is also used as the time\
-limit for a rejoin operation. Rejoin should rarely time out, since it is a\
+Time limit for failover and switchover operations. The default
+values are 90 seconds for both. `switchover_timeout` is also used as the time
+limit for a rejoin operation. Rejoin should rarely time out, since it is a
 faster operation than switchover.
 
-The timeouts are specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeouts is seconds, a timeout specified in milliseconds will be rejected,\
+The timeouts are specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeouts is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If no successful failover/switchover takes place within the configured time\
-period, a message is logged and automatic failover is disabled. This prevents\
+If no successful failover/switchover takes place within the configured time
+period, a message is logged and automatic failover is disabled. This prevents
 further automatic modifications to the misbehaving cluster.
 
 **`verify_master_failure`**
@@ -1010,24 +1010,24 @@ further automatic modifications to the misbehaving cluster.
 
 Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and [master\_failure\_timeout](mariadb-maxscale-2302-mariadb-monitor.md#master_failure_timeout) defines the timeout.
 
-The primary failure timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The primary failure timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-Failure verification is performed by checking whether the replica servers are\
-still connected to the primary and receiving events. An event is either a change\
-in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat\
-event. Effectively, if a replica has received an event within`master_failure_timeout` duration, the primary is not considered down when\
-deciding whether to failover, even if MaxScale cannot connect to the primary.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of\
+Failure verification is performed by checking whether the replica servers are
+still connected to the primary and receiving events. An event is either a change
+in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat
+event. Effectively, if a replica has received an event within`master_failure_timeout` duration, the primary is not considered down when
+deciding whether to failover, even if MaxScale cannot connect to the primary.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of
 the replica connection to be effective.
 
 If every replica loses its connection to the primary (_Slave\_IO\_Running_ is not\
-"Yes"), primary failure is considered verified regardless of timeout. This allows\
+"Yes"), primary failure is considered verified regardless of timeout. This allows
 faster failover when the primary properly disconnects.
 
-For automatic failover to activate, the `failcount` requirement must also be\
+For automatic failover to activate, the `failcount` requirement must also be
 met.
 
 **`master_failure_timeout`**
@@ -1037,10 +1037,10 @@ met.
 * Dynamic: Yes
 * Default: `10s`
 
-`master_failure_timeout` is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+`master_failure_timeout` is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 **`servers_no_promotion`**
@@ -1050,11 +1050,11 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: None
 
-This is a comma-separated list of server names that will not be chosen for\
-primary promotion during a failover or autoselected for switchover. This does not\
-affect switchover if the user selects the server to promote. Using this setting\
-can disrupt new primary selection for failover such that an non-optimal server is\
-chosen. At worst, this will cause replication to break. Alternatively, failover\
+This is a comma-separated list of server names that will not be chosen for
+primary promotion during a failover or autoselected for switchover. This does not
+affect switchover if the user selects the server to promote. Using this setting
+can disrupt new primary selection for failover such that an non-optimal server is
+chosen. At worst, this will cause replication to break. Alternatively, failover
 may fail if all valid promotion candidates are in the exclusion list.
 
 ```
@@ -1069,30 +1069,30 @@ servers_no_promotion=backup_dc_server1,backup_dc_server2
 * Default: None
 
 These optional settings are paths to text files with SQL statements in them.\
-During promotion or demotion, the contents are read line-by-line and executed on\
-the backend. Use these settings to execute custom statements on the servers to\
+During promotion or demotion, the contents are read line-by-line and executed on
+the backend. Use these settings to execute custom statements on the servers to
 complement the built-in operations.
 
-Empty lines or lines starting with '#' are ignored. Any results returned by the\
-statements are ignored. All statements must succeed for the failover, switchover\
-or rejoin to continue. The monitor user may require additional privileges and\
+Empty lines or lines starting with '#' are ignored. Any results returned by the
+statements are ignored. All statements must succeed for the failover, switchover
+or rejoin to continue. The monitor user may require additional privileges and
 grants for the custom commands to succeed.
 
-When promoting a replica to primary during switchover or failover, the`promotion_sql_file` is read and executed on the new primary server after its\
-read-only flag is disabled. The commands are ran _before_ starting replication\
+When promoting a replica to primary during switchover or failover, the`promotion_sql_file` is read and executed on the new primary server after its
+read-only flag is disabled. The commands are ran _before_ starting replication
 from an external primary if any.
 
-`demotion_sql_file` is ran on an old primary during demotion to replica, before the\
-old primary starts replicating from the new primary. The file is also ran before\
-rejoining a standalone server to the cluster, as the standalone server is\
-typically a former primary server. When redirecting a replica replicating from a\
+`demotion_sql_file` is ran on an old primary during demotion to replica, before the
+old primary starts replicating from the new primary. The file is also ran before
+rejoining a standalone server to the cluster, as the standalone server is
+typically a former primary server. When redirecting a replica replicating from a
 wrong primary, the sql-file is not executed.
 
-Since the queries in the files are ran during operations which modify\
-replication topology, care is required. If `promotion_sql_file` contains data\
-modification (DML) queries, the new primary server may not be able to\
-successfully replicate from an external primary. `demotion_sql_file` should never\
-contain DML queries, as these may not replicate to the replica servers before\
+Since the queries in the files are ran during operations which modify
+replication topology, care is required. If `promotion_sql_file` contains data
+modification (DML) queries, the new primary server may not be able to
+successfully replicate from an external primary. `demotion_sql_file` should never
+contain DML queries, as these may not replicate to the replica servers before
 replica threads are stopped, breaking replication.
 
 ```
@@ -1107,71 +1107,71 @@ demotion_sql_file=/home/root/scripts/demotion.sql
 * Dynamic: Yes
 * Default: `true`
 
-If enabled, the monitor continuously queries the\
-servers for enabled scheduled events and uses this information when performing\
+If enabled, the monitor continuously queries the
+servers for enabled scheduled events and uses this information when performing
 cluster operations, enabling and disabling events as appropriate.
 
 When a server is being demoted, any events with "ENABLED" status are set to\
 "SLAVESIDE\_DISABLED". When a server is being promoted to primary, events that are either\
-"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled\
-on the old primary server last time it was successfully queried. Events are considered\
-identical if they have the same schema and name. When a standalone server is rejoined to\
+"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled
+on the old primary server last time it was successfully queried. Events are considered
+identical if they have the same schema and name. When a standalone server is rejoined to
 the cluster, its events are also disabled since it is now a replica.
 
-The monitor does not check whether the same events were disabled and enabled during a\
+The monitor does not check whether the same events were disabled and enabled during a
 switchover or failover/rejoin. All events that meet the criteria above are altered.
 
-The monitor does not enable or disable the event scheduler itself. For the\
-events to run on the new primary server, the scheduler should be enabled by the\
+The monitor does not enable or disable the event scheduler itself. For the
+events to run on the new primary server, the scheduler should be enabled by the
 admin. Enabling it in the server configuration file is recommended.
 
-Events running at high frequency may cause replication to break in a failover\
-scenario. If an old primary which was failed over restarts, its event scheduler\
-will be on if set in the server configuration file. Its events will also\
-remember their "ENABLED"-status and run when scheduled. This may happen before\
-the monitor rejoins the server and disables the events. This should only be an\
-issue for events running more often than the monitor interval or events that run\
+Events running at high frequency may cause replication to break in a failover
+scenario. If an old primary which was failed over restarts, its event scheduler
+will be on if set in the server configuration file. Its events will also
+remember their "ENABLED"-status and run when scheduled. This may happen before
+the monitor rejoins the server and disables the events. This should only be an
+issue for events running more often than the monitor interval or events that run
 immediately after the server has restarted.
 
 ### Cooperative monitoring
 
-As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means\
-that multiple monitors (typically in different MaxScale instances) can monitor\
-the same backend server cluster and only one will be the primary monitor. Only\
+As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means
+that multiple monitors (typically in different MaxScale instances) can monitor
+the same backend server cluster and only one will be the primary monitor. Only
 the primary monitor may perform _switchover_, _failover_ or _rejoin_ operations.\
-The primary also decides which server is the primary. Cooperative monitoring is\
+The primary also decides which server is the primary. Cooperative monitoring is
 enabled with the [cooperative\_monitoring\_locks](mariadb-maxscale-2302-mariadb-monitor.md#cooperative_monitoring_locks)-setting.\
 Even with this setting, only one monitor per server per MaxScale is allowed.\
-This limitation can be circumvented by defining multiple copies of a server in\
+This limitation can be circumvented by defining multiple copies of a server in
 the configuration file.
 
-Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)\
-for coordinating between monitors. When cooperating, the monitor regularly\
-checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and\
-acquires it if free. If the monitor acquires a majority of locks, it is the\
+Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)
+for coordinating between monitors. When cooperating, the monitor regularly
+checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and
+acquires it if free. If the monitor acquires a majority of locks, it is the
 primary. If a monitor cannot claim majority locks, it is a secondary monitor.
 
 The primary monitor of a cluster also acquires the lock _maxscale\_mariadbmonitor\_master_ on the primary server. Secondary monitors check
 which server this lock is taken on and only accept that server as the primary.\
-This arrangement is required so that multiple monitors can agree on which server\
-is the primary regardless of replication topology. If a secondary monitor does\
-not see the primary-lock taken, then it won't mark any server as \[Master],\
+This arrangement is required so that multiple monitors can agree on which server
+is the primary regardless of replication topology. If a secondary monitor does
+not see the primary-lock taken, then it won't mark any server as \[Master],
 causing writes to fail.
 
-The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor\
-needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three\
-servers needs two locks for majority, a cluster of four needs three, and a\
+The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor
+needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three
+servers needs two locks for majority, a cluster of four needs three, and a
 cluster of five needs three.\
-This scheme is resistant against split-brain situations in the sense\
-that multiple monitors cannot be primary simultaneously. However, a split may\
-cause both monitors to consider themselves secondary, in which case a primary\
+This scheme is resistant against split-brain situations in the sense
+that multiple monitors cannot be primary simultaneously. However, a split may
+cause both monitors to consider themselves secondary, in which case a primary
 server won't be detected.
 
-Even without a network split, `cooperative_monitoring_locks=majority_of_all`\
-will lead to neither monitor claiming lock majority once too many servers go\
-down. This scenario is depicted in the image below. Only two out of four servers\
-are running when three are needed for majority. Although both MaxScales see both\
-running servers, neither is certain they have majority and the cluster stays in\
+Even without a network split, `cooperative_monitoring_locks=majority_of_all`
+will lead to neither monitor claiming lock majority once too many servers go
+down. This scenario is depicted in the image below. Only two out of four servers
+are running when three are needed for majority. Although both MaxScales see both
+running servers, neither is certain they have majority and the cluster stays in
 read-only mode. If the primary server is down, no failover is performed either.
 
 ```mermaid
@@ -1202,17 +1202,17 @@ flowchart TD
 ```
 _No majority: both MaxScale instances see the same two reachable servers, so neither can lock a majority and both remain secondary._
 
-Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only\
-servers currently \[Running] are considered. This scheme adapts to multiple\
+Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only
+servers currently \[Running] are considered. This scheme adapts to multiple
 servers going down, ensuring that claiming lock majority is always possible.\
-However, it can lead to multiple monitors claiming primary status in a\
-split-brain situation. As an example, consider a cluster with servers 1 to 4\
-with MaxScales A and B, as in the image below. MaxScale A can connect to\
-servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to\
-a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B\
+However, it can lead to multiple monitors claiming primary status in a
+split-brain situation. As an example, consider a cluster with servers 1 to 4
+with MaxScales A and B, as in the image below. MaxScale A can connect to
+servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to
+a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B
 does the opposite, claiming servers 3 and 4 and assuming 1 and 2 are down.\
-Both MaxScales claim two locks out of two available and assume that they have\
-lock majority. Both MaxScales may then promote their own primaries and route\
+Both MaxScales claim two locks out of two available and assume that they have
+lock majority. Both MaxScales may then promote their own primaries and route
 writes to different servers.
 
 ```mermaid
@@ -1245,23 +1245,23 @@ flowchart TD
 ```
 _Split brain: a broken heartbeat between datacenters lets both MaxScale A and MaxScale B act as primary at once, each locking its own read-write server._
 
-The recommended strategy depends on which failure scenario is more likely and/or\
-more destructive. If it's unlikely that multiple servers are ever down\
-simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other\
-hand, if split-brain is unlikely but multiple servers may be down\
+The recommended strategy depends on which failure scenario is more likely and/or
+more destructive. If it's unlikely that multiple servers are ever down
+simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other
+hand, if split-brain is unlikely but multiple servers may be down
 simultaneously, then _majority\_of\_running_ would keep the cluster operational.
 
-To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the\
-monitor has lock majority on the cluster. If cooperative monitoring is disabled,\
-the field value is _null_. Lock information for individual servers is listed in\
-the server-specific field **lock\_held**. Again, _null_ indicates that locks are\
+To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the
+monitor has lock majority on the cluster. If cooperative monitoring is disabled,
+the field value is _null_. Lock information for individual servers is listed in
+the server-specific field **lock\_held**. Again, _null_ indicates that locks are
 not in use or the lock status is unknown.
 
-If a MaxScale instance tries to acquire the locks but fails to get majority\
-(perhaps another MaxScale was acquiring locks simultaneously) it will release\
-any acquired locks and try again after a random number of monitor ticks. This\
+If a MaxScale instance tries to acquire the locks but fails to get majority
+(perhaps another MaxScale was acquiring locks simultaneously) it will release
+any acquired locks and try again after a random number of monitor ticks. This
 prevents multiple MaxScales from fighting over the locks continuously as one\
-MaxScale will eventually wait less time than the others. Conflict probability\
+MaxScale will eventually wait less time than the others. Conflict probability
 can be further decreased by configuring each monitor with a different\_monitor\_interval\_.
 
 The flowchart below illustrates the lock handling logic.
@@ -1307,19 +1307,19 @@ _MariaDB Monitor cooperative locking: on each tick, a MaxScale that holds (or ca
 
 #### Releasing locks
 
-Monitor cooperation depends on the server locks. The locks are\
-connection-specific. The owning connection can manually release a lock, allowing\
+Monitor cooperation depends on the server locks. The locks are
+connection-specific. The owning connection can manually release a lock, allowing
 another connection to claim it. Also, if the owning connection closes, the\
-MariaDB Server process releases the lock. How quickly a lost connection is\
-detected affects how quickly the primary monitor status moves from one monitor\
+MariaDB Server process releases the lock. How quickly a lost connection is
+detected affects how quickly the primary monitor status moves from one monitor
 and MaxScale to another.
 
-If the primary MaxScale or its monitor is stopped normally, the monitor\
+If the primary MaxScale or its monitor is stopped normally, the monitor
 connections are properly closed, releasing the locks. This allows the secondary\
-MaxScale to quickly claim the locks. However, if the primary simply vanishes\
+MaxScale to quickly claim the locks. However, if the primary simply vanishes
 (broken network), the connection may just look idle. In this case, the\
-MariaDB Server may take a long time before it considers the monitor connection\
-lost. This time ultimately depends on TCP keepalive settings on the machines\
+MariaDB Server may take a long time before it considers the monitor connection
+lost. This time ultimately depends on TCP keepalive settings on the machines
 running MariaDB Server.
 
 On MariaDB Server 10.3.3 and later, the TCP keepalive settings can be configured\
@@ -1328,15 +1328,15 @@ for information on settings _tcp\_keepalive\_interval_, _tcp\_keepalive\_probes_
 level, as described [here](https://www.tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html).
 
 As of MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6 and 24.02.2, configuring\
-TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_\
-variable when acquiring a lock. This causes the MariaDB Server to close the\
-monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout\
+TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_
+variable when acquiring a lock. This causes the MariaDB Server to close the
+monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout
 settings, and is logged at MaxScale startup.
 
-A monitor can also be ordered to manually release its locks via the module\
-command _release-locks_. This is useful for manually changing the primary\
-monitor. After running the release-command, the monitor will not attempt to\
-reacquire the locks for one minute, even if it wasn't the primary monitor to\
+A monitor can also be ordered to manually release its locks via the module
+command _release-locks_. This is useful for manually changing the primary
+monitor. After running the release-command, the monitor will not attempt to
+reacquire the locks for one minute, even if it wasn't the primary monitor to
 begin with. This command can cause the cluster to become temporarily unusable by\
 MaxScale. Only use it when there is another monitor ready to claim the locks.
 
@@ -1346,38 +1346,38 @@ maxctrl call command mariadbmon release-locks MyMonitor1
 
 ### Backup operations
 
-Backup operations manipulate the contents of a MariaDB Server, saving it or\
+Backup operations manipulate the contents of a MariaDB Server, saving it or
 overwriting it. MariaDB-Monitor supports three backup operations:
 
-1. rebuild-server: Replace the contents of a database server with the\
+1. rebuild-server: Replace the contents of a database server with the
    contents of another.
-2. create-backup: Copy the contents of a database server to a storage\
+2. create-backup: Copy the contents of a database server to a storage
    location.
-3. restore-from-backup: Overwrite the contents of a database server with a\
+3. restore-from-backup: Overwrite the contents of a database server with a
    backup.
 
-These operations do not modify server config files, only files in the data\
+These operations do not modify server config files, only files in the data
 directory _/var/lib/mysql_ are affected.
 
 All of these operations are monitor commands and best launched with MaxCtrl.\
-The operations are asynchronous, which means MaxCtrl won't wait for the\
-operation to complete and instead immediately returns "OK". To see the current\
-status of an operation, either check MaxScale log or use the\
-fetch-cmd-result-command\
+The operations are asynchronous, which means MaxCtrl won't wait for the
+operation to complete and instead immediately returns "OK". To see the current
+status of an operation, either check MaxScale log or use the
+fetch-cmd-result-command
 (e.g. `maxctrl call command mariadbmon fetch-cmd-result MyMonitor`).
 
-To perform backup operations, MaxScale requires ssh-access on all affected\
+To perform backup operations, MaxScale requires ssh-access on all affected
 machines. The _ssh\_user_ and _ssh\_keyfile_-settings define the SSH credentials\
-MaxScale uses to access the servers. MaxScale must be able to run commands with\_sudo\_ on both the source and target servers. See [settings](mariadb-maxscale-2302-mariadb-monitor.md#settings) and [sudoers.d configuration](mariadb-maxscale-2302-mariadb-monitor.md#sudoersd-configuration) below\
+MaxScale uses to access the servers. MaxScale must be able to run commands with\_sudo\_ on both the source and target servers. See [settings](mariadb-maxscale-2302-mariadb-monitor.md#settings) and [sudoers.d configuration](mariadb-maxscale-2302-mariadb-monitor.md#sudoersd-configuration) below
 for more information.
 
 The following tools need to be installed on the backends:
 
 1. mariadb-backup. Backs up and restores MariaDB Server contents. Installed e.g.\
-   with `yum install MariaDB-backup`. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup) for more\
+   with `yum install MariaDB-backup`. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup) for more
    information.
 2. pigz. Compresses and decompresses the backup stream. Installed e.g. with`yum install pigz`.
-3. socat. Streams data from one machine to another. Is likely already\
+3. socat. Streams data from one machine to another. Is likely already
    installed. If not, can be installed e.g. with `yum install socat`.
 
 mariadb-backup needs server credentials to log in and authenticate to the\
@@ -1387,91 +1387,91 @@ for more details.
 
 #### Rebuild server
 
-The rebuild server-operation replaces the contents of a database server with the\
-contents of another server. The source server is effectively cloned and all data\
-on the target server is lost. This is useful when a replica server has diverged\
+The rebuild server-operation replaces the contents of a database server with the
+contents of another server. The source server is effectively cloned and all data
+on the target server is lost. This is useful when a replica server has diverged
 from the primary server, or when adding a new server to the cluster.\
-MaxScale performs this operation by running mariadb-backup on both the\
+MaxScale performs this operation by running mariadb-backup on both the
 source and target servers.
 
-When launched, the rebuild operation proceeds as below. If any step fails, the\
+When launched, the rebuild operation proceeds as below. If any step fails, the
 operation is stopped and the target server will be left in an unspecified state.
 
-1. Log in to both servers with ssh and check that the tools listed above are\
+1. Log in to both servers with ssh and check that the tools listed above are
    present (e.g. `mariadb-backup -v` should succeed).
-2. Check that the port used for transferring the backup is free on the source\
-   server. If not, kill the process holding it. This requires running lsof and\
+2. Check that the port used for transferring the backup is free on the source
+   server. If not, kill the process holding it. This requires running lsof and
    kill.
-3. Test the connection by streaming a short message from the source host to the\
+3. Test the connection by streaming a short message from the source host to the
    target.
-4. Launch mariadb-backup on the source machine, compress the stream and listen\
+4. Launch mariadb-backup on the source machine, compress the stream and listen
    for an incoming connection. This is performed with a command like`mariadb-backup --backup --safe-slave-backup --stream=xbstream | pigz -c | socat - TCP-LISTEN:<port>`.
-5. Stop MariaDB-server on the target machine and delete all contents of the data\
+5. Stop MariaDB-server on the target machine and delete all contents of the data
    directory /var/lib/mysql.
-6. On the target machine, connect to the source machine, read the backup stream,\
-   decompress it and write to the data directory. This is performed with a command\
-   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can\
+6. On the target machine, connect to the source machine, read the backup stream,
+   decompress it and write to the data directory. This is performed with a command
+   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can
    take a long time if there is much data to transfer.
-7. Check that the data directory on the target machine is not empty,\
+7. Check that the data directory on the target machine is not empty,
    i.e. that the transfer at least appears to have succeeded.
-8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if\
+8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if
    the source server performed writes during data transfer.
-9. On the target server, change ownership of datadir contents to the\
+9. On the target server, change ownership of datadir contents to the
    mysql-user and start MariaDB-server.
-10. Read gtid from the data directory. Have the target server start replicating\
+10. Read gtid from the data directory. Have the target server start replicating
     from the primary if it is not one already.
 
 The rebuild-operation is a monitor module command and takes three arguments:\
 the monitor name, target server name and source server name.\
 The source server can be left out, in which case it is autoselected.\
-When autoselecting, the monitor prefers to pick an up-to-date replica server to\
+When autoselecting, the monitor prefers to pick an up-to-date replica server to
 avoid increasing load on a primary server.\
-Due to the `--safe-slave-backup`-option, the replica will stop\
+Due to the `--safe-slave-backup`-option, the replica will stop
 replicating until the backup data has been transferred.
 
 ```
 maxctrl call command mariadbmon async-rebuild-server MyMonitor MyTargetServer MySourceServer
 ```
 
-The operation does not launch if the target server is already replicating or if\
+The operation does not launch if the target server is already replicating or if
 the source server is not a primary or replica.
 
-Steps 6 and 8 can take a long time depending on the size of the database and if\
-writes are ongoing. During these steps, the monitor will continue monitoring the\
-cluster normally. After each monitor tick the monitor checks if the\
-rebuild-operation can proceed. No other monitor operations, either manual or\
+Steps 6 and 8 can take a long time depending on the size of the database and if
+writes are ongoing. During these steps, the monitor will continue monitoring the
+cluster normally. After each monitor tick the monitor checks if the
+rebuild-operation can proceed. No other monitor operations, either manual or
 automatic, can run until the rebuild completes.
 
 #### Create backup
 
-The create backup-operation copies the contents of a database server to the\
-backup storage. The source server is not modified but may slow down during\
-backup creation. MaxScale performs this operation by running\
-mariadb-backup on both the source and storage servers. The storage location is\
+The create backup-operation copies the contents of a database server to the
+backup storage. The source server is not modified but may slow down during
+backup creation. MaxScale performs this operation by running
+mariadb-backup on both the source and storage servers. The storage location is
 defined by the _backup\_storage\_address_ and _backup\_storage\_path_ settings.\
-Normal ssh-settings are used to access the storage server. The backup storage\
+Normal ssh-settings are used to access the storage server. The backup storage
 machine does not need to have a MariaDB Server installed.
 
-Backup creation runs somewhat similar to rebuild-server. The main difference\
-is that the backup data is simply saved to a directory and not prepared or\
-used to start a MariaDB Server. If any step fails, the operation is stopped\
+Backup creation runs somewhat similar to rebuild-server. The main difference
+is that the backup data is simply saved to a directory and not prepared or
+used to start a MariaDB Server. If any step fails, the operation is stopped
 and the backup storage directory will be left in an unspecified state.
 
 1. Init. See rebuild-server.
 2. Check listen port on backup storage machine. See rebuild-server.
-3. Check that the backup storage main directory exists. Check that it does not\
-   contain a backup with the same name as the one being created. Create the final\
+3. Check that the backup storage main directory exists. Check that it does not
+   contain a backup with the same name as the one being created. Create the final
    backup directory.
-4. Test the connection by streaming a short message from the source host to the\
+4. Test the connection by streaming a short message from the source host to the
    backup storage.
 5. Serve backup on source. Similar to rebuild-server step 4.
-6. Transfer backup directly to the final storage directory. Similar to\
+6. Transfer backup directly to the final storage directory. Similar to
    rebuild-server step 5.
 7. Check that the copied backup data looks ok.
 
-Backup creation is a monitor module command and takes three\
-arguments: the monitor name, source server name and backup name. Backup name\
-defines the subdirectory where the backup is saved and should be a valid\
+Backup creation is a monitor module command and takes three
+arguments: the monitor name, source server name and backup name. Backup name
+defines the subdirectory where the backup is saved and should be a valid
 directory name. The command
 
 ```
@@ -1481,55 +1481,55 @@ maxctrl call command mariadbmon async-create-backup MyMonitor MySourceServer wed
 would save the backup of MySourceServer to `<backup_storage_path>/wednesday_161122` on the host defined in _backup\_storage\_address_. _ssh\_user_ needs to have read and write access
 to the main storage directory. The source server must be a primary or replica.
 
-Similar to rebuild-server, the monitor will continue monitoring the servers\
+Similar to rebuild-server, the monitor will continue monitoring the servers
 while the backup is transferred.
 
 #### Restore from backup
 
-The restore-operation is the reverse of create-backup. It overwrites the\
+The restore-operation is the reverse of create-backup. It overwrites the
 contents of an existing MariaDB Server with a backup from the backup storage.\
-The backup is not removed and can be used again. MaxScale performs this\
-operation by transferring the backup contents as a tar archive and overwriting\
-the target server data directory. The backup storage is defined in monitor\
+The backup is not removed and can be used again. MaxScale performs this
+operation by transferring the backup contents as a tar archive and overwriting
+the target server data directory. The backup storage is defined in monitor
 settings similar to create-backup.
 
-The restore-operation runs somewhat similar to rebuild-server. The main\
+The restore-operation runs somewhat similar to rebuild-server. The main
 difference is that the backup data is copied with _tar_ instead of mariadb-backup.\
-If any step fails, the operation is stopped and the target server will be\
+If any step fails, the operation is stopped and the target server will be
 left in an unspecified state.
 
 1. Init. See rebuild-server.
 2. Check listen port on target machine. See rebuild-server.
-3. Check that the backup storage main directory exists and that it contains\
+3. Check that the backup storage main directory exists and that it contains
    a backup with the name requested.
-4. Test the connection by streaming a short message from the backup storage to\
+4. Test the connection by streaming a short message from the backup storage to
    the target machine.
-5. On the backup storage machine, compress the backup with tar and serve it\
-   with socat, listening for an incoming connection. This is performed with\
+5. On the backup storage machine, compress the backup with tar and serve it
+   with socat, listening for an incoming connection. This is performed with
    a command like `tar -zc -C <backup_dir> . | socat - TCP-LISTEN:<port>`.
-6. Stop MariaDB-server on the target machine and delete all contents of the data\
+6. Stop MariaDB-server on the target machine and delete all contents of the data
    directory /var/lib/mysql.
-7. On the target machine, connect to the source machine, read the backup stream,\
-   decompress it and write to the data directory. This is performed with a command\
+7. On the target machine, connect to the source machine, read the backup stream,
+   decompress it and write to the data directory. This is performed with a command
    like `socat -u TCP:<host>:<port> STDOUT | sudo tar -xz -C /var/lib/mysql/`.\
    This step can take a long time if there is much data to transfer.
 8. From here on, the operation proceeds as from rebuild-server step 7.
 
-Server restoration is a monitor module command and takes three\
-arguments: the monitor name, target server name and backup name. Backup name\
-defines the subdirectory where the backup is read from and should be an\
+Server restoration is a monitor module command and takes three
+arguments: the monitor name, target server name and backup name. Backup name
+defines the subdirectory where the backup is read from and should be an
 existing directory on the backup storage host. The command
 
 ```
 maxctrl call command mariadbmon async-restore-from-backup MyMonitor MyTargetServer wednesday_161122
 ```
 
-would erase the contents of MyTargetServer and replace them with the backup\
+would erase the contents of MyTargetServer and replace them with the backup
 contained in `<backup_storage_path>/wednesday_161122` on the host defined in _backup\_storage\_address_. _ssh\_user_ needs to have read access
-to the main storage directory and the backup. The target server must not be\
+to the main storage directory and the backup. The target server must not be
 a primary or replica.
 
-Similar to rebuild-server, the monitor will continue monitoring the servers\
+Similar to rebuild-server, the monitor will continue monitoring the servers
 while the backup is transferred and prepared.
 
 #### Settings
@@ -1550,7 +1550,7 @@ Ssh username. Used when logging in to backend servers to run commands.
 * Dynamic: Yes
 * Default: None
 
-Path to file with an ssh private key. Used when logging in to backend servers to\
+Path to file with an ssh private key. Used when logging in to backend servers to
 run commands.
 
 **`ssh_check_host_key`**
@@ -1560,7 +1560,7 @@ run commands.
 * Dynamic: Yes
 * Default: `true`
 
-Boolean, default: true. When logging in to backends, require that the server is\
+Boolean, default: true. When logging in to backends, require that the server is
 already listed in the known\_hosts-file of the user running MaxScale.
 
 **`ssh_timeout`**
@@ -1570,10 +1570,10 @@ already listed in the known\_hosts-file of the user running MaxScale.
 * Dynamic: Yes
 * Default: `10s`
 
-The rebuild operation consists of multiple ssh\
-commands. Most of the commands are assumed to complete quickly. If these\
-commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust\
-this setting if rebuild fails due to ssh commands timing out. This setting does\
+The rebuild operation consists of multiple ssh
+commands. Most of the commands are assumed to complete quickly. If these
+commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust
+this setting if rebuild fails due to ssh commands timing out. This setting does
 not affect steps 5 and 6, as these are assumed to take significant time.
 
 **`ssh_port`**
@@ -1592,9 +1592,9 @@ SSH port. Used for running remote commands on servers.
 * Dynamic: Yes
 * Default: `4444`
 
-The port which the source server listens on for a\
-connection. The port must not be blocked by a firewall or listened on by any\
-other program. If another process is listening on the port when rebuild is\
+The port which the source server listens on for a
+connection. The port must not be blocked by a firewall or listened on by any
+other program. If another process is listening on the port when rebuild is
 starting, MaxScale will attempt to kill the process.
 
 **`backup_storage_address`**
@@ -1604,8 +1604,8 @@ starting, MaxScale will attempt to kill the process.
 * Dynamic: Yes
 * Default: None
 
-Address of the backup storage. Does not need to have MariaDB Server\
-running or be monitored by the monitor. Connected to with ssh. Must have enough\
+Address of the backup storage. Does not need to have MariaDB Server
+running or be monitored by the monitor. Connected to with ssh. Must have enough
 disk space to store all backups.
 
 ```
@@ -1619,7 +1619,7 @@ backup_storage_address=192.168.1.11
 * Dynamic: Yes
 * Default: None
 
-Path to main backup storage directory on backup storage host. _ssh\_user_\
+Path to main backup storage directory on backup storage host. _ssh\_user_
 needs to have full access to this directory to save and read backups.
 
 ```
@@ -1628,10 +1628,10 @@ backup_storage_path=/home/maxscale_ssh_user/backup_storage
 
 #### sudoers.d configuration
 
-If giving MaxScale general sudo-access is out of the question, MaxScale must be\
-allowed to run the specific commands required by the backup operations. This can\
-be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the\
-power to run commands as root. The contents of the file may need to be tweaked\
+If giving MaxScale general sudo-access is out of the question, MaxScale must be
+allowed to run the specific commands required by the backup operations. This can
+be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the
+power to run commands as root. The contents of the file may need to be tweaked
 due to changes in install locations.
 
 ```
@@ -1649,31 +1649,31 @@ johnny ALL= NOPASSWD: /bin/tar -xz -C /var/lib/mysql/
 
 ### ColumnStore commands
 
-Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative\
+Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative
 commands against a ColumnStore cluster. The commands interact with the\
-ColumnStore REST-API present in recent ColumnStore versions and have been tested\
-with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the\
-commands affect monitor configuration or replication topology. MariaDB Monitor\
+ColumnStore REST-API present in recent ColumnStore versions and have been tested
+with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the
+commands affect monitor configuration or replication topology. MariaDB Monitor
 simply relays the commands to the backend cluster.
 
-MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop\
-the cluster, and set cluster read-only or readwrite. MaxScale only communicates\
+MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop
+the cluster, and set cluster read-only or readwrite. MaxScale only communicates
 with the first server in the `servers`-list.
 
-Most of the commands are asynchronous, i.e. they do not wait for the operation\
+Most of the commands are asynchronous, i.e. they do not wait for the operation
 to complete on the ColumnStore backend before returning to the command prompt.\
-MariaDB Monitor itself, however, runs the command in the background and does not\
-perform normal monitoring until the operation completes or fails. After an\
-operation has started the user should use _fetch-cmd-result_ to check its\
-status. The examples below show how to run the commands using MaxCtrl. If a\
-command takes a timeout-parameter, the timeout can be given in seconds (s),\
+MariaDB Monitor itself, however, runs the command in the background and does not
+perform normal monitoring until the operation completes or fails. After an
+operation has started the user should use _fetch-cmd-result_ to check its
+status. The examples below show how to run the commands using MaxCtrl. If a
+command takes a timeout-parameter, the timeout can be given in seconds (s),
 minutes (m) or hours (h).
 
 ColumnStore command settings are listed [here](mariadb-maxscale-2302-mariadb-monitor.md#settings). At least`cs_admin_api_key` must be set.
 
 #### Get status
 
-Fetch cluster status. Returns the result as is. Status fetching has an automatic\
+Fetch cluster status. Returns the result as is. Status fetching has an automatic
 timeout of ten seconds.
 
 ```
@@ -1787,7 +1787,7 @@ maxctrl call command mariadbmon fetch-cmd-result MyMonitor
 
 **`cs_admin_port`**
 
-Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes\
+Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes
 are assumed to listen on the same port.
 
 ```
@@ -1811,9 +1811,9 @@ String, default: _/cmapi/0.4.0_. Base path sent with the REST-API request.
 
 #### `fetch-cmd-result`
 
-Fetches the result of the last manual command. Requires monitor name as\
-parameter. Most commands only return a generic success message or an error\
-description. ColumnStore commands may return more data. Scheduling another\
+Fetches the result of the last manual command. Requires monitor name as
+parameter. Most commands only return a generic success message or an error
+description. ColumnStore commands may return more data. Scheduling another
 command clears a stored result.
 
 ```
@@ -1823,11 +1823,11 @@ maxctrl call command mariadbmon fetch-cmd-result MariaDB-Monitor
 
 #### `cancel-cmd`
 
-Cancels the latest operation, whether manual or automatic, if possible. Requires\
-monitor name as parameter. A scheduled manual command is simply canceled\
-before it can run. If a command is already running, it stops as soon as\
+Cancels the latest operation, whether manual or automatic, if possible. Requires
+monitor name as parameter. A scheduled manual command is simply canceled
+before it can run. If a command is already running, it stops as soon as
 possible. The _cancel-cmd_ itself does not wait for a running operation to stop.\
-Use _fetch-cmd-result_ or check the log to see if the operation has truly\
+Use _fetch-cmd-result_ or check the log to see if the operation has truly
 completed. Canceling is most useful for stopping a stalled rebuild operation.
 
 ```
@@ -1841,48 +1841,48 @@ OK
 
 See the [Limitations and requirements-section](mariadb-maxscale-2302-mariadb-monitor.md#limitations_and_requirements).
 
-Before performing failover or switchover, the monitor checks that\
-prerequisites are fulfilled, printing any errors and warnings found. This should\
+Before performing failover or switchover, the monitor checks that
+prerequisites are fulfilled, printing any errors and warnings found. This should
 catch and explain most issues with failover or switchover not working.\
-If the operations are attempted and still fail, then most likely one of\
-the commands the monitor issued to a server failed or timed out. The log should\
+If the operations are attempted and still fail, then most likely one of
+the commands the monitor issued to a server failed or timed out. The log should
 explain which query failed.
 
-A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the\
-monitor will retry most such queries if the failure was caused by a timeout. The retrying\
-continues until the total time for a failover or switchover has been spent. If the log\
-shows warnings or errors about commands timing out, increasing the backend timeout\
+A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the
+monitor will retry most such queries if the failure was caused by a timeout. The retrying
+continues until the total time for a failover or switchover has been spent. If the log
+shows warnings or errors about commands timing out, increasing the backend timeout
 settings of the monitor should help. Other settings to look at are `query_retries` and`query_retry_timeout`. These are general MaxScale settings described in the [Configuration guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md). Setting`query_retries` to 2 is a reasonable first try.
 
-If switchover causes the old primary (now replica) to fail replication, then most\
-likely a user or perhaps a scheduled event performed a write while monitor\
+If switchover causes the old primary (now replica) to fail replication, then most
+likely a user or perhaps a scheduled event performed a write while monitor
 had set `read_only=1`. This is possible if the user performing the write has\
-"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick\
-out SUPER-users but this is not certain to succeed. Remove these privileges\
-from any users that regularly do writes to prevent them from interfering with\
+"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick
+out SUPER-users but this is not certain to succeed. Remove these privileges
+from any users that regularly do writes to prevent them from interfering with
 switchover.
 
-The server configuration files should have `log-slave-updates=1` to ensure that\
-a newly promoted primary has binary logs of previous events. This allows the new\
+The server configuration files should have `log-slave-updates=1` to ensure that
+a newly promoted primary has binary logs of previous events. This allows the new
 primary to replicate past events to any lagging replicas.
 
-To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the\
-backends by monitors and authenticators. The printed queries may include\
+To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the
+backends by monitors and authenticators. The printed queries may include
 usernames and passwords.
 
 #### Replica detection shows external primaries
 
 If a replica is shown in _maxctrl_ as "Slave of External Server" instead of\
-"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection\
-does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default\
-assumes that the replica connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact\
-same "Master\_Host" as used the MaxScale configuration file server definitions. This is\
+"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection
+does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default
+assumes that the replica connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact
+same "Master\_Host" as used the MaxScale configuration file server definitions. This is
 controlled by the setting [assume\_unique\_hostnames](mariadb-maxscale-2302-mariadb-monitor.md#assume_unique_hostnames).
 
 ### Using the MariaDB Monitor With Binlogrouter
 
-Since MaxScale 2.2 it's possible to detect a replication setup\
-which includes Binlog Server: the required action is to add the\
+Since MaxScale 2.2 it's possible to detect a replication setup
+which includes Binlog Server: the required action is to add the
 binlog server to the list of servers only if _master\_id_ identity is set.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-xpand-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-xpand-monitor.md
@@ -2,8 +2,8 @@
 
 ### Overview
 
-The Xpand Monitor is a monitor that monitors a Xpand cluster. It is\
-capable of detecting the cluster setup and creating corresponding server\
+The Xpand Monitor is a monitor that monitors a Xpand cluster. It is
+capable of detecting the cluster setup and creating corresponding server
 instances within MaxScale.
 
 ### Required Grants
@@ -17,7 +17,7 @@ GRANT SELECT ON system.nodeinfo TO 'maxscale'@'maxscalehost';
 GRANT SELECT ON system.softfailed_nodes TO 'maxscale'@'maxscalehost';
 ```
 
-Further, if you want be able to _softfail_ and _unsoftfail_ a node via MaxScale,\
+Further, if you want be able to _softfail_ and _unsoftfail_ a node via MaxScale,
 then the monitor user must have `SUPER` privileges:
 
 ```
@@ -26,19 +26,19 @@ GRANT SUPER ON *.* TO 'maxscale'@'maxscalehost';
 
 ### Configuration
 
-A minimal configuration for a monitor requires one server in the Xpand\
-cluster, and a username and a password to connect to the server. Note that\
-by default the Xpand monitor will only use that server in order to\
-dynamically find out the configuration of the cluster; after startup it\
-will completely rely upon information obtained at runtime. To change the\
+A minimal configuration for a monitor requires one server in the Xpand
+cluster, and a username and a password to connect to the server. Note that
+by default the Xpand monitor will only use that server in order to
+dynamically find out the configuration of the cluster; after startup it
+will completely rely upon information obtained at runtime. To change the
 default behaviour, please see the parameter [dynamic\_node\_detection](mariadb-maxscale-2302-xpand-monitor.md#dynamic_node_detection).
 
-To ensure that the Xpand monitor will be able to start, it is advisable\
-to provide _more_ than one server to cater for the case that not all nodes\
+To ensure that the Xpand monitor will be able to start, it is advisable
+to provide _more_ than one server to cater for the case that not all nodes
 are always up when MaxScale starts.
 
-**Note:** All services that use servers monitored by xpandmon should use\
-the `cluster` parameter to define the set of servers they use. This will\
+**Note:** All services that use servers monitored by xpandmon should use
+the `cluster` parameter to define the set of servers they use. This will
 guarantee that the services use servers that are valid members of the\
 XPand cluster.
 
@@ -67,12 +67,12 @@ Xpand node will be named like
 @@<name-of-xpand-monitor>:node-<id>
 ```
 
-where `<name-of-xpand-monitor>` is the name of the Xpand monitor\
-instance, as defined in the MaxScale configuration file, and `<id>` is the\
+where `<name-of-xpand-monitor>` is the name of the Xpand monitor
+instance, as defined in the MaxScale configuration file, and `<id>` is the
 id of the Xpand node.
 
-For instance, with the Xpand monitor defined as above and a Xpand\
-cluster consisting of 3 nodes whose ids are `1`, `2` and `3` respectively,\
+For instance, with the Xpand monitor defined as above and a Xpand
+cluster consisting of 3 nodes whose ids are `1`, `2` and `3` respectively,
 the names of the created server objects will be:
 
 ```
@@ -82,7 +82,7 @@ the names of the created server objects will be:
 ```
 
 When dynamic servers are created, the values for the configuration settings`max_routing_connections`, `persistmaxtime`, `persistpoolmax` and`proxy_protocol` are copied from the settings of the bootstrap servers.\
-Note that the values of these settings must be **identical** on every\
+Note that the values of these settings must be **identical** on every
 bootstrap server.
 
 ### Common Monitor Parameters
@@ -95,21 +95,21 @@ These are optional parameters specific to the Xpand Monitor.
 
 #### `cluster_monitor_interval`
 
-Defines, in milliseconds, how often the monitor checks the state of the\
-entire cluster. The default value is 60000 (1 minute), which should not\
+Defines, in milliseconds, how often the monitor checks the state of the
+entire cluster. The default value is 60000 (1 minute), which should not
 be lowered as that may have an adverse effect on the Cluster itself.
 
 ```
 cluster_monitor_interval=120000ms
 ```
 
-The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.
 
 #### `health_check_threshold`
 
-Defines how many times the health check may fail before the monitor\
+Defines how many times the health check may fail before the monitor
 considers a particular node to be down. The default value is 2.
 
 ```
@@ -118,11 +118,11 @@ health_check_threshold=3
 
 #### `dynamic_node_detection`
 
-By default, the Xpand monitor will only use the bootstrap nodes\
-in order to connect to the Xpand cluster and then find out the\
+By default, the Xpand monitor will only use the bootstrap nodes
+in order to connect to the Xpand cluster and then find out the
 cluster configuration dynamically at runtime.
 
-That behaviour can be turned off with this optional parameter, in\
+That behaviour can be turned off with this optional parameter, in
 which case all Xpand nodes must manually be defined as shown below.
 
 ```
@@ -151,7 +151,7 @@ See also [health\_check\_port](mariadb-maxscale-2302-xpand-monitor.md#health_che
 
 #### `health_check_port`
 
-With this optional parameter it can be specified what health check\
+With this optional parameter it can be specified what health check
 port to use, if `dynamic_node_detection` has been disabled.
 
 ```
@@ -160,7 +160,7 @@ health_check_port=4711
 
 The default value is `3581`.
 
-Note that this parameter is _ignored_ unless `dynamic_node_detection`\
+Note that this parameter is _ignored_ unless `dynamic_node_detection`
 is `false`. Note also that the port must be the same for all nodes.
 
 ### Commands
@@ -170,8 +170,8 @@ The Xpand monitor supports the following module commands.
 #### `softfail`
 
 With the `softfail` module command, a node can be _softfailed_ via\
-MaxScale. The command requires as argument the name of the Xpand\
-monitor instance (as defined in the configuration file) and the name\
+MaxScale. The command requires as argument the name of the Xpand
+monitor instance (as defined in the configuration file) and the name
 of the node to be softfailed.
 
 For instance, with a configuration file like
@@ -183,56 +183,56 @@ module=xpandmon
 ...
 ```
 
-then the node whose server name is `@@TheXpandMonitor:node-1` can\
+then the node whose server name is `@@TheXpandMonitor:node-1` can
 be softfailed like
 
 ```
 $ maxctrl call command xpandmon softfail TheXpandMonitor @@TheXpandMonitor:node-1
 ```
 
-If the softfailing of a node is successfully initiated, then the status\
-of the corresponding MaxScale server object will be set to `Draining`,\
+If the softfailing of a node is successfully initiated, then the status
+of the corresponding MaxScale server object will be set to `Draining`,
 which will prevent new connections from being created to the node.
 
-When the number of connections through MaxScale to the node has dropped\
-to 0, its state will change to `Drained`. Note that the state `Drained`\
-only tells that there are no connections to the node, not what the state\
+When the number of connections through MaxScale to the node has dropped
+to 0, its state will change to `Drained`. Note that the state `Drained`
+only tells that there are no connections to the node, not what the state
 of the softfailing operation is.
 
 #### `unsoftfail`
 
 With the `unsoftfail` module command, a node can be _unsoftfailed_ via\
-MaxScale. The command requires as argument the name of the Xpand\
-monitor instance (as defined in the configuration file) and the name\
+MaxScale. The command requires as argument the name of the Xpand
+monitor instance (as defined in the configuration file) and the name
 of the node to be unsoftfailed.
 
-With a setup similar to the `softfail` case, a node can be unsoftfailed\
+With a setup similar to the `softfail` case, a node can be unsoftfailed
 like:
 
 ```
 $ maxctrl call command xpandmon unsoftfail TheXpandMonitor @@TheXpandMonitor:node-1
 ```
 
-If a node is successfully softfailed, then a `Draining` status of\
+If a node is successfully softfailed, then a `Draining` status of
 the corresponding MaxScale server object will be cleared.
 
 ### SOFTFAILed nodes
 
-During the cluster check, which is performed once per`cluster_monitor_interval`, the monitor will also check whether any\
-nodes are being softfailed. The status of the corresponding server\
-object of a node being softfailed will be set to `Draining`,\
+During the cluster check, which is performed once per`cluster_monitor_interval`, the monitor will also check whether any
+nodes are being softfailed. The status of the corresponding server
+object of a node being softfailed will be set to `Draining`,
 which will prevent new connections from being created to that node.
 
-When the number of connections through MaxScale to the node has dropped\
-to 0, its state will change to `Drained`. Note that the state `Drained`\
-only tells that there are no connections to the node, not what the state\
+When the number of connections through MaxScale to the node has dropped
+to 0, its state will change to `Drained`. Note that the state `Drained`
+only tells that there are no connections to the node, not what the state
 of the softfailing operation is.
 
-If a node that was softfailed is UNSOFTFAILed then the `Draining`\
+If a node that was softfailed is UNSOFTFAILed then the `Draining`
 status will be cleared.
 
-If the softfailing and unsoftfailing is initiated using the `softfail`\
-and `unsoftfail` commands of the Xpand monitor, then there will be\
+If the softfailing and unsoftfailing is initiated using the `softfail`
+and `unsoftfail` commands of the Xpand monitor, then there will be
 no delay between the softfailing or unsoftfailing being initiated and the`Draining` status being turned on/off.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-change-data-capture-cdc-protocol.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-change-data-capture-cdc-protocol.md
@@ -1,10 +1,10 @@
 # Change Data Capture (CDC) Protocol
 
-CDC is a new protocol that allows compatible clients to authenticate and\
-register for Change Data Capture events. The new protocol must be use in\
+CDC is a new protocol that allows compatible clients to authenticate and
+register for Change Data Capture events. The new protocol must be use in
 conjunction with AVRO router which currently converts MariaDB binlog events into\
-AVRO records. Change Data Capture protocol is used by clients in order to\
-interact with stored AVRO file and also allows registered clients to be notified\
+AVRO records. Change Data Capture protocol is used by clients in order to
+interact with stored AVRO file and also allows registered clients to be notified
 with the new events coming from MariaDB 10.0/10.1 database.
 
 ### Creating Users
@@ -47,12 +47,12 @@ In the future, optional flags could be implemented.
 
 #### Authentication
 
-The authentication starts when the client sends the hexadecimal representation\
+The authentication starts when the client sends the hexadecimal representation
 of the username concatenated with a colon (`:`) and the SHA1 of the password.
 
 `bin2hex(username + ':' + SHA1(password))`
 
-For example the user _foobar_ with a password of _foopasswd_ should send the\
+For example the user _foobar_ with a password of _foopasswd_ should send the
 following hexadecimal string
 
 ```
@@ -83,9 +83,9 @@ Server returns `OK` on success and `ERR` on failure.
 
 `REQUEST-DATA DATABASE.TABLE[.VERSION] [GTID]`
 
-This command fetches data from specified table in a database and returns the\
-output in the requested format (AVRO or JSON). Data records are sent to clients\
-and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new\
+This command fetches data from specified table in a database and returns the
+output in the requested format (AVRO or JSON). Data records are sent to clients
+and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new
 schema and data will be sent as well.
 
 The data will be streamed until the client closes the connection.
@@ -102,7 +102,7 @@ REQUEST-DATA db2.table4 0-11-345
 
 ### Example Client
 
-MaxScale includes an example CDC client application written in Python 3. You can\
+MaxScale includes an example CDC client application written in Python 3. You can
 find the source code for it [in the MaxScale repository](https://github.com/mariadb-corporation/MaxScale/tree/2.0/server/modules/protocol/examples/cdc.py).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-change-data-capture-cdc-users.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-change-data-capture-cdc-users.md
@@ -1,12 +1,12 @@
 # Change Data Capture (CDC) users
 
-Change Data Capture (CDC) is a new MaxScale protocol that allows compatible\
-clients to authenticate and register for Change Data Capture events. The new\
+Change Data Capture (CDC) is a new MaxScale protocol that allows compatible
+clients to authenticate and register for Change Data Capture events. The new
 protocol must be use in conjunction with AVRO router which currently converts\
-MariaDB binlog events into AVRO records. Clients connect to CDC listener and\
+MariaDB binlog events into AVRO records. Clients connect to CDC listener and
 authenticate using credentials provided in a format described in the [CDC Protocol documentation](mariadb-maxscale-2302-change-data-capture-cdc-protocol.md).
 
-**Note**: If no users are found in that file or if it doesn't exist, the only\
+**Note**: If no users are found in that file or if it doesn't exist, the only
 available user will be the _service user_:
 
 ```
@@ -26,7 +26,7 @@ Starting with MaxScale 2.1, users can also be created through maxctrl:
 maxctrl call command cdc add_user <service> <name> <password>
 ```
 
-The should be the service name where the user is created. Older\
+The should be the service name where the user is created. Older
 versions of MaxScale should use the _cdc\_users.py_ script.
 
 ```
@@ -39,7 +39,7 @@ The output of this command should be appended to the _cdcusers_ file at`/var/lib
 bash$ cdc_users.py user1 pass1 >> /var/lib/maxscale/avro-service/cdcusers
 ```
 
-Users can be deleted by removing the related rows in 'cdcusers' file. For\
+Users can be deleted by removing the related rows in 'cdcusers' file. For
 more details on the format of the _cdcusers_ file, read the [CDC Protocol documentation](mariadb-maxscale-2302-change-data-capture-cdc-protocol.md).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-maxscale-2302-mariadb-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-maxscale-2302-mariadb-protocol-module.md
@@ -2,7 +2,7 @@
 
 The `mariadbprotocol` module implements the MariaDB client-server protocol.
 
-The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all\
+The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all
 aliases to `mariadbprotocol`.
 
 * [MariaDB Protocol Module](mariadb-maxscale-2302-maxscale-2302-mariadb-protocol-module.md#mariadb-protocol-module)
@@ -11,7 +11,7 @@ aliases to `mariadbprotocol`.
 
 ### Configuration
 
-Protocol level parameters are defined in the listeners. They must be defined\
+Protocol level parameters are defined in the listeners. They must be defined
 using the scoped parameter syntax where the protocol name is used as the prefix.
 
 ```
@@ -32,8 +32,8 @@ For the MariaDB protocol module, the prefix is always `mariadbprotocol`.
 * Dynamic: Yes
 * Default: true
 
-Whether the use of the replication protocol is allowed through this listener. If\
-disabled with `mariadbprotocol.allow_replication=false`, all attempts to start\
+Whether the use of the replication protocol is allowed through this listener. If
+disabled with `mariadbprotocol.allow_replication=false`, all attempts to start
 replication will be rejected with a ER\_FEATURE\_DISABLED error (error number\
 1289\).
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-nosql-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-nosql-protocol-module.md
@@ -1,20 +1,20 @@
 # NoSQL Protocol Module
 
-The `nosqlprotocol` module allows a MariaDB server or cluster to be\
+The `nosqlprotocol` module allows a MariaDB server or cluster to be
 used as the backend of an application using a MongoDB® client library.\
 Internally, all documents are stored in a table containing two columns;\
 an `id` column for the object id and a `doc` column for the document itself.
 
-When the MongoDB® client application issues MongoDB protocol _commands_,\
-either directly or indirectly via the client library, they are transparently\
+When the MongoDB® client application issues MongoDB protocol _commands_,
+either directly or indirectly via the client library, they are transparently
 converted into the equivalent SQL and executed against the MariaDB backend.\
-The MariaDB responses are then in turn converted into the format expected by\
+The MariaDB responses are then in turn converted into the format expected by
 the MongoDB® client library and application.
 
 ## Configuring
 
-There are a number of [parameters](mariadb-maxscale-2302-nosql-protocol-module.md#parameters) with which the behavior\
-of _nosqlprotocol_ can be adjusted. A minimal configuration looks\
+There are a number of [parameters](mariadb-maxscale-2302-nosql-protocol-module.md#parameters) with which the behavior
+of _nosqlprotocol_ can be adjusted. A minimal configuration looks
 like:
 
 ```
@@ -31,13 +31,13 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-`nosqlprotocol.user` and `nosqlprotocol.password` specify the\
-credentials that will be used when accessing the backend database or\
+`nosqlprotocol.user` and `nosqlprotocol.password` specify the
+credentials that will be used when accessing the backend database or
 cluster. Note that the same credentials will be used for _all_ connecting\
 MongoDB® clients.
 
-Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which\
-the client requests will be sent. _Nosqlprotocol_ places no limitations\
+Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which
+the client requests will be sent. _Nosqlprotocol_ places no limitations
 on what filters, routers or backends can be used.
 
 To configure the same listener with MaxCtrl, the parameters must be passed in a\
@@ -47,7 +47,7 @@ JSON object in the following manner:
 maxctrl create listener TheService MongoDB-Listener --protocol=nosqlprotocol 'nosqlprotocol={"user":"the_user", "password": "the_password"}'
 ```
 
-All the parameters that the nosqlprotocol module takes must be passed in the\
+All the parameters that the nosqlprotocol module takes must be passed in the
 same JSON object.
 
 A complete example can be found at the [end](mariadb-maxscale-2302-nosql-protocol-module.md#example) of this document.
@@ -57,18 +57,18 @@ A complete example can be found at the [end](mariadb-maxscale-2302-nosql-protoco
 Nosqlprotocol supports _SCRAM_ _authentication_ as implemented by MongoDB®.\
 The mechanisms `SCRAM-SHA-1` and `SCRAM-SHA-256` are both supported.
 
-If nosqlprotocol has been setup so that no authentication is required, then\
-when connecting only the host and port should be provided, but neither a\
+If nosqlprotocol has been setup so that no authentication is required, then
+when connecting only the host and port should be provided, but neither a
 username nor a password.
 
-For instance, if the _MongoDB Node.JS Driver_ is used, then the connection\
+For instance, if the _MongoDB Node.JS Driver_ is used, then the connection
 string should look like:
 
 ```
 const uri = "mongodb://127.0.0.1:17017"
 ```
 
-Similarly, if the _Mongo Shell_ is used, only the host and port should\
+Similarly, if the _Mongo Shell_ is used, only the host and port should
 be provided:
 
 ```
@@ -80,26 +80,26 @@ MongoDB shell version v4.4.1
 
 ### NoSQL and MariaDB Users
 
-A MariaDB user consists of a name and a host part. A user `'user'@'%'`\
-and a user `'user'@'127.0.0.1'` are completely different. The host part\
-specifies where a user may connect from, with `%` being a wildcard that\
-matches all hosts. What data a user is allowed to access and modify is\
+A MariaDB user consists of a name and a host part. A user `'user'@'%'`
+and a user `'user'@'127.0.0.1'` are completely different. The host part
+specifies where a user may connect from, with `%` being a wildcard that
+matches all hosts. What data a user is allowed to access and modify is
 specified by what _privileges_ are granted to the user.
 
-A NoSQL user is somewhat different. It is created in the context of a\
-particular database, so there may be a user `userx` in the database `dbA`\
-and different user with the same name `userx` in the database `dbB`. What\
-hosts a user may connect from can be restricted, but that is a property of\
-the user and not an implicit part of it. What data a user is allowed to\
-access and modify is specified by the _roles_ that have been assigned to\
+A NoSQL user is somewhat different. It is created in the context of a
+particular database, so there may be a user `userx` in the database `dbA`
+and different user with the same name `userx` in the database `dbB`. What
+hosts a user may connect from can be restricted, but that is a property of
+the user and not an implicit part of it. What data a user is allowed to
+access and modify is specified by the _roles_ that have been assigned to
 the user.
 
-From the above it should be clear that there is not a 1-to-1\
-correspondence between the concept of a user in NoSQL and the concept\
+From the above it should be clear that there is not a 1-to-1
+correspondence between the concept of a user in NoSQL and the concept
 of a user in MariaDB, but that some additional conventions are needed.
 
-To make it possible to have different NoSQL users with the same name,\
-the database in whose context the user is created is prepended to the\
+To make it possible to have different NoSQL users with the same name,
+the database in whose context the user is created is prepended to the
 user name, separated with a dot, when the MariaDB user is created.
 
 This is perhaps easiest to illustrate using an example:
@@ -115,7 +115,7 @@ MariaDB [(none)]> select user, host from mysql.user;
 2 rows in set (0.001 sec)
 ```
 
-Currently there are two user accounts defined. Even though there is\
+Currently there are two user accounts defined. Even though there is
 a user `bob`, creating a NoSQL user `bob` succeeds.
 
 ```
@@ -139,20 +139,20 @@ MariaDB [(none)]> select user, host from mysql.user;
 3 rows in set (0.001 sec)
 ```
 
-The MariaDB user corresponding to the NoSQL user `bob`, created in the\
+The MariaDB user corresponding to the NoSQL user `bob`, created in the
 context of the database `test`, has `test` as a prefix.
 
 #### The `mariadb` database
 
-The fact that NoSQL users have the database embedded in the MariaDB\
-name may be inconvenient if the same data is accessed both as NoSQL\
-via nosqlprotocol and as SQL directly from MariaDB. It also makes\
+The fact that NoSQL users have the database embedded in the MariaDB
+name may be inconvenient if the same data is accessed both as NoSQL
+via nosqlprotocol and as SQL directly from MariaDB. It also makes
 it impossible to use an existing MariaDB account from NoSQL.
 
-To provide a solution for this problem, the database `mariadb` is treated\
-in a specific fashion. A user created in the context of the `mariadb`\
+To provide a solution for this problem, the database `mariadb` is treated
+in a specific fashion. A user created in the context of the `mariadb`
 database is created in the MariaDB server without the database prefix.\
-If we now try to create a user `bob` in the `mariadb` database it will fail,\
+If we now try to create a user `bob` in the `mariadb` database it will fail,
 because the user `'bob'@'%'` exists already.
 
 ```
@@ -195,7 +195,7 @@ we will see that `alice` was created without a database prefix.
 
 When creating a user nosqlprotocol accepts all roles as predefined by\
 MongoDB®, but not all of them are translated into GRANT privileges.\
-The following table shows what privilege(s) a particular role is\
+The following table shows what privilege(s) a particular role is
 converted to.
 
 | Role      | Privileges                                    |
@@ -212,21 +212,21 @@ The following roles are shorthands for several other roles.
 | dbOwner | dbAdmin, readWrite, userAdmin |
 | root    | dbAdmin, readWrite, userAdmin |
 
-`dbOwner` differs from `root` in that the privileges of the former\
-apply only to a particular database, while the privileges of the\
-latter apply to _all_ databases. However, the role `root` can\
+`dbOwner` differs from `root` in that the privileges of the former
+apply only to a particular database, while the privileges of the
+latter apply to _all_ databases. However, the role `root` can
 only be assigned to a user in the `admin` database.
 
-In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in\
-the `admin` database. If so, then the privilege is granted on `*.*`,\
+In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in
+the `admin` database. If so, then the privilege is granted on `*.*`,
 otherwise on `<db>.*`.
 
-If the `root` role is assigned to a user in the `admin` database,\
+If the `root` role is assigned to a user in the `admin` database,
 then the privileges are granted on `*.*`, otherwise on `<db>.*`.
 
-Other pre-defined roles are recognized and stored in the local\
-nosqlprotocol account database, but they do not affect what privileges\
-are granted to the MariaDB user. Currently user-defined roles are\
+Other pre-defined roles are recognized and stored in the local
+nosqlprotocol account database, but they do not affect what privileges
+are granted to the MariaDB user. Currently user-defined roles are
 not supported.
 
 ### Client Authentication
@@ -239,11 +239,11 @@ Authenticationwise nosqlprotocol can be used in three different ways:
 
 #### Anonymously
 
-If there is an anonymous user on the MariaDB server and if nosqlprotocol\
-is configured without a user/password, then all nosqlprotocol clients will\
+If there is an anonymous user on the MariaDB server and if nosqlprotocol
+is configured without a user/password, then all nosqlprotocol clients will
 access the MariaDB server as anonymous users.
 
-Note that the anonymous MariaDB user is only intended for testing and\
+Note that the anonymous MariaDB user is only intended for testing and
 should in general not be used, but deleted.
 
 #### Shared Credentials
@@ -257,18 +257,18 @@ nosqlprotocol.password=thepassword
 ```
 
 then each MongoDB® client will use those credentials when accessing the\
-MariaDB server. Note that from the perspective of the MariaDB server, it\
+MariaDB server. Note that from the perspective of the MariaDB server, it
 is not possible to distinguish between different MongoDB® clients.
 
 #### Unique Credentials
 
-If nosqlprotocol authentication has been taken into use and a MongoDB®\
-client authenticates, either when connecting or later, then the credentials\
+If nosqlprotocol authentication has been taken into use and a MongoDB®
+client authenticates, either when connecting or later, then the credentials
 of MongoDB® client will be used when accessing the MariaDB server.
 
-Note that even if nosqlprotocol authentication has been enabled, authentication\
-is not required, and if the MongoDB® client has not authenticated itself, the\
-credentials specified with `nosqlprotocol.[user|password]` (or the anonymous\
+Note that even if nosqlprotocol authentication has been enabled, authentication
+is not required, and if the MongoDB® client has not authenticated itself, the
+credentials specified with `nosqlprotocol.[user|password]` (or the anonymous
 user) will be used when accessing the MariaDB server.
 
 #### Enforce Authentication
@@ -279,14 +279,14 @@ To enforce authentication, specify
 nosqlprotocol.authentication_required=true
 ```
 
-in the configuration. If authentication is required, then any command\
-that requires access to the MariaDB server will fail, unless the client\
+in the configuration. If authentication is required, then any command
+that requires access to the MariaDB server will fail, unless the client
 has authenticated.
 
 ### Authorization
 
-By default nosqlprotocol does no authorization. However, a nosqlprotocol\
-client is _always_ subject to the authorization performed by the MariaDB\
+By default nosqlprotocol does no authorization. However, a nosqlprotocol
+client is _always_ subject to the authorization performed by the MariaDB
 server.
 
 When nosqlprotocol authorization is enabled by adding
@@ -295,8 +295,8 @@ When nosqlprotocol authorization is enabled by adding
 nosqlprotocol.authorization_enabled=true
 ```
 
-to the configuration file, some commands will be subject to authorization,\
-by nosqlprotocol. The following table lists the commands and what role they\
+to the configuration file, some commands will be subject to authorization,
+by nosqlprotocol. The following table lists the commands and what role they
 require.
 
 | Command                                                                                   | Role      |
@@ -311,27 +311,27 @@ require.
 | [updateUser](mariadb-maxscale-2302-nosql-protocol-module.md#updateUser)                   | userAdmin |
 | [usersInfo](mariadb-maxscale-2302-nosql-protocol-module.md#usersInfo)                     | userAdmin |
 
-It is important to note that even if nosqlprotocol authorization\
-is enabled, the MariaDB server has the final word. That is, even if the\
-roles of a user would be sufficient for a particular operation, if the\
-granted privileges are not, the operation will not succeed. There may\
-be a mismatch between roles and grants, for instance, if the wrong roles\
-were specified when the user was added, or if the grants have been\
+It is important to note that even if nosqlprotocol authorization
+is enabled, the MariaDB server has the final word. That is, even if the
+roles of a user would be sufficient for a particular operation, if the
+granted privileges are not, the operation will not succeed. There may
+be a mismatch between roles and grants, for instance, if the wrong roles
+were specified when the user was added, or if the grants have been
 altered directly and not via nosqlprotocol.
 
 ### Bootstrapping the Authentication/Authorization
 
-The authentication/authorization can be bootstrapped explicitly\
-or implicitly. Bootstrapping explicitly provides more control, while\
+The authentication/authorization can be bootstrapped explicitly
+or implicitly. Bootstrapping explicitly provides more control, while
 bootstrapping implicitly is much more convenient.
 
 #### Explicit bootstrapping
 
-In order to enable authorization you need to have NoSQL users and\
-those can be created with [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser) or added\
+In order to enable authorization you need to have NoSQL users and
+those can be created with [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser) or added
 with [mxsAddUser](mariadb-maxscale-2302-nosql-protocol-module.md#addUser).
 
-If you want to _create_ a user, then you first need to configure\
+If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
 
 ```
@@ -339,7 +339,7 @@ nosqlprotocol.user = user_with_privileges_for_creating_a_user
 nosqlprotocol.password = the_users_password
 ```
 
-At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that\
+At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that
 as those are their default values, they do not have to be specified.
 
 Start MaxScale and connect to it with the MongoDB® command line client
@@ -359,8 +359,8 @@ switched to db admin
 { "ok" : 1 }
 ```
 
-Alternatively you can add an existing user. Note that it should be\
-added to the `mariadb` database, unless it was created with the\
+Alternatively you can add an existing user. Note that it should be
+added to the `mariadb` database, unless it was created with the
 convention of having the database as a prefix, e.g. `db.bob`.
 
 ```
@@ -379,12 +379,12 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but\
-as they will be ignored with `nosqlprotocol.authentication_required=true`\
+The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but
+as they will be ignored with `nosqlprotocol.authentication_required=true`
 being present, it is not mandatory.
 
-If you now try to create a user when not having been authenticated or\
-when authenticated as a user without the `userAdmin` role, the result\
+If you now try to create a user when not having been authenticated or
+when authenticated as a user without the `userAdmin` role, the result
 will be:
 
 ```
@@ -399,105 +399,105 @@ switched to db test
 }
 ```
 
-**NOTE** When a client authenticates, the password will not be\
-transferred in cleartext over the network, so, even without SSL,\
-it is not possible to gain access to a password by monitoring the\
+**NOTE** When a client authenticates, the password will not be
+transferred in cleartext over the network, so, even without SSL,
+it is not possible to gain access to a password by monitoring the
 network traffic.
 
-However, when a user is created or added (or the password is changed),\
-the password will be transferred in _cleartext_. To prevent eavesdropping,\
+However, when a user is created or added (or the password is changed),
+the password will be transferred in _cleartext_. To prevent eavesdropping,
 create/add users when connecting over a domain socket, or use [TLS/SSL](mariadb-maxscale-2302-nosql-protocol-module.md#tlsssl)
 
 #### Implicit bootstrapping
 
-With implicit bootstrapping, you should first create the MariaDB\
-user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2302-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat\
-different in MariaDB and NoSQL, which means that certain factors\
-must be taken into account when creating the MariaDB user. Then\
+With implicit bootstrapping, you should first create the MariaDB
+user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2302-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat
+different in MariaDB and NoSQL, which means that certain factors
+must be taken into account when creating the MariaDB user. Then
 at first startup, nosqlprotocol will create the corresponding\
-NoSQL user, which will enable the authenticated and authorized\
+NoSQL user, which will enable the authenticated and authorized
 use of nosqlprotocol.
 
 When MaxScale is started, if the following hold
 
-* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration\
+* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration
   section of the nosqlprotocol listener,
 * `nosqlprotocol.user` and `nosqlprotocol.password` are provided, and
 * there are no NoSQL users in the NoSQL account database.
 
 then, MaxScale will
 
-* wait until the primary of the service pointed to by the listener\
+* wait until the primary of the service pointed to by the listener
   is available,
-* connect using the credentials specified in `nosqlprotocol.user`\
+* connect using the credentials specified in `nosqlprotocol.user`
   and `nosqlprotocol.password`,
 * execute `SHOW GRANTS`,
 * translate the privileges into the equivalent NoSQL roles, and
 * create a corresponding NoSQL user into the NoSQL account database.
 
-Immediately thereafter it is possible to connect to the nosqlprotocol\
+Immediately thereafter it is possible to connect to the nosqlprotocol
 port with a MongoDB® client using the specified credentials.
 
-Note that after the bootstrapping, nosqlprotocol will not use\
+Note that after the bootstrapping, nosqlprotocol will not use
 the `user` and `password` settings and they can be removed.
 
 **Grants**
 
-When a NoSQL user is created using [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser)\
-the MariaDB grants are obtained from the specified NoSQL roles\
+When a NoSQL user is created using [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser)
+the MariaDB grants are obtained from the specified NoSQL roles
 as explained [here](mariadb-maxscale-2302-nosql-protocol-module.md#Roles_and_privileges).
 
 When implicitly creating a NoSQL user from an existing user in\
-MariaDB, the inverse operation must be performed. There are\
-many factors that affect what NoSQL roles the grants of a user\
+MariaDB, the inverse operation must be performed. There are
+many factors that affect what NoSQL roles the grants of a user
 are translated into:
 
 * whether the user is a regular or admin user,
 * whether the privileges are on `*.*` or some specific `db.*`, and
 * the privileges themselves, e.g. `SELECT`, `DELETE`, etc.
 
-In NoSQL, every user resides in a specific database. Note that\
-this does **not** mean that database would have to exist\
+In NoSQL, every user resides in a specific database. Note that
+this does **not** mean that database would have to exist
 in MariaDB.
 
-When it comes to users, the database effectively means a scope,\
-which in the case of nosqlprotocol is handled by prefixing the\
+When it comes to users, the database effectively means a scope,
+which in the case of nosqlprotocol is handled by prefixing the
 corresponding MariaDB user name with the database/scope name.
 
-When creating a user to be used from NoSQL, there are three\
+When creating a user to be used from NoSQL, there are three
 options for the user's name:
 
 * The name can be of the format `some_db.user_name` where`some_db` can be anything (subject to the naming rules of\
-  MariaDB), except `admin` or `mariadb`. In this case, the\
-  user will be a regular user, who can access data in\
+  MariaDB), except `admin` or `mariadb`. In this case, the
+  user will be a regular user, who can access data in
   databases that she has been granted access to.
-* The name can be of the format `admin.user_name` where `admin`\
-  is exactly just that. In this case, the user will be an\
+* The name can be of the format `admin.user_name` where `admin`
+  is exactly just that. In this case, the user will be an
   admin user, who can access any database.
-* The name can be of the format `user_name`. In this case, the\
-  user will be a regular user that from the NoSQL side appears\
-  to reside in the `mariadb` database. The primary purpose of\
-  this alternative is to enable the use of existing users from\
+* The name can be of the format `user_name`. In this case, the
+  user will be a regular user that from the NoSQL side appears
+  to reside in the `mariadb` database. The primary purpose of
+  this alternative is to enable the use of existing users from
   the NoSQL side.
 
-What database the privileges can be specified `ON` depends on\
+What database the privileges can be specified `ON` depends on
 what kind of user is being created.
 
-* If it is a regular user, the privileges must be granted on a\
+* If it is a regular user, the privileges must be granted on a
   specific database, such as `\`dbA\`\`.\*\`. Note that there is no\
   dependency between this database and the (conceptual) database\
   the user resides in.
 * If it is an admin user, the privileges must be granted on\
   the `*.*` database.
 
-In NoSQL, a role can be database specific or generic. However,\
-a generic role can _only_ be assigned to a user in the _admin_\
-database. In practice this means that if the privileges are\
-on `*.*`, then the user must reside in the _admin_ database\
+In NoSQL, a role can be database specific or generic. However,
+a generic role can _only_ be assigned to a user in the _admin_
+database. In practice this means that if the privileges are
+on `*.*`, then the user must reside in the _admin_ database
 (e.g. `admin.bob`) or it is treated as an error.
 
-The following table shows what privileges are required for a\
-role to be assigned. Note that `ALL PRIVILEGES` can be used as\
+The following table shows what privileges are required for a
+role to be assigned. Note that `ALL PRIVILEGES` can be used as
 well.
 
 | ALTER | CREATE | CREATE USER | DROP | DELETE | INDEX | INSERT | SHOW DATABASES(1) | SELECT | UPDATE | WITH GRANT OPTION | Role                    |
@@ -509,19 +509,19 @@ well.
 
 1. Only required if the user is an admin user.
 
-The `AnyDatabase` version will be assigned, if the user is\
+The `AnyDatabase` version will be assigned, if the user is
 an _admin_ user.
 
-If certain roles are assigned, then other roles will be\
+If certain roles are assigned, then other roles will be
 assigned as well.
 
-* If the roles `dbAdmin`, `readWrite` and `userAdmin` are\
+* If the roles `dbAdmin`, `readWrite` and `userAdmin` are
   assigned, then `dbOwner` will be assigned as well.
-* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`\
-  and `userAdminAnyDatabase` are assigned, then `root` will\
+* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`
+  and `userAdminAnyDatabase` are assigned, then `root` will
   be assigned as well.
 
-Once the user has been created and the desired privileges have\
+Once the user has been created and the desired privileges have
 been granted, the NoSQL listener should be configured as follows:
 
 ```
@@ -540,7 +540,7 @@ At MaxScale startup, the NoSQL user will then be created.
 
 **Admin User**
 
-We want the initial NoSQL user to be an administrator, with\
+We want the initial NoSQL user to be an administrator, with
 full rights.
 
 ```
@@ -548,8 +548,8 @@ CREATE USER 'admin.nosql_admin'@'%' IDENTIFIED BY 'nosql_password';
 GRANT ALL PRIVILEGES ON *.* TO 'admin.nosql_admin'@'%' WITH GRANT OPTION;
 ```
 
-As we want an admin user, the name is prefixed with `admin`,\
-which will have that effect. And since it is an admin user, the\
+As we want an admin user, the name is prefixed with `admin`,
+which will have that effect. And since it is an admin user, the
 privileges are granted ON `*.*`.
 
 Thereafter, we specify the following in the configuration file,
@@ -567,16 +567,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'admin.nosql_admin'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -586,9 +586,9 @@ $ mongo --quiet --port 17017 -u nosql_admin -p nosql_password admin
 >
 ```
 
-Note that when connecting the user is passed as `nosql_admin` and _not_\
-as `admin.nosql_admin`. The fact that we want to authenticate against\
-the `admin` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `nosql_admin` and _not_
+as `admin.nosql_admin`. The fact that we want to authenticate against
+the `admin` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -627,13 +627,13 @@ argument.
 }
 ```
 
-As can be seen, the user has the _any_ roles on the `admin`\
-database, which means that all databases can be accessed and\
+As can be seen, the user has the _any_ roles on the `admin`
+database, which means that all databases can be accessed and
 modified, and that new users can be created.
 
 **Test User**
 
-We want the initial NoSQL user to be a user with limited rights,\
+We want the initial NoSQL user to be a user with limited rights,
 intended to be used for testing.
 
 ```
@@ -641,11 +641,11 @@ CREATE USER 'test.test_user'@'%' IDENTIFIED BY 'test_password';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX ON `test`.* TO 'test.test_user'@'%';
 ```
 
-As we want a user with limited rights, the name is _not_ prefixed\
+As we want a user with limited rights, the name is _not_ prefixed
 with `admin`. The privileges are granted specifically on database`test.*`. Indeed, if `*.*` had been used, the creation of the initial\
-NoSQL user would have failed with an error. Here, the user is created\
-in the same database that the user is given access to, but it could\
-have been another one. Further, several `GRANT` statements could have\
+NoSQL user would have failed with an error. Here, the user is created
+in the same database that the user is given access to, but it could
+have been another one. Further, several `GRANT` statements could have
 been used, had we wanted to give access to several databases.
 
 Thereafter, we specify the following in the configuration file,
@@ -663,16 +663,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'test.test_user'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -682,9 +682,9 @@ $ mongo --quiet --port 17017 -u test_user -p test_password test
 >
 ```
 
-Note that when connecting the user is passed as `test_user` and _not_\
-as `test.test_user`. The fact that we want to authenticate against\
-the `test` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `test_user` and _not_
+as `test.test_user`. The fact that we want to authenticate against
+the `test` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -711,44 +711,44 @@ argument.
 }
 ```
 
-As can be seen, the user has the `readWrite` role on the `test` database,\
+As can be seen, the user has the `readWrite` role on the `test` database,
 which means that only the `test` database can be accessed and modified.
 
 #### TLS/SSL
 
-Since `nosqlprotocol` is a regular protocol module used in a listener,\
-the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](https://mariadb.com/kb/en/Getting-Started/Configuration-Guide#tsl-encryption)\
+Since `nosqlprotocol` is a regular protocol module used in a listener,
+the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](https://mariadb.com/kb/en/Getting-Started/Configuration-Guide#tsl-encryption)
 for details.
 
 ### NoSQL Account Database
 
-So as to be able to connect to the MariaDB server on behalf of\
-clients, nosqlprotocol must know their password. As the password\
-is not transferred to nosqlprotocol during the authentication in\
-a way that could be used when logging into MariaDB, the password\
-must be stored when the user is created with [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser)\
+So as to be able to connect to the MariaDB server on behalf of
+clients, nosqlprotocol must know their password. As the password
+is not transferred to nosqlprotocol during the authentication in
+a way that could be used when logging into MariaDB, the password
+must be stored when the user is created with [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser)
 or added with [mxsAddUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsAddUser).
 
-Note that the password is not stored in cleartext but as three\
-different hashes; hashed with sha1 for use with MariaDB, salted\
-and hashed with sha1 for use with the `SCRAM-SHA-1` authentication\
-mechanism (if that is enabled for the user) and salted and hashed\
-with sha256 for use with the `SCRAM-SHA-256` authentication mechanism\
+Note that the password is not stored in cleartext but as three
+different hashes; hashed with sha1 for use with MariaDB, salted
+and hashed with sha1 for use with the `SCRAM-SHA-1` authentication
+mechanism (if that is enabled for the user) and salted and hashed
+with sha256 for use with the `SCRAM-SHA-256` authentication mechanism
 (if that is enabled for the user).
 
-The account information can be stored _privately_, in which case it\
-can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can\
-share the information and a user created/added on one instance\
+The account information can be stored _privately_, in which case it
+can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can
+share the information and a user created/added on one instance
 can be used on another.
 
 #### Private
 
-In the private case, the account information of nosqlprotocol is\
-stored in an [sqlite3](https://sqlite.org/index.html) database\
-whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,\
-where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the\
-listener section in the MaxScale configuration file, and `-v1`\
-a suffix for making schema evolution easier, should there be\
+In the private case, the account information of nosqlprotocol is
+stored in an [sqlite3](https://sqlite.org/index.html) database
+whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,
+where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the
+listener section in the MaxScale configuration file, and `-v1`
+a suffix for making schema evolution easier, should there be
 a need for that.
 
 For instance, given a configuration like
@@ -763,41 +763,41 @@ protocol=nosqlprotocol
 
 the account information will be stored in the file`<libdir>/nosqlprotocol/NoSQL-Listener-v1.db`.
 
-Note that since the database name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the database name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
-To retain the accounts, the database file should also be\
+To retain the accounts, the database file should also be
 renamed.
 
-At first startup, the `nosqlprotocol` directory and\
-the file `NoSQL-Listener-v1.db` will be created. They will\
-be created with file permissions that only allow MaxScale\
-access. At subsequent startups the permissions will be checked\
-and MaxScale will refuse to start if the permissions allow\
+At first startup, the `nosqlprotocol` directory and
+the file `NoSQL-Listener-v1.db` will be created. They will
+be created with file permissions that only allow MaxScale
+access. At subsequent startups the permissions will be checked
+and MaxScale will refuse to start if the permissions allow
 access to others.
 
 **We strongly recommend that no manual modifications are made**\
 **to the database.**
 
-Note that we make **no** guarantees that the way in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the way in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ### Shared
 
-In the shared case, the account information of nosqlprotocol\
+In the shared case, the account information of nosqlprotocol
 is stored in the cluster of the service in front of which the\
-NoSQL listener resides. The primary of the cluster will be used\
+NoSQL listener resides. The primary of the cluster will be used
 both for reading and writing data.
 
 A table whose name is the same as the listener's name in the\
-MaxScale configuration will be created in the database\
-specified with the [authentication\_db](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_db)\
-parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of\
+MaxScale configuration will be created in the database
+specified with the [authentication\_db](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_db)
+parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of
 the listener section in the MaxScale configuration file.
 
 For instance, given a configuration like
@@ -812,61 +812,61 @@ protocol=nosqlprotocol
 
 the account information will be stored in the table`nosqlprotocol.NoSQL-Listener`.
 
-Note that since the table name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the table name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
 To retain the accounts, the table should also be renamed.
 
-`nosqlprotocol` will create the table when needed, so the\
-user specified with [authentication\_user](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_user)\
+`nosqlprotocol` will create the table when needed, so the
+user specified with [authentication\_user](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_user)
 must have sufficient grants to be able to do that.
 
-`nosqlprotocol` will store in the table, data that allow\
-any MaxScale to authenticate a MongoDB® client, irrespective\
+`nosqlprotocol` will store in the table, data that allow
+any MaxScale to authenticate a MongoDB® client, irrespective
 of which MaxScale instance was used when the user was created.
 
-`nosqlprotocol` also stores in the table the SHA1 of a user's\
+`nosqlprotocol` also stores in the table the SHA1 of a user's
 password, to be able to authenticate against the MariaDB server.\
-Therefore it is **strongly** suggested to enable encryption key\
-management in MaxScale and to provide an authentication\
-key ID with [authentication\_key\_id](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_key_id) so\
+Therefore it is **strongly** suggested to enable encryption key
+management in MaxScale and to provide an authentication
+key ID with [authentication\_key\_id](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_key_id) so
 that the data will be encrypted.
 
-If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_password) must also\
-be provided. With [authentication\_db](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_db) the\
-database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_key_id) an\
-encryption key ID, using which the sensitive data is encrypted,\
+If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_password) must also
+be provided. With [authentication\_db](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_db) the
+database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2302-nosql-protocol-module.md#authentication_key_id) an
+encryption key ID, using which the sensitive data is encrypted,
 can optionally be provided.
 
-Note that we make **no** guarantees that the table in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the table in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ## Wire Protocol
 
-_Nosqlprotocol_ fully supports wire protocol version 6 and only provides\
-rudimentary support for earlier wire protocol versions, but reports at\
-startup that it would support versions 0 to 6. The reason is that some\
-client libraries are buggy and use an old wire protocol version if the\
-server claims to support only version 6. Consequently, one should use a\
+_Nosqlprotocol_ fully supports wire protocol version 6 and only provides
+rudimentary support for earlier wire protocol versions, but reports at
+startup that it would support versions 0 to 6. The reason is that some
+client libraries are buggy and use an old wire protocol version if the
+server claims to support only version 6. Consequently, one should use a
 client library version that at least supports wire protocol version 6.
 
 ## Client Library
 
-As the goal of _nosqlprotocol_ is to implement, to the extent that it\
-is feasible, the wire protocol and the database commands the way MongoDB®\
+As the goal of _nosqlprotocol_ is to implement, to the extent that it
+is feasible, the wire protocol and the database commands the way MongoDB®
 implements them, it should be possible to use any language specific driver.
 
-However, during the development of _nosqlprotocol_, the _only_ client library\
+However, during the development of _nosqlprotocol_, the _only_ client library
 that has been verified to work is version 3.6 of _MongoDB Node.JS Driver_.
 
 ## Parameters
 
-Using the following parameters, the behavior of _nosqlprotocol_ can be\
+Using the following parameters, the behavior of _nosqlprotocol_ can be
 adjusted. As they are not generic listener parameters, but specific to _nosqlprotocol_ they must be qualified with the `nosqlprotocol`-prefix.
 
 For instance:
@@ -888,7 +888,7 @@ nosqlprotocol.on_unknown_command=return_error
 * Mandatory: No
 * Default: `""`
 
-Specifies the _user_ to be used when connecting to the backend, if the MongoDB®\
+Specifies the _user_ to be used when connecting to the backend, if the MongoDB®
 client is not authenticated.
 
 ### `password`
@@ -897,8 +897,8 @@ client is not authenticated.
 * Mandatory: No
 * Default: `""`
 
-Specifies the _password_ to be used when connecting to the backend, is the MongoDB®\
-client is not authenticated. Note that the same _user_/_password_ combination will be\
+Specifies the _password_ to be used when connecting to the backend, is the MongoDB®
+client is not authenticated. Note that the same _user_/_password_ combination will be
 used for all unauthenticated MongoDB® clients connecting to the same listener port.
 
 ### `authentication_required`
@@ -907,11 +907,11 @@ used for all unauthenticated MongoDB® clients connecting to the same listener p
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the client always must authenticate. If authentication is required,\
-it does not matter whether `user` and `password` have been specified, the client must\
+Specifies whether the client always must authenticate. If authentication is required,
+it does not matter whether `user` and `password` have been specified, the client must
 authenticate.
 
-Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsAddUser),\
+Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsAddUser),
 with authentication being optional and authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -923,7 +923,7 @@ MariaDB server.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the NoSQL account information should be stored in a shared\
+Specifies whether the NoSQL account information should be stored in a shared
 manner or privately.
 
 ### `authentication_db`
@@ -932,10 +932,10 @@ manner or privately.
 * Mandatory: No
 * Default: `"NoSQL"`
 
-Specifies the database of the table where the NoSQL account information\
-is stored, if `authentication_shared` is `true`. If the database does not\
-exist, nosqlprotocol will attempt to create it, so either is should be\
-manually created or the used specified with `authentication_user` should\
+Specifies the database of the table where the NoSQL account information
+is stored, if `authentication_shared` is `true`. If the database does not
+exist, nosqlprotocol will attempt to create it, so either is should be
+manually created or the used specified with `authentication_user` should
 have the grants required to do so.
 
 ### `authentication_key_id`
@@ -944,11 +944,11 @@ have the grants required to do so.
 * Mandatory: No
 * Default: `""`
 
-The encryption key ID, using which the NoSQL account information should be\
-encrypted with when stored in the MariaDB server. If an encryption key ID is\
+The encryption key ID, using which the NoSQL account information should be
+encrypted with when stored in the MariaDB server. If an encryption key ID is
 given, the encryption key manager in MaxScale must also be enabled.
 
-The encryption key must be a 256-bit key. Keys of shorter length are rejected\
+The encryption key must be a 256-bit key. Keys of shorter length are rejected
 as invalid encryption keys.
 
 ### `authentication_user`
@@ -956,7 +956,7 @@ as invalid encryption keys.
 * Type: string
 * Mandatory: Yes, if `authentication_shared` is true.
 
-Specifies the _user_ to be used when modifying and accessing the NoSQL\
+Specifies the _user_ to be used when modifying and accessing the NoSQL
 account information stored in the MariaDB server.
 
 ### `authentication_password`
@@ -973,9 +973,9 @@ Specifies the _password_ of `authentication_user`.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether nosqlprotocol itself should perform authorization in the context\
-of the commands [mxsAddUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users\
-have been created with [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsAddUser)\
+Specifies whether nosqlprotocol itself should perform authorization in the context
+of the commands [mxsAddUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users
+have been created with [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2302-nosql-protocol-module.md#mxsAddUser)
 with authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -988,8 +988,8 @@ MariaDB server.
 * Default: `"%"`
 
 Specifies the _host_ to be used when a MariaDB user is created via nosqlprotocol.\
-By default all users are created as `...@'%'`, which means that it is possible to\
-connect to the MariaDB server from any host using the credentials of the created\
+By default all users are created as `...@'%'`, which means that it is possible to
+connect to the MariaDB server from any host using the credentials of the created
 user. For tighter security, the IP-address of the MaxScale host can be specified.
 
 NOTE: This value does **not** specify from which host it is allowed to connect to\
@@ -1015,8 +1015,8 @@ Enumeration values:
 * Mandatory: No
 * Default: `false`
 
-Specifies whether an unknown command should be logged. This is primarily\
-for debugging purposes, to find out whether a client uses a command that\
+Specifies whether an unknown command should be logged. This is primarily
+for debugging purposes, to find out whether a client uses a command that
 currently is not supported.
 
 ### `auto_create_databases`
@@ -1038,7 +1038,7 @@ Note that setting this parameter to `true`, without also setting`auto_create_tab
 Specifies whether tables should automatically be created, as needed.
 
 Note that this applies only if the relevant database already exists.\
-If a database should also be created if needed, then `auto_create_databases`\
+If a database should also be created if needed, then `auto_create_databases`
 must also be set to `true`.
 
 ### `id_length`
@@ -1059,16 +1059,16 @@ Specifies the length of the id column in tables that are automatically created.
 
 Enumeration values:
 
-* `default`: Each document is inserted using a separate `INSERT`, either in a\
-  multi-statement or in a compound statement. Whether an error causes the remaining\
-  insertions to be aborted, depends on the value of `ordered` specified in the\
+* `default`: Each document is inserted using a separate `INSERT`, either in a
+  multi-statement or in a compound statement. Whether an error causes the remaining
+  insertions to be aborted, depends on the value of `ordered` specified in the
   insert command.
-* `atomic`: If the value of `ordered` in the insert command is `true`\
-  (the default) then all documents are inserted using a single `INSERT` statement,\
-  that is, either all insertions succeed or none will. If `ordered` is false, then\
+* `atomic`: If the value of `ordered` in the insert command is `true`
+  (the default) then all documents are inserted using a single `INSERT` statement,
+  that is, either all insertions succeed or none will. If `ordered` is false, then
   the behavior is as in the `default` case.
 
-What combination of `ordered_insert_behavior` and `ordered` (in the insert command\
+What combination of `ordered_insert_behavior` and `ordered` (in the insert command
 document) is used, has an impact on the performance. Please see the discussion at [insert](mariadb-maxscale-2302-nosql-protocol-module.md#insert).
 
 ### `cursor_timeout`
@@ -1077,7 +1077,7 @@ document) is used, has an impact on the performance. Please see the discussion a
 * Mandatory: No
 * Default: `60s`
 
-Specifies how long a cursor can be idle, that is, not accessed, before it is\
+Specifies how long a cursor can be idle, that is, not accessed, before it is
 automatically closed.
 
 ### `debug`
@@ -1102,21 +1102,21 @@ So, specify
 nosqlprotocol.debug=in,out,back
 ```
 
-to have the incoming command, the corresponding SQL sent to the backend\
+to have the incoming command, the corresponding SQL sent to the backend
 and the resulting response sent to the client logged.
 
 ## Databases and Tables
 
 By default, _nosqlprotocol_ automatically creates databases as needed.\
-The default behavior can be changed by setting `auto_create_databases` to\
+The default behavior can be changed by setting `auto_create_databases` to
 false. In that case, databases must manually be created.
 
 Each MongoDB® _collection_ corresponds to a MariaDB table with the same name.\
-However, it is always possible to access a collection irrespective of whether\
+However, it is always possible to access a collection irrespective of whether
 the corresponding table exists or not; it will simply appear to be empty.
 
-Inserting documents into a collection, whose corresponding table does not\
-exist, succeeds, provided `auto_create_tables` is `true`, as the table will\
+Inserting documents into a collection, whose corresponding table does not
+exist, succeeds, provided `auto_create_tables` is `true`, as the table will
 in that case be created.
 
 When _nosqlprotocol_ creates a table, it uses a statement like
@@ -1127,19 +1127,19 @@ CREATE TABLE name (id VARCHAR(35) AS (JSON_COMPACT(JSON_EXTRACT(doc, "$._id"))) 
                    CONSTRAINT id_not_null CHECK(id IS NOT NULL));
 ```
 
-where the length of the `VARCHAR` is specified by the value of `id_length`,\
+where the length of the `VARCHAR` is specified by the value of `id_length`,
 whose default and minimum is 35.
 
-_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain\
+_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain
 a similar constraint.
 
-Note that _nosqlprotocol_ does not in any way verify that the table\
-corresponding to a collection being accessed or modified does indeed\
-have the expected columns `id` and `doc` of the expected types, but it\
-simply uses the table, which will fail if the layout is not the expected\
+Note that _nosqlprotocol_ does not in any way verify that the table
+corresponding to a collection being accessed or modified does indeed
+have the expected columns `id` and `doc` of the expected types, but it
+simply uses the table, which will fail if the layout is not the expected
 one.
 
-To reduce the risk for confusion, the recommendation is to use a specific\
+To reduce the risk for confusion, the recommendation is to use a specific
 database for tables that contain documents.
 
 ## Operators
@@ -1175,7 +1175,7 @@ The following operators are currently supported.
 
 **`$type`**
 
-When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset\
+When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset
 of types can be used in `$type` queries:
 
 | Type           | Number | Alias    | MariaDB Type |
@@ -1222,10 +1222,10 @@ As arguments, only the operators `$eq` and `$ne` are supported.
 
 ## Database Commands
 
-The following commands are supported. At each command is specified\
+The following commands are supported. At each command is specified
 what fields are relevant for the command.
 
-**All** non-listed fields are ignored; their presence or absence have no\
+**All** non-listed fields are ignored; their presence or absence have no
 impact, unless otherwise explicitly specified.
 
 ### Aggregation Commands
@@ -1296,7 +1296,7 @@ The `projection` parameter takes a document of the following form:
 { <field1>: <value>, <field2>: <value> ... }
 ```
 
-If a `projection` document is not provided or if it is empty, the entire document\
+If a `projection` document is not provided or if it is empty, the entire document
 will be returned.
 
 | Projection     | Description                         |
@@ -1310,23 +1310,23 @@ For fields in an embedded documents, the field can be specified using:
 
 * dot notation; e.g. `"field.nestedfield": <value>`
 
-In particular, specifying fields in embedded documents using nested form\
+In particular, specifying fields in embedded documents using nested form
 is not supported.
 
 **`_id` Field Projection**
 
-The `_id` field is included in the returned documents by default unless you\
+The `_id` field is included in the returned documents by default unless you
 explicitly specify `_id: 0` in the projection to suppress the field.
 
 **Inclusion or Exclusion**
 
-A `projection` cannot contain both include and exclude specifications,\
+A `projection` cannot contain both include and exclude specifications,
 with the exception of the `_id` field:
 
 * In projections that explicitly include fields, the `_id` field is the only field that can be explicitly excluded.
 * In projections that explicitly excludes fields, the `_id` field is the only field that can be explicitly include; however, the `_id` field is included by default.
 
-_NOTE_ Currently `_id` is the only field that can be excluded, and _only_\
+_NOTE_ Currently `_id` is the only field that can be excluded, and _only_
 if other fields are explicitly included._NOTE_ Currently exclusion of other fields but `_id` is not supported.
 
 **Filtering by `_id`**
@@ -1355,7 +1355,7 @@ and in the latter
 ... WHERE (JSON_EXTRACT(doc, '$._id') = 4711)
 ```
 
-That is, in the former case the _indexed_ column `id` will be used, in the\
+That is, in the former case the _indexed_ column `id` will be used, in the
 latter it will not.
 
 #### findAndModify
@@ -1395,9 +1395,9 @@ The following fields are relevant.
 
 #### insert
 
-The `insert` command inserts one or more documents into the table whose\
-name is the same as that of the collection. If the option `auto_create_tables`\
-is `true`, then the table is created if it does not already exist. If the\
+The `insert` command inserts one or more documents into the table whose
+name is the same as that of the collection. If the option `auto_create_tables`
+is `true`, then the table is created if it does not already exist. If the
 value is `false`, then the insert will fail unless the table already exists.
 
 The following fields are relevant.
@@ -1414,9 +1414,9 @@ The impact of `ordered` is dependent upon the value of `ordered_insert_behavior`
 
 **`default`**
 
-In this case `ordered` has the same impact as in MongoDB®. That is, if the value\
-is `true`, then when an insert of a document fails, return without inserting any\
-remaining documents listed in the inserts array. If `false`, then when an insert\
+In this case `ordered` has the same impact as in MongoDB®. That is, if the value
+is `true`, then when an insert of a document fails, return without inserting any
+remaining documents listed in the inserts array. If `false`, then when an insert
 of a document fails, continue to insert the remaining documents.
 
 **`atomic`**
@@ -1428,7 +1428,7 @@ then the behavior is identical with that of `default`.
 
 **Performance**
 
-What combination of `ordered_insert_behavior` and `ordered` is used, has an\
+What combination of `ordered_insert_behavior` and `ordered` is used, has an
 impact on the performance.
 
 | ordered\_insert\_behavior | ordered = true                                                                                                                        | ordered = false                                                                                                                        |
@@ -1436,8 +1436,8 @@ impact on the performance.
 | default                   | All documents are inserted within a compound statement, in a transaction containing as many INSERT statements as there are documents. | All documents are inserted in a single multi-statement transaction containing as many INSERT IGNORE statements as there are documents. |
 | atomic                    | All documents are inserted using a single INSERT statement.                                                                           | Same as above                                                                                                                          |
 
-Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,\
-being roughly twice as slow. The performance of 'default + true' is halfway between\
+Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,
+being roughly twice as slow. The performance of 'default + true' is halfway between
 the two.
 
 #### resetError
@@ -1470,10 +1470,10 @@ Each document contains the following fields:
 | u     | document | The modifications to apply. See behavior below for details.                                                                                                        |
 | multi | boolean  | Optional. If true, updates all documents that meet the query criteria. If false limit the update to one document that meets the query criteria. Defaults to false. |
 
-Note that currently it is possible to set `multi` to `true` in conjunction\
+Note that currently it is possible to set `multi` to `true` in conjunction
 with a _replacement-style_ update, even though MongoDB® rejects that.
 
-All other fields are ignored, with the exception of `upsert` that if present\
+All other fields are ignored, with the exception of `upsert` that if present
 with the value of `true` will cause the command to fail.
 
 **Behavior**
@@ -1499,7 +1499,7 @@ In this case, the update command updates only the corresponding fields in the do
 
 **Update with a Replacement Document**
 
-The update statement field `u` field can accept a _replacement document_,\
+The update statement field `u` field can accept a _replacement document_,
 i.e. the document contains only `field:value` expressions. For example:
 
 ```
@@ -1514,12 +1514,12 @@ updates: [
 ```
 
 In this case, the update command replaces the matching document with the update document.\
-The update command can only replace a single matching document; i.e. the multi field\
+The update command can only replace a single matching document; i.e. the multi field
 cannot be true.
 
-**Note** If the replacement document contains an `_id` field, it will be ignored and the\
-document id will remain non-changed while the document otherwise is replaced. This is\
-different from MongoDB® where the presence of the `_id` field in the replacement document\
+**Note** If the replacement document contains an `_id` field, it will be ignored and the
+document id will remain non-changed while the document otherwise is replaced. This is
+different from MongoDB® where the presence of the `_id` field in the replacement document
 causes an error, if the value is not the same as it is in the document being replaced.
 
 ### Authentication Commands
@@ -1534,7 +1534,7 @@ The following fields are relevant.
 
 If you are not logged in and using authentication, `logout` has no effect.
 
-Note that in order to be logged out, the logging out must be done while\
+Note that in order to be logged out, the logging out must be done while
 using the same database that was used when you logged on.
 
 Always returns
@@ -1547,7 +1547,7 @@ Always returns
 
 #### createUser
 
-Creates a new MariaDB user and adds an entry to the local nosqlprotocol\
+Creates a new MariaDB user and adds an entry to the local nosqlprotocol
 account database.
 
 The following fields are relevant.
@@ -1561,8 +1561,8 @@ The following fields are relevant.
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is\
-the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the\
+The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is
+the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the
 following command
 
 ```
@@ -1572,19 +1572,19 @@ following command
 
 the MariaDB user `'myDatabase.user1'@'%'` will be created.
 
-The elements of the `roles` array are converted into privileges\
+The elements of the `roles` array are converted into privileges
 as explained in [here](mariadb-maxscale-2302-nosql-protocol-module.md#roles_and_privileges).
 
 In practice the creation is performed as follows:_First the MariaDB user is created._ Then the privileges are granted.
 
 * Finally the local nosqlprotocol account database is updated.
 
-If the granting of privileges fails, an attempt will be made to\
+If the granting of privileges fails, an attempt will be made to
 drop the user.
 
 #### dropAllUsersFromDatabase
 
-Drops all users from the local nosqlprotocol account database and\
+Drops all users from the local nosqlprotocol account database and
 the corresponding MariaDB users.
 
 The following fields are relevant.
@@ -1606,13 +1606,13 @@ The following fields are relevant.
 | -------- | ------ | ----------------------------------- |
 | dropUser | string | The name of the user to be dropped. |
 
-The user will first be dropped from the MariaDB server and if\
+The user will first be dropped from the MariaDB server and if
 that succeeds also from the local nosqlprotocol account database.
 
 #### grantRolesToUser
 
-This command _adds_ more roles to a NoSQL user, which may imply\
-that additional privileges are granted to the corresponding MariaDB\
+This command _adds_ more roles to a NoSQL user, which may imply
+that additional privileges are granted to the corresponding MariaDB
 user.
 
 | Field            | Type   | Description                                    |
@@ -1621,12 +1621,12 @@ user.
 | roles            | array  | An array of additional roles.                  |
 
 Note that roles assigned to different databases will result in separate\
-GRANT statements, which means that it is possible that some succeed and\
+GRANT statements, which means that it is possible that some succeed and
 others do not.
 
 #### revokeRolesFromUser
 
-This command _removes_ roles from an NoSQL user, which may imply\
+This command _removes_ roles from an NoSQL user, which may imply
 that privileges are revoked from the corresponding MariaDB user.
 
 | Field               | Type   | Description                                |
@@ -1634,8 +1634,8 @@ that privileges are revoked from the corresponding MariaDB user.
 | revokeRolesFromUser | string | The name of the user to remove roles from. |
 | roles               | array  | An array of roles to remove.               |
 
-Note that roles to be removed from different databases will result in\
-separate REVOKE statements, which means that it is possible that some\
+Note that roles to be removed from different databases will result in
+separate REVOKE statements, which means that it is possible that some
 succeed and others do not.
 
 #### updateUser
@@ -1650,8 +1650,8 @@ This command updates the information about a particular user.
 | roles      | array    | Optional. The roles granted to the user. Note that the existing ones are replaced and not amended with these roles.                                                                                                                                                |
 | mechanisms | array    | Optional. The specific SCRAM mechanisms for user credentials. Note that if a new pwd is provided, then the array can contain all supported SCRAM mechanisms. If a new pwd is not provided, then the array must be a subset of the existing mechanisms of the user. |
 
-Changes to `customData` or `mechanisism` are made only to the local\
-nosqlprotocol database, but changes to `pwd` or `roles` require\
+Changes to `customData` or `mechanisism` are made only to the local
+nosqlprotocol database, but changes to `pwd` or `roles` require
 the MariaDB server to be updated.
 
 #### usersInfo
@@ -1675,11 +1675,11 @@ The returned information depends the value of `usersInfo`:
 | { usersInfo: \[{ user: , db: }, ...]} | Returns information about specified users.                                          |
 | { usersInfo: \[ , ... ]}              | Returns information about specified users in the database where the command is run. |
 
-Note that users may always view their own information. Otherwise the user must\
+Note that users may always view their own information. Otherwise the user must
 have the `userAdmin` or `userAdminAnyDatabase` role.
 
 If `showCredentials` is true, the returned object(s) will contain a`mariadb: { password: "*..."}` field, where `password` is the`SHA1(SHA1())` value of the password used when logging to MariaDB.\
-That is, the same string that is found in the `password` column in\
+That is, the same string that is found in the `password` column in
 the `mysql.user` table.
 
 ### Replication Commands
@@ -1741,8 +1741,8 @@ The following fields are relevant.
 | capped | boolean | Optional. If specified, the value must be false as capped collections are not supported. |
 | viewOn | string  | Optional. If specified, the command will fail as views are not supported.                |
 
-Currently, _capped collections_ and _views_ are not supported. Consequently,\
-specifying that the collection should be capped or that it should be a\
+Currently, _capped collections_ and _views_ are not supported. Consequently,
+specifying that the collection should be capped or that it should be a
 view on another collection, will cause the command to fail.
 
 #### createIndexes
@@ -1753,9 +1753,9 @@ The following fields are relevant.
 | ------------- | ------ | ------------------------------------------- |
 | createIndexes | string | The collection for which to create indexes. |
 
-**NOTE** Currently it is not possible to create indexes, but the command\
-will nonetheless return success, provide the index specification passes\
-some rudimentary sanity checks. Note also that the collection will be\
+**NOTE** Currently it is not possible to create indexes, but the command
+will nonetheless return success, provide the index specification passes
+some rudimentary sanity checks. Note also that the collection will be
 created if it does not exist.
 
 #### drop
@@ -1782,9 +1782,9 @@ The following fields are relevant.
 | ----------- | ---- | ----------- |
 | dropIndexes | any  | Ignored.    |
 
-**NOTE** Currently it is not possible to create indexes and thus there\
-will never be any indexes that could be dropped. However, provided the\
-specified collection exists, dropping indexes will always succeed except\
+**NOTE** Currently it is not possible to create indexes and thus there
+will never be any indexes that could be dropped. However, provided the
+specified collection exists, dropping indexes will always succeed except
 for an attempt to drop the built-in `_id_` index.
 
 #### fsync
@@ -1825,8 +1825,8 @@ The following fields are relevant.
 | filter          | document | The field name is honored, other fields are not but cause warnings to be logged.                                                                 |
 | nameOnly        | boolean  | Optional. A flag to indicate whether the command should return just the collection names and type or return both the name and other information. |
 
-Note that the command lists all collections (that is, tables) that are found\
-in the current database. The listed collections may or may not be suitable\
+Note that the command lists all collections (that is, tables) that are found
+in the current database. The listed collections may or may not be suitable
 for being accessed using _nosqlprotocol_.
 
 #### listDatabases
@@ -1846,9 +1846,9 @@ The following fields are relevant.
 | ----------- | ------ | --------------------------- |
 | listIndexes | string | The name of the collection. |
 
-**NOTE** As it currently is not possible to actually create indexes,\
-although an attempt to do so using `createIndexes` will succeed, the\
-result will always only contain information about the built-in\
+**NOTE** As it currently is not possible to actually create indexes,
+although an attempt to do so using `createIndexes` will succeed, the
+result will always only contain information about the built-in
 index `_id_`.
 
 #### renameCollection
@@ -1956,8 +1956,8 @@ The following fields are relevant.
 | -------- | ------ | --------------------------------------- |
 | validate | string | The name of the collection to validate. |
 
-The command does not actually perform any validation but for checking\
-that the collection exists. The response will contain in `nrecords`\
+The command does not actually perform any validation but for checking
+that the collection exists. The response will contain in `nrecords`
 the current number of documents/rows it contains.
 
 #### whatsmyuri
@@ -1994,11 +1994,11 @@ The following document will always be returned:
 
 **mxsAddUser**
 
-The `mxsAddUser` command adds an _existing_ MariaDB user to the local\
+The `mxsAddUser` command adds an _existing_ MariaDB user to the local
 nosqlprotocol account database. Use [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createUser) if the\
 MariaDB user should be created as well.
 
-Note that the `mxsAddUser` command does not check that the user exists\
+Note that the `mxsAddUser` command does not check that the user exists
 or that the specified roles are compatible with the grants of the user.
 
 **Syntax**
@@ -2034,17 +2034,17 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The value of `mxsAddUser` should be the name (without the host part) of\
-an existing user in the MariaDB server and the value of `pwd` should be\
+The value of `mxsAddUser` should be the name (without the host part) of
+an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2302-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2302-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the addition of the user succeeds, the command returns a document\
+If the addition of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2070,7 +2070,7 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsCreateDatabase**
 
-The 'mxsCreateDatabase' command creates a new database and must be run\
+The 'mxsCreateDatabase' command creates a new database and must be run
 against the `admin` database.
 
 **Syntax**
@@ -2095,7 +2095,7 @@ The command takes the following fields:
 
 **Returns**
 
-If database creation succeeds, the command returns a document with the\
+If database creation succeeds, the command returns a document with the
 single field `ok` whose value is `1`.
 
 ```
@@ -2146,7 +2146,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains diagnostics of the command\
+The command returns a document that contains diagnostics of the command
 provided as argument. For example:
 
 ```
@@ -2171,19 +2171,19 @@ provided as argument. For example:
 }
 ```
 
-`kind` specifies of what kind the command is; an _immediate_ command is one for\
-which MaxScale autonomously can generate the response, a _single_ command is one\
-where the command will cause a single SQL statement to be sent to the backend, and\
-a _multi_ command is one where potentially multiple SQL statements will be sent to\
+`kind` specifies of what kind the command is; an _immediate_ command is one for
+which MaxScale autonomously can generate the response, a _single_ command is one
+where the command will cause a single SQL statement to be sent to the backend, and
+a _multi_ command is one where potentially multiple SQL statements will be sent to
 the backend.
 
-If the command is _immediate_ then there will be a field `response` containing\
-the actual response of the command, if the command is _single_ then there will be\
-a field `sql` containing the actual statement that would have been sent to the backend,\
-and if the command is _multi_ then there will be a field `sql` containing an array\
+If the command is _immediate_ then there will be a field `response` containing
+the actual response of the command, if the command is _single_ then there will be
+a field `sql` containing the actual statement that would have been sent to the backend,
+and if the command is _multi_ then there will be a field `sql` containing an array
 of statements that would have been sent to the backend.
 
-If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that\
+If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that
 the value of `ok` will always be 1.
 
 #### mxsGetConfig
@@ -2192,7 +2192,7 @@ the value of `ok` will always be 1.
 
 **mxsGetConfig**
 
-The `mxsGetConfig` command returns the current configuration of the session\
+The `mxsGetConfig` command returns the current configuration of the session
 and must be run against the 'admin' database.
 
 **Syntax**
@@ -2216,7 +2216,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the current configuration of\
+The command returns a document that contains the current configuration of
 the session. For example:
 
 ```
@@ -2238,8 +2238,8 @@ the session. For example:
 
 **mxsRemoveUser**
 
-The `mxsRemoveUser` removes a user from the local nosqlprotocol account\
-database. Use [dropUser](mariadb-maxscale-2302-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped\
+The `mxsRemoveUser` removes a user from the local nosqlprotocol account
+database. Use [dropUser](mariadb-maxscale-2302-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped
 as well.
 
 **Syntax**
@@ -2264,7 +2264,7 @@ The command has the following fields:
 
 **Returns**
 
-If the removal of the user succeeds, the command returns a document\
+If the removal of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2290,10 +2290,10 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsSetConfig**
 
-The `mxsSetConfig` command changes the configuration of the session\
+The `mxsSetConfig` command changes the configuration of the session
 and must be run against the 'admin' database.
 
-Note that the changes only affect the current session and are **not**\
+Note that the changes only affect the current session and are **not**
 persisted.
 
 **Syntax**
@@ -2325,7 +2325,7 @@ The document takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the changed configuration of\
+The command returns a document that contains the changed configuration of
 the session. For example:
 
 ```
@@ -2357,12 +2357,12 @@ the session. For example:
 
 **mxsUpdateUser**
 
-The `mxsUpdateUser` command updates a user in the local nosqlprotocol\
-account database. Use [updateUser](mariadb-maxscale-2302-nosql-protocol-module.md#updateUser) to update MariaDB user\
+The `mxsUpdateUser` command updates a user in the local nosqlprotocol
+account database. Use [updateUser](mariadb-maxscale-2302-nosql-protocol-module.md#updateUser) to update MariaDB user
 as well.
 
-Note that the `mxsUpdateUser` command does not check that the changed\
-data is compatible e.g. with the grants of the corresponding MariaDB\
+Note that the `mxsUpdateUser` command does not check that the changed
+data is compatible e.g. with the grants of the corresponding MariaDB
 user.
 
 **Syntax**
@@ -2398,13 +2398,13 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. If a new password is not provided, the specified mechanisms must be a subset of the current mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2302-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2302-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the updating of the user succeeds, the command returns a document\
+If the updating of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2426,27 +2426,27 @@ If there is a failure of some kind, the command returns an error document
 
 ## Object Id
 
-When a document is created, an id of type `ObjectId` will be autogenerated by\
-the MongoDB® client library. If the id is provided explicitly, by assigning a\
-value to the `_id` field, the value must be an `ObjectId`, a string or an\
+When a document is created, an id of type `ObjectId` will be autogenerated by
+the MongoDB® client library. If the id is provided explicitly, by assigning a
+value to the `_id` field, the value must be an `ObjectId`, a string or an
 integer.
 
 ## Compatibility
 
-Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)\
+Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)
 test-suite pass.
 
 ## Example
 
-The following is a minimal setup for getting _nosqlprotocol_ up and\
-running. It is assumed the reader knows how to configure MaxScale for\
+The following is a minimal setup for getting _nosqlprotocol_ up and
+running. It is assumed the reader knows how to configure MaxScale for
 normal use. If not, please start with the [MaxScale tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-setting-up-mariadb-maxscale.md).\
-Note that as _nosqlprotocol_ is the first component in the MaxScale\
+Note that as _nosqlprotocol_ is the first component in the MaxScale
 routing chain, it can be used with all routers and filters.
 
 ### Configuring MaxScale
 
-In the following it is assumed that MaxScale already has been configured\
+In the following it is assumed that MaxScale already has been configured
 for normal use and that there exists a _service_ `[TheService]`.
 
 ```
@@ -2463,10 +2463,10 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-The values `the_user` and `the_password` must be replaced with the\
+The values `the_user` and `the_password` must be replaced with the
 actual credentials to be used for every MongoDB® client that connects.
 
-If MaxScale is now started, the following entry should appear in the\
+If MaxScale is now started, the following entry should appear in the
 log file.
 
 ```
@@ -2477,8 +2477,8 @@ log file.
 
 The mongo Shell is a powerful tool with which to access and manipulate a\
 MongoDB database. It is part of the MongoDB® package. Having the native\
-MongoDB database installed is convenient, as it makes it easy to ascertain\
-whether a problem is due to _nosqlprotocol_ not fully implementing something\
+MongoDB database installed is convenient, as it makes it easy to ascertain
+whether a problem is due to _nosqlprotocol_ not fully implementing something
 or due to the API not being used in the correct fashion.
 
 With the _mongo shell_, all that is needed is to invoke it with the port\_nosqlprotocol\_ is listening on:
@@ -2495,7 +2495,7 @@ MongoDB server version: 4.4.1
 >
 ```
 
-If the shell prompt appears, then a connection was successfully\
+If the shell prompt appears, then a connection was successfully
 established and the shell can be used.
 
 ```
@@ -2503,13 +2503,13 @@ established and the shell can be used.
 { "n" : 1, "ok" : 1 }
 ```
 
-The `db` variable is implicitly available, and refers by default to\
+The `db` variable is implicitly available, and refers by default to
 the `test` database.
 
 The command inserted a document into the collection called `collection`.\
-The table corresponding to that collection is created implicitly because\
-the default value of `auto_create_tables` is `true`. Here, the object id\
-is specified explicitly, but there is no need for that, as one will be\
+The table corresponding to that collection is created implicitly because
+the default value of `auto_create_tables` is `true`. Here, the object id
+is specified explicitly, but there is no need for that, as one will be
 created if needed.
 
 To check whether the documents was inserted into the collection, the`find` command can be issued:
@@ -2544,18 +2544,18 @@ MariaDB [(none)]> select * from test.collection;
 +------+------------------------------------+
 ```
 
-The collection `collection` is represented by a table `collection` with\
-the two columns `id` and `doc`. `id` is a virtual column whose content is\
+The collection `collection` is represented by a table `collection` with
+the two columns `id` and `doc`. `id` is a virtual column whose content is
 the value of the `_id` field of the document in the `doc` column.
 
-All MongoDB® commands that _mongdbprotocol_ support (but for the ones that\
-do not require database access), basically access or manipulate the\
+All MongoDB® commands that _mongdbprotocol_ support (but for the ones that
+do not require database access), basically access or manipulate the
 content in the `doc` column using the [JSON functions](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements-and-structure/sql-statements/built-in-functions/special-functions/json-functions) of MariaDB.
 
-From within the mongo shell itself it is easy to find out just what SQL\
+From within the mongo shell itself it is easy to find out just what SQL
 a particular MongoDB command is translated into.
 
-For instance, the SQL that the insert command with which the document was\
+For instance, the SQL that the insert command with which the document was
 added can be found out like:
 
 ```
@@ -2580,18 +2580,18 @@ Similarly, the SQL of the `find` command can be find out like:
 }
 ```
 
-The returned SQL can be directly pasted at the `mysql` prompt, which is\
+The returned SQL can be directly pasted at the `mysql` prompt, which is
 quite convenient in case the MongoDB® command does not behave as expected.
 
 ### MongoDB® Node.JS Driver
 
-As all client libraries implement and depend on the MongoDB® wire protocol,\
-all client libraries should work with _nosqlprotocol_. However, the\
-only client library that has been used and that has been verified to work\
+As all client libraries implement and depend on the MongoDB® wire protocol,
+all client libraries should work with _nosqlprotocol_. However, the
+only client library that has been used and that has been verified to work
 is version 3.6 of the _MongoDB Node.JS Driver_.
 
-In principle, the only thing that needs to be altered in an existing\
-program using the library is to change the uri string that typically\
+In principle, the only thing that needs to be altered in an existing
+program using the library is to change the uri string that typically
 is something like
 
 ```
@@ -2606,8 +2606,8 @@ const uri = "mongodb://<maxscale-ip>:17017";
 
 with the assumption that the default _nosqlprotocol_ port is used.
 
-In practice, additional modifications may be needed since _nosqlprotocol_\
-does not implement all commands and does not in all cases implement the\
+In practice, additional modifications may be needed since _nosqlprotocol_
+does not implement all commands and does not in all cases implement the
 full functionality of the commands that it supports.
 
 #### Inserting a Document

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md
@@ -1,13 +1,13 @@
 # MaxCtrl
 
-MaxCtrl is a command line administrative client for MaxScale which uses\
-the MaxScale REST API for communication. It has replaced the legacy MaxAdmin\
+MaxCtrl is a command line administrative client for MaxScale which uses
+the MaxScale REST API for communication. It has replaced the legacy MaxAdmin
 command line client that is no longer supported or included.
 
-By default, the MaxScale REST API listens on port 8989 on the local host. The\
+By default, the MaxScale REST API listens on port 8989 on the local host. The
 default credentials for the REST API are `admin:mariadb`. The users used by the\
-REST API are the same that are used by the MaxAdmin network interface. This\
-means that any users created for the MaxAdmin network interface should work with\
+REST API are the same that are used by the MaxAdmin network interface. This
+means that any users created for the MaxAdmin network interface should work with
 the MaxScale REST API and MaxCtrl.
 
 For more information about the MaxScale REST API, refer to the [REST API documentation](../mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md) and the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md).
@@ -18,10 +18,10 @@ For more information about the MaxScale REST API, refer to the [REST API documen
 
 ## .maxctrl.cnf
 
-If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the\
-section `[maxctrl]` as defaults for command line arguments. For instance,\
-to avoid having to specify the user and password on the command line,\
-create the file `.maxctrl.cnf` in your home directory, with the following\
+If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the
+section `[maxctrl]` as defaults for command line arguments. For instance,
+to avoid having to specify the user and password on the command line,
+create the file `.maxctrl.cnf` in your home directory, with the following
 content:
 
 ```
@@ -30,11 +30,11 @@ u = my-name
 p = my-password
 ```
 
-Note that all access rights to the file must be removed from everybody else\
-but the owner. MaxCtrl refuses to use the file unless the rights have been\
+Note that all access rights to the file must be removed from everybody else
+but the owner. MaxCtrl refuses to use the file unless the rights have been
 removed.
 
-Another file from which to read the defaults can be specified with the `-c`\
+Another file from which to read the defaults can be specified with the `-c`
 flag.
 
 ## Commands

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-module-commands.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-module-commands.md
@@ -1,16 +1,16 @@
 # Module commands
 
-Introduced in MaxScale 2.1, the module commands are special, module-specific\
+Introduced in MaxScale 2.1, the module commands are special, module-specific
 commands. They allow the modules to expand beyond the capabilities of the module\
 API. Currently, only MaxCtrl implements an interface to the module commands.
 
-All registered module commands can be shown with `maxctrl list commands` and\
+All registered module commands can be shown with `maxctrl list commands` and
 they can be executed with `maxctrl call command <module> <name> ARGS...` whereis the name of the module and is the name of the command._ARGS_ is a command specific list of arguments.
 
 ### Developer reference
 
-The module command API is defined in the _modulecmd.h_ header. It consists of\
-various functions to register and call module commands. Read the function\
+The module command API is defined in the _modulecmd.h_ header. It consists of
+various functions to register and call module commands. Read the function
 documentation in the header for more details.
 
 The following example registers the module command _my\_command_ for module _my\_module_.
@@ -50,11 +50,11 @@ int main(int argc, char **argv)
 }
 ```
 
-The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of\
-arguments the command expects. The first argument is a boolean and the second\
+The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of
+arguments the command expects. The first argument is a boolean and the second
 argument is an optional string.
 
-Arguments are passed to the parsing function as an array of void pointers. They\
+Arguments are passed to the parsing function as an array of void pointers. They
 are interpreted as the types the command expects.
 
 When the module command is executed, the _argv_ parameter for the _my\_simple\_cmd_ contains the parsed arguments received from the caller of the

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-admin-user-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-admin-user-resource.md
@@ -11,7 +11,7 @@ MaxScale's configuration.
 GET /v1/users/inet/:name
 ```
 
-Get a single network user. The _:name_ in the URI must be a valid network\
+Get a single network user. The _:name_ in the URI must be a valid network
 user name.
 
 **Response**
@@ -134,7 +134,7 @@ Get all administrative users.
 POST /v1/users/inet
 ```
 
-Create a new network user. The request body must define at least the\
+Create a new network user. The request body must define at least the
 following fields.
 
 * `data.id`
@@ -146,11 +146,11 @@ following fields.
 * `data.attributes.account`
 * Set to `admin` for administrative users and `basic` to read-only users
 
-Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic\
-account performs one of the aforementioned request, the REST API will respond\
+Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic
+account performs one of the aforementioned request, the REST API will respond
 with a `401 Unauthorized` error.
 
-Here is an example request body defining the network user _my-user_ with the\
+Here is an example request body defining the network user _my-user_ with the
 password _my-password_ that is allowed to execute only read-only operations.
 
 ```
@@ -178,7 +178,7 @@ Status: 204 No Content
 POST /v1/users/unix
 ```
 
-This enables an existing UNIX account on the system for administrative\
+This enables an existing UNIX account on the system for administrative
 operations. The request body must define at least the following fields.
 
 * `data.id`
@@ -242,8 +242,8 @@ Status: 204 No Content
 PATCH /v1/users/inet/:name
 ```
 
-Update network user. Currently, only the password can be updated. This\
-means that the request body must define the `data.attributes.password`\
+Update network user. Currently, only the password can be updated. This
+means that the request body must define the `data.attributes.password`
 field.
 
 Here is an example request body that updates the password.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-filter-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-filter-resource.md
@@ -1,6 +1,6 @@
 # Filter Resource
 
-A filter resource represents an instance of a filter inside MaxScale. Multiple\
+A filter resource represents an instance of a filter inside MaxScale. Multiple
 services can use the same filter and a single service can use multiple filters.
 
 ### Resource Operations
@@ -186,7 +186,7 @@ GET /v1/filters
 POST /v1/filters
 ```
 
-Create a new filter. The posted object must define at\
+Create a new filter. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -198,8 +198,8 @@ least the following fields.
 
 All of the filter parameters should be defined at creation time in the`data.attributes.parameters` object.
 
-As the service to filter relationship is ordered (filters are applied in the\
-order they are listed), filter to service relationships cannot be defined at\
+As the service to filter relationship is ordered (filters are applied in the
+order they are listed), filter to service relationships cannot be defined at
 creation time.
 
 The following example defines a request body which creates a new filter.
@@ -231,8 +231,8 @@ Filter is created:
 PATCH /v1/filters/:name
 ```
 
-Filter parameters can be updated at runtime if the module supports it. Refer to\
-the individual module documentation for more details on whether it supports\
+Filter parameters can be updated at runtime if the module supports it. Refer to
+the individual module documentation for more details on whether it supports
 runtime configuration and which parameters can be updated.
 
 The following example modifies a filter by changing the `match` parameter to`.*users.*`.
@@ -264,10 +264,10 @@ DELETE /v1/filters/:filter
 The _:filter_ in the URI must map to the name of the filter to be destroyed.
 
 A filter can only be destroyed if no service uses it. This means that the`data.relationships` object for the filter must be empty. Note that the service\
-→ filter relationship cannot be modified from the filters resource and must be\
+→ filter relationship cannot be modified from the filters resource and must be
 done via the services resource.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the filter by first removing it from all services that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-listener-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-listener-resource.md
@@ -1,6 +1,6 @@
 # Listener Resource
 
-A listener resource represents a listener of a service in MaxScale. All\
+A listener resource represents a listener of a service in MaxScale. All
 listeners point to a service in MaxScale.
 
 ### Resource Operations
@@ -208,10 +208,10 @@ Creates a new listener. The request body must define the following fields.
 * `data.type`
 * Type of the object, must be `listeners`
 * `data.attributes.parameters.port` OR `data.attributes.parameters.socket`
-* The TCP port or UNIX Domain Socket the listener listens on. Only one of the\
+* The TCP port or UNIX Domain Socket the listener listens on. Only one of the
   fields can be defined.
 * `data.relationships.services.data`
-* The service relationships data, must define a JSON object with an `id` value\
+* The service relationships data, must define a JSON object with an `id` value
   that defines the service to use and a `type` value set to `services`.
 
 The following is the minimal required JSON object for defining a new listener.
@@ -237,7 +237,7 @@ The following is the minimal required JSON object for defining a new listener.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md) for\
+Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md) for
 a full list of listener parameters.
 
 **Response**
@@ -252,15 +252,15 @@ Listener is created:
 PATCH /v1/listeners/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the listener.
 
 All parameters marked as modifiable at runtime can be modified. Currently, all\
-TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters\
+TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters
 can be modified at runtime.
 
-Parameters that affect the network address or the port the listener listens on\
-cannot be modified at runtime. To modify these parameters, recreate the\
+Parameters that affect the network address or the port the listener listens on
+cannot be modified at runtime. To modify these parameters, recreate the
 listener.
 
 **Response**
@@ -275,7 +275,7 @@ Listener is modified:
 DELETE /v1/listeners/:name
 ```
 
-The _:name_ must be a valid listener name. When a listener is destroyed, the\
+The _:name_ must be a valid listener name. When a listener is destroyed, the
 network port it listens on is available for reuse.
 
 **Response**
@@ -294,7 +294,7 @@ Listener cannot be deleted:
 PUT /v1/listeners/:name/stop
 ```
 
-Stops a started listener. When a listener is stopped, new connections are no\
+Stops a started listener. When a listener is stopped, new connections are no
 longer accepted and are queued until the listener is started again.
 
 **Parameters**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-maxscale-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-maxscale-resource.md
@@ -1,6 +1,6 @@
 # MaxScale Resource
 
-The MaxScale resource represents a MaxScale instance and it is the core on top\
+The MaxScale resource represents a MaxScale instance and it is the core on top
 of which the modules build upon.
 
 ### Resource Operations
@@ -11,7 +11,7 @@ of which the modules build upon.
 GET /v1/maxscale
 ```
 
-Retrieve global information about a MaxScale instance. This includes various\
+Retrieve global information about a MaxScale instance. This includes various
 file locations, configuration options and version information.
 
 **Response**
@@ -149,8 +149,8 @@ file locations, configuration options and version information.
 PATCH /v1/maxscale
 ```
 
-Update MaxScale parameters. The request body must define updated values for the`data.attributes.parameters` object. The parameters that can be modified are\
-listed in the `/v1/maxscale/modules/maxscale` endpoint and have the `modifiable`\
+Update MaxScale parameters. The request body must define updated values for the`data.attributes.parameters` object. The parameters that can be modified are
+listed in the `/v1/maxscale/modules/maxscale` endpoint and have the `modifiable`
 value set to `true`.
 
 **Response**
@@ -169,8 +169,8 @@ Invalid JSON body:
 GET /v1/maxscale/threads/:id
 ```
 
-Get the information and statistics of a particular thread. The _:id_ in\
-the URI must map to a valid thread number between 0 and the configured\
+Get the information and statistics of a particular thread. The _:id_ in
+the URI must map to a valid thread number between 0 and the configured
 value of `threads`.
 
 **Response**
@@ -389,15 +389,15 @@ Get the information for all threads. Returns a collection of threads resources.
 GET /v1/maxscale/logs
 ```
 
-Get information about the current state of logging, enabled log files and the\
+Get information about the current state of logging, enabled log files and the
 location where the log files are stored.
 
-**Note:** The parameters in this endpoint are a subset of the parameters in the`/v1/maxscale` endpoint. Because of this, the parameters in this endpoint are\
+**Note:** The parameters in this endpoint are a subset of the parameters in the`/v1/maxscale` endpoint. Because of this, the parameters in this endpoint are
 deprecated as of MaxScale 6.0.
 
-**Note:** In MaxScale 2.5 the `log_throttling` and `ms_timestamp` parameters\
-were incorrectly named as `throttling` and `highprecision`. In MaxScale 6,\
-the parameter names are now correct which means the parameters declared here\
+**Note:** In MaxScale 2.5 the `log_throttling` and `ms_timestamp` parameters
+were incorrectly named as `throttling` and `highprecision`. In MaxScale 6,
+the parameter names are now correct which means the parameters declared here
 aren't fully backwards compatible.
 
 **Response**
@@ -447,11 +447,11 @@ GET /v1/maxscale/logs/data
 
 Get the contents of the MaxScale logs. This endpoint was added in MaxScale 6.
 
-To navigate the log, use the `prev` link to move backwards to older log\
+To navigate the log, use the `prev` link to move backwards to older log
 entries. The latest log entries can be read with the `last` link.
 
-The entries are sorted in ascending order by the time they were logged. This\
-means that with the default parameters, the latest logged event is the last\
+The entries are sorted in ascending order by the time they were logged. This
+means that with the default parameters, the latest logged event is the last
 element in the returned array.
 
 **Parameters**
@@ -459,19 +459,19 @@ element in the returned array.
 This endpoint supports the following parameters:
 
 * `page[size]`
-* Set number of rows of data to read. By default, 50 rows of data are read\
+* Set number of rows of data to read. By default, 50 rows of data are read
   from the log.
 * `page[cursor]`
-* Set position from where the log data is retrieved. The default position to\
+* Set position from where the log data is retrieved. The default position to
   retrieve the log data is the end of the log.\
-  This value should not be modified by the user and the values returned in the`links` object should be used instead. This way the navigation will provide\
+  This value should not be modified by the user and the values returned in the`links` object should be used instead. This way the navigation will provide
   a consistent view of the log that does not overlap.\
-  Optionally, the `id` values in the returned data can be used as the values\
+  Optionally, the `id` values in the returned data can be used as the values
   for this parameter to read data from a known point in the file.
 * `priority`
-* Include messages only from these log levels. The default is to include all\
+* Include messages only from these log levels. The default is to include all
   messages.\
-  The value given should be a comma-separated list of log priorities. The\
+  The value given should be a comma-separated list of log priorities. The
   priorities are `alert`, `error`, `warning`, `notice`, `info` and`debug`. Note that the `debug` log level is only used in debug builds of\
   MaxScale.
 
@@ -524,10 +524,10 @@ GET /v1/maxscale/logs/stream
 
 Stream the contents of the MaxScale logs. This endpoint was added in MaxScale 6.
 
-This endpoint opens a [WebSocket](https://tools.ietf.org/html/rfc6455)\
-connection and streams the contents of the log to it. Each WebSocket message\
-will contain the JSON representation of the log message. The JSON is formatted\
-in the same way as the values in the `log` array of the `/v1/maxscale/logs/data`\
+This endpoint opens a [WebSocket](https://tools.ietf.org/html/rfc6455)
+connection and streams the contents of the log to it. Each WebSocket message
+will contain the JSON representation of the log message. The JSON is formatted
+in the same way as the values in the `log` array of the `/v1/maxscale/logs/data`
 endpoint:
 
 ```
@@ -541,12 +541,12 @@ endpoint:
 
 #### Limitations
 
-* If the client writes any data to the open socket, it will be treated as\
+* If the client writes any data to the open socket, it will be treated as
   an error and the stream is closed.
-* The WebSocket ping and close commands are not yet supported and will be\
+* The WebSocket ping and close commands are not yet supported and will be
   treated as errors.
-* When `maxlog` is used as source of log data, any log messages logged after log\
-  rotation will not be sent if the file was moved or truncated. To fetch new\
+* When `maxlog` is used as source of log data, any log messages logged after log
+  rotation will not be sent if the file was moved or truncated. To fetch new
   events after log rotation, reopen the WebSocket connection.
 
 **Parameters**
@@ -554,14 +554,14 @@ endpoint:
 This endpoint supports the following parameters:
 
 * `page[cursor]`
-* Set position from where the log data is retrieved. The default position to\
+* Set position from where the log data is retrieved. The default position to
   retrieve the log data is the end of the log.\
-  To stream data from a known point, first read the data via the`/v1/maxscale/logs/data` endpoint and then use the `id` value of the newest\
+  To stream data from a known point, first read the data via the`/v1/maxscale/logs/data` endpoint and then use the `id` value of the newest
   log message (i.e. the first value in the `log` array) to start the stream.
 * `priority`
-* Include messages only from these log levels. The default is to include all\
+* Include messages only from these log levels. The default is to include all
   messages.\
-  The value given should be a comma-separated list of log priorities. The\
+  The value given should be a comma-separated list of log priorities. The
   priorities are `alert`, `error`, `warning`, `notice`, `info` and`debug`. Note that the `debug` log level is only used in debug builds of\
   MaxScale.
 
@@ -577,7 +577,7 @@ Client didn't request a WebSocket upgrade:
 
 ### Update logging parameters
 
-**Note:** The modification of logging parameters via this endpoint has\
+**Note:** The modification of logging parameters via this endpoint has
 deprecated in MaxScale 6.0. The parameters should be modified with the`/v1/maxscale` endpoint instead.
 
 Any PATCH requests done to this endpoint will be redirected to the`/v1/maxscale` endpoint. Due to the misspelling of the `ms_timestamp` and`log_throttling` parameters, this is not fully backwards compatible.
@@ -604,7 +604,7 @@ Invalid JSON body:
 POST /v1/maxscale/logs/flush
 ```
 
-Flushes any pending messages to disk and reopens the log files. The body of the\
+Flushes any pending messages to disk and reopens the log files. The body of the
 message is ignored.
 
 **Response**
@@ -617,15 +617,15 @@ message is ignored.
 POST /v1/maxscale/tls/reload
 ```
 
-Reloads all TLS certificates for listeners and servers as well as the REST API\
-itself. If the reloading fails, the old certificates will remain in use for the\
-objects that failed to reload. This also causes the JWT signature keys to be\
-reloaded if one of the asymmetric key algorithms is being used. If JWTs are\
+Reloads all TLS certificates for listeners and servers as well as the REST API
+itself. If the reloading fails, the old certificates will remain in use for the
+objects that failed to reload. This also causes the JWT signature keys to be
+reloaded if one of the asymmetric key algorithms is being used. If JWTs are
 being signed with a random symmetric keys, a new random key is created.
 
-The reloading is not transactional: if a single listener or server fails to\
-reload its certificates, the remaining ones are not reloaded. This means that a\
-failed reload can partially reload certificates. The REST API certificates are\
+The reloading is not transactional: if a single listener or server fails to
+reload its certificates, the remaining ones are not reloaded. This means that a
+failed reload can partially reload certificates. The REST API certificates are
 only reloaded if all other certificate reloads were successful.
 
 **Response**
@@ -638,16 +638,16 @@ only reloaded if all other certificate reloads were successful.
 GET /v1/maxscale/modules/:name
 ```
 
-Retrieve information about a loaded module. The _:name_ must be the name of a\
+Retrieve information about a loaded module. The _:name_ must be the name of a
 valid loaded module or either `maxscale` or `servers`.
 
-The `maxscale` module will display the global configuration options\
+The `maxscale` module will display the global configuration options
 (i.e. everything under the `[maxscale]` section) as a module.
 
-The `servers` module displays the server object type and the configuration\
+The `servers` module displays the server object type and the configuration
 parameters it accepts as a module.
 
-Any parameter with the `modifiable` value set to `true` can be modified\
+Any parameter with the `modifiable` value set to `true` can be modified
 at runtime using a PATCH command on the corresponding object endpoint.
 
 **Response**
@@ -1152,8 +1152,8 @@ GET /v1/maxscale/modules
 
 Retrieve information about all loaded modules.
 
-This endpoint supports the `load=all` parameter. When defined, all modules\
-located in the MaxScale module directory (`libdir`) will be loaded. This allows\
+This endpoint supports the `load=all` parameter. When defined, all modules
+located in the MaxScale module directory (`libdir`) will be loaded. This allows
 one to see the parameters of a module before the object is created.
 
 **Response**
@@ -4293,16 +4293,16 @@ For commands that can modify data:
 POST /v1/maxscale/modules/:module/:command
 ```
 
-Modules can expose commands that can be called via the REST API. The module\
-resource lists all commands in the `data.attributes.commands` list. Each value\
-is a command sub-resource identified by its `id` field and the HTTP method the\
+Modules can expose commands that can be called via the REST API. The module
+resource lists all commands in the `data.attributes.commands` list. Each value
+is a command sub-resource identified by its `id` field and the HTTP method the
 command uses is defined by the `attributes.method` field.
 
-The _:module_ in the URI must be a valid name of a loaded module and _:command_\
-must be a valid command identifier that is exposed by that module. All\
+The _:module_ in the URI must be a valid name of a loaded module and _:command_
+must be a valid command identifier that is exposed by that module. All
 parameters to the module commands are passed as HTTP request parameters.
 
-Here is an example POST requests to the mariadbmon module command _reset-replication_ with\
+Here is an example POST requests to the mariadbmon module command _reset-replication_ with
 two parameters, the name of the monitor instance and the server name:
 
 ```
@@ -4328,8 +4328,8 @@ Command with output:
 }
 ```
 
-The contents of the `meta` field will contain the output of the module\
-command. This output depends on the command that is being executed. It can\
+The contents of the `meta` field will contain the output of the module
+command. This output depends on the command that is being executed. It can
 contain any valid JSON value.
 
 Command with no output:

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-monitor-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-monitor-resource.md
@@ -1,6 +1,6 @@
 # Monitor Resource
 
-A monitor resource represents a monitor inside MaxScale that monitors one or\
+A monitor resource represents a monitor inside MaxScale that monitors one or
 more servers.
 
 ### Resource Operations
@@ -345,7 +345,7 @@ Get all monitors.
 POST /v1/monitors
 ```
 
-Create a new monitor. The request body must define at least the following\
+Create a new monitor. The request body must define at least the following
 fields.
 
 * `data.id`
@@ -361,8 +361,8 @@ fields.
 
 All monitor parameters can be defined at creation time.
 
-The following example defines a request body which creates a new monitor and\
-assigns two servers to be monitored by it. It also defines a custom value for\
+The following example defines a request body which creates a new monitor and
+assigns two servers to be monitored by it. It also defines a custom value for
 the _monitor\_interval_ parameter.
 
 ```
@@ -408,7 +408,7 @@ Monitor is created:
 PATCH /v1/monitors/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 monitor.
 
 #### Modifiable Fields
@@ -423,8 +423,8 @@ The following standard server parameter can be modified.
 * [backend\_read\_timeout](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-common-monitor-parameters.md#backend_read_timeout)
 * [backend\_connect\_attempts](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-common-monitor-parameters.md#backend_connect_attempts)
 
-In addition to these standard parameters, the monitor specific parameters can\
-also be modified. Refer to the monitor module documentation for details on these\
+In addition to these standard parameters, the monitor specific parameters can
+also be modified. Refer to the monitor module documentation for details on these
 parameters.
 
 **Response**
@@ -443,12 +443,12 @@ Invalid request body:
 PATCH /v1/monitors/:name/relationships/servers
 ```
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the monitor.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 server relationship for a monitor.
 
 ```
@@ -487,10 +487,10 @@ Invalid JSON body:
 DELETE /v1/monitors/:name
 ```
 
-Destroy a created monitor. The monitor must not have relationships to any\
+Destroy a created monitor. The monitor must not have relationships to any
 servers in order to be destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the monitor by first unlinking it from all servers that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md
@@ -4,28 +4,28 @@ This document describes the version 1 of the MaxScale REST API.
 
 ### Note About Syntax
 
-Although JSON does not define a syntax for comments, some of the JSON examples\
-have C-style inline comments in them. These comments use `//` to mark the start\
+Although JSON does not define a syntax for comments, some of the JSON examples
+have C-style inline comments in them. These comments use `//` to mark the start
 of the comment and extend to the end of the current line.
 
 ### Configuration
 
-Read the [REST API](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#rest-api-configuration)\
+Read the [REST API](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#rest-api-configuration)
 section of the configuration guide for more details on how to configure the REST API.
 
 ### Authentication
 
-The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)\
-authentication with the MaxScale administrative interface users. The default\
+The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)
+authentication with the MaxScale administrative interface users. The default
 user is `admin:mariadb`.
 
-It is highly recommended to enable HTTPS on the MaxScale REST API to make the\
-communication between the client and MaxScale secure. Without it, the passwords\
-can be intercepted from the network traffic. Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#admin_ssl_key) for more\
+It is highly recommended to enable HTTPS on the MaxScale REST API to make the
+communication between the client and MaxScale secure. Without it, the passwords
+can be intercepted from the network traffic. Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#admin_ssl_key) for more
 details on how to enable HTTPS for the MaxScale REST API.
 
-For more details on how administrative interface users are created and managed,\
-refer to the [MaxCtrl](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md) documentation as well as the\
+For more details on how administrative interface users are created and managed,
+refer to the [MaxCtrl](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md) documentation as well as the
 documentation of the [users](mariadb-maxscale-2302-admin-user-resource.md) resource.
 
 #### JSON Web Tokens
@@ -36,7 +36,7 @@ MaxScale supports authentication via [JSON Web Tokens](https://tools.ietf.org/ht
 GET /v1/auth
 ```
 
-The `/v1/auth` endpoint can be used to generate new tokens which are returned in\
+The `/v1/auth` endpoint can be used to generate new tokens which are returned in
 the following form.
 
 ```
@@ -47,41 +47,41 @@ the following form.
 }
 ```
 
-Note that by default the `/auth` endpoint requires the connection to be\
-encrypted (HTTPS) and attempts to use it without encryption will be treated as\
+Note that by default the `/auth` endpoint requires the connection to be
+encrypted (HTTPS) and attempts to use it without encryption will be treated as
 an error. To allow use of the `/auth` endpoint without encryption, use`admin_secure_gui=false`.
 
-If the token is used to authenticate users in a web browser, the token can be\
-optionally stored in cookies. This can be enabled with the `persist=yes`\
+If the token is used to authenticate users in a web browser, the token can be
+optionally stored in cookies. This can be enabled with the `persist=yes`
 parameter in the request:
 
 ```
 GET /v1/auth?persist=yes
 ```
 
-When the token is stored in the cookies, it will be stored in the `token_sig`\
+When the token is stored in the cookies, it will be stored in the `token_sig`
 cookie using the `SameSite=Strict` and `HttpOnly` cookie options. This means the\
-JavaScript context of the browser will not have access to it. This is done to\
+JavaScript context of the browser will not have access to it. This is done to
 prevent CSRF attacks.
 
-By default, the generated tokens are valid for 8 hours. The token validity\
+By default, the generated tokens are valid for 8 hours. The token validity
 period can be set with the `max-age` request parameter:
 
 ```
 GET /v1/auth?max-age=28800
 ```
 
-When `max-age` is combined with `persist`, the `Max-Age` cookie option is\
+When `max-age` is combined with `persist`, the `Max-Age` cookie option is
 also set to the same value.
 
-The maximum lifetime of the tokens is controlled by the `admin_jwt_max_age`\
-parameter. If the configured value is less than 8 hours, the default token\
-lifetime is also lowered to it. A request for a token with a lifetime longer\
-than `admin_jwt_max_age` will be accepted but the token will have its lifetime\
+The maximum lifetime of the tokens is controlled by the `admin_jwt_max_age`
+parameter. If the configured value is less than 8 hours, the default token
+lifetime is also lowered to it. A request for a token with a lifetime longer
+than `admin_jwt_max_age` will be accepted but the token will have its lifetime
 set to `admin_jwt_max_age`.
 
-To use the token for authentication, the generated token must be presented in\
-the Authorization header with the Bearer authentication scheme. For example, the\
+To use the token for authentication, the generated token must be presented in
+the Authorization header with the Bearer authentication scheme. For example, the
 token above would be used in the following manner:
 
 ```
@@ -92,24 +92,24 @@ If MaxScale is restarted, all generated tokens are invalidated.
 
 **`/auth` Request Parameters**
 
-The `/auth` endpoint supports the following request parameters that must be\
+The `/auth` endpoint supports the following request parameters that must be
 given in the HTTP query string.
 
 * `max-age`
-* Sets the token maximum age in seconds. The default is `max-age=28800`. Only\
-  positive values between 1 and 2147483646 are accepted and if a non-positive\
+* Sets the token maximum age in seconds. The default is `max-age=28800`. Only
+  positive values between 1 and 2147483646 are accepted and if a non-positive
   or a non-integer value is found, the parameter is ignored.
 * `persist`
 * Store the generated token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the
   response is 204 No Content instead of 200 OK.\
-  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie\
-  which prevents access to from JavaScript. This is done to mitigate any\
+  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie
+  which prevents access to from JavaScript. This is done to mitigate any
   attacks that might leak the token.
 
 ### Resources
 
-The MaxScale REST API provides the following resources. All resources conform to\
+The MaxScale REST API provides the following resources. All resources conform to
 the [JSON API](https://jsonapi.org/format/) specification.
 
 * [maxscale](mariadb-maxscale-2302-maxscale-resource.md)
@@ -122,45 +122,45 @@ the [JSON API](https://jsonapi.org/format/) specification.
 * [users](mariadb-maxscale-2302-admin-user-resource.md)
 * [sql](mariadb-maxscale-2302-sql-resource.md)
 
-In addition to the named resources, the REST API will respond with a HTTP 200 OK\
-response to GET requests on the root resource (`/`) as well as the namespace\
-root resource (`/v1/`). These can be used for HTTP health checks to determine\
+In addition to the named resources, the REST API will respond with a HTTP 200 OK
+response to GET requests on the root resource (`/`) as well as the namespace
+root resource (`/v1/`). These can be used for HTTP health checks to determine
 whether MaxScale is running.
 
 ### API Versioning
 
 All of the current resources are in the `/v1/` namespace of the MaxScale REST\
-API. Further additions to the namespace can be added that do not break backwards\
+API. Further additions to the namespace can be added that do not break backwards
 compatibility of any existing resources. What this means in practice is that:
 
 * No resources or URLs will be removed
 * The API will be JSON API compliant
 
-Note that this means that the contents of individual resources can change. New\
-fields can be added, old ones can be removed and the meaning of existing fields\
-can change. The aim is to be as backwards compatible as reasonably possible\
+Note that this means that the contents of individual resources can change. New
+fields can be added, old ones can be removed and the meaning of existing fields
+can change. The aim is to be as backwards compatible as reasonably possible
 without sacrificing the clarity and functionality of the API.
 
-Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the\
+Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the
 prefix is not used, the latest API version is used.
 
 #### Resource Relationships
 
-All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other\
+All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other
 objects. This closely resembles the JSON API definition of links.
 
-In the _relationships_ objects, all resources have a _self_ link that points to\
-the resource itself. This allows easy access to the objects pointed by the\
+In the _relationships_ objects, all resources have a _self_ link that points to
+the resource itself. This allows easy access to the objects pointed by the
 relationships as the reply URL is included in the response itself.
 
-To create a relationship between two objects, define it in the initial POST\
-request. To modify the relationships of existing objects, perform a PATCH\
-request with the new definition of the relevant relationship. To completely\
-remove all relationships from an object, the `data` field of the corresponding\
+To create a relationship between two objects, define it in the initial POST
+request. To modify the relationships of existing objects, perform a PATCH
+request with the new definition of the relevant relationship. To completely
+remove all relationships from an object, the `data` field of the corresponding
 relationship object must be set to an empty array.
 
-The following lists the resources and the types of links each resource can have\
-in addition to the _self_ link. Examples of these relationships can be seen in\
+The following lists the resources and the types of links each resource can have
+in addition to the _self_ link. Examples of these relationships can be seen in
 the resource documentation.
 
 * `services` - Service resource
@@ -170,7 +170,7 @@ the resource documentation.
   List of services used by the service
 * `filters`\
   List of filters used by the service\
-  NOTE: This is an ordered relationship where the order of the filters\
+  NOTE: This is an ordered relationship where the order of the filters
   defines the order in which they process queries.
 * `listeners`\
   List of listeners used by the service
@@ -193,57 +193,57 @@ the resource documentation.
 ### Common Request Parameters
 
 All parameters that use boolean values use the same rules that are used for the [boolean values](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#booleans) in the\
-MaxScale configuration. For example, both `pretty=off` and `pretty=false`\
+MaxScale configuration. For example, both `pretty=off` and `pretty=false`
 disable the `pretty` option.
 
-All the resources that return JSON content also support the following\
+All the resources that return JSON content also support the following
 parameters. Parameters are given in the HTTP query string:`https://localhost:8989/v1/servers?pretty=true&fields[servers]=state`.
 
 * `pretty`
 * Pretty-print output.\
-  If this parameter is set to `true` then the returned objects are formatted\
-  in a more human readable format. If the parameter is set to `false` then the\
-  returned objects are formatted in a compact format. All resources support\
+  If this parameter is set to `true` then the returned objects are formatted
+  in a more human readable format. If the parameter is set to `false` then the
+  returned objects are formatted in a compact format. All resources support
   this parameter. The default value for this parameter is `true`.
 * `fields[TYPE]=field1,field2...`
 * Return a [Sparse Fieldset](https://jsonapi.org/format/#fetching-sparse-fieldsets)\
-  This parameter controls which fields are returned in the REST API\
-  response. The `TYPE` value in the `fields` parameter must be the resource\
-  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated\
-  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which\
-  fields of the object to return. Only fields in objects in the `attributes`\
-  and `relationships` objects are inspected. This means that if the path\
-  marked by the JSON Pointer contains an array in it, it will not advance past\
+  This parameter controls which fields are returned in the REST API
+  response. The `TYPE` value in the `fields` parameter must be the resource
+  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated
+  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which
+  fields of the object to return. Only fields in objects in the `attributes`
+  and `relationships` objects are inspected. This means that if the path
+  marked by the JSON Pointer contains an array in it, it will not advance past
   this array.\
-  For example, to return only the server state output from the `/servers`\
-  endpoint, the `fields[servers]=state` parameter can be used. This would\
-  return only the `data.attributes.state` part of the resource. To return the\
-  nested value `data.attributes.statistics.connections`, the corresponding\
+  For example, to return only the server state output from the `/servers`
+  endpoint, the `fields[servers]=state` parameter can be used. This would
+  return only the `data.attributes.state` part of the resource. To return the
+  nested value `data.attributes.statistics.connections`, the corresponding
   parameter would be `fields[servers]=statistics/connections`.
 * `filter=json_ptr=expr`
 * Filter the output of the result\
-  This parameter controls which rows are returned in a REST API response that\
-  returns an array in the `data` member (i.e. a request to a resource\
+  This parameter controls which rows are returned in a REST API response that
+  returns an array in the `data` member (i.e. a request to a resource
   collection). Requests to individual resources are not filtered.\
-  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a\
-  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2302-rest-api.md#filter-expressions). The comparison is done for each\
-  individual object in the `data` array of the result. If given only a JSON\
-  value, the stored value is compared for equality. If an expression is used,\
+  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a
+  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2302-rest-api.md#filter-expressions). The comparison is done for each
+  individual object in the `data` array of the result. If given only a JSON
+  value, the stored value is compared for equality. If an expression is used,
   the expression is evaluated and only rows that match are returned.\
-  For example, if the object stored in `data[0]` has a value pointed by the\
-  given JSON pointer and that value compares equal to the given JSON value,\
-  the array row is kept in the result. Examples for filtering expression can\
+  For example, if the object stored in `data[0]` has a value pointed by the
+  given JSON pointer and that value compares equal to the given JSON value,
+  the array row is kept in the result. Examples for filtering expression can
   be found [here](mariadb-maxscale-2302-rest-api.md#filter-expression-examples).\
-  A practical use for this parameter is to return only sessions for a\
-  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can\
-  be used. Note the double quotes around the `"RW-Split-Router"`, they are\
+  A practical use for this parameter is to return only sessions for a
+  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
+  be used. Note the double quotes around the `"RW-Split-Router"`, they are
   required to correctly convert strings into JSON values.
 * `filter[json_path]=expr`
 * Filter based on a JSONPath and a filtering expression.\
-  Similar to the `filter` parameter that takes a JSON Pointer, this version of\
-  the `filter` controls which rows are returned in a REST API response for a\
+  Similar to the `filter` parameter that takes a JSON Pointer, this version of
+  the `filter` controls which rows are returned in a REST API response for a
   resource collection. Requests to individual resources are never filtered.\
-  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)\
+  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)
   expression that MaxScale supports. The currently supported syntax is:
   * dot notation: `$.store.book`
   * bracket notation: `$['store']['book']`
@@ -253,53 +253,53 @@ parameters. Parameters are given in the HTTP query string:`https://localhost:898
   * object wildcards: `$.store.bicycle.*`
   * optional root object: `store.book`
 
-The root object being optional is an extension to the JSONPath specification\
+The root object being optional is an extension to the JSONPath specification
 that MaxScale implements.\
-The `expr` value must be a [filter-expression](mariadb-maxscale-2302-rest-api.md#filter-expressions). Similarly to the other `filter`\
-parameter, the comparison is done for each individual object in the `data`\
+The `expr` value must be a [filter-expression](mariadb-maxscale-2302-rest-api.md#filter-expressions). Similarly to the other `filter`
+parameter, the comparison is done for each individual object in the `data`
 array of the result.\
-If the JSONPath expression returns multiple objects, the comparison is done\
-for each element and if any of them matches, the object is considered to\
+If the JSONPath expression returns multiple objects, the comparison is done
+for each element and if any of them matches, the object is considered to
 match. In other words, wildcard JSONPath expressions are ORed together.\
-If multiple `filter[json_path]=expr` parameters are found in the request,\
-all returned values must match all of them. In other words, the filter\
-parameters are all combined into an AND expression. For example, the\
-following filter will only return all values whose `id` field is `"srv1` and\
+If multiple `filter[json_path]=expr` parameters are found in the request,
+all returned values must match all of them. In other words, the filter
+parameters are all combined into an AND expression. For example, the
+following filter will only return all values whose `id` field is `"srv1` and
 the `attributes.parameters.port` field is 3306:`filter[id]=eq("srv1")&filter[attributes.parameters.port]=eq(3306)`
 
 * `page[size]`
-* The number of elements that are returned for resource collections. By\
-  default all elements in the resource collection are returned. The value must\
-  be a valid positive integer, otherwise the parameter is ignored. If\
-  pagination is used, the `links` object will have pagination links to the\
+* The number of elements that are returned for resource collections. By
+  default all elements in the resource collection are returned. The value must
+  be a valid positive integer, otherwise the parameter is ignored. If
+  pagination is used, the `links` object will have pagination links to the
   next page if more elements are available.
 * `page[number]`
-* How many pages of results to skip. The first page of results starts from 0\
-  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This\
-  should be considered pseudo-pagination as the results are not guaranteed to\
+* How many pages of results to skip. The first page of results starts from 0
+  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This
+  should be considered pseudo-pagination as the results are not guaranteed to
   be consistent between requests.
 * `sync`
 * Control configuration synchronization.\
-  If this parameter is set to `false` then the configuration synchronization\
-  is disabled for this request. This can be used to perform configuration\
-  changes when MaxScale is unable to reach the cluster used to synchronize the\
-  configuration. The modifications to the local configuration will be\
-  overwritten when the next modification to the cluster's configuration is\
+  If this parameter is set to `false` then the configuration synchronization
+  is disabled for this request. This can be used to perform configuration
+  changes when MaxScale is unable to reach the cluster used to synchronize the
+  configuration. The modifications to the local configuration will be
+  overwritten when the next modification to the cluster's configuration is
   done which means this should only be used to perform temporary fixes.
 
 #### Filter Expressions
 
-MaxScale 24.02 added support for expressions in the `filter` request\
-parameter. Each resource in a resource collection that evaluates to a true value\
-will be kept in the returned result. All rows that evaluate to false are\
+MaxScale 24.02 added support for expressions in the `filter` request
+parameter. Each resource in a resource collection that evaluates to a true value
+will be kept in the returned result. All rows that evaluate to false are
 removed.
 
-Equality and inequality is defined for all JSON types but ordering is defined\
-only for numbers and strings. The logical operators allow one or more\
+Equality and inequality is defined for all JSON types but ordering is defined
+only for numbers and strings. The logical operators allow one or more
 sub-expressions.
 
-The following table lists the supported operations in the filter expressions. In\
-it, the stored value is marked as `S` and the literal JSON value in the\
+The following table lists the supported operations in the filter expressions. In
+it, the stored value is marked as `S` and the literal JSON value in the
 expression as `V`. For the logical operators, the sub-expression is marked as`expr`.
 
 | Expression   | Logic          | Types               |
@@ -316,25 +316,25 @@ expression as `V`. For the logical operators, the sub-expression is marked as`ex
 
 **Filter Expression Examples**
 
-Ranges of values can be defined using an `and()` expression with the range\
-limits defined with the ordering operators `ge()` and `le()`. To filter the\
-sessions in MaxScale to ones that have an ID between 50 and 100, the following\
+Ranges of values can be defined using an `and()` expression with the range
+limits defined with the ordering operators `ge()` and `le()`. To filter the
+sessions in MaxScale to ones that have an ID between 50 and 100, the following
 filtering expression can be used.
 
 ```
 filter=id=and(ge(50),le(100))
 ```
 
-Limiting the result to only the given values can be done with an `or()`\
-expression that uses `eq()` expressions to select the rows to return. To only\
-return sessions with IDs 1, 5, 10 the following filtering expression can be\
+Limiting the result to only the given values can be done with an `or()`
+expression that uses `eq()` expressions to select the rows to return. To only
+return sessions with IDs 1, 5, 10 the following filtering expression can be
 used.
 
 ```
 filter=id=or(eq(1),eq(5),eq(10))
 ```
 
-Similarly, excluding certain rows from the result can be done by simply\
+Similarly, excluding certain rows from the result can be done by simply
 replacing `or()` with `not()`. This expression would exclude sessions with the\
 IDs 1, 5 and 10 from the result.
 
@@ -346,22 +346,22 @@ filter=id=not(eq(1),eq(5),eq(10))
 
 #### Request Headers
 
-REST makes use of the HTTP protocols in its aim to provide a natural way to\
-understand the workings of an API. The following request headers are understood\
+REST makes use of the HTTP protocols in its aim to provide a natural way to
+understand the workings of an API. The following request headers are understood
 by this API.
 
 **Authorization**
 
 Credentials for authentication. This header should consist of a HTTP Basic\
-Access authentication type payload which is the base64 encoded value of the\
+Access authentication type payload which is the base64 encoded value of the
 username and password joined by a colon e.g. `Base64("maxuser:maxpwd")`.
 
 **Content-Type**
 
-All PUT and POST requests must use the `Content-Type: application/json` media\
-type and the request body must be a complete and valid JSON representation of a\
-resource. All PATCH requests must use the `Content-Type: application/json` media\
-type and the request body must be a JSON document containing a partial\
+All PUT and POST requests must use the `Content-Type: application/json` media
+type and the request body must be a complete and valid JSON representation of a
+resource. All PATCH requests must use the `Content-Type: application/json` media
+type and the request body must be a JSON document containing a partial
 definition of the modified resource.
 
 **Host**
@@ -370,59 +370,59 @@ The address and port of the server.
 
 **If-Match**
 
-The request is performed only if the provided ETag value matches the one on the\
-server. This field should be used with PATCH requests to prevent concurrent\
+The request is performed only if the provided ETag value matches the one on the
+server. This field should be used with PATCH requests to prevent concurrent
 updates to the same resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Modified-Since**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **If-None-Match**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Unmodified-Since**
 
-The request is performed only if the requested resource has not been modified\
+The request is performed only if the requested resource has not been modified
 since the provided date.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **X-HTTP-Method-Override**
 
-Some clients only support GET and PUT requests. By providing the string value of\
-the intended method in the `X-HTTP-Method-Override` header, a client can, for\
-example, perform a POST, PATCH or DELETE request with the PUT method\
+Some clients only support GET and PUT requests. By providing the string value of
+the intended method in the `X-HTTP-Method-Override` header, a client can, for
+example, perform a POST, PATCH or DELETE request with the PUT method
 (e.g. `X-HTTP-Method-Override: PATCH`).
 
-If this header is defined in the request, the current method of the request is\
-replaced with the one in the header. The HTTP method must be in uppercase and it\
+If this header is defined in the request, the current method of the request is
+replaced with the one in the header. The HTTP method must be in uppercase and it
 must be one of the methods that the requested resource supports.
 
 #### Response Headers
 
 **Allow**
 
-All resources return the Allow header with the supported HTTP methods. For\
-example the resource `/services` will always return the `Accept: GET, PATCH, PUT`\
+All resources return the Allow header with the supported HTTP methods. For
+example the resource `/services` will always return the `Accept: GET, PATCH, PUT`
 header.
 
 **Accept-Patch**
 
-All PATCH capable resources return the `Accept-Patch: application/json-patch`\
+All PATCH capable resources return the `Accept-Patch: application/json-patch`
 header.
 
 **Date**
@@ -432,12 +432,12 @@ English and it uses the server's local timezone.
 
 **ETag**
 
-An identifier for a specific version of a resource. The value of this header\
-changes whenever a resource is modified via the REST API. It will not change if\
-an internal MaxScale event (e.g. server changing state or statistics being\
+An identifier for a specific version of a resource. The value of this header
+changes whenever a resource is modified via the REST API. It will not change if
+an internal MaxScale event (e.g. server changing state or statistics being
 updated) causes a change.
 
-When the client sends the `If-Match` or `If-None-Match` header, the provided\
+When the client sends the `If-Match` or `If-None-Match` header, the provided
 value should be the value of the `ETag` header of an earlier GET.
 
 **Last-Modified**
@@ -446,29 +446,29 @@ The date when the resource was last modified in "HTTP-date" format.
 
 **Location**
 
-If an out of date resource location is requested, a HTTP return code of 3XX with\
-the `Location` header is returned. The value of the header contains the new\
+If an out of date resource location is requested, a HTTP return code of 3XX with
+the `Location` header is returned. The value of the header contains the new
 location of the requested resource as a relative URI.
 
 **WWW-Authenticate**
 
-The requested authentication method. For example, `WWW-Authenticate: Basic`\
+The requested authentication method. For example, `WWW-Authenticate: Basic`
 would require basic HTTP authentication.
 
 **Mxs-Warning**
 
-This header is used for sending generic warnings to clients about actions that\
-were successful and valid but could cause problems in the future. Currently\
-these are used to indicate when a configuration change was made to a static\
-object and an overriding configuration is created or when a static object is\
+This header is used for sending generic warnings to clients about actions that
+were successful and valid but could cause problems in the future. Currently
+these are used to indicate when a configuration change was made to a static
+object and an overriding configuration is created or when a static object is
 being deleted at runtime.
 
-The content of the header is the human-readable warning that should be displayed\
+The content of the header is the human-readable warning that should be displayed
 to a user.
 
 ### Response Codes
 
-Every HTTP response starts with a line with a return code which indicates the\
+Every HTTP response starts with a line with a return code which indicates the
 outcome of the request. The API uses some of the standard HTTP values:
 
 #### 2xx Success
@@ -478,37 +478,37 @@ outcome of the request. The API uses some of the standard HTTP values:
 * 201 Created
 * A new resource was created.
 * 202 Accepted
-* The request has been accepted for processing, but the processing has not\
+* The request has been accepted for processing, but the processing has not
   been completed.
 * 204 No Content
 * Successful HTTP requests, response has no body.
 
 #### 3xx Redirection
 
-This class of status code indicates the client must take additional action to\
+This class of status code indicates the client must take additional action to
 complete the request.
 
 * 301 Moved Permanently
 * This and all future requests should be directed to the given URI.
 * 302 Found
-* The response to the request can be found under another URI using the same\
+* The response to the request can be found under another URI using the same
   method as in the original request.
 * 303 See Other
-* The response to the request can be found under another URI using a GET\
+* The response to the request can be found under another URI using a GET
   method.
 * 304 Not Modified
-* Indicates that the resource has not been modified since the version\
+* Indicates that the resource has not been modified since the version
   specified by the request headers If-Modified-Since or If-None-Match.
 * 307 Temporary Redirect
-* The request should be repeated with another URI but future requests should\
+* The request should be repeated with another URI but future requests should
   use the original URI.
 * 308 Permanent Redirect
 * The request and all future requests should be repeated using another URI.
 
 #### 4xx Client Error
 
-The 4xx class of status code is when the client seems to have erred. Except when\
-responding to a HEAD request, the body of the response _MAY_ contains a JSON\
+The 4xx class of status code is when the client seems to have erred. Except when
+responding to a HEAD request, the body of the response _MAY_ contains a JSON
 representation of the error.
 
 ```
@@ -519,7 +519,7 @@ representation of the error.
 }
 ```
 
-The _error_ field contains a short error description and the _description_ field\
+The _error_ field contains a short error description and the _description_ field
 contains a more detailed version of the error message.
 
 * 400 Bad Request
@@ -527,41 +527,41 @@ contains a more detailed version of the error message.
 * 401 Unauthorized
 * Authentication is required. The response includes a WWW-Authenticate header.
 * 403 Forbidden
-* The request was a valid request, but the client does not have the necessary\
+* The request was a valid request, but the client does not have the necessary
   permissions for the resource.
 * 404 Not Found
 * The requested resource could not be found.
 * 405 Method Not Allowed
 * A request method is not supported for the requested resource.
 * 406 Not Acceptable
-* The requested resource is capable of generating only content not acceptable\
+* The requested resource is capable of generating only content not acceptable
   according to the Accept headers sent in the request.
 * 409 Conflict
-* Indicates that the request could not be processed because of conflict in the\
+* Indicates that the request could not be processed because of conflict in the
   request, such as an edit conflict be tween multiple simultaneous updates.
 * 411 Length Required
-* The request did not specify the length of its content, which is required by\
+* The request did not specify the length of its content, which is required by
   the requested resource.
 * 412 Precondition Failed
-* The server does not meet one of the preconditions that the requester put on\
+* The server does not meet one of the preconditions that the requester put on
   the request.
 * 413 Payload Too Large
 * The request is larger than the server is willing or able to process.
 * 414 URI Too Long
 * The URI provided was too long for the server to process.
 * 415 Unsupported Media Type
-* The request entity has a media type which the server or resource does not\
+* The request entity has a media type which the server or resource does not
   support.
 * 422 Unprocessable Entity
-* The request was well-formed but was unable to be followed due to semantic\
+* The request was well-formed but was unable to be followed due to semantic
   errors.
 * 423 Locked
 * The resource that is being accessed is locked.
 * 428 Precondition Required
-* The origin server requires the request to be conditional. This error code is\
+* The origin server requires the request to be conditional. This error code is
   returned when none of the `Modified-Since` or `Match` type headers are used.
 * 431 Request Header Fields Too Large
-* The server is unwilling to process the request because either an individual\
+* The server is unwilling to process the request because either an individual
   header field, or all the header fields collectively, are too large.
 
 #### 5xx Server Error
@@ -569,30 +569,30 @@ contains a more detailed version of the error message.
 The server failed to fulfill an apparently valid request.
 
 * 500 Internal Server Error
-* A generic error message, given when an unexpected condition was encountered\
+* A generic error message, given when an unexpected condition was encountered
   and no more specific message is suitable.
 * 501 Not Implemented
-* The server either does not recognize the request method, or it lacks the\
+* The server either does not recognize the request method, or it lacks the
   ability to fulfill the request.
 * 502 Bad Gateway
-* The server was acting as a gateway or proxy and received an invalid response\
+* The server was acting as a gateway or proxy and received an invalid response
   from the upstream server.
 * 503 Service Unavailable
-* The server is currently unavailable (because it is overloaded or down for\
+* The server is currently unavailable (because it is overloaded or down for
   maintenance). Generally, this is a temporary state.
 * 504 Gateway Timeout
-* The server was acting as a gateway or proxy and did not receive a timely\
+* The server was acting as a gateway or proxy and did not receive a timely
   response from the upstream server.
 * 505 HTTP Version Not Supported
 * The server does not support the HTTP protocol version used in the request.
 * 506 Variant Also Negotiates
-* Transparent content negotiation for the request results in a circular\
+* Transparent content negotiation for the request results in a circular
   reference.
 * 507 Insufficient Storage
-* The server is unable to store the representation needed to complete the\
+* The server is unable to store the representation needed to complete the
   request.
 * 508 Loop Detected
-* The server detected an infinite loop while processing the request (sent in\
+* The server detected an infinite loop while processing the request (sent in
   lieu of 208 Already Reported).
 * 510 Not Extended
 * Further extensions to the request are required for the server to fulfil it.
@@ -603,23 +603,23 @@ The following response headers are not currently in use. Future versions of the\
 API could return them.
 
 * 206 Partial Content
-* The server is delivering only part of the resource (byte serving) due to a\
+* The server is delivering only part of the resource (byte serving) due to a
   range header sent by the client.
 * 300 Multiple Choices
-* Indicates multiple options for the resource from which the client may choose\
+* Indicates multiple options for the resource from which the client may choose
   (via agent-driven content negotiation).
 * 407 Proxy Authentication Required
 * The client must first authenticate itself with the proxy.
 * 408 Request Timeout
-* The server timed out waiting for the request. According to HTTP\
-  specifications: "The client did not produce a request within the time that\
-  the server was prepared to wait. The client MAY repeat the request without\
+* The server timed out waiting for the request. According to HTTP
+  specifications: "The client did not produce a request within the time that
+  the server was prepared to wait. The client MAY repeat the request without
   modifications at any later time."
 * 410 Gone
-* Indicates that the resource requested is no longer available and will not be\
+* Indicates that the resource requested is no longer available and will not be
   available again.
 * 416 Range Not Satisfiable
-* The client has asked for a portion of the file (byte serving), but the\
+* The client has asked for a portion of the file (byte serving), but the
   server cannot supply that portion.
 * 417 Expectation Failed
 * The server cannot meet the requirements of the Expect request-header field.
@@ -628,10 +628,10 @@ API could return them.
 * 424 Failed Dependency
 * The request failed due to failure of a previous request.
 * 426 Upgrade Required
-* The client should switch to a different protocol such as TLS/1.0, given in\
+* The client should switch to a different protocol such as TLS/1.0, given in
   the Upgrade header field.
 * 429 Too Many Requests
-* The user has sent too many requests in a given amount of time. Intended for\
+* The user has sent too many requests in a given amount of time. Intended for
   use with rate-limiting schemes.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-server-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-server-resource.md
@@ -761,7 +761,7 @@ Response contains a resource collection with all servers.
 POST /v1/servers
 ```
 
-Create a new server by defining the resource. The posted object must define at\
+Create a new server by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -769,10 +769,10 @@ least the following fields.
 * `data.type`
 * Type of the object, must be `servers`
 * `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-* The [address](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#address) or [socket](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#socket) to use. Only\
+* The [address](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#address) or [socket](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#socket) to use. Only
   one of the fields can be defined.
 * `data.attributes.parameters.port`
-* The [port](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#port) to use. Needs\
+* The [port](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#port) to use. Needs
   to be defined if the `address` field is defined.
 
 The following is the minimal required JSON object for defining a new server.
@@ -792,7 +792,7 @@ The following is the minimal required JSON object for defining a new server.
 }
 ```
 
-The relationships of a server can also be defined at creation time. This allows\
+The relationships of a server can also be defined at creation time. This allows
 new servers to be created and immediately taken into use.
 
 ```
@@ -832,7 +832,7 @@ new servers to be created and immediately taken into use.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)
 for a full list of server parameters.
 
 **Response**
@@ -851,19 +851,19 @@ Invalid JSON body:
 PATCH /v1/servers/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 server.
 
 #### Modifiable Fields
 
-In addition to the server [parameters](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#server-1), the _services_\
-and _monitors_ fields of the _relationships_ object can be modified. Removal,\
-addition and modification of the links will change which service and monitors\
+In addition to the server [parameters](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#server-1), the _services_
+and _monitors_ fields of the _relationships_ object can be modified. Removal,
+addition and modification of the links will change which service and monitors
 use this server.
 
 For example, removing the first value in the _services_ list in the_relationships_ object from the following JSON document will remove the_server1_ from the service _RW-Split-Router_.
 
-Removing a service from a server is analogous to removing the server from the\
+Removing a service from a server is analogous to removing the server from the
 service. Both unlink the two objects from each other.
 
 Request for `PATCH /v1/servers/server1` that modifies the address of the server:
@@ -901,9 +901,9 @@ Request for `PATCH /v1/servers/server1` that modifies the server relationships:
 }
 ```
 
-If parts of the resource are not defined (e.g. the `attributes` field in the\
-above example), those parts of the resource are not modified. All parts that are\
-defined are interpreted as the new definition of those part of the resource. In\
+If parts of the resource are not defined (e.g. the `attributes` field in the
+above example), those parts of the resource are not modified. All parts that are
+defined are interpreted as the new definition of those part of the resource. In
 the above example, the `relationships` of the resource are completely redefined.
 
 **Response**
@@ -922,15 +922,15 @@ Invalid JSON body:
 PATCH /v1/servers/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _services_, for service\
+The _:type_ in the URI must be either _services_, for service
 relationships, or _monitors_, for monitor relationships.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the particular type from the server.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 service relationship for a server.
 
 ```
@@ -969,11 +969,11 @@ Invalid JSON body:
 DELETE /v1/servers/:name
 ```
 
-A server can only be deleted if it is not used by any services or\
+A server can only be deleted if it is not used by any services or
 monitors.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the server by first unlinking it from all services and monitors that use\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the server by first unlinking it from all services and monitors that use
 it.
 
 **Response**
@@ -992,7 +992,7 @@ Server is in use:
 PUT /v1/servers/:name/set
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the following values.
 
 | Value       | State Description                |
@@ -1004,19 +1004,19 @@ request. The value of `state` must be one of the following values.
 | synced      | Server is a Galera node          |
 | drain       | Server is drained of connections |
 
-For example, to set the server _db-server-1_ into maintenance mode, a request to\
+For example, to set the server _db-server-1_ into maintenance mode, a request to
 the following URL must be made:
 
 ```
 PUT /v1/servers/db-server-1/set?state=maintenance
 ```
 
-This endpoint also supports the `force=yes` parameter that will cause all\
-connections to the server to be closed if `state=maintenance` is also set. By\
-default setting a server into maintenance mode will cause connections to be\
+This endpoint also supports the `force=yes` parameter that will cause all
+connections to the server to be closed if `state=maintenance` is also set. By
+default setting a server into maintenance mode will cause connections to be
 closed only after the next request is sent.
 
-The following example forcefully closes all connections to server _db-server-1_\
+The following example forcefully closes all connections to server _db-server-1_
 and sets it into maintenance mode:
 
 ```
@@ -1039,7 +1039,7 @@ Missing or invalid parameter:
 PUT /v1/servers/:name/clear
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the values defined in the_set_ endpoint documentation.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-service-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-service-resource.md
@@ -1,6 +1,6 @@
 # Service Resource
 
-A service resource represents a service inside MaxScale. A service is a\
+A service resource represents a service inside MaxScale. A service is a
 collection of network listeners, filters, a router and a set of backend servers.
 
 ### Resource Operations
@@ -724,7 +724,7 @@ Get all services.
 POST /v1/services
 ```
 
-Create a new service by defining the resource. The posted object must define at\
+Create a new service by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -738,24 +738,24 @@ least the following fields.
 * `data.attributes.parameters.password`
 * The [password](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#password) to use
 
-The `data.attributes.parameters` object is used to define router and service\
-parameters. All configuration parameters that can be defined in the\
-configuration file can also be added to the parameters object. The exceptions to\
-this are the `type`, `router`, `servers` and `filters` parameters which must not\
+The `data.attributes.parameters` object is used to define router and service
+parameters. All configuration parameters that can be defined in the
+configuration file can also be added to the parameters object. The exceptions to
+this are the `type`, `router`, `servers` and `filters` parameters which must not
 be defined.
 
-As with other REST API resources, the `data.relationships` field defines the\
-relationships of the service to other resources. Services can have two types of\
+As with other REST API resources, the `data.relationships` field defines the
+relationships of the service to other resources. Services can have two types of
 relationships: `servers` and `filters` relationships.
 
-If the request body defines a valid `relationships` object, the service is\
-linked to those resources. For servers, this is equivalent to adding the list of\
-server names into the [servers](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#servers) parameter. For\
-filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#filters) parameter in the\
-order they appear. For other services, this is equivalent to adding the list of\
+If the request body defines a valid `relationships` object, the service is
+linked to those resources. For servers, this is equivalent to adding the list of
+server names into the [servers](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#servers) parameter. For
+filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#filters) parameter in the
+order they appear. For other services, this is equivalent to adding the list of
 server names into the [targets](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#targets) parameter.
 
-The following example defines a new service with both a server and a filter\
+The following example defines a new service with both a server and a filter
 relationship.
 
 ```
@@ -804,21 +804,21 @@ Service is created:
 DELETE /v1/services/:name
 ```
 
-A service can only be destroyed if the service uses no servers or filters and\
-all the listeners pointing to the service have been destroyed. This means that\
-the `data.relationships` must be an empty object and `data.attributes.listeners`\
+A service can only be destroyed if the service uses no servers or filters and
+all the listeners pointing to the service have been destroyed. This means that
+the `data.relationships` must be an empty object and `data.attributes.listeners`
 must be an empty array in order for the service to qualify for destruction.
 
-If there are open client connections that use the service when it is destroyed,\
-they are allowed to gracefully close before the service is destroyed. This means\
-that the destruction of a service can be acknowledged via the REST API before\
+If there are open client connections that use the service when it is destroyed,
+they are allowed to gracefully close before the service is destroyed. This means
+that the destruction of a service can be acknowledged via the REST API before
 the destruction process has fully completed.
 
-To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2302-session-resource.md) resource should be used. If a session for\
+To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2302-session-resource.md) resource should be used. If a session for
 the service is still open, it has not yet been destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the service by first unlinking it from all servers and filters that it\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the service by first unlinking it from all servers and filters that it
 uses.
 
 **Response**
@@ -833,15 +833,15 @@ Service is destroyed:
 PATCH /v1/services/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the service.
 
-All standard service parameters can be modified. Refer to the [service](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#service) documentation on\
+All standard service parameters can be modified. Refer to the [service](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#service) documentation on
 the details of these parameters.
 
-In addition to the standard service parameters, router parameters can be updated\
-at runtime if the router module supports it. Refer to the individual router\
-documentation for more details on whether the router supports it and which\
+In addition to the standard service parameters, router parameters can be updated
+at runtime if the router module supports it. Refer to the individual router
+documentation for more details on whether the router supports it and which
 parameters can be updated at runtime.
 
 The following example modifies a service by changing the `user` parameter to `admin`.
@@ -870,22 +870,22 @@ Service is modified:
 PATCH /v1/services/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _servers_, _services_ or _filters_,\
+The _:type_ in the URI must be either _servers_, _services_ or _filters_,
 depending on which relationship is being modified.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of this type for the service.
 
-_Note:_ The order of the values in the `filters` relationship will define the\
-order the filters are set up in. The order in which the filters appear in the\
-array will be the order in which the filters are applied to each query. Refer\
-to the [filters](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#filters) parameter\
+_Note:_ The order of the values in the `filters` relationship will define the
+order the filters are set up in. The order in which the filters appear in the
+array will be the order in which the filters are applied to each query. Refer
+to the [filters](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#filters) parameter
 for more details.
 
-The following is an example request and request body that defines a single\
-server relationship for a service that is equivalent to a `servers=my-server`\
+The following is an example request and request body that defines a single
+server relationship for a service that is equivalent to a `servers=my-server`
 parameter.
 
 ```
@@ -981,7 +981,7 @@ This endpoint is deprecated, use the [this](mariadb-maxscale-2302-listener-resou
 GET /v1/services/:name/listeners/:listener
 ```
 
-This endpoint is deprecated, use the [this](mariadb-maxscale-2302-listener-resource.md#get-a-listener)\
+This endpoint is deprecated, use the [this](mariadb-maxscale-2302-listener-resource.md#get-a-listener)
 listeners endpoint instead.
 
 #### Create a new listener

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-session-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-session-resource.md
@@ -1,7 +1,7 @@
 # Session Resource
 
-A session is an abstraction of a client connection, any number of related backend\
-connections, a router module session and possibly filter module sessions. Each\
+A session is an abstraction of a client connection, any number of related backend
+connections, a router module session and possibly filter module sessions. Each
 session is created on a service and each service can have multiple sessions.
 
 ### Resource Operations
@@ -12,11 +12,11 @@ session is created on a service and each service can have multiple sessions.
 GET /v1/sessions/:id
 ```
 
-Get a single session. _:id_ must be a valid session ID. The session ID is the\
+Get a single session. _:id_ must be a valid session ID. The session ID is the
 same that is exposed to the client as the connection ID.
 
-This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to\
-perform reverse DNS on the client IP address. As this requires communicating with\
+This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to
+perform reverse DNS on the client IP address. As this requires communicating with
 an external server, the operation may be expensive.
 
 **Response**
@@ -207,10 +207,10 @@ Get all sessions.
 PATCH /v1/sessions/:id
 ```
 
-The request body must be a JSON object which represents the new configuration of\
+The request body must be a JSON object which represents the new configuration of
 the session. The `:id` must be a valid session ID that is active.
 
-The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean\
+The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean
 parameters control whether the associated logging level is enabled:
 
 ```
@@ -225,11 +225,11 @@ parameters control whether the associated logging level is enabled:
 }
 ```
 
-The filters that a session uses can be updated by re-defining the filter\
-relationship of the session. This causes new filter sessions to be opened\
-immediately. The old filter session are closed and replaced with the new filter\
-session the next time the session is idle. The order in which the filters are\
-defined in the request body is the order in which the filters are installed,\
+The filters that a session uses can be updated by re-defining the filter
+relationship of the session. This causes new filter sessions to be opened
+immediately. The old filter session are closed and replaced with the new filter
+session the next time the session is idle. The order in which the filters are
+defined in the request body is the order in which the filters are installed,
 similar to how the filter relationship for services behaves.
 
 ```
@@ -261,14 +261,14 @@ Session is modified:
 POST /v1/sessions/:id/restart
 ```
 
-This endpoint causes the session to re-read the configuration from the\
-service. As a result of this, all backend connections will be closed and then\
-opened again. All router and filter sessions will be created again which means\
-that for modules that perform something whenever a new module session is opened,\
+This endpoint causes the session to re-read the configuration from the
+service. As a result of this, all backend connections will be closed and then
+opened again. All router and filter sessions will be created again which means
+that for modules that perform something whenever a new module session is opened,
 this behaves as if a new session was started.
 
-This endpoint can be used to apply configuration changes that were done after\
-the session was started. This can be useful for situations where the client\
+This endpoint can be used to apply configuration changes that were done after
+the session was started. This can be useful for situations where the client
 connections live for a long time and connections are not recycled often enough.
 
 **Response**
@@ -283,7 +283,7 @@ Session is was restarted:
 POST /v1/sessions/restart
 ```
 
-This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint\
+This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint
 except that it applies to all sessions.
 
 **Response**
@@ -305,8 +305,8 @@ This endpoint causes the session to be forcefully closed.
 This endpoint supports the following request parameters.
 
 * `ttl`
-* The time after which the session is killed. If this parameter is not given,\
-  the session is killed immediately. This can be used to give the session time\
+* The time after which the session is killed. If this parameter is not given,
+  the session is killed immediately. This can be used to give the session time
   to finish the work it is performing before the connection is closed.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource.md
@@ -7,35 +7,35 @@ The SQL resource represents a database connection.
 The following endpoints provide a simple REST API interface for executing\
 SQL queries on servers and services in MaxScale.
 
-This endpoint also supports executing SQL queries using an ODBC driver. The\
-results returned by connections that use ODBC drivers can differ from the ones\
+This endpoint also supports executing SQL queries using an ODBC driver. The
+results returned by connections that use ODBC drivers can differ from the ones
 returned by normal SQL connections to objects in MaxScale.
 
-This document uses the `:id` value in the URL to represent a connection ID and\
-the `:query_id` to represent a query ID. These values do not need to be manually\
+This document uses the `:id` value in the URL to represent a connection ID and
+the `:query_id` to represent a query ID. These values do not need to be manually
 added as the relevant links are returned in the request body of each endpoint.
 
-The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A\
-connection token can be acquired with a `POST /v1/sql` request and can be used\
-with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in\
+The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A
+connection token can be acquired with a `POST /v1/sql` request and can be used
+with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in
 the `token` parameter of the request:
 
 ```
 POST /v1/sql/query?token=eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhZG1pbiIsImV4cCI6MTU4MzI1NDE1MSwiaWF0IjoxNTgzMjI1MzUxLCJpc3MiOiJtYXhzY2FsZSJ9.B1BqhjjKaCWKe3gVXLszpOPfeu8cLiwSb4CMIJAoyqw
 ```
 
-In addition to request parameters, the token can be stored in cookies in which\
-case they are automatically used by the REST API. For more information about\
+In addition to request parameters, the token can be stored in cookies in which
+case they are automatically used by the REST API. For more information about
 token storage in cookies, see the documentation for `POST /v1/sql`.
 
 ### Request Parameters
 
-All of the endpoints that operate on a single connection support the following\
-request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an\
+All of the endpoints that operate on a single connection support the following
+request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an
 exception as they ignore the current connection token.
 
 * `token`
-* The connection token to use for the request. If provided, the value is\
+* The connection token to use for the request. If provided, the value is
   unconditionally used even if a cookie with a valid token exists.
 
 #### Get one SQL connection
@@ -131,24 +131,24 @@ POST /v1/sql
 The request body must be a JSON object consisting of the following fields:
 
 * `target`
-* The object to connect to. This is a mandatory value and the\
+* The object to connect to. This is a mandatory value and the
   given value must be the name of a valid server, service or listener in\
   MaxScale or the value `odbc` if an ODBC connection is being made.
 * `user`
-* The username to use when creating the connection. This is a mandatory value\
+* The username to use when creating the connection. This is a mandatory value
   when connecting to an object in MaxScale.
 * `password`
-* The password for the user. This is a mandatory value when connecting to an\
+* The password for the user. This is a mandatory value when connecting to an
   object in MaxScale.
 * `db`
-* The default database for the connection. By default the connection will have\
+* The default database for the connection. By default the connection will have
   no default database. This is ignored by ODBC connections.
 * `timeout`
-* Connection timeout in seconds. The default connection timeout is 10\
-  seconds. This controls how long the SQL connection creation can take before\
+* Connection timeout in seconds. The default connection timeout is 10
+  seconds. This controls how long the SQL connection creation can take before
   an error is returned. This is accepted by all connection types.
 * `connection_string`
-* Connection string that defines the ODBC connection. This is a required value\
+* Connection string that defines the ODBC connection. This is a required value
   for ODBC type connections and is ignored by all other connection types.
 
 Here is an example request body:
@@ -163,7 +163,7 @@ Here is an example request body:
 }
 ```
 
-And here is an example request that uses an ODBC driver to connect to a remote\
+And here is an example request that uses an ODBC driver to connect to a remote
 server:
 
 ```
@@ -173,16 +173,16 @@ server:
 }
 ```
 
-The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token\
-is stored in cookies instead of the metadata object and the response body will\
+The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token
+is stored in cookies instead of the metadata object and the response body will
 not contain the token.
 
-The location of the newly created connection will be stored at `links.self` in\
+The location of the newly created connection will be stored at `links.self` in
 the response body as well as in the `Location` header.
 
-The token must be given to all subsequent requests that use the connection. It\
-must be either given in the `token` parameter of a request or it must be stored\
-in the cookies. If both a `token` parameter and a cookie exist at the same time,\
+The token must be given to all subsequent requests that use the connection. It
+must be either given in the `token` parameter of a request or it must be stored
+in the cookies. If both a `token` parameter and a cookie exist at the same time,
 the `token` parameter will be used instead of the cookie.
 
 **Request Parameters**
@@ -191,12 +191,12 @@ This endpoint supports the following request parameters.
 
 * `persist`
 * Store the connection token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie
   where the `<id>` part is replaced by the ID of the connection.
 * `max-age`
-* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or\
-  a non-integer value is found, the parameter is ignored. Once the token age\
-  exceeds the configured maximum value, the token can no longer be used and a\
+* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or
+  a non-integer value is found, the parameter is ignored. Once the token age
+  exceeds the configured maximum value, the token can no longer be used and a
   new connection must be created.
 
 **Response**
@@ -256,12 +256,12 @@ Missing or invalid connection token:
 POST /v1/sql/:id/reconnect
 ```
 
-Reconnects an existing connection. This can also be used if the connection to\
+Reconnects an existing connection. This can also be used if the connection to
 the backend server was lost due to a network error.
 
 The connection will use the same credentials that were passed to the `POST /v1/sql` endpoint. The new connection will still have the same ID in the REST\
-API but will be treated as a new connection by the database. A reconnection\
-re-initializes the connection and resets the session state. Reconnections cannot\
+API but will be treated as a new connection by the database. A reconnection
+re-initializes the connection and resets the session state. Reconnections cannot
 take place while a transaction is open.
 
 **Response**
@@ -284,17 +284,17 @@ Missing or invalid connection token:
 POST /v1/sql/:id/clone
 ```
 
-Clones an existing connection. This is done by opening a new connection using\
+Clones an existing connection. This is done by opening a new connection using
 the credentials and configuration from the given connection.
 
 **Request Parameters**
 
-This endpoint supports the same request parameters as the `POST /v1/sql`\
+This endpoint supports the same request parameters as the `POST /v1/sql`
 endpoint.
 
 **Response**
 
-The response is identical to the one in the `POST /v1/sql` endpoint. In\
+The response is identical to the one in the `POST /v1/sql` endpoint. In
 addition, this endpoint can return the following responses.
 
 Connection is already in use:
@@ -311,7 +311,7 @@ Missing or invalid connection token:
 POST /v1/sql/:id/queries
 ```
 
-The request body must be a JSON object with the value of the `sql` field set to\
+The request body must be a JSON object with the value of the `sql` field set to
 the SQL to be executed:
 
 ```
@@ -324,23 +324,23 @@ the SQL to be executed:
 The request body must be a JSON object consisting of the following fields:
 
 * `sql`
-* The SQL to be executed. If the SQL contain multiple statements, multiple\
+* The SQL to be executed. If the SQL contain multiple statements, multiple
   results are returned in the response body.
 * `max_rows`
-* The maximum number of rows returned in the response. By default this is 1000\
-  rows. Setting the value to 0 means no limit. Any extra rows in the result\
+* The maximum number of rows returned in the response. By default this is 1000
+  rows. Setting the value to 0 means no limit. Any extra rows in the result
   will be discarded.
 
-By default, the complete result is returned in the response body. If the SQL\
-query returns more than one result, the `results` array will contain all the\
-results. If the `async=true` request option is used, the query is queued for\
+By default, the complete result is returned in the response body. If the SQL
+query returns more than one result, the `results` array will contain all the
+results. If the `async=true` request option is used, the query is queued for
 execution.
 
-The `results` array can have three types of objects: resultsets, errors, and OK\
+The `results` array can have three types of objects: resultsets, errors, and OK
 responses.
 
-* A resultset consists of the `data` field with the result data stored as a two\
-  dimensional array. The names of the fields are stored in an array in the`fields` field. These types of results will be returned for any operation that\
+* A resultset consists of the `data` field with the result data stored as a two
+  dimensional array. The names of the fields are stored in an array in the`fields` field. These types of results will be returned for any operation that
   returns rows (i.e. `SELECT` statements)
 
 ```
@@ -378,7 +378,7 @@ responses.
 }
 ```
 
-* An error consists of an object with the `errno` field set to the MariaDB error\
+* An error consists of an object with the `errno` field set to the MariaDB error
   code, the `message` field set to the human-readable error message and the`sqlstate` field set to the current SQLSTATE of the connection.
 
 ```
@@ -404,9 +404,9 @@ responses.
 }
 ```
 
-* An OK response is returned for any result that completes successfully but not\
-  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`\
-  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field\
+* An OK response is returned for any result that completes successfully but not
+  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`
+  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field
   contains the number of warnings raised by the operation.
 
 ```
@@ -432,17 +432,17 @@ responses.
 }
 ```
 
-It is also possible for the fields of the error response to be present in the\
-resultset response if the result ended with an error but still generated some\
-data. Usually this happens when query execution is interrupted but a partial\
+It is also possible for the fields of the error response to be present in the
+resultset response if the result ended with an error but still generated some
+data. Usually this happens when query execution is interrupted but a partial
 result was generated by the server.
 
 **Request Parameters**
 
 * `async`
-* If set to `true`, the query is queued for asynchronous execution and the\
-  results must be retrieved later from the URL stored in `links.self` field\
-  of the response. The HTTP response code is set to HTTP 202 Accepted if the\
+* If set to `true`, the query is queued for asynchronous execution and the
+  results must be retrieved later from the URL stored in `links.self` field
+  of the response. The HTTP response code is set to HTTP 202 Accepted if the
   query was successfully queued for execution.
 
 **Response**
@@ -508,7 +508,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 #### Get Asynchronous Query Results
@@ -517,10 +517,10 @@ Fatal connection error:
 GET /v1/sql/:id/queries/:query_id
 ```
 
-The results are only available if a `POST /v1/sql/:id/queries` was executed with\
-the `async` field set to `true`. The result of any asynchronous query can be\
-read multiple times. Only the latest result is stored: executing a new query\
-will cause the latest result to be erased. Results can be explicitly erased\
+The results are only available if a `POST /v1/sql/:id/queries` was executed with
+the `async` field set to `true`. The result of any asynchronous query can be
+read multiple times. Only the latest result is stored: executing a new query
+will cause the latest result to be erased. Results can be explicitly erased
 with a `DELETE` request.
 
 **Response**
@@ -570,7 +570,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 #### Erase Asynchronous Query Results
@@ -579,7 +579,7 @@ Fatal connection error:
 DELETE /v1/sql/:id/queries/:query_id
 ```
 
-Erases the latest result of an asynchronously executed query. All asynchronous\
+Erases the latest result of an asynchronously executed query. All asynchronous
 results are erased when the connection that owns them is closed.
 
 **Response**
@@ -602,12 +602,12 @@ Missing connection token:
 POST /v1/sql/:id/cancel
 ```
 
-This endpoint cancels the current query being executed by this connection. If no\
+This endpoint cancels the current query being executed by this connection. If no
 query is being done and the connection is idle, no action is taken.
 
-If the connection is busy but it is not executing a query, an attempt to cancel\
-is still made: in this case the results of this operation are undefined for ODBC\
-connections, for MariaDB connections this will cause a `KILL QUERY` command to\
+If the connection is busy but it is not executing a query, an attempt to cancel
+is still made: in this case the results of this operation are undefined for ODBC
+connections, for MariaDB connections this will cause a `KILL QUERY` command to
 be executed.
 
 **Response**
@@ -630,9 +630,9 @@ Missing connection token:
 GET /v1/sql/odbc/drivers
 ```
 
-Get the list of configured ODBC drivers found by the driver manager. The list of\
-drivers includes all drivers known to the driver manager for which an installed\
-library was found (i.e. `Driver` or `Driver64` in `/etc/odbcinst.ini` points to\
+Get the list of configured ODBC drivers found by the driver manager. The list of
+drivers includes all drivers known to the driver manager for which an installed
+library was found (i.e. `Driver` or `Driver64` in `/etc/odbcinst.ini` points to
 a file).
 
 **Response**
@@ -667,14 +667,14 @@ The response contains a resource collection with all available drivers.
 POST /v1/sql/:id/etl/prepare
 ```
 
-The ETL operation requires two connections: an ODBC connection to a remote\
-server (source connection) and a connection to a server in MaxScale (destination\
+The ETL operation requires two connections: an ODBC connection to a remote
+server (source connection) and a connection to a server in MaxScale (destination
 connection). All ETL operations must be done on the ODBC connection.
 
 The ETL operations require that the MariaDB ODBC driver is installed on the\
-MaxScale server. This driver is often available in the package manager of your\
-operating system but it can also be downloaded from the MariaDB\
-website. Installation instructions for installing the driver manually can be\
+MaxScale server. This driver is often available in the package manager of your
+operating system but it can also be downloaded from the MariaDB
+website. Installation instructions for installing the driver manually can be
 found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#installing-mariadb-connectorodbc-on-linux).
 
 The request body must be a JSON object consisting of the following fields:
@@ -682,12 +682,12 @@ The request body must be a JSON object consisting of the following fields:
 * `target`
 
 The target connection ID that defines the destination server. This must be the\
-ID of a connection (i.e. `data.attributes.id` ) to a server in MaxScale\
+ID of a connection (i.e. `data.attributes.id` ) to a server in MaxScale
 created via the `POST /v1/sql/` endpoint.
 
 * `type`
 
-The type of the ETL data source. The value must be a string with one of the\
+The type of the ETL data source. The value must be a string with one of the
 following values:
 
 ```
@@ -715,48 +715,48 @@ following values:
 
 * `tables`
 
-An array of objects, each of which must define a `table` and a `schema`\
+An array of objects, each of which must define a `table` and a `schema`
 field. The `table` field defines the name of the table to be imported and the`schema` field defines the schema it is in. If the objects contain a value for`create`, `select` or `insert`, the SQL generation for that part is skipped.
 
 * `connection_string`
 
-Extra connection string that is appended to the destination server's\
-connection string. This connection will always use the MariaDB ODBC\
+Extra connection string that is appended to the destination server's
+connection string. This connection will always use the MariaDB ODBC
 driver. The list of supported options can be found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#parameters).
 
 * `threads`
 
-The number of parallel connections used during the ETL operation. By default\
+The number of parallel connections used during the ETL operation. By default
 the ETL operation will use up to 16 connections.
 
 * `timeout`
 
-The connection and query timeout in seconds. By default a timeout of 30\
+The connection and query timeout in seconds. By default a timeout of 30
 seconds is used.
 
 * `create_mode`
 
-A string with either `normal`, `ignore` or `replace` which controls how tables\
+A string with either `normal`, `ignore` or `replace` which controls how tables
 are handled that already exist on the destination server.
 
-If left undefined or set to `normal`, the tables are created using a normal`CREATE TABLE` statement. This will cause an error to be reported if the table\
-already exist and will prevent the ETL from proceeding past the object\
+If left undefined or set to `normal`, the tables are created using a normal`CREATE TABLE` statement. This will cause an error to be reported if the table
+already exist and will prevent the ETL from proceeding past the object
 creation stage.
 
-If set to `ignore` the tables are created with `CREATE TABLE IF NOT EXISTS`\
-which will ignore any existing tables and assume that they are compatible with\
-the rest of the ETL operation. This mode can be used to continuously load data\
+If set to `ignore` the tables are created with `CREATE TABLE IF NOT EXISTS`
+which will ignore any existing tables and assume that they are compatible with
+the rest of the ETL operation. This mode can be used to continuously load data
 from an external source into MariaDB.
 
-If set to `replace`, the tables are created with `CREATE OR REPLACE TABLE`\
-which will cause existing tables to be dropped if they exist. This is not a\
+If set to `replace`, the tables are created with `CREATE OR REPLACE TABLE`
+which will cause existing tables to be dropped if they exist. This is not a
 reversible process so caution should be taken when this mode is used.
 
 * `catalog`
 
 The catalog for the tables. This is only used when `type` is set to`generic`. In all other cases this value is ignored.
 
-Here is an example payload that prepares the table `test.t1` for extraction from\
+Here is an example payload that prepares the table `test.t1` for extraction from
 a MariaDB server.
 
 ```
@@ -772,9 +772,9 @@ a MariaDB server.
 }
 ```
 
-The token for the source connection is provided the same way it is\
-provided for all other `/v1/sql` endpoints: in the `token` request\
-parameter or in the cookies. The destination connection token is\
+The token for the source connection is provided the same way it is
+provided for all other `/v1/sql` endpoints: in the `token` request
+parameter or in the cookies. The destination connection token is
 provided either in the `target_token` request parameter or as a cookie.
 
 ### Request Parameters
@@ -782,8 +782,8 @@ provided either in the `target_token` request parameter or as a cookie.
 This endpoints supports the following additional request parameters.
 
 * `target_token`
-* The connection token for the destination connection. If provided, the value\
-  is unconditionally used even if a cookie with a valid token exists for the\
+* The connection token for the destination connection. If provided, the value
+  is unconditionally used even if a cookie with a valid token exists for the
   destination connection.
 
 **Response**
@@ -792,7 +792,7 @@ ETL operation prepared:
 
 `Status: 202 Accepted`
 
-Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the\
+Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the
 following result.
 
 ```
@@ -834,32 +834,32 @@ Invalid payload or missing connection token:
 POST /v1/sql/:id/etl/start
 ```
 
-The behavior of this endpoint is identical to the preparation but instead of\
-preparing the operation, this endpoint will execute the prepared ETL and load\
+The behavior of this endpoint is identical to the preparation but instead of
+preparing the operation, this endpoint will execute the prepared ETL and load
 the data into MariaDB.
 
-The intended way of doing an ETL operation is to first prepare it using the`/v1/sql/:id/etl/prepare` endpoint to retrieve the SQL statements that define\
-the ETL operation. Then if the ETL preparation is successful, the`data.attributes.results.tables` value from the response is used as the `tables`\
+The intended way of doing an ETL operation is to first prepare it using the`/v1/sql/:id/etl/prepare` endpoint to retrieve the SQL statements that define
+the ETL operation. Then if the ETL preparation is successful, the`data.attributes.results.tables` value from the response is used as the `tables`
 value for the ETL start operation, done on the `/v1/sql/:id/etl/start` endpoint.
 
-If any of the `create`, `select` or `insert` fields for a table in the `tables`\
-list have not been defined, the SQL will be automatically generated by querying\
-the source server, similarly to how the preparation generates the SQL\
-statements. This means that the preparation step is optional if there is no need\
+If any of the `create`, `select` or `insert` fields for a table in the `tables`
+list have not been defined, the SQL will be automatically generated by querying
+the source server, similarly to how the preparation generates the SQL
+statements. This means that the preparation step is optional if there is no need
 to adjust the automatically generated SQL.
 
-The ETL operation can be canceled using the `/v1/sql/:id/cancel` endpoint which\
-will roll back the ETL operation. Any tables that were created during the ETL\
-operation are not deleted on the destination server and must be manually cleaned\
+The ETL operation can be canceled using the `/v1/sql/:id/cancel` endpoint which
+will roll back the ETL operation. Any tables that were created during the ETL
+operation are not deleted on the destination server and must be manually cleaned
 up.
 
-If the ETL fails to extract the SQL from the source server or an error was\
-encountered during table creation, the response will have the `"ok"` field set\
-to false. Both the top-level object as well as the individual tables can have\
+If the ETL fails to extract the SQL from the source server or an error was
+encountered during table creation, the response will have the `"ok"` field set
+to false. Both the top-level object as well as the individual tables can have
 the `"error"` field set to the error message. This field is filled during the\
 ETL operation which means errors are visible even if the ETL is still ongoing.
 
-During the ETL operation, tables that have been fully processed will have a`"execution_time"` field. This field has the total time in seconds it took to\
+During the ETL operation, tables that have been fully processed will have a`"execution_time"` field. This field has the total time in seconds it took to
 execute the data loading step.
 
 **Response**
@@ -868,7 +868,7 @@ ETL operation started:
 
 `Status: 202 Accepted`
 
-Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the\
+Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the
 following result.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avrorouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avrorouter.md
@@ -1,13 +1,13 @@
 # Avrorouter
 
-The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes\
+The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes
 binary logs from a local directory and transforms them into a set of Avro files.\
 These files can then be queried by clients for various purposes.
 
 This router is intended to be used in tandem with the [Binlog Server](mariadb-maxscale-2302-binlogrouter.md).\
 The Binlog Server can connect to a primary server and request binlog records.\
-These records can then consumed by the avrorouter directly from the binlog cache\
-of the Binlog Server. This allows MariaDB MaxScale to automatically transform\
+These records can then consumed by the avrorouter directly from the binlog cache
+of the Binlog Server. This allows MariaDB MaxScale to automatically transform
 binlog events on the primary to local Avro format files.
 
 ```mermaid
@@ -64,25 +64,25 @@ flowchart LR
 ```
 _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog events are converted to Avro-formatted change data and streamed to CDC clients, Kafka, and Hadoop._
 
-The avrorouter can also consume binary logs straight from the primary. This will\
-remove the need to configure the Binlog Server but it will increase the disk space\
+The avrorouter can also consume binary logs straight from the primary. This will
+remove the need to configure the Binlog Server but it will increase the disk space
 requirement on the primary server by at least a factor of two.
 
-The converted Avro files can be requested with the CDC protocol. This protocol\
-should be used to communicate with the avrorouter and currently it is the only\
-supported protocol. The clients can request either Avro or JSON format data\
+The converted Avro files can be requested with the CDC protocol. This protocol
+should be used to communicate with the avrorouter and currently it is the only
+supported protocol. The clients can request either Avro or JSON format data
 streams from a database table.
 
 ### Direct Replication Mode
 
-MaxScale 2.4.0 added a direct replication mode that connects the avrorouter\
-directly to a MariaDB server. This mode is an improvement over the binlogrouter\
-based replication as it provides a more space-efficient and faster conversion\
-process. This is the recommended method of using the avrorouter as it is faster,\
+MaxScale 2.4.0 added a direct replication mode that connects the avrorouter
+directly to a MariaDB server. This mode is an improvement over the binlogrouter
+based replication as it provides a more space-efficient and faster conversion
+process. This is the recommended method of using the avrorouter as it is faster,
 more efficient and less prone to errors caused by missing DDL events.
 
-To enable the direct replication mode, add either the `servers` or the `cluster`\
-parameter to the avrorouter service. The avrorouter will then use one of the\
+To enable the direct replication mode, add either the `servers` or the `cluster`
+parameter to the avrorouter service. The avrorouter will then use one of the
 servers as the replication source.
 
 Here is a minimal avrorouter direct replication configuration:
@@ -110,12 +110,12 @@ protocol=CDC
 port=4001
 ```
 
-In direct replication mode, the avrorouter stores the latest replicated GTID in\
-the `last_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove\
+In direct replication mode, the avrorouter stores the latest replicated GTID in
+the `last_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove
 the file.
 
-Additionally, the avrorouter will attempt to automatically create any missing\
-schema files for tables that have data events for them but the DDL for those\
+Additionally, the avrorouter will attempt to automatically create any missing
+schema files for tables that have data events for them but the DDL for those
 tables is not contained in the binlogs.
 
 ### Configuration
@@ -131,13 +131,13 @@ For information about common service parameters, refer to the [Configuration Gui
 * Dynamic: No
 * Default: `""`
 
-The GTID where avrorouter starts the replication from in direct replication\
-mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where\
-the first number is the replication domain, the second the server\_id value of\
+The GTID where avrorouter starts the replication from in direct replication
+mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where
+the first number is the replication domain, the second the server\_id value of
 the server and the last is the GTID sequence number.
 
-This parameter has no effect in the traditional mode. If this parameter is\
-defined, the replication will start from the implicit GTID that the primary first\
+This parameter has no effect in the traditional mode. If this parameter is
+defined, the replication will start from the implicit GTID that the primary first
 serves.
 
 **`server_id`**
@@ -147,7 +147,7 @@ serves.
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
 used when replicating from the primary in direct replication mode.
 
 **`codec`**
@@ -161,7 +161,7 @@ used when replicating from the primary in direct replication mode.
 The compression codec to use. By default, the avrorouter does not use compression.
 
 This parameter takes one of the following two values; _null_ or\_deflate\_. These are the mandatory compression algorithms required by the\
-Avro specification. For more information about the compression types,\
+Avro specification. For more information about the compression types,
 refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specification/#required-codecs).
 
 **`match` and `exclude`**
@@ -171,13 +171,13 @@ refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specificat
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+These [regular expression settings](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 filter events for processing depending on table names. Avrorouter does not support the\_options\_-parameter for regular expressions.
 
-To prevent excessive matching of similarly named tables, surround each table\
-name with the `^` and `$` tokens. For example, to match the `test.clients` table\
-but not `test.clients_old` table use `match=^test[.]clients$`. For multiple\
-tables, surround each table in parentheses and add a pipe character between\
+To prevent excessive matching of similarly named tables, surround each table
+name with the `^` and `$` tokens. For example, to match the `test.clients` table
+but not `test.clients_old` table use `match=^test[.]clients$`. For multiple
+tables, surround each table in parentheses and add a pipe character between
 them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 
 **`binlogdir`**
@@ -187,8 +187,8 @@ them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location of the binary log files. This is the first mandatory parameter\
-and it defines where the module will read binlog files from. Read access to\
+The location of the binary log files. This is the first mandatory parameter
+and it defines where the module will read binlog files from. Read access to
 this directory is required.
 
 **`avrodir`**
@@ -198,14 +198,14 @@ this directory is required.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location where the Avro files are stored. This is the second mandatory\
-parameter and it governs where the converted files are stored. This directory\
-will be used to store the Avro files, plain-text Avro schemas and other files\
-needed by the avrorouter. The user running MariaDB MaxScale will need both read and\
+The location where the Avro files are stored. This is the second mandatory
+parameter and it governs where the converted files are stored. This directory
+will be used to store the Avro files, plain-text Avro schemas and other files
+needed by the avrorouter. The user running MariaDB MaxScale will need both read and
 write access to this directory.
 
-The avrorouter will also use the _avrodir_ to store various internal\
-files. These files are named _avro.index_ and _avro-conversion.ini_. By default,\
+The avrorouter will also use the _avrodir_ to store various internal
+files. These files are named _avro.index_ and _avro-conversion.ini_. By default,
 the default data directory, _/var/lib/maxscale/_, is used. Before version 2.1 of\
 MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 
@@ -216,7 +216,7 @@ MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 * Dynamic: No
 * Default: `mysql-bin`
 
-The base name of the binlog files. The binlog files are assumed to follow the\
+The base name of the binlog files. The binlog files are assumed to follow the
 naming schema _._ where is the binlog number and is the value of this router option.
 
 For example, with the following parameters:
@@ -236,11 +236,11 @@ The first binlog file the avrorouter would look for is `/var/lib/mysql/binlogs/m
 * Default: `1`
 
 The starting index number of the binlog file. The default value is 1.\
-For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_\
+For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_
 the index would be 5.
 
-If you need to start from a binlog file other than 1, you need to set the value\
-of this option to the correct index. The avrorouter will always start from the\
+If you need to start from a binlog file other than 1, you need to set the value
+of this option to the correct index. The avrorouter will always start from the
 beginning of the binary log file.
 
 #### `cooperative_replication`
@@ -250,39 +250,39 @@ beginning of the binary log file.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
-cluster. This is a boolean parameter and is disabled by default. It was\
+Controls whether multiple instances cooperatively replicate from the same
+cluster. This is a boolean parameter and is disabled by default. It was
 added in MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`),\
-the replication is only active if the monitor owns the cluster it is\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`),
+the replication is only active if the monitor owns the cluster it is
 monitoring.
 
-With this feature, multiple MaxScale instances can replicate from the same set\
-of servers and only one of them actively processes the replication stream. This\
-allows the avrorouter instances to be made highly-available without having to\
+With this feature, multiple MaxScale instances can replicate from the same set
+of servers and only one of them actively processes the replication stream. This
+allows the avrorouter instances to be made highly-available without having to
 have them all process the events at the same time.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID processed by that\
-instance. This means that if the instance hasn't replicated events that have\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID processed by that
+instance. This means that if the instance hasn't replicated events that have
 been purged from the binary logs, the replication cannot continue.
 
 **Avro File Related Parameters**
 
 These options control how large the Avro file data blocks can get.\
-Increasing or lowering the block size could have a positive effect\
-depending on your use case. For more information about the Avro file\
+Increasing or lowering the block size could have a positive effect
+depending on your use case. For more information about the Avro file
 format and how it organizes data, refer to the [Avro documentation](https://avro.apache.org/docs/current/).
 
-The avrorouter will flush a block and start a new one when either `group_trx`\
-transactions or `group_rows` row events have been processed. Changing these\
-options will also allow more frequent updates to stored data but this\
+The avrorouter will flush a block and start a new one when either `group_trx`
+transactions or `group_rows` row events have been processed. Changing these
+options will also allow more frequent updates to stored data but this
 will cause a small increase in file size and search times.
 
-It is highly recommended to keep the block sizes relatively large to allow\
-larger chunks of memory to be flushed to disk at one time. This will make\
+It is highly recommended to keep the block sizes relatively large to allow
+larger chunks of memory to be flushed to disk at one time. This will make
 the conversion process noticeably faster.
 
 **`group_trx`**
@@ -292,7 +292,7 @@ the conversion process noticeably faster.
 * Dynamic: No
 * Default: `1`
 
-Controls the number of transactions that are grouped into a single Avro\
+Controls the number of transactions that are grouped into a single Avro
 data block.
 
 **`group_rows`**
@@ -302,7 +302,7 @@ data block.
 * Dynamic: No
 * Default: `1000`
 
-Controls the number of row events that are grouped into a single Avro\
+Controls the number of row events that are grouped into a single Avro
 data block.
 
 **`block_size`**
@@ -312,10 +312,10 @@ data block.
 * Dynamic: Yes
 * Default: `16KiB`
 
-The Avro data block size in bytes. The default is 16 kilobytes. Increase this\
-value if individual events in the binary logs are very large. The value is a\
+The Avro data block size in bytes. The default is 16 kilobytes. Increase this
+value if individual events in the binary logs are very large. The value is a
 size type parameter which means that it can also be defined with an SI suffix.\
-Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)
 for more details about size type parameters and how to use them.
 
 **`max_file_size`**
@@ -325,17 +325,17 @@ for more details about size type parameters and how to use them.
 * Dynamic: No
 * Default: 0
 
-If the size of a single Avro data file exceeds this limit, the avrorouter will\
-rotate to a new file. This is done by closing the existing file and creating a\
-new one with the next version number. By default the avrorouter does not rotate\
-files based on their size. Setting the value to 0 disables file rotation based on\
+If the size of a single Avro data file exceeds this limit, the avrorouter will
+rotate to a new file. This is done by closing the existing file and creating a
+new one with the next version number. By default the avrorouter does not rotate
+files based on their size. Setting the value to 0 disables file rotation based on
 size.
 
-This uses the size of the file as reported by the operating system. The check\
-for the file size is done after a transaction has been processed which means\
+This uses the size of the file as reported by the operating system. The check
+for the file size is done after a transaction has been processed which means
 that large transactions can still cause the file size to exceed the given limit.
 
-File rotation only works with the direct replication mode. The legacy file based\
+File rotation only works with the direct replication mode. The legacy file based
 replication mode does not support this.
 
 **`max_data_age`**
@@ -345,17 +345,17 @@ replication mode does not support this.
 * Dynamic: No
 * Default: 0s
 
-When enabled, the avrorouter will automatically purge any files that only have\
-data that is older than the given limit. This means that all data files with at\
-least one event that is newer than the configured limit will not be removed,\
-even if the age of all the other events is above the limit. The purge operation\
-is only done when a file rotation takes place (either manual or automatic) or\
+When enabled, the avrorouter will automatically purge any files that only have
+data that is older than the given limit. This means that all data files with at
+least one event that is newer than the configured limit will not be removed,
+even if the age of all the other events is above the limit. The purge operation
+is only done when a file rotation takes place (either manual or automatic) or
 when a schema change is detected.
 
-This parameter is best combined with `max_file_size` to provide automatic\
+This parameter is best combined with `max_file_size` to provide automatic
 removal of stale data.
 
-Automatic file purging only works with the direct replication mode. The legacy\
+Automatic file purging only works with the direct replication mode. The legacy
 file based replication mode does not support this.
 
 **Example configuration**
@@ -378,94 +378,94 @@ avrodir=/var/lib/maxscale
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-module-commands.md) documentation for
 details about module commands.
 
 The avrorouter supports the following module commands.
 
 #### `avrorouter::convert SERVICE {start | stop}`
 
-Start or stop the binary log to Avro conversion. The first parameter is the name\
-of the service to stop and the second parameter tells whether to start the\
+Start or stop the binary log to Avro conversion. The first parameter is the name
+of the service to stop and the second parameter tells whether to start the
 conversion process or to stop it.
 
 #### `avrorouter::purge SERVICE`
 
 This command will delete all files created by the avrorouter. This includes all\
-.avsc schema files and .avro data files as well as the internal state tracking\
+.avsc schema files and .avro data files as well as the internal state tracking
 files. Use this to completely reset the conversion process.
 
-**Note:** Once the command has completed, MaxScale must be restarted to restart\
+**Note:** Once the command has completed, MaxScale must be restarted to restart
 the conversion process. Issuing a `convert start` command **will not work**.
 
-**WARNING:** You will lose any and all converted data when this command is\
+**WARNING:** You will lose any and all converted data when this command is
 executed.
 
 ### Files Created by the Avrorouter
 
-The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store\
-the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains\
-the last converted position and GTID in the binlogs. If you need to reset the\
+The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store
+the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains
+the last converted position and GTID in the binlogs. If you need to reset the
 conversion process, delete these two files and restart MaxScale.
 
 ### Resetting the Conversion Process
 
-To reset the binlog conversion process, issue the `purge` module command by\
-executing it via MaxCtrl and stop MaxScale. If manually created schema files\
+To reset the binlog conversion process, issue the `purge` module command by
+executing it via MaxCtrl and stop MaxScale. If manually created schema files
 were used, they need to be recreated once MaxScale is stopped. After stopping\
-MaxScale and optionally creating the schema files, the conversion process can be\
+MaxScale and optionally creating the schema files, the conversion process can be
 started by starting MaxScale.
 
 ### Stopping the Avrorouter
 
-The safest way to stop the avrorouter when used with the binlogrouter is to\
+The safest way to stop the avrorouter when used with the binlogrouter is to
 follow the following steps:
 
 * Issue `STOP SLAVE` on the binlogrouter
 * Wait for the avrorouter to process all files
 * Stop MaxScale with `systemctl stop maxscale`
 
-This guarantees that the conversion process halts at a known good position in\
+This guarantees that the conversion process halts at a known good position in
 the latest binlog file.
 
 ### Example Client
 
 The avrorouter comes with an example client program, _cdc.py_, written in Python 3.\
-This client can connect to a MaxScale configured with the CDC protocol and the\
+This client can connect to a MaxScale configured with the CDC protocol and the
 avrorouter.
 
-Before using this client, you will need to install the Python 3 interpreter and\
-add users to the service with the _cdc\_users.py_ script. Fore more details about\
-the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-change-data-capture-cdc-protocol.md)\
+Before using this client, you will need to install the Python 3 interpreter and
+add users to the service with the _cdc\_users.py_ script. Fore more details about
+the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-change-data-capture-cdc-protocol.md)
 and [CDC Users](../mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-change-data-capture-cdc-users.md) documentation.
 
-Read the output of `cdc.py --help` for a full list of supported options\
+Read the output of `cdc.py --help` for a full list of supported options
 and a short usage description of the client program.
 
 ### Avro Schema Generator
 
-The avrorouter needs to have access to the CREATE TABLE statement for all tables\
-for which there are data events in the binary logs. If the CREATE TABLE\
-statements for the tables aren't present in the current binary logs, the schema\
+The avrorouter needs to have access to the CREATE TABLE statement for all tables
+for which there are data events in the binary logs. If the CREATE TABLE
+statements for the tables aren't present in the current binary logs, the schema
 files must be created.
 
-In the direct replication mode, avrorouter will automatically create the missing\
-schema files by connecting to the database and executing a `SHOW CREATE TABLE`\
-statement. If a connection cannot be made or the service user lacks the\
-permission, an error will be logged and the data events for that table will not\
+In the direct replication mode, avrorouter will automatically create the missing
+schema files by connecting to the database and executing a `SHOW CREATE TABLE`
+statement. If a connection cannot be made or the service user lacks the
+permission, an error will be logged and the data events for that table will not
 be processed.
 
-For the legacy binlog mode, the files must be generated with a schema file\
+For the legacy binlog mode, the files must be generated with a schema file
 generator. There are currently two methods to generate the .avsc schema files.
 
 #### Simple Schema Generator
 
-The `cdc_one_schema.py` generates a schema file for a single table by reading a\
-tab separated list of field and type names from the standard input. This is the\
-recommended schema generation tool as it does not directly communicate with the\
+The `cdc_one_schema.py` generates a schema file for a single table by reading a
+tab separated list of field and type names from the standard input. This is the
+recommended schema generation tool as it does not directly communicate with the
 database thus making it more flexible.
 
-The only requirement to run the script is that a Python interpreter is\
+The only requirement to run the script is that a Python interpreter is
 installed.
 
 To use this script, pipe the output of the `mysql` command line into the`cdc_one_schema.py` script:
@@ -474,15 +474,15 @@ To use this script, pipe the output of the `mysql` command line into the`cdc_one
 mysql -ss -u <user> -p -h <host> -P <port> -e 'DESCRIBE `<database>`.`<table>`'|./cdc_one_schema.py <database> <table>
 ```
 
-Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with\
-appropriate values and run the command. Note that the `-ss` parameter is\
-mandatory as that will generate the tab separated output instead of the default\
+Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with
+appropriate values and run the command. Note that the `-ss` parameter is
+mandatory as that will generate the tab separated output instead of the default
 pretty-printed output.
 
-An .avsc file named after the database and table name will be generated in the\
+An .avsc file named after the database and table name will be generated in the
 current working directory. Copy this file to the location pointed by the`avrodir` parameter of the avrorouter.
 
-Alternatively, you can also copy the output of the `mysql` command to a file and\
+Alternatively, you can also copy the output of the `mysql` command to a file and
 feed it into the script if you cannot execute the SQL command directly:
 
 ```
@@ -505,31 +505,31 @@ usage: cdc_schema.py [--help] [-h HOST] [-P PORT] [-u USER] [-p PASSWORD] DATABA
 The _cdc\_schema.py_ executable is installed as a part of MaxScale. This is a\
 Python 3 script that generates Avro schema files from an existing database.
 
-The script will generate the .avsc schema files into the current directory. Run\
-the script for all required databases copy the generated .avsc files to the\
+The script will generate the .avsc schema files into the current directory. Run
+the script for all required databases copy the generated .avsc files to the
 directory where the avrorouter stores the .avro files (the value of `avrodir`).
 
 #### Go Schema Generator
 
-The _cdc\_schema.go_ example Go program is provided with MaxScale. This file\
-can be used to create Avro schemas for the avrorouter by connecting to a\
-database and reading the table definitions. You can find the file in MaxScale's\
+The _cdc\_schema.go_ example Go program is provided with MaxScale. This file
+can be used to create Avro schemas for the avrorouter by connecting to a
+database and reading the table definitions. You can find the file in MaxScale's
 share directory in `/usr/share/maxscale/`.
 
-You'll need to install the Go compiler and run `go get` to resolve Go\
-dependencies before you can use the _cdc\_schema_ program. After resolving the\
-dependencies you can run the program with `go run cdc_schema.go`. The program\
-will create .avsc files in the current directory. These files should be moved\
-to the location pointed by the _avrodir_ option of the avrorouter if they are\
+You'll need to install the Go compiler and run `go get` to resolve Go
+dependencies before you can use the _cdc\_schema_ program. After resolving the
+dependencies you can run the program with `go run cdc_schema.go`. The program
+will create .avsc files in the current directory. These files should be moved
+to the location pointed by the _avrodir_ option of the avrorouter if they are
 to be used by the router itself.
 
-Read the output of `go run cdc_schema.go -help` for more information on how\
+Read the output of `go run cdc_schema.go -help` for more information on how
 to run the program.
 
 ### Examples
 
-The [Avrorouter Tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-avrorouter-tutorial.md) shows you how\
-the Avrorouter works with the Binlog Server to convert binlogs from a primary server\
+The [Avrorouter Tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-avrorouter-tutorial.md) shows you how
+the Avrorouter works with the Binlog Server to convert binlogs from a primary server
 into easy to process Avro data.
 
 Here is a simple configuration example which reads binary logs locally from`/var/lib/mysql/` and stores them as Avro files in `/var/lib/maxscale/avro/`.\
@@ -559,7 +559,7 @@ Python script. It queries the table _test.mytable_ for all change records.
 cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytable
 ```
 
-You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change\
+You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change
 records to a Kafka broker.
 
 ```
@@ -567,28 +567,28 @@ cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytab
 cdc_kafka_producer.py --kafka-broker 127.0.0.1:9092 --kafka-topic test.mytable
 ```
 
-For more information on how to use these scripts, see the output of `cdc.py -h`\
+For more information on how to use these scripts, see the output of `cdc.py -h`
 and `cdc_kafka_producer.py -h`.
 
 ### Building Avrorouter
 
-To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development\
+To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development
 headers. When configuring MaxScale with CMake, you will need to add`-DBUILD_CDC=Y` to build the CDC module set.
 
-The Avro C library needs to be build with position independent code enabled. You\
-can do this by adding the following flags to the CMake invocation when\
+The Avro C library needs to be build with position independent code enabled. You
+can do this by adding the following flags to the CMake invocation when
 configuring the Avro C library.
 
 ```
 -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC
 ```
 
-For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-building-mariadb-maxscale-from-source-code.md)\
+For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-building-mariadb-maxscale-from-source-code.md)
 document.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for an avrorouter service contains the following\
+The `router_diagnostics` output for an avrorouter service contains the following
 fields.
 
 * `infofile`: File where the avrorouter stores the conversion process state.
@@ -608,8 +608,8 @@ The avrorouter does not support the following data types, conversions or SQL sta
 * Fields CAST from integer types to string types
 * [CREATE TABLE ... AS SELECT statements](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/tables/create-table)
 
-The avrorouter does not do any crash recovery. This means that the avro files\
-need to be removed or truncated to valid block lengths before starting the\
+The avrorouter does not do any crash recovery. This means that the avro files
+need to be removed or truncated to valid block lengths before starting the
 avrorouter.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-binlogrouter-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-binlogrouter-24.md
@@ -1,63 +1,63 @@
 # Binlogrouter 2.4
 
 **NOTE** This is the documentation for the binlogrouter in\
-MaxScale 2.4 and is only provided for reference. The documentation\
+MaxScale 2.4 and is only provided for reference. The documentation
 for the binlogrouter in MaxScale 2.5 is provided [here](mariadb-maxscale-2302-binlogrouter.md).
 
 ### Introduction
 
 The binlogrouter is a replication protocol proxy module for MariaDB\
-MaxScale. This module allows MariaDB MaxScale to connect to a master server and\
-retrieve binary logs while slave servers can connect to MariaDB MaxScale like\
-they would connect to a normal master server. If the master server goes down,\
-the slave servers can still connect to MariaDB MaxScale and read binary\
-logs. You can switch to a new master server without the slaves noticing that the\
-actual master server has changed. This allows for a more highly available\
+MaxScale. This module allows MariaDB MaxScale to connect to a master server and
+retrieve binary logs while slave servers can connect to MariaDB MaxScale like
+they would connect to a normal master server. If the master server goes down,
+the slave servers can still connect to MariaDB MaxScale and read binary
+logs. You can switch to a new master server without the slaves noticing that the
+actual master server has changed. This allows for a more highly available
 replication setup where replication is high-priority.
 
 ### Configuration
 
 #### Mandatory Router Parameters
 
-The binlogrouter requires the `user` and `password` parameters. These should be\
+The binlogrouter requires the `user` and `password` parameters. These should be
 configured according to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#service).
 
-In addition to these two parameters, the `server_id` and `binlogdir` parameters\
+In addition to these two parameters, the `server_id` and `binlogdir` parameters
 needs to be defined.
 
 #### Router Parameters
 
 The binlogrouter accepts the following parameters.
 
-**Note:** Earlier versions of MaxScale supported the configuration of the\
-binlogrouter only via `router_options` (a the comma-separated list of key-value\
-pairs). As of MaxScale 2.1, all of the router options should be defined as\
-parameters. The values defined in `router_options` will have priority over the\
-parameters to support legacy configurations. The use of `router_options` is\
+**Note:** Earlier versions of MaxScale supported the configuration of the
+binlogrouter only via `router_options` (a the comma-separated list of key-value
+pairs). As of MaxScale 2.1, all of the router options should be defined as
+parameters. The values defined in `router_options` will have priority over the
+parameters to support legacy configurations. The use of `router_options` is
 deprecated.
 
 **`binlogdir`**
 
-This parameter controls the location where MariaDB MaxScale stores the binary log\
+This parameter controls the location where MariaDB MaxScale stores the binary log
 files. This is a mandatory parameter.
 
-The _binlogdir_ also contains the _cache_ subdirectory which stores data\
-retrieved from the master during the slave registration phase. The\
-master.ini file also resides in the _binlogdir_. This file keeps track of\
+The _binlogdir_ also contains the _cache_ subdirectory which stores data
+retrieved from the master during the slave registration phase. The
+master.ini file also resides in the _binlogdir_. This file keeps track of
 the current master configuration and it is updated when a `CHANGE MASTER TO` query is executed.
 
-From 2.1 onwards, the 'cache' directory is stored in the same location as other\
-user credential caches. This means that with the default options, the user\
+From 2.1 onwards, the 'cache' directory is stored in the same location as other
+user credential caches. This means that with the default options, the user
 credential cache is stored in`/var/cache/maxscale/<Service Name>/<Listener Name>/cache/`.
 
-Read the [MySQL Authenticator](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-mysql-authenticator.md)\
-documentation for instructions on how to define a custom location for the user\
+Read the [MySQL Authenticator](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-mysql-authenticator.md)
+documentation for instructions on how to define a custom location for the user
 cache.
 
 **`server_id`**
 
-MariaDB MaxScale must have a unique _server\_id_. This parameter configures\
-the value of the _server\_id_ that MariaDB MaxScale will use when\
+MariaDB MaxScale must have a unique _server\_id_. This parameter configures
+the value of the _server\_id_ that MariaDB MaxScale will use when
 connecting to the master. This is a mandatory parameter.
 
 Older versions of MaxScale allowed the ID to be specified using `server-id`.\
@@ -65,11 +65,11 @@ This has been deprecated and will be removed in a future release of MariaDB MaxS
 
 **`master_id`**
 
-The _server\_id_ value that MariaDB MaxScale should use to report to the slaves\
+The _server\_id_ value that MariaDB MaxScale should use to report to the slaves
 that connect to MariaDB MaxScale.
 
-This may either be the same as the server id of the real master or can be\
-chosen to be different if the slaves need to be aware of the proxy\
+This may either be the same as the server id of the real master or can be
+chosen to be different if the slaves need to be aware of the proxy
 layer. The real master server ID will be used if the option is not set.
 
 Older versions of MaxScale allowed the ID to be specified using `master-id`.\
@@ -77,52 +77,52 @@ This has been deprecated and will be removed in a future release of MariaDB MaxS
 
 **`uuid`**
 
-This is used to set the unique UUID that the binlog router uses when it connects\
+This is used to set the unique UUID that the binlog router uses when it connects
 to the master server. By default the UUID will be generated.
 
 **`master_uuid`**
 
-It is a requirement of replication that each server has a unique UUID value. If\
-this option is not set, binlogrouter will identify itself to the slaves using\
+It is a requirement of replication that each server has a unique UUID value. If
+this option is not set, binlogrouter will identify itself to the slaves using
 the UUID of the real master.
 
 **`master_version`**
 
-By default, the router will identify itself to the slaves using the server\
-version of the real master. This option allows the router to use a custom\
+By default, the router will identify itself to the slaves using the server
+version of the real master. This option allows the router to use a custom
 version string.
 
 **`master_hostname`**
 
-By default, the router will identify itself to the slaves using the hostname of\
+By default, the router will identify itself to the slaves using the hostname of
 the real master. This option allows the router to use a custom hostname.
 
 **`slave_hostname`**
 
-Since MaxScale 2.1.6 the router can optionally identify itself to the master\
-using a custom hostname. The specified hostname can be seen in the master via`SHOW SLAVE HOSTS` command. The default is not to send any hostname string\
+Since MaxScale 2.1.6 the router can optionally identify itself to the master
+using a custom hostname. The specified hostname can be seen in the master via`SHOW SLAVE HOSTS` command. The default is not to send any hostname string
 during registration.
 
 **`user`**
 
-_Note:_ This is option can only be given to the `router_options` parameter. Use\
+_Note:_ This is option can only be given to the `router_options` parameter. Use
 the `user` parameter of the service instead.
 
-This is the user name that MariaDB MaxScale uses when it connects to the\
-master. This user name must have the rights required for replication as with any\
-other user that a slave uses for replication purposes. If the user parameter is\
-not given in the router options then the same user as is used to retrieve the\
-credential information will be used for the replication connection, i.e. the\
+This is the user name that MariaDB MaxScale uses when it connects to the
+master. This user name must have the rights required for replication as with any
+other user that a slave uses for replication purposes. If the user parameter is
+not given in the router options then the same user as is used to retrieve the
+credential information will be used for the replication connection, i.e. the
 user in the service entry.
 
 This user is the only one available for MySQL connection to MaxScale Binlog\
 Server for administration when master connection is not done yet.
 
-In MaxScale 2.1, the service user injection is done by the MySQLAuth\
-authenticator module. Read the [MySQL Authenticator](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-mysql-authenticator.md)\
+In MaxScale 2.1, the service user injection is done by the MySQLAuth
+authenticator module. Read the [MySQL Authenticator](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-mysql-authenticator.md)
 documentation for more details.
 
-The user that is used for replication must be granted replication privileges on\
+The user that is used for replication must be granted replication privileges on
 the database server.
 
 ```
@@ -132,47 +132,47 @@ GRANT REPLICATION SLAVE ON *.* TO 'repl'@'maxscalehost';
 
 **`password`**
 
-_Note:_ This is option can only be given to the `router_options` parameter. Use\
+_Note:_ This is option can only be given to the `router_options` parameter. Use
 the `password` parameter of the service instead.
 
-The password for the user. If the password is not explicitly given then the\
-password in the service entry will be used. For compatibility with other\
-username and password definitions within the MariaDB MaxScale configuration file\
+The password for the user. If the password is not explicitly given then the
+password in the service entry will be used. For compatibility with other
+username and password definitions within the MariaDB MaxScale configuration file
 it is also possible to use the parameter `passwd`.
 
 **`heartbeat`**
 
-This defines the value of the heartbeat interval for the connection\
-to the master. The duration can be specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as seconds in MaxScale 2.4. In\
-subsequent versions a value without a unit may be rejected. Note that since\
-the granularity of the parameter is seconds, a value specified in milliseconds\
+This defines the value of the heartbeat interval for the connection
+to the master. The duration can be specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as seconds in MaxScale 2.4. In
+subsequent versions a value without a unit may be rejected. Note that since
+the granularity of the parameter is seconds, a value specified in milliseconds
 will be rejected, even if the duration is longer than a second.\
 The default value for the heartbeat period is every 5 minutes.
 
-MariaDB MaxScale requests the master to ensure that a binlog event is sent at\
-least every heartbeat period. If there are no real binlog events to send the\
-master will sent a special heartbeat event. The current interval value is\
+MariaDB MaxScale requests the master to ensure that a binlog event is sent at
+least every heartbeat period. If there are no real binlog events to send the
+master will sent a special heartbeat event. The current interval value is
 reported in the diagnostic output.
 
 **`burstsize`**
 
-This parameter is used to define the maximum amount of data that will be sent to\
-a slave by MariaDB MaxScale when that slave is lagging behind the master. The\
+This parameter is used to define the maximum amount of data that will be sent to
+a slave by MariaDB MaxScale when that slave is lagging behind the master. The
 default value is `1M`.
 
-The burst size can be provided as specified [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#sizes), except that IEC binary\
-prefixes can be used as suffixes only from MaxScale 2.1 onwards. MaxScale 2.0\
+The burst size can be provided as specified [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#sizes), except that IEC binary
+prefixes can be used as suffixes only from MaxScale 2.1 onwards. MaxScale 2.0
 and earlier only support `burstsize` defined in bytes.
 
-In this situation the slave is said to be in "catchup mode", this parameter is\
-designed to both prevent flooding of that slave and also to prevent threads\
-within MariaDB MaxScale spending disproportionate amounts of time with slaves\
+In this situation the slave is said to be in "catchup mode", this parameter is
+designed to both prevent flooding of that slave and also to prevent threads
+within MariaDB MaxScale spending disproportionate amounts of time with slaves
 that are lagging behind the master.
 
 **`mariadb10-compatibility`**
 
-This parameter allows binlogrouter to replicate from a MariaDB 10.0 master\
+This parameter allows binlogrouter to replicate from a MariaDB 10.0 master
 server: this parameter is enabled by default since MaxScale 2.2.0.\
 In earlier versions the parameter was disabled by default.
 
@@ -181,7 +181,7 @@ In earlier versions the parameter was disabled by default.
 mariadb10-compatibility=1
 ```
 
-Additionally, since MaxScale 2.2.1, MariaDB 10.x slave servers\
+Additionally, since MaxScale 2.2.1, MariaDB 10.x slave servers
 can connect to binlog server using GTID value instead of binlog name and position.
 
 Example of a MariaDB 10.x slave connection to MaxScale
@@ -198,51 +198,51 @@ MariaDB> START SLAVE;
 **Note:**
 
 * Slave servers can connect either with file and pos or GTID.
-* MaxScale saves all the incoming MariaDB GTIDs (DDLs and DMLs)\
+* MaxScale saves all the incoming MariaDB GTIDs (DDLs and DMLs)
   in a sqlite3 database located in binlogdir (`gtid_maps.db`).\
-  When a slave server connects with a GTID request a lookup is made for\
+  When a slave server connects with a GTID request a lookup is made for
   the value match and following binlog events will be sent.
 
 **`transaction_safety`**
 
-This parameter is used to enable/disable incomplete transactions detection in\
+This parameter is used to enable/disable incomplete transactions detection in
 binlog router. The default value is _off_.
 
-When MariaDB MaxScale starts an error message may appear if current binlog file\
-is corrupted or an incomplete transaction is found. During normal operations\
-binlog events are not distributed to the slaves until a COMMIT is seen. Set\
+When MariaDB MaxScale starts an error message may appear if current binlog file
+is corrupted or an incomplete transaction is found. During normal operations
+binlog events are not distributed to the slaves until a COMMIT is seen. Set
 transaction\_safety=on to enable detection of incomplete transactions.
 
 **`send_slave_heartbeat`**
 
-This defines whether MariaDB MaxScale sends the heartbeat packet to the slave\
-when there are no real binlog events to send. This parameter takes a boolean\
-value and the default value is false. This means that no heartbeat events are\
+This defines whether MariaDB MaxScale sends the heartbeat packet to the slave
+when there are no real binlog events to send. This parameter takes a boolean
+value and the default value is false. This means that no heartbeat events are
 sent to slave servers.
 
-If value is set to true the interval value (requested by the slave during\
-registration) is reported in the diagnostic output and the packet is send after\
+If value is set to true the interval value (requested by the slave during
+registration) is reported in the diagnostic output and the packet is send after
 the time interval without any event to send.
 
 **`semisync`**
 
-This parameter controls whether binlog server could ask Master server to start\
-the Semi-Synchronous replication. This parameter takes a boolean value and the\
+This parameter controls whether binlog server could ask Master server to start
+the Semi-Synchronous replication. This parameter takes a boolean value and the
 default value is false.
 
-In order to get semi-sync working, the Master server must have the_rpl\_semi\_sync\_master_ plugin installed. The availability of the plugin and the\
+In order to get semi-sync working, the Master server must have the_rpl\_semi\_sync\_master_ plugin installed. The availability of the plugin and the
 value of the GLOBAL VARIABLE _rpl\_semi\_sync\_master\_enabled_ are checked in the\
-Master registration phase: if the plugin is installed in the Master database,\
+Master registration phase: if the plugin is installed in the Master database,
 the binlog server subsequently requests the semi-sync option.
 
 **Note:**
 
-* the network replication stream from Master has two additional bytes before\
+* the network replication stream from Master has two additional bytes before
   each binlog event.
 * the Semi-Sync protocol requires an acknowledge packet to be sent back to\
   Master only when requested: the semi-sync flag will have value of 1.\
   This flag is set only if _rpl\_semi\_sync\_master\_enabled=1_ is set in the\
-  Master, otherwise it will always have value of 0 and no ack packet is sent\
+  Master, otherwise it will always have value of 0 and no ack packet is sent
   back.
 
 Please note that semi-sync replication is only related to binlog server to\
@@ -250,32 +250,32 @@ Master communication.
 
 **`ssl_cert_verification_depth`**
 
-This parameter sets the maximum length of the certificate authority chain that\
-will be accepted. Legal values are positive integers. This applies to SSL\
-connection to master server that could be activated either by writing options in\
-master.ini or later via a _CHANGE MASTER TO_ command. This parameter cannot be\
+This parameter sets the maximum length of the certificate authority chain that
+will be accepted. Legal values are positive integers. This applies to SSL
+connection to master server that could be activated either by writing options in
+master.ini or later via a _CHANGE MASTER TO_ command. This parameter cannot be
 modified at runtime. The default verification depth is 9.
 
 **`encrypt_binlog`**
 
 Whether to encrypt binlog files: the default is _off_.
 
-When set to _on_ the binlog files will be encrypted using specified AES algorithm\
+When set to _on_ the binlog files will be encrypted using specified AES algorithm
 and the KEY in the specified key file.
 
-**Note:** binlog encryption must be used while replicating from a MariaDB 10.1\
-server and serving data to MariaDB 10.x slaves. In order to use binlog\
-encryption the master server MariaDB 10.1 must have encryption active\
-(encrypt-binlog=1 in my.cnf). This is required because both master and maxscale\
-must store encrypted data for a working scenario for Secure\
+**Note:** binlog encryption must be used while replicating from a MariaDB 10.1
+server and serving data to MariaDB 10.x slaves. In order to use binlog
+encryption the master server MariaDB 10.1 must have encryption active
+(encrypt-binlog=1 in my.cnf). This is required because both master and maxscale
+must store encrypted data for a working scenario for Secure
 data-at-rest. Additionally, as long as Master server doesn't send the\
-StartEncryption event (which contains encryption setup information for the\
-binlog file), there is a position gap between end of FormatDescription event pos\
-and next event start pos. The StartEncryption event size is 36 or 40 (depending\
+StartEncryption event (which contains encryption setup information for the
+binlog file), there is a position gap between end of FormatDescription event pos
+and next event start pos. The StartEncryption event size is 36 or 40 (depending
 on CRC32 being used), so the gap has that size.
 
-MaxScale binlog server adds its own StartEncryption to binlog files consequently\
-the binlog events positions in binlog file are the same as in the master binlog\
+MaxScale binlog server adds its own StartEncryption to binlog files consequently
+the binlog events positions in binlog file are the same as in the master binlog
 file and there is no position mismatch.
 
 **`encryption_algorithm`**
@@ -290,11 +290,11 @@ The specified key file must contains lines with following format:
 
 Id is the scheme identifier, which must have the value 1 for binlog encryption\
 , the ';' is a separator and HEX(KEY) contains the hex representation of the KEY.\
-The KEY must have exact 16, 24 or 32 bytes size and the selected algorithm\
+The KEY must have exact 16, 24 or 32 bytes size and the selected algorithm
 (aes\_ctr or aes\_cbc) with 128, 192 or 256 ciphers will be used.
 
-**Note:** the key file has the same format as MariaDB 10.1 server so it's\
-possible to use an existing key file (not encrypted) which could contain several`scheme;key` values: only key id with value 1 will be parsed, and if not found\
+**Note:** the key file has the same format as MariaDB 10.1 server so it's
+possible to use an existing key file (not encrypted) which could contain several`scheme;key` values: only key id with value 1 will be parsed, and if not found
 an error will be reported.
 
 Example key file with multiple keys:
@@ -312,11 +312,11 @@ Example key file with multiple keys:
 
 **`mariadb10_master_gtid`**
 
-This option allows MaxScale binlog router to register with MariaDB 10.X master\
-using GTID instead of _binlog\_file_ name and _position_ in CHANGE MASTER TO\
+This option allows MaxScale binlog router to register with MariaDB 10.X master
+using GTID instead of _binlog\_file_ name and _position_ in CHANGE MASTER TO
 admin command. This feature is disabled by default.
 
-The user can set a known GTID or an empty value (in this case the Master server\
+The user can set a known GTID or an empty value (in this case the Master server
 will send events from it's first available binlog file).
 
 Example of MaxScale connection to a MariaDB 10.X Master
@@ -334,41 +334,41 @@ MariaDB> START SLAVE;
 If using GTID request then it's no longer possible to use MASTER\_LOG\_FILE and\
 MASTER\_LOG\_POS in `CHANGE MASTER TO` command: an error will be reported.
 
-If this feature is enabled, the _transaction\_safety_ option will be\
-automatically enabled. The binlog files will also be stored in a\
+If this feature is enabled, the _transaction\_safety_ option will be
+automatically enabled. The binlog files will also be stored in a
 hierarchical directory tree instead of a single directory.
 
 **Note:**
 
 * When the option is On, the connecting slaves can only use GTID request:\
-  specifying file and pos will end up in an error sent by MaxScale and\
+  specifying file and pos will end up in an error sent by MaxScale and
   replication cannot start.
-* The GTID request could cause the writing of events\
-  in any position of the binlog file, whose name has been sent\
+* The GTID request could cause the writing of events
+  in any position of the binlog file, whose name has been sent
   by the master server before any event.\
-  In order to avoid holes in the binlog files, MaxScale will fill all gaps\
+  In order to avoid holes in the binlog files, MaxScale will fill all gaps
   in the binlog files with ignorable events.
-* It's not possible to specify the GTID \_domain\_id: the master one\
-  is being used for all operations. All slave servers must use the same replication\
+* It's not possible to specify the GTID \_domain\_id: the master one
+  is being used for all operations. All slave servers must use the same replication
   domain as the master server.
 
 **`master_retry_count`**
 
-This option sets the maximum number of connection retries when the master server is\
+This option sets the maximum number of connection retries when the master server is
 disconnected or not reachable.\
 Default value is 1000.
 
 **`connect_retry`**
 
 The option sets the time interval for a new connection retry to master server.\
-The duration can be specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as seconds in MaxScale 2.4. In\
-subsequent versions a value without a unit may be rejected. Note that since\
-the granularity of the parameter is seconds, a value specified in milliseconds\
+The duration can be specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as seconds in MaxScale 2.4. In
+subsequent versions a value without a unit may be rejected. Note that since
+the granularity of the parameter is seconds, a value specified in milliseconds
 will be rejected, even if the duration is longer than a second.\
 The default value is 60 seconds.
 
-**A complete example** of a service entry for a binlog router service would be as\
+**A complete example** of a service entry for a binlog router service would be as
 follows.
 
 ```
@@ -387,7 +387,7 @@ encryption_key_file=/var/binlogs/enc_key.txt
 
 #### Using secondary masters
 
-From MaxScale 2.3 onwards it is possible to specify secondary masters that\
+From MaxScale 2.3 onwards it is possible to specify secondary masters that
 the binlog router can use in case the connection to the default master fails.
 
 **Note:** This is _only_ supported in a Galera Cluster environment in which:
@@ -395,10 +395,10 @@ the binlog router can use in case the connection to the default master fails.
 * Wsrep GTID mode is enabled in the cluster.
 * All of the requirements for wsrep GTID mode are met by the cluster.
 
-_Wsrep GTID mode_ is also imperfect, so this secondary master functionality is\
+_Wsrep GTID mode_ is also imperfect, so this secondary master functionality is
 only guaranteed to work if GTIDs have not become inconsistent within the cluster.
 
-See [Wsrep GTID Mode](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/high-availability/using-mariadb-replication-with-mariadb-galera-cluster/using-mariadb-gtids-with-mariadb-galera-cluster)\
+See [Wsrep GTID Mode](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/high-availability/using-mariadb-replication-with-mariadb-galera-cluster/using-mariadb-gtids-with-mariadb-galera-cluster)
 for more information.
 
 The initial setup is performed exactly like when there is but one default master.
@@ -414,7 +414,7 @@ MariaDB> CHANGE MASTER TO
          MASTER_USE_GTID=Slave_pos;
 ```
 
-After the setup of the default master, secondary masters can be configured\
+After the setup of the default master, secondary masters can be configured
 as follows:
 
 ```
@@ -426,12 +426,12 @@ MariaDB> CHANGE MASTER ':2' TO
          MASTER_USE_GTID=Slave_pos;
 ```
 
-That is, a connection name must be provided and the name must be of the\
-format `:N` where `N` is a positive integer. If several secondary masters\
+That is, a connection name must be provided and the name must be of the
+format `:N` where `N` is a positive integer. If several secondary masters
 are specified, they must be numbered consecutively, starting from `2`.
 
-All settings that are not explicitly specified are copied from the\
-default master. That is, the following is equivalent with the command\
+All settings that are not explicitly specified are copied from the
+default master. That is, the following is equivalent with the command
 above:
 
 ```
@@ -446,17 +446,17 @@ For instance, the following command would only change the password of `:2`.
 MariaDB> CHANGE MASTER ':2' TO MASTER_PASSWORD='repl2';
 ```
 
-It is not possible to delete a particular secondary master, but if`MASTER_HOST` is set on the default master, even if it is set to the same\
+It is not possible to delete a particular secondary master, but if`MASTER_HOST` is set on the default master, even if it is set to the same
 value, then _all_ secondary master configurations are deleted.
 
-When `START SLAVE` is issued, MaxScale will first attempt to connect to the\
-default master and if that fails, try the secondary masters in order, until\
+When `START SLAVE` is issued, MaxScale will first attempt to connect to the
+default master and if that fails, try the secondary masters in order, until
 a connection can be created. Only if all connection attempts fail, will\
-MaxScale wait as specified with `connect_retry`, before doing the cycle over\
+MaxScale wait as specified with `connect_retry`, before doing the cycle over
 again.
 
-Once the binlog router has successfully connected to a server, it will stay\
-connected to that server until the connection breaks or `STOP SLAVE` is\
+Once the binlog router has successfully connected to a server, it will stay
+connected to that server until the connection breaks or `STOP SLAVE` is
 issued.
 
 The configurations of the secondary masters are also stored to the`master.ini` in sections whose name include the connection name.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-binlogrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-binlogrouter.md
@@ -1,27 +1,27 @@
 # Binlogrouter
 
-The binlogrouter is a router that acts as a replication proxy for MariaDB\
-primary-replica replication. The router connects to a primary, retrieves the binary\
-logs and stores them locally. Replica servers can connect to MaxScale like they\
-would connect to a normal primary server. If the primary server goes down,\
-replication between MaxScale and the replicas can still continue up to the latest\
-point to which the binlogrouter replicated to. The primary can be changed without\
-disconnecting the replicas and without them noticing that the primary server has\
+The binlogrouter is a router that acts as a replication proxy for MariaDB
+primary-replica replication. The router connects to a primary, retrieves the binary
+logs and stores them locally. Replica servers can connect to MaxScale like they
+would connect to a normal primary server. If the primary server goes down,
+replication between MaxScale and the replicas can still continue up to the latest
+point to which the binlogrouter replicated to. The primary can be changed without
+disconnecting the replicas and without them noticing that the primary server has
 changed. This allows for a more highly available replication setup.
 
-In addition to the high availability benefits, the binlogrouter creates only one\
-connection to the primary whereas with normal replication each individual replica\
-will create a separate connection. This reduces the amount of work the primary\
-database has to do which can be significant if there are a large number of\
+In addition to the high availability benefits, the binlogrouter creates only one
+connection to the primary whereas with normal replication each individual replica
+will create a separate connection. This reduces the amount of work the primary
+database has to do which can be significant if there are a large number of
 replicating replicas.
 
 ### Supported SQL Commands
 
-The binlogrouter supports a subset of the SQL constructs that the MariaDB server\
+The binlogrouter supports a subset of the SQL constructs that the MariaDB server
 supports. The following commands are supported:
 
 * `CHANGE MASTER TO`
-* The binlogrouter supports the same syntax as the MariaDB server but only the\
+* The binlogrouter supports the same syntax as the MariaDB server but only the
   following values are allowed:
   * `MASTER_HOST`
   * `MASTER_PORT`
@@ -38,7 +38,7 @@ supports. The following commands are supported:
   * `MASTER_SSL_CIPHER`
   * `MASTER_SSL_VERIFY_SERVER_CERT`
 
-NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported\
+NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported
 as binlogrouter only supports GTID based replication.
 
 * `STOP SLAVE`
@@ -46,56 +46,56 @@ as binlogrouter only supports GTID based replication.
 * `START SLAVE`
 * Starts replication, same as MariaDB.
 * `RESET SLAVE`
-* Resets replication. Note that the `RESET SLAVE ALL` form that is supported\
+* Resets replication. Note that the `RESET SLAVE ALL` form that is supported
   by MariaDB isn't supported by the binlogrouter.
 * `SHOW BINARY LOGS`
-* Lists the current files and their sizes. These will be different from the\
-  ones listed by the original primary where the binlogrouter is replicating\
+* Lists the current files and their sizes. These will be different from the
+  ones listed by the original primary where the binlogrouter is replicating
   from.
 * `PURGE { BINARY | MASTER } LOGS TO <filename>`
-* Purges binary logs up to but not including the given file. The file name\
-  must be one of the names shown in `SHOW BINARY LOGS`. The version of this\
+* Purges binary logs up to but not including the given file. The file name
+  must be one of the names shown in `SHOW BINARY LOGS`. The version of this
   command which accepts a timestamp is not currently supported.\
-  Automatic purging is supported using the configuration\
+  Automatic purging is supported using the configuration
   parameter [expire\_log\_duration](mariadb-maxscale-2302-binlogrouter.md#expire_log_duration).\
-  The files are purged in the order they were created. If a file to be purged\
-  is detected to be in use, the purge stops. This means that the purge will\
+  The files are purged in the order they were created. If a file to be purged
+  is detected to be in use, the purge stops. This means that the purge will
   stop at the oldest file that a replica is still reading.\
-  NOTE: You should still take precaution not to purge files that a potential\
-  replica will need in the future. MaxScale can only detect that a file is\
+  NOTE: You should still take precaution not to purge files that a potential
+  replica will need in the future. MaxScale can only detect that a file is
   in active use when a replica is connected, and requesting events from it.
 * `SHOW MASTER STATUS`
-* Shows the name and position of the file to which the binlogrouter will write\
-  the next replicated data. The name and position do not correspond to the\
+* Shows the name and position of the file to which the binlogrouter will write
+  the next replicated data. The name and position do not correspond to the
   name and position in the primary.
 * `SHOW SLAVE STATUS`
-* Shows the replica status information similar to what a normal MariaDB replica\
-  server shows. Some of the values are replaced with constants values that\
+* Shows the replica status information similar to what a normal MariaDB replica
+  server shows. Some of the values are replaced with constants values that
   never change. The following values are not constant:
-  * `Slave_IO_State`: Set to `Waiting for primary to send event` when\
+  * `Slave_IO_State`: Set to `Waiting for primary to send event` when
     replication is ongoing.
   * `Master_Host`: Address of the current primary.
   * `Master_User`: The user used to replicate.
   * `Master_Port`: The port the primary is listening on.
-  * `Master_Log_File`: The name of the latest file that the binlogrouter is\
+  * `Master_Log_File`: The name of the latest file that the binlogrouter is
     writing to.
-  * `Read_Master_Log_Pos`: The current position where the last event was\
+  * `Read_Master_Log_Pos`: The current position where the last event was
     written in the latest binlog.
-  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's\
+  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's
     not.
-  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's\
+  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's
     not.
   * `Exec_Master_Log_Pos`: Same as `Read_Master_Log_Pos`.
   * `Gtid_IO_Pos`: The latest replicated GTID.
 * `SELECT { Field } ...`
-* The binlogrouter implements a small subset of the MariaDB SELECT syntax as\
-  it is mainly used by the replicating replicas to query various parameters. If\
-  a field queried by a client is not known to the binlogrouter, the value\
-  will be returned back as-is. The following list of functions and variables\
+* The binlogrouter implements a small subset of the MariaDB SELECT syntax as
+  it is mainly used by the replicating replicas to query various parameters. If
+  a field queried by a client is not known to the binlogrouter, the value
+  will be returned back as-is. The following list of functions and variables
   are understood by the binlogrouter and are replaced with actual values:
-  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of\
+  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of
     these return the latest GTID replicated from the primary.
-  * `version()` or `@@version`: The version string returned by MaxScale when\
+  * `version()` or `@@version`: The version string returned by MaxScale when
     a client connects to it.
   * `UNIX_TIMESTAMP()`: The current timestamp.
   * `@@version_comment`: Always `pinloki`.
@@ -123,27 +123,27 @@ as binlogrouter only supports GTID based replication.
   * `@@tx_isolation`: Always `REPEATABLE-READ`
   * `@@wait_timeout`: Always `28800`
 * `SET`
-* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should\
+* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should
   start replicating. E.g. `SET @@global.gtid_slave_pos="0-1000-1234,1-1001-5678"`
 * `SHOW VARIABLES LIKE '...'`
-* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`\
-  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`\
-  is not currently supported. In addition, the `LIKE` operator in\
+* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`
+  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`
+  is not currently supported. In addition, the `LIKE` operator in
   binlogrouter only supports exact matches.\
-  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID\
-  coordinates of the binlogrouter. In addition to these, the `server_id`\
+  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID
+  coordinates of the binlogrouter. In addition to these, the `server_id`
   variable will return the configured server ID of the binlogrouter.
 
 ### Semi-sync replication
 
-If the server from which the binlogrouter replicates from is using semi-sync\
+If the server from which the binlogrouter replicates from is using semi-sync
 replication, the binlogrouter will acknowledge the replicated events.
 
 ### Configuration Parameters
 
 The binlogrouter is configured similarly to how normal routers are configured in\
-MaxScale. It requires at least one listener where clients can connect to and one\
-server from which the database user information can be retrieved. An example\
+MaxScale. It requires at least one listener where clients can connect to and one
+server from which the database user information can be retrieved. An example
 configuration can be found in the [example](mariadb-maxscale-2302-binlogrouter.md#example) section of this document.
 
 #### `datadir`
@@ -162,7 +162,7 @@ Directory where binary log files are stored.
 * Dynamic: No
 * Default: `1234`
 
-The server ID that MaxScale uses when connecting to the master and when serving\
+The server ID that MaxScale uses when connecting to the master and when serving
 binary logs to the slaves.
 
 #### `net_timeout`
@@ -183,26 +183,26 @@ Network connection and read timeout in seconds for the connection to the master.
 
 Automatically select the master server to replicate from.
 
-When this feature is enabled, the primary which binlogrouter will replicate\
+When this feature is enabled, the primary which binlogrouter will replicate
 from will be selected from the servers defined by a monitor `cluster=TheMonitor`.\
-Alternatively servers can be listed in `servers`. The servers should be monitored\
-by a monitor. Only servers with the `Master` status are used. If multiple primary\
+Alternatively servers can be listed in `servers`. The servers should be monitored
+by a monitor. Only servers with the `Master` status are used. If multiple primary
 servers are available, the first available primary server will be used.
 
-If a `CHANGE MASTER TO` command is received while `select_master` is on, the\
+If a `CHANGE MASTER TO` command is received while `select_master` is on, the
 command will be honored and `select_master` turned off until the next reboot.\
 This allows the Monitor to perform failover, and more importantly, switchover.\
-It also allows the user to manually redirect the Binlogrouter. The current\
+It also allows the user to manually redirect the Binlogrouter. The current
 primary is "sticky", meaning that the same primary will be chosen on reboot.
 
-**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is\
-monitoring a binlogrouter. The binlogrouter does not support all the SQL\
-commands that the monitor will send and the rejoin will fail. This restriction\
+**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is
+monitoring a binlogrouter. The binlogrouter does not support all the SQL
+commands that the monitor will send and the rejoin will fail. This restriction
 will be lifted in a future version.
 
 The GTID the replication will start from, will be based on the latest replicated\
-GTID. If no GTID has been replicated, the router will start replication from the\
-start. Manual configuration of the GTID can be done by first configuring the\
+GTID. If no GTID has been replicated, the router will start replication from the
+start. Manual configuration of the GTID can be done by first configuring the
 replication manually with `CHANGE MASTER TO`.
 
 #### `expire_log_duration`
@@ -214,9 +214,9 @@ replication manually with `CHANGE MASTER TO`.
 
 Duration after which a binary log file can be automatically removed.
 
-The duration is measured from the last modification of the log file. Files are\
-purged in the order they were created. The automatic purge works in a similar\
-manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if\
+The duration is measured from the last modification of the log file. Files are
+purged in the order they were created. The automatic purge works in a similar
+manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if
 an eligible file is in active use, i.e. being read by a replica.
 
 #### `expire_log_minimum_files`
@@ -226,7 +226,7 @@ an eligible file is in active use, i.e. being read by a replica.
 * Dynamic: No
 * Default: `2`
 
-The minimum number of log files the automatic purge keeps. At least one file\
+The minimum number of log files the automatic purge keeps. At least one file
 is always kept.
 
 #### `ddl_only`
@@ -237,9 +237,9 @@ is always kept.
 
 When enabled, only DDL events are written to the binary logs. This means that`CREATE`, `ALTER` and `DROP` events are written but `INSERT`, `UPDATE` and`DELETE` events are not.
 
-This mode can be used to keep a record of all the schema changes that occur on a\
-database. As only the DDL events are stored, it becomes very easy to set up an\
-empty server with no data in it by simply pointing it at a binlogrouter instance\
+This mode can be used to keep a record of all the schema changes that occur on a
+database. As only the DDL events are stored, it becomes very easy to set up an
+empty server with no data in it by simply pointing it at a binlogrouter instance
 that has `ddl_only` enabled.
 
 #### `encryption_key_id`
@@ -250,23 +250,23 @@ that has `ddl_only` enabled.
 * Default: `""`
 
 Encryption key ID used to encrypt the binary logs. If configured, an [Encryption\
-Key Manager](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encryption-key-managers)\
-must also be configured and it must contain the key with the given ID. If the\
-encryption key manager supports versioning, new binary logs will be encrypted\
-using the latest encryption key. Old binlogs will remain encrypted with older\
-key versions and remain readable as long as the key versions used to encrypt\
+Key Manager](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#encryption-key-managers)
+must also be configured and it must contain the key with the given ID. If the
+encryption key manager supports versioning, new binary logs will be encrypted
+using the latest encryption key. Old binlogs will remain encrypted with older
+key versions and remain readable as long as the key versions used to encrypt
 them are available.
 
-Once binary log encryption has been enabled, the encryption key ID cannot be\
-changed and the key must remain available to MaxScale in order for replication\
-to work. If an encryption key is not available or the key manager fails to\
-retrieve it, the replication from the currently selected primary server will\
-stop. If the replication is restarted manually, the encryption key retrieval is\
+Once binary log encryption has been enabled, the encryption key ID cannot be
+changed and the key must remain available to MaxScale in order for replication
+to work. If an encryption key is not available or the key manager fails to
+retrieve it, the replication from the currently selected primary server will
+stop. If the replication is restarted manually, the encryption key retrieval is
 attempted again.
 
-Re-encryption of binlogs using another encryption key is not possible. However,\
-this is possible if the data is replicated to a second MaxScale server that uses\
-a different encryption key. The same approach can also be used to decrypt\
+Re-encryption of binlogs using another encryption key is not possible. However,
+this is possible if the data is replicated to a second MaxScale server that uses
+a different encryption key. The same approach can also be used to decrypt
 binlogs.
 
 #### `encryption_cipher`
@@ -277,7 +277,7 @@ binlogs.
 * Values: `AES_CBC`, `AES_CTR`, `AES_GCM`
 * Default: `AES_GCM`
 
-The encryption cipher to use. The encryption key size also affects which mode is\
+The encryption cipher to use. The encryption key size also affects which mode is
 used: only 128, 192 and 256 bit encryption keys are currently supported.
 
 Possible values are:
@@ -295,16 +295,16 @@ Possible values are:
 * Default: false
 * Dynamic: Yes
 
-Enable [semi-synchronous](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
-replication when replicating from a MariaDB server. If enabled, the binlogrouter\
-will send acknowledgment for each received event. Note that the [rpl\_semi\_sync\_master\_enabled](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication#rpl_semi_sync_master_enabled)\
-parameter must be enabled in the MariaDB server where the replication is done\
+Enable [semi-synchronous](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
+replication when replicating from a MariaDB server. If enabled, the binlogrouter
+will send acknowledgment for each received event. Note that the [rpl\_semi\_sync\_master\_enabled](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication#rpl_semi_sync_master_enabled)
+parameter must be enabled in the MariaDB server where the replication is done
 from for the semi-synchronous replication to take place.
 
 ### New installation
 
 1. Configure and start MaxScale.
-2. If you have not configured `select_master=true` (automatic\
+2. If you have not configured `select_master=true` (automatic
    primary selection), issue a `CHANGE MASTER TO` command to binlogrouter.
 
 ```
@@ -326,29 +326,29 @@ SHOW SLAVE STATUS \G
 
 ### Upgrading from legacy versions
 
-Binlogrouter does not read any of the data that a version prior to 2.5\
-has saved. By default binlogrouter will request the replication stream\
-from the blank state (from the start of time), which is basically meant\
-for new systems. If a system is live, the entire replication data probably\
-does not exist, and if it does, it is not necessary for binlogrouter to read\
+Binlogrouter does not read any of the data that a version prior to 2.5
+has saved. By default binlogrouter will request the replication stream
+from the blank state (from the start of time), which is basically meant
+for new systems. If a system is live, the entire replication data probably
+does not exist, and if it does, it is not necessary for binlogrouter to read
 and store all the data.
 
 #### Before you start
 
 * Note that binlogrouter only supports GTID based replication.
-* Make sure that the configured data directory for the new binlogrouter\
+* Make sure that the configured data directory for the new binlogrouter
   is different from the old one, or move old data away.\
   See [datadir](mariadb-maxscale-2302-binlogrouter.md#datadir).
-* If the primary contains binlogs from the blank state, and there\
+* If the primary contains binlogs from the blank state, and there
   is a large amount of data, consider purging old binlogs.\
   See [Using and Maintaining the Binary Log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log).
 
 #### Deployment
 
-The method described here inflicts the least downtime. Assuming you have\
+The method described here inflicts the least downtime. Assuming you have
 configured MaxScale version 2.5 or newer, and it is ready to go:
 
-1. Redirect each replica that replicates from Binlogrouter to replicate from the\
+1. Redirect each replica that replicates from Binlogrouter to replicate from the
    primary.
 
 ```
@@ -371,7 +371,7 @@ master_user=USER,master_password="PASSWORD", master_use_gtid=slave_pos;
 ```
 
 1. Run `maxctrl list servers`. Make sure all your servers are accounted for.\
-   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and\
+   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and
    issue this command to Binlogrouter:
 
 ```
@@ -380,8 +380,8 @@ SET @@global.gtid_slave_pos = "0-1000-1234,1-1001-5678";
 START SLAVE
 ```
 
-**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos\
-if any binlog files have been purged on the primary. The server will only stream\
+**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos
+if any binlog files have been purged on the primary. The server will only stream
 from the start of time if the first binlog file is present.\
 See [select\_master](mariadb-maxscale-2302-binlogrouter.md#select_master).
 
@@ -399,7 +399,7 @@ SHOW SLAVE STATUS \G
 
 ### Galera cluster
 
-When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2302-binlogrouter.md#select_master) must be\
+When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2302-binlogrouter.md#select_master) must be
 set to true, and the servers must be monitored by the [Galera Monitor](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-galera-monitor.md).\
 Configuring binlogrouter is the same as described above.
 
@@ -464,8 +464,8 @@ port=3306
 
 ### Limitations
 
-* Old-style replication with binlog name and file offset is not supported\
-  and the replication must be started by setting up the GTID to replicate\
+* Old-style replication with binlog name and file offset is not supported
+  and the replication must be started by setting up the GTID to replicate
   from.
 * Only replication from MariaDB servers (including Galera) is supported.
 * Old encrypted binary logs are not re-encrypted with newer key versions ([MXS-4140](https://jira.mariadb.org/browse/MXS-4140))

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-cat.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-cat.md
@@ -2,8 +2,8 @@
 
 The `cat` router is a special router that concatenates result sets.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Configuration
@@ -12,28 +12,28 @@ The router has no special parameters. To use it, define a service with`router=ca
 
 ### Behavior
 
-The order the servers are defined in is the order in which the servers are\
-queried. This means that the results are ordered based on the `servers`\
-parameter of the service. The result will only be completed once all servers\
+The order the servers are defined in is the order in which the servers are
+queried. This means that the results are ordered based on the `servers`
+parameter of the service. The result will only be completed once all servers
 have executed this.
 
-All commands executed via this router will be executed on all servers. This\
-means that an INSERT through the `cat` router will send it to all servers. In\
-the case of commands that do not return resultsets, the response of the last\
-server is sent to the client. This means that if one of the earlier servers\
+All commands executed via this router will be executed on all servers. This
+means that an INSERT through the `cat` router will send it to all servers. In
+the case of commands that do not return resultsets, the response of the last
+server is sent to the client. This means that if one of the earlier servers
 returns a different result, the client will not see it.
 
-As the intended use-case of the router is to mainly reduce multiple result sets\
-into one, it has no mechanisms to prevent writes from being executed on slave\
-servers (which would cause data corruption or replication failure). Take great\
+As the intended use-case of the router is to mainly reduce multiple result sets
+into one, it has no mechanisms to prevent writes from being executed on slave
+servers (which would cause data corruption or replication failure). Take great
 care when performing administrative operations though this router.
 
-If a connection to one of the servers is lost, the client connection will also\
+If a connection to one of the servers is lost, the client connection will also
 be closed.
 
 ### Example
 
-Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-servers.md) tutorial and the\
+Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-servers.md) tutorial and the
 credentials from the [MaxScale Tutorial](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-setting-up-mariadb-maxscale.md).
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-hintrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-hintrouter.md
@@ -4,27 +4,27 @@ HintRouter was introduced in 2.2 and is still beta.
 
 ### Overview
 
-The **HintRouter** module is a simple router intended to operate in conjunction\
-with the NamedServerFilter. The router looks at the hints embedded in a packet\
-buffer and attempts to route the packet according to the hint. The user can also\
-set a default action to be taken when a query has no hints or when the hints\
+The **HintRouter** module is a simple router intended to operate in conjunction
+with the NamedServerFilter. The router looks at the hints embedded in a packet
+buffer and attempts to route the packet according to the hint. The user can also
+set a default action to be taken when a query has no hints or when the hints
 could not be applied.
 
-If a packet has multiple hints attached, the router will read them in order and\
-attempt routing. Any successful routing ends the process and any further hints\
+If a packet has multiple hints attached, the router will read them in order and
+attempt routing. Any successful routing ends the process and any further hints
 are ignored for the packet.
 
 ### Configuration
 
-The HintRouter is a rather simple router and only accepts a few configuration\
+The HintRouter is a rather simple router and only accepts a few configuration
 settings.
 
 ```
 default_action=<master|slave|named|all>
 ```
 
-This setting defines what happens when a query has no routing hint or applying\
-the routing hint(s) fails. If also the default action fails, the routing will\
+This setting defines what happens when a query has no routing hint or applying
+the routing hint(s) fails. If also the default action fails, the routing will
 end in error and the session closes. The different values are:
 
 | Value  | Description                                                                |
@@ -34,40 +34,40 @@ end in error and the session closes. The different values are:
 | named  | Route to a named server. The name is given in the default\_server-setting. |
 | all    | Default value. Route to all connected servers.                             |
 
-Note that setting default action to anything other than `all` means that session\
+Note that setting default action to anything other than `all` means that session
 variable write commands are by default not routed to all backends.
 
 ```
 default_server=<server-name>
 ```
 
-Defines the default backend name if `default_action=named`. `<server-name>` must\
+Defines the default backend name if `default_action=named`. `<server-name>` must
 be a valid backend name.
 
 ```
 max_slaves=<limit>
 ```
 
-`<limit>` should be an integer, -1 by default. Defines how many backend replica\
-servers a session should attempt to connect to. Having less replicas defined in\
-the services and/or less successful connections during session creation is not\
-an error. The router will attempt to distribute replicas evenly between sessions\
-by assigning them in a round robin fashion. The session will always try to\
-connect to a primary regardless of this setting, although not finding one is not\
+`<limit>` should be an integer, -1 by default. Defines how many backend replica
+servers a session should attempt to connect to. Having less replicas defined in
+the services and/or less successful connections during session creation is not
+an error. The router will attempt to distribute replicas evenly between sessions
+by assigning them in a round robin fashion. The session will always try to
+connect to a primary regardless of this setting, although not finding one is not
 an error.
 
-Negative values activate default mode, in which case this value is set to the\
-number of backends in the service - 1, so that the sessions are connected to all\
+Negative values activate default mode, in which case this value is set to the
+number of backends in the service - 1, so that the sessions are connected to all
 replicas.
 
-If the hints or the `default_action` point to a named server, this setting is\
-probably best left to default to ensure that the specific server is connected to\
-at session creation. The router will not attempt to connect to additional\
+If the hints or the `default_action` point to a named server, this setting is
+probably best left to default to ensure that the specific server is connected to
+at session creation. The router will not attempt to connect to additional
 servers after session creation.
 
 ### Examples
 
-A minimal configuration doesn't require any parameters as all settings have\
+A minimal configuration doesn't require any parameters as all settings have
 reasonable defaults.
 
 ```
@@ -77,7 +77,7 @@ router=hintrouter
 servers=replica1,replica2,replica3
 ```
 
-If packets should be routed to the primary server by default and only a few\
+If packets should be routed to the primary server by default and only a few
 connections are required, the configuration might be as follows.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-kafkacdc.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-kafkacdc.md
@@ -2,10 +2,10 @@
 
 ### Overview
 
-The KafkaCDC module reads data changes in MariaDB via replication and converts\
+The KafkaCDC module reads data changes in MariaDB via replication and converts
 them into JSON objects that are then streamed to a Kafka broker.
 
-DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the\
+DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the
 following format (example created by `CREATE TABLE test.t1(id INT)`):
 
 ```
@@ -65,10 +65,10 @@ following format (example created by `CREATE TABLE test.t1(id INT)`):
 }
 ```
 
-The `domain`, `server_id` and `sequence` fields contain the GTID that this event\
-belongs to. The `event_number` field is the sequence number of events inside the\
-transaction starting from 1. The `timestamp` field is the UNIX timestamp when\
-the event occurred. The `event_type` field contains the type of the event, one\
+The `domain`, `server_id` and `sequence` fields contain the GTID that this event
+belongs to. The `event_number` field is the sequence number of events inside the
+transaction starting from 1. The `timestamp` field is the UNIX timestamp when
+the event occurred. The `event_type` field contains the type of the event, one
 of:
 
 * `insert`: the event is the data that was added to MariaDB
@@ -76,13 +76,13 @@ of:
 * `update_before`: the event contains the data before an update statement modified it
 * `update_after`: the event contains the data after an update statement modified it
 
-All remaining fields contains data from the table. In the example event this\
+All remaining fields contains data from the table. In the example event this
 would be the fields `id` and `data`.
 
 The sending of these schema objects is optional and can be disabled using`send_schema=false`.
 
-DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that\
-follow the format specified in the DDL event. The objects are in the following\
+DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that
+follow the format specified in the DDL event. The objects are in the following
 format (example created by `INSERT INTO test.t1 VALUES (1)`):
 
 ```
@@ -99,28 +99,28 @@ format (example created by `INSERT INTO test.t1 VALUES (1)`):
 }
 ```
 
-The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These\
+The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These
 contain the table name and schema the event targets.
 
-The router stores table metadata in the MaxScale data directory. The\
-default value is `/var/lib/maxscale/<service name>`. If data for a table\
-is replicated before a DDL event for it is replicated, the CREATE TABLE\
+The router stores table metadata in the MaxScale data directory. The
+default value is `/var/lib/maxscale/<service name>`. If data for a table
+is replicated before a DDL event for it is replicated, the CREATE TABLE
 will be queried from the primary server.
 
-During shutdown, the Kafka event queue is flushed. This can take up to 60\
+During shutdown, the Kafka event queue is flushed. This can take up to 60
 seconds if the network is slow or there are network problems.
 
 ### Configuration
 
-* In order for `kafkacdc` to work, the binary logging on the source server must\
-  be configured to use row-based replication and the row image must be set to\
+* In order for `kafkacdc` to work, the binary logging on the source server must
+  be configured to use row-based replication and the row image must be set to
   full by configuring `binlog_format=ROW` and `binlog_row_image=FULL`.
-* The `servers` parameter defines the set of servers where the data is\
-  replicated from. The replication will be done from the first primary server\
+* The `servers` parameter defines the set of servers where the data is
+  replicated from. The replication will be done from the first primary server
   that is found.
-* The `user` and `password` of the service will be used to connect to the\
+* The `user` and `password` of the service will be used to connect to the
   primary. This user requires the `REPLICATION SLAVE` grant.
-* The KafkaCDC service must not be configured to use listeners. If a listener is\
+* The KafkaCDC service must not be configured to use listeners. If a listener is
   configured, all attempts to start a session will fail.
 
 ### Parameters
@@ -131,7 +131,7 @@ seconds if the network is slow or there are network problems.
 * Mandatory: Yes
 * Dynamic: No
 
-The list of Kafka brokers to use in `host:port` format. Multiple values\
+The list of Kafka brokers to use in `host:port` format. Multiple values
 can be separated with commas. This is a mandatory parameter.
 
 #### `topic`
@@ -140,7 +140,7 @@ can be separated with commas. This is a mandatory parameter.
 * Mandatory: Yes
 * Dynamic: No
 
-The Kafka topic where the replicated events will be sent. This is a\
+The Kafka topic where the replicated events will be sent. This is a
 mandatory parameter.
 
 #### `enable_idempotence`
@@ -150,22 +150,22 @@ mandatory parameter.
 * Dynamic: No
 * Default: `false`
 
-Enable idempotent producer mode. This feature requires Kafka version 0.11 or\
+Enable idempotent producer mode. This feature requires Kafka version 0.11 or
 newer to work and is disabled by default.
 
-When enabled, the Kafka producer enters a strict mode which avoids event\
-duplication due to broker outages or other network errors. In HA scenarios where\
-there are more than two MaxScale instances, event duplication can still happen\
+When enabled, the Kafka producer enters a strict mode which avoids event
+duplication due to broker outages or other network errors. In HA scenarios where
+there are more than two MaxScale instances, event duplication can still happen
 as there is no synchronization between the MaxScale instances.
 
-The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),\
+The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),
 describes the parameter as follows:
 
-When set to true, the producer will ensure that messages are successfully\
-produced exactly once and in the original produce order. The following\
-configuration properties are adjusted automatically (if not modified by the\
-user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must\
-be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),\
+When set to true, the producer will ensure that messages are successfully
+produced exactly once and in the original produce order. The following
+configuration properties are adjusted automatically (if not modified by the
+user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must
+be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),
 acks=all, queuing.strategy=fifo.
 
 #### `timeout`
@@ -184,12 +184,12 @@ The connection and read timeout for the replication stream.
 * Dynamic: No
 * Default: `""`
 
-The initial GTID position from where the replication is started. By default the\
-replication is started from the beginning. The value of this parameter is only\
-used if no previously replicated events with GTID positions can be retrieved\
+The initial GTID position from where the replication is started. By default the
+replication is started from the beginning. The value of this parameter is only
+used if no previously replicated events with GTID positions can be retrieved
 from Kafka.
 
-Once the replication has started and a GTID position has been recorded, this\
+Once the replication has started and a GTID position has been recorded, this
 parameter will be ignored. To reset the recorded GTID position, delete the`current_gtid.txt` file located in `/var/lib/maxscale/<SERVICE>/` where`<SERVICE>` is the name of the KafkaCDC service.
 
 #### `server_id`
@@ -199,8 +199,8 @@ parameter will be ignored. To reset the recorded GTID position, delete the`curre
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
-used when replicating from the primary in direct replication mode. The default\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
+used when replicating from the primary in direct replication mode. The default
 value is 1234. This parameter was added in MaxScale 2.5.7.
 
 #### `match`
@@ -214,13 +214,13 @@ Only include data from tables that match this pattern.
 
 For example, if configured with `match=accounts[.].*`, only data from the`accounts` database is sent to Kafka.
 
-The pattern is matched against the combined database and table name separated by\
-a period. This means that the event for the table `t1` in the `test` database\
-would appear as `test.t1`. The behavior is the same even if the database or the\
-table name contains a period. This means that an event for the `test.table`\
+The pattern is matched against the combined database and table name separated by
+a period. This means that the event for the table `t1` in the `test` database
+would appear as `test.t1`. The behavior is the same even if the database or the
+table name contains a period. This means that an event for the `test.table`
 table in the `my.data` database would appear as `my.data.test.table`.
 
-Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are\
+Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are
 filtered out using the `exclude` parameter.
 
 ```
@@ -245,11 +245,11 @@ exclude=db1 [.](accounts|users)
 
 Exclude data from tables that match this pattern.
 
-For example, if configured with `exclude=mydb[.].*`, all data from the tables in\
+For example, if configured with `exclude=mydb[.].*`, all data from the tables in
 the `mydb` database is not sent to Kafka.
 
-The pattern matching works the same way for both of the `exclude` and `match`\
-parameters. See [match](mariadb-maxscale-2302-kafkacdc.md#match) for an explanation on how the patterns are\
+The pattern matching works the same way for both of the `exclude` and `match`
+parameters. See [match](mariadb-maxscale-2302-kafkacdc.md#match) for an explanation on how the patterns are
 matched against the database and table names.
 
 #### `cooperative_replication`
@@ -259,22 +259,22 @@ matched against the database and table names.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
+Controls whether multiple instances cooperatively replicate from the same
 cluster. This is a boolean parameter and is disabled by default. It was added in\
 MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`), the\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`), the
 replication is only active if the monitor owns the cluster it is monitoring.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID that was delivered\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID that was delivered
 to Kafka.
 
-This means that multiple MaxScale instances can replicate from the same set of\
-servers and the event is only processed once. This feature does not provide\
-exactly-once semantics for the Kafka event delivery. However, it does provide\
-high-availability for the `kafkacdc` instances which allows automated failover\
+This means that multiple MaxScale instances can replicate from the same set of
+servers and the event is only processed once. This feature does not provide
+exactly-once semantics for the Kafka event delivery. However, it does provide
+high-availability for the `kafkacdc` instances which allows automated failover
 between multiple MaxScale instances.
 
 #### `send_schema`
@@ -284,12 +284,12 @@ between multiple MaxScale instances.
 * Dynamic: Yes
 * Default: true
 
-Send JSON schema object into the stream whenever the table schema changes. These\
-events, as described [here](mariadb-maxscale-2302-kafkacdc.md#overview), can be used to detect whenever the\
+Send JSON schema object into the stream whenever the table schema changes. These
+events, as described [here](mariadb-maxscale-2302-kafkacdc.md#overview), can be used to detect whenever the
 format of the data being sent changes.
 
-If this information in these schema change events is not needed or the code that\
-processes the Kafka stream can't handle them, they can be disabled with this\
+If this information in these schema change events is not needed or the code that
+processes the Kafka stream can't handle them, they can be disabled with this
 parameter.
 
 #### `read_gtid_from_kafka`
@@ -299,10 +299,10 @@ parameter.
 * Dynamic: No
 * Default: `true`
 
-On startup, the latest GTID is by default read from the Kafka cluster. This\
+On startup, the latest GTID is by default read from the Kafka cluster. This
 makes it possible to recover the replication position stored by another\
-MaxScale. Sometimes this is not desirable and the GTID should only be read from\
-the local file or started anew. Examples of these are when the GTIDs are reset\
+MaxScale. Sometimes this is not desirable and the GTID should only be read from
+the local file or started anew. Examples of these are when the GTIDs are reset
 or the replication topology has changed.
 
 #### `kafka_ssl`
@@ -312,7 +312,7 @@ or the replication topology has changed.
 * Dynamic: No
 * Default: `false`
 
-Enable SSL for Kafka connections. This is a boolean parameter and is disabled by\
+Enable SSL for Kafka connections. This is a boolean parameter and is disabled by
 default.
 
 #### `kafka_ssl_ca`
@@ -322,7 +322,7 @@ default.
 * Dynamic: No
 * Default: `""`
 
-Path to the certificate authority file in PEM format. If this is not provided,\
+Path to the certificate authority file in PEM format. If this is not provided,
 the default system certificates will be used.
 
 #### `kafka_ssl_cert`
@@ -334,8 +334,8 @@ the default system certificates will be used.
 
 Path to the public certificate in PEM format.
 
-The client must provide a certificate if the Kafka server performs authentication\
-of the client certificates. This feature is enabled by default in Kafka and is\
+The client must provide a certificate if the Kafka server performs authentication
+of the client certificates. This feature is enabled by default in Kafka and is
 controlled by [ssl.endpoint.identification.algorithm](https://kafka.apache.org/documentation/#brokerconfigs_ssl.endpoint.identification.algorithm).
 
 If `kafka_ssl_cert` is provided, `kafka_ssl_key` must also be provided.
@@ -381,8 +381,8 @@ If `kafka_sasl_password` is provided, `kafka_sasl_user` must also be provided.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-The SASL mechanism used. The default value is `PLAIN` which uses plaintext\
-authentication. It is recommended to enable SSL whenever plaintext\
+The SASL mechanism used. The default value is `PLAIN` which uses plaintext
+authentication. It is recommended to enable SSL whenever plaintext
 authentication is used.
 
 Allowed values are:
@@ -396,7 +396,7 @@ Kafka broker.
 
 ### Example Configuration
 
-The following configuration defines the minimal setup for streaming replication\
+The following configuration defines the minimal setup for streaming replication
 events from MariaDB into Kafka as JSON:
 
 ```
@@ -428,8 +428,8 @@ topic=my-cdc-topic
 
 ### Limitations
 
-* The KafkaCDC module provides at-least-once semantics for the generated\
-  events. This means that each replication event is delivered to kafka at least\
+* The KafkaCDC module provides at-least-once semantics for the generated
+  events. This means that each replication event is delivered to kafka at least
   once but there can be duplicate events in case of failures.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-mirror.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-mirror.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-The `mirror` router is designed for data consistency and database behavior\
-verification during system upgrades. It allows statement duplication to multiple\
+The `mirror` router is designed for data consistency and database behavior
+verification during system upgrades. It allows statement duplication to multiple
 servers in a manner similar to that of the [Tee filter](../mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-tee-filter.md) with exporting of collected query metrics.
 
-For each executed query the router exports a JSON object that describes the\
+For each executed query the router exports a JSON object that describes the
 query results and has the following fields:
 
 | Key       | Description                                              |
@@ -17,7 +17,7 @@ query results and has the following fields:
 | query\_id | Query sequence number, starts from 1                     |
 | results   | Array of query result objects                            |
 
-The objects in the `results` array describe an individual query result and have\
+The objects in the `results` array describe an individual query result and have
 the following fields:
 
 | Key      | Description                                |
@@ -37,12 +37,12 @@ the following fields:
 * Mandatory: Yes
 * Dynamic: Yes
 
-The main target from which results are returned to the client. This is a\
+The main target from which results are returned to the client. This is a
 mandatory parameter and must define one of the targets configured in the`targets` parameter of the service.
 
-If the connection to the main target cannot be created or is lost mid-session,\
-the client connection will be closed. Connection failures to other targets are\
-not fatal errors and any open connections to them will be closed. The router\
+If the connection to the main target cannot be created or is lost mid-session,
+the client connection will be closed. Connection failures to other targets are
+not fatal errors and any open connections to them will be closed. The router
 does not create new connections after the initial connections are created.
 
 #### `exporter`
@@ -52,7 +52,7 @@ does not create new connections after the initial connections are created.
 * Dynamic: Yes
 * Values: `log`, `file`, `kafka`
 
-The exporter where the data is exported. This is a mandatory parameter. Possible\
+The exporter where the data is exported. This is a mandatory parameter. Possible
 values are:
 
 * `log`
@@ -60,7 +60,7 @@ values are:
 * `file`
 * Exports metrics to a file. Configured with the [file](mariadb-maxscale-2302-mirror.md#file) parameter.
 * `kafka`
-* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2302-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2302-mirror.md#kafka_topic)\
+* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2302-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2302-mirror.md#kafka_topic)
   parameters.
 
 #### `file`
@@ -70,12 +70,12 @@ values are:
 * Mandatory: No
 * Dynamic: Yes
 
-The output file where the metrics will be written. The file must be writable by\
+The output file where the metrics will be written. The file must be writable by
 the user that is running MaxScale, usually the `maxscale` user.
 
-When the `file` parameter is altered at runtime, the old file is closed before\
-the new file is opened. This makes it a convenient way of rotating the file\
-where the metrics are exported. Note that the file name alteration must change\
+When the `file` parameter is altered at runtime, the old file is closed before
+the new file is opened. This makes it a convenient way of rotating the file
+where the metrics are exported. Note that the file name alteration must change
 the value for it to take effect.
 
 This is a mandatory parameter when configured with `exporter=file`.
@@ -87,7 +87,7 @@ This is a mandatory parameter when configured with `exporter=file`.
 * Mandatory: No
 * Dynamic: Yes
 
-The Kafka broker list. Must be given as a comma-separated list of broker hosts\
+The Kafka broker list. Must be given as a comma-separated list of broker hosts
 with optional ports in `host:port` format.
 
 This is a mandatory parameter when configured with `exporter=kafka`.
@@ -114,12 +114,12 @@ This is a mandatory parameter when configured with `exporter=kafka`.
 What to do when a backend network connection fails. Accepted values are:
 
 * `ignore`
-* Ignore the failing backend if it's not the backend that the `main` parameter\
+* Ignore the failing backend if it's not the backend that the `main` parameter
   points to.
 * `close`
 * Close the client connection when the first backend fails.
 
-This parameter was added in MaxScale 6.0. Older versions always ignored\
+This parameter was added in MaxScale 6.0. Older versions always ignored
 failing backends.
 
 #### `report`
@@ -137,7 +137,7 @@ When to report the result of the queries. Accepted values are:
 * `on_conflict`
 * Only report when one or more backends returns a conflicting result.
 
-This parameter was added in MaxScale 6.0. Older versions always reported the\
+This parameter was added in MaxScale 6.0. Older versions always reported the
 result.
 
 ### Example Configuration
@@ -182,8 +182,8 @@ port=3306
 * Broken network connections are not recreated.
 * Prepared statements are not supported.
 * Contents of non-SQL statements are not added to the exported metrics.
-* Data synchronization in dynamic environments (e.g. when replication is in use)\
-  is not guaranteed. This means that result mismatches can be reported when the\
+* Data synchronization in dynamic environments (e.g. when replication is in use)
+  is not guaranteed. This means that result mismatches can be reported when the
   data is only eventually consistent.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readconnroute.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readconnroute.md
@@ -1,29 +1,29 @@
 # Readconnroute
 
-This document provides an overview of the **readconnroute** router module\
-and its intended use case scenarios. It also displays all router\
+This document provides an overview of the **readconnroute** router module
+and its intended use case scenarios. It also displays all router
 configuration parameters with their descriptions.
 
 ### Overview
 
-The readconnroute router provides simple and lightweight load balancing\
-across a set of servers. The router can also be configured to balance\
+The readconnroute router provides simple and lightweight load balancing
+across a set of servers. The router can also be configured to balance
 connections based on a weighting parameter defined in the server's section.
 
 Note that \*_readconnroute_ balances _connections_ and not _statements_.\
-When a client connects, the router selects a server based upon the router\
-configuration and current server load, but the single created connection\
-is fixed and will not be changed for the duration of the session. If the\
-connection between MaxScale and the server breaks, the connection can not\
-be re-established and the session will be closed. The fact that the server\
+When a client connects, the router selects a server based upon the router
+configuration and current server load, but the single created connection
+is fixed and will not be changed for the duration of the session. If the
+connection between MaxScale and the server breaks, the connection can not
+be re-established and the session will be closed. The fact that the server
 is fixed when the client connects also means that routing hints are ignored.
 
-**Warning:** `readconnroute` will not prevent writes from being done even if you\
-define `router_options=slave`. The client application is responsible for\
-making sure that it only performs read-only queries in such\
-cases. `readconnroute` is simple by design: it selects a server for each\
-client connection and routes all queries there. If something more complex is\
-required, the [readwritesplit](mariadb-maxscale-2302-readwritesplit.md) router is usually the right\
+**Warning:** `readconnroute` will not prevent writes from being done even if you
+define `router_options=slave`. The client application is responsible for
+making sure that it only performs read-only queries in such
+cases. `readconnroute` is simple by design: it selects a server for each
+client connection and routes all queries there. If something more complex is
+required, the [readwritesplit](mariadb-maxscale-2302-readwritesplit.md) router is usually the right
 choice.
 
 ### Configuration
@@ -38,8 +38,8 @@ For more details about the standard service parameters, refer to the [Configurat
 * Values: `master`, `slave`, `synced`, `running`
 * Default: `running`
 
-**`router_options`** can contain a comma separated list of valid server\
-roles. These roles are used as the valid types of servers the router will\
+**`router_options`** can contain a comma separated list of valid server
+roles. These roles are used as the valid types of servers the router will
 form connections to when new sessions are created.
 
 Examples:
@@ -58,14 +58,14 @@ Here is a list of all possible values for the `router_options`.
 | synced  | A Galera cluster node which is in a synced state with the cluster.                                                                                                                                                           |
 | running | A server that is up and running. All servers that MariaDB MaxScale can connect to are labeled as running.                                                                                                                    |
 
-If no `router_options` parameter is configured in the service definition,\
-the router will use the default value of `running`. This means that it will\
-load balance connections across all running servers defined in the `servers`\
+If no `router_options` parameter is configured in the service definition,
+the router will use the default value of `running`. This means that it will
+load balance connections across all running servers defined in the `servers`
 parameter of the service.
 
-When a connection is being created and the candidate server is being chosen,\
-the list of servers is processed in from first entry to last. This means\
-that if two servers with equal weight and status are found, the one that's\
+When a connection is being created and the candidate server is being chosen,
+the list of servers is processed in from first entry to last. This means
+that if two servers with equal weight and status are found, the one that's
 listed first in the _servers_ parameter for the service is chosen.
 
 #### `master_accept_reads`
@@ -76,8 +76,8 @@ listed first in the _servers_ parameter for the service is chosen.
 * Default: true
 
 This option can be used to prevent queries from being sent to the current primary.\
-If `router_options` does not contain `master`, the readconnroute instance is\
-usually meant for reading. Setting `master_accept_reads=false` excludes the primary\
+If `router_options` does not contain `master`, the readconnroute instance is
+usually meant for reading. Setting `master_accept_reads=false` excludes the primary
 from server selection (and thus from receiving reads).
 
 If `router_options` contains `master`, the setting of `master_accept_reads` has no effect.
@@ -91,22 +91,22 @@ By default `master_accept_reads=true`.
 * Dynamic: Yes
 * Default: 0s
 
-The maximum acceptable replication lag. The value is in seconds and is specified\
-as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). The\
+The maximum acceptable replication lag. The value is in seconds and is specified
+as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). The
 default value is `0s`, which means that the lag is ignored.
 
-The replication lag of a server must be less than the configured value in order\
-for it to be used for routing. To configure the router to not allow any lag, use\
+The replication lag of a server must be less than the configured value in order
+for it to be used for routing. To configure the router to not allow any lag, use
 the smallest duration larger than 0, that is, `max_replication_lag=1s`.
 
 ### Examples
 
-The most common use for the readconnroute is to provide either a read or\
-write port for an application. This provides a more lightweight routing\
-solution than the more complex readwritesplit router but requires the\
+The most common use for the readconnroute is to provide either a read or
+write port for an application. This provides a more lightweight routing
+solution than the more complex readwritesplit router but requires the
 application to be able to use distinct write and read ports.
 
-To configure a read-only service that tolerates primary failures, we first\
+To configure a read-only service that tolerates primary failures, we first
 need to add a new section in to the configuration file.
 
 ```
@@ -117,11 +117,11 @@ servers=replica1,replica2,replica3
 router_options=slave
 ```
 
-Here the `router_options` designates replicas as the only valid server\
-type. With this configuration, the queries are load balanced across the\
+Here the `router_options` designates replicas as the only valid server
+type. With this configuration, the queries are load balanced across the
 replica servers.
 
-For more complex examples of the readconnroute router, take a look at the\
+For more complex examples of the readconnroute router, take a look at the
 examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
 
 ### Router Diagnostics

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md
@@ -1,52 +1,52 @@
 # Readwritesplit
 
-This document provides a short overview of the **readwritesplit** router module\
-and its intended use case scenarios. It also displays all router configuration\
-parameters with their descriptions. A list of current limitations of the module\
+This document provides a short overview of the **readwritesplit** router module
+and its intended use case scenarios. It also displays all router configuration
+parameters with their descriptions. A list of current limitations of the module
 is included and use examples are provided.
 
 ### Overview
 
-The **readwritesplit** router is designed to increase the read-only processing\
-capability of a cluster while maintaining consistency. This is achieved by\
-splitting the query load into read and write queries. Read queries, which do not\
-modify data, are spread across multiple nodes while all write queries will be\
+The **readwritesplit** router is designed to increase the read-only processing
+capability of a cluster while maintaining consistency. This is achieved by
+splitting the query load into read and write queries. Read queries, which do not
+modify data, are spread across multiple nodes while all write queries will be
 sent to a single node.
 
-The router is designed to be used with a traditional Primary-Replica replication\
-cluster. It automatically detects changes in the primary server and will use the\
-current primary server of the cluster. With a Galera cluster, one can achieve a\
+The router is designed to be used with a traditional Primary-Replica replication
+cluster. It automatically detects changes in the primary server and will use the
+current primary server of the cluster. With a Galera cluster, one can achieve a
 resilient setup and easy primary failover by using one of the Galera nodes as a\
-Write-Primary node, where all write queries are routed, and spreading the read\
+Write-Primary node, where all write queries are routed, and spreading the read
 load over all the nodes.
 
 ### Interaction with servers in `Maintenance` and `Draining` state
 
-When a server that readwritesplit uses is put into maintenance mode, any ongoing\
-requests are allowed to finish before the connection is closed. If the server\
-that is put into maintenance mode is a primary, open transaction are allowed to\
-complete before the connection is closed. Note that this means neither idle\
-session nor long-running transactions will be closed by readwritesplit. To\
+When a server that readwritesplit uses is put into maintenance mode, any ongoing
+requests are allowed to finish before the connection is closed. If the server
+that is put into maintenance mode is a primary, open transaction are allowed to
+complete before the connection is closed. Note that this means neither idle
+session nor long-running transactions will be closed by readwritesplit. To
 forcefully close the connections, use the following command:
 
 ```
 maxctrl set server <server> maintenance --force
 ```
 
-If a server is put into the `Draining` state while a connection is open, the\
-connection will be used normally. Whenever a new connection needs to be created,\
-whether that be due to a network error or when a new session being opened, only\
+If a server is put into the `Draining` state while a connection is open, the
+connection will be used normally. Whenever a new connection needs to be created,
+whether that be due to a network error or when a new session being opened, only
 servers that are neither `Draining` nor `Drained` will be used.
 
 ### Configuration
 
-Readwritesplit router-specific settings are specified in the configuration file\
-of MariaDB MaxScale in its specific section. The section can be freely named but\
+Readwritesplit router-specific settings are specified in the configuration file
+of MariaDB MaxScale in its specific section. The section can be freely named but
 the name is used later as a reference in a listener section.
 
 For more details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md).
 
-Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be\
+Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be
 taken into use by new sessions.
 
 ### Parameters
@@ -58,45 +58,45 @@ taken into use by new sessions.
 * Dynamic: Yes
 * Default: 255
 
-`max_slave_connections` sets the maximum number of replicas a router session uses\
-at any moment. The default is to use at most 255 replica connections per client\
-connection. In older versions the default was to use all available replicas with\
+`max_slave_connections` sets the maximum number of replicas a router session uses
+at any moment. The default is to use at most 255 replica connections per client
+connection. In older versions the default was to use all available replicas with
 no limit.
 
 For MaxScale 2.5.12 and newer, the minimum value is 0.
 
-For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions\
-suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that\
-causes the parameter to accept any values but only function when a value greater\
+For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions
+suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that
+causes the parameter to accept any values but only function when a value greater
 than one was given.
 
-Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be\
+Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be
 removed in a future release.
 
-For example, if you have configured MaxScale with one primary and three replicas\
-and set `max_slave_connections=2`, for each client connection a connection to\
-the primary and two replica connections would be opened. The read query load\
-balancing is then done between these two replicas and writes are sent to the\
+For example, if you have configured MaxScale with one primary and three replicas
+and set `max_slave_connections=2`, for each client connection a connection to
+the primary and two replica connections would be opened. The read query load
+balancing is then done between these two replicas and writes are sent to the
 primary.
 
-By tuning this parameter, you can control how dynamic the load balancing is at\
-the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of\
-possible replica servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more\
-resources but load balancing will almost always give the best single query\
+By tuning this parameter, you can control how dynamic the load balancing is at
+the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of
+possible replica servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more
+resources but load balancing will almost always give the best single query
 response time and performance. Longer sessions are less affected by a high`max_slave_connections` as the relative cost of opening a connection is lower.
 
 **Behavior of `max_slave_connections=0`**
 
-When readwritesplit is configured with `max_slave_connections=0`, readwritesplit\
-will behave slightly differently in that it will route all reads to the current\
-master server. This is a convenient way to force all of the traffic to go to a\
-single node while still being able to leverage the replay and reconnection\
+When readwritesplit is configured with `max_slave_connections=0`, readwritesplit
+will behave slightly differently in that it will route all reads to the current
+master server. This is a convenient way to force all of the traffic to go to a
+single node while still being able to leverage the replay and reconnection
 features of readwritesplit.
 
-In this mode, the behavior of `master_failure_mode=fail_on_write` also changes\
-slightly. If the current `Master` server fails and a read is done when there's\
-no other `Master` server available, the connection will be closed. This is done\
-to prevent an extra slave connection from being opened that would not be closed\
+In this mode, the behavior of `master_failure_mode=fail_on_write` also changes
+slightly. If the current `Master` server fails and a read is done when there's
+no other `Master` server available, the connection will be closed. This is done
+to prevent an extra slave connection from being opened that would not be closed
 if a new `Master` server would arrive.
 
 #### `slave_connections`
@@ -106,17 +106,17 @@ if a new `Master` server would arrive.
 * Dynamic: Yes
 * Default: 255
 
-This parameter controls how many replica connections each new session starts\
+This parameter controls how many replica connections each new session starts
 with. The default value is 255 which is the same as the default value of`max_slave_connections`.
 
-In contrast to `max_slave_connections`, `slave_connections` serves as a\
-soft limit on how many replica connections are created. The number of replica\
-connections can exceed `slave_connections` if the load balancing algorithm\
+In contrast to `max_slave_connections`, `slave_connections` serves as a
+soft limit on how many replica connections are created. The number of replica
+connections can exceed `slave_connections` if the load balancing algorithm
 finds an unconnected replica server better than all other replicas.
 
-Setting this parameter to 1 allows faster connection creation and improved\
-resource usage due to the smaller amount of initial backend\
-connections. It is recommended to use `slave_connections=1` when the\
+Setting this parameter to 1 allows faster connection creation and improved
+resource usage due to the smaller amount of initial backend
+connections. It is recommended to use `slave_connections=1` when the
 lifetime of the client connections is short.
 
 #### `max_slave_replication_lag`
@@ -126,32 +126,32 @@ lifetime of the client connections is short.
 * Dynamic: Yes
 * Default: 0s
 
-Specify how many seconds a replica is allowed to be behind the primary. The lag of\
-a replica must be less than the configured value in order for it to be used for\
+Specify how many seconds a replica is allowed to be behind the primary. The lag of
+a replica must be less than the configured value in order for it to be used for
 routing. If set to 0 (the default value), the feature is disabled.
 
-In MaxScale 2.5.0, the replica lag must be less than `max_slave_replication_lag`\
-whereas in older versions the replica lag had to be less than or equal to`max_slave_replication_lag`. This means that in MaxScale 2.5.0 it is possible to\
-define, with `max_slave_replication_lag=1`, that all replicas must be up to date\
+In MaxScale 2.5.0, the replica lag must be less than `max_slave_replication_lag`
+whereas in older versions the replica lag had to be less than or equal to`max_slave_replication_lag`. This means that in MaxScale 2.5.0 it is possible to
+define, with `max_slave_replication_lag=1`, that all replicas must be up to date
 in order for them to be used for routing.
 
-Note that this feature does not guarantee that writes done on the primary are\
-visible for reads done on the replica. This is mainly due to the method of\
+Note that this feature does not guarantee that writes done on the primary are
+visible for reads done on the replica. This is mainly due to the method of
 replication lag measurement. For a feature that guarantees this, refer to [causal\_reads](mariadb-maxscale-2302-readwritesplit.md#causal_reads).
 
-The lag is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the lag is seconds, a lag specified in milliseconds will be rejected, even if\
+The lag is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the lag is seconds, a lag specified in milliseconds will be rejected, even if
 the duration is longer than a second.
 
-The Readwritesplit-router does not detect the replication lag itself. A monitor\
-such as the MariaDB-monitor for a Primary-Replica cluster is required. This option\
-only affects Primary-Replica clusters. Galera clusters do not have a concept of\
-replica lag even if the application of write sets might have lag. When a server is\
-disqualified from routing because of replication lag, a warning is logged. Similarly,\
-when the server has caught up enough to be a valid routing target, another warning\
-is logged. These messages are only logged when a query is being routed and the\
+The Readwritesplit-router does not detect the replication lag itself. A monitor
+such as the MariaDB-monitor for a Primary-Replica cluster is required. This option
+only affects Primary-Replica clusters. Galera clusters do not have a concept of
+replica lag even if the application of write sets might have lag. When a server is
+disqualified from routing because of replication lag, a warning is logged. Similarly,
+when the server has caught up enough to be a valid routing target, another warning
+is logged. These messages are only logged when a query is being routed and the
 replication state changes.
 
 #### `use_sql_variables_in`
@@ -162,8 +162,8 @@ replication state changes.
 * Values: `master`, `all`
 * Default: `all`
 
-This parameter controls how `SELECT` statements that use SQL user variables are\
-handled. Here is an example of such a query that uses it to return an increasing\
+This parameter controls how `SELECT` statements that use SQL user variables are
+handled. Here is an example of such a query that uses it to return an increasing
 row number for a resultset:
 
 ```
@@ -171,31 +171,31 @@ SET @rownum := 0;
 SELECT @rownum := @rownum + 1 AS rownum, user, host FROM mysql.user;
 ```
 
-By default MaxScale will route both the `SET` and `SELECT` statements to all\
+By default MaxScale will route both the `SET` and `SELECT` statements to all
 nodes. Any future reads of the user variables can also be performed on any node.
 
 The possible values for this parameter are:
 
 * `all` (default)
-* Modifications to user variables inside `SELECT` statements as well as reads\
+* Modifications to user variables inside `SELECT` statements as well as reads
   of user variables are routed to all servers.\
-  Versions before MaxScale 22.08 returned an error if a user variable was\
-  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was\
-  used. MaxScale 22.08 will instead route the query to all servers and discard\
+  Versions before MaxScale 22.08 returned an error if a user variable was
+  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was
+  used. MaxScale 22.08 will instead route the query to all servers and discard
   the extra results.
 * `master`
-* Modifications to user variables inside `SELECT` statements as well as reads\
-  of user variables are routed to the primary server. This forces more of the\
-  traffic onto the primary server but it reduces the amount of data that is\
-  discarded for any `SELECT` statement that also modifies a user\
-  variable. With this mode, the state of user variables is not deterministic\
-  if they are modified inside of a `SELECT` statement. `SET` statements that\
+* Modifications to user variables inside `SELECT` statements as well as reads
+  of user variables are routed to the primary server. This forces more of the
+  traffic onto the primary server but it reduces the amount of data that is
+  discarded for any `SELECT` statement that also modifies a user
+  variable. With this mode, the state of user variables is not deterministic
+  if they are modified inside of a `SELECT` statement. `SET` statements that
   modify user variables are still routed to all servers.
 
-DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user\
-variables are still treated as writes and are only routed to the primary\
-server. For example, after the following query the value of `@myid` is no longer\
-the same on all servers and the `SELECT` statement can return different values\
+DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user
+variables are still treated as writes and are only routed to the primary
+server. For example, after the following query the value of `@myid` is no longer
+the same on all servers and the `SELECT` statement can return different values
 depending where it ends up being executed:
 
 ```
@@ -206,13 +206,13 @@ SELECT @myid; -- Might return 1 or 0
 
 #### `connection_keepalive`
 
-**Note:** This parameter has been moved into the MaxScale core. For the\
-current documentation, read the [connection\_keepalive](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#connection_keepalive)\
+**Note:** This parameter has been moved into the MaxScale core. For the
+current documentation, read the [connection\_keepalive](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#connection_keepalive)
 section in the configuration guide.
 
 Send keepalive pings to backend servers. This feature was introduced in MaxScale\
-2.2.0. The default value is 300 seconds starting with 2.3.2 and for older\
-versions the feature was disabled by default. This parameter was converted into\
+2.2.0. The default value is 300 seconds starting with 2.3.2 and for older
+versions the feature was disabled by default. This parameter was converted into
 a service parameter in MaxScale 2.5.0.
 
 #### `master_reconnection`
@@ -225,26 +225,26 @@ a service parameter in MaxScale 2.5.0.
 Allow the primary server to change mid-session. This feature was introduced in\
 MaxScale 2.3.0 and is disabled by default. This feature requires that`disable_sescmd_history` is not used.
 
-When a readwritesplit session starts, it will pick a primary server as the\
-current primary server of that session. By default, when this primary server is\
+When a readwritesplit session starts, it will pick a primary server as the
+current primary server of that session. By default, when this primary server is
 lost or changes to another server, the connection will be closed.
 
-When `master_reconnection` is enabled, readwritesplit can sometimes recover a\
+When `master_reconnection` is enabled, readwritesplit can sometimes recover a
 lost connection to the primary server. This largely depends on the value of`master_failure_mode`.
 
-With `master_failure_mode=fail_instantly`, the primary server is only allowed to\
-change to another server. This change must happen without a loss of the primary\
+With `master_failure_mode=fail_instantly`, the primary server is only allowed to
+change to another server. This change must happen without a loss of the primary
 server.
 
-With `master_failure_mode=fail_on_write`, the loss of the primary server is no\
-longer a fatal error: if a replacement primary server appears before any write\
-queries are received, readwritesplit will transparently reconnect to the new\
+With `master_failure_mode=fail_on_write`, the loss of the primary server is no
+longer a fatal error: if a replacement primary server appears before any write
+queries are received, readwritesplit will transparently reconnect to the new
 primary server.
 
-In both cases the change in the primary server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet\
+In both cases the change in the primary server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet
 been exceeded and the session does not have an open transaction.
 
-The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance\
+The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance
 without any risk to the consistency of the database.
 
 #### `slave_selection_criteria`
@@ -255,8 +255,8 @@ without any risk to the consistency of the database.
 * Values: `LEAST_CURRENT_OPERATIONS`, `ADAPTIVE_ROUTING`, `LEAST_BEHIND_MASTER`, `LEAST_ROUTER_CONNECTIONS`, `LEAST_GLOBAL_CONNECTIONS`
 * Default: `LEAST_CURRENT_OPERATIONS`
 
-This option controls how the readwritesplit router chooses the replicas it\
-connects to and how the load balancing is done. The default behavior is to route\
+This option controls how the readwritesplit router chooses the replicas it
+connects to and how the load balancing is done. The default behavior is to route
 read queries to the replica server with the lowest amount of ongoing queries i.e.`LEAST_CURRENT_OPERATIONS`.
 
 The option syntax:
@@ -273,55 +273,55 @@ Where `<criteria>` is one of the following values.
 * `LEAST_GLOBAL_CONNECTIONS`, the replica with least connections from MariaDB MaxScale
 * `LEAST_ROUTER_CONNECTIONS`, the replica with least connections from this service
 
-`LEAST_CURRENT_OPERATIONS` uses the current number of active operations\
-(i.e. SQL queries) as the load balancing metric and it optimizes for maximal\
-query throughput. Each query gets routed to the server with the least active\
+`LEAST_CURRENT_OPERATIONS` uses the current number of active operations
+(i.e. SQL queries) as the load balancing metric and it optimizes for maximal
+query throughput. Each query gets routed to the server with the least active
 operations which results in faster servers processing more traffic.
 
-`ADAPTIVE_ROUTING` uses the server response time and current estimated server\
-load as the load balancing metric. The server that is estimated to finish an\
-additional query first is chosen. A modified average response time for each\
-server is continuously updated to allow slow servers at least some traffic and\
-quickly react to changes in server load conditions. This selection criteria is\
-designed for heterogeneous clusters: servers of differing hardware, differing\
-network distances, or when other loads are running on the servers (including a\
-backup). If the servers are queried by other clients than MaxScale, the load\
+`ADAPTIVE_ROUTING` uses the server response time and current estimated server
+load as the load balancing metric. The server that is estimated to finish an
+additional query first is chosen. A modified average response time for each
+server is continuously updated to allow slow servers at least some traffic and
+quickly react to changes in server load conditions. This selection criteria is
+designed for heterogeneous clusters: servers of differing hardware, differing
+network distances, or when other loads are running on the servers (including a
+backup). If the servers are queried by other clients than MaxScale, the load
 caused by them is indirectly taken into account.
 
-`LEAST_BEHIND_MASTER` uses the measured replication lag as the load balancing\
-metric. This means that servers that are more up-to-date are favored which\
-increases the likelihood of the data being read being up-to-date. However, this\
-is not as effective as `causal_reads` would be as there's no guarantee that\
-writes done by the same connection will be routed to a server that has\
+`LEAST_BEHIND_MASTER` uses the measured replication lag as the load balancing
+metric. This means that servers that are more up-to-date are favored which
+increases the likelihood of the data being read being up-to-date. However, this
+is not as effective as `causal_reads` would be as there's no guarantee that
+writes done by the same connection will be routed to a server that has
 replicated those changes. The recommended approach is to use`LEAST_CURRENT_OPERATIONS` or `ADAPTIVE_ROUTING` in combination with`causal_reads`
 
-**NOTE**: `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` should not\
-be used, they are legacy options that exist only for backwards\
-compatibility. Using them will result in skewed load balancing as the algorithm\
-uses a metric that's too coarse (number of connections) to load balance\
+**NOTE**: `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` should not
+be used, they are legacy options that exist only for backwards
+compatibility. Using them will result in skewed load balancing as the algorithm
+uses a metric that's too coarse (number of connections) to load balance
 something that's finer (individual SQL queries).
 
-The `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` use the\
-connections from MariaDB MaxScale to the server, not the amount of connections\
+The `LEAST_GLOBAL_CONNECTIONS` and `LEAST_ROUTER_CONNECTIONS` use the
+connections from MariaDB MaxScale to the server, not the amount of connections
 reported by the server itself.
 
-Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,\
-lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid\
+Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,
+lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid
 values.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#max_sescmd_history)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#max_sescmd_history)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#disable_sescmd_history)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#disable_sescmd_history)
 in MaxScale 6.0.
 
 #### `prune_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#prune_sescmd_history)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#prune_sescmd_history)
 in MaxScale 6.0.
 
 #### `master_accept_reads`
@@ -331,12 +331,12 @@ in MaxScale 6.0.
 * Dynamic: Yes
 * Default: false
 
-**`master_accept_reads`** allows the primary server to be used for reads. This is\
-a useful option to enable if you are using a small number of servers and wish to\
+**`master_accept_reads`** allows the primary server to be used for reads. This is
+a useful option to enable if you are using a small number of servers and wish to
 use the primary for reads as well.
 
-By default, no reads are sent to the primary as long as there is a valid replica\
-server available. If no replicas are available, reads are sent to the primary\
+By default, no reads are sent to the primary as long as there is a valid replica
+server available. If no replicas are available, reads are sent to the primary
 regardless of the value of `master_accept_reads`.
 
 ```
@@ -351,18 +351,18 @@ master_accept_reads=true
 * Dynamic: Yes
 * Default: false
 
-This option is disabled by default since MaxScale 2.2.1. In older versions, this\
+This option is disabled by default since MaxScale 2.2.1. In older versions, this
 option was enabled by default.
 
-When a client executes a multi-statement query, it will be treated as if it were\
-a DML statement and routed to the primary. If the option is enabled, all queries\
-after a multi-statement query will be routed to the primary to guarantee a\
+When a client executes a multi-statement query, it will be treated as if it were
+a DML statement and routed to the primary. If the option is enabled, all queries
+after a multi-statement query will be routed to the primary to guarantee a
 consistent session state.
 
-If the feature is disabled, queries are routed normally after a multi-statement\
+If the feature is disabled, queries are routed normally after a multi-statement
 query.
 
-**Warning:** Enable the strict mode only if you know that the clients will send\
+**Warning:** Enable the strict mode only if you know that the clients will send
 statements that cause inconsistencies in the session state.
 
 ```
@@ -377,8 +377,8 @@ strict_multi_stmt=true
 * Dynamic: Yes
 * Default: false
 
-Similar to `strict_multi_stmt`, this option allows all queries after a CALL\
-operation on a stored procedure to be routed to the primary. This option is\
+Similar to `strict_multi_stmt`, this option allows all queries after a CALL
+operation on a stored procedure to be routed to the primary. This option is
 disabled by default and was added in MaxScale 2.1.9.
 
 All warnings and restrictions that apply to `strict_multi_stmt` also apply to`strict_sp_calls`.
@@ -391,10 +391,10 @@ All warnings and restrictions that apply to `strict_multi_stmt` also apply to`st
 * Values: `fail_instantly`, `fail_on_write`, `error_on_write`
 * Default: `fail_instantly`
 
-This option controls how the failure of a primary server is handled. By default,\
+This option controls how the failure of a primary server is handled. By default,
 the router will close the client connection as soon as the primary is lost.
 
-The following table describes the values for this option and how they treat the\
+The following table describes the values for this option and how they treat the
 loss of a primary server.
 
 | Value            | Description                                                                                                                      |
@@ -403,22 +403,22 @@ loss of a primary server.
 | fail\_on\_write  | The client connection is closed if a write query is received when no primary is available.                                       |
 | error\_on\_write | If no primary is available and a write query is received, an error is returned stating that the connection is in read-only mode. |
 
-These also apply to new sessions created after the primary has failed. This means\
-that in `fail_on_write` or `error_on_write` mode, connections are accepted as\
+These also apply to new sessions created after the primary has failed. This means
+that in `fail_on_write` or `error_on_write` mode, connections are accepted as
 long as replica servers are available.
 
-When configured with `fail_on_write` or `error_on_write`, sessions that are idle\
-will not be closed even if all backend connections for that session have\
-failed. This is done in the hopes that before the next query from the idle\
-session arrives, a reconnection to one of the replicas is made. However, this can\
-leave idle connections around unless the client application actively closes\
-them. To prevent this, use the [connection\_timeout](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#connection_timeout)\
+When configured with `fail_on_write` or `error_on_write`, sessions that are idle
+will not be closed even if all backend connections for that session have
+failed. This is done in the hopes that before the next query from the idle
+session arrives, a reconnection to one of the replicas is made. However, this can
+leave idle connections around unless the client application actively closes
+them. To prevent this, use the [connection\_timeout](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#connection_timeout)
 parameter.
 
-**Note:** If `master_failure_mode` is set to `error_on_write` and the connection\
-to the primary is lost, by default, clients will not be able to execute write\
-queries without reconnecting to MariaDB MaxScale once a new primary is\
-available. If [master\_reconnection](mariadb-maxscale-2302-readwritesplit.md#master_reconnection) is enabled, the\
+**Note:** If `master_failure_mode` is set to `error_on_write` and the connection
+to the primary is lost, by default, clients will not be able to execute write
+queries without reconnecting to MariaDB MaxScale once a new primary is
+available. If [master\_reconnection](mariadb-maxscale-2302-readwritesplit.md#master_reconnection) is enabled, the
 session can recover if one of the replicas is promoted as the primary.
 
 #### `retry_failed_reads`
@@ -431,9 +431,9 @@ session can recover if one of the replicas is promoted as the primary.
 This option controls whether autocommit selects are retried in case of failure.\
 This option is enabled by default.
 
-When a simple autocommit select is being executed outside of a transaction and\
-the replica server where the query is being executed fails, readwritesplit can\
-retry the read on a replacement server. This makes the failure of a replica\
+When a simple autocommit select is being executed outside of a transaction and
+the replica server where the query is being executed fails, readwritesplit can
+retry the read on a replacement server. This makes the failure of a replica
 transparent to the client.
 
 #### `delayed_retry`
@@ -443,34 +443,34 @@ transparent to the client.
 * Dynamic: Yes
 * Default: false
 
-Retry queries over a period of time. This parameter takes a boolean value, was\
+Retry queries over a period of time. This parameter takes a boolean value, was
 added in Maxscale 2.3.0 and is disabled by default.
 
-When this feature is enabled, a failure to route a query due to a connection\
-problem will not immediately result in an error. The routing of the query is\
-delayed until either a valid candidate server is available or the retry timeout\
-is reached. If a candidate server becomes available before the timeout is\
-reached, the query is routed normally and no connection error is returned. If no\
-candidates are found and the timeout is exceeded, the router returns to normal\
+When this feature is enabled, a failure to route a query due to a connection
+problem will not immediately result in an error. The routing of the query is
+delayed until either a valid candidate server is available or the retry timeout
+is reached. If a candidate server becomes available before the timeout is
+reached, the query is routed normally and no connection error is returned. If no
+candidates are found and the timeout is exceeded, the router returns to normal
 behavior and returns an error.
 
-When combined with the `master_reconnection` parameter, failures of writes done\
-outside of transactions can be hidden from the client connection. This allows a\
+When combined with the `master_reconnection` parameter, failures of writes done
+outside of transactions can be hidden from the client connection. This allows a
 primary to be replaced while writes are being sent.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, `delayed_retry` will no longer attempt to retry a query if it was\
-already sent to the database. If a query is received while a valid target server\
-is not available, the execution of the query is delayed until a valid target is\
-found or the delayed retry timeout is hit. If a query was already sent, it will\
+24.08.1, `delayed_retry` will no longer attempt to retry a query if it was
+already sent to the database. If a query is received while a valid target server
+is not available, the execution of the query is delayed until a valid target is
+found or the delayed retry timeout is hit. If a query was already sent, it will
 not be replayed to prevent duplicate execution of statements.
 
-In older versions of MaxScale, duplicate execution of a statement can occur if\
-the connection to the server is lost or the server crashes but the server comes\
-back up before the timeout for the retrying is exceeded. At this point, if the\
-server managed to read the client's statement, it will be executed. For this\
+In older versions of MaxScale, duplicate execution of a statement can occur if
+the connection to the server is lost or the server crashes but the server comes
+back up before the timeout for the retrying is exceeded. At this point, if the
+server managed to read the client's statement, it will be executed. For this
 reason, it is recommended to only enable `delayed_retry` for older versions of\
-MaxScale when the possibility of duplicate statement execution is an acceptable\
+MaxScale when the possibility of duplicate statement execution is an acceptable
 risk.
 
 #### `delayed_retry_timeout`
@@ -482,10 +482,10 @@ risk.
 
 The duration to wait until an error is returned to the client when`delayed_retry` is enabled. The default value is 10 seconds.
 
-The timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `transaction_replay`
@@ -495,20 +495,20 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Replay interrupted transactions. This parameter was added in MaxScale 2.3.0 and\
-is disabled by default. Enabling this parameter enables both `delayed_retry` and`master_reconnection` and sets `master_failure_mode` to `fail_on_write`, thereby\
+Replay interrupted transactions. This parameter was added in MaxScale 2.3.0 and
+is disabled by default. Enabling this parameter enables both `delayed_retry` and`master_reconnection` and sets `master_failure_mode` to `fail_on_write`, thereby
 overriding any configured values for these parameters.
 
-When the server where the transaction is in progress fails, readwritesplit can\
-migrate the transaction to a replacement server. This can completely hide the\
+When the server where the transaction is in progress fails, readwritesplit can
+migrate the transaction to a replacement server. This can completely hide the
 failure of a primary node without any visible effects to the client.
 
 If no replacement node becomes available, the client connection is closed.
 
 To control how long a transaction replay can take, use`transaction_replay_timeout`.
 
-Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2302-readwritesplit.md#transaction-replay-limitations) section for\
-a more detailed explanation of what should and should not be done with\
+Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2302-readwritesplit.md#transaction-replay-limitations) section for
+a more detailed explanation of what should and should not be done with
 transaction replay.
 
 #### `transaction_replay_max_size`
@@ -518,20 +518,20 @@ transaction replay.
 * Dynamic: Yes
 * Default: 1 MiB
 
-The limit on transaction size for transaction replay in bytes. Any transaction\
-that exceeds this limit will not be replayed. The default value is 1 MiB. This\
-limit applies at a session level which means that the total peak memory\
-consumption can be `transaction_replay_max_size` times the number of client\
+The limit on transaction size for transaction replay in bytes. Any transaction
+that exceeds this limit will not be replayed. The default value is 1 MiB. This
+limit applies at a session level which means that the total peak memory
+consumption can be `transaction_replay_max_size` times the number of client
 connections.
 
-The amount of memory needed to store a particular transaction will be slightly\
-larger than the length in bytes of the SQL used in the transaction. If the limit\
+The amount of memory needed to store a particular transaction will be slightly
+larger than the length in bytes of the SQL used in the transaction. If the limit
 is ever exceeded, a message will be logged at the info level.
 
-Starting with MaxScale 6.4.10, the number of times that this limit has been\
+Starting with MaxScale 6.4.10, the number of times that this limit has been
 exceeded is shown in `maxctrl show service` as `trx_max_size_exceeded`.
 
-Read [the configuration guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#sizes)\
+Read [the configuration guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#sizes)
 for more details on size type parameters in MaxScale.
 
 #### `transaction_replay_attempts`
@@ -541,13 +541,13 @@ for more details on size type parameters in MaxScale.
 * Dynamic: Yes
 * Default: 5
 
-The upper limit on how many times a transaction replay is attempted before\
+The upper limit on how many times a transaction replay is attempted before
 giving up. The default value is 5.
 
-A transaction replay failure can happen if the server where the transaction is\
-being replayed fails while the replay is in progress. In practice this parameter\
-controls how many server and network failures a single transaction replay\
-tolerates. If a transaction is replayed successfully, the counter for failed\
+A transaction replay failure can happen if the server where the transaction is
+being replayed fails while the replay is in progress. In practice this parameter
+controls how many server and network failures a single transaction replay
+tolerates. If a transaction is replayed successfully, the counter for failed
 attempts is reset.
 
 #### `transaction_replay_timeout`
@@ -557,30 +557,30 @@ attempts is reset.
 * Dynamic: Yes
 * Default: 0s
 
-The time how long transactions are attempted for. This feature is disabled by\
-default and was added in MaxScale 6.2.1. To explicitly disable this feature, set\
+The time how long transactions are attempted for. This feature is disabled by
+default and was added in MaxScale 6.2.1. To explicitly disable this feature, set
 the value to 0 seconds.
 
-The timeout is [a duration type](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations)\
+The timeout is [a duration type](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations)
 and the value must include a unit for the duration.
 
-When `transaction_replay_timeout` is enabled, the time a transaction replay can\
-take is controlled solely by this parameter. This is a more convenient and\
-predictable method of controlling how long a transaction replay can be attempted\
+When `transaction_replay_timeout` is enabled, the time a transaction replay can
+take is controlled solely by this parameter. This is a more convenient and
+predictable method of controlling how long a transaction replay can be attempted
 before the connection is closed.
 
-If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set\
+If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set
 to the same value.
 
-By default the time how long a transaction can be retried is controlled by`delayed_retry_timeout` and `transaction_replay_attempts`. This can result in a\
-maximum replay time limit of `delayed_retry_timeout` multiplied by`transaction_replay_attempts`, by default this is 50 seconds. The minimum replay\
-time limit can be as low as `transaction_replay_attempts` seconds (5 seconds by\
-default) in cases where the connection fails after it was created. Usually this\
-happens due to problems like the max\_connections limit being hit on the database\
+By default the time how long a transaction can be retried is controlled by`delayed_retry_timeout` and `transaction_replay_attempts`. This can result in a
+maximum replay time limit of `delayed_retry_timeout` multiplied by`transaction_replay_attempts`, by default this is 50 seconds. The minimum replay
+time limit can be as low as `transaction_replay_attempts` seconds (5 seconds by
+default) in cases where the connection fails after it was created. Usually this
+happens due to problems like the max\_connections limit being hit on the database
 server.
 
-With the introduction of `transaction_replay_timeout`, these problems are\
-avoided. Starting with MaxScale 6.2.1, this is the recommended method of\
+With the introduction of `transaction_replay_timeout`, these problems are
+avoided. Starting with MaxScale 6.2.1, this is the recommended method of
 controlling the timeouts for transaction replay.
 
 #### `transaction_replay_retry_on_deadlock`
@@ -590,15 +590,15 @@ controlling the timeouts for transaction replay.
 * Dynamic: Yes
 * Default: false
 
-Enable automatic retrying of transactions that end up in a deadlock. This\
-parameter was added in MaxScale 2.4.6 and the feature is disabled by\
-default. MaxScale versions from 2.4.0 to 2.4.5 always tried to replay deadlocked\
+Enable automatic retrying of transactions that end up in a deadlock. This
+parameter was added in MaxScale 2.4.6 and the feature is disabled by
+default. MaxScale versions from 2.4.0 to 2.4.5 always tried to replay deadlocked
 transactions.
 
-If this feature is enabled and a transaction returns a deadlock error\
-(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),\
-the transaction is automatically retried. If the retrying of the transaction\
-results in another deadlock error, it is retried until it either succeeds or a\
+If this feature is enabled and a transaction returns a deadlock error
+(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),
+the transaction is automatically retried. If the retrying of the transaction
+results in another deadlock error, it is retried until it either succeeds or a
 transaction checksum error is encountered.
 
 #### `transaction_replay_retry_on_mismatch`
@@ -611,8 +611,8 @@ transaction checksum error is encountered.
 Retry transactions that end in checksum mismatch. This parameter was added in\
 MaxScale 6.2.1 is disabled by default.
 
-When enabled, any replayed transactions that end with a checksum mismatch are\
-retried until they either succeeds or one of the transaction replay limits is\
+When enabled, any replayed transactions that end with a checksum mismatch are
+retried until they either succeeds or one of the transaction replay limits is
 reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_replay_attempts`).
 
 #### `transaction_replay_checksum`
@@ -623,30 +623,30 @@ reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_re
 * Values: `full`, `result_only`, `no_insert_id`
 * Default: `full`
 
-Selects which transaction checksum method is used to verify the result of the\
+Selects which transaction checksum method is used to verify the result of the
 replayed transaction.
 
-Note that only `transaction_replay_checksum=full` is guaranteed to retain the\
+Note that only `transaction_replay_checksum=full` is guaranteed to retain the
 consistency of the replayed transaction.
 
 Possible values are:
 
 * `full` (default)
-* All responses from the server are included in the checksum. This retains the\
-  full consistency guarantee of the replayed transaction as it must match\
+* All responses from the server are included in the checksum. This retains the
+  full consistency guarantee of the replayed transaction as it must match
   exactly the one that was already returned to the client.
 * `result_only`
-* Only resultsets and errors are included in the checksum. OK packets\
-  (i.e. successful queries that do not return results) are ignored. This mode\
+* Only resultsets and errors are included in the checksum. OK packets
+  (i.e. successful queries that do not return results) are ignored. This mode
   is intended to be used in cases where the extra information (auto-generated\
-  ID, warnings etc.) returned in the OK packet is not used by the\
+  ID, warnings etc.) returned in the OK packet is not used by the
   application.\
-  This mode is safe to use only if the auto-generated ID is not actually used\
-  by any following queries. An example of such behavior would be a transaction\
+  This mode is safe to use only if the auto-generated ID is not actually used
+  by any following queries. An example of such behavior would be a transaction
   that ends with an `INSERT` into a table with an `AUTO_INCREMENT` field.
 * `no_insert_id`
-* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the\
-  result of the query is not used by any subsequent statement in the\
+* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the
+  result of the query is not used by any subsequent statement in the
   transaction.
 
 #### `optimistic_trx`
@@ -656,21 +656,21 @@ Possible values are:
 * Dynamic: Yes
 * Default: false
 
-Enable optimistic transaction execution. This parameter controls whether normal\
-transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across\
+Enable optimistic transaction execution. This parameter controls whether normal
+transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across
 replicas. This feature is disabled by default and enabling it implicitly enables`transaction_replay`, `delayed_retry` and `master_reconnection` parameters.
 
-When this mode is enabled, all transactions are first attempted on replica\
-servers. If the transaction contains no statements that modify data, it is\
-completed on the replica. If the transaction contains statements that modify data,\
-it is rolled back on the replica server and restarted on the primary. The rollback\
-is initiated the moment a data modifying statement is intercepted by\
+When this mode is enabled, all transactions are first attempted on replica
+servers. If the transaction contains no statements that modify data, it is
+completed on the replica. If the transaction contains statements that modify data,
+it is rolled back on the replica server and restarted on the primary. The rollback
+is initiated the moment a data modifying statement is intercepted by
 readwritesplit so only read-only statements are executed on replica servers.
 
-As with `transaction_replay` and transactions that are replayed, if the results\
-returned by the primary server are not identical to the ones returned by the\
-replica up to the point where the first data modifying statement was executed, the\
-connection is closed. If the execution of ROLLBACK statement on the replica fails,\
+As with `transaction_replay` and transactions that are replayed, if the results
+returned by the primary server are not identical to the ones returned by the
+replica up to the point where the first data modifying statement was executed, the
+connection is closed. If the execution of ROLLBACK statement on the replica fails,
 the connection to that replica is closed.
 
 All limitations that apply to `transaction_replay` also apply to`optimistic_trx`.
@@ -686,12 +686,12 @@ All limitations that apply to `transaction_replay` also apply to`optimistic_trx`
 Enable causal reads. This parameter is disabled by default and was introduced in\
 MaxScale 2.3.0.
 
-If a client connection modifies the database and `causal_reads` is enabled, any\
-subsequent reads performed on replica servers will be done in a manner that\
+If a client connection modifies the database and `causal_reads` is enabled, any
+subsequent reads performed on replica servers will be done in a manner that
 prevents replication lag from affecting the results.
 
-The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2302-readwritesplit.md#implementation-of-causal_reads) for more\
-information on what a sync consists of and why minimizing the number of them is\
+The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2302-readwritesplit.md#implementation-of-causal_reads) for more
+information on what a sync consists of and why minimizing the number of them is
 important.
 
 | Mode         | Level of Causality | Latency                                                  |
@@ -702,19 +702,19 @@ important.
 | fast\_global | Service            | None, no sync at all.                                    |
 | universal    | Cluster            | High, one sync per read plus a roundtrip to the primary. |
 
-The `fast` and `fast_global` modes should only be used when low latency is more\
-important than proper distribution of reads. These modes should only be used\
-when the workload is mostly read-only with only occasional writes. If used with\
-a mixed or a write-heavy workload, the traffic will end up being routed almost\
+The `fast` and `fast_global` modes should only be used when low latency is more
+important than proper distribution of reads. These modes should only be used
+when the workload is mostly read-only with only occasional writes. If used with
+a mixed or a write-heavy workload, the traffic will end up being routed almost
 exclusively to the primary server.
 
-**Note:** This feature requires MariaDB 10.2.16 or newer to function. In\
+**Note:** This feature requires MariaDB 10.2.16 or newer to function. In
 addition to this, the `session_track_system_variables` parameter must include`last_gtid` in its list of tracked system variables.
 
-**Note:** This feature also enables multi-statement execution of SQL in the\
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)\
+**Note:** This feature also enables multi-statement execution of SQL in the
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
-Connector/C. The _Implementation of causal\_reads_ section explains why this is\
+Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.
 
 The possible values for this parameter are:
@@ -722,86 +722,86 @@ The possible values for this parameter are:
 * `none` (default)
 * Read causality is disabled.
 * `local`
-* Writes are locally visible. Writes are guaranteed to be visible only to the\
-  connection that does it. Unrelated modifications done by other connections\
-  are not visible. This mode improves read scalability at the cost of latency\
-  and reduces the overall load placed on the primary server without breaking\
+* Writes are locally visible. Writes are guaranteed to be visible only to the
+  connection that does it. Unrelated modifications done by other connections
+  are not visible. This mode improves read scalability at the cost of latency
+  and reduces the overall load placed on the primary server without breaking
   causality guarantees.
 * `global`
-* Writes are globally visible. If one connection writes a value, all\
-  connections to the same service will see it. In general this mode is slower\
-  than the `local` mode due to the extra synchronization it has to do. This\
-  guarantees global happens-before ordering of reads when all transactions are\
-  inside a single GTID domain.This mode gives similar benefits as the `local`\
+* Writes are globally visible. If one connection writes a value, all
+  connections to the same service will see it. In general this mode is slower
+  than the `local` mode due to the extra synchronization it has to do. This
+  guarantees global happens-before ordering of reads when all transactions are
+  inside a single GTID domain.This mode gives similar benefits as the `local`
   mode in that it improves read scalability at the cost of latency.\
-  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads\
-  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this\
-  was fixed and all the GTID coordinates are passed alongside all requests\
+  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads
+  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this
+  was fixed and all the GTID coordinates are passed alongside all requests
   which makes multi-domain GTIDs safe to use. However, this does mean that the\
-  GTID coordinates will never be reset: if replication is reset and GTID\
-  coordinates go "backwards", readwritesplit will not consider these as being\
-  newer than the ones already stored. To reset the stored GTID coordinates in\
+  GTID coordinates will never be reset: if replication is reset and GTID
+  coordinates go "backwards", readwritesplit will not consider these as being
+  newer than the ones already stored. To reset the stored GTID coordinates in
   readwritesplit, MaxScale must be restarted.\
-  MaxScale 6.4.11 added the new `reset-gtid` module command to\
+  MaxScale 6.4.11 added the new `reset-gtid` module command to
   readwritesplit. This allows the global GTID state used by`causal_reads=global` to be reset without having to restart MaxScale.
 * `fast`
-* This mode is similar to the `local` mode where it will only affect the\
-  connection that does the write but where the `local` mode waits for a replica\
-  server to catch up, the `fast` mode will only use servers that are known to\
-  have replicated the write. This means that if no replica has replicated the\
-  write, the primary where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication\
-  state is only updated by the mariadbmon monitor whenever the servers are\
-  monitored. This means that a smaller `monitor_interval` provides faster\
+* This mode is similar to the `local` mode where it will only affect the
+  connection that does the write but where the `local` mode waits for a replica
+  server to catch up, the `fast` mode will only use servers that are known to
+  have replicated the write. This means that if no replica has replicated the
+  write, the primary where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication
+  state is only updated by the mariadbmon monitor whenever the servers are
+  monitored. This means that a smaller `monitor_interval` provides faster
   replication state updates and possibly better overall usage of servers.\
-  This mode is the inverse of the `local` mode in the sense that it improves\
-  read latency at the cost of read scalability while still retaining the\
-  causality guarantees for reads. This functionality can also be considered an\
+  This mode is the inverse of the `local` mode in the sense that it improves
+  read latency at the cost of read scalability while still retaining the
+  causality guarantees for reads. This functionality can also be considered an
   improved version of the functionality that the [CCRFilter](../mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-consistent-critical-read-filter.md) module provides.
 * `fast_global`
 * This mode is identical to the `fast` mode except that it uses the global\
-  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`\
-  is ignored in this mode. Currently the replication state is only updated by\
-  the mariadbmon monitor whenever the servers are monitored. This means that a\
-  smaller `monitor_interval` provides faster replication state updates and\
+  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`
+  is ignored in this mode. Currently the replication state is only updated by
+  the mariadbmon monitor whenever the servers are monitored. This means that a
+  smaller `monitor_interval` provides faster replication state updates and
   possibly better overall usage of servers.
 * `universal`
-* The universal mode guarantees that all SELECT statements always see the\
-  latest observable transaction state on a database cluster. The basis of this\
-  is the `@@gtid_current_pos` variable which is read from the current primary\
-  server before each read. This guarantees that if a transaction was visible\
-  at the time the read is received by readwritesplit, the transaction is\
+* The universal mode guarantees that all SELECT statements always see the
+  latest observable transaction state on a database cluster. The basis of this
+  is the `@@gtid_current_pos` variable which is read from the current primary
+  server before each read. This guarantees that if a transaction was visible
+  at the time the read is received by readwritesplit, the transaction is
   guaranteed to be complete on the replica server where the read is done.\
-  This mode is the most consistent of all the modes. It provides consistency\
-  regardless of where a write originated from but it comes at the cost of\
-  increased latency. For every read, a round trip to the current primary server\
-  is done. This means that the latency of any given SELECT statement increases\
-  by roughly twice the network latency between MaxScale and the database\
-  cluster. In addition, an extra SELECT statement is always executed on the\
+  This mode is the most consistent of all the modes. It provides consistency
+  regardless of where a write originated from but it comes at the cost of
+  increased latency. For every read, a round trip to the current primary server
+  is done. This means that the latency of any given SELECT statement increases
+  by roughly twice the network latency between MaxScale and the database
+  cluster. In addition, an extra SELECT statement is always executed on the
   primary which places some load on the server.
 
-Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean\
+Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean
 parameter. False values translated to `none` and true values translated to`local`. The use of boolean parameters is deprecated but still accepted in\
 MaxScale 2.5.0.
 
 **Implementation of `causal_reads`**
 
-This feature is based on the `MASTER_GTID_WAIT` function and the tracking of\
-server-side status variables. By tracking the latest GTID that each statement\
-generates, readwritesplit can then perform a synchronization operation with the\
+This feature is based on the `MASTER_GTID_WAIT` function and the tracking of
+server-side status variables. By tracking the latest GTID that each statement
+generates, readwritesplit can then perform a synchronization operation with the
 help of the `MASTER_GTID_WAIT` function.
 
-If the replica has not caught up to the primary within the configured time, as\
-specified by [causal\_reads\_timeout](mariadb-maxscale-2302-readwritesplit.md#causal_reads_timeout), it will\
-be retried on the primary. In MaxScale 2.3.0 an error was returned to the client\
+If the replica has not caught up to the primary within the configured time, as
+specified by [causal\_reads\_timeout](mariadb-maxscale-2302-readwritesplit.md#causal_reads_timeout), it will
+be retried on the primary. In MaxScale 2.3.0 an error was returned to the client
 when the replica timed out.
 
-The exception to this rule is the `fast` mode which does not do any\
-synchronization at all. This can be done as any reads that would go to\
+The exception to this rule is the `fast` mode which does not do any
+synchronization at all. This can be done as any reads that would go to
 out-of-date servers will be re-routed to the current primary.
 
 **Normal SQL**
 
-A practical example can be given by the following set of SQL commands executed\
+A practical example can be given by the following set of SQL commands executed
 with `autocommit=1`.
 
 ```
@@ -809,17 +809,17 @@ INSERT INTO test.t1 (id) VALUES (1);
 SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-As the statements are not executed inside a transaction, from the load balancer's\
-point of view, the latter statement can be routed to a replica server. The problem\
-with this is that if the value that was inserted on the primary has not yet\
-replicated to the server where the SELECT statement is being performed, it can\
+As the statements are not executed inside a transaction, from the load balancer's
+point of view, the latter statement can be routed to a replica server. The problem
+with this is that if the value that was inserted on the primary has not yet
+replicated to the server where the SELECT statement is being performed, it can
 appear as if the value we just inserted is not there.
 
-By prefixing these types of SELECT statements with a command that guarantees\
-consistent results for the reads, read scalability can be improved without\
+By prefixing these types of SELECT statements with a command that guarantees
+consistent results for the reads, read scalability can be improved without
 sacrificing consistency.
 
-The set of example SQL above will be translated by MaxScale into the following\
+The set of example SQL above will be translated by MaxScale into the following
 statements.
 
 ```
@@ -833,18 +833,18 @@ SET @maxscale_secret_variable=(
     END); SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-The `SET` command will synchronize the replica to a certain logical point in the\
-replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more\
-details). If the synchronization fails, the query will not run and it will be\
+The `SET` command will synchronize the replica to a certain logical point in the
+replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more
+details). If the synchronization fails, the query will not run and it will be
 retried on the server where the transaction was originally done.
 
 **Prepared Statements**
 
-Binary protocol prepared statements are handled in a different manner. Instead\
-of adding the synchronization SQL into the original SQL query, it is sent as a\
+Binary protocol prepared statements are handled in a different manner. Instead
+of adding the synchronization SQL into the original SQL query, it is sent as a
 separate packet before the prepared statement is executed.
 
-We'll use the same example SQL but use a binary protocol prepared statement for\
+We'll use the same example SQL but use a binary protocol prepared statement for
 the SELECT:
 
 ```
@@ -862,24 +862,24 @@ COM_QUERY:         IF (MASTER_GTID_WAIT('0-3000-8', 10) <> 0) THEN KILL (SELECT 
 COM_STMT_EXECUTE:  ? = 123
 ```
 
-Both the synchronization query and the execution of the prepared statement are\
-sent at the same time. This is done to remove the need to wait for the result of\
-the synchronization query before routing the execution of the prepared\
-statement. This keeps the performance of causal\_reads for prepared statements\
+Both the synchronization query and the execution of the prepared statement are
+sent at the same time. This is done to remove the need to wait for the result of
+the synchronization query before routing the execution of the prepared
+statement. This keeps the performance of causal\_reads for prepared statements
 the same as it is for normal SQL queries.
 
-As a result of this, each time the synchronization query times out, the\
-connection will be killed by the `KILL` statement and readwritesplit will retry\
-the query on the primary. This is done to prevent the execution of the prepared\
+As a result of this, each time the synchronization query times out, the
+connection will be killed by the `KILL` statement and readwritesplit will retry
+the query on the primary. This is done to prevent the execution of the prepared
 statement that follows the synchronization query from being processed by the\
 MariaDB server.
 
-It is recommend that the session command history is enabled whenever prepared\
-statements are used with `causal_reads`. This allows new connections to be\
+It is recommend that the session command history is enabled whenever prepared
+statements are used with `causal_reads`. This allows new connections to be
 created whenever a causal read times out.
 
-Starting with MaxScale 2.5.17, a failed causal read inside of a read-only\
-transaction started with `START TRANSACTION READ ONLY` will return the following\
+Starting with MaxScale 2.5.17, a failed causal read inside of a read-only
+transaction started with `START TRANSACTION READ ONLY` will return the following
 error:
 
 ```
@@ -888,25 +888,25 @@ SQLSTATE: 25006
 Message:  Causal read timed out while in a read-only transaction, cannot retry command.
 ```
 
-Older versions of MaxScale attempted to retry the command on the current primary\
+Older versions of MaxScale attempted to retry the command on the current primary
 server which would cause the connection to be closed and a warning to be logged.
 
 **Limitations of Causal Reads**
 
-* This feature does not work with Galera or any other non-standard\
-  replication mechanisms. As Galera does not update the `gtid_slave_pos`\
-  variable when events are replicated via the Galera library, the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)\
-  function used by MaxScale to synchronize reads will wait until the\
-  timeout. With Galera this is not a serious issue as it, by nature, is a\
+* This feature does not work with Galera or any other non-standard
+  replication mechanisms. As Galera does not update the `gtid_slave_pos`
+  variable when events are replicated via the Galera library, the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)
+  function used by MaxScale to synchronize reads will wait until the
+  timeout. With Galera this is not a serious issue as it, by nature, is a
   mostly-synchronous replication mechanism.
-* If the combination of the original SQL statement and the modifications\
-  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),\
+* If the combination of the original SQL statement and the modifications
+  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),
   the causal read will not be attempted and a non-causal read is done instead.\
-  This applies only to text protocol queries as the binary protocol queries use\
+  This applies only to text protocol queries as the binary protocol queries use
   a different synchronization mechanism.
-* SQL like `INSERT ... RETURNING` that commits a transaction and returns a\
+* SQL like `INSERT ... RETURNING` that commits a transaction and returns a
   resultset will only work with causal reads if the connector supports the\
-  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB\
+  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB
   connectors and whether they support the protocol feature.
 
 | Connector         | Supported | Version |
@@ -925,13 +925,13 @@ server which would cause the connection to be closed and a warning to be logged.
 * Dynamic: Yes
 * Default: 10s
 
-The timeout for the replica synchronization done by `causal_reads`. The\
+The timeout for the replica synchronization done by `causal_reads`. The
 default value is 10 seconds.
 
-The timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `lazy_connect`
@@ -941,16 +941,16 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Lazy connection creation causes connections to backend servers to be opened only\
-when they are needed. This reduces the load that is placed on the backend\
-servers when the client connections are short. This parameter is a boolean type\
+Lazy connection creation causes connections to backend servers to be opened only
+when they are needed. This reduces the load that is placed on the backend
+servers when the client connections are short. This parameter is a boolean type
 and is disabled by default.
 
-By default readwritesplit opens as many connections as it can when the session\
-is first opened. This makes the execution of the first query faster when all\
-available connections are already created. When `lazy_connect` is enabled, this\
-initial connection creation is skipped. If the client executes only read\
-queries, no connection to the primary is made. If only write queries are made,\
+By default readwritesplit opens as many connections as it can when the session
+is first opened. This makes the execution of the first query faster when all
+available connections are already created. When `lazy_connect` is enabled, this
+initial connection creation is skipped. If the client executes only read
+queries, no connection to the primary is made. If only write queries are made,
 only the primary connection is used.
 
 #### `reuse_prepared_statements`
@@ -960,22 +960,22 @@ only the primary connection is used.
 * Dynamic: Yes
 * Default: false
 
-Reuse identical prepared statements inside the same client connection. This is a\
-boolean parameter and is disabled by default. This feature only applies to\
+Reuse identical prepared statements inside the same client connection. This is a
+boolean parameter and is disabled by default. This feature only applies to
 binary protocol prepared statements.
 
-When this parameter is enabled and the connection prepares an identical prepared\
-statement multiple times, instead of preparing it on the server the existing\
-prepared statement handle is reused. This also means that whenever prepared\
+When this parameter is enabled and the connection prepares an identical prepared
+statement multiple times, instead of preparing it on the server the existing
+prepared statement handle is reused. This also means that whenever prepared
 statements are closed by the client, they will be left open by readwritesplit.
 
-Enabling this feature will increase memory usage of a session. The amount of\
-memory stored per prepared statement is proportional to the length of the\
+Enabling this feature will increase memory usage of a session. The amount of
+memory stored per prepared statement is proportional to the length of the
 prepared SQL statement and the number of parameters the statement has.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a readwritesplit service contains the\
+The `router_diagnostics` output for a readwritesplit service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -996,48 +996,48 @@ following fields.
 
 ### Server Ranks
 
-The general rule with server ranks is that primary servers will be used before\
-secondary servers. Readwritesplit is an exception to this rule. The following\
+The general rule with server ranks is that primary servers will be used before
+secondary servers. Readwritesplit is an exception to this rule. The following
 rules govern how readwritesplit behaves with servers that have different ranks.
 
-* Sessions will use the current primary server as long as possible. This means\
-  that sessions with a secondary primary will not use the primary primary as long\
+* Sessions will use the current primary server as long as possible. This means
+  that sessions with a secondary primary will not use the primary primary as long
   as the secondary primary is available.
-* All replica connections will use the same rank as the primary connection. Any\
+* All replica connections will use the same rank as the primary connection. Any
   stale connections with a different rank than the primary will be discarded.
-* If no primary connection is available and `master_reconnection` is enabled, a\
-  connection to the best primary is created. If the new primary has a different\
-  priority than existing connections have, the connections with a different rank\
+* If no primary connection is available and `master_reconnection` is enabled, a
+  connection to the best primary is created. If the new primary has a different
+  priority than existing connections have, the connections with a different rank
   will be discarded.
-* If open connections exist, these will be used for routing. This means that if\
-  the primary is lost but the session still has replica servers with the same rank,\
+* If open connections exist, these will be used for routing. This means that if
+  the primary is lost but the session still has replica servers with the same rank,
   they will remain in use.
 * If no open connections exist, the servers with the best rank will used.
 
 ### Routing hints
 
-The readwritesplit router supports routing hints. For a detailed guide on hint\
-syntax and functionality, please read [this](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-hint-syntax.md)\
+The readwritesplit router supports routing hints. For a detailed guide on hint
+syntax and functionality, please read [this](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-hint-syntax.md)
 document.
 
-**Note**: Routing hints will always have the highest priority when a routing\
-decision is made. This means that it is possible to cause inconsistencies in\
-the session state and the actual data in the database by adding routing hints\
-to DDL/DML statements which are then directed to replica servers. Only use routing\
+**Note**: Routing hints will always have the highest priority when a routing
+decision is made. This means that it is possible to cause inconsistencies in
+the session state and the actual data in the database by adding routing hints
+to DDL/DML statements which are then directed to replica servers. Only use routing
 hints when you are sure that they can cause no harm.
 
-An exception to this rule is `transaction_replay`: when it is enabled, all\
-routing hints inside transaction are ignored. This is done to prevent changes\
-done inside a re-playable transaction from affecting servers outside of the\
-transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed\
+An exception to this rule is `transaction_replay`: when it is enabled, all
+routing hints inside transaction are ignored. This is done to prevent changes
+done inside a re-playable transaction from affecting servers outside of the
+transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed
 routing hints to override the transaction logic.
 
 #### Known Limitations of Routing Hints
 
-* If a `SELECT` statement with a `maxscale route to slave` hint is received\
-  while autocommit is disabled, the query will be routed to a replica server. This\
-  causes some metadata locks to be acquired on the database in question which\
-  will block DDL statements on the server until either the connection is closed\
+* If a `SELECT` statement with a `maxscale route to slave` hint is received
+  while autocommit is disabled, the query will be routed to a replica server. This
+  causes some metadata locks to be acquired on the database in question which
+  will block DDL statements on the server until either the connection is closed
   or autocommit is enabled again.
 
 ### Module Commands
@@ -1046,11 +1046,11 @@ The readwritesplit router implements the following module commands.
 
 #### `reset-gtid`
 
-The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is\
-reverted to an earlier state and the GTIDs recorded in MaxScale are no longer\
+The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is
+reverted to an earlier state and the GTIDs recorded in MaxScale are no longer
 valid.
 
-The first and only argument to the command is the router name. For example, to\
+The first and only argument to the command is the router name. For example, to
 reset the GTID state of a readwritesplit named `My-RW-Router`, the following\
 MaxCtrl command should be used:
 
@@ -1064,12 +1064,12 @@ Examples of the readwritesplit router in use can be found in the [Tutorials](htt
 
 ### Readwritesplit routing decisions
 
-Here is a small explanation which shows what kinds of queries are routed to\
+Here is a small explanation which shows what kinds of queries are routed to
 which type of server.
 
 #### Routing to Primary
 
-Routing to primary is important for data consistency and because majority of\
+Routing to primary is important for data consistency and because majority of
 writes are written to binlog and thus become replicated to replicas.
 
 The following operations are routed to primary:
@@ -1090,34 +1090,34 @@ The following operations are routed to primary:
 * `@@last_insert_id`
 * `@@identity`
 
-In addition to these, if the **readwritesplit** service is configured with the`max_slave_replication_lag` parameter, and if all replicas suffer from too much\
-replication lag, then statements will be routed to the primary. (There might be\
-other similar configuration parameters in the future which limit the number of\
+In addition to these, if the **readwritesplit** service is configured with the`max_slave_replication_lag` parameter, and if all replicas suffer from too much
+replication lag, then statements will be routed to the primary. (There might be
+other similar configuration parameters in the future which limit the number of
 statements that will be routed to replicas.)
 
 **Transaction Isolation Level Tracking**
 
-Use of the SERIALIZABLE transaction isolation level with readwritesplit is not\
+Use of the SERIALIZABLE transaction isolation level with readwritesplit is not
 recommended as it somewhat goes against the goals of load balancing.
 
-If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB\
-server, readwritesplit will track the transaction isolation level and lock the\
-session to the primary when the isolation level is set to serializable. This\
-retains the correctness of the isolation level which can otherwise cause\
-problems. Once a session is locked to the primary, it will not be unlocked. To\
+If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB
+server, readwritesplit will track the transaction isolation level and lock the
+session to the primary when the isolation level is set to serializable. This
+retains the correctness of the isolation level which can otherwise cause
+problems. Once a session is locked to the primary, it will not be unlocked. To
 reinstate the normal routing behavior, a new connection must be created.
 
-For example, if transaction isolation level tracking cannot be done and an\
-autocommit SELECT is routed to a replica, it no longer behaves in a serializable\
+For example, if transaction isolation level tracking cannot be done and an
+autocommit SELECT is routed to a replica, it no longer behaves in a serializable
 manner. This can also have an effect on the replication in the replica server.
 
 #### Routing to Replicas
 
-The ability to route some statements to replicas is important because it also\
-decreases the load targeted to _primary_. Moreover, it is possible to have multiple\
+The ability to route some statements to replicas is important because it also
+decreases the load targeted to _primary_. Moreover, it is possible to have multiple
 replicas to share the load in contrast to single primary.
 
-Queries which can be routed to replicas must be auto committed and belong to one\
+Queries which can be routed to replicas must be auto committed and belong to one
 of the following group:
 
 * Read-only statements (i.e. `SELECT`) that only use read-only built-in functions
@@ -1128,10 +1128,10 @@ The list of supported built-in functions can be found [here](https://github.com/
 
 #### Routing to every session backend
 
-A third class of statements includes those which modify session data, such as\
-session system variables, user-defined variables, the default database, etc. We\
-call them session commands, and they must be replicated as they affect the\
-future results of read and write operations. They must be executed on all\
+A third class of statements includes those which modify session data, such as
+session system variables, user-defined variables, the default database, etc. We
+call them session commands, and they must be replicated as they affect the
+future results of read and write operations. They must be executed on all
 servers that could execute statements on behalf of this client.
 
 Session commands include for example:
@@ -1141,26 +1141,26 @@ Session commands include for example:
 * Binary protocol prepared statements
 * Other miscellaneous commands (COM\_QUIT, COM\_PING etc.)
 
-**NOTE**: if variable assignment is embedded in a write statement it is routed\
-to _primary_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be\
+**NOTE**: if variable assignment is embedded in a write statement it is routed
+to _primary_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be
 routed to _primary_ only.
 
-The router stores all of the executed session commands so that in case of a\
-replica failure, a replacement replica can be chosen and the session command history\
-can be repeated on that new replica. This means that the router stores each\
-executed session command for the duration of the session. Applications that use\
-long-running sessions might cause MariaDB MaxScale to consume a growing amount\
-of memory unless the sessions are closed. This can be solved by adjusting the\
+The router stores all of the executed session commands so that in case of a
+replica failure, a replacement replica can be chosen and the session command history
+can be repeated on that new replica. This means that the router stores each
+executed session command for the duration of the session. Applications that use
+long-running sessions might cause MariaDB MaxScale to consume a growing amount
+of memory unless the sessions are closed. This can be solved by adjusting the
 value of `max_sescmd_history`.
 
 #### Routing to previous target
 
-In the following cases, a query is routed to the same server where the previous\
-query was executed. If no previous target is found, the query is routed to the\
+In the following cases, a query is routed to the same server where the previous
+query was executed. If no previous target is found, the query is routed to the
 current primary.
 
-* If a query uses the `FOUND_ROWS()` function, it will be routed to the server\
-  where the last query was executed. This is done with the assumption that a\
+* If a query uses the `FOUND_ROWS()` function, it will be routed to the server
+  where the last query was executed. This is done with the assumption that a
   query with `SQL_CALC_FOUND_ROWS` was previously executed.
 * COM\_STMT\_FETCH\_ROWS will always be routed to the same server where the\
   COM\_STMT\_EXECUTE was routed.
@@ -1175,59 +1175,59 @@ Read queries are routed to the primary server in the following situations:
 
 #### Prepares Statement Limitations
 
-If a prepared statement targets a temporary table on the primary, the replica\
-servers will fail to execute it. This will cause all replica connections to be\
+If a prepared statement targets a temporary table on the primary, the replica
+servers will fail to execute it. This will cause all replica connections to be
 closed (MXS-1816).
 
 #### Transaction Replay Limitations
 
-If the results from the replacement server are not identical when the\
-transaction is replayed, the client connection is closed. This means that any\
-transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot\
+If the results from the replacement server are not identical when the
+transaction is replayed, the client connection is closed. This means that any
+transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot
 be replayed successfully but it will still be attempted.
 
-If a transaction reads data before updating it, the rows should be locked by\
-using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when\
+If a transaction reads data before updating it, the rows should be locked by
+using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when
 multiple transactions are being replayed that modify the same set of rows.
 
-If the connection to the server where the transaction is being executed is\
-lost when the final `COMMIT` is being executed, it is impossible to know\
-whether the transaction was successfully committed. This means that there\
-is a possibility for duplicate transaction execution which can result in\
-data duplication in certain cases. Data duplication can happen if the\
+If the connection to the server where the transaction is being executed is
+lost when the final `COMMIT` is being executed, it is impossible to know
+whether the transaction was successfully committed. This means that there
+is a possibility for duplicate transaction execution which can result in
+data duplication in certain cases. Data duplication can happen if the
 transaction consists of the following statement types:
 
 * INSERT of rows into a table that does not have an auto-increment primary key
 * A "blind update" of one or more rows e.g. `UPDATE t SET c = c + 1 WHERE id = 123`
 * A "blind delete" e.g. `DELETE FROM t LIMIT 100`
 
-This is not an exhaustive list and any operations that do not check the row\
+This is not an exhaustive list and any operations that do not check the row
 contents before performing the operation on them might face this problem.
 
-In all cases the problem of duplicate transaction execution can be avoided by\
-including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that\
-in the case that the transaction fails when it is being committed, the row is\
+In all cases the problem of duplicate transaction execution can be avoided by
+including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that
+in the case that the transaction fails when it is being committed, the row is
 only modified if it matches the expected contents.
 
-Similarly, a connection loss during `COMMIT` can also result in transaction\
-replay failure. This happens due to the same reason as duplicate transaction\
-execution but the retried transaction will not be committed. This can be\
-considered a success case as the transaction replay detected that the results of\
-the two transactions are different. In these cases readwritesplit will abort the\
+Similarly, a connection loss during `COMMIT` can also result in transaction
+replay failure. This happens due to the same reason as duplicate transaction
+execution but the retried transaction will not be committed. This can be
+considered a success case as the transaction replay detected that the results of
+the two transactions are different. In these cases readwritesplit will abort the
 transaction and close the client connection.
 
-Statements that result in an implicit commit do not reset the transaction when\
-transaction\_replay is enabled. This means that if the transaction is replayed,\
-the transaction will be committed twice due to the implicit commit being\
-present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the\
+Statements that result in an implicit commit do not reset the transaction when
+transaction\_replay is enabled. This means that if the transaction is replayed,
+the transaction will be committed twice due to the implicit commit being
+present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the
 transaction to be correctly reset.
 
-Any changes to the session state (e.g. autocommit state, SQL mode) done inside a\
-transaction will remain in effect even if the connection to the server where the\
-transaction is being executed fails. When readwritesplit creates a new\
-connection to a server to replay the transaction, it will first restore the\
-session state by executing all session commands that were executed. This means\
-that if the session state is changed mid-transaction in a way that affects the\
+Any changes to the session state (e.g. autocommit state, SQL mode) done inside a
+transaction will remain in effect even if the connection to the server where the
+transaction is being executed fails. When readwritesplit creates a new
+connection to a server to replay the transaction, it will first restore the
+session state by executing all session commands that were executed. This means
+that if the session state is changed mid-transaction in a way that affects the
 results, transaction replay will fail.
 
 The following partial transaction demonstrates the problem by using [SQL\_MODE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) inside a transaction.
@@ -1240,7 +1240,7 @@ SET SQL_MODE='ANSI_QUOTES'; -- A session command
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-If this transaction has to be replayed the actual SQL that gets executed is the\
+If this transaction has to be replayed the actual SQL that gets executed is the
 following.
 
 ```
@@ -1251,55 +1251,55 @@ SELECT "hello world";       -- Returns an error
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-First the session state is restored by executing all commands that changed the\
+First the session state is restored by executing all commands that changed the
 state after which the actual transaction is replayed. Due to the fact that the\
-SQL\_MODE was changed mid-transaction, one of the queries will now return an\
+SQL\_MODE was changed mid-transaction, one of the queries will now return an
 error instead of the result we expected leading to a transaction replay failure.
 
-In a service-to-service configuration (i.e. a service using another service in\
-its `targets` list ), if the topmost service starts a transaction, all\
-lower-level readwritesplit services will also behave as if a transaction is\
-open. If a connection to a backend database fails during this, it can result in\
-unnecessary transaction replays which in turn can end up with checksum\
-conflicts. The recommended approach is to not use any commands inside a\
+In a service-to-service configuration (i.e. a service using another service in
+its `targets` list ), if the topmost service starts a transaction, all
+lower-level readwritesplit services will also behave as if a transaction is
+open. If a connection to a backend database fails during this, it can result in
+unnecessary transaction replays which in turn can end up with checksum
+conflicts. The recommended approach is to not use any commands inside a
 transaction that would be routed to more than one node.
 
-If the connection to the server where a transaction is being executed is lost\
-while a `ROLLBACK` is being executed, readwritesplit will still attempt to\
-replay the transaction in the hopes that the real response can be delivered to\
-the client. However, this does mean that it is possible that a rolled back\
-transaction which gets replayed ends up with a conflict and is reported as a\
-replay failure when in reality a rolled back transaction could be safely\
+If the connection to the server where a transaction is being executed is lost
+while a `ROLLBACK` is being executed, readwritesplit will still attempt to
+replay the transaction in the hopes that the real response can be delivered to
+the client. However, this does mean that it is possible that a rolled back
+transaction which gets replayed ends up with a conflict and is reported as a
+replay failure when in reality a rolled back transaction could be safely
 ignored.
 
 #### Legacy Configuration
 
-In older versions of MaxScale, routers were configured via the _router\_options_\
+In older versions of MaxScale, routers were configured via the _router\_options_
 parameter. This functionality was deprecated in 2.2 and was removed in 2.3.
 
 #### JDBC Batched Statements
 
-Readwritesplit does not support pipelining of JDBC batched statements. This is\
-caused by the fact that readwritesplit executes the statements one at a time to\
+Readwritesplit does not support pipelining of JDBC batched statements. This is
+caused by the fact that readwritesplit executes the statements one at a time to
 track the state of the response.
 
 **Limitations in multi-statement handling**
 
-When a multi-statement query is executed through the readwritesplit router, it\
-will always be routed to the primary. See [strict\_multi\_stmt](mariadb-maxscale-2302-readwritesplit.md) for more\
+When a multi-statement query is executed through the readwritesplit router, it
+will always be routed to the primary. See [strict\_multi\_stmt](mariadb-maxscale-2302-readwritesplit.md) for more
 details.
 
-If the multi-statement query creates a temporary table, it will not be\
-detected and reads to this table can be routed to replica servers. To\
-prevent this, always execute the temporary table creation as an individual\
+If the multi-statement query creates a temporary table, it will not be
+detected and reads to this table can be routed to replica servers. To
+prevent this, always execute the temporary table creation as an individual
 statement.
 
 **Limitations in client session handling**
 
-Some of the queries that a client sends are routed to all backends instead of\
-just to one. These queries include `USE <db name>` and `SET autocommit=0`, among\
-many others. Readwritesplit sends a copy of these queries to each backend server\
-and forwards the primary's reply to the client. Below is a list of MySQL commands\
+Some of the queries that a client sends are routed to all backends instead of
+just to one. These queries include `USE <db name>` and `SET autocommit=0`, among
+many others. Readwritesplit sends a copy of these queries to each backend server
+and forwards the primary's reply to the client. Below is a list of MySQL commands
 which are classified as session commands.
 
 ```
@@ -1321,19 +1321,19 @@ SELECT ..INTO variable|OUTFILE|DUMPFILE
 SET autocommit=1|0
 ```
 
-Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were\
+Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were
 not supported and caused the session to be closed.
 
-There is a possibility for misbehavior. If `USE mytable` is executed in one of\
-the replicas and fails, it may be due to replication lag rather than the database\
-not existing. Thus, the same command may produce different result in different\
-backend servers. The replicas which fail to execute a session command will be\
-dropped from the active list of replicas for this session to guarantee a\
-consistent session state across all the servers used by the session. In\
-addition, the server will not be used again for routing for the duration of the\
+There is a possibility for misbehavior. If `USE mytable` is executed in one of
+the replicas and fails, it may be due to replication lag rather than the database
+not existing. Thus, the same command may produce different result in different
+backend servers. The replicas which fail to execute a session command will be
+dropped from the active list of replicas for this session to guarantee a
+consistent session state across all the servers used by the session. In
+addition, the server will not be used again for routing for the duration of the
 session.
 
-The above-mentioned behavior for user variables can be partially controlled with\
+The above-mentioned behavior for user variables can be partially controlled with
 the configuration parameter `use_sql_variables_in`:
 
 ```
@@ -1342,10 +1342,10 @@ use_sql_variables_in=[master|all] (default: all)
 
 **WARNING**
 
-If a SELECT query modifies a user variable when the `use_sql_variables_in`\
-parameter is set to `all`, it will not be routed and the client will receive an\
-error. A log message is written into the log further explaining the reason for\
-the error. Here is an example use of a SELECT query which modifies a user\
+If a SELECT query modifies a user variable when the `use_sql_variables_in`
+parameter is set to `all`, it will not be routed and the client will receive an
+error. A log message is written into the log further explaining the reason for
+the error. Here is an example use of a SELECT query which modifies a user
 variable and how MariaDB MaxScale responds to it.
 
 ```
@@ -1356,7 +1356,7 @@ MySQL [(none)]> SELECT @id := @id + 1 FROM test.t1;
 ERROR 1064 (42000): Routing query to backend failed. See the error log for further details.
 ```
 
-Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user\
+Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user
 variables to the primary.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-schemarouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-schemarouter.md
@@ -1,15 +1,15 @@
 # SchemaRouter
 
-The SchemaRouter provides an easy and manageable sharding solution by\
-building a single logical database server from multiple separate ones. Each\
-database is shown to the client and queries targeting unique databases are\
-routed to their respective servers. In addition to providing simple\
-database-based sharding, the schemarouter also enables cross-node\
-session variable usage by routing all queries that modify the session to all\
+The SchemaRouter provides an easy and manageable sharding solution by
+building a single logical database server from multiple separate ones. Each
+database is shown to the client and queries targeting unique databases are
+routed to their respective servers. In addition to providing simple
+database-based sharding, the schemarouter also enables cross-node
+session variable usage by routing all queries that modify the session to all
 nodes.
 
-By default the SchemaRouter assumes that each database and table is only located\
-on one server. If it finds the same database or table on multiple servers, it\
+By default the SchemaRouter assumes that each database and table is only located
+on one server. If it finds the same database or table on multiple servers, it
 will close the session with the following error:
 
 ```
@@ -18,14 +18,14 @@ ERROR 5000 (DUPDB): Error: duplicate tables found on two different shards.
 
 The exception to this rule are the system tables `mysql`, `information_schema`,`performance_schema`, `sys` that are never treated as duplicates.
 
-If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2302-schemarouter.md#ignore_tables_regex) parameter to controls which\
+If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2302-schemarouter.md#ignore_tables_regex) parameter to controls which
 duplicate tables are allowed. To disable the duplicate database detection, use`ignore_tables_regex=.*`.
 
-Schemarouter compares table and database names case-insensitively. This means\
+Schemarouter compares table and database names case-insensitively. This means
 that the tables `test.t1` and `test.T1` are assumed to refer to the same table.
 
-The main limitation of SchemaRouter is that aside from session variable writes\
-and some specific queries, a query can only target one server. This means that\
+The main limitation of SchemaRouter is that aside from session variable writes
+and some specific queries, a query can only target one server. This means that
 queries which depend on results from multiple servers give incorrect results.\
 See [Limitations](mariadb-maxscale-2302-schemarouter.md#limitations) for more information.
 
@@ -33,51 +33,51 @@ From 2.3.0 onwards, SchemaRouter is capable of limited table family sharding.
 
 ### Changes in Version 6
 
-* The `auth_all_servers` parameter is no longer automatically enabled by the\
-  schemarouter. To retain the old behavior that was present in 2.5, explicitly\
+* The `auth_all_servers` parameter is no longer automatically enabled by the
+  schemarouter. To retain the old behavior that was present in 2.5, explicitly
   define `auth_all_servers=true` for all schemarouter services.
 
 ### Routing Logic
 
-* If a command modifies the session state by modifying any session or user\
-  variables, the query is routed to all nodes. These statements include `SET`\
-  statements as well as any other statements that modify the behavior of the\
+* If a command modifies the session state by modifying any session or user
+  variables, the query is routed to all nodes. These statements include `SET`
+  statements as well as any other statements that modify the behavior of the
   client.
-* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers\
-  that contain the database. This same logic applies when a client connects with\
-  a default database: the default database is set only on servers that actually\
+* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers
+  that contain the database. This same logic applies when a client connects with
+  a default database: the default database is set only on servers that actually
   contain it.
-* If a query targets one or more tables that the schemarouter has discovered\
-  during the database mapping phase, the query is only routed if a server is\
-  found that contains all of the tables that the query uses. If no such server\
-  is found, the query is routed to the server that was previously used or to the\
-  first available backend if none have been used. If a query uses a table but\
-  doesn't define the database it is in, it is assumed to be located on the\
+* If a query targets one or more tables that the schemarouter has discovered
+  during the database mapping phase, the query is only routed if a server is
+  found that contains all of the tables that the query uses. If no such server
+  is found, the query is routed to the server that was previously used or to the
+  first available backend if none have been used. If a query uses a table but
+  doesn't define the database it is in, it is assumed to be located on the
   default database of the connection.
-* If a query targets a table or a database that is present on all nodes\
-  (e.g. `information_schema`) and the connection is using a default database,\
-  the query is routed based on the default database. This makes it possible to\
-  control where queries that do match a specific node are routed. If the\
-  connection is not using a default database, the query is routed based solely\
+* If a query targets a table or a database that is present on all nodes
+  (e.g. `information_schema`) and the connection is using a default database,
+  the query is routed based on the default database. This makes it possible to
+  control where queries that do match a specific node are routed. If the
+  connection is not using a default database, the query is routed based solely
   on the tables it contains.
-* If a query uses a table that is unknown to the schemarouter or executes a\
-  command that doesn't target a table, the query is routed to a server contains\
-  the current active default database. If the connection does not have a default\
-  database, the query is routed to the backend that was last used or to the\
-  first available backend if none have been used. If the query contains a\
+* If a query uses a table that is unknown to the schemarouter or executes a
+  command that doesn't target a table, the query is routed to a server contains
+  the current active default database. If the connection does not have a default
+  database, the query is routed to the backend that was last used or to the
+  first available backend if none have been used. If the query contains a
   routing hint that directs it to a server, the query is routed there.
 
-This means that all administrative commands, replication related command as\
-well as certain transaction control statements (XA transaction) are routed to\
-the first available server in certain cases. To avoid problems, use routing\
+This means that all administrative commands, replication related command as
+well as certain transaction control statements (XA transaction) are routed to
+the first available server in certain cases. To avoid problems, use routing
 hints to direct where these statements should go.
 
-* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`\
-  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the\
-  queries to the first available backend. This means that cross-shard\
-  transactions are technically possible but, without external synchronization,\
+* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`
+  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the
+  queries to the first available backend. This means that cross-shard
+  transactions are technically possible but, without external synchronization,
   the transactions are not guaranteed to be globally consistent.
-* `LOAD DATA LOCAL INFILE` commands are routed to the first available server\
+* `LOAD DATA LOCAL INFILE` commands are routed to the first available server
   that contains the tables listed in the query.
 
 #### Custom SQL Commands
@@ -94,24 +94,24 @@ db1.t2   |MyServer1    |
 db2.t1   |MyServer2    |
 ```
 
-The schemarouter will also intercept the `SHOW DATABASES` command and generate\
-it based on its internal data. This means that newly created databases will not\
-show up immediately and will only be visible when the cached data has been\
+The schemarouter will also intercept the `SHOW DATABASES` command and generate
+it based on its internal data. This means that newly created databases will not
+show up immediately and will only be visible when the cached data has been
 updated.
 
 #### Database Mapping
 
-The schemarouter maps each of the servers to know where each database and table\
-is located. As each user has access to a different set of tables and databases,\
-the result is unique to the username and the set of servers that the service\
-uses. These results are cached by the schemarouter. The lifetime of the cached\
+The schemarouter maps each of the servers to know where each database and table
+is located. As each user has access to a different set of tables and databases,
+the result is unique to the username and the set of servers that the service
+uses. These results are cached by the schemarouter. The lifetime of the cached
 result is controlled by the `refresh_interval` parameter.
 
-When a server needs to be mapped, the schemarouter will route a query to each of\
-the servers using the client's credentials. While this query is being executed,\
-all other sessions that would otherwise share the cached result will wait for\
-the update to complete. This waiting functionality was added in MaxScale 2.4.19,\
-older versions did not wait for existing updates to finish and would perform\
+When a server needs to be mapped, the schemarouter will route a query to each of
+the servers using the client's credentials. While this query is being executed,
+all other sessions that would otherwise share the cached result will wait for
+the update to complete. This waiting functionality was added in MaxScale 2.4.19,
+older versions did not wait for existing updates to finish and would perform
 parallel database mapping queries.
 
 ### Configuration
@@ -127,24 +127,24 @@ user=myuser
 password=mypwd
 ```
 
-The module generates the list of databases based on the servers parameter\
-using the connecting client's credentials. The user and password parameters\
-define the credentials that are used to fetch the authentication data from\
-the database servers. The credentials used only require the same grants as\
+The module generates the list of databases based on the servers parameter
+using the connecting client's credentials. The user and password parameters
+define the credentials that are used to fetch the authentication data from
+the database servers. The credentials used only require the same grants as
 mentioned in the configuration documentation.
 
-The list of databases is built by sending a SHOW DATABASES query to all the\
-servers. This requires the user to have at least USAGE and SELECT grants on\
+The list of databases is built by sending a SHOW DATABASES query to all the
+servers. This requires the user to have at least USAGE and SELECT grants on
 the databases that need be sharded.
 
-If you are connecting directly to a database or have different users on some\
-of the servers, you need to get the authentication data from all the\
-servers. You can control this with the `auth_all_servers` parameter. With\
-this parameter, MariaDB MaxScale forms a union of all the users and their\
-grants from all the servers. By default, the schemarouter will fetch the\
+If you are connecting directly to a database or have different users on some
+of the servers, you need to get the authentication data from all the
+servers. You can control this with the `auth_all_servers` parameter. With
+this parameter, MariaDB MaxScale forms a union of all the users and their
+grants from all the servers. By default, the schemarouter will fetch the
 authentication data from all servers.
 
-For example, if two servers have the database `shard` and the following\
+For example, if two servers have the database `shard` and the following
 rights are granted only on one server, all queries targeting the database`shard` would be routed to the server where the grants were given.
 
 ```
@@ -155,9 +155,9 @@ CREATE USER 'john'@'%' IDENTIFIED BY 'password';
 GRANT SELECT,USAGE ON shard.* TO 'john'@'%';
 ```
 
-This would in effect allow the user 'john' to only see the database 'shard'\
+This would in effect allow the user 'john' to only see the database 'shard'
 on this server. Take notice that these grants are matched against MariaDB\
-MaxScale's hostname instead of the client's hostname. Only user\
+MaxScale's hostname instead of the client's hostname. Only user
 authentication uses the client's hostname and all other grants use MariaDB\
 MaxScale's hostname.
 
@@ -170,7 +170,7 @@ MaxScale's hostname.
 * Dynamic: Yes
 * Default: `""`
 
-List of full table names (e.g. db1.t1) to ignore when checking for duplicate\
+List of full table names (e.g. db1.t1) to ignore when checking for duplicate
 tables. By default no tables are ignored.
 
 This parameter was once called `ignore_databases`.
@@ -182,11 +182,11 @@ This parameter was once called `ignore_databases`.
 * Dynamic: No
 * Default: `""`
 
-A [PCRE2 regular expression](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#regular-expressions)\
+A [PCRE2 regular expression](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#regular-expressions)
 that is matched against database names when checking for duplicate databases.\
 By default no tables are ignored.
 
-The following configuration ignores duplicate tables in the databases `db1` and `db2`,\
+The following configuration ignores duplicate tables in the databases `db1` and `db2`,
 and all tables starting with "t" in `db3`.
 
 ```
@@ -203,12 +203,12 @@ This parameter was once called `ignore_databases_regex`.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#max_sescmd_history)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#max_sescmd_history)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#disable_sescmd_history)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#disable_sescmd_history)
 in MaxScale 6.0.
 
 #### `refresh_databases`
@@ -218,11 +218,11 @@ in MaxScale 6.0.
 * Dynamic: No
 * Default: `false`
 
-Enable database map refreshing mid-session. These are triggered by a failure to\
+Enable database map refreshing mid-session. These are triggered by a failure to
 change the database i.e. `USE ...` queries. This feature is disabled by default.
 
-Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0\
-release of MaxScale this parameter now works again but it is disabled by default\
+Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0
+release of MaxScale this parameter now works again but it is disabled by default
 to retain the same behavior as in older releases.
 
 #### `refresh_interval`
@@ -232,26 +232,26 @@ to retain the same behavior as in older releases.
 * Dynamic: Yes
 * Default: `300s`
 
-The minimum interval between database map refreshes in seconds. The default\
+The minimum interval between database map refreshes in seconds. The default
 value is 300 seconds.
 
-The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 ### Table Family Sharding
 
 This functionality was introduced in 2.3.0.
 
-If the same database exists on multiple servers, but the database contains different\
-tables in each server, SchemaRouter is capable of routing queries to the right server,\
+If the same database exists on multiple servers, but the database contains different
+tables in each server, SchemaRouter is capable of routing queries to the right server,
 depending on which table is being addressed.
 
-As an example, suppose the database `db` exists on servers _server1_ and _server2_, but\
-that the database on _server1_ contains the table `tbl1` and on _server2_ contains the\
-table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table\
+As an example, suppose the database `db` exists on servers _server1_ and _server2_, but
+that the database on _server1_ contains the table `tbl1` and on _server2_ contains the
+table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table
 names must be qualified with the database names for table-level sharding to work.\
 Specifically, the query series below is not supported.
 
@@ -262,7 +262,7 @@ SELECT * FROM tbl1; // May be routed to an incorrect backend if using table shar
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a schemarouter service contains the\
+The `router_diagnostics` output for a schemarouter service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -277,46 +277,46 @@ following fields.
 
 ### Limitations
 
-* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the\
-  first explicit database in the query, the current database in use or to the first\
+* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the
+  first explicit database in the query, the current database in use or to the first
   available database, depending on which succeeds.
-* Without a default database, queries that do not use fully qualified table\
-  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will\
-  be routed to the first available server. This includes queries such as explicit\
-  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`\
-  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`\
-  statements that do not directly refer to a table. `CREATE` commands should be\
-  done directly on the node or the router should be equipped with the hint filter\
-  and a routing hint should be used. Queries that modify the session state\
-  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the\
-  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,\
-  otherwise routing hints are required to correctly route the transaction control\
-  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the\
-  routing of transaction control commands to route them to all servers used by the\
+* Without a default database, queries that do not use fully qualified table
+  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will
+  be routed to the first available server. This includes queries such as explicit
+  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`
+  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`
+  statements that do not directly refer to a table. `CREATE` commands should be
+  done directly on the node or the router should be equipped with the hint filter
+  and a routing hint should be used. Queries that modify the session state
+  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the
+  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,
+  otherwise routing hints are required to correctly route the transaction control
+  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the
+  routing of transaction control commands to route them to all servers used by the
   schemarouter.
-* SELECT queries that modify session variables are not supported because uniform results\
-  can not be guaranteed. If such a query is executed, the behavior of the router is\
+* SELECT queries that modify session variables are not supported because uniform results
+  can not be guaranteed. If such a query is executed, the behavior of the router is
   undefined. To work around this limitation, the query must be executed in separate parts.
-* If a query targets a database the SchemaRouter has not mapped to a server, the\
-  query will be routed to the first available server. This possibly returns an\
+* If a query targets a database the SchemaRouter has not mapped to a server, the
+  query will be routed to the first available server. This possibly returns an
   error about database rights instead of a missing database.
-* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the\
+* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the
   correct backend if the statement is known and only requires one backend server. EXECUTE\
-  IMMEDIATE is not supported and is routed to the first available backend and may give\
+  IMMEDIATE is not supported and is routed to the first available backend and may give
   wrong results. Similarly, preparing a statement from a variable (e.g. `PREPARE stmt FROM @a`) is not supported and may be routed wrong.
-* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only\
-  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are\
+* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only
+  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are
   ignored. Starting with MaxScale 22.08, the database names will always be in lowercase.
-* `SHOW TABLES` is routed to the server with the current database. If using\
-  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table\
+* `SHOW TABLES` is routed to the server with the current database. If using
+  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table
   sharding. Use `SHOW SHARDS` to get results from the router itself. Starting with\
   MaxScale 22.08, the database names will always be in lowercase.
-* `USE db1` is routed to the server with `db1`. If the database is divided to multiple\
+* `USE db1` is routed to the server with `db1`. If the database is divided to multiple
   servers, only one server will get the command.
 
 ### Examples
 
-[Here](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-simple-sharding-with-two-servers.md) is a small tutorial on how\
+[Here](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-simple-sharding-with-two-servers.md) is a small tutorial on how
 to set up a sharded database.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-smartrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-smartrouter.md
@@ -2,20 +2,20 @@
 
 ### Overview
 
-SmartRouter is the query router of the SmartQuery framework. Based on the type\
-of the query, each query is routed to the server or cluster that can best\
+SmartRouter is the query router of the SmartQuery framework. Based on the type
+of the query, each query is routed to the server or cluster that can best
 handle it.
 
 For workloads where both transactional and analytical queries are needed,\
-SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into\
-a single entry point in MaxScale. This allows a MaxScale client to freely mix\
-transactional and analytical queries using the same connection. This is known\
+SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into
+a single entry point in MaxScale. This allows a MaxScale client to freely mix
+transactional and analytical queries using the same connection. This is known
 as Hybrid Transactional and Analytical Processing, HTAP.
 
 ### Configuration
 
-SmartRouter is configured as a service that either routes to other MaxScale\
-routers or plain servers. Although one can configure SmartRouter to use a plain\
+SmartRouter is configured as a service that either routes to other MaxScale
+routers or plain servers. Although one can configure SmartRouter to use a plain
 server directly, we refer to the configured "servers" as clusters.
 
 For details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md).
@@ -26,10 +26,10 @@ For details about the standard service parameters, refer to the [Configuration G
 * Mandatory: Yes
 * Dynamic: No
 
-One of the clusters must be designated as the **`master`**. All writes go to the\
+One of the clusters must be designated as the **`master`**. All writes go to the
 primary cluster, which for all practical purposes should be a primary-replica\
-ReadWriteSplit. This document does not go into details about setting up\
-primary-replica clusters, but suffice to say, that when setting up the ColumnStore\
+ReadWriteSplit. This document does not go into details about setting up
+primary-replica clusters, but suffice to say, that when setting up the ColumnStore
 servers they should be configured to be replicas of a MariaDB server running an\
 InnoDB engine.\
 The ReadWriteSplit [documentation](mariadb-maxscale-2302-readwritesplit.md) has more on primary-replica setup.
@@ -85,8 +85,8 @@ service = SmartQuery
 port = <port>
 ```
 
-Note that the SmartQuery listener listens on a port, while the Row and Column\
-service listeners listen on Unix domain sockets. The reason is that there is a\
+Note that the SmartQuery listener listens on a port, while the Row and Column
+service listeners listen on Unix domain sockets. The reason is that there is a
 significant performance benefit when SmartRouter accesses the services over a\
 Unix domain socket compared to accessing them over a TCP/IP socket.
 
@@ -94,31 +94,31 @@ A complete configuration example can be found at the end of this document.
 
 ### Cluster selection - how queries are routed
 
-SmartRouter keeps track of the performance, or the execution time, of queries to\
+SmartRouter keeps track of the performance, or the execution time, of queries to
 the clusters. Measurements are stored with the canonical of a query as the key.\
-The canonical of a query is the sql with all user-defined constants replaced with\
-question marks. When SmartRouter sees a read-query whose canonical has not been\
-seen before, it will send the query to all clusters. The first response from a\
-cluster will designate that cluster as the best one for that canonical. Also,\
-when the first response is received, the other queries are cancelled. The\
-response is sent to the client once all clusters have responded to the query\
+The canonical of a query is the sql with all user-defined constants replaced with
+question marks. When SmartRouter sees a read-query whose canonical has not been
+seen before, it will send the query to all clusters. The first response from a
+cluster will designate that cluster as the best one for that canonical. Also,
+when the first response is received, the other queries are cancelled. The
+response is sent to the client once all clusters have responded to the query
 or the cancel.
 
-There is obviously overhead when a new canonical is seen. This means that\
-queries after a MaxScale start will be slightly slower than normal. The\
-execution time of a query depends on the database engine, and on the contents\
-of the tables being queried. As a result, MaxScale will periodically re-measure\
+There is obviously overhead when a new canonical is seen. This means that
+queries after a MaxScale start will be slightly slower than normal. The
+execution time of a query depends on the database engine, and on the contents
+of the tables being queried. As a result, MaxScale will periodically re-measure
 queries.
 
-The performance behavior of queries under dynamic conditions, and their effect\
-on different storage engines is being studied at MariaDB. As we learn more, we\
+The performance behavior of queries under dynamic conditions, and their effect
+on different storage engines is being studied at MariaDB. As we learn more, we
 will be able to better categorize queries and move that knowledge into\
 SmartRouter.
 
 ### Limitations
 
 * `LOAD DATA LOCAL INFILE` is not supported.
-* The performance data is not persisted. The measurements will be performed\
+* The performance data is not persisted. The measurements will be performed
   anew after each startup.
 
 ### Complete configuration example

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-automatic-failover-with-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-automatic-failover-with-mariadb-monitor.md
@@ -1,23 +1,23 @@
 # Automatic Failover With MariaDB Monitor
 
-The [MariaDB Monitor](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md) is not only capable\
-of monitoring the state of a MariaDB primary-replica cluster but is also\
-capable of performing _failover_ and _switchover_. In addition, in some\
-circumstances it is capable of _rejoining_ a primary that has gone down and\
+The [MariaDB Monitor](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md) is not only capable
+of monitoring the state of a MariaDB primary-replica cluster but is also
+capable of performing _failover_ and _switchover_. In addition, in some
+circumstances it is capable of _rejoining_ a primary that has gone down and
 later reappears.
 
-Note that the failover (and switchover and rejoin) functionality is only\
-supported in conjunction with GTID-based replication and initially only\
+Note that the failover (and switchover and rejoin) functionality is only
+supported in conjunction with GTID-based replication and initially only
 for simple topologies, that is, 1 primary and several replicas.
 
-The failover, switchover and rejoin functionality are inherent parts of\
-the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin\
+The failover, switchover and rejoin functionality are inherent parts of
+the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin
 are enabled by default.
 
-The following examples have been written with the assumption that there\
-are four servers - `server1`, `server2`, `server3` and `server4` - of\
+The following examples have been written with the assumption that there
+are four servers - `server1`, `server2`, `server3` and `server4` - of
 which `server1` is the initial primary and the other servers are replicas.\
-In addition there is a monitor called _TheMonitor_ that monitors those\
+In addition there is a monitor called _TheMonitor_ that monitors those
 servers.
 
 Somewhat simplified, the MaxScale configuration file would look like:
@@ -46,7 +46,7 @@ servers=server1,server2,server3,server4
 
 ## Manual Failover
 
-If everything is in order, the state of the cluster will look something\
+If everything is in order, the state of the cluster will look something
 like this:
 
 ```
@@ -64,7 +64,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If the primary now for any reason goes down, then the cluster state will\
+If the primary now for any reason goes down, then the cluster state will
 look like this:
 
 ```
@@ -84,7 +84,7 @@ $ maxctrl list servers
 
 Note that the status for `server1` is _Down_.
 
-Since failover is by default _not_ enabled, the failover mechanism must be\
+Since failover is by default _not_ enabled, the failover mechanism must be
 invoked manually:
 
 ```
@@ -99,11 +99,11 @@ There are quite a few arguments, so let's look at each one separately:
 * `failover` is the command we want to invoke, and
 * `TheMonitor` is the first and only argument to that command, the name of the monitor as specified in the configuration file.
 
-The MariaDB Monitor will now autonomously deduce which replica is the most\
-appropriate one to be promoted to primary, promote it to primary and modify\
+The MariaDB Monitor will now autonomously deduce which replica is the most
+appropriate one to be promoted to primary, promote it to primary and modify
 the other replicas accordingly.
 
-If we now check the cluster state we will see that one of the remaining\
+If we now check the cluster state we will see that one of the remaining
 replicas has been made into primary.
 
 ```
@@ -121,7 +121,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, it will not be rejoined to the cluster, as\
+If `server1` now reappears, it will not be rejoined to the cluster, as
 shown by the following output:
 
 ```
@@ -139,15 +139,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Had `auto_rejoin=true` been specified in the monitor section, then an\
+Had `auto_rejoin=true` been specified in the monitor section, then an
 attempt to rejoin `server1` would have been made.
 
-In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a\
+In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a
 subsequent version a command to that effect will be provided.
 
 ## Automatic Failover
 
-To enable automatic failover, simply add `auto_failover=true` to the\
+To enable automatic failover, simply add `auto_failover=true` to the
 monitor section in the configuration file.
 
 ```
@@ -176,7 +176,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now goes down, failover will automatically be performed and\
+If `server1` now goes down, failover will automatically be performed and
 an existing replica promoted to new primary.
 
 ```
@@ -194,12 +194,12 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴────────────────────────┘
 ```
 
-If you are continuously monitoring the server states, you may notice for a\
+If you are continuously monitoring the server states, you may notice for a
 brief period that the state of `server1` is _Down_ and the state of`server2` is still _Slave, Running_.
 
 ## Rejoin
 
-To enable automatic rejoin, simply add `auto_rejoin=true` to the\
+To enable automatic rejoin, simply add `auto_rejoin=true` to the
 monitor section in the configuration file.
 
 ```
@@ -211,7 +211,7 @@ auto_rejoin=true
 ...
 ```
 
-When automatic rejoin is enabled, the MariaDB Monitor will attempt to\
+When automatic rejoin is enabled, the MariaDB Monitor will attempt to
 rejoin a failed primary as a replica, if it reappears.
 
 When everything is running fine, the cluster state looks like follows:
@@ -231,8 +231,8 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Assuming `auto_failover=true` has been specified in the configuration\
-file, when `server1` goes down for some reason, failover will be performed\
+Assuming `auto_failover=true` has been specified in the configuration
+file, when `server1` goes down for some reason, failover will be performed
 and we end up with the following cluster state:
 
 ```
@@ -250,15 +250,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, the MariaDB Monitor will detect that and\
+If `server1` now reappears, the MariaDB Monitor will detect that and
 attempt to rejoin the old primary as a replica.
 
-Whether rejoining will succeed depends upon the actual state of the old\
-primary. For instance, if the old primary was modified and the changes had\
-not been replicated to the new primary, before the old primary went down,\
+Whether rejoining will succeed depends upon the actual state of the old
+primary. For instance, if the old primary was modified and the changes had
+not been replicated to the new primary, before the old primary went down,
 then automatic rejoin will not be possible.
 
-If rejoining can be performed, then the cluster state will end up looking\
+If rejoining can be performed, then the cluster state will end up looking
 like:
 
 ```
@@ -278,11 +278,11 @@ $ maxctrl list servers
 
 ## Switchover
 
-Switchover is for cases when you explicitly want to move the primary\
+Switchover is for cases when you explicitly want to move the primary
 role from one server to another.
 
-If we continue from the cluster state at the end of the previous example\
-and want to make `server1` primary again, then we must issue the following\
+If we continue from the cluster state at the end of the previous example
+and want to make `server1` primary again, then we must issue the following
 command:
 
 ```
@@ -299,7 +299,7 @@ There are quite a few arguments, so let's look at each one separately:
 * `server1` is the second argument to the command, the name of the server we want to make into _primary_, and
 * `server2` is the third argument to the command, the name of the _current primary_.
 
-If the command executes successfully, we will end up with the following\
+If the command executes successfully, we will end up with the following
 cluster state:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-avrorouter-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-avrorouter-tutorial.md
@@ -1,11 +1,11 @@
 # Avrorouter Tutorial
 
-This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avrorouter.md), how to set it up and how it interacts\
+This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avrorouter.md), how to set it up and how it interacts
 with the binlogrouter.
 
-The first part configures the services and sets them up for the binary log to Avro\
-file conversion. The second part of this tutorial uses the client listener\
-interface for the avrorouter and shows how to communicate with the service\
+The first part configures the services and sets them up for the binary log to Avro
+file conversion. The second part of this tutorial uses the client listener
+interface for the avrorouter and shows how to communicate with the service
 over the network.
 
 ```mermaid
@@ -66,8 +66,8 @@ _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog
 
 ### Preparing the primary server
 
-The primary server where we will be replicating from needs to have binary logging\
-enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_\
+The primary server where we will be replicating from needs to have binary logging
+enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_
 file of the primary.
 
 ```
@@ -79,9 +79,9 @@ _You can find out more about replication formats from the_[_MariaDB documentatio
 
 ### Configuring MaxScale
 
-We start by adding two new services into the configuration file. The first\
-service is the binlogrouter service which will read the binary logs from the\
-primary server. The second service will read the binlogs as they are streamed\
+We start by adding two new services into the configuration file. The first
+service is the binlogrouter service which will read the binary logs from the
+primary server. The second service will read the binlogs as they are streamed
 from the primary and convert them into Avro format files.
 
 ```
@@ -117,13 +117,13 @@ protocol=CDC
 port=4001
 ```
 
-The `source` parameter in the _avro-service_ points to the _replication-service_\
-we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog\
-number to start from. With these parameters, the avrorouter will start reading\
+The `source` parameter in the _avro-service_ points to the _replication-service_
+we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog
+number to start from. With these parameters, the avrorouter will start reading
 events from binlog `binlog.000015`.
 
-Note that the _filestem_ and _start\_index_ must point to the file that is the\
-first binlog that the binlogrouter will replicate. For example, if the first\
+Note that the _filestem_ and _start\_index_ must point to the file that is the
+first binlog that the binlogrouter will replicate. For example, if the first
 file you are replicating is `my-binlog-file.001234`, set the parameters to`filestem=my-binlog-file` and `start_index=1234`.
 
 For more information on the avrorouter options, read the [Avrorouter\
@@ -131,31 +131,31 @@ Documentation](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avroroute
 
 ## Preparing the data in the primary server
 
-Before starting the MaxScale process, we need to make sure that the binary logs\
-of the primary server contain the DDL statements that define the table\
-layouts. What this means is that the `CREATE TABLE` statements need to be in the\
+Before starting the MaxScale process, we need to make sure that the binary logs
+of the primary server contain the DDL statements that define the table
+layouts. What this means is that the `CREATE TABLE` statements need to be in the
 binary logs before the conversion process is started.
 
-If the binary logs contain data modification events for tables that aren't\
-created in the binary logs, the Avro schema of the table needs to be manually\
+If the binary logs contain data modification events for tables that aren't
+created in the binary logs, the Avro schema of the table needs to be manually
 created. There are multiple ways to do this:
 
-* Dump the database to a replica, configure it to replicate from the primary and\
-  point MaxScale to this replica (this is the recommended method as it requires no\
+* Dump the database to a replica, configure it to replicate from the primary and
+  point MaxScale to this replica (this is the recommended method as it requires no
   extra steps)
-* Use the [cdc\_schema Go utility](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avrorouter.md#avro-schema-generator)\
+* Use the [cdc\_schema Go utility](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avrorouter.md#avro-schema-generator)
   and copy the generated .avsc files to the avrodir
-* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)\
+* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)
   and copy the generated .avsc files to the avrodir
 
-If you used the schema generator scripts, all Avro schema files for tables that\
-are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of\
+If you used the schema generator scripts, all Avro schema files for tables that
+are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of
 the _test.t1_ table would be `test.t1.0000001.avsc`.
 
 ## Starting MariaDB MaxScale
 
-The next step is to start MariaDB MaxScale and set up the binlogrouter. We do\
-that by connecting to the MySQL listener of the _replication\_router_ service and\
+The next step is to start MariaDB MaxScale and set up the binlogrouter. We do
+that by connecting to the MySQL listener of the _replication\_router_ service and
 executing a few commands.
 
 ```
@@ -169,22 +169,22 @@ CHANGE MASTER TO MASTER_HOST='172.18.0.1',
 START SLAVE;
 ```
 
-**NOTE:** GTID replication is not currently supported and file-and-position\
+**NOTE:** GTID replication is not currently supported and file-and-position
 replication must be used.
 
 This will start the replication of binary logs from the primary server at\
-172.18.0.1 listening on port 3000. The first file that the binlogrouter\
-replicates is `binlog.000015`. This is the same file that was configured as the\
+172.18.0.1 listening on port 3000. The first file that the binlogrouter
+replicates is `binlog.000015`. This is the same file that was configured as the
 starting file in the avrorouter.
 
 For more details about the SQL commands, refer to the [Binlogrouter](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-binlogrouter.md) documentation.
 
-After the binary log streaming has started, the avrorouter will automatically\
+After the binary log streaming has started, the avrorouter will automatically
 start processing the binlogs.
 
 ## Creating and Processing Data
 
-Next, create a simple test table and populated it with some data by executing\
+Next, create a simple test table and populated it with some data by executing
 the following statements.
 
 ```
@@ -192,21 +192,21 @@ CREATE TABLE test.t1 (id INT);
 INSERT INTO test.t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 ```
 
-To use the _cdc.py_ command line client to connect to the CDC service, we must first\
+To use the _cdc.py_ command line client to connect to the CDC service, we must first
 create a user. This can be done via maxctrl by executing the following command.
 
 ```
 maxctrl call command cdc add_user avro-service maxuser maxpwd
 ```
 
-This will create the _maxuser:maxpwd_ credentials which can then be used to\
+This will create the _maxuser:maxpwd_ credentials which can then be used to
 request a JSON data stream of the `test.t1` table that was created earlier.
 
 ```
 cdc.py -u maxuser -p maxpwd -h 127.0.0.1 -P 4001 test.t1
 ```
 
-The output is a stream of JSON events describing the changes done to the\
+The output is a stream of JSON events describing the changes done to the
 database.
 
 ```
@@ -223,8 +223,8 @@ database.
 {"domain": 0, "server_id": 3000, "sequence": 11, "event_number": 10, "timestamp": 1537429419, "event_type": "insert", "id": 10}
 ```
 
-The first record is always the JSON format schema for the table describing the\
-types and names of the fields. All records that follow it represent the changes\
+The first record is always the JSON format schema for the table describing the
+types and names of the fields. All records that follow it represent the changes
 that have happened on the database.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-servers.md
@@ -1,6 +1,6 @@
 # MaxScale 23.02 Configuring Servers
 
-The first step is to define the servers that make up the cluster. These servers\
+The first step is to define the servers that make up the cluster. These servers
 will be used by the services and are monitored by the monitor.
 
 ```
@@ -24,10 +24,10 @@ The `address` and `port` parameters tell where the server is located.
 
 ### Enabling TLS
 
-To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`\
+To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`
 to the server section. To enable server certificate verification, add`ssl_verify_peer_certificate=true`.
 
-The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line\
+The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line
 client.
 
 For more information about TLS, refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-the-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-the-galera-monitor.md
@@ -16,19 +16,19 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
-This monitor module will assign one node within the Galera Cluster as the\
-current primary and other nodes as replica. Only those nodes that are active\
-members of the cluster are considered when making the choice of primary node. The\
+This monitor module will assign one node within the Galera Cluster as the
+current primary and other nodes as replica. Only those nodes that are active
+members of the cluster are considered when making the choice of primary node. The
 primary node will be the node with the lowest value of `wsrep_local_index`.
 
 ### Monitor User
 
-The monitor user does not require any special grants to monitor a Galera\
+The monitor user does not require any special grants to monitor a Galera
 cluster. To create a user for the monitor, execute the following SQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-the-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-the-mariadb-monitor.md
@@ -1,6 +1,6 @@
 # Configuring the MariaDB Monitor
 
-This document describes how to configure a MariaDB primary-replica cluster monitor\
+This document describes how to configure a MariaDB primary-replica cluster monitor
 to be used with MaxScale.
 
 ### Configuring the Monitor
@@ -17,14 +17,14 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
 ### Monitor User
 
-The monitor user requires the REPLICATION CLIENT privileges to do basic\
+The monitor user requires the REPLICATION CLIENT privileges to do basic
 monitoring. To create a user with the proper grants, execute the following SQL.
 
 ```
@@ -32,7 +32,7 @@ CREATE USER 'monitor_user'@'%' IDENTIFIED BY 'my_password';
 GRANT REPLICATION CLIENT ON *.* TO 'monitor_user'@'%';
 ```
 
-**Note:** If the automatic failover of the MariaDB Monitor will used, the user\
+**Note:** If the automatic failover of the MariaDB Monitor will used, the user
 will require additional grants. Execute the following SQL to grant them.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-the-xpand-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-configuring-the-xpand-monitor.md
@@ -1,18 +1,18 @@
 # Configuring the Xpand Monitor
 
-This document describes how to configure the Xpand monitor for use\
+This document describes how to configure the Xpand monitor for use
 with a Xpand cluster.
 
 ### Configuring the Monitor
 
-Contrary to the other monitors of MaxScale, the Xpand monitor will\
-autonomously figure out the cluster configuration and for each Xpand\
+Contrary to the other monitors of MaxScale, the Xpand monitor will
+autonomously figure out the cluster configuration and for each Xpand
 node create the corresponding MaxScale server object.
 
-In order to do that, a _sufficient_ number of "bootstrap" server instances\
-must be specified in the MaxScale configuration file for the Xpand\
-monitor to start with. One server instance is in principle sufficient, but\
-if the corresponding node happens to be down when MaxScale starts, the\
+In order to do that, a _sufficient_ number of "bootstrap" server instances
+must be specified in the MaxScale configuration file for the Xpand
+monitor to start with. One server instance is in principle sufficient, but
+if the corresponding node happens to be down when MaxScale starts, the
 monitor will not be able to function.
 
 ```
@@ -29,8 +29,8 @@ port=3306
 protocol=mariadbbackend
 ```
 
-The server configuration is identical with that of any other server, but since\
-these servers are _only_ used for bootstrapping the Xpand monitor it is\
+The server configuration is identical with that of any other server, but since
+these servers are _only_ used for bootstrapping the Xpand monitor it is
 adviceable to use names that clearly will identify them as such.
 
 The actual Xpand monitor configuration looks as follows:
@@ -46,20 +46,20 @@ monitor_interval=2s
 cluster_monitor_interval=60s
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to use for bootstrapping and the username and password to use\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to use for bootstrapping and the username and password to use
 when connecting to the servers.
 
-The `monitor_interval` parameter specifies how frequently the monitor should\
-ping the health check port of each server and the `cluster_monitor_interval`\
-specifies how frequently the monitor should do a complete cluster check, that\
-is, access the `system` tables of the Cluster for checking the Cluster\
-configuration. The default values are `2000` and `60000`, that is, 2 seconds\
+The `monitor_interval` parameter specifies how frequently the monitor should
+ping the health check port of each server and the `cluster_monitor_interval`
+specifies how frequently the monitor should do a complete cluster check, that
+is, access the `system` tables of the Cluster for checking the Cluster
+configuration. The default values are `2000` and `60000`, that is, 2 seconds
 and 1 minute, respectively.
 
-For each detected Xpand node a corresponding MaxScale server object will be\
-created, whose name is `@@<Monitor-Name>:node-<id>, where _Monitor-Name_ is the name of the monitor, in this example`Xpand\` and _id_ is the node id\
-of the Xpand node. So, with a cluster of three nodes, the created servers\
+For each detected Xpand node a corresponding MaxScale server object will be
+created, whose name is `@@<Monitor-Name>:node-<id>, where _Monitor-Name_ is the name of the monitor, in this example`Xpand\` and _id_ is the node id
+of the Xpand node. So, with a cluster of three nodes, the created servers
 might be named like.
 
 ```
@@ -68,9 +68,9 @@ might be named like.
 @@Xpand:node-7`
 ```
 
-Note that as these are created at runtime and may disappear at any moment,\
-depending on changes happening in and made to the Xpand cluster, they\
-should never be referred to directly from service configurations. Instead,\
+Note that as these are created at runtime and may disappear at any moment,
+depending on changes happening in and made to the Xpand cluster, they
+should never be referred to directly from service configurations. Instead,
 services should refer to the monitor, as shown in the following:
 
 ```
@@ -82,9 +82,9 @@ password=service_password
 cluster=Xpand
 ```
 
-Instead of listing the servers of the service explicitly using the `servers`\
-parameter as usually is the case, the service refers to the Xpand monitor\
-using the `cluster` parameter. This will cause the service to use the Xpand\
+Instead of listing the servers of the service explicitly using the `servers`
+parameter as usually is the case, the service refers to the Xpand monitor
+using the `cluster` parameter. This will cause the service to use the Xpand
 nodes that the Xpand monitor discovers at runtime.
 
 For additional details, please consult the monitor [documentation](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-xpand-monitor.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-connection-routing-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-connection-routing-with-mariadb-maxscale.md
@@ -1,7 +1,7 @@
 # Connection Routing with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that has two ports available, one for\
-write connections and another for read connections. The read connections are load-\
+The goal of this tutorial is to configure a system that has two ports available, one for
+write connections and another for read connections. The read connections are load-
 balanced across replica servers.
 
 ### Setting up MariaDB MaxScale
@@ -11,11 +11,11 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring services
 
-We want two services and ports to which the client application can connect. One service\
-routes client connections to the primary server, the other load balances between replica\
+We want two services and ports to which the client application can connect. One service
+routes client connections to the primary server, the other load balances between replica
 servers. To achieve this, we need to define two services in the configuration file.
 
-Create the following two sections in your configuration file. The section names are the\
+Create the following two sections in your configuration file. The section names are the
 names of the services and should be meaningful. For this tutorial, we use the names_Write-Service_ and _Read-Service_.
 
 ```
@@ -36,18 +36,18 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readconnroute_ for\
+_router_ defines the routing module used. Here we use _readconnroute_ for
 connection-level routing.
 
-A service needs a list of servers to route queries to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers to route queries to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _router\_options_-parameter tells the _readconnroute_-module which servers it should\
-route a client connection to. For the write service we use the `master`-type and for the\
+The _router\_options_-parameter tells the _readconnroute_-module which servers it should
+route a client connection to. For the write service we use the `master`-type and for the
 read service the `slave`-type.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2302-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2302-encrypting-passwords.md).
@@ -55,7 +55,7 @@ For increased security, see [password encryption](mariadb-maxscale-2302-encrypti
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one per service is enough.
 
 ```
@@ -70,13 +70,13 @@ service=Read-Service
 port=3307
 ```
 
-The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set\
+The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set
 it to _Read-Service_.
 
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-encrypting-passwords.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-encrypting-passwords.md
@@ -1,23 +1,23 @@
 # MaxScale 23.02 Encrypting Passwords
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
-There are two options for representing the password, either plain text or\
-encrypted passwords may be used. In order to use encrypted passwords a set of\
-keys must be generated that will be used by the encryption and decryption\
+There are two options for representing the password, either plain text or
+encrypted passwords may be used. In order to use encrypted passwords a set of
+keys must be generated that will be used by the encryption and decryption
 process. To generate the keys, use the `maxkeys` command.
 
 ```
 maxkeys
 ```
 
-By default the key file will be generated in `/var/lib/maxscale`. If a different\
-directory is required, it can be given as the first argument to the program. For\
+By default the key file will be generated in `/var/lib/maxscale`. If a different
+directory is required, it can be given as the first argument to the program. For
 more information, see `maxkeys --help`.
 
-Once the keys have been created the `maxpasswd` command can be used to generate\
+Once the keys have been created the `maxpasswd` command can be used to generate
 the encrypted password.
 
 ```
@@ -25,10 +25,10 @@ maxpasswd plainpassword
 96F99AA1315BDC3604B006F427DD9484
 ```
 
-The username and password, either encrypted or plain text, are stored in the\
+The username and password, either encrypted or plain text, are stored in the
 service section using the `user` and `password` parameters.
 
-If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For\
+If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For
 more information, see `maxkeys --help`.
 
 Here is an example configuration that uses an encrypted password.
@@ -43,7 +43,7 @@ user=maxscale
 password=96F99AA1315BDC3604B006F427DD9484
 ```
 
-If the key file is not in the default location, the [datadir](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#datadir) parameter must be\
+If the key file is not in the default location, the [datadir](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#datadir) parameter must be
 set to the directory that contains it.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-mariadb-maxscale-administration-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-mariadb-maxscale-administration-tutorial.md
@@ -1,46 +1,46 @@
 # MariaDB MaxScale Administration Tutorial
 
-The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator\
-to a few of the common administration tasks. This is intended to be an\
-introduction for administrators who are new to MariaDB MaxScale and not a\
+The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator
+to a few of the common administration tasks. This is intended to be an
+introduction for administrators who are new to MariaDB MaxScale and not a
 reference to all the tasks that may be performed.
 
 ### Administration audit file
 
-The REST API calls that MaxCtrl and MaxGui issue to MaxScale can be logged\
+The REST API calls that MaxCtrl and MaxGui issue to MaxScale can be logged
 by enabling [admin\_audit](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#admin_audit).
 
 The generated file is a csv file that can be opened in most spread sheet programs.
 
 \[Rotating Log Files]\(#Rotating Log Files) also applies to the audit file.\
-The admin audit file will never be overwritten as a result of a rotate, unlike the\
+The admin audit file will never be overwritten as a result of a rotate, unlike the
 regular log file (in case a rotate is issued, but the file name has not been moved).\
-There is also the option to change the audit file name, which effectively rotates it\
+There is also the option to change the audit file name, which effectively rotates it
 independently of the regular log file.
 
 For e.g. `maxctrl alter maxscale admin_audit_file=/var/log/maxscale/admin_audit.march.csv`.
 
 ### Starting and Stopping MariaDB MaxScale
 
-MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,\
+MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,
 use `systemctl start maxscale`. To stop it, use `systemctl stop maxscale`.
 
 The systemd service file for MaxScale is located in`/lib/systemd/system/maxscale.service`.
 
 #### Additional Options for MaxScale
 
-Additional command line options and other systemd configuration options\
-can be given to MariaDB MaxScale by creating a drop-in file for the\
-service unit file. You can do this with the `systemctl edit maxscale.service`\
-command. For more information about systemd drop-in\
-files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)\
+Additional command line options and other systemd configuration options
+can be given to MariaDB MaxScale by creating a drop-in file for the
+service unit file. You can do this with the `systemctl edit maxscale.service`
+command. For more information about systemd drop-in
+files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)
 and [the systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html).
 
 ### Checking The Status Of The MariaDB MaxScale Services
 
-It is possible to use the maxctrl command to obtain statistics about the\
-services that are running within MaxScale. The maxctrl command `list services`\
-will give very basic information regarding services. This command may be either\
+It is possible to use the maxctrl command to obtain statistics about the
+services that are running within MaxScale. The maxctrl command `list services`
+will give very basic information regarding services. This command may be either
 run in interactive mode or passed on the maxctrl command line.
 
 ```
@@ -60,16 +60,16 @@ $ maxctrl list services
 └────────────────────────┴────────────────┴─────────────┴───────────────────┴────────────────────────────────────┘
 ```
 
-Network listeners count as a user of the service, therefore there will always be\
-one user per network port in which the service listens. More details can be\
+Network listeners count as a user of the service, therefore there will always be
+one user per network port in which the service listens. More details can be
 obtained by using the "show service" command.
 
 ### What Clients Are Connected To MariaDB MaxScale
 
-To determine what client are currently connected to MariaDB MaxScale, you can\
-use the `list sessions` command within maxctrl. This will give you IP address\
-and the ID of the session for that connection. As with any maxctrl\
-command this can be passed on the command line or typed interactively in\
+To determine what client are currently connected to MariaDB MaxScale, you can
+use the `list sessions` command within maxctrl. This will give you IP address
+and the ID of the session for that connection. As with any maxctrl
+command this can be passed on the command line or typed interactively in
 maxctrl.
 
 ```
@@ -83,32 +83,32 @@ $ maxctrl list sessions
 
 ### Rotating Log Files
 
-Log rotation applies to the MaxScale log file, admin audit file and\
+Log rotation applies to the MaxScale log file, admin audit file and
 qlafilter files.
 
 MariaDB MaxScale logs messages of different priority into a single log file.\
-With the exception if error messages that are always logged, whether messages of\
-a particular priority should be logged or not can be enabled via the maxctrl\
-interface or in the configuration file. By default, MaxScale keeps on writing to\
-the same log file. To prevent the file from growing indefinitely, the\
+With the exception if error messages that are always logged, whether messages of
+a particular priority should be logged or not can be enabled via the maxctrl
+interface or in the configuration file. By default, MaxScale keeps on writing to
+the same log file. To prevent the file from growing indefinitely, the
 administrator must take action.
 
-The name of the log file is maxscale.log. When the log is rotated, MaxScale\
+The name of the log file is maxscale.log. When the log is rotated, MaxScale
 closes the current log file and opens a new one using the same name.
 
-Log file rotation is achieved by use of the `rotate logs` command\
+Log file rotation is achieved by use of the `rotate logs` command
 in maxctrl.
 
 ```
 maxctrl rotate logs
 ```
 
-As there currently is only the maxscale log, that is the only one that will be\
+As there currently is only the maxscale log, that is the only one that will be
 rotated.
 
-This may be integrated into the Linux _logrotate_ mechanism by adding a\
-configuration file to the /etc/logrotate.d directory. If we assume we want to\
-rotate the log files once per month and wish to keep 5 log files worth of\
+This may be integrated into the Linux _logrotate_ mechanism by adding a
+configuration file to the /etc/logrotate.d directory. If we assume we want to
+rotate the log files once per month and wish to keep 5 log files worth of
 history, the configuration file would look as follows.
 
 ```
@@ -127,7 +127,7 @@ endscript
 }
 ```
 
-MariaDB MaxScale will also rotate all of its log files if it receives the USR1\
+MariaDB MaxScale will also rotate all of its log files if it receives the USR1
 signal. Using this the logrotate configuration script can be rewritten as
 
 ```
@@ -143,41 +143,41 @@ endscript
 }
 ```
 
-In older versions MaxScale renamed the log file, behavior which is not fully\
-compliant with the assumptions of logrotate and may lead to issues, depending on\
-the used logrotate configuration file. From version 2.1 onward, MaxScale will\
-not itself rename the log file, but when the log is rotated, MaxScale will\
-simply close and reopen the same log file. That will make the behavior fully\
+In older versions MaxScale renamed the log file, behavior which is not fully
+compliant with the assumptions of logrotate and may lead to issues, depending on
+the used logrotate configuration file. From version 2.1 onward, MaxScale will
+not itself rename the log file, but when the log is rotated, MaxScale will
+simply close and reopen the same log file. That will make the behavior fully
 compliant with logrotate.
 
 ### Taking Objects Temporarily Out of Use
 
 #### Putting Servers into Maintenance
 
-MariaDB MaxScale supports the concept of maintenance mode for servers within a\
-cluster. This allows for planned, temporary removal of a database from the\
+MariaDB MaxScale supports the concept of maintenance mode for servers within a
+cluster. This allows for planned, temporary removal of a database from the
 cluster without the need to change the MariaDB MaxScale configuration.
 
 ```
 maxctrl set server db-server-3 maintenance
 ```
 
-To achieve this, you can use the `set server` command in maxctrl to set the\
-maintenance mode flag for the server. This may be done interactively within\
+To achieve this, you can use the `set server` command in maxctrl to set the
+maintenance mode flag for the server. This may be done interactively within
 maxctrl or by passing the command on the command line.
 
-This will cause MariaDB MaxScale to stop routing any new requests to the server,\
-however if there are currently requests executing on the server these will not\
-be interrupted. Connections to servers in maintenance mode are closed as soon as\
-the next request arrives. To close them immediately, use the `--force` option\
+This will cause MariaDB MaxScale to stop routing any new requests to the server,
+however if there are currently requests executing on the server these will not
+be interrupted. Connections to servers in maintenance mode are closed as soon as
+the next request arrives. To close them immediately, use the `--force` option
 for `maxctrl set server`.
 
 ```
 maxctrl clear server db-server-3 maintenance
 ```
 
-Clearing the maintenance mode for a server will bring it back into use. If\
-multiple MariaDB MaxScale instances are configured to use the node then\
+Clearing the maintenance mode for a server will bring it back into use. If
+multiple MariaDB MaxScale instances are configured to use the node then
 maintenance mode must be set within each MariaDB MaxScale instance.
 
 ### Stopping and Starting Services
@@ -186,16 +186,16 @@ maintenance mode must be set within each MariaDB MaxScale instance.
 maxctrl stop service db-service
 ```
 
-Services can be stopped to temporarily halt their use. Stopping a service will\
-cause it to stop accepting new connections until it is started. New connections\
-are not refused if the service is stopped and are queued instead. This means\
+Services can be stopped to temporarily halt their use. Stopping a service will
+cause it to stop accepting new connections until it is started. New connections
+are not refused if the service is stopped and are queued instead. This means
 that connecting clients will wait until the service is started again.
 
 ```
 maxctrl start service db-service
 ```
 
-Starting a service will cause it to accept all queued connections that were\
+Starting a service will cause it to accept all queued connections that were
 created while it was stopped.
 
 #### Stopping and Starting Monitors
@@ -204,35 +204,35 @@ created while it was stopped.
 maxctrl stop monitor db-monitor
 ```
 
-Stopping a monitor will cause it to stop monitoring the state of the servers\
-assigned to it. This is useful when the state of the servers is assigned\
+Stopping a monitor will cause it to stop monitoring the state of the servers
+assigned to it. This is useful when the state of the servers is assigned
 manually with `maxctrl set server`.
 
 ```
 maxctrl start monitor db-monitor
 ```
 
-Starting a monitor will make it resume monitoring of the servers. Any manually\
+Starting a monitor will make it resume monitoring of the servers. Any manually
 assigned states will be overwritten by the monitor.
 
 ### Runtime Configuration Modification
 
-The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,\
+The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,
 modify or destroy objects (servers, services, monitors etc.) inside\
-MaxScale. The exact syntax for each of the commands and any additional options\
+MaxScale. The exact syntax for each of the commands and any additional options
 that they take can be seen with `maxctrl --help <command>`.
 
-Not all parameters can be modified at runtime. Refer to the module documentation\
-for more information on which parameters can be modified at runtime. If a\
-parameter cannot be modified at runtime, the object can be destroyed and\
+Not all parameters can be modified at runtime. Refer to the module documentation
+for more information on which parameters can be modified at runtime. If a
+parameter cannot be modified at runtime, the object can be destroyed and
 recreated in order to change it.
 
-All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime\
-persist through restarts. Any changes done to objects in the main configuration\
+All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime
+persist through restarts. Any changes done to objects in the main configuration
 file are ignored if a persisted entry is found for it.
 
-For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete\
-configuration for the object. To remove all runtime changes for all objects,\
+For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete
+configuration for the object. To remove all runtime changes for all objects,
 remove all files found in `/var/lib/maxscale/maxscale.cnf.d`.
 
 #### Core Parameter Configuration
@@ -243,7 +243,7 @@ Modify global MaxScale parameters:
 maxctrl alter maxscale auth_connect_timeout 5s
 ```
 
-Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md) for a full list\
+Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md) for a full list
 of parameters that can be modified at runtime.
 
 #### Managing Servers
@@ -266,8 +266,8 @@ maxctrl alter server db-server-1 port 3307
 maxctrl destroy server db-server-1
 ```
 
-A server can only be destroyed if it is not used by any services or monitors. To\
-automatically remove the server from the services and monitors that use it, use\
+A server can only be destroyed if it is not used by any services or monitors. To
+automatically remove the server from the services and monitors that use it, use
 the `--force` flag.
 
 **Drain a Server**
@@ -276,9 +276,9 @@ the `--force` flag.
 maxctrl set server db-server-1 drain
 ```
 
-When a server is set into the `drain` state, no new connections to it are\
-created. Unlike to the `maintenance` state which immediately stops all new\
-requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them\
+When a server is set into the `drain` state, no new connections to it are
+created. Unlike to the `maintenance` state which immediately stops all new
+requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them
 in order to be gracefully closed once the client disconnects.
 
 To remove the `drain` state, use `clear server` command:
@@ -287,7 +287,7 @@ To remove the `drain` state, use `clear server` command:
 maxctrl clear server db-server-1 drain
 ```
 
-Servers with the `Master` state cannot be drained. To drain them, first perform\
+Servers with the `Master` state cannot be drained. To drain them, first perform
 a switchover to another node and then drain the server.
 
 #### Managing Monitors
@@ -322,7 +322,7 @@ maxctrl unlink monitor db-monitor db-server-1
 maxctrl destroy monitor db-monitor
 ```
 
-A monitor can only be destroyed if it is not monitoring any servers. To\
+A monitor can only be destroyed if it is not monitoring any servers. To
 automatically remove the servers from the monitor, use the `--force` flag.
 
 #### Managing Services
@@ -345,7 +345,7 @@ maxctrl alter service db-service user new-db-user
 maxctrl link service db-service db-server1
 ```
 
-Any servers added to services will only be used by new sessions. Existing\
+Any servers added to services will only be used by new sessions. Existing
 sessions will use the servers that were available when they connected.
 
 **Remove Servers from a Service**
@@ -354,8 +354,8 @@ sessions will use the servers that were available when they connected.
 maxctrl unlink service db-service db-server1
 ```
 
-Similarly to adding servers, removing servers from a service will only affect\
-new sessions. Existing sessions keep using the servers even if they are removed\
+Similarly to adding servers, removing servers from a service will only affect
+new sessions. Existing sessions keep using the servers even if they are removed
 from a service.
 
 **Change the Filters of a Service**
@@ -364,9 +364,9 @@ from a service.
 maxctrl alter service-filters my-regexfilter my-qlafilter
 ```
 
-The order of the filters is significant: the first filter will be the first to\
-receive the query. The new set of filters will only be used by new\
-sessions. Existing sessions will keep using the filters that were configured\
+The order of the filters is significant: the first filter will be the first to
+receive the query. The new set of filters will only be used by new
+sessions. Existing sessions will keep using the filters that were configured
 when they connected.
 
 **Destroy a Service**
@@ -375,9 +375,9 @@ when they connected.
 maxctrl destroy service db-service
 ```
 
-The service can only be destroyed if it uses no servers or clusters and has no\
-listeners associated with it. To force destruction of a service even if it does\
-use servers or has listeners, use the `--force` flag. This will also destroy any\
+The service can only be destroyed if it uses no servers or clusters and has no
+listeners associated with it. To force destruction of a service even if it does
+use servers or has listeners, use the `--force` flag. This will also destroy any
 listeners associated with the service.
 
 #### Managing Filters
@@ -394,11 +394,11 @@ maxctrl create filter regexfilter match=ENGINE=MyISAM replace=ENGINE=InnoDB
 maxctrl destroy filter my-regexfilter
 ```
 
-A filter can only be destroyed if it is not used by any services. To\
-automatically remove the filter from all services using it, use the `--force`\
+A filter can only be destroyed if it is not used by any services. To
+automatically remove the filter from all services using it, use the `--force`
 flag.
 
-Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters\
+Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters
 of a filter, destroy it and recreate it with the modified parameters.
 
 #### Managing Listeners
@@ -415,16 +415,16 @@ maxctrl create listener db-listener db-service 4006
 maxctrl destroy listener db-listener
 ```
 
-Destroying a listener will close the network socket and stop it from accepting\
-new connections. Existing connections that were created through it will keep\
+Destroying a listener will close the network socket and stop it from accepting
+new connections. Existing connections that were created through it will keep
 displaying it as the originating listener.
 
-Listeners cannot be moved from one service to another. In order to do this, the\
+Listeners cannot be moved from one service to another. In order to do this, the
 listener must be destroyed and then recreated with the new service.
 
 ### Managing MaxCtrl and REST API Users
 
-MaxCtrl uses the same credentials as the MaxScale REST API. These users can be\
+MaxCtrl uses the same credentials as the MaxScale REST API. These users can be
 managed via MaxCtrl.
 
 #### Create a New MaxCtrl User
@@ -433,14 +433,14 @@ managed via MaxCtrl.
 maxctrl create user basic-user basic-password
 ```
 
-By default new users are only allowed to read data. To make the account an\
+By default new users are only allowed to read data. To make the account an
 administrative account, add the `--type=admin` option to the command:
 
 ```
 maxctrl create user admin-user admin-password --type=admin
 ```
 
-Administrative accounts are allowed to use all MaxCtrl commands and modify any\
+Administrative accounts are allowed to use all MaxCtrl commands and modify any
 parts of MaxScale.
 
 #### Change the Password of an Existing User

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-maxscale-and-xpand-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-maxscale-and-xpand-tutorial.md
@@ -1,24 +1,24 @@
 # MaxScale and Xpand Tutorial
 
-Since version 2.4, MaxScale has built-in support for Xpand. This\
-tutorial explains how to setup MaxScale in front of a Xpand\
+Since version 2.4, MaxScale has built-in support for Xpand. This
+tutorial explains how to setup MaxScale in front of a Xpand
 cluster.
 
-There is no Xpand specific router, but both the [readconnroute](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readconnroute.md) and\
-the [readwritesplit](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md) routers can be\
+There is no Xpand specific router, but both the [readconnroute](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readconnroute.md) and
+the [readwritesplit](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md) routers can be
 used.
 
 ### Xpand and Readconnroute
 
-With _readconnroute_ you get simple connection based routing, where\
-each new connection is created (by default) to the Xpand node with\
-the least amount of existing connections. That is, with readconnroute\
-the behaviour will be very similar to the behaviour when [HAProxy](https://www.haproxy.org) is used as the Xpand load\
+With _readconnroute_ you get simple connection based routing, where
+each new connection is created (by default) to the Xpand node with
+the least amount of existing connections. That is, with readconnroute
+the behaviour will be very similar to the behaviour when [HAProxy](https://www.haproxy.org) is used as the Xpand load
 balancer.
 
 #### Bootstrap servers
 
-The Xpand monitor is capable of autonomously figuring out the cluster\
+The Xpand monitor is capable of autonomously figuring out the cluster
 configuration, but in order to get going there must be at least one_server_-section referring to a node in the Xpand cluster.
 
 ```
@@ -29,9 +29,9 @@ port=3306
 protocol=MySQLBackend
 ```
 
-That server definition will be used by the monitor in order to connect\
-to the Xpand cluster. There can be more than one such "bootstrap"\
-definition to cater for the case that the node used as a bootstrap\
+That server definition will be used by the monitor in order to connect
+to the Xpand cluster. There can be more than one such "bootstrap"
+definition to cater for the case that the node used as a bootstrap
 server is down when MaxScale starts.
 
 **NOTE** These bootstrap servers should _only_ be referred to from the\
@@ -39,7 +39,7 @@ Xpand monitor configuration, but _never_ from a service.
 
 #### Monitor
 
-In the Xpand monitor section, the bootstrap servers are referred to\
+In the Xpand monitor section, the bootstrap servers are referred to
 in the same way as "ordinary" servers are referred to in other monitors.
 
 ```
@@ -60,19 +60,19 @@ GRANT SELECT ON system.nodeinfo TO 'maxscale-monitor'@'maxscalehost';
 GRANT SELECT ON system.softfailed_nodes TO 'maxscale-monitor'@'maxscalehost';
 ```
 
-In case the same user is used both for the monitor and the service (see below),\
+In case the same user is used both for the monitor and the service (see below),
 then the user must be given the grants required by the service as well.
 
-The bootstrap servers are only used for connecting to the Xpand\
-cluster; thereafter the Xpand monitor will dynamically find out the\
+The bootstrap servers are only used for connecting to the Xpand
+cluster; thereafter the Xpand monitor will dynamically find out the
 cluster configuration.
 
-The discovered cluster configuration will be stored (the ips and ports\
-of the Xpand nodes) and upon subsequent restarts the Xpand\
-monitor will use that information if the bootstrap servers happen to\
+The discovered cluster configuration will be stored (the ips and ports
+of the Xpand nodes) and upon subsequent restarts the Xpand
+monitor will use that information if the bootstrap servers happen to
 be unavailable.
 
-With the configuration above `maxctrl list servers` might output\
+With the configuration above `maxctrl list servers` might output
 the following:
 
 ```
@@ -91,7 +91,7 @@ the following:
 
 All servers whose name start with `@@` have been detected dynamically.
 
-Note that the address `10.2.224.101` appears twice; once for`Bootstrap-1` and another time for `@@Xpand:node-6`. The Xpand\
+Note that the address `10.2.224.101` appears twice; once for`Bootstrap-1` and another time for `@@Xpand:node-6`. The Xpand
 monitor will create a dynamic server instance for _all_ nodes in the\
 Xpand cluster; also for the ones used in bootstrap server sections.
 
@@ -116,22 +116,22 @@ GRANT SELECT ON system.users TO 'maxscale-service'@'maxscalehost';
 GRANT SELECT ON system.user_acl TO 'maxscale-service'@'maxscalehost';
 ```
 
-In case the same user is used both for the monitor (see above) and the service,\
+In case the same user is used both for the monitor (see above) and the service,
 then the user must be given the grants required by the monitor as well.
 
-Note that the service does _not_ list any specific servers, but\
+Note that the service does _not_ list any specific servers, but
 instead refers, using the argument `cluster`, to the Xpand monitor.
 
-In practice this means that the service will use the servers of the\
-monitor named `Xpand` and in the case of a Xpand monitor those\
-servers will be the ones that the monitor has detected\
-dynamically. That is, when setup like this, the service will\
-automatically adjust to any changes taking place in the Xpand\
+In practice this means that the service will use the servers of the
+monitor named `Xpand` and in the case of a Xpand monitor those
+servers will be the ones that the monitor has detected
+dynamically. That is, when setup like this, the service will
+automatically adjust to any changes taking place in the Xpand
 cluster.
 
-**NOTE** There is no need to specify any `router_options`, but the\
+**NOTE** There is no need to specify any `router_options`, but the
 default `router_options=running` provides the desired behaviour.\
-In particular do **not** specify `router_options=master` as that will\
+In particular do **not** specify `router_options=master` as that will
 cause only a _single_ node to be used.
 
 #### Listener
@@ -148,22 +148,22 @@ port=4008
 
 ### Xpand and Readwritesplit
 
-The primary purpose of the router _readwritesplit_ is to split\
+The primary purpose of the router _readwritesplit_ is to split
 statements between one primary and multiple replicas. In the case of\
-Xpand, all servers will be primaries, but _readwritesplit_ may still\
+Xpand, all servers will be primaries, but _readwritesplit_ may still
 be the right choice.
 
-Namely, as _readwritesplit_ is transaction aware and capable of\
-replaying transactions, it can be used for hiding certain events\
+Namely, as _readwritesplit_ is transaction aware and capable of
+replaying transactions, it can be used for hiding certain events
 taking place in Xpand from the clients that use it.
 
-For instance, whenever a node is removed from or added to a Xpand\
-cluster there will be a _group change_, which is visible to a client\
-as a transaction rollback. However, if _readwritesplit_ is used and\
-transaction replay is enabled, then MaxScale may be able to hide the\
+For instance, whenever a node is removed from or added to a Xpand
+cluster there will be a _group change_, which is visible to a client
+as a transaction rollback. However, if _readwritesplit_ is used and
+transaction replay is enabled, then MaxScale may be able to hide the
 group change so that the client only detects a slight delay.
 
-Apart from the service section, the configuration when using_readwritesplit_ is identical to the _readconnroute_ configuration\
+Apart from the service section, the configuration when using_readwritesplit_ is identical to the _readconnroute_ configuration
 described above.
 
 #### Service
@@ -181,20 +181,20 @@ transaction_replay=true
 slave_selection_criteria=LEAST_GLOBAL_CONNECTIONS
 ```
 
-With this configuration, subject to the boundary conditions of\
-transaction replaying, a client will neither notice group change\
-events nor the disappearance of the very node the client is connected\
-to. In that latter case, MaxScale will simply connect to another node\
-and replay the current transaction (if one is active). For detailed\
-information about the transaction replay functionality, please refer\
+With this configuration, subject to the boundary conditions of
+transaction replaying, a client will neither notice group change
+events nor the disappearance of the very node the client is connected
+to. In that latter case, MaxScale will simply connect to another node
+and replay the current transaction (if one is active). For detailed
+information about the transaction replay functionality, please refer
 to the _readwritesplit_[documentation](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md).
 
-**NOTE** It is vital to have`slave_selection_criteria=LEAST_GLOBAL_CONNECTIONS`, as otherwise\
-connections will **not** be distributed evenly across all Xpand\
+**NOTE** It is vital to have`slave_selection_criteria=LEAST_GLOBAL_CONNECTIONS`, as otherwise
+connections will **not** be distributed evenly across all Xpand
 nodes.
 
-As a rule of thumb, use _readwritesplit_ if it is important that\
-changes taking place in the cluster configuration are hidden from the\
+As a rule of thumb, use _readwritesplit_ if it is important that
+changes taking place in the cluster configuration are hidden from the
 applications, otherwise use _readconnroute_.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-read-write-splitting-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-read-write-splitting-with-mariadb-maxscale.md
@@ -1,7 +1,7 @@
 # Read-Write Splitting with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that appears to the client as a single\
-database. MariaDB MaxScale will split the statements such that write statements are sent\
+The goal of this tutorial is to configure a system that appears to the client as a single
+database. MariaDB MaxScale will split the statements such that write statements are sent
 to the primary server and read statements are balanced across the replica servers.
 
 ### Setting up MariaDB MaxScale
@@ -11,9 +11,9 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring the service
 
-After configuring the servers and the monitor, we create a read-write-splitter service\
-configuration. Create the following section in your configuration file. The section name\
-is also the name of the service and should be meaningful. For this tutorial, we use the\
+After configuring the servers and the monitor, we create a read-write-splitter service
+configuration. Create the following section in your configuration file. The section name
+is also the name of the service and should be meaningful. For this tutorial, we use the
 name _Splitter-Service_.
 
 ```
@@ -25,14 +25,14 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readwritesplit_ for\
+_router_ defines the routing module used. Here we use _readwritesplit_ for
 query-level read-write-splitting.
 
-A service needs a list of servers where queries will be routed to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers where queries will be routed to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2302-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2302-encrypting-passwords.md).
@@ -40,7 +40,7 @@ For increased security, see [password encryption](mariadb-maxscale-2302-encrypti
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one is enough.
 
 ```
@@ -55,7 +55,7 @@ The _service_ parameter tells which service the listener connects to. For the_Sp
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-rest-api-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-rest-api-tutorial.md
@@ -1,22 +1,22 @@
 # MaxScale REST API Tutorial
 
-This tutorial is a quick overview of what the MaxScale REST API offers, how it\
-can be used to inspect the state of MaxScale and how to use it to modify the\
-runtime configuration of MaxScale. The tutorial uses the `curl` command line\
+This tutorial is a quick overview of what the MaxScale REST API offers, how it
+can be used to inspect the state of MaxScale and how to use it to modify the
+runtime configuration of MaxScale. The tutorial uses the `curl` command line
 client to demonstrate how the API is used.
 
 ### Configuration and Hardening
 
-The MaxScale REST API listens on port 8989 on the local host. The `admin_port`\
-and `admin_host` parameters control which port and address the REST API listens\
-on. Note that for security reasons the API only listens for local connections\
-with the default configuration. It is critical that the default credentials are\
-changed and TLS/SSL encryption is configured before exposing the REST API to a\
+The MaxScale REST API listens on port 8989 on the local host. The `admin_port`
+and `admin_host` parameters control which port and address the REST API listens
+on. Note that for security reasons the API only listens for local connections
+with the default configuration. It is critical that the default credentials are
+changed and TLS/SSL encryption is configured before exposing the REST API to a
 network.
 
-The default user for the REST API is `admin` and the password is `mariadb`. The\
-easiest way to secure the REST API is to use the `maxctrl` command line client\
-to create a new admin user and delete the default one. To do this, run the\
+The default user for the REST API is `admin` and the password is `mariadb`. The
+easiest way to secure the REST API is to use the `maxctrl` command line client
+to create a new admin user and delete the default one. To do this, run the
 following commands:
 
 ```
@@ -24,13 +24,13 @@ maxctrl create user my_user my_password --type=admin
 maxctrl destroy user admin
 ```
 
-This will create the user `my_user` with the password `my_password` that is an\
-administrative account. After this account is created, the default `admin`\
+This will create the user `my_user` with the password `my_password` that is an
+administrative account. After this account is created, the default `admin`
 account is removed with the next command.
 
-The next step is to enable TLS encryption. To do this, you need a CA\
-certificate, a private key and a public certificate file all in PEM format. Add\
-the following three parameters under the `[maxscale]` section of the MaxScale\
+The next step is to enable TLS encryption. To do this, you need a CA
+certificate, a private key and a public certificate file all in PEM format. Add
+the following three parameters under the `[maxscale]` section of the MaxScale
 configuration file and restart MaxScale.
 
 ```
@@ -39,15 +39,15 @@ admin_ssl_cert=/certs/server-cert.pem
 admin_ssl_ca_cert=/certs/ca-cert.pem
 ```
 
-Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our\
-server certificates are self-signed so the `--tls-verify-server-cert=false`\
+Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our
+server certificates are self-signed so the `--tls-verify-server-cert=false`
 option is required.
 
 ```
 maxctrl --user=my_user --password=my_password --secure --tls-ca-cert=/certs/ca-cert.pem --tls-verify-server-cert=false show maxscale
 ```
 
-If no errors are raised, this means that the communication via the REST API is\
+If no errors are raised, this means that the communication via the REST API is
 now secure and can be used across networks.
 
 ### Requesting Data
@@ -55,8 +55,8 @@ now secure and can be used across networks.
 **Note:** For the sake of brevity, the rest of this tutorial will omit the\
 TLS/SSL options from the `curl` command line. For more information, refer to the`curl` manpage.
 
-The most basic task to do with the REST API is to see whether MaxScale is up and\
-running. To do this, we do a HTTP request on the root resource (the `-i` option\
+The most basic task to do with the REST API is to see whether MaxScale is up and
+running. To do this, we do a HTTP request on the root resource (the `-i` option
 shows the HTTP headers).
 
 `curl -i 127.0.0.1:8989/v1/`
@@ -70,7 +70,7 @@ ETag: "0"
 Date: Mon, 04 Mar 19 08:29:41 GMT
 ```
 
-To query a resource collection endpoint, append it to the URL. The `/v1/filters/`\
+To query a resource collection endpoint, append it to the URL. The `/v1/filters/`
 endpoint shows the list of filters configured in MaxScale. This is a _resource collection_ endpoint: it contains the list of all resources of a particular type.
 
 `curl 127.0.0.1:8989/v1/filters`
@@ -145,17 +145,17 @@ endpoint shows the list of filters configured in MaxScale. This is a _resource c
 }
 ```
 
-The `data` holds the actual list of resources: the `Hint` and `Logger`\
-filters. Each object has the `id` field which is the unique name of that\
+The `data` holds the actual list of resources: the `Hint` and `Logger`
+filters. Each object has the `id` field which is the unique name of that
 object. It is the same as the section name in `maxscale.cnf`.
 
-Each resource in the list has a `relationships` object. This shows the\
-relationship links between resources. In our example, the `Hint` filter is used\
-by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in\
+Each resource in the list has a `relationships` object. This shows the
+relationship links between resources. In our example, the `Hint` filter is used
+by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in
 use.
 
-To request an individual resource, we add the object name to the resource\
-collection URL. For example, if we want to get only the `Logger` filter we\
+To request an individual resource, we add the object name to the resource
+collection URL. For example, if we want to get only the `Logger` filter we
 execute the following command.
 
 `curl 127.0.0.1:8989/v1/filters/Logger`
@@ -204,18 +204,18 @@ execute the following command.
 }
 ```
 
-Note that this time the `data` member holds an object instead of an array of\
-objects. All other parts of the response are similar to what was shown in the\
+Note that this time the `data` member holds an object instead of an array of
+objects. All other parts of the response are similar to what was shown in the
 previous example.
 
 ### Creating Objects
 
-One of the uses of the REST API is to create new objects in MaxScale at\
-runtime. This allows new servers, services, filters, monitor and listeners to be\
+One of the uses of the REST API is to create new objects in MaxScale at
+runtime. This allows new servers, services, filters, monitor and listeners to be
 created without restarting MaxScale.
 
-For example, to create a new server in MaxScale the JSON definition of a server\
-must be sent to the REST API at the `/v1/servers/` endpoint. The request body\
+For example, to create a new server in MaxScale the JSON definition of a server
+must be sent to the REST API at the `/v1/servers/` endpoint. The request body
 defines the server name as well as the parameters for it.
 
 To create objects with `curl`, first write the JSON definition into a file.
@@ -241,9 +241,9 @@ To send the data, use the following command.
 curl -X POST -d @new_server.txt 127.0.0.1:8989/v1/servers
 ```
 
-The `-d` option takes a file name prefixed with a `@` as an argument. Here we\
-have `@new_server.txt` which is the name of the file where the JSON definition\
-was stored. The `-X` option defines the HTTP verb to use and to create a new\
+The `-d` option takes a file name prefixed with a `@` as an argument. Here we
+have `@new_server.txt` which is the name of the file where the JSON definition
+was stored. The `-X` option defines the HTTP verb to use and to create a new
 object we must use the POST verb.
 
 To verify the data request the newly created object.
@@ -254,18 +254,18 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Modifying Data
 
-The easiest way to modify an object is to first request it, store the result in\
+The easiest way to modify an object is to first request it, store the result in
 a file, edit it and then send the updated object back to the REST API.
 
-Let's say we want to modify the port that the server we created earlier listens\
+Let's say we want to modify the port that the server we created earlier listens
 on. First we request the current object and store the result in a file.
 
 ```
 curl 127.0.0.1:8989/v1/servers/server1 > server1.txt
 ```
 
-After that we edit the file and change the port from 3003 to 3306. Next the\
-modified JSON object is sent to the REST API as a PATCH command. To do this,\
+After that we edit the file and change the port from 3003 to 3306. Next the
+modified JSON object is sent to the REST API as a PATCH command. To do this,
 execute the following command.
 
 ```
@@ -280,12 +280,12 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Object Relationships
 
-To continue with our previous example, we add the updated server to a\
-service. To do this, the `relationships` object of the server must be modified\
+To continue with our previous example, we add the updated server to a
+service. To do this, the `relationships` object of the server must be modified
 to include the service we want to add the server to.
 
-To define a relationship between a server and a service, the `data` member must\
-have the `relationships` field and it must contain an object with the `services`\
+To define a relationship between a server and a service, the `data` member must
+have the `relationships` field and it must contain an object with the `services`
 field (some fields omitted for brevity).
 
 ```
@@ -308,13 +308,13 @@ field (some fields omitted for brevity).
 }
 ```
 
-The `data.relationships.services.data` field contains a list of objects that\
-define the `id` and `type` fields. The id is the name of the object (a service\
-or a monitor for servers) and the type tells which type it is. Only `services`\
+The `data.relationships.services.data` field contains a list of objects that
+define the `id` and `type` fields. The id is the name of the object (a service
+or a monitor for servers) and the type tells which type it is. Only `services`
 type objects should be present in the `services` object.
 
-In our example we are linking the `server1` server to the `RW-Split-Router`\
-service. As was seen with the previous example, the easiest way to do this is to\
+In our example we are linking the `server1` server to the `RW-Split-Router`
+service. As was seen with the previous example, the easiest way to do this is to
 store the result, edit it and then send it back with a HTTP PATCH.
 
 If we want to remove a server from _all_ services and monitors, we can set the`data` member of the `services` and `monitors` relationships to an empty array:
@@ -334,39 +334,39 @@ If we want to remove a server from _all_ services and monitors, we can set the`d
 }
 ```
 
-This is useful if you want to delete the server which can only be done if it has\
+This is useful if you want to delete the server which can only be done if it has
 no relationships to other objects.
 
 ### Deleting Objects
 
-To delete an object, simply execute a HTTP DELETE request on the resource you\
-want to delete. For example, to delete the `server1` server, execute the\
+To delete an object, simply execute a HTTP DELETE request on the resource you
+want to delete. For example, to delete the `server1` server, execute the
 following command.
 
 ```
 curl -X DELETE 127.0.0.1:8989/v1/servers/server1
 ```
 
-In order to delete an object, it must not have any relationships to other\
+In order to delete an object, it must not have any relationships to other
 objects.
 
 ### Further Reading
 
 The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md).
 
-The `maxctrl` command line client is self-documenting and the `maxctrl help`\
-command is a good tool for exploring the various commands that are available in\
-it. The `maxctrl api get` command can be useful way to explore the REST API as\
+The `maxctrl` command line client is self-documenting and the `maxctrl help`
+command is a good tool for exploring the various commands that are available in
+it. The `maxctrl api get` command can be useful way to explore the REST API as
 it provides a way to easily extract values out of the JSON data generated by the\
 REST API.
 
-There is a multitude of REST API clients readily available and most of them are\
-far more convenient to use than `curl`. We recommend investigating what you need\
-and how you intend to either integrate or use the MaxScale REST API. Most modern\
-languages either have a built-in HTTP library or there exists a de facto\
+There is a multitude of REST API clients readily available and most of them are
+far more convenient to use than `curl`. We recommend investigating what you need
+and how you intend to either integrate or use the MaxScale REST API. Most modern
+languages either have a built-in HTTP library or there exists a de facto
 standard library.
 
-The MaxScale REST API follows the JSON API specification and there exist\
+The MaxScale REST API follows the JSON API specification and there exist
 libraries that are built specifically for these sorts of APIs
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-setting-up-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-setting-up-mariadb-maxscale.md
@@ -3,26 +3,26 @@
 This document is designed as a quick introduction to setting up MariaDB MaxScale.
 
 The installation and configuration of the MariaDB Server is not covered in this document.\
-See the following MariaDB documentation articles for more information on setting up a\
-primary-replica-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)\
+See the following MariaDB documentation articles for more information on setting up a
+primary-replica-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)
 and [Getting Started With MariaDB Galera Cluster](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster)\
 .
 
-This tutorial assumes that one of the standard MaxScale binary distributions is used and\
+This tutorial assumes that one of the standard MaxScale binary distributions is used and
 that MaxScale is installed using default options.
 
 Building from source code in GitHub is covered in [Building from Source](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-building-mariadb-maxscale-from-source-code.md).
 
 ### Installing MaxScale
 
-The precise installation process varies from one distribution to another. Details on\
+The precise installation process varies from one distribution to another. Details on
 package installation can be found in the [Installation Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-installation-guide.md).
 
 ### Creating a user account for MaxScale
 
-MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve\
-user authentication information from the backend databases. Create a special user\
-account for this purpose by executing the following SQL commands on the primary server of\
+MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve
+user authentication information from the backend databases. Create a special user
+account for this purpose by executing the following SQL commands on the primary server of
 your database cluster. The following tutorials will use these credentials.
 
 ```
@@ -41,12 +41,12 @@ MariaDB versions 10.2.2 to 10.2.10 also require `GRANT SELECT ON mysql.* TO 'max
 
 ### Creating client user accounts
 
-Because MariaDB MaxScale sits between the clients and the backend databases, the backend\
-databases will see all clients as if they were connecting from MaxScale's address. This\
+Because MariaDB MaxScale sits between the clients and the backend databases, the backend
+databases will see all clients as if they were connecting from MaxScale's address. This
 usually means that two sets of grants for each user are required.
 
 For example, assume that the user _'jdoe'@'client-host'_ exists and MaxScale is located at _maxscale-host_. If _'jdoe'@'client-host'_ needs to be able to connect through MaxScale,
-another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the\
+another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the
 same password and similar grants as _'jdoe'@'client-host'_.
 
 The quickest way to do this is to first create the new user:
@@ -73,18 +73,18 @@ Then copy the same grants to the `'jdoe'@'maxscale-host'` user.
 GRANT SELECT, INSERT, UPDATE, DELETE ON *.* TO 'jdoe'@'maxscale-host';
 ```
 
-An alternative to generating two separate accounts is to use one account with a wildcard\
-host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than\
+An alternative to generating two separate accounts is to use one account with a wildcard
+host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than
 having specific user accounts as it allows access from all hosts.
 
 ### Creating the configuration file
 
-MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is\
+MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is
 provided with the MaxScale installation.
 
-A global _maxscale_ section is included in every MaxScale configuration file. This section\
-sets the values of various global parameters, such as the number of threads MaxScale uses\
-to handle client requests. To set thread count to the number of available cpu cores, set\
+A global _maxscale_ section is included in every MaxScale configuration file. This section
+sets the values of various global parameters, such as the number of threads MaxScale uses
+to handle client requests. To set thread count to the number of available cpu cores, set
 the following.
 
 ```
@@ -94,7 +94,7 @@ threads=auto
 
 ### Configuring the servers
 
-Read the [Configuring Servers](mariadb-maxscale-2302-configuring-servers.md) mini-tutorial for server\
+Read the [Configuring Servers](mariadb-maxscale-2302-configuring-servers.md) mini-tutorial for server
 configuration instructions.
 
 ### Configuring the monitor
@@ -111,7 +111,7 @@ For a simple connection based setup, read the [Connection Routing Tutorial](mari
 
 ### Starting MaxScale
 
-After configuration is complete, MariaDB MaxScale is ready to start. For systems that\
+After configuration is complete, MariaDB MaxScale is ready to start. For systems that
 use systemd, use the _systemctl_ command.
 
 ```
@@ -124,13 +124,13 @@ For older SysV systems, use the _service_ command.
 sudo service maxscale start
 ```
 
-If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see\
+If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see
 if any errors are detected in the configuration file.
 
 ### Checking MaxScale status with MaxCtrl
 
-The _maxctrl_-command can be used to confirm that MaxScale is running and the services,\
-listeners and servers have been correctly configured. The following shows expected output\
+The _maxctrl_-command can be used to confirm that MaxScale is running and the services,
+listeners and servers have been correctly configured. The following shows expected output
 when using a read-write-splitting configuration.
 
 ```
@@ -163,7 +163,7 @@ when using a read-write-splitting configuration.
 └───────────────────┴──────┴──────┴─────────┘
 ```
 
-MariaDB MaxScale is now ready to start accepting client connections and route queries to\
+MariaDB MaxScale is now ready to start accepting client connections and route queries to
 the backend cluster.
 
 More options can be found in the [Configuration Guide](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md),[readwritesplit module documentation](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md) and [readconnroute module documentation](../mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readconnroute.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-using-maxgui-tutorial.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This tutorial is an overview of what the MaxGUI offers as an alternative\
+This tutorial is an overview of what the MaxGUI offers as an alternative
 solution to [MaxCtrl](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md).
 
 ## Dashboard
@@ -12,11 +12,11 @@ solution to [MaxCtrl](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-
 ### Annotation
 
 1. [MaxScale object](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#objects). i.e.\
-   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate\
+   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate
    to its detail page)
 2. Create a new MaxScale object.
 3. Dashboard Tab Navigation.
-4. Search Input. This can be used as a quick way to search for a keyword in\
+4. Search Input. This can be used as a quick way to search for a keyword in
    tables.
 5. Dashboard graphs. Refresh interval is 10 seconds.
 
@@ -30,18 +30,18 @@ solution to [MaxCtrl](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-
 
 ### Create a new MaxScale object
 
-Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating\
+Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating
 a new object.
 
 ### View Replication Status
 
-The replication status of a server monitored by [MariaDB-Monitor](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md) can be viewed by mousing over\
+The replication status of a server monitored by [MariaDB-Monitor](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md) can be viewed by mousing over
 the server name. A tooltip will be displayed with the following information:\
 replication\_state, seconds\_behind\_master, slave\_io\_running, slave\_sql\_running.
 
 ### How to kill a session
 
-A session can be killed easily on the "Current Sessions" list which can be\
+A session can be killed easily on the "Current Sessions" list which can be
 found on the [Dashboard](mariadb-maxscale-2302-using-maxgui-tutorial.md#dashboard), Server detail, and Service detail page.
 
 ![](../../../../.gitbook/assets/MaxGUI-kill-session.png.png)
@@ -53,34 +53,34 @@ found on the [Dashboard](mariadb-maxscale-2302-using-maxgui-tutorial.md#dashboar
 
 ## Detail
 
-This page shows information on each MaxScale object and allow to edit its\
-parameter, relationships and perform other manipulation operations. Most of the\
+This page shows information on each MaxScale object and allow to edit its
+parameter, relationships and perform other manipulation operations. Most of the
 control buttons will be shown on the mouse hover. Below is a screenshot of a\
-Monitor Detail page, other Detail pages also have a similar layout structure so\
+Monitor Detail page, other Detail pages also have a similar layout structure so
 this is used for illustration purpose.
 
 ![](../../../../.gitbook/assets/MaxGUI-detail.png.png)
 
 ### Annotation
 
-1. Settings option. Clicking on the gear icon will show icons allowing to do\
+1. Settings option. Clicking on the gear icon will show icons allowing to do
    different operations depending on the type of the Detail page.
 
 * Monitor Detail page, there are icons to Stop, Start, and Destroy monitor.
 * Service Detail page, there are icons to Stop, Start, and Destroy service.
-* Server Detail page, there are icons to Set maintenance mode, Clear server\
+* Server Detail page, there are icons to Set maintenance mode, Clear server
   state, Drain and Delete server.
-* Filter and Listener Detail page, there is a delete icon to delete the\
+* Filter and Listener Detail page, there is a delete icon to delete the
   object.
 
-1. Switchover button. This button is shown on the mouse hover allowing to\
+1. Switchover button. This button is shown on the mouse hover allowing to
    swap the running primary server with a designated secondary server.
-2. Edit parameters button. This button is shown on the mouse hover allowing\
-   to edit the MaxScale object's parameter. Clicking on it will enable editable\
+2. Edit parameters button. This button is shown on the mouse hover allowing
+   to edit the MaxScale object's parameter. Clicking on it will enable editable
    mode on the table. After finishing editing the parameters, simply click the\
    Done Editing button.
-3. A Detail page has tables showing "Relationship" between other MaxScale\
-   object. This "unlink" icon is shown on the mouse hover allowing to\
+3. A Detail page has tables showing "Relationship" between other MaxScale
+   object. This "unlink" icon is shown on the mouse hover allowing to
    remove the relationship between two objects.
 4. This button is used to link other MaxScale objects to the relationship.
 
@@ -96,12 +96,12 @@ This page visualizes MaxScale configuration as shown in the figure below.
 
 #### Annotation
 
-1. A MaxScale object (a node graph). The position of the node in the graph can\
+1. A MaxScale object (a node graph). The position of the node in the graph can
    be changed by dragging and dropping it.
-2. Anchor link. The detail page of each MaxScale object can be accessed by\
+2. Anchor link. The detail page of each MaxScale object can be accessed by
    clicking on the name of the node.
-3. Filter visualization button. By default, if the number of filters used by a\
-   service is larger than 3, filter nodes aren't visualized as shown in the\
+3. Filter visualization button. By default, if the number of filters used by a
+   service is larger than 3, filter nodes aren't visualized as shown in the
    figure. Clicking this button will visualize them.
 4. Hide filter visualization button.
 5. Refresh rate dropdown. The frequency with which the data is refreshed.
@@ -110,42 +110,42 @@ This page visualizes MaxScale configuration as shown in the figure below.
 ### Clusters
 
 This page shows all monitor clusters using [mariadbmon](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md) module in a card-like view.\
-Clicking on the card will visualize the cluster into a tree graph as shown in\
+Clicking on the card will visualize the cluster into a tree graph as shown in
 the figure below.
 
 ![](../../../../.gitbook/assets/MaxGUI-cluster-visualization.png.png)
 
 #### Annotation
 
-1. Drag a secondary server on top of a primary server to promote the secondary\
+1. Drag a secondary server on top of a primary server to promote the secondary
    server as the new primary server.
-2. Server manipulation operations button. Showing a dropdown with the following\
+2. Server manipulation operations button. Showing a dropdown with the following
    operations:
 
 * Set maintenance mode: Setting a server to a maintenance mode.
 * Clear server state: Clear current server state.
 * Drain server: Drain the server of connections.
 
-1. Quick access to query editor button. Opening the `Query Editor` page for\
-   this server. If the connection is already created for that server, it'll use\
-   it. Otherwise, it creates a blank worksheet and shows a connection dialog to\
+1. Quick access to query editor button. Opening the `Query Editor` page for
+   this server. If the connection is already created for that server, it'll use
+   it. Otherwise, it creates a blank worksheet and shows a connection dialog to
    connect to that server.
-2. Carousel navigation button. Viewing more information about the server in the\
+2. Carousel navigation button. Viewing more information about the server in the
    next slide.
 3. Collapse the carousel.
-4. Anchor link of the server. Opening the detail page of the server in a new\
+4. Anchor link of the server. Opening the detail page of the server in a new
    tab.
 5. Collapse its children nodes.
-6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be\
+6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be
    manually rejoined by dragging it on top of the primary server.
-7. Monitor manipulation operations button. Showing a dropdown with the\
+7. Monitor manipulation operations button. Showing a dropdown with the
    following operations:
 
 * Stop monitor.
 * Start monitor.
 * Reset Replication.
 * Release Locks.
-* Master failover. Manually performing a primary failover. This option is\
+* Master failover. Manually performing a primary failover. This option is
   visible only when the `auto_failover` parameter is disabled.
 
 1. Refresh rate dropdown. The frequency with which the data is refreshed.
@@ -159,11 +159,11 @@ This page shows and allows editing of MaxScale parameters.
 
 ### Annotation
 
-1. Edit parameters button. This button is shown on the mouse hover allowing\
-   to edit the MaxScale parameter. Clicking on it will enable editable mode on\
+1. Edit parameters button. This button is shown on the mouse hover allowing
+   to edit the MaxScale parameter. Clicking on it will enable editable mode on
    the table..
 2. Editable parameters are visible as it's illustrated in the screenshot.
-3. After finishing editing the parameters, simply click the Done Editing\
+3. After finishing editing the parameters, simply click the Done Editing
    button.
 
 ## Logs Archive
@@ -185,7 +185,7 @@ On this page, you may add numerous worksheets, each of which can be used for eit
 
 ### Run Queries
 
-Clicking on the "Run Queries" card will pop-up a dialog, providing options\
+Clicking on the "Run Queries" card will pop-up a dialog, providing options
 to establish a connection to different MaxScale object types, including\
 "Listener, Server, Service".
 
@@ -199,10 +199,10 @@ There are various features in the Query Editor worksheet, the most notable ones 
 
 **Create a new connection**
 
-If the connection of the Query Editor expires, or if you wish to make\
-a new connection for the active worksheet, simply clicking on the button\
-located on the right side of the query tabs navigation bar which features a\
-server icon and an active connection name as a label. This will open the\
+If the connection of the Query Editor expires, or if you wish to make
+a new connection for the active worksheet, simply clicking on the button
+located on the right side of the query tabs navigation bar which features a
+server icon and an active connection name as a label. This will open the
 connection dialog and allow you to create a new connection.
 
 **Schemas objects sidebar**
@@ -212,7 +212,7 @@ connection dialog and allow you to create a new connection.
 There are two ways to set the current database:
 
 * Double-click on the name of the database.
-* Right-click on the name of the database to show the context menu, then select\
+* Right-click on the name of the database to show the context menu, then select
   the `Use database` option.
 
 **Preview table data of the top 1000 rows**
@@ -220,7 +220,7 @@ There are two ways to set the current database:
 There are two ways to preview data of a table:
 
 * Click on the name of the table.
-* Right-click on the name of the table to show the context menu, then select\
+* Right-click on the name of the table to show the context menu, then select
   the `Preview Data (top 1000)` option.
 
 **Describe table**
@@ -229,7 +229,7 @@ Right-click on the name of the table to show the context menu, then select the`V
 
 **Alter/Drop/Truncate table**
 
-Right-click on the name of the table to show the context menu, then select the\
+Right-click on the name of the table to show the context menu, then select the
 desired option.
 
 **Quickly insert an object into the editor**
@@ -237,7 +237,7 @@ desired option.
 There are two ways to quickly insert an object to the editor:
 
 * Drag the object and drop it in the desire position in the editor.
-* Right-click on the object to show the context menu, then mouse\
+* Right-click on the object to show the context menu, then mouse
   hover the `Place to Editor` option and select the desired insert option.
 
 **Editor**
@@ -247,44 +247,44 @@ Visual Studio Code.
 
 To see the command palette, press F1 while the cursor is active on the editor.
 
-The editor also comes with various options to assist your querying tasks. To see\
+The editor also comes with various options to assist your querying tasks. To see
 available options, right-click on the editor to show the context menu.
 
 **Re-execute old queries**
 
 Every executed query will be saved in the browser's storage (IndexedDB).\
 Query history can be seen in the `History/Snippets` tab.\
-To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2302-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)\
+To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2302-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)
 and click the execute query button in the editor.
 
 **Create query snippet**
 
 Press CTRL/CMD + D to save the current SQL in the editor to the snippets storage.\
-A snippet is created with a prefix keyword, so when that keyword is typed in\
+A snippet is created with a prefix keyword, so when that keyword is typed in
 the editor, it will be suggested in the "code completion" menu.
 
 ### Data Migration
 
-Clicking on the "Data Migration" card will pop-up a dialog, providing an option\
-to name the task. The Data Migration worksheet will be rendered in the active\
+Clicking on the "Data Migration" card will pop-up a dialog, providing an option
+to name the task. The Data Migration worksheet will be rendered in the active
 worksheet after clicking the `Create` button in the dialog.
 
 #### Data Migration worksheet
 
-MaxScale uses ODBC for extracting and loading from the data source to a server\
-in MaxScale. Before starting a migration, ensure that you have set up the\
-necessary configurations on the MaxScale server. Instruction can be found [here](../mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource.md#prepare-etl-operation)\
+MaxScale uses ODBC for extracting and loading from the data source to a server
+in MaxScale. Before starting a migration, ensure that you have set up the
+necessary configurations on the MaxScale server. Instruction can be found [here](../mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource.md#prepare-etl-operation)
 and limitations [here](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md#etl-limitations).
 
 **Connections**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-data-migration-set-up-connections.png.png)
 
-Source connection shows the most common parameter inputs for creating\
-an ODBC connection. For extra parameters, enable the `Advanced` mode\
+Source connection shows the most common parameter inputs for creating
+an ODBC connection. For extra parameters, enable the `Advanced` mode
 to manually edit the `Connection String` input.
 
-After successfully connected to both source and destination servers,\
+After successfully connected to both source and destination servers,
 click on the `Select objects to migrate` to navigate to the next stage.
 
 **Objects Selection**
@@ -293,35 +293,35 @@ click on the `Select objects to migrate` to navigate to the next stage.
 
 Select the objects you wish to migrate to the MariaDB server.
 
-After selecting the desired objects, click on the `Prepare Migration Script` to\
-navigate to the next stage. The migration scripts will be generated\
-differently based on the value selected for the `Create mode` input. Hover over\
+After selecting the desired objects, click on the `Prepare Migration Script` to
+navigate to the next stage. The migration scripts will be generated
+differently based on the value selected for the `Create mode` input. Hover over
 the question icon for additional information on the modes.
 
 **Migration**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-data-migration-migration-script.png.png)
 
-As shown in the screenshot, you can quickly modify the script for each object\
-by selecting the corresponding object in the table and using the editors on the\
+As shown in the screenshot, you can quickly modify the script for each object
+by selecting the corresponding object in the table and using the editors on the
 right-hand side to make any necessary changes.
 
-After clicking the `Start Migration` button, the script for each object will be\
+After clicking the `Start Migration` button, the script for each object will be
 executed in parallel.
 
 **Migration report**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-data-migration-migration-report.png.png)
 
-If errors are reported for certain objects, review the output messages and\
+If errors are reported for certain objects, review the output messages and
 adjust the script accordingly. Then, click the `Manage` button and select `Restart`.
 
-To migrate additional objects, click the `Manage` button and select`Migrate other objects`. Doing so will replace the current migration\
+To migrate additional objects, click the `Manage` button and select`Migrate other objects`. Doing so will replace the current migration
 report for the current object with a new one.
 
 To retain the report and terminate open connections after migration, click the`Manage` button, then select `Disconnect`, and finally delete the worksheet.
 
-Deleting the worksheet will not delete the migration task. To clean-up\
+Deleting the worksheet will not delete the migration task. To clean-up
 everything after migration, click the `Manage` button, then select`Delete`.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-maxscale-2302-upgrading-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-maxscale-2302-upgrading-mariadb-maxscale.md
@@ -2,7 +2,7 @@
 
 For more information about what has changed, please refer to the [ChangeLog](../maxscale-23.02-changelog.md) and to the [release notes](https://mariadb.com/kb/Release-Notes/).
 
-Before starting the upgrade, any existing configuration files should\
+Before starting the upgrade, any existing configuration files should
 be backed up.
 
 ## Upgrading MariaDB MaxScale from 22.08 to 23.02
@@ -17,24 +17,24 @@ be backed up.
 
 ### Removed Features
 
-* The support for legacy encryption keys generated with `maxkeys` from pre-2.5\
-  versions has been removed. This feature was deprecated in MaxScale 2.5 when\
-  the new key storage format was introduced. To migrate to the new key storage\
+* The support for legacy encryption keys generated with `maxkeys` from pre-2.5
+  versions has been removed. This feature was deprecated in MaxScale 2.5 when
+  the new key storage format was introduced. To migrate to the new key storage
   format, create a new key file with `maxkeys` and re-encrypt the passwords with`maxpasswd`.
 * The deprecated Database Firewall filter has been removed.
 
 ## Upgrading MariaDB MaxScale from 2.5 to 21.06
 
-**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have\
-been released as 6.4.16 in June, was released as 21.06.16. The purpose of this\
-change is to make the versioning scheme used by all MaxScale series\
+**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have
+been released as 6.4.16 in June, was released as 21.06.16. The purpose of this
+change is to make the versioning scheme used by all MaxScale series
 identical. 21.06 denotes the year and month when the first 6 release was made.
 
 ### Duration Type Parameters
 
 Using duration type parameters without an explicit suffix has been deprecated in\
 MaxScale 2.4. In MaxScale 6 they are no longer allowed when used with the REST\
-API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that\
+API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that
 use a duration type parameter must explicitly specify the suffix of the unit.
 
 For example, the following command:
@@ -49,8 +49,8 @@ should be replaced with:
 maxctrl alter service My-Service connection_keepalive 30000ms
 ```
 
-Duration type parameters can still be defined in the configuration file without\
-an explicit suffix but this behavior is deprecated. The recommended approach is\
+Duration type parameters can still be defined in the configuration file without
+an explicit suffix but this behavior is deprecated. The recommended approach is
 to add explicit suffixes to all duration type parameters when upgrading to\
 MaxScale 6.
 
@@ -72,22 +72,22 @@ The following deprecated core parameters have been removed:
 
 The deprecated aliases for the schemarouter parameters `ignore_databases` and`ignore_databases_regex` have been removed. They can be replaced with`ignore_tables` and `ignore_tables_regex`.
 
-In addition, the `preferred_server` parameter that was deprecated in 2.5 has\
+In addition, the `preferred_server` parameter that was deprecated in 2.5 has
 also been removed.
 
 #### `mariadbmon`
 
-* MariaDBMonitor settings `ignore_external_masters`, `detect_replication_lagdetect_standalone_master`, `detect_stale_master` and `detect_stale_slave`\
-  have been removed. The first two were ineffective, the latter three are\
+* MariaDBMonitor settings `ignore_external_masters`, `detect_replication_lagdetect_standalone_master`, `detect_stale_master` and `detect_stale_slave`
+  have been removed. The first two were ineffective, the latter three are
   replaced by `master_conditions` and `slave_conditions`.
 
 ### Session Command History
 
-The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`\
-have been made into generic service parameters that are shared between all\
+The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`
+have been made into generic service parameters that are shared between all
 routers that support it.
 
-The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it\
+The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it
 being enabled or are not affected by it.
 
 ## Upgrading MariaDB MaxScale from 2.4 to 2.5
@@ -95,33 +95,33 @@ being enabled or are not affected by it.
 ### MaxAdmin
 
 The deprecated MaxAdmin interface has been removed in 2.5.0 in favor of the REST\
-API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can\
+API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can
 no longer be used.
 
 ### Authentication
 
-The credentials used by services now require additional grants. For a full list\
+The credentials used by services now require additional grants. For a full list
 of required grants, refer to the [protocol documentation](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md).
 
 ### MariaDB-Monitor
 
-The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in\
+The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in
 a later version.
 
 #### Password encryption
 
-The encrypted passwords feature has been updated to be more secure. Users are\
-recommended to generate a new encryption key and re-encrypt their passwords\
+The encrypted passwords feature has been updated to be more secure. Users are
+recommended to generate a new encryption key and re-encrypt their passwords
 using the `maxkeys` and `maxpasswd` utilities. Old passwords still work.
 
 ### Default Server State
 
-The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally\
+The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally
 used before they were monitored.
 
 ### Columnstore Monitor
 
-It is now mandatory to specify in the configuration what version the\
+It is now mandatory to specify in the configuration what version the
 monitored Columnstore cluster is.
 
 ```
@@ -132,20 +132,20 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)\
+Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)
 for details.
 
 ### New binlog router
 
-The binlog router delivered with MaxScale 2.5 is completely new and\
-not 100% backward compatible with the binlog router delivered with\
-earlier MaxScale versions. If you use the binlog router, carefully\
-assess whether the functionality provided by the new one fulfills\
+The binlog router delivered with MaxScale 2.5 is completely new and
+not 100% backward compatible with the binlog router delivered with
+earlier MaxScale versions. If you use the binlog router, carefully
+assess whether the functionality provided by the new one fulfills
 your requirements, before upgrading MaxScale.
 
 ### Tee Filter
 
-The tee filter parameter `service` has been deprecated in favor of the `target`\
+The tee filter parameter `service` has been deprecated in favor of the `target`
 parameter. All usages of `service` can be replaced with `target`.
 
 ## Upgrading MariaDB MaxScale from 2.3 to 2.4
@@ -154,10 +154,10 @@ parameter. All usages of `service` can be replaced with `target`.
 
 #### Reserved Names
 
-Section and object names starting with `@@` are now reserved for\
+Section and object names starting with `@@` are now reserved for
 internal use by MaxScale.
 
-In case such names have been used, they must manually be changed\
+In case such names have been used, they must manually be changed
 in all configuration files of MaxScale, before MaxScale 2.4 is started.
 
 Those files are:
@@ -168,7 +168,7 @@ Those files are:
 
 #### Whitespace in Names
 
-Whitespace in section names that was deprecated in MaxScale 2.2 will now be\
+Whitespace in section names that was deprecated in MaxScale 2.2 will now be
 rejected, which will cause the startup of MaxScale to fail.
 
 To prevent that, section names like
@@ -195,11 +195,11 @@ servers=MyServer
 
 ### Durations
 
-Durations can now be specified using one of the suffixes `h`, `m`, `s`\
-and `ms` for specifying durations in hours, minutes, seconds and\
+Durations can now be specified using one of the suffixes `h`, `m`, `s`
+and `ms` for specifying durations in hours, minutes, seconds and
 milliseconds, respectively.
 
-_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,\
+_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,
 so it is advisable to add suffixes to durations. For instance,
 
 ```
@@ -209,12 +209,12 @@ some_param=60000ms
 
 ### Improved Admin User Encryption
 
-MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a\
+MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a
 user to use the better hashing algorithm, either recreate the user or use the`maxctrl alter user` command.
 
 ### MariaDB-Monitor
 
-The following settings have been removed and cause a startup error\
+The following settings have been removed and cause a startup error
 if defined:
 
 * `mysql51_replication`
@@ -223,45 +223,45 @@ if defined:
 
 ### ReadWriteSplit
 
-* If multiple masters are available for a readwritesplit service, the one with\
+* If multiple masters are available for a readwritesplit service, the one with
   the lowest connection count is selected.
-* If a master server is placed into maintenance mode, all open transactions are\
-  allowed to gracefully finish before the session is closed. To forcefully close\
+* If a master server is placed into maintenance mode, all open transactions are
+  allowed to gracefully finish before the session is closed. To forcefully close
   the connections, use the `--force` option for `maxctrl set server`.
-* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the\
+* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the
   overall load on the system when connections are rapidly opened and closed.
-* Transaction replays now have a limit on how many times a replay is\
+* Transaction replays now have a limit on how many times a replay is
   attempted. The default values is five attempts and is controlled by the`transaction_replay_attempts` parameter.
-* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the\
+* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the
   transaction is automatically retried.
 
 ## Upgrading MariaDB MaxScale from 2.2 to 2.3
 
 ### Increased Memory Use
 
-Starting with MaxScale 2.3.0 up to 40% of the memory can be used for\
-caching parsed queries. The most noticeable change is that it improves\
-performance in almost all cases where queries need to be parsed. Most of\
+Starting with MaxScale 2.3.0 up to 40% of the memory can be used for
+caching parsed queries. The most noticeable change is that it improves
+performance in almost all cases where queries need to be parsed. Most of
 the time this happens when the readwritesplit router or filters are used.
 
-The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total\
-memory to 1GB, add `query_classifier_cache_size=1G` to your\
+The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total
+memory to 1GB, add `query_classifier_cache_size=1G` to your
 configuration. To disable it, set the value to `0`.
 
-In addition to the aforementioned query classifier caching, the\
-readwritesplit session command history is enabled by default in 2.3 but is\
-limited to a maximum of 50 commands after which the history is\
-disabled. This is unlikely to show in any metrics but it contributes to\
+In addition to the aforementioned query classifier caching, the
+readwritesplit session command history is enabled by default in 2.3 but is
+limited to a maximum of 50 commands after which the history is
+disabled. This is unlikely to show in any metrics but it contributes to
 the increased memory foorprint of MaxScale.
 
 ### Unknown Global Parameters
 
-All unknown parameters are now treated as errors. Check your configuration for\
+All unknown parameters are now treated as errors. Check your configuration for
 errors if MaxScale fails to start after upgrading to 2.3.1.
 
 ### `passwd` is deprecated
 
-In the configuration file, passwords for monitors and services should be\
+In the configuration file, passwords for monitors and services should be
 specified using `password`; the support for the deprecated`passwd` will be removed in the future. That is, the following
 
 ```
@@ -298,61 +298,61 @@ Authenticator options are now only used with listeners.
 
 #### Administrative Users
 
-The file format for the administrative users used by MaxScale has been\
-changed. Old style files are automatically upgraded and a backup of the old file is\
+The file format for the administrative users used by MaxScale has been
+changed. Old style files are automatically upgraded and a backup of the old file is
 stored in `/var/lib/maxscale/passwd.backup`.
 
 #### Regular Expression Parameters
 
-Modules may now use a built-in regular expression string parameter type instead\
-of a normal string when accepting patterns. The modules that use the new regex\
-parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the\
+Modules may now use a built-in regular expression string parameter type instead
+of a normal string when accepting patterns. The modules that use the new regex
+parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the
 string in slashes, e.g. `match=/^select/` defines the pattern `^select`.
 
 #### Binlog Server
 
-Binlog server automatically accepts GTID connection from MariaDB 10 slave servers\
+Binlog server automatically accepts GTID connection from MariaDB 10 slave servers
 by saving all incoming GTIDs into a SQLite map database.
 
 #### MaxCtrl Included in Main Package
 
-In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2\
-it is in the main `maxscale` package. If you have a previous installation\
+In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2
+it is in the main `maxscale` package. If you have a previous installation
 of MaxCtrl, please remove it before upgrading to MaxScale 2.2.2.
 
 ## Upgrading MariaDB MaxScale from 2.0 to 2.1
 
 ### IPv6 Support
 
-MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to\
-was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,\
+MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to
+was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,
 add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)\
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files
 
-The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The\
+The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The
 default location for the log file is _/var/log/maxscale/maxscale.log_.
 
-Rotating the log files will cause MaxScale to reopen the file instead of\
+Rotating the log files will cause MaxScale to reopen the file instead of
 renaming them. This makes the MaxScale logging facility _logrotate_ compatible.
 
 ### ReadWriteSplit
 
-The `disable_sescmd_history` option is now enabled by default. This means that\
-slaves will not be recovered mid-session even if a replacement slave is\
-available. To enable the legacy behavior, add the `disable_sescmd_history=true`\
+The `disable_sescmd_history` option is now enabled by default. This means that
+slaves will not be recovered mid-session even if a replacement slave is
+available. To enable the legacy behavior, add the `disable_sescmd_history=true`
 parameter to the service definition.
 
 ### Persistent Connections
 
-The MariaDB session state is reset in MaxScale 2.1 for persistent\
-connections. This means that any modifications to the session state (default\
-database, user variable etc.) will not survive if the connection is put into the\
+The MariaDB session state is reset in MaxScale 2.1 for persistent
+connections. This means that any modifications to the session state (default
+database, user variable etc.) will not survive if the connection is put into the
 connection pool. For most users, this is the expected behavior.
 
 ### User Data Cache
@@ -361,27 +361,27 @@ The location of the MariaDB user data cache was moved from`/var/cache/maxscale/<
 
 ### Galeramon Monitoring Algorithm
 
-Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with\
+Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with
 multiple MaxScales but it also causes slower changes of the master node.
 
-To enable the legacy behavior, add `root_node_as_master=false` to the Galera\
+To enable the legacy behavior, add `root_node_as_master=false` to the Galera
 monitor configuration.
 
 ### MaxAdmin Editing Mode
 
-The default editing mode was changed from _vim_ to _emacs_ mode. To start\
+The default editing mode was changed from _vim_ to _emacs_ mode. To start
 maxadmin in the legacy mode, use the `-i` option.
 
 ## Upgrading MariaDB MaxScale from 1.4 to 2.0
 
 ### MaxAdmin
 
-The default way the communication between MaxAdmin and MariaDB MaxScale is\
+The default way the communication between MaxAdmin and MariaDB MaxScale is
 handled has been changed from an internet socket to a Unix domain socket.\
 The former alternative is still available but has been _deprecated_.
 
 If no arguments are given to MaxAdmin, it will attempt to connect to\
-MariaDB MaxScale using a Unix domain socket. After the upgrade you will\
+MariaDB MaxScale using a Unix domain socket. After the upgrade you will
 need to provide at least one internet socket related flag - `-h`, `-P`,`-u` or `-p` - to force MaxAdmin to use the internet socket approach.
 
 E.g.
@@ -393,16 +393,16 @@ user@host $ maxadmin -u admin
 ### MySQL Monitor
 
 The MySQL Monitor now assigns the stale state to the master server by default.\
-In addition to this, the slave servers receive the stale slave state when they\
-lose the connection to the master. This should not cause changes in behavior\
+In addition to this, the slave servers receive the stale slave state when they
+lose the connection to the master. This should not cause changes in behavior
 but the output of MaxAdmin will show new states when replication is broken.
 
 ## Upgrading MaxScale from 1.3 to 1.4
 
 ### Service user permissions
 
-The service users now also need SELECT privileges on mysql.tables\_priv. This is\
-required for the resolution of table level grants. To grant SELECT privileges\
+The service users now also need SELECT privileges on mysql.tables\_priv. This is
+required for the resolution of table level grants. To grant SELECT privileges
 for the service user, replace the user and hostname in the following example.
 
 ```
@@ -417,8 +417,8 @@ For more information about how to do this, please read the installation guide:[M
 
 ### SSL
 
-The SSL configuration parameters are now a part of the listeners. If a service\
-used the old style SSL configuration parameters, the values should be moved to\
+The SSL configuration parameters are now a part of the listeners. If a service
+used the old style SSL configuration parameters, the values should be moved to
 the listener which is associated with that service.
 
 Here is an example of an old style configuration.
@@ -463,23 +463,23 @@ ssl_ca_cert=/home/user/certs/ca.pem
 ssl_version=TLSv12
 ```
 
-Please also note that the `enabled` SSL mode is no longer supported due to\
-the inherent security issues with allowing SSL and non-SSL connections on\
-the same port. In addition to this, SSLv3 is no longer supported due to\
+Please also note that the `enabled` SSL mode is no longer supported due to
+the inherent security issues with allowing SSL and non-SSL connections on
+the same port. In addition to this, SSLv3 is no longer supported due to
 vulnerabilities found in it.
 
 ## Upgrading MaxScale from 1.2 to 1.3
 
 ### Binlog Router
 
-The master server details are now provided with a **master.ini** file located in\
-the binlog directory and it can be changed using a CHANGE MASTER TO command issued\
+The master server details are now provided with a **master.ini** file located in
+the binlog directory and it can be changed using a CHANGE MASTER TO command issued
 via a MySQL connection to MaxScale.
 
-This file, properly filled, is now mandatory and without it the binlog router\
+This file, properly filled, is now mandatory and without it the binlog router
 cannot connect to the master database.
 
-Before starting binlog router after MaxScale 1.3 upgrade, please add relevant\
+Before starting binlog router after MaxScale 1.3 upgrade, please add relevant
 information to _master.ini_, example:
 
 ```
@@ -491,26 +491,26 @@ master_password=somepass
 filestem=repl-bin
 ```
 
-Additionally, the option `servers=masterdb` in the service definition is no\
+Additionally, the option `servers=masterdb` in the service definition is no
 longer required.
 
 ## Upgrading MaxScale from 1.1 to 1.2
 
-This document describes upgrading MaxScale from version 1.1.1 to 1.2 and\
-the major differences in the new version compared to the old version. The\
-major changes can be found in the `Changelog.txt` file in the installation\
+This document describes upgrading MaxScale from version 1.1.1 to 1.2 and
+the major differences in the new version compared to the old version. The
+major changes can be found in the `Changelog.txt` file in the installation
 directory and the official release notes in the `ReleaseNotes.txt` file.
 
 ### Installation
 
 Upgrading MaxScale will copy the `MaxScale.cnf` file in`/usr/local/mariadb-maxscale/etc/` to `/etc/` and renamed to `maxscale.cnf`.\
-Binary log files are not automatically copied and should be manually moved\
+Binary log files are not automatically copied and should be manually moved
 from `/usr/local/mariadb-maxscale` to `/var/lib/maxscale/`.
 
 ### File location changes
 
-MaxScale 1.2 follows the [FHS-standard](https://www.pathname.com/fhs/) and\
-installs to `/usr/` and `/var/` subfolders. Here are the major changes and\
+MaxScale 1.2 follows the [FHS-standard](https://www.pathname.com/fhs/) and
+installs to `/usr/` and `/var/` subfolders. Here are the major changes and
 file locations.
 
 * Configuration files are located in `/etc/` and use lowercase letters: `/etc/maxscale.cnf`
@@ -522,26 +522,26 @@ file locations.
 
 ### Running MaxScale without root permissions
 
-MaxScale can run as a non-root user with the 1.2 version. RPM and DEB\
-packages install the `maxscale` user and `maxscale` group which are used\
-by the init scripts and systemd configuration files. If you are installing\
-from a binary tarball, you can run the `postinst` script included in it to\
+MaxScale can run as a non-root user with the 1.2 version. RPM and DEB
+packages install the `maxscale` user and `maxscale` group which are used
+by the init scripts and systemd configuration files. If you are installing
+from a binary tarball, you can run the `postinst` script included in it to
 manually create these groups.
 
 ## Upgrading MaxScale from 1.0 to 1.1
 
-This document describes upgrading MaxScale from version 1.0.5 to 1.1.0 and\
-the major differences in the new version compared to the old version. The\
-major changes can be found in the `Changelog.txt` file in the installation\
+This document describes upgrading MaxScale from version 1.0.5 to 1.1.0 and
+the major differences in the new version compared to the old version. The
+major changes can be found in the `Changelog.txt` file in the installation
 directory and the official release notes in the `ReleaseNotes.txt` file.
 
 ### Installation
 
-If you are installing MaxScale from a RPM package, we recommend you back\
-up your configuration and log files and that you remove the old installation\
-of MaxScale completely. If you choose to upgrade MaxScale instead of removing\
-it and re-installing it afterwards, the init scripts in `/etc/init.d` folder\
-will be missing. This is due to the RPM packaging system but the script can\
+If you are installing MaxScale from a RPM package, we recommend you back
+up your configuration and log files and that you remove the old installation
+of MaxScale completely. If you choose to upgrade MaxScale instead of removing
+it and re-installing it afterwards, the init scripts in `/etc/init.d` folder
+will be missing. This is due to the RPM packaging system but the script can
 be re-installed by running the `postinst` script found in the`/usr/local/mariadb-maxscale` folder.
 
 ```
@@ -550,14 +550,14 @@ cd /usr/local/mariadb-maxscale
 ./postinst
 ```
 
-The 1.1.0 version of MaxScale installs into `/usr/local/mariadb-maxscale`\
-instead of `/usr/local/skysql/maxscale`. This will cause external references\
-to MaxScale's home directory to stop working so remember to update all\
+The 1.1.0 version of MaxScale installs into `/usr/local/mariadb-maxscale`
+instead of `/usr/local/skysql/maxscale`. This will cause external references
+to MaxScale's home directory to stop working so remember to update all
 paths with the new version.
 
 ### MaxAdmin changes
 
-The MaxAdmin client's default password in MaxScale 1.1.0 is `mariadb`\
+The MaxAdmin client's default password in MaxScale 1.1.0 is `mariadb`
 instead of `skysql`.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-14-to-20.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-14-to-20.md
@@ -7,17 +7,17 @@ For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog](bro
 
 ### Installation
 
-Before starting the upgrade, we **strongly** recommend you back up your current\
+Before starting the upgrade, we **strongly** recommend you back up your current
 configuration file.
 
 ### MaxAdmin
 
-The default way the communication between MaxAdmin and MariaDB MaxScale is\
+The default way the communication between MaxAdmin and MariaDB MaxScale is
 handled has been changed from an internet socket to a Unix domain socket.\
 The former alternative is still available but has been _deprecated_.
 
 If no arguments are given to MaxAdmin, it will attempt to connect to\
-MariaDB MaxScale using a Unix domain socket. After the upgrade you will\
+MariaDB MaxScale using a Unix domain socket. After the upgrade you will
 need to provide at least one internet socket related flag - `-h`, `-P`,`-u` or `-p` - to force MaxAdmin to use the internet socket approach.
 
 E.g.
@@ -29,8 +29,8 @@ user@host $ maxadmin -u admin
 ### MySQL Monitor
 
 The MySQL Monitor now assigns the stale state to the master server by default.\
-In addition to this, the slave servers receive the stale slave state when they\
-lose the connection to the master. This should not cause changes in behavior\
+In addition to this, the slave servers receive the stale slave state when they
+lose the connection to the master. This should not cause changes in behavior
 but the output of MaxAdmin will show new states when replication is broken.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -7,40 +7,40 @@ For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog]
 
 ### Installation
 
-Before starting the upgrade, we **strongly** recommend you back up your current\
+Before starting the upgrade, we **strongly** recommend you back up your current
 configuration file.
 
 ### IPv6 Support
 
-MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to\
-was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,\
+MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to
+was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,
 add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)\
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files
 
-The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The\
+The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The
 default location for the log file is _/var/log/maxscale/maxscale.log_.
 
-Rotating the log files will cause MaxScale to reopen the file instead of\
+Rotating the log files will cause MaxScale to reopen the file instead of
 renaming them. This makes the MaxScale logging facility _logrotate_ compatible.
 
 ### ReadWriteSplit
 
-The `disable_sescmd_history` option is now enabled by default. This means that\
-slaves will not be recovered mid-session even if a replacement slave is\
-available. To enable the legacy behavior, add the `disable_sescmd_history=true`\
+The `disable_sescmd_history` option is now enabled by default. This means that
+slaves will not be recovered mid-session even if a replacement slave is
+available. To enable the legacy behavior, add the `disable_sescmd_history=true`
 parameter to the service definition.
 
 ### Persistent Connections
 
-The MariaDB session state is reset in MaxScale 2.1 for persistent\
-connections. This means that any modifications to the session state (default\
-database, user variable etc.) will not survive if the connection is put into the\
+The MariaDB session state is reset in MaxScale 2.1 for persistent
+connections. This means that any modifications to the session state (default
+database, user variable etc.) will not survive if the connection is put into the
 connection pool. For most users, this is the expected behavior.
 
 ### User Data Cache
@@ -49,15 +49,15 @@ The location of the MariaDB user data cache was moved from`/var/cache/maxscale/<
 
 ### Galeramon Monitoring Algorithm
 
-Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with\
+Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with
 multiple MaxScales but it also causes slower changes of the master node.
 
-To enable the legacy behavior, add `root_node_as_master=false` to the Galera\
+To enable the legacy behavior, add `root_node_as_master=false` to the Galera
 monitor configuration.
 
 ### MaxAdmin Editing Mode
 
-The default editing mode was changed from _vim_ to _emacs_ mode. To start\
+The default editing mode was changed from _vim_ to _emacs_ mode. To start
 maxadmin in the legacy mode, use the `-i` option.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-21-to-22.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-21-to-22.md
@@ -5,31 +5,31 @@ This document describes possible issues upgrading MariaDB MaxScale from version\
 
 For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, we recommend you back up your current configuration\
+Before starting the upgrade, we recommend you back up your current configuration
 file.
 
 #### Administrative Users
 
-The file format for the administrative users used by MaxScale has been\
-changed. Old style files are automatically upgraded and a backup of the old file is\
+The file format for the administrative users used by MaxScale has been
+changed. Old style files are automatically upgraded and a backup of the old file is
 stored in `/var/lib/maxscale/passwd.backup`.
 
 #### Regular Expression Parameters
 
-Modules may now use a built-in regular expression string parameter type instead\
-of a normal string when accepting patterns. The modules that use the new regex\
-parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the\
+Modules may now use a built-in regular expression string parameter type instead
+of a normal string when accepting patterns. The modules that use the new regex
+parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the
 string in slashes, e.g. `match=/^select/` defines the pattern `^select`.
 
 #### Binlog Server
 
-Binlog server automatically accepts GTID connection from MariaDB 10 slave servers\
+Binlog server automatically accepts GTID connection from MariaDB 10 slave servers
 by saving all incoming GTIDs into a SQLite map database.
 
 #### MaxCtrl Included in Main Package
 
-In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2\
-it is in the main `maxscale` package. If you have a previous installation\
+In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2
+it is in the main `maxscale` package. If you have a previous installation
 of MaxCtrl, please remove it before upgrading to MaxScale 2.2.2.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-22-to-23.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-22-to-23.md
@@ -3,37 +3,37 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.2 to 2.3.
 
-For more information about MariaDB MaxScale 2.3, please refer\
+For more information about MariaDB MaxScale 2.3, please refer
 to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, we recommend you back up your current\
+Before starting the upgrade, we recommend you back up your current
 configuration file.
 
 ### Increased Memory Use
 
-Starting with MaxScale 2.3.0 up to 40% of the memory can be used for\
-caching parsed queries. The most noticeable change is that it improves\
-performance in almost all cases where queries need to be parsed. Most of\
+Starting with MaxScale 2.3.0 up to 40% of the memory can be used for
+caching parsed queries. The most noticeable change is that it improves
+performance in almost all cases where queries need to be parsed. Most of
 the time this happens when the readwritesplit router or filters are used.
 
-The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total\
-memory to 1GB, add `query_classifier_cache_size=1G` to your\
+The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total
+memory to 1GB, add `query_classifier_cache_size=1G` to your
 configuration. To disable it, set the value to `0`.
 
-In addition to the aforementioned query classifier caching, the\
-readwritesplit session command history is enabled by default in 2.3 but is\
-limited to a maximum of 50 commands after which the history is\
-disabled. This is unlikely to show in any metrics but it contributes to\
+In addition to the aforementioned query classifier caching, the
+readwritesplit session command history is enabled by default in 2.3 but is
+limited to a maximum of 50 commands after which the history is
+disabled. This is unlikely to show in any metrics but it contributes to
 the increased memory foorprint of MaxScale.
 
 ### Unknown Global Parameters
 
-All unknown parameters are now treated as errors. Check your configuration for\
+All unknown parameters are now treated as errors. Check your configuration for
 errors if MaxScale fails to start after upgrading to 2.3.1.
 
 ### `passwd` is deprecated
 
-In the configuration file, passwords for monitors and services should be\
+In the configuration file, passwords for monitors and services should be
 specified using `password`; the support for the deprecated`passwd` will be removed in the future. That is, the following
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md
@@ -1,11 +1,11 @@
 # Upgrading MariaDB MaxScale from 22.08 to 23.02
 
-This document describes possible issues when upgrading MariaDB MaxScale from\
+This document describes possible issues when upgrading MariaDB MaxScale from
 version 22.08 to 23.02.
 
 For more information about MaxScale 23.02, refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, any existing configuration files should be backed\
+Before starting the upgrade, any existing configuration files should be backed
 up.
 
 ## Removed Features

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-23-to-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-23-to-24.md
@@ -3,20 +3,20 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.3 to 2.4.
 
-For more information about MariaDB MaxScale 2.4, please refer\
+For more information about MariaDB MaxScale 2.4, please refer
 to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, we recommend you back up your current\
+Before starting the upgrade, we recommend you back up your current
 configuration file.
 
 ### Section Names
 
 #### Reserved Names
 
-Section and object names starting with `@@` are now reserved for\
+Section and object names starting with `@@` are now reserved for
 internal use by MaxScale.
 
-In case such names have been used, they must manually be changed\
+In case such names have been used, they must manually be changed
 in all configuration files of MaxScale, before MaxScale 2.4 is started.
 
 Those files are:
@@ -27,7 +27,7 @@ Those files are:
 
 #### Whitespace in Names
 
-Whitespace in section names that was deprecated in MaxScale 2.2 will now be\
+Whitespace in section names that was deprecated in MaxScale 2.2 will now be
 rejected, which will cause the startup of MaxScale to fail.
 
 To prevent that, section names like
@@ -54,11 +54,11 @@ servers=MyServer
 
 ### Durations
 
-Durations can now be specified using one of the suffixes `h`, `m`, `s`\
-and `ms` for specifying durations in hours, minutes, seconds and\
+Durations can now be specified using one of the suffixes `h`, `m`, `s`
+and `ms` for specifying durations in hours, minutes, seconds and
 milliseconds, respectively.
 
-_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,\
+_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,
 so it is advisable to add suffixes to durations. For instance,
 
 ```
@@ -68,12 +68,12 @@ some_param=60000ms
 
 ### Improved Admin User Encryption
 
-MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a\
+MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a
 user to use the better hashing algorithm, either recreate the user or use the`maxctrl alter user` command.
 
 ### MariaDB-Monitor
 
-The following settings have been removed and cause a startup error\
+The following settings have been removed and cause a startup error
 if defined:
 
 * `mysql51_replication`
@@ -82,16 +82,16 @@ if defined:
 
 ### ReadWriteSplit
 
-* If multiple masters are available for a readwritesplit service, the one with\
+* If multiple masters are available for a readwritesplit service, the one with
   the lowest connection count is selected.
-* If a master server is placed into maintenance mode, all open transactions are\
-  allowed to gracefully finish before the session is closed. To forcefully close\
+* If a master server is placed into maintenance mode, all open transactions are
+  allowed to gracefully finish before the session is closed. To forcefully close
   the connections, use the `--force` option for `maxctrl set server`.
-* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the\
+* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the
   overall load on the system when connections are rapidly opened and closed.
-* Transaction replays now have a limit on how many times a replay is\
+* Transaction replays now have a limit on how many times a replay is
   attempted. The default values is five attempts and is controlled by the`transaction_replay_attempts` parameter.
-* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the\
+* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the
   transaction is automatically retried.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -5,39 +5,39 @@ MaxScale from version 2.4 to 2.5.
 
 For more information about MaxScale 2.5, refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, any existing configuration files should be\
+Before starting the upgrade, any existing configuration files should be
 backed up.
 
 ### MaxAdmin
 
 The deprecated MaxAdmin interface has been removed in 2.5.0 in favor of the REST\
-API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can\
+API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can
 no longer be used.
 
 ### Authentication
 
-The credentials used by services now require additional grants. For a full list\
+The credentials used by services now require additional grants. For a full list
 of required grants, refer to the [protocol documentation](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md).
 
 ### MariaDB-Monitor
 
-The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in\
+The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in
 a later version.
 
 #### Password encryption
 
-The encrypted passwords feature has been updated to be more secure. Users are\
-recommended to generate a new encryption key and re-encrypt their passwords\
+The encrypted passwords feature has been updated to be more secure. Users are
+recommended to generate a new encryption key and re-encrypt their passwords
 using the `maxkeys` and `maxpasswd` utilities. Old passwords still work.
 
 ### Default Server State
 
-The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally\
+The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally
 used before they were monitored.
 
 ### Columnstore Monitor
 
-It is now mandatory to specify in the configuration what version the\
+It is now mandatory to specify in the configuration what version the
 monitored Columnstore cluster is.
 
 ```
@@ -48,20 +48,20 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)\
+Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)
 for details.
 
 ### New binlog router
 
-The binlog router delivered with MaxScale 2.5 is completely new and\
-not 100% backward compatible with the binlog router delivered with\
-earlier MaxScale versions. If you use the binlog router, carefully\
-assess whether the functionality provided by the new one fulfills\
+The binlog router delivered with MaxScale 2.5 is completely new and
+not 100% backward compatible with the binlog router delivered with
+earlier MaxScale versions. If you use the binlog router, carefully
+assess whether the functionality provided by the new one fulfills
 your requirements, before upgrading MaxScale.
 
 ### Tee Filter
 
-The tee filter parameter `service` has been deprecated in favor of the `target`\
+The tee filter parameter `service` has been deprecated in favor of the `target`
 parameter. All usages of `service` can be replaced with `target`.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-25-to-6.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-25-to-6.md
@@ -1,26 +1,26 @@
 # Upgrading MariaDB MaxScale from 2.5 to 6
 
-This document describes possible issues when upgrading MariaDB MaxScale from\
+This document describes possible issues when upgrading MariaDB MaxScale from
 version 2.5 to 6.
 
-Note that the versioning scheme has changed and that version 6 immediately\
-follows version 2.5. Effectively, the non-changing `2.`-prefix has been dropped\
-and henceforth at a major release, the _major_, instead of the _minor_ version\
-number, will be bumped. This change also affects how maintenance releases are\
-versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was\
+Note that the versioning scheme has changed and that version 6 immediately
+follows version 2.5. Effectively, the non-changing `2.`-prefix has been dropped
+and henceforth at a major release, the _major_, instead of the _minor_ version
+number, will be bumped. This change also affects how maintenance releases are
+versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was
 followed by the maintenance release 2.5.2. 6.1, the first GA version of MaxScale\
 6, will be followed by the maintenance release 6.2.
 
 For more information about MaxScale 6, refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, any existing configuration files should be backed\
+Before starting the upgrade, any existing configuration files should be backed
 up.
 
 ### Duration Type Parameters
 
 Using duration type parameters without an explicit suffix has been deprecated in\
 MaxScale 2.4. In MaxScale 6 they are no longer allowed when used with the REST\
-API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that\
+API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that
 use a duration type parameter must explicitly specify the suffix of the unit.
 
 For example, the following command:
@@ -35,8 +35,8 @@ should be replaced with:
 maxctrl alter service My-Service connection_keepalive 30000ms
 ```
 
-Duration type parameters can still be defined in the configuration file without\
-an explicit suffix but this behavior is deprecated. The recommended approach is\
+Duration type parameters can still be defined in the configuration file without
+an explicit suffix but this behavior is deprecated. The recommended approach is
 to add explicit suffixes to all duration type parameters when upgrading to\
 MaxScale 6.
 
@@ -58,16 +58,16 @@ The following deprecated core parameters have been removed:
 
 The deprecated aliases for the schemarouter parameters `ignore_databases` and`ignore_databases_regex` have been removed. They can be replaced with`ignore_tables` and `ignore_tables_regex`.
 
-In addition, the `preferred_server` parameter that was deprecated in 2.5 has\
+In addition, the `preferred_server` parameter that was deprecated in 2.5 has
 also been removed.
 
 ### Session Command History
 
-The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`\
-have been made into generic service parameters that are shared between all\
+The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`
+have been made into generic service parameters that are shared between all
 routers that support it.
 
-The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it\
+The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it
 being enabled or are not affected by it.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208.md
@@ -1,18 +1,18 @@
 # Upgrading MariaDB MaxScale from 6 to 22.08
 
-This document describes possible issues when upgrading MariaDB MaxScale from\
+This document describes possible issues when upgrading MariaDB MaxScale from
 version 6 to 22.08.
 
 For more information about MaxScale 22.08, refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, any existing configuration files should be backed\
+Before starting the upgrade, any existing configuration files should be backed
 up.
 
 ## Removed Features
 
-* The support for legacy encryption keys generated with `maxkeys` from pre-2.5\
-  versions has been removed. This feature was deprecated in MaxScale 2.5 when\
-  the new key storage format was introduced. To migrate to the new key storage\
+* The support for legacy encryption keys generated with `maxkeys` from pre-2.5
+  versions has been removed. This feature was deprecated in MaxScale 2.5 when
+  the new key storage format was introduced. To migrate to the new key storage
   format, create a new key file with `maxkeys` and re-encrypt the passwords with`maxpasswd`.
 * The deprecated Database Firewall filter has been removed.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-2302-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-2302-contents.md
@@ -46,8 +46,8 @@ Here are tutorials on monitoring and managing MariaDB MaxScale in cluster enviro
 
 ### Routers
 
-The routing module is the core of a MariaDB MaxScale service. The router documentation\
-contains all module specific configuration options and detailed explanations\
+The routing module is the core of a MariaDB MaxScale service. The router documentation
+contains all module specific configuration options and detailed explanations
 of their use.
 
 * [Avrorouter](mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avrorouter.md)
@@ -108,7 +108,7 @@ The MaxScale CDC Connector provides a C++ API for consuming data from a CDC syst
 
 ### Authenticators
 
-A short description of the authentication module type can be found in the [Authentication Modules](mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md)\
+A short description of the authentication module type can be found in the [Authentication Modules](mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-authentication-modules.md)
 document.
 
 * [MariaDB/MySQL Authenticator](mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-mysql-authenticator.md)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-about-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-about-mariadb-maxscale.md
@@ -4,49 +4,49 @@
 
 ## About MariaDB MaxScale
 
-**MariaDB MaxScale** is a database proxy that forwards database statements to\
+**MariaDB MaxScale** is a database proxy that forwards database statements to
 one or more database servers.
 
-The forwarding is performed using rules based on the semantic understanding of\
-the database statements and on the roles of the servers within the backend\
+The forwarding is performed using rules based on the semantic understanding of
+the database statements and on the roles of the servers within the backend
 cluster of databases.
 
-MariaDB MaxScale is designed to provide, transparently to applications, load\
-balancing and high availability functionality. MariaDB MaxScale has a scalable\
-and flexible architecture, with plugin components to support different protocols\
+MariaDB MaxScale is designed to provide, transparently to applications, load
+balancing and high availability functionality. MariaDB MaxScale has a scalable
+and flexible architecture, with plugin components to support different protocols
 and routing approaches.
 
 MariaDB MaxScale makes extensive use of the asynchronous I/O capabilities of the\
-Linux operating system, combined with a fixed number of worker threads. _epoll_\
-is used to provide the event driven framework for the input and output via\
+Linux operating system, combined with a fixed number of worker threads. _epoll_
+is used to provide the event driven framework for the input and output via
 sockets.
 
-Many of the services provided by MariaDB MaxScale are implemented as external\
-shared object modules loaded at runtime. These modules support a fixed\
-interface, communicating the entry points via a structure consisting of a set of\
-function pointers. This structure is called the "module object". Additional\
+Many of the services provided by MariaDB MaxScale are implemented as external
+shared object modules loaded at runtime. These modules support a fixed
+interface, communicating the entry points via a structure consisting of a set of
+function pointers. This structure is called the "module object". Additional
 modules can be created to work with MariaDB MaxScale.
 
-Commonly used module types are _protocol_, _router_ and _filter_. Protocol\
-modules implement the communication between clients and MariaDB MaxScale, and\
-between MariaDB MaxScale and backend servers. Routers inspect the queries from\
-clients and decide the target backend. The decisions are usually based on\
-routing rules and backend server status. Filters work on data as it passes\
-through MariaDB MaxScale. Filter are often used for logging queries or modifying\
+Commonly used module types are _protocol_, _router_ and _filter_. Protocol
+modules implement the communication between clients and MariaDB MaxScale, and
+between MariaDB MaxScale and backend servers. Routers inspect the queries from
+clients and decide the target backend. The decisions are usually based on
+routing rules and backend server status. Filters work on data as it passes
+through MariaDB MaxScale. Filter are often used for logging queries or modifying
 server responses.
 
-A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,\
+A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,
 issues and communicate with the MariaDB MaxScale community. Send email to [maxscale@googlegroups.com](https://mariadb.com/kb/en/mailto:maxscale@googlegroups.com) or use the [forum](https://groups.google.com/forum/#!forum/maxscale) interface.
 
 Bugs can be reported in the MariaDB Jira [jira.mariadb.org](https://jira.mariadb.org)
 
 ### Installing MariaDB MaxScale
 
-Information about installing MariaDB MaxScale, either from a repository or by\
+Information about installing MariaDB MaxScale, either from a repository or by
 building from source code, is included in the [MariaDB MaxScale Installation\
 Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-installation-guide.md).
 
-The same guide also provides basic information on running MariaDB MaxScale. More\
+The same guide also provides basic information on running MariaDB MaxScale. More
 detailed information about configuring MariaDB MaxScale can be found in the [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/).
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md
@@ -4,43 +4,43 @@
 
 ## Limitations and Known Issues within MariaDB MaxScale
 
-This document lists known issues and limitations in MariaDB MaxScale and its\
-plugins. Since limitations are related to specific plugins, this document is\
+This document lists known issues and limitations in MariaDB MaxScale and its
+plugins. Since limitations are related to specific plugins, this document is
 divided into several sections.
 
 ### Configuration limitations
 
-In versions 2.1.2 and earlier, the configuration files are limited to 1024\
+In versions 2.1.2 and earlier, the configuration files are limited to 1024
 characters per line. This limitation was increased to 16384 characters in\
 MaxScale 2.1.3. MaxScale 2.3.0 increased this limit to 16777216 characters.
 
-In versions 2.2.12 and earlier, the section names in the configuration files\
-were limited to 49 characters. This limitation was increased to 1023 characters\
+In versions 2.2.12 and earlier, the section names in the configuration files
+were limited to 49 characters. This limitation was increased to 1023 characters
 in MaxScale 2.2.13.
 
 #### Multiple MaxScales on same server
 
-Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to\
-the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale\
-instances to listen on the same network port if the directories used by both\
-instances are completely separate and there are no conflicts which can cause\
-unexpected splitting of connections. This will only happen if users explicitly\
-tell MaxScale to ignore the default directories and will not happen in normal\
+Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to
+the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale
+instances to listen on the same network port if the directories used by both
+instances are completely separate and there are no conflicts which can cause
+unexpected splitting of connections. This will only happen if users explicitly
+tell MaxScale to ignore the default directories and will not happen in normal
 use.
 
 ### Security limitations
 
 #### MariaDB 10.2
 
-The parser of MaxScale correctly parses `WITH` statements, but fails to\
+The parser of MaxScale correctly parses `WITH` statements, but fails to
 collect columns, functions and tables used in the `SELECT` defining the`WITH` clause.
 
-Consequently, the database firewall will **not** block `WITH` statements\
+Consequently, the database firewall will **not** block `WITH` statements
 where the `SELECT` of the `WITH` clause refers to forbidden columns.
 
 ### MariaDB Default Values
 
-MaxScale assumes that certain configuration parameters in MariaDB are set to\
+MaxScale assumes that certain configuration parameters in MariaDB are set to
 their default values. These include but are not limited to:
 
 * `autocommit`: Autocommit is enabled for all new connections.
@@ -55,38 +55,38 @@ require query classification, a custom parser is used to detect them. Currently\
 the only situation in which this parser is used is when a `readconnroute`\
 service uses the `cache` filter.
 
-The custom parser detects a subset of the full SQL syntax used to start\
-transactions. This means that more complex statements will not be fully parsed\
-and will cause the transaction state to not match the real state on the\
-database. For example, `SET @my_var = (SELECT 1), autocommit = 0` is not parsed\
+The custom parser detects a subset of the full SQL syntax used to start
+transactions. This means that more complex statements will not be fully parsed
+and will cause the transaction state to not match the real state on the
+database. For example, `SET @my_var = (SELECT 1), autocommit = 0` is not parsed
 by the custom parser and causes the autocommit modification to not be noticed.
 
 #### XA Transactions
 
-MaxScale will treat statements executed after `XA START` and before `XA END` as\
-if they were executed in a normal read-write transaction started with `START TRANSACTION`. This means that only XA transactions in the ACTIVE state will be\
+MaxScale will treat statements executed after `XA START` and before `XA END` as
+if they were executed in a normal read-write transaction started with `START TRANSACTION`. This means that only XA transactions in the ACTIVE state will be
 routed as transactions and all statements after `XA END` are routed normally.
 
-XA transactions and normal transactions are mutually exclusive in MariaDB. This\
-means that a `START TRANSACTION` command will fail if the connection already has\
-an open XA transaction. MaxScale currently only inspects the SQL and deduces the\
-transaction state from that. If a transaction fails to start due to an open XA\
-transaction, the state in MaxScale and in MariaDB can be different and MaxScale\
-will keep routing statements as if they were inside of a transaction. However,\
+XA transactions and normal transactions are mutually exclusive in MariaDB. This
+means that a `START TRANSACTION` command will fail if the connection already has
+an open XA transaction. MaxScale currently only inspects the SQL and deduces the
+transaction state from that. If a transaction fails to start due to an open XA
+transaction, the state in MaxScale and in MariaDB can be different and MaxScale
+will keep routing statements as if they were inside of a transaction. However,
 as this is an unlikely scenario, usually no action needs to be taken.
 
 ### Prepared Statements
 
-For its proper functioning, MaxScale needs in general to be aware of the\
-transaction state and _autocommit_ mode. In order to be that, MaxScale\
+For its proper functioning, MaxScale needs in general to be aware of the
+transaction state and _autocommit_ mode. In order to be that, MaxScale
 parses statements going through it.
 
-However, if a transaction is committed or rolled back, or the autocommit\
-mode is changed using a prepared statement, MaxScale will miss that and its\
-internal state will be incorrect, until the transaction state or autocommit\
+However, if a transaction is committed or rolled back, or the autocommit
+mode is changed using a prepared statement, MaxScale will miss that and its
+internal state will be incorrect, until the transaction state or autocommit
 mode is changed using an explicit statement.
 
-For instance, after the following sequence of commands, MaxScale will still\
+For instance, after the following sequence of commands, MaxScale will still
 think _autocommit_ is on:
 
 ```
@@ -95,7 +95,7 @@ PREPARE hide_autocommit FROM "set autocommit=0"
 EXECUTE hide_autocommit
 ```
 
-To ensure that MaxScale functions properly, do not commit or rollback a\
+To ensure that MaxScale functions properly, do not commit or rollback a
 transaction or change the autocommit mode using a prepared statement.
 
 ### Protocol limitations
@@ -103,65 +103,65 @@ transaction or change the autocommit mode using a prepared statement.
 #### Limitations with MySQL/MariaDB Protocol support (MariaDBClient)
 
 * Compression is not included in the server handshake.
-* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept\
-  it. If the ID matches a MaxScale session ID, it will be closed by sending\
-  modified `KILL` commands of the same type to all backend server to which the\
-  session in question is connected to. This results in behavior that is similar\
-  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,\
+* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept
+  it. If the ID matches a MaxScale session ID, it will be closed by sending
+  modified `KILL` commands of the same type to all backend server to which the
+  session in question is connected to. This results in behavior that is similar
+  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,
   all connections with a matching username will be closed instead.
-* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type\
-  statements. If a query by a query ID is to be killed, it needs to be done\
+* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type
+  statements. If a query by a query ID is to be killed, it needs to be done
   directly on the backend databases.
 * Any `KILL` commands executed using a prepared statement are ignored by\
-  MaxScale. If any are executed, it is highly likely that the wrong connection\
+  MaxScale. If any are executed, it is highly likely that the wrong connection
   ends up being killed.
-* If a `KILL` connection kills a session that is connected to a readwritesplit\
-  service that has `transaction_replay` or `delayed_retry` enabled, it is\
-  possible that the query is retried even if the connection is killed. To avoid\
+* If a `KILL` connection kills a session that is connected to a readwritesplit
+  service that has `transaction_replay` or `delayed_retry` enabled, it is
+  possible that the query is retried even if the connection is killed. To avoid
   this, use `KILL QUERY` instead.
-* A `KILL` on one service can cause a connection from another service to be\
+* A `KILL` on one service can cause a connection from another service to be
   closed even if it uses a different protocol.
-* The change user command (COM\_CHANGE\_USER) only works with standard\
+* The change user command (COM\_CHANGE\_USER) only works with standard
   authentication.
-* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session\
-  ends up in an inconsistent state. This can happen if the password of the\
-  target user is changed and MaxScale uses old user account data when processing\
-  the change user. In such a situation, MaxScale and server will disagree on the\
+* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session
+  ends up in an inconsistent state. This can happen if the password of the
+  target user is changed and MaxScale uses old user account data when processing
+  the change user. In such a situation, MaxScale and server will disagree on the
   current user. This can affect e.g. reconnections.
 
 ### Authenticator limitations
 
 #### Limitations in the MySQL authenticator (MariaDBAuth)
 
-* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use\
+* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use
   a new authentication protocol which does not support pre-4.1 style passwords.
 * When users have different passwords based on the host from which they connect\
-  MariaDB MaxScale is unable to determine which password it should use to connect\
-  to the backend database. This results in failed connections and unusable\
+  MariaDB MaxScale is unable to determine which password it should use to connect
+  to the backend database. This results in failed connections and unusable
   usernames in MariaDB MaxScale.
 
 ### Filter limitations
 
 #### Tee filter limitations (tee)
 
-The Tee filter does not support binary protocol prepared statements. The\
-execution of a prepared statements through a service that uses the tee filter is\
-not guaranteed to succeed on the service where the filter branches to as it does\
+The Tee filter does not support binary protocol prepared statements. The
+execution of a prepared statements through a service that uses the tee filter is
+not guaranteed to succeed on the service where the filter branches to as it does
 on the original service.
 
-This possibility exists due to the fact that the binary protocol prepared\
-statements are identified by a server-generated ID. The ID sent to the client\
-from the main service is not guaranteed to be the same that is sent by the\
+This possibility exists due to the fact that the binary protocol prepared
+statements are identified by a server-generated ID. The ID sent to the client
+from the main service is not guaranteed to be the same that is sent by the
 branch service.
 
 ### Monitor limitations
 
-A server can only be monitored by one monitor. Two or more monitors monitoring\
+A server can only be monitored by one monitor. Two or more monitors monitoring
 the same server is considered an error.
 
 #### Limitations with Galera Cluster Monitoring (galeramon)
 
-The default master selection is based only on MIN(wsrep\_local\_index). This\
+The default master selection is based only on MIN(wsrep\_local\_index). This
 can be influenced with the server priority mechanic described in the [Galera Monitor](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-galera-monitor.md) manual.
 
 ### Router limitations
@@ -170,38 +170,38 @@ Refer to individual router documentation for a list of their limitations.
 
 ## ETL Limitations
 
-The ETL feature in MaxScale always uses the MariaDB Connector/ODBC driver to\
-perform the data loading into MariaDB. The recommended minimum version of the\
-connector is 3.1.18. Older versions of the driver suffer from problems that may\
-manifest as crashes or memory leaks. The driver must be installed on the system\
+The ETL feature in MaxScale always uses the MariaDB Connector/ODBC driver to
+perform the data loading into MariaDB. The recommended minimum version of the
+connector is 3.1.18. Older versions of the driver suffer from problems that may
+manifest as crashes or memory leaks. The driver must be installed on the system
 in order for the ETL feature to work.
 
-The data loading into MariaDB is done with `autocommit`, `unique_checks` and`foreign_key_checks` disabled inside of a single transaction. This is done to\
-leverage the optimizations done for InnoDB that allows faster insertions into\
-empty tables. When loading data into MariaDB versions 10.5 or older, this can\
+The data loading into MariaDB is done with `autocommit`, `unique_checks` and`foreign_key_checks` disabled inside of a single transaction. This is done to
+leverage the optimizations done for InnoDB that allows faster insertions into
+empty tables. When loading data into MariaDB versions 10.5 or older, this can
 translate into long rollback times in case the ETL operation fails.
 
 ### ETL Limitations with PostgreSQL as the Source
 
-For ETL operations that migrate data from PostgreSQL, we recommend using the\
-official PostgreSQL ODBC driver. Use of other PostgreSQL ODBC drivers is\
-possible but not recommended: correct configuration of the driver is necessary\
+For ETL operations that migrate data from PostgreSQL, we recommend using the
+official PostgreSQL ODBC driver. Use of other PostgreSQL ODBC drivers is
+possible but not recommended: correct configuration of the driver is necessary
 to prevent the driver from consuming too much memory.
 
 #### Limitations in Automatic SQL Generation
 
 * Triggers on tables are not migrated automatically.
-* Check constraints are defined using the native PostgreSQL\
+* Check constraints are defined using the native PostgreSQL
   syntax. Incompatibilities must be manually fixed.
 * All indexes specific to PostgreSQL will be converted into normal indexes in\
   MariaDB.
-* The `GEOMETRY` type is assumed to be the type provided by PostGIS. It is\
+* The `GEOMETRY` type is assumed to be the type provided by PostGIS. It is
   converted into a MariaDB `GEOMETRY` type and is extracted using `ST_AsText`.
 
 ### ETL Limitations with Generic ODBC Targets
 
-It is the responsibility of the end-user to correctly configure the ODBC\
-driver. Some drivers read the whole resultset into memory by default which will\
+It is the responsibility of the end-user to correctly configure the ODBC
+driver. Some drivers read the whole resultset into memory by default which will
 result in MaxScale running out of memory
 
 * ETL operations that operate on more than one catalog are not supported.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md
@@ -7,45 +7,45 @@
 This document describes general MySQL protocol authentication in MaxScale. For\
 REST-api authentication, see the [configuration guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/) and the [REST-api guide](../../../../../en/mariadb-maxscale-2308-maxscale-rest-api/).
 
-Similar to the MariaDB Server, MaxScale uses authentication plugins to implement\
-different authentication schemes for incoming clients. The same plugins also\
-handle authenticating the clients to backend servers. The authentication plugins\
+Similar to the MariaDB Server, MaxScale uses authentication plugins to implement
+different authentication schemes for incoming clients. The same plugins also
+handle authenticating the clients to backend servers. The authentication plugins
 available in MaxScale are [standard MySQL password](../../../../../en/mariadbmysql-authenticator/),[GSSAPI](mariadb-maxscale-2308-gssapi-client-authenticator.md) and [pluggable authentication modules (PAM)](mariadb-maxscale-2308-pam-authenticator.md).
 
-Most of the authentication processing is performed on the protocol level, before\
-handing it over to one of the plugins. This shared part is described in this\
+Most of the authentication processing is performed on the protocol level, before
+handing it over to one of the plugins. This shared part is described in this
 document. For information on an individual plugin, see its documentation.
 
 ### User account management
 
-Every MaxScale service with a MariaDB protocol listener requires knowledge of\
-the user accounts defined on the backend databases. The service maintains this\
+Every MaxScale service with a MariaDB protocol listener requires knowledge of
+the user accounts defined on the backend databases. The service maintains this
 information in an internal component called the _user account manager_ (UAM).\
-The UAM queries relevant data from the _mysql_-database of the backends and\
-stores it. Typically, only the current primary server is queried, as all servers\
-are assumed to have the same users. The service settings _user_ and _password_\
+The UAM queries relevant data from the _mysql_-database of the backends and
+stores it. Typically, only the current primary server is queried, as all servers
+are assumed to have the same users. The service settings _user_ and _password_
 define the credentials used when fetching user accounts.
 
-The service uses the stored data when authenticating clients, checking their\
-passwords and database access rights. This results in an authentication process\
-very similar to the MariaDB Server itself. Unauthorized users are generally\
-detected already at the MaxScale level instead of the backend servers. This may\
+The service uses the stored data when authenticating clients, checking their
+passwords and database access rights. This results in an authentication process
+very similar to the MariaDB Server itself. Unauthorized users are generally
+detected already at the MaxScale level instead of the backend servers. This may
 not apply in some cases, for example if MaxScale is using old user account data.
 
-If authentication fails, the UAM updates its data from a backend. MaxScale may\
-attempt authenticating the client again with the refreshed data without\
-communicating the first failure to the client. This transparent user data update\
+If authentication fails, the UAM updates its data from a backend. MaxScale may
+attempt authenticating the client again with the refreshed data without
+communicating the first failure to the client. This transparent user data update
 does not always work, in which case the client should try to log in again.
 
-As the UAM is shared between all listeners of a service, its settings are\
-defined in the service configuration. For more information, search the [configuration guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/)\
-for _users\_refresh\_time_, _users\_refresh\_interval_ and\_auth\_all\_servers\_. Other settings which affect how the UAM connects to backends\
-are the global settings _auth\_connect\_timeout_ and _local\_address_, and\
+As the UAM is shared between all listeners of a service, its settings are
+defined in the service configuration. For more information, search the [configuration guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/)
+for _users\_refresh\_time_, _users\_refresh\_interval_ and\_auth\_all\_servers\_. Other settings which affect how the UAM connects to backends
+are the global settings _auth\_connect\_timeout_ and _local\_address_, and
 the various server-level ssl-settings.
 
 #### Required grants
 
-To properly fetch user account information, the MaxScale service user must be\
+To properly fetch user account information, the MaxScale service user must be
 able to read from various tables in the _mysql_-database: _user_, _db_,_tables\_priv_, _columns\_priv_, _procs\_priv_, _proxies\_priv_ and _roles\_mapping_.\
 The user should also have the _SHOW DATABASES_-grant.
 
@@ -70,23 +70,23 @@ GRANT ALL ON infinidb_vtable.* TO 'maxscale'@'maxscalehost';
 ### Limitations and troubleshooting
 
 When a client logs in to MaxScale, MaxScale sees the client's IP address. When\
-MaxScale then connects the client to backends (using the client's username and\
+MaxScale then connects the client to backends (using the client's username and
 password), the backends see the connection coming from the IP address of\
-MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this\
-is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),\
+MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this
+is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),
 authentication to backends will fail.
 
 There are two primary ways to deal with this:
 
-1. Duplicate user accounts. For every user account with a restricted hostname an\
+1. Duplicate user accounts. For every user account with a restricted hostname an
    equivalent user account for MaxScale is added (`'alice'@'maxscale-ip'`).
 2. Use [proxy protocol](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#proxy_protocol).
 
-Option 1 limits the passwords for user accounts with shared usernames. Such\
+Option 1 limits the passwords for user accounts with shared usernames. Such
 accounts must use the same password since they will effectively share the\
 MaxScale-to-backend user account. Option 2 requires server support.
 
-See [MaxScale Troubleshooting](../../../../maxscale-versions/maxscale-troubleshooting.md)\
+See [MaxScale Troubleshooting](../../../../maxscale-versions/maxscale-troubleshooting.md)
 for additional information on how to solve authentication issues.
 
 #### Wildcard database grants
@@ -94,14 +94,14 @@ for additional information on how to solve authentication issues.
 MaxScale supports wildcards `_` and `%` for database-level grants. As with\
 MariaDB Server, `grant select on test_.* to 'alice'@'%';` gives access to _test\__ as well as _test1_, _test2_ and so on. If the GRANT command escapes the
 wildcard (`grant select on` test\_`.* to 'alice'@'%';`) both MaxScale and the\
-MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`\
+MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`
 are only interpreted as wildcards when the grant is to a database:`grant select on` test\_`.t1 to 'alice'@'%';` only grants access to the\_test\_.t1\_-table, not to _test1.t1_.
 
 ### Authenticator options
 
-The listener configuration defines authentication options which only affect the\
-listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an\
-individual authentication plugin or the authentication as a whole. The latter\
+The listener configuration defines authentication options which only affect the
+listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an
+individual authentication plugin or the authentication as a whole. The latter
 are explained below. Multiple options can be given as a comma-separated list.
 
 ```
@@ -115,20 +115,20 @@ authenticator_options=skip_authentication=true,lower_case_table_names=1
 * Dynamic: No
 * Default: `false`
 
-If enabled, MaxScale will not check the\
+If enabled, MaxScale will not check the
 passwords of incoming clients and just assumes that they are correct.\
-Wrong passwords are instead detected when MaxScale tries to authenticate to the\
+Wrong passwords are instead detected when MaxScale tries to authenticate to the
 backend servers.
 
-This setting is mainly meant for failure tolerance in situations where the\
-password check is performed outside of MaxScale. If, for example, MaxScale\
-cannot use an LDAP-server but the backend databases can, enabling this setting\
-allows clients to log in. Even with this setting enabled, a user account\
+This setting is mainly meant for failure tolerance in situations where the
+password check is performed outside of MaxScale. If, for example, MaxScale
+cannot use an LDAP-server but the backend databases can, enabling this setting
+allows clients to log in. Even with this setting enabled, a user account
 matching the incoming client username and IP must exist on the backends for\
 MaxScale to accept the client.
 
 This setting is incompatible with standard MariaDB/MySQL authentication plugin\
-(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to\
+(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to
 backend servers using standard authentication.
 
 ```
@@ -142,14 +142,14 @@ authenticator_options=skip_authentication=true
 * Dynamic: No
 * Default: `true`
 
-If disabled, MaxScale does not require that a\
+If disabled, MaxScale does not require that a
 valid user account entry for incoming clients exists on the backends.\
-Specifically, only the client username needs to match a user account,\
+Specifically, only the client username needs to match a user account,
 hostname/IP is ignored.
 
-This setting may be used to force clients to connect through MaxScale. Normally,\
+This setting may be used to force clients to connect through MaxScale. Normally,
 creating the user _jdoe@%_ will allow the user _jdoe_ to connect from any\
-IP-address. By disabling _match\_host_ and replacing the user with\_jdoe@maxscale-IP\_, the user can still connect from any client IP but will be\
+IP-address. By disabling _match\_host_ and replacing the user with\_jdoe@maxscale-IP\_, the user can still connect from any client IP but will be
 forced to go through MaxScale.
 
 ```
@@ -163,29 +163,29 @@ authenticator_options=match_host=false
 * Dynamic: No
 * Default: `0`
 
-Controls database name matching for authentication\
-when an incoming client logs in to a non-empty database. The setting functions\
-similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)\
+Controls database name matching for authentication
+when an incoming client logs in to a non-empty database. The setting functions
+similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)
 and should be set to the value used by the backends.
 
 The setting accepts the values 0, 1 or 2:
 
 * `0`: case-sensitive matching (default)
-* `1`: convert the requested database name to lower case before using case-insensitive\
+* `1`: convert the requested database name to lower case before using case-insensitive
   matching. Assumes that database names on the server are stored in lower case.
 * `2`: use case-insensitive matching.
 
-_true_ and _false_ are also accepted for backwards compatibility. These map to 1\
+_true_ and _false_ are also accepted for backwards compatibility. These map to 1
 and 0, respectively.
 
-The identifier names are converted using an ASCII-only function. This means that\
+The identifier names are converted using an ASCII-only function. This means that
 non-ASCII characters will retain their case-sensitivity.
 
-Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior\
-of `lower_case_table_names=1` is identical with how the MariaDB server\
-behaves. In older releases the comparisons were done in a case-sensitive manner\
-after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes\
-it a safe alternative to use when a mix of older and newer MaxScale versions is\
+Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior
+of `lower_case_table_names=1` is identical with how the MariaDB server
+behaves. In older releases the comparisons were done in a case-sensitive manner
+after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes
+it a safe alternative to use when a mix of older and newer MaxScale versions is
 being used.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-ed25519-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-ed25519-authenticator.md
@@ -4,20 +4,20 @@
 
 ## Ed25519 Authenticator
 
-Ed25519 is a highly secure authentication method based on public key\
+Ed25519 is a highly secure authentication method based on public key
 cryptography. It is used with the auth\_ed25519-plugin of MariaDB Server.
 
-When a client authenticates via ed25519, MaxScale first sends them a random\
-message. The client signs the message using their password as private key and\
-sends the signature back. MaxScale then checks the signature using the public\
-key fetched from the _mysql.user_-table. The client password or an equivalent\
+When a client authenticates via ed25519, MaxScale first sends them a random
+message. The client signs the message using their password as private key and
+sends the signature back. MaxScale then checks the signature using the public
+key fetched from the _mysql.user_-table. The client password or an equivalent
 token is never exposed. For more information, see [server documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-ed25519).
 
-The security of this authentication scheme presents a problem for a proxy such\
-as MaxScale since MaxScale needs to log in to backend servers on behalf of the\
-client. Since each server will generate their own random messages, MaxScale\
-cannot simply forward the original signature. Either the real password is\
-required, or a different authentication scheme must be used between MaxScale\
+The security of this authentication scheme presents a problem for a proxy such
+as MaxScale since MaxScale needs to log in to backend servers on behalf of the
+client. Since each server will generate their own random messages, MaxScale
+cannot simply forward the original signature. Either the real password is
+required, or a different authentication scheme must be used between MaxScale
 and backends. The MaxScale ed25519auth-plugin supports both alternatives.
 
 ### Configuration
@@ -32,17 +32,17 @@ service=Read-Write-Service
 authenticator=ed25519auth
 ```
 
-MaxScale will now authenticate incoming clients with ed25519 if their user\
-account has _plugin_ set to "ed25519" in the _mysql.user_-table. However,\
-routing queries will fail since MaxScale cannot authenticate to backends. To\
-continue, either use a mapping file or enable sha256-mode. Sha256-mode is\
+MaxScale will now authenticate incoming clients with ed25519 if their user
+account has _plugin_ set to "ed25519" in the _mysql.user_-table. However,
+routing queries will fail since MaxScale cannot authenticate to backends. To
+continue, either use a mapping file or enable sha256-mode. Sha256-mode is
 enabled with the following settings.
 
 #### `ed_mode`
 
 This setting defines the authentication mode used. Two values are supported:
 
-* `ed25519` (default) Digital signature based authentication. Requires mapping\
+* `ed25519` (default) Digital signature based authentication. Requires mapping
   for backend support.
 * `sha256` Authenticate client with caching\_sha2\_password-plugin instead.\
   Requires either SSL or configured RSA-keys.
@@ -53,7 +53,7 @@ authenticator_options=ed_mode=sha256
 
 #### `ed_rsa_privkey_path` and `ed_rsa_pubkey_path`
 
-Defines the RSA-keys used for encrypting the client password if SSL is not in\
+Defines the RSA-keys used for encrypting the client password if SSL is not in
 use. Should point to files with the private and public keys.
 
 ```
@@ -64,13 +64,13 @@ authenticator_options=ed_mode=sha256,
 
 ### Using a mapping file
 
-To enable MaxScale to authenticate to backends,[user mapping](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#user_mapping_file)\
+To enable MaxScale to authenticate to backends,[user mapping](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#user_mapping_file)
 can be used. The mapping and backend passwords are given in a json-file.\
-The client can map to an identical username or to another user, and the backend\
+The client can map to an identical username or to another user, and the backend
 authentication scheme can be something else than ed25519.
 
-The following example maps user "alpha" to "beta" and MaxScale then uses\
-standard authentication to log into backends as "beta". User "alpha"\
+The following example maps user "alpha" to "beta" and MaxScale then uses
+standard authentication to log into backends as "beta". User "alpha"
 authenticates to MaxScale using whatever method configured in the server.\
 User "gamma" does not map to another user, just the password is given.
 
@@ -116,16 +116,16 @@ user_mapping_file=/home/joe/mapping.json
 
 ### Using sha256-authentication
 
-The mapping-based solution requires the DBA to maintain a file with user\
+The mapping-based solution requires the DBA to maintain a file with user
 passwords, which has security and upkeep implications. To avoid this,\
-MaxScale can instead use the caching\_sha2\_password-plugin to authenticate\
-the client. This authentication scheme transmits the client password to MaxScale\
-in full, allowing MaxScale to log into backends using ed25519. MaxScale\
-effectively lies to the client about its authentication plugin and then uses\
-the correct plugin with the backends. Enable sha256-authentication by setting\
+MaxScale can instead use the caching\_sha2\_password-plugin to authenticate
+the client. This authentication scheme transmits the client password to MaxScale
+in full, allowing MaxScale to log into backends using ed25519. MaxScale
+effectively lies to the client about its authentication plugin and then uses
+the correct plugin with the backends. Enable sha256-authentication by setting
 authentication option _ed\_mode_ to "sha256".
 
-sha256-authentication is best used with encrypted connections. The example\
+sha256-authentication is best used with encrypted connections. The example
 below shows a listener configured for sha256-mode and SSL.
 
 ```
@@ -143,9 +143,9 @@ ssl_ca=/tmp/myCA.pem
 
 If SSL is not in use, caching\_sha2\_password transmits the password using\
 RSA-encryption. In this case, MaxScale needs the public and private RSA-keys.\
-MaxScale sends the public key to the client if they don't already have it and\
-the client uses it to encrypt the password. MaxScale then uses the private key\
-to decrypt the password. The example below shows a listener configured for\
+MaxScale sends the public key to the client if they don't already have it and
+the client uses it to encrypt the password. MaxScale then uses the private key
+to decrypt the password. The example below shows a listener configured for
 sha256-mode without SSL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-gssapi-client-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-gssapi-client-authenticator.md
@@ -4,25 +4,25 @@
 
 ## GSSAPI Client Authenticator
 
-GSSAPI is an authentication protocol that is commonly implemented with Kerberos\
-on Unix or Active Directory on Windows. This document describes GSSAPI\
+GSSAPI is an authentication protocol that is commonly implemented with Kerberos
+on Unix or Active Directory on Windows. This document describes GSSAPI
 authentication in MaxScale. The authentication module name in MaxScale is_GSSAPIAuth_.
 
 ### Preparing the GSSAPI system
 
-For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short\
+For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short
 guide on how to set up Kerberos for MaxScale.
 
-The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB\
-documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)\
+The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB
+documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)
 is a good example on how to set it up.
 
-The next step is to copy the keytab file from the server where MariaDB is\
-installed to the server where MaxScale is located. The keytab file must be\
-placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an\
+The next step is to copy the keytab file from the server where MariaDB is
+installed to the server where MaxScale is located. The keytab file must be
+placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an
 authenticator option.
 
-The location of the keytab file can be changed with the KRB5\_KTNAME environment\
+The location of the keytab file can be changed with the KRB5\_KTNAME environment
 variable: [keytab\_def.html](https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html)
 
 To take GSSAPI authentication into use, add the following to the listener.
@@ -43,10 +43,10 @@ The principal name should be the same as on the MariaDB servers.
 * Dynamic: No
 * Default: `mariadb/localhost.localdomain`
 
-The service principal name to send to the client. This parameter is a string\
+The service principal name to send to the client. This parameter is a string
 parameter which is used by the client to request the token.
 
-This parameter _must_ be the same as the principal name that the backend MariaDB\
+This parameter _must_ be the same as the principal name that the backend MariaDB
 server uses.
 
 #### `gssapi_keytab_path`
@@ -56,10 +56,10 @@ server uses.
 * Dynamic: No
 * Default: Kerberos Default
 
-Keytab file location. This should be an absolute path to the file containing the\
-keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that\
+Keytab file location. This should be an absolute path to the file containing the
+keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that
 multiple listeners with GSSAPIAuth will override each other. If using multiple\
-GSSAPI authenticators, either do not set this option or use the same value for\
+GSSAPI authenticators, either do not set this option or use the same value for
 all listeners.
 
 ```
@@ -68,23 +68,23 @@ authenticator_options=principal_name=mymariadb@EXAMPLE.COM,gssapi_keytab_path=/h
 
 ### Implementation details
 
-Read the [Authentication Modules](mariadb-maxscale-2308-authentication-modules.md) document for more\
+Read the [Authentication Modules](mariadb-maxscale-2308-authentication-modules.md) document for more
 details on how authentication modules work in MaxScale.
 
 #### GSSAPI authentication
 
-The GSSAPI plugin authentication starts when the database server sends the\
-service principal name in the AuthSwitchRequest packet. The principal name will\
+The GSSAPI plugin authentication starts when the database server sends the
+service principal name in the AuthSwitchRequest packet. The principal name will
 usually be in the form `service@REALM.COM`.
 
-The client searches its local cache for a token for the service or may request\
-it from the GSSAPI server. If found, the client sends the token to the database\
-server. The database server verifies the authenticity of the token using its\
+The client searches its local cache for a token for the service or may request
+it from the GSSAPI server. If found, the client sends the token to the database
+server. The database server verifies the authenticity of the token using its
 keytab file and sends the final OK packet to the client.
 
 ### Building the module
 
-The GSSAPI authenticator modules require the GSSAPI development libraries\
+The GSSAPI authenticator modules require the GSSAPI development libraries
 (krb5-devel on CentOS 7).
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-mariadbmysql-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-mariadbmysql-authenticator.md
@@ -4,38 +4,38 @@
 
 ## MariaDB/MySQL Authenticator
 
-The _MariaDBAuth_-module implements the client and backend authentication for the\
-server plugin _mysql\_native\_password_. This is the default authentication\
+The _MariaDBAuth_-module implements the client and backend authentication for the
+server plugin _mysql\_native\_password_. This is the default authentication
 plugin used by both MariaDB and MySQL.
 
 ### Authenticator options
 
-The following settings may be given in the _authenticator\_options_ of the\
+The following settings may be given in the _authenticator\_options_ of the
 listener.
 
 #### `clear_pw_passthrough`
 
 Boolean, default value is "false". Activates passthrough-mode. In this mode,\
-MaxScale does not check client credentials at all and defers authentication to\
-the backend server. This feature is primarily meant to be used with Xpand LDAP-\
-authentication, although it may be useful in any situation where MaxScale\
+MaxScale does not check client credentials at all and defers authentication to
+the backend server. This feature is primarily meant to be used with Xpand LDAP-
+authentication, although it may be useful in any situation where MaxScale
 cannot check the existence of client user account nor authenticate the client.
 
-When a client connects to a listener with this setting enabled, MaxScale will\
-change authentication method to "mysql\_clear\_password", causing the client to\
-send their cleartext password to MaxScale. MaxScale will then attempt to use\
-the password to authenticate to backends. The authentication result of the\
+When a client connects to a listener with this setting enabled, MaxScale will
+change authentication method to "mysql\_clear\_password", causing the client to
+send their cleartext password to MaxScale. MaxScale will then attempt to use
+the password to authenticate to backends. The authentication result of the
 first backend to respond will be sent to the client. The backend may ask\
-MaxScale for either cleartext password or standard ("mysql\_native\_password")\
-authentication token. MaxScale can work with both backend plugins since it has\
+MaxScale for either cleartext password or standard ("mysql\_native\_password")
+authentication token. MaxScale can work with both backend plugins since it has
 the original password.
 
-This feature is incompatible with service setting _lazy\_connect_. Either leave\
-it unspecified or set `lazy_connect=false` in the linked service. Also,\
-multiple client authenticators are not allowed on the listener when\
+This feature is incompatible with service setting _lazy\_connect_. Either leave
+it unspecified or set `lazy_connect=false` in the linked service. Also,
+multiple client authenticators are not allowed on the listener when
 passthrough-mode is on.
 
-Because passwords are sent in cleartext, the listener should be configured for\
+Because passwords are sent in cleartext, the listener should be configured for
 ssl.
 
 ```
@@ -54,10 +54,10 @@ ssl=true
 * Dynamic: No
 * Default: `false`
 
-The service setting _log\_auth\_warnings_ must\
-also be enabled for this setting to have effect. When both settings are enabled,\
-password hashes are logged if a client gives a wrong password. This feature may\
-be useful when diagnosing authentication issues. It should only be enabled on a\
+The service setting _log\_auth\_warnings_ must
+also be enabled for this setting to have effect. When both settings are enabled,
+password hashes are logged if a client gives a wrong password. This feature may
+be useful when diagnosing authentication issues. It should only be enabled on a
 secure system as the logging of password hashes may be a security risk.
 
 #### `cache_dir`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-pam-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-pam-authenticator.md
@@ -5,15 +5,15 @@
 ## PAM Authenticator
 
 Pluggable authentication module (PAM) is a general purpose authentication API.\
-An application using PAM can authenticate a user without knowledge about the\
-underlying authentication implementation. The actual authentication scheme is\
-defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be\
-quite elaborate. MaxScale supports a very limited form of the PAM protocol,\
+An application using PAM can authenticate a user without knowledge about the
+underlying authentication implementation. The actual authentication scheme is
+defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be
+quite elaborate. MaxScale supports a very limited form of the PAM protocol,
 which this document details.
 
 ### Configuration
 
-The MaxScale PAM module requires little configuration. All that is required\
+The MaxScale PAM module requires little configuration. All that is required
 is to change the listener authenticator module to "PAMAuth".
 
 ```
@@ -29,14 +29,14 @@ address=123.456.789.10
 port=12345
 ```
 
-MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_\
-set to "pam" in the _mysql.user_-table. The PAM service name of a user is read\
-from the _authetication\_string_-column. The matching PAM service in the\
-operating system PAM config is used for authenticating the user. If the\_authetication\_string\_ for a user is empty, the fallback service "mysql" is\
+MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_
+set to "pam" in the _mysql.user_-table. The PAM service name of a user is read
+from the _authetication\_string_-column. The matching PAM service in the
+operating system PAM config is used for authenticating the user. If the\_authetication\_string\_ for a user is empty, the fallback service "mysql" is
 used.
 
-PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)\
-for more information. A simple service definition used for testing this module\
+PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)
+for more information. A simple service definition used for testing this module
 is below.
 
 ```
@@ -52,8 +52,8 @@ account         required        pam_unix.so
 * Default: `false`
 
 If enabled, MaxScale communicates with the client as if using [mysql\_clear\_password](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/1-connecting/connection#mysql_clear_password-plugin).\
-This setting has no effect on MaxScale-to-backend communication, which adapts to\
-either "dialog" or "mysql\_clear\_password", depending on which one the backend\
+This setting has no effect on MaxScale-to-backend communication, which adapts to
+either "dialog" or "mysql\_clear\_password", depending on which one the backend
 suggests. This setting is meant to be used with the similarly named MariaDB\
 Server setting.
 
@@ -79,23 +79,23 @@ This setting defines the authentication mode used. Two values are supported:
 authenticator_options=pam_mode=password_2FA
 ```
 
-If set to _password\_2FA_, any users authenticating via PAM will be asked two\
-passwords ("Password" and "Verification code") during login. MaxScale uses the\
+If set to _password\_2FA_, any users authenticating via PAM will be asked two
+passwords ("Password" and "Verification code") during login. MaxScale uses the
 normal password when either the local PAM api or a backend asks for "Password".\
-MaxScale answers any other password prompt (e.g. "Verification code") with the\
-second password. See [the limitations section](mariadb-maxscale-2308-pam-authenticator.md#implementation-details-and-limitations)\
+MaxScale answers any other password prompt (e.g. "Verification code") with the
+second password. See [the limitations section](mariadb-maxscale-2308-pam-authenticator.md#implementation-details-and-limitations)
 for more details. Two-factor mode is incompatible with\_pam\_use\_cleartext\_plugin\_.
 
-If set to _suid_, MaxScale will launch a separate subprocess for every client to\
-handle pam authentication. This subprocess runs the binary`maxscale_pam_auth_tool` (installed in the binary directory), which calls the\
-system pam libraries. The binary is installed with the SUID bit set, which means\
-that it runs with root-privileges regardless of the user launching it. This\
-should bypass any file grant issues (e.g. reading `etc/shadow`) that may arise\
-with the _password_ or _password\_2FA_ options. The _suid_-option may also\
-perform faster if many clients authenticate with pam simultaneously due\
-to better separation of clients. It may also resist buggy pam plugins crashing,\
-as the crash would be limited to the subprocess only. The MariaDB Server uses\
-a similar pam authentication scheme. _suid_-mode supports two-factor\
+If set to _suid_, MaxScale will launch a separate subprocess for every client to
+handle pam authentication. This subprocess runs the binary`maxscale_pam_auth_tool` (installed in the binary directory), which calls the
+system pam libraries. The binary is installed with the SUID bit set, which means
+that it runs with root-privileges regardless of the user launching it. This
+should bypass any file grant issues (e.g. reading `etc/shadow`) that may arise
+with the _password_ or _password\_2FA_ options. The _suid_-option may also
+perform faster if many clients authenticate with pam simultaneously due
+to better separation of clients. It may also resist buggy pam plugins crashing,
+as the crash would be limited to the subprocess only. The MariaDB Server uses
+a similar pam authentication scheme. _suid_-mode supports two-factor
 authentication.
 
 #### `pam_backend_mapping`
@@ -106,7 +106,7 @@ authentication.
 * Values: `none`, `mariadb`
 * Default: `none`
 
-Defines backend authentication mapping, i.e. switch of authentication method\
+Defines backend authentication mapping, i.e. switch of authentication method
 between client-to-MaxScale and MaxScale-to-backend. Supported values:
 
 * `none` No mapping
@@ -116,28 +116,28 @@ between client-to-MaxScale and MaxScale-to-backend. Supported values:
 authenticator_options=pam_backend_mapping=mariadb
 ```
 
-If set to "mariadb", MaxScale will authenticate clients to backends using\
+If set to "mariadb", MaxScale will authenticate clients to backends using
 standard MariaDB authentication. Authentication to MaxScale itself still uses\
-PAM. MaxScale asks the local PAM system if the client username was mapped\
-to another username during authentication, and use the mapped username when\
-logging in to backends. Passwords for the mapped users can be given in a file,\
-see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to\
-authenticate without a password. Because of this, normal PAM users and mapped\
+PAM. MaxScale asks the local PAM system if the client username was mapped
+to another username during authentication, and use the mapped username when
+logging in to backends. Passwords for the mapped users can be given in a file,
+see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to
+authenticate without a password. Because of this, normal PAM users and mapped
 users cannot be used on the same listener.
 
-Because the client still needs to authenticate to MaxScale normally, an\
-anonymous user may be required. If the backends do not allow such a user, one\
+Because the client still needs to authenticate to MaxScale normally, an
+anonymous user may be required. If the backends do not allow such a user, one
 can be manually added using the service setting [user\_accounts\_file](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#user_accounts_file).
 
-To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be\
-installed separately. It is included in recent MariaDB Server packages and can\
-also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)\
-for more information on how to configure the module. If the goal is to only map\
-users from PAM to MariaDB in MaxScale, then configuring user mapping\
+To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be
+installed separately. It is included in recent MariaDB Server packages and can
+also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)
+for more information on how to configure the module. If the goal is to only map
+users from PAM to MariaDB in MaxScale, then configuring user mapping
 on just the machine running MaxScale is enough.
 
-Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#user_mapping_file),\
-as it is easier to configure. `pam_backend_mapping` should only be used when\
+Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#user_mapping_file),
+as it is easier to configure. `pam_backend_mapping` should only be used when
 the user mapping needs to be defined by pam.
 
 #### `pam_mapped_pw_file`
@@ -147,19 +147,19 @@ the user mapping needs to be defined by pam.
 * Dynamic: No
 * Default: None
 
-Path to a json-text file with user passwords. Default value is empty, which\
+Path to a json-text file with user passwords. Default value is empty, which
 disables the feature.
 
 ```
 authenticator_options=pam_mapped_pw_file=/home/root/passwords.json,pam_backend_mapping=mariadb
 ```
 
-This feature only works together with `pam_backend_mapping=mariadb`. The file is\
-only read during listener creation (typically MaxScale start) or when a listener\
-is modified during runtime. The file should contain passwords for the mapped\
-users. When a client is authenticating, MaxScale searches the password data for a\
-matching username. If one is found, MaxScale uses the supplied password when\
-logging in to backends. Otherwise, MaxScale tries to authenticate without a\
+This feature only works together with `pam_backend_mapping=mariadb`. The file is
+only read during listener creation (typically MaxScale start) or when a listener
+is modified during runtime. The file should contain passwords for the mapped
+users. When a client is authenticating, MaxScale searches the password data for a
+matching username. If one is found, MaxScale uses the supplied password when
+logging in to backends. Otherwise, MaxScale tries to authenticate without a
 password.
 
 One array, "users\_and\_passwords", is read from the file. Each array element in the array must define the following fields:
@@ -186,105 +186,105 @@ An example file is below.
 
 ### Anonymous user mapping
 
-When backend authenticator mapping is not in use\
-(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator\
+When backend authenticator mapping is not in use
+(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator
 supports a limited version of [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
 It requires less configuration but is also less accurate than proper mapping.\
 Anonymous mapping is enabled in MaxScale if the following user exists:
 
 * Empty username (e.g. `''@'%'` or `''@'myhost.com'`)
 * `plugin = 'pam'`
-* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one\
+* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one
   row with `GRANT PROXY ON ...`)
 
-When the authenticator detects such users, anonymous account mapping is enabled\
-for the hosts of the anonymous users. To verify this, enable the info log\
-(`log_info=1` in MaxScale config file). When a client is logging in using the\
-anonymous user account, MaxScale will log a message starting with "Found\
+When the authenticator detects such users, anonymous account mapping is enabled
+for the hosts of the anonymous users. To verify this, enable the info log
+(`log_info=1` in MaxScale config file). When a client is logging in using the
+anonymous user account, MaxScale will log a message starting with "Found
 matching anonymous user ...".
 
-When mapping is on, the MaxScale PAM authenticator does not require client\
-accounts to exist in the `mysql.user`-table received from the backend. MaxScale\
-only requires that the hostname of the incoming client matches the host field of\
-one of the anonymous users (comparison performed using `LIKE`). If a match is\
-found, MaxScale attempts to authenticate the client to the local machine with\
-the username and password supplied. The PAM service used for authentication is\
-read from the `authentication_string`-field of the anonymous user. If\
-authentication was successful, MaxScale then uses the username and password to\
+When mapping is on, the MaxScale PAM authenticator does not require client
+accounts to exist in the `mysql.user`-table received from the backend. MaxScale
+only requires that the hostname of the incoming client matches the host field of
+one of the anonymous users (comparison performed using `LIKE`). If a match is
+found, MaxScale attempts to authenticate the client to the local machine with
+the username and password supplied. The PAM service used for authentication is
+read from the `authentication_string`-field of the anonymous user. If
+authentication was successful, MaxScale then uses the username and password to
 log to the backends.
 
-Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2308-pam-authenticator.md#configuration). This means,\
-that if a user is found and the authentication fails, anonymous authentication\
-is not attempted even when it could use a different PAM service with a different\
+Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2308-pam-authenticator.md#configuration). This means,
+that if a user is found and the authentication fails, anonymous authentication
+is not attempted even when it could use a different PAM service with a different
 outcome.
 
-Setting up PAM group mapping for the MariaDB server is a more involved process\
+Setting up PAM group mapping for the MariaDB server is a more involved process
 as the server requires details on which Unix user or group is mapped to which\
-MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)\
-for more details. Performing all the steps in the guide also on the MaxScale\
-machine is not required, as the MaxScale PAM plugin only checks that the client\
-host matches an anonymous user and that the client (with the username and\
-password it provided) can log into the local PAM configuration. If using normal\
-password authentication, simply generating the Unix user and password should be\
+MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)
+for more details. Performing all the steps in the guide also on the MaxScale
+machine is not required, as the MaxScale PAM plugin only checks that the client
+host matches an anonymous user and that the client (with the username and
+password it provided) can log into the local PAM configuration. If using normal
+password authentication, simply generating the Unix user and password should be
 enough.
 
 ### Implementation details and limitations
 
 The general PAM authentication scheme is difficult for a proxy such as MaxScale.\
-An application using the PAM interface needs to define a _conversation function_\
-to allow the OS PAM modules to communicate with the client, possibly exchanging\
-multiple messages. This works when a client logs in to a normal server, but not\
+An application using the PAM interface needs to define a _conversation function_
+to allow the OS PAM modules to communicate with the client, possibly exchanging
+multiple messages. This works when a client logs in to a normal server, but not
 with MaxScale since it needs to autonomously log into multiple backends. For\
-MaxScale to successfully log into the servers, the messages and answers need to\
-be predefined. The passwords given to MaxScale need to work as is when MaxScale\
+MaxScale to successfully log into the servers, the messages and answers need to
+be predefined. The passwords given to MaxScale need to work as is when MaxScale
 logs into the backends. This requirement prevents the use of one-time passwords.
 
-The MaxScale PAM authentication module supports two password modes. In normal\
+The MaxScale PAM authentication module supports two password modes. In normal
 mode, client authentication begins with MaxScale sending an\
-AuthSwitchRequest packet. In addition to the command, the packet contains the\
-client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)\
-and the message "Password: ". In the next packet, the client should send the\
-password, which MaxScale will forward to the PAM api running on the local\
-machine. If the password is correct, an OK packet is sent to the client. If the\
-local PAM api asks for additional credentials as is typical in two-factor\
-authentication schemes, authentication fails. Informational messages such as\
-password expiration notifications are allowed. These are simply printed to the\
+AuthSwitchRequest packet. In addition to the command, the packet contains the
+client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)
+and the message "Password: ". In the next packet, the client should send the
+password, which MaxScale will forward to the PAM api running on the local
+machine. If the password is correct, an OK packet is sent to the client. If the
+local PAM api asks for additional credentials as is typical in two-factor
+authentication schemes, authentication fails. Informational messages such as
+password expiration notifications are allowed. These are simply printed to the
 log.
 
-On the backend side, MaxScale expects the servers to act as MaxScale did towards\
-the client. The servers should send an AuthSwitchRequest packet as defined\
-above, MaxScale responds with the password received by the client authenticator\
-and finally backend replies with OK. Informational messages from backends are\
+On the backend side, MaxScale expects the servers to act as MaxScale did towards
+the client. The servers should send an AuthSwitchRequest packet as defined
+above, MaxScale responds with the password received by the client authenticator
+and finally backend replies with OK. Informational messages from backends are
 only printed to the info-log.
 
 #### Two-factor authentication support
 
-MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the\
-client to log in to the local PAM api as well as all the backends, the code must\
-be reusable. This prevents the use of any kind of centrally checked one-use\
-codes. Time-based codes work, assuming the backends are checking the codes\
+MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the
+client to log in to the local PAM api as well as all the backends, the code must
+be reusable. This prevents the use of any kind of centrally checked one-use
+codes. Time-based codes work, assuming the backends are checking the codes
 independently of each other. Automatic reconnection features (e.g.\
-readwritesplit-router) will not work, as the code has likely changed since\
+readwritesplit-router) will not work, as the code has likely changed since
 original authentication.
 
-Optionally, the PAM configuration on the backend servers can be weakened such\
-that the servers only asks for the normal password. This way, MaxScale will\
-check the 2FA-code of the incoming client, while MaxScale logs into the backends\
+Optionally, the PAM configuration on the backend servers can be weakened such
+that the servers only asks for the normal password. This way, MaxScale will
+check the 2FA-code of the incoming client, while MaxScale logs into the backends
 using only the password.
 
-Due to technical reasons, MaxScale does not forward the password prompts from\
+Due to technical reasons, MaxScale does not forward the password prompts from
 the PAM api to the client. MaxScale will always ask for "Password" and\
-"Verification code", even if the PAM api asks for other items. This prevents the\
+"Verification code", even if the PAM api asks for other items. This prevents the
 use of authentication schemes where a specific question must be answered (e.g.\
-"Input code Nr. 5"). This is not a significant limitation, as such schemes would\
+"Input code Nr. 5"). This is not a significant limitation, as such schemes would
 not work with backend servers anyway.
 
 ### Test tool
 
-MaxScale binary directory contains the _test\_pam\_login_-executable. This simple\
-program asks for a username, password and PAM service and then uses the given\
-credentials to login to the given service. _test\_pam\_login_ uses the same code\
-as MaxScale itself to communicate with the OS PAM interface and may be useful\
+MaxScale binary directory contains the _test\_pam\_login_-executable. This simple
+program asks for a username, password and PAM service and then uses the given
+credentials to login to the given service. _test\_pam\_login_ uses the same code
+as MaxScale itself to communicate with the OS PAM interface and may be useful
 for diagnosing PAM login issues.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-binlog-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-binlog-filter.md
@@ -8,22 +8,22 @@ This filter was introduced in MariaDB MaxScale 2.3.0.
 
 ### Overview
 
-The `binlogfilter` can be combined with a `binlogrouter` service to selectively\
+The `binlogfilter` can be combined with a `binlogrouter` service to selectively
 replicate the binary log events to replica servers.
 
-The filter uses two settings, _match_ and _exclude_, to determine which events\
-are replicated. If a binlog event does not match or is excluded, the event is\
-replaced with an empty data event. The empty event is always 35 bytes which\
+The filter uses two settings, _match_ and _exclude_, to determine which events
+are replicated. If a binlog event does not match or is excluded, the event is
+replaced with an empty data event. The empty event is always 35 bytes which
 translates to a space reduction in most cases.
 
-When statement-based replication is used, any query events that are filtered out\
-are replaced with a SQL comment. This causes the query event to do nothing and\
-thus the event will not modify the contents of the database. The GTID position\
-of the replicating database will still advance which means that downstream\
+When statement-based replication is used, any query events that are filtered out
+are replaced with a SQL comment. This causes the query event to do nothing and
+thus the event will not modify the contents of the database. The GTID position
+of the replicating database will still advance which means that downstream
 servers replicating from it keep functioning correctly.
 
-The filter works with both row based and statement based replication but we\
-recommend using row based replication with the binlogfilter. This guarantees\
+The filter works with both row based and statement based replication but we
+recommend using row based replication with the binlogfilter. This guarantees
 that there are no ambiguities in the event filtering.
 
 ### Configuration
@@ -46,18 +46,18 @@ Include queries that match the regex. See next entry, `exclude`, for more inform
 
 Exclude queries that match the regex.
 
-If neither `match` nor `exclude` are defined, the filter does nothing and all events\
-are replicated. This filter does not accept regular expression options as a separate\
-setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for\
+If neither `match` nor `exclude` are defined, the filter does nothing and all events
+are replicated. This filter does not accept regular expression options as a separate
+setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for
 more information.
 
-The two settings are matched against the database and table name concatenated\
-with a period. For example, the string the patterns are matched against for the\
+The two settings are matched against the database and table name concatenated
+with a period. For example, the string the patterns are matched against for the
 database `test` and table `t1` is `test.t1`.
 
-For statement based replication, the pattern is matched against all the tables\
-in the statements. If any of the tables matches the _match_ pattern, the event\
-is replicated. If any of the tables matches the _exclude_ pattern, the event is\
+For statement based replication, the pattern is matched against all the tables
+in the statements. If any of the tables matches the _match_ pattern, the event
+is replicated. If any of the tables matches the _exclude_ pattern, the event is
 not replicated.
 
 #### `rewrite_src`
@@ -77,28 +77,28 @@ See the next entry, `rewrite_dest`, for more information.
 * Default: None
 
 `rewrite_src` and `rewrite_dest` control the statement rewriting of the binlogfilter.\
-The `rewrite_src` setting is a PCRE2 regular expression that is matched against\
-the default database and the SQL of statement based replication events (query\
+The `rewrite_src` setting is a PCRE2 regular expression that is matched against
+the default database and the SQL of statement based replication events (query
 events). `rewrite_dest` is the replacement string which supports the normal\
-PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,\
+PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,
 etc.).
 
 Both `rewrite_src` and `rewrite_dest` must be defined to enable statement rewriting.
 
-When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)\
-must be used. The filter will disallow replication for all replicas that attempt\
+When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)
+must be used. The filter will disallow replication for all replicas that attempt
 to replicate with traditional file-and-position based replication.
 
-The replacement is done both on the default database as well as the SQL\
-statement in the query event. This means that great care must be taken when\
-defining the rewriting rules. To prevent accidental modification of the SQL into\
-a form that is no longer valid, use database and table names that never occur in\
+The replacement is done both on the default database as well as the SQL
+statement in the query event. This means that great care must be taken when
+defining the rewriting rules. To prevent accidental modification of the SQL into
+a form that is no longer valid, use database and table names that never occur in
 the inserted data and is never used as a constant value.
 
 ### Example Configuration
 
-With the following configuration, only events belonging to database `customers`\
-are replicated. In addition to this, events for the table `orders` are excluded\
+With the following configuration, only events belonging to database `customers`
+are replicated. In addition to this, events for the table `orders` are excluded
 and thus are not replicated.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md
@@ -8,34 +8,34 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-From MaxScale version 2.2.11 onwards, the cache filter is no longer\
-considered experimental. The following changes to the default behaviour\
+From MaxScale version 2.2.11 onwards, the cache filter is no longer
+considered experimental. The following changes to the default behaviour
 have also been made:
 
 * The default value of `cached_data` is now `thread_specific` (used to be`shared`).
 * The default value of `selects` is now `assume_cacheable` (used to be`verify_cacheable`).
 
 The cache filter is a simple cache that is capable of caching the result of\
-SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,\
+SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,
 without the queries being routed to any server.
 
 By _default_ the cache will be used and populated in the following circumstances:
 
 * There is no explicit transaction active, that is, autocommit is used,
 * there is an explicitly read-only transaction (that is,`START TRANSACTION READ ONLY`) active, or
-* there is a transaction active and no statement that modifies the database\
+* there is a transaction active and no statement that modifies the database
   has been performed.
 
-In practice, the last bullet point basically means that if a transaction has\
+In practice, the last bullet point basically means that if a transaction has
 been started with `BEGIN`, `START TRANSACTION` or `START TRANSACTION READ WRITE`, then the cache will be used and populated until the first `UPDATE`,`INSERT` or `DELETE` statement is encountered.
 
-That is, in default mode the cache effectively causes the system to behave\
-as if the _isolation level_ would be `READ COMMITTED`, irrespective of what\
+That is, in default mode the cache effectively causes the system to behave
+as if the _isolation level_ would be `READ COMMITTED`, irrespective of what
 the isolation level of the backends actually is.
 
 The default behaviour can be altered using the configuration parameter [cache\_in\_transactions](mariadb-maxscale-2308-cache.md#cache_in_transactions).
 
-By default it is assumed that all `SELECT` statements are cacheable, which\
+By default it is assumed that all `SELECT` statements are cacheable, which
 means that also statements like `SELECT LOCALTIME` are cached. Please check [selects](mariadb-maxscale-2308-cache.md#selects) for how to change the default behaviour.
 
 ### Limitations
@@ -54,34 +54,34 @@ Multi-statements are always sent to the backend and their result is**not** cache
 
 The cache is **not** aware of grants.
 
-The implication is that unless the cache has been explicitly configured\
-who the caching should apply to, the presence of the cache may provide\
+The implication is that unless the cache has been explicitly configured
+who the caching should apply to, the presence of the cache may provide
 a user with access to data he should not have access to.
 
 Please read the section [Security](mariadb-maxscale-2308-cache.md#security-1) for more detailed information.
 
-However, from 2.5 onwards it is possible to configure the cache to cache\
-the data of each user separately, which effectively means that there can\
-be no unintended sharing. Please see [users](mariadb-maxscale-2308-cache.md#users) for how to change\
+However, from 2.5 onwards it is possible to configure the cache to cache
+the data of each user separately, which effectively means that there can
+be no unintended sharing. Please see [users](mariadb-maxscale-2308-cache.md#users) for how to change
 the default behaviour.
 
 #### `information_schema`
 
-When [invalidation](mariadb-maxscale-2308-cache.md#invalidation) is enabled, SELECTs targeting tables\
-in `information_schema` are not cached. The reason is that as the content\
-of the tables changes as the side-effect of something else, the cache would\
+When [invalidation](mariadb-maxscale-2308-cache.md#invalidation) is enabled, SELECTs targeting tables
+in `information_schema` are not cached. The reason is that as the content
+of the tables changes as the side-effect of something else, the cache would
 not know when to invalidate the cache-entries.
 
 ### Invalidation
 
-Since MaxScale 2.5, the cache is capable of invalidating entries in the\
-cache when a modification (UPDATE, INSERT or DELETE) that may affect those\
+Since MaxScale 2.5, the cache is capable of invalidating entries in the
+cache when a modification (UPDATE, INSERT or DELETE) that may affect those
 entries is made.
 
-The cache invalidation works on the table-level, that is, a modification\
-made to a particular table will cause all cache entries that refer to that\
-table to be invalidated, irrespective of whether the modification actually\
-has an impact on the cache entries or not. For instance, suppose the result\
+The cache invalidation works on the table-level, that is, a modification
+made to a particular table will cause all cache entries that refer to that
+table to be invalidated, irrespective of whether the modification actually
+has an impact on the cache entries or not. For instance, suppose the result
 of the following SELECT has been cached
 
 ```
@@ -94,55 +94,55 @@ An insert like
 INSERT INTO t SET a=42;
 ```
 
-will cause the cache entry containing the result of that SELECT to be\
+will cause the cache entry containing the result of that SELECT to be
 invalidated even if the INSERT actually does not affect it. Please see [invalidate](mariadb-maxscale-2308-cache.md#invalidate) for how to enable the invalidation.
 
-When invalidation has been enabled MaxScale must be able to completely\
-parse a SELECT statement for its results to be stored in the cache. The\
-reason is that in order to be able to invalidate cache entries, MaxScale\
-must know what tables a SELECT statement depends upon. Consequently, if\
-(and only if) invalidation has been enabled and MaxScale fails to parse a\
+When invalidation has been enabled MaxScale must be able to completely
+parse a SELECT statement for its results to be stored in the cache. The
+reason is that in order to be able to invalidate cache entries, MaxScale
+must know what tables a SELECT statement depends upon. Consequently, if
+(and only if) invalidation has been enabled and MaxScale fails to parse a
 statement, the result of that particular statement will not be cached.
 
 When invalidation has been enabled, MaxScale will also parse all UPDATE,\
-INSERT and DELETE statements, in order to find out what tables are\
-modified. If that parsing fails, MaxScale will _by default_ clear the\
-entire cache. The reason is that unless MaxScale can completely parse\
-the statement it cannot know what tables are modified and hence not what\
-cache entries should be invalidated. Consequently, to prevent stale data\
-from being returned, the entire cache is cleared. The default behaviour\
+INSERT and DELETE statements, in order to find out what tables are
+modified. If that parsing fails, MaxScale will _by default_ clear the
+entire cache. The reason is that unless MaxScale can completely parse
+the statement it cannot know what tables are modified and hence not what
+cache entries should be invalidated. Consequently, to prevent stale data
+from being returned, the entire cache is cleared. The default behaviour
 can be changed using the configuration parameter [clear\_cache\_on\_parse\_errors](mariadb-maxscale-2308-cache.md#clear_cache_on_parse_errors).
 
-Note that what threading approach is used has a big impact on the\
-invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2308-cache.md#threads-users-and-invalidation)\
+Note that what threading approach is used has a big impact on the
+invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2308-cache.md#threads-users-and-invalidation)
 for how the threading approach affects the invalidation.
 
-Note also that since the invalidation may not, depending on how the\
-cache has been configured, be visible to all sessions of all users, it\
+Note also that since the invalidation may not, depending on how the
+cache has been configured, be visible to all sessions of all users, it
 is still important to configure a reasonable [soft](mariadb-maxscale-2308-cache.md#soft_ttl) and [hard](mariadb-maxscale-2308-cache.md#hard_ttl) TTL.
 
 #### Best Efforts
 
-The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the\
-cache in all circumstances reflects the state in the actual database,\
-would require that the operations involving the cache and the MariaDB\
+The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the
+cache in all circumstances reflects the state in the actual database,
+would require that the operations involving the cache and the MariaDB
 server are synchronized, which would cause an unacceptable overhead.
 
 What _best efforts_ means in this context is best illustrated using an example.
 
-Suppose a client executes the statement `SELECT * FROM tbl` and that the result\
-is cached. Next time that or any other client executes the same statement, the\
-result is returned from the cache and the MariaDB server will not be accessed\
+Suppose a client executes the statement `SELECT * FROM tbl` and that the result
+is cached. Next time that or any other client executes the same statement, the
+result is returned from the cache and the MariaDB server will not be accessed
 at all.
 
-If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the\
-cached value for the `SELECT` statement above and all other statements that are\
-dependent upon `tbl` will be invalidated. That is, the next time someone executes\
+If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the
+cached value for the `SELECT` statement above and all other statements that are
+dependent upon `tbl` will be invalidated. That is, the next time someone executes
 the statement `SELECT * FROM tbl` the result will again be fetched from the\
 MariaDB server and stored to the cache.
 
-However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`\
-at the same time someone else executes the `INSERT ...` statement. A possible\
+However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`
+at the same time someone else executes the `INSERT ...` statement. A possible
 chain of events is as follows:
 
 ```
@@ -153,7 +153,7 @@ MaxScale -> DB                                   SELECT COUNT(*) FROM tbl
 MaxScale -> DB        INSERT ...
 ```
 
-That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of\
+That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of
 each other, the events may be re-ordered as far as the cache is concerned.
 
 ```
@@ -161,16 +161,16 @@ MaxScale -> Cache     Delete invalidated values
 MaxScale -> Cache                                Store result and invalidation key
 ```
 
-That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the\
+That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the
 situation _before_ the insert and will thus not be correct.
 
-The stale result will be returned until the value has reached its _time-to-live_\
+The stale result will be returned until the value has reached its _time-to-live_
 or its invalidation is caused by some update operation.
 
 ### Configuration
 
-The cache is simple to add to any existing service. However, some experimentation\
-may be required in order to find the configuration settings that provide\
+The cache is simple to add to any existing service. However, some experimentation
+may be required in order to find the configuration settings that provide
 the maximum benefit.
 
 ```
@@ -188,21 +188,21 @@ type=service
 filters=Cache
 ```
 
-Each configured cache filter uses a storage of its own. That is, if there\
-are two services, each configured with a specific cache filter, then,\
-even if queries target the very same servers the cached data will not\
+Each configured cache filter uses a storage of its own. That is, if there
+are two services, each configured with a specific cache filter, then,
+even if queries target the very same servers the cached data will not
 be shared.
 
-Two services can use the same cache filter, but then either the services\
-should use the very same servers _or_ a completely different set of servers,\
-where the used table names are different. Otherwise there can be unintended\
+Two services can use the same cache filter, but then either the services
+should use the very same servers _or_ a completely different set of servers,
+where the used table names are different. Otherwise there can be unintended
 sharing.
 
 #### Filter Parameters
 
 The cache filter has no mandatory parameters but a range of optional ones.\
-Note that it is advisable to specify `max_size` to prevent the cache from\
-using up all memory there is, in case there is very little overlap among the\
+Note that it is advisable to specify `max_size` to prevent the cache from
+using up all memory there is, in case there is very little overlap among the
 queries.
 
 **`storage`**
@@ -212,8 +212,8 @@ queries.
 * Dynamic: No
 * Default: `storage_inmemory`
 
-The name of the module that provides the storage for the cache. That\
-module will be loaded and provided with the value of `storage_options` as\
+The name of the module that provides the storage for the cache. That
+module will be loaded and provided with the value of `storage_options` as
 argument. For instance:
 
 ```
@@ -231,11 +231,11 @@ See [Storage](mariadb-maxscale-2308-cache.md#storage-1) for what storage modules
 
 **NOTE** Deprecated in 23.02.
 
-A string that is provided verbatim to the storage module specified in `storage`,\
-when the module is loaded. Note that the needed arguments and their format depend\
+A string that is provided verbatim to the storage module specified in `storage`,
+when the module is loaded. Note that the needed arguments and their format depend
 upon the specific module.
 
-From 23.02 onwards, the storage module configuration should be provided using\
+From 23.02 onwards, the storage module configuration should be provided using
 nested parameters.
 
 **`hard_ttl`**
@@ -245,8 +245,8 @@ nested parameters.
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Hard time to live_; the maximum amount of time the cached\
-result is used before it is discarded and the result is fetched from the\
+_Hard time to live_; the maximum amount of time the cached
+result is used before it is discarded and the result is fetched from the
 backend (and cached). See also [soft\_ttl](mariadb-maxscale-2308-cache.md#soft_ttl).
 
 ```
@@ -260,21 +260,21 @@ hard_ttl=60s
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Soft time to live_; the amount of time - in seconds - the cached result is\
-used before it is refreshed from the server. When `soft_ttl` has passed, the\
+_Soft time to live_; the amount of time - in seconds - the cached result is
+used before it is refreshed from the server. When `soft_ttl` has passed, the
 result will be refreshed when the _first_ client requests the value.
 
-However, as long as [hard\_ttl](mariadb-maxscale-2308-cache.md#hard_ttl) has not passed, _all_ other clients\
-requesting the same value will use the result from the cache while it is being\
-fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`\
-has passed, even if several clients request the same value at the same time,\
+However, as long as [hard\_ttl](mariadb-maxscale-2308-cache.md#hard_ttl) has not passed, _all_ other clients
+requesting the same value will use the result from the cache while it is being
+fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`
+has passed, even if several clients request the same value at the same time,
 there will be just one request to the backend.
 
 ```
 soft_ttl=60s
 ```
 
-If the value of `soft_ttl` is larger than `hard_ttl` it will be adjusted\
+If the value of `soft_ttl` is larger than `hard_ttl` it will be adjusted
 down to the same value.
 
 **`max_resultset_rows`**
@@ -284,7 +284,7 @@ down to the same value.
 * Dynamic: No
 * Default: `0` (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 stored in the cache. A resultset larger than this, will not be stored.
 
 ```
@@ -299,14 +299,14 @@ max_resultset_rows=1000
 * Default: `0` (no limit)
 
 Specifies the maximum size of a resultset, for it to be stored in the cache.\
-A resultset larger than this, will not be stored. The size can be specified\
+A resultset larger than this, will not be stored. The size can be specified
 as described [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#sizes).
 
 ```
 max_resultset_size=128Ki
 ```
 
-Note that the value of `max_resultset_size` should not be larger than the\
+Note that the value of `max_resultset_size` should not be larger than the
 value of `max_size`.
 
 **`max_count`**
@@ -316,12 +316,12 @@ value of `max_size`.
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum number of items the cache may contain. If the limit has been\
+The maximum number of items the cache may contain. If the limit has been
 reached and a new item should be stored, then an older item will be evicted.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
-is used, then the total number of cached items is #threads \* the value\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
+is used, then the total number of cached items is #threads \* the value
 of `max_count`.
 
 ```
@@ -335,11 +335,11 @@ max_count=1000
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum size the cache may occupy. If the limit has been reached and a new\
+The maximum size the cache may occupy. If the limit has been reached and a new
 item should be stored, then some older item(s) will be evicted to make space.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
 is used, then the total size is #threads \* the value of `max_size`.
 
 ```
@@ -353,15 +353,15 @@ max_size=100Mi
 * Dynamic: Yes
 * Default: `""` (no rules)
 
-Specifies the path of the file where the caching rules are stored. A relative\
+Specifies the path of the file where the caching rules are stored. A relative
 path is interpreted relative to the _data directory_ of MariaDB MaxScale.
 
 ```
 rules=/path/to/rules-file
 ```
 
-Note that the rules will be reloaded, and applied if different, every time\
-a dynamic configuration change is made. Thus, to cause a reloading of the\
+Note that the rules will be reloaded, and applied if different, every time
+a dynamic configuration change is made. Thus, to cause a reloading of the
 rules, alter the rules parameter to the same value it has.
 
 ```
@@ -376,22 +376,22 @@ maxctrl alter filter MyCache rules='/path/to/rules-file'
 * Values: `shared`, `thread_specific`
 * Default: `thread_specific`
 
-An enumeration option specifying how data is shared between threads. The\
+An enumeration option specifying how data is shared between threads. The
 allowed values are:
 
-* `shared`: The cached data is shared between threads. On the one hand\
-  it implies that there will be synchronization between threads, on\
+* `shared`: The cached data is shared between threads. On the one hand
+  it implies that there will be synchronization between threads, on
   the other hand that all threads will use data fetched by any thread.
-* `thread_specific`: The cached data is specific to a thread. On the\
-  one hand it implies that no synchronization is needed between threads,\
-  on the other hand that the very same data may be fetched and stored\
+* `thread_specific`: The cached data is specific to a thread. On the
+  one hand it implies that no synchronization is needed between threads,
+  on the other hand that the very same data may be fetched and stored
   multiple times.
 
 ```
 cached_data=shared
 ```
 
-Default is `thread_specific`. See `max_count` and `max_size` what implication\
+Default is `thread_specific`. See `max_count` and `max_size` what implication
 changing this setting to `shared` has.
 
 **`selects`**
@@ -402,35 +402,35 @@ changing this setting to `shared` has.
 * Values: `assume_cacheable`, `verify_cacheable`
 * Default: `assume_cacheable`
 
-An enumeration option specifying what approach the cache should take with\
+An enumeration option specifying what approach the cache should take with
 respect to `SELECT` statements. The allowed values are:
 
-* `assume_cacheable`: The cache can assume that all `SELECT` statements,\
+* `assume_cacheable`: The cache can assume that all `SELECT` statements,
   without exceptions, are cacheable.
-* `verify_cacheable`: The cache can not assume that all `SELECT`\
+* `verify_cacheable`: The cache can not assume that all `SELECT`
   statements are cacheable, but must verify that.
 
 ```
 selects=verify_cacheable
 ```
 
-Default is `assume_cacheable`. In this case, all `SELECT` statements are\
-assumed to be cacheable and will be parsed _only_ if some specific rule\
+Default is `assume_cacheable`. In this case, all `SELECT` statements are
+assumed to be cacheable and will be parsed _only_ if some specific rule
 requires that.
 
-If `verify_cacheable` is specified, then all `SELECT` statements will be\
-parsed and only those that are safe for caching - e.g. do _not_ call any\
-non-cacheable functions or access any non-cacheable variables - will be\
+If `verify_cacheable` is specified, then all `SELECT` statements will be
+parsed and only those that are safe for caching - e.g. do _not_ call any
+non-cacheable functions or access any non-cacheable variables - will be
 subject to caching.
 
-If `verify_cacheable` has been specified, the cache will not be used in\
+If `verify_cacheable` has been specified, the cache will not be used in
 the following circumstances:
 
 * The `SELECT` uses any of the following functions: `BENCHMARK`,`CONNECTION_ID`, `CONVERT_TZ`, `CURDATE`, `CURRENT_DATE`, `CURRENT_TIMESTAMP`,`CURTIME`, `DATABASE`, `ENCRYPT`, `FOUND_ROWS`, `GET_LOCK`, `IS_FREE_LOCK`,`IS_USED_LOCK`, `LAST_INSERT_ID`, `LOAD_FILE`, `LOCALTIME`, `LOCALTIMESTAMP`,`MASTER_POS_WAIT`, `NOW`, `RAND`, `RELEASE_LOCK`, `SESSION_USER`, `SLEEP`,`SYSDATE`, `SYSTEM_USER`, `UNIX_TIMESTAMP`, `USER`, `UUID`, `UUID_SHORT`.
 * The `SELECT` accesses any of the following fields: `CURRENT_DATE`,`CURRENT_TIMESTAMP`, `LOCALTIME`, `LOCALTIMESTAMP`
 * The `SELECT` uses system or user variables.
 
-Note that parsing all `SELECT` statements carries a performance\
+Note that parsing all `SELECT` statements carries a performance
 cost. Please read [performance](mariadb-maxscale-2308-cache.md#performance) for more details.
 
 **`cache_in_transactions`**
@@ -441,21 +441,21 @@ cost. Please read [performance](mariadb-maxscale-2308-cache.md#performance) for 
 * Values: `never`, `read_only_transactions`, `all_transactions`
 * Default: `all_transactions`
 
-An enumeration option specifying how the cache should behave when there\
+An enumeration option specifying how the cache should behave when there
 are active transactions:
 
-* `never`: When there is an active transaction, no data will be returned\
+* `never`: When there is an active transaction, no data will be returned
   from the cache, but all requests will always be sent to the backend.\
   The cache will be populated inside explicitly read-only transactions.\
-  Inside transactions that are not explicitly read-only, the cache will\
+  Inside transactions that are not explicitly read-only, the cache will
   be populated until the first non-SELECT statement.
-* `read_only_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be populated, but not used\
+* `read_only_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be populated, but not used
   until the first non-SELECT statement.
-* `all_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be used and populated until the\
+* `all_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be used and populated until the
   first non-SELECT statement.
 
 ```
@@ -464,7 +464,7 @@ cache_in_transactions=never
 
 Default is `all_transactions`.
 
-The values `read_only_transactions` and `all_transactions` have roughly the\
+The values `read_only_transactions` and `all_transactions` have roughly the
 same effect as changing the isolation level of the backend to `read_committed`.
 
 **`debug`**
@@ -474,8 +474,8 @@ same effect as changing the isolation level of the backend to `read_committed`.
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the cache\
-can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the cache
+can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -504,9 +504,9 @@ Specifies whether the cache is initially enabled or disabled.
 enabled=false
 ```
 
-The value affects the initial state of the MaxScale user\
-variables using which the behaviour of the cache can be modified\
-at runtime. Please see [Runtime Configuration](mariadb-maxscale-2308-cache.md#runtime-configuration)\
+The value affects the initial state of the MaxScale user
+variables using which the behaviour of the cache can be modified
+at runtime. Please see [Runtime Configuration](mariadb-maxscale-2308-cache.md#runtime-configuration)
 for details.
 
 **`invalidate`**
@@ -517,7 +517,7 @@ for details.
 * Values: `never`, `current`
 * Default: `never`
 
-An enumeration option specifying how the cache should invalidate\
+An enumeration option specifying how the cache should invalidate
 cache entries.
 
 ```
@@ -528,18 +528,18 @@ cache entries.
   not.
 ```
 
-The effect of `current` depends upon the value of `cached_data`. If the value\
-is `shared`, that is, all threads share the same cache, then the effect of an\
+The effect of `current` depends upon the value of `cached_data`. If the value
+is `shared`, that is, all threads share the same cache, then the effect of an
 invalidation is immediately visible to all sessions, as there is just one cache.\
-However, if the value is `thread_specific`, then an invalidation will affect only\
+However, if the value is `thread_specific`, then an invalidation will affect only
 the cache that the session happens to be using.
 
-If it is important and _sufficient_ that an application immediately sees a change\
-that it itself has caused, then a combination of `invalidate=current`\
+If it is important and _sufficient_ that an application immediately sees a change
+that it itself has caused, then a combination of `invalidate=current`
 and `cached_data=thread_specific` can be used.
 
-If it is important that an application _immediately_ sees all changes, irrespective\
-of who has caused them, then a combination of `invalidate=current`\
+If it is important that an application _immediately_ sees all changes, irrespective
+of who has caused them, then a combination of `invalidate=current`
 and `cached_data=shared` _must_ be used.
 
 **`clear_cache_on_parse_errors`**
@@ -549,18 +549,18 @@ and `cached_data=shared` _must_ be used.
 * Dynamic: No
 * Default: `true`
 
-This boolean option specifies how the cache should behave in case of\
+This boolean option specifies how the cache should behave in case of
 parsing errors when invalidation has been enabled.
 
-* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE\
+* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE
   statement then all cached data will be cleared.
-* `false`: A failure to parse an UPDATE/INSERT/DELETE statement\
+* `false`: A failure to parse an UPDATE/INSERT/DELETE statement
   is ignored and no invalidation will take place due that statement.
 
 The default value is `true`.
 
-Changing the value to `false` may mean that stale data is returned from\
-the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement\
+Changing the value to `false` may mean that stale data is returned from
+the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement
 affects entries in the cache.
 
 **`users`**
@@ -571,7 +571,7 @@ affects entries in the cache.
 * Values: `mixed`, `isolated`
 * Default: `mixed`
 
-An enumeration option specifying how the cache should cache data for\
+An enumeration option specifying how the cache should cache data for
 different users.
 
 ```
@@ -582,11 +582,11 @@ different users.
   no unintended sharing.
 ```
 
-Note that if `isolated` has been specified, then each user will\
-conceptually have a cache of his own, which is populated\
-independently from each other. That is, if two users make the\
-same query, then the data will be fetched twice and also stored\
-twice. So, a `isolated` cache will in general use more memory and\
+Note that if `isolated` has been specified, then each user will
+conceptually have a cache of his own, which is populated
+independently from each other. That is, if two users make the
+same query, then the data will be fetched twice and also stored
+twice. So, a `isolated` cache will in general use more memory and
 cause more traffic to the backend compared to a `mixed` cache.
 
 **`timeout`**
@@ -596,7 +596,7 @@ cause more traffic to the backend compared to a `mixed` cache.
 * Dynamic: No
 * Default: `5s`
 
-The _timeout_ used when performing operations to distributed storages\
+The _timeout_ used when performing operations to distributed storages
 such as _redis_ or _memcached_.
 
 ```
@@ -605,19 +605,19 @@ timeout=7000ms
 
 #### Runtime Configuration
 
-The cache filter can be configured at runtime by executing SQL commands. If\
-there is more than one cache filter in a service, only the first cache filter\
-will be able to process the variables. The remaining filters will not see them\
+The cache filter can be configured at runtime by executing SQL commands. If
+there is more than one cache filter in a service, only the first cache filter
+will be able to process the variables. The remaining filters will not see them
 and thus configuring them at runtime is not possible.
 
 **`@maxscale.cache.populate`**
 
-Using the variable `@maxscale.cache.populate` it is possible to specify at\
-runtime whether the cache should be populated or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.populate` it is possible to specify at
+runtime whether the cache should be populated or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be populated.
 
 ```
@@ -627,10 +627,10 @@ SET @maxscale.cache.populate=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-In the example above, the first `SELECT` will always be sent to the\
-server and the result will be cached, provided the actual cache rules\
-specifies that it should be. The second `SELECT` may be served from the\
-cache, depending on the value of `@maxscale.cache.use` (and the cache\
+In the example above, the first `SELECT` will always be sent to the
+server and the result will be cached, provided the actual cache rules
+specifies that it should be. The second `SELECT` may be served from the
+cache, depending on the value of `@maxscale.cache.use` (and the cache
 rules).
 
 The value of `@maxscale.cache.populate` can be queried
@@ -643,12 +643,12 @@ but only _after_ it has been explicitly set once.
 
 **`@maxscale.cache.use`**
 
-Using the variable `@maxscale.cache.use` it is possible to specify at\
-runtime whether the cache should be used or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.use` it is possible to specify at
+runtime whether the cache should be used or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be used.
 
 ```
@@ -658,15 +658,15 @@ SET @maxscale.cache.use=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-The first `SELECT` will be served from the cache, providing the rules\
-specify that the statement should be cached, the cache indeed contains\
+The first `SELECT` will be served from the cache, providing the rules
+specify that the statement should be cached, the cache indeed contains
 the result and the date is not stale (as specified by the _TTL_).
 
-If the data is stale, the `SELECT` will be sent to the server **and**\
+If the data is stale, the `SELECT` will be sent to the server **and**
 the cache entry will be updated, irrespective of the value of`@maxscale.cache.populate`.
 
-If `@maxscale.cache.use` is `true` but the result is not found in the\
-cache, and the result is subsequently fetched from the server, the\
+If `@maxscale.cache.use` is `true` but the result is not found in the
+cache, and the result is subsequently fetched from the server, the
 result will **not** be added to the cache, unless`@maxscale.cache.populate` is also `true`.
 
 The value of `@maxscale.cache.use` can be queried
@@ -679,12 +679,12 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.soft_ttl`**
 
-Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime\
-to specify _in seconds_ what _soft ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `soft_ttl`. That is,\
+Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime
+to specify _in seconds_ what _soft ttl_ should be applied. Its initial
+value is the value of the configuration parameter `soft_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _soft ttl_ should be applied.
 
 ```
@@ -694,13 +694,13 @@ SET @maxscale.cache.soft_ttl=60;
 SELECT c, d FROM important;
 ```
 
-When data is `SELECT`ed from the unimportant table `unimportant`, the data\
-will be returned from the cache provided it is no older than 10 minutes,\
-but when data is `SELECT`ed from the important table `important`, the\
+When data is `SELECT`ed from the unimportant table `unimportant`, the data
+will be returned from the cache provided it is no older than 10 minutes,
+but when data is `SELECT`ed from the important table `important`, the
 data will be returned from the cache provided it is no older than 1 minute.
 
-Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`\
-in the sense that if the former is less that the latter, then _soft ttl_\
+Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`
+in the sense that if the former is less that the latter, then _soft ttl_
 will, when used, be adjusted down to the value of _hard ttl_.
 
 The value of `@maxscale.cache.soft_ttl` can be queried
@@ -713,16 +713,16 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.hard_ttl`**
 
-Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime\
-to specify _in seconds_ what _hard ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `hard_ttl`. That is,\
+Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime
+to specify _in seconds_ what _hard ttl_ should be applied. Its initial
+value is the value of the configuration parameter `hard_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _hard ttl_ should be applied.
 
-Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,\
-is important to ensure that the former is at least as large as the latter\
+Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,
+is important to ensure that the former is at least as large as the latter
 and for best overall performance that it is larger.
 
 ```
@@ -742,11 +742,11 @@ but only after it has explicitly been set once.
 
 **Client Driven Caching**
 
-With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible\
+With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible
 to make the caching completely client driven.
 
-Provide no `rules` file, which means that _all_ `SELECT` statements are\
-subject to caching and that all users receive data from the cache. Set\
+Provide no `rules` file, which means that _all_ `SELECT` statements are
+subject to caching and that all users receive data from the cache. Set
 the startup mode of the cache to _disabled_.
 
 ```
@@ -766,10 +766,10 @@ SELECT e, f FROM tbl3;
 SET @maxscale.cache.populate=FALSE;
 ```
 
-Note that those `SELECT`s must return something in order for the\
+Note that those `SELECT`s must return something in order for the
 statement to be _marked_ for caching.
 
-After this, the value of `@maxscale.cache.use` will decide whether\
+After this, the value of `@maxscale.cache.use` will decide whether
 or not the cache is considered.
 
 ```
@@ -778,12 +778,12 @@ SELECT a, b FROM tbl1;
 SET @maxscale.cache.use=FALSE;
 ```
 
-With `@maxscale.cache.use` being `true`, the cache is considered\
-and the result returned from there, if not stale. If it is stale,\
+With `@maxscale.cache.use` being `true`, the cache is considered
+and the result returned from there, if not stale. If it is stale,
 the result is fetched from the server and the cached entry is updated.
 
-By setting a very long _TTL_ it is possible to prevent the cache\
-from ever considering an entry to be stale and instead manually\
+By setting a very long _TTL_ it is possible to prevent the cache
+from ever considering an entry to be stale and instead manually
 cause the cache to be updated when needed.
 
 ```
@@ -795,8 +795,8 @@ SET @maxscale.cache.populate=FALSE;
 
 ### Threads, Users and Invalidation
 
-What caching approach is used and how different users are treated\
-has a significant impact on the behaviour of the cache. In the\
+What caching approach is used and how different users are treated
+has a significant impact on the behaviour of the cache. In the
 following the implication of different combinations is explained.
 
 | cached\_data/users | mixed                                                                                                                          | isolated                                                                                                                        |
@@ -806,14 +806,14 @@ following the implication of different combinations is explained.
 
 #### Invalidation
 
-Invalidation takes place only in the current cache, so how _visible_\
+Invalidation takes place only in the current cache, so how _visible_
 the invalidation is, depends upon the configuration value of`cached_data`.
 
 **`cached_data=thread_specific`**
 
-The invalidation is visible only to the sessions that are handled by\
-the same worker thread where the invalidation occurred. Sessions of the\
-same or other users that are handled by different worker threads will\
+The invalidation is visible only to the sessions that are handled by
+the same worker thread where the invalidation occurred. Sessions of the
+same or other users that are handled by different worker threads will
 not see the new value before the TTL causes the value to be refreshed.
 
 **`cache_data=shared`**
@@ -824,8 +824,8 @@ The invalidation is immediately visible to all sessions of all users.
 
 The caching rules are expressed as a JSON object or as an array of JSON objects.
 
-There are two decisions to be made regarding the caching; in what circumstances\
-should data be stored to the cache and in what circumstances should the data in\
+There are two decisions to be made regarding the caching; in what circumstances
+should data be stored to the cache and in what circumstances should the data in
 the cache be used.
 
 Expressed in JSON this looks as follows
@@ -849,9 +849,9 @@ or, in case an array is used, as
 ]
 ```
 
-The `store` field specifies in what circumstances data should be stored to\
-the cache and the `use` field specifies in what circumstances the data in\
-the cache should be used. In both cases, the value is a JSON array containing\
+The `store` field specifies in what circumstances data should be stored to
+the cache and the `use` field specifies in what circumstances the data in
+the cache should be used. In both cases, the value is a JSON array containing
 objects.
 
 If an array of rule objects is specified, then, when looking for a rule that\
@@ -861,14 +861,14 @@ deciding whether data in the cache should be used.
 
 #### When to Store
 
-By default, if no rules file have been provided or if the `store` field is\
-missing from the object, the results of all queries will be stored to the\
-cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter\
+By default, if no rules file have been provided or if the `store` field is
+missing from the object, the results of all queries will be stored to the
+cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter
 parameters.
 
-By providing a `store` field in the JSON object, the decision whether to\
-store the result of a particular query to the cache can be controlled in\
-a more detailed manner. The decision to cache the results of a query can\
+By providing a `store` field in the JSON object, the decision whether to
+store the result of a particular query to the cache can be controlled in
+a more detailed manner. The decision to cache the results of a query can
 depend upon
 
 * the database,
@@ -892,21 +892,21 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`\
+If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`
 or `unlike`, then _value_ is interpreted as a _pcre2_ regular expression.\
-Note though that if _attribute_ is `database`, `table` or `column`, then\
-the string is interpreted as a name, where a dot `.` denotes qualification\
+Note though that if _attribute_ is `database`, `table` or `column`, then
+the string is interpreted as a name, where a dot `.` denotes qualification
 or scoping.
 
-The objects in the `store` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `store` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 result of the query in question will be stored to the cache.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then the result of the query is not stored to the cache.
 
-Note that as the query itself is used as the key, although the following\
+Note that as the query itself is used as the key, although the following
 queries
 
 ```
@@ -920,7 +920,7 @@ USE db1;
 SELECT * FROM tbl
 ```
 
-target the same table and produce the same results, they will be cached\
+target the same table and produce the same results, they will be cached
 separately. The same holds for queries like
 
 ```
@@ -933,13 +933,13 @@ and
 SELECT * FROM tbl WHERE b = 3 AND a = 2;
 ```
 
-as well. Although they conceptually are identical, there will be two\
+as well. Although they conceptually are identical, there will be two
 cache entries.
 
-Note that if a column has been specified in a rule, then a statement\
+Note that if a column has been specified in a rule, then a statement
 will match _irrespective_ of where that particular column appears.\
-For instance, if a rule specifies that the result of statements referring\
-to the column _a_ should be cached, then the following statement will\
+For instance, if a rule specifies that the result of statements referring
+to the column _a_ should be cached, then the following statement will
 match
 
 ```
@@ -954,7 +954,7 @@ SELECT b FROM tbl WHERE a > 5;
 
 **Qualified Names**
 
-When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,\
+When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,
 dot (`.`) denotes qualification or scope.
 
 In practice that means that if _attribute_ is `database` then _value_ may\
@@ -963,20 +963,20 @@ dot, used for separating the database and table names respectively, and\
 if _attribute_ is `column` then _value_ may contain one or two dots, used\
 for separating table and column names, or database, table and column names.
 
-Note that if a qualified name is used as a _value_, then all parts of the\
-name must be available for a match. Currently Maria DB MaxScale may not\
-always be capable of deducing in what table a particular column is. If\
-that is the case, then a value like `tbl.field` may not necessarily\
+Note that if a qualified name is used as a _value_, then all parts of the
+name must be available for a match. Currently Maria DB MaxScale may not
+always be capable of deducing in what table a particular column is. If
+that is the case, then a value like `tbl.field` may not necessarily
 be a match even if the field is `field` and the table actually is `tbl`.
 
 **Implication of the default database**
 
-If the rules concerns the `database`, then only if the statement refers\
+If the rules concerns the `database`, then only if the statement refers
 to _no_ specific database, will the default database be considered.
 
 **Regexp Matching**
 
-The string used for matching the regular expression contains as much\
+The string used for matching the regular expression contains as much
 information as there is available. For instance, in a situation like
 
 ```
@@ -1016,8 +1016,8 @@ Cache all queries _not_ targeting a particular table
 }
 ```
 
-That will exclude queries targeting table _tbl1_ irrespective of which\
-database it is in. To exclude a table in a particular database, specify\
+That will exclude queries targeting table _tbl1_ irrespective of which
+database it is in. To exclude a table in a particular database, specify
 the table name using a qualified name.
 
 ```
@@ -1046,16 +1046,16 @@ Cache all queries containing a WHERE clause
 }
 ```
 
-Note that will actually cause all queries that contain WHERE anywhere,\
+Note that will actually cause all queries that contain WHERE anywhere,
 to be cached.
 
 #### When to Use
 
-By default, if no rules file have been provided or if the `use` field is\
+By default, if no rules file have been provided or if the `use` field is
 missing from the object, all users may be returned data from the cache.
 
-By providing a `use` field in the JSON object, the decision whether to use\
-data from the cache can be controlled in a more detailed manner. The decision\
+By providing a `use` field in the JSON object, the decision whether to use
+data from the cache can be controlled in a more detailed manner. The decision
 to use data from the cache can depend upon
 
 * the user.
@@ -1076,7 +1076,7 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account\
+If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account
 string, that is, `%` means indicates wildcard, but if _op_ is `like` or`unlike` it is simply assumed _value_ is a pcre2 regular expression.
 
 For instance, the following are equivalent:
@@ -1095,26 +1095,26 @@ For instance, the following are equivalent:
 }
 ```
 
-Note that if _op_ is `=` or `!=` then the usual assumptions apply,\
-that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_\
-or _unlike_ is used, then no assumptions apply, but the string is\
+Note that if _op_ is `=` or `!=` then the usual assumptions apply,
+that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_
+or _unlike_ is used, then no assumptions apply, but the string is
 used verbatim as a regular expression.
 
-The objects in the `use` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `use` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 data in the cache will be used, subject to the value of `ttl`.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then data in the cache will not be used.
 
-Note that `use` is relevant only if the query is subject to caching,\
-that is, if all queries are cached or if a query matches a particular\
+Note that `use` is relevant only if the query is subject to caching,
+that is, if all queries are cached or if a query matches a particular
 rule in the `store` array.
 
 **Examples**
 
-Use data from the cache for all users except `admin` (actually `'admin'@'%'`),\
+Use data from the cache for all users except `admin` (actually `'admin'@'%'`),
 regardless of what host the `admin` user comes from.
 
 ```
@@ -1131,15 +1131,15 @@ regardless of what host the `admin` user comes from.
 
 ### Security
 
-As the cache is not aware of grants, unless the cache has been explicitly\
-configured who the caching should apply to, the presence of the cache\
+As the cache is not aware of grants, unless the cache has been explicitly
+configured who the caching should apply to, the presence of the cache
 may provide a user with access to data he should not have access to.\
 Note that the following applies _only_ if `users=mixed` has been configured.\
-If `users=isolated` has been configured, then there can never be any\
+If `users=isolated` has been configured, then there can never be any
 unintended sharing between users.
 
-Suppose there is a table `access` that the user _alice_ has access to,\
-but the user _bob_ does not. If _bob_ tries to access the table, he will\
+Suppose there is a table `access` that the user _alice_ has access to,
+but the user _bob_ does not. If _bob_ tries to access the table, he will
 get an error as reply:
 
 ```
@@ -1147,8 +1147,8 @@ MySQL [testdb]> select * from access;
 ERROR 1142 (42000): SELECT command denied to user 'bob'@'localhost' for table 'access'
 ```
 
-If we now setup caching for the table, using the simplest possible rules\
-file, _bob_ will get access to data from the table, provided he executes\
+If we now setup caching for the table, using the simplest possible rules
+file, _bob_ will get access to data from the table, provided he executes
 a select identical with one _alice_ has executed.
 
 For instance, suppose the rules look as follows:
@@ -1165,7 +1165,7 @@ For instance, suppose the rules look as follows:
 }
 ```
 
-If _alice_ now queries the table, she will get the result, which also will\
+If _alice_ now queries the table, she will get the result, which also will
 be cached:
 
 ```
@@ -1177,7 +1177,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-If _bob_ now executes the very same query, and the result is still in the\
+If _bob_ now executes the very same query, and the result is still in the
 cache, it will be returned to him.
 
 ```
@@ -1197,7 +1197,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-That can be prevented, by explicitly declaring in the rules that the caching\
+That can be prevented, by explicitly declaring in the rules that the caching
 should be applied to _alice_ only.
 
 ```
@@ -1219,24 +1219,24 @@ should be applied to _alice_ only.
 }
 ```
 
-With these rules in place, _bob_ is again denied access, since queries\
+With these rules in place, _bob_ is again denied access, since queries
 targeting the table `access` will in his case not be served from the cache.
 
 ### Storage
 
 There are two types of storages that can be used; _local_ and _shared_.
 
-The only _local_ storage implementation is `storage_inmemory` that simply\
-stores the cache values in memory. The storage is not persistent and is\
-destroyed when MaxScale terminates. Since the storage exists in the MaxScale\
+The only _local_ storage implementation is `storage_inmemory` that simply
+stores the cache values in memory. The storage is not persistent and is
+destroyed when MaxScale terminates. Since the storage exists in the MaxScale
 process, it is very fast and provides almost always a performance benefit.
 
-Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)\
+Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)
 and [redis](https://redis.io/) respectively.
 
 The shared storages are accessed across the network and consequently it is _not_ self-evident that their use will provide any performance benefit.
-Namely, irrespective of whether the data is fetched from the cache or from\
-the server there will be a network hop and often that network hop is, as far\
+Namely, irrespective of whether the data is fetched from the cache or from
+the server there will be a network hop and often that network hop is, as far
 as the performance goes, what costs the most.
 
 The presence of a shared cache _may_ provide a performance benefit
@@ -1245,12 +1245,12 @@ The presence of a shared cache _may_ provide a performance benefit
 * if the used SELECT statements are heavy (that is, take a significant amount of time) to process for the database server, or
 * if the presence of the cache reduces the overall load of an otherwise overloaded database server.
 
-As a general rule a _shared_ storage should not be used without first\
+As a general rule a _shared_ storage should not be used without first
 assessing its value using a realistic workload.
 
 #### `storage_inmemory`
 
-This simple storage module uses the standard memory allocator for storing\
+This simple storage module uses the standard memory allocator for storing
 the cached data.
 
 ```
@@ -1261,12 +1261,12 @@ This storage module takes no arguments.
 
 #### `storage_memcached`
 
-This storage module uses [memcached](https://memcached.org/) for storing the\
+This storage module uses [memcached](https://memcached.org/) for storing the
 cached data.
 
-Multiple MaxScale instances can share the same memcached server and items\
+Multiple MaxScale instances can share the same memcached server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
@@ -1290,18 +1290,18 @@ If no port is provided, then the default port `11211` will be used.
 * Dynamic: No
 * Default: 1Mi
 
-By default, the maximum size of a value stored to memcached is 1MiB, but that\
-can be configured to something else, in which case this parameter should be\
+By default, the maximum size of a value stored to memcached is 1MiB, but that
+can be configured to something else, in which case this parameter should be
 set accordingly.
 
-The value of `max_value_size` will be used for capping `max_resultset_size`,\
-that is, if memcached has been configured to allow larger values than 1MiB\
-but `max_value_size` has not been set accordingly, only resultsets up to 1MiB\
+The value of `max_value_size` will be used for capping `max_resultset_size`,
+that is, if memcached has been configured to allow larger values than 1MiB
+but `max_value_size` has not been set accordingly, only resultsets up to 1MiB
 in size will be cached.
 
 **Example**
 
-From MaxScale 23.02 onwards, the storage configuration should be provided\
+From MaxScale 23.02 onwards, the storage configuration should be provided
 as nested parameters.
 
 ```
@@ -1313,7 +1313,7 @@ storage_memcached.server=192.168.1.31
 storage_memcached.max_value_size=10M
 ```
 
-Although _deprecated_ in 23.02, the configuration can also be provided\
+Although _deprecated_ in 23.02, the configuration can also be provided
 using `storage_options`:
 
 ```
@@ -1327,39 +1327,39 @@ storage_options="server=192.168.1.31,max_value_size=10M"
 
 **Security**
 
-_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and\
-the memcached server is encrypted. Consequently, _anybody_ with access to the\
+_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and
+the memcached server is encrypted. Consequently, _anybody_ with access to the
 memcached server or to the network have access to the cached data.
 
 #### `storage_redis`
 
-This storage module uses [redis](https://redis.io/) for storing the\
+This storage module uses [redis](https://redis.io/) for storing the
 cached data.
 
-Note that Redis should be configured with no idle timeout or with a timeout that\
-is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which\
+Note that Redis should be configured with no idle timeout or with a timeout that
+is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which
 will hurt both the functionality and the performance.
 
-Multiple MaxScale instances can share the same redis server and items\
+Multiple MaxScale instances can share the same redis server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
 storage=storage_redis
 ```
 
-If `storage_redis` cannot connect to the Redis server, caching will silently\
-be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2308-cache.md#timeout)\
+If `storage_redis` cannot connect to the Redis server, caching will silently
+be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2308-cache.md#timeout)
 interval.
 
-If a timeout error occurs during an operation, reconnecting will be attempted\
-after a delay, which will be an increasing multiple of `timeout`. For example,\
-if `timeout` is the default 5 seconds, then reconnection attempts will first\
-be made after 10 seconds, then after 15 seconds, then 20 and so on. However,\
-once 60 seconds have been reached, the delay will no longer be increased but\
-the delay will stay at one minute. Note that each time a reconnection attempt\
-is made, unless the reason for the timeout has disappeared, the client will be\
+If a timeout error occurs during an operation, reconnecting will be attempted
+after a delay, which will be an increasing multiple of `timeout`. For example,
+if `timeout` is the default 5 seconds, then reconnection attempts will first
+be made after 10 seconds, then after 15 seconds, then 20 and so on. However,
+once 60 seconds have been reached, the delay will no longer be increased but
+the delay will stay at one minute. Note that each time a reconnection attempt
+is made, unless the reason for the timeout has disappeared, the client will be
 stalled for `timeout` seconds.
 
 `storage_redis` has the following parameters:
@@ -1406,7 +1406,7 @@ Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
 * Dynamic: No
 * Default: `""`
 
-The SSL client certificate that MaxScale should use with the Redis\
+The SSL client certificate that MaxScale should use with the Redis
 server. The certificate must match the key defined in `ssl_key`.
 
 Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
@@ -1429,7 +1429,7 @@ Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
 * Dynamic: No
 * Default: `""`
 
-The Certificate Authority (CA) certificate for the CA that signed the\
+The Certificate Authority (CA) certificate for the CA that signed the
 certificate specified with `ssl_cert`.
 
 Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
@@ -1448,16 +1448,16 @@ then both _username_ and _password_ must be provided.
 
 **SSL**
 
-If `ssl_key`, `ssl_cert` and `ssl_ca` are provided, then SSL/TLS will be used\
+If `ssl_key`, `ssl_cert` and `ssl_ca` are provided, then SSL/TLS will be used
 in the communication with the Redis server, if `ssl` is set to `true`.
 
-Note that the SSL/TLS support is only available in Redis from version 6\
-onwards and that the support is not by default built into Redis, but has\
+Note that the SSL/TLS support is only available in Redis from version 6
+onwards and that the support is not by default built into Redis, but has
 to be specifically enabled at compile time as explained [here](https://redis.io/docs/management/security/encryption/).
 
 **Example**
 
-From MaxScale 23.02 onwards, the storage configuration should be provided\
+From MaxScale 23.02 onwards, the storage configuration should be provided
 as nested parameters.
 
 ```
@@ -1470,7 +1470,7 @@ storage_redis.username=hello
 storage_redis.password=world
 ```
 
-Although _deprecated_ in 23.02, the configuration can also be provided\
+Although _deprecated_ in 23.02, the configuration can also be provided
 using `storage_options`:
 
 ```
@@ -1484,12 +1484,12 @@ storage_options="server=192.168.1.31,username=hello,password=world"
 
 **Invalidation**
 
-`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2308-cache.md#best-efforts)\
-are of greater significance since also the communication between the cache and the\
+`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2308-cache.md#best-efforts)
+are of greater significance since also the communication between the cache and the
 cache storage is asynchronous and takes place over the network.
 
-_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation\
-mode), redis must be flushed as otherwise there will be entries in the cache that\
+_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation
+mode), redis must be flushed as otherwise there will be entries in the cache that
 will not be affected by the invalidation.
 
 ```
@@ -1498,15 +1498,15 @@ $ redis-cli flushall
 
 **Security**
 
-The data in the redis server is _not_ encrypted. Consequently, _anybody_ with\
+The data in the redis server is _not_ encrypted. Consequently, _anybody_ with
 access to the redis server has access to the cached data.
 
-Unless [SSL](mariadb-maxscale-2308-cache.md#ssl) has been enabled, _anybody_ with access to the network has\
+Unless [SSL](mariadb-maxscale-2308-cache.md#ssl) has been enabled, _anybody_ with access to the network has
 access to the cached data.
 
 ### Example
 
-In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size\
+In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size
 of the cached data is `50` mebibytes. The rules for the cache are in the file`cache_rules.json`.
 
 #### Configuration
@@ -1546,16 +1546,16 @@ The rules specify that the data of the table `sbtest` should be cached.
 
 ### Performance
 
-When the cache filter was introduced, the most significant factor affecting\
+When the cache filter was introduced, the most significant factor affecting
 the performance of the cache was whether the statements needed to be parsed.\
-Initially, all statements were parsed in order to exclude `SELECT` statements\
-that use non-cacheable functions, access non-cacheable variables or refer\
-to system or user variables. Later, the default value of the `selects` parameter\
+Initially, all statements were parsed in order to exclude `SELECT` statements
+that use non-cacheable functions, access non-cacheable variables or refer
+to system or user variables. Later, the default value of the `selects` parameter
 was changed to `assume_cacheable`, to maximize the default performance.
 
-With the default configuration, the cache itself will not cause the statements\
-to be parsed. However, even with `assume_cacheable` configured, a rule referring\
-specifically to a _database_, _table_ or _column_ will still cause the\
+With the default configuration, the cache itself will not cause the statements
+to be parsed. However, even with `assume_cacheable` configured, a rule referring
+specifically to a _database_, _table_ or _column_ will still cause the
 statement to be parsed.
 
 For instance, a simple rule like
@@ -1590,15 +1590,15 @@ If the rule is instead expressed using a regular expression
 
 then the statement will not be parsed.
 
-However, when the [query classifier cache](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#query_classifier_cache_size)\
-was introduced, the parsing cost was significantly reduced and\
-currently the cost for parsing and regular expression matching\
+However, when the [query classifier cache](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#query_classifier_cache_size)
+was introduced, the parsing cost was significantly reduced and
+currently the cost for parsing and regular expression matching
 is roughly the same.
 
-In the following is a table with numbers giving a rough picture\
+In the following is a table with numbers giving a rough picture
 of the relative cost of different approaches.
 
-In the table, _regexp match_ means that the cacheable statements\
+In the table, _regexp match_ means that the cacheable statements
 were picked out using a rule like
 
 ```
@@ -1609,7 +1609,7 @@ were picked out using a rule like
 }
 ```
 
-while _exact match_ means that the cacheable statements were picked out using a\
+while _exact match_ means that the cacheable statements were picked out using a
 rule like
 
 ```
@@ -1622,12 +1622,12 @@ rule like
 
 The exact match rule requires all statements to be parsed.
 
-As the purpose of the test is to illustrate the overhead of\
-different approaches, the rules were formulated so that\
+As the purpose of the test is to illustrate the overhead of
+different approaches, the rules were formulated so that
 all SELECT statements would match.
 
 Note that these figures were obtained by running sysbench,\
-MaxScale and the server in the same computer, so they are\
+MaxScale and the server in the same computer, so they are
 only indicative.
 
 | selects           | Rule         | qps |
@@ -1641,18 +1641,18 @@ only indicative.
 
 For comparison, without caching, the qps is `33`.
 
-As can be seen, due to the query classifier cache there is\
+As can be seen, due to the query classifier cache there is
 no difference between exact and regex based matching.
 
 #### Summary
 
 For maximum performance:
 
-* Arrange the situation so that the default `selects=assume_cacheable`\
+* Arrange the situation so that the default `selects=assume_cacheable`
   can be used, and use no rules.
 
-Otherwise it is mostly a personal preference whether exact or regex\
-based rules are used. However, one should always test with real data\
+Otherwise it is mostly a personal preference whether exact or regex
+based rules are used. However, one should always test with real data
 and real queries before choosing one over the other.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-comment-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-comment-filter.md
@@ -6,8 +6,8 @@
 
 ### Overview
 
-With the _comment_ filter it is possible to define comments that are\
-injected before the actual statements. These comments appear as sql\
+With the _comment_ filter it is possible to define comments that are
+injected before the actual statements. These comments appear as sql
 comments when they are received by the server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-consistent-critical-read-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-consistent-critical-read-filter.md
@@ -8,41 +8,41 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Consistent Critical Read (CCR) filter allows consistent critical reads to be\
+The Consistent Critical Read (CCR) filter allows consistent critical reads to be
 done through MaxScale while still allowing scaleout of non-critical reads.
 
-When the filter detects a statement that would modify the database, it attaches\
-a routing hint to all following statements done by that connection. This routing\
-hint guides the routing module to route the statement to the primary server where\
-data is guaranteed to be in an up-to-date state. Writes from one session do not,\
+When the filter detects a statement that would modify the database, it attaches
+a routing hint to all following statements done by that connection. This routing
+hint guides the routing module to route the statement to the primary server where
+data is guaranteed to be in an up-to-date state. Writes from one session do not,
 by default, propagate to other sessions.
 
-_Note:_ This filter does not work with prepared statements. Only text protocol\
+_Note:_ This filter does not work with prepared statements. Only text protocol
 queries are handled by this filter.
 
 #### Controlling the Filter with SQL Comments
 
-The triggering of the filter can be limited further by adding MaxScale supported\
-comments to queries and/or by using regular expressions. The query comments take\
-precedence: if a comment is found it is obeyed even if a regular expression\
+The triggering of the filter can be limited further by adding MaxScale supported
+comments to queries and/or by using regular expressions. The query comments take
+precedence: if a comment is found it is obeyed even if a regular expression
 parameter might give a different result. Even a comment cannot cause a\
-SELECT-query to trigger the filter. Such a comment is considered an error and\
+SELECT-query to trigger the filter. Such a comment is considered an error and
 ignored.
 
-The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-hint-syntax.md)\
-and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a\
-query has a MaxScale supported comment line which defines the parameter `ccr`,\
-that comment is caught by the CCR-filter. Parameter values `match` and `ignore`\
-are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)\
+The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-hint-syntax.md)
+and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a
+query has a MaxScale supported comment line which defines the parameter `ccr`,
+that comment is caught by the CCR-filter. Parameter values `match` and `ignore`
+are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)
 on receiving the write query. For example, the query
 
 ```
 INSERT INTO departments VALUES ('d1234', 'NewDepartment'); -- maxscale ccr=ignore
 ```
 
-would normally cause the filter to trigger, but does not because of the\
-comment. The `match`-comment typically has no effect, since write queries by\
-default trigger the filter anyway. It can be used to override an ignore-type\
+would normally cause the filter to trigger, but does not because of the
+comment. The `match`-comment typically has no effect, since write queries by
+default trigger the filter anyway. It can be used to override an ignore-type
 regular expression that would otherwise prevent triggering.
 
 ### Filter Parameters
@@ -56,19 +56,19 @@ The CCR filter has no mandatory parameters.
 * Dynamic: Yes
 * Default: `60s`
 
-The time window during which queries are routed to the primary. The duration\
-can be specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations)\
+The time window during which queries are routed to the primary. The duration
+can be specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations)
 but the value will always be rounded to the nearest second.\
-If no explicit unit has been specified, the value is interpreted as seconds\
+If no explicit unit has been specified, the value is interpreted as seconds
 in MaxScale 2.4. In subsequent versions a value without a unit may be rejected.\
 The default value for this parameter is 60 seconds.
 
-When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new\
-data modifying SQL statement is processed within the time window, the timer is\
+When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new
+data modifying SQL statement is processed within the time window, the timer is
 reset to the value of _time_.
 
-Enabling this parameter in combination with the _count_ parameter causes both\
-the time window and number of queries to be inspected. If either of the two\
+Enabling this parameter in combination with the _count_ parameter causes both
+the time window and number of queries to be inspected. If either of the two
 conditions are met, the query is re-routed to the primary.
 
 #### `count`
@@ -81,10 +81,10 @@ conditions are met, the query is re-routed to the primary.
 The number of SQL statements to route to primary after detecting a data modifying\
 SQL statement. This feature is disabled by default.
 
-After processing a data modifying SQL statement, a counter is set to the value\
-of _count_ and all statements are routed to the primary. Each executed statement\
-after a data modifying SQL statement cause the counter to be decremented. Once\
-the counter reaches zero, the statements are routed normally. If a new data\
+After processing a data modifying SQL statement, a counter is set to the value
+of _count_ and all statements are routed to the primary. Each executed statement
+after a data modifying SQL statement cause the counter to be decremented. Once
+the counter reaches zero, the statements are routed normally. If a new data
 modifying SQL statement is processed, the counter is reset to the value of_count_.
 
 #### `match`, `ignore`
@@ -94,9 +94,9 @@ modifying SQL statement is processed, the counter is reset to the value of_count
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
-control which statements trigger statement re-routing. Only non-SELECT statements are\
-inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works\
+These [regular expression settings](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+control which statements trigger statement re-routing. Only non-SELECT statements are
+inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works
 similarly.
 
 ```
@@ -122,16 +122,16 @@ Regular expression options for `match` and `ignore`.
 * Dynamic: Yes
 * Default: `false`
 
-`global` is a boolean parameter that when enabled causes writes from one\
-connection to propagate to all other connections. This can be used to work\
-around cases where one connection writes data and another reads it, expecting\
+`global` is a boolean parameter that when enabled causes writes from one
+connection to propagate to all other connections. This can be used to work
+around cases where one connection writes data and another reads it, expecting
 the write done by the other connection to be visible.
 
 This parameter only works with the `time` parameter. The use of `global` and`count` at the same time is not allowed and will be treated as an error.
 
 ### Example Configuration
 
-Here is a minimal filter configuration for the CCRFilter which should solve most\
+Here is a minimal filter configuration for the CCRFilter which should solve most
 problems with critical reads after writes.
 
 ```
@@ -141,13 +141,13 @@ module=ccrfilter
 time=5
 ```
 
-With this configuration, whenever a connection does a write, all subsequent\
+With this configuration, whenever a connection does a write, all subsequent
 reads done by that connection will be forced to the primary for 5 seconds.
 
-This prevents read scaling until the modifications have been replicated to the\
-replicas. For best performance, the value of _time_ should be slightly greater\
-than the actual replication lag between the primary and its replicas. If the number\
-of critical read statements is known, the _count_ parameter could be used to\
+This prevents read scaling until the modifications have been replicated to the
+replicas. For best performance, the value of _time_ should be slightly greater
+than the actual replication lag between the primary and its replicas. If the number
+of critical read statements is known, the _count_ parameter could be used to
 control the number reads that are sent to the primary.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-hintfilter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-hintfilter.md
@@ -8,14 +8,14 @@ This filter adds routing hints to a service. The filter has no parameters.
 
 ## Hint Syntax
 
-**Note:** If a query has more than one comment only the first comment is\
-processed. Always place any MaxScale related comments first before any other\
+**Note:** If a query has more than one comment only the first comment is
+processed. Always place any MaxScale related comments first before any other
 comments that might appear in the query.
 
 ### Comments and comment types
 
-The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and\
-they need to be enabled by passing the `--comments` or `-c` option to it. Most,\
+The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and
+they need to be enabled by passing the `--comments` or `-c` option to it. Most,
 if not all, connectors keep all comments intact in executed queries.
 
 ```
@@ -23,10 +23,10 @@ if not all, connectors keep all comments intact in executed queries.
 mariadb --comments -u my-user -psecret -e "SELECT @@hostname -- maxscale route to server db1"
 ```
 
-For comment types, use either `--` (notice the whitespace after the double\
+For comment types, use either `--` (notice the whitespace after the double
 hyphen) or `#` after the semicolon or `/* ... */` before the semicolon.
 
-Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character\
+Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character
 after the start tag or before the end tag but adding the whitespace is advised.
 
 ### Hint body
@@ -37,12 +37,12 @@ All hints must start with the `maxscale` tag.
 -- maxscale <hint body>
 ```
 
-The hints have two types, ones that define a server type and others that contain\
+The hints have two types, ones that define a server type and others that contain
 name-value pairs.
 
 #### Routing destination hints
 
-These hints will instruct the router to route a query to a certain type of a\
+These hints will instruct the router to route a query to a certain type of a
 server.
 
 ```
@@ -55,8 +55,8 @@ server.
 -- maxscale route to master
 ```
 
-A `master` value in a routing hint will route the query to a primary server. This\
-can be used to direct read queries to a primary server for a up-to-date result\
+A `master` value in a routing hint will route the query to a primary server. This
+can be used to direct read queries to a primary server for a up-to-date result
 with no replication lag.
 
 **Route to replica**
@@ -65,8 +65,8 @@ with no replication lag.
 -- maxscale route to slave
 ```
 
-A `slave` value will route the query to a replica server. Please note that the\
-hints will override any decisions taken by the routers which means that it is\
+A `slave` value will route the query to a replica server. Please note that the
+hints will override any decisions taken by the routers which means that it is
 possible to force writes to a replica server.
 
 **Route to named server**
@@ -75,7 +75,7 @@ possible to force writes to a replica server.
 -- maxscale route to server <server name>
 ```
 
-A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in\
+A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in
 maxscale.cnf. If the server is not used by the service, the hint is ignored.
 
 **Route to last used server**
@@ -84,8 +84,8 @@ maxscale.cnf. If the server is not used by the service, the hint is ignored.
 -- maxscale route to last
 ```
 
-A `last` value will route the query to the server that processed the last\
-query. This hint can be used to force certain queries to be grouped to the same\
+A `last` value will route the query to the server that processed the last
+query. This hint can be used to force certain queries to be grouped to the same
 server.
 
 **Name-value hints**
@@ -94,13 +94,13 @@ server.
 -- maxscale <param>=<value>
 ```
 
-These control the behavior and affect the routing decisions made by the\
-router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower\
+These control the behavior and affect the routing decisions made by the
+router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower
 replication lag than this parameter's value.
 
 ### Hint stack
 
-Hints can be either single-use hints, which makes them affect only one query, or\
+Hints can be either single-use hints, which makes them affect only one query, or
 named hints, which can be pushed on and off a stack of active hints.
 
 Defining named hints:
@@ -127,7 +127,7 @@ You can define and activate a hint in a single command using the following:
 -- maxscale <hint name> begin <hint content>
 ```
 
-You can also push anonymous hints onto the stack which are only used as long as\
+You can also push anonymous hints onto the stack which are only used as long as
 they are on the stack:
 
 ```
@@ -136,14 +136,14 @@ they are on the stack:
 
 ## Prepared Statements
 
-The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared\
+The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared
 statements.
 
 ### Binary Protocol
 
-With binary protocol prepared statements, a routing hint in the prepared\
-statement is applied to the execution of the statement but not the preparation\
-of it. The preparation of the statement is routed normally and is sent to all\
+With binary protocol prepared statements, a routing hint in the prepared
+statement is applied to the execution of the statement but not the preparation
+of it. The preparation of the statement is routed normally and is sent to all
 servers.
 
 For example, when the following prepared statement is prepared with the MariaDB\
@@ -169,13 +169,13 @@ Support for direct execution of prepared statements was added in MaxScale\
 
 ### Text Protocol
 
-Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL\
-commands) behave differently. If a `PREPARE` command has a routing hint, it will\
-be routed according to the routing hint. Any subsequent `EXECUTE` command will\
-not be affected by the routing hint in the `PREPARE` statement. This means they\
+Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL
+commands) behave differently. If a `PREPARE` command has a routing hint, it will
+be routed according to the routing hint. Any subsequent `EXECUTE` command will
+not be affected by the routing hint in the `PREPARE` statement. This means they
 must have their own routing hints.
 
-The following example is the recommended method of executing text protocol\
+The following example is the recommended method of executing text protocol
 prepared statements with hints:
 
 ```
@@ -189,7 +189,7 @@ The `PREPARE` is routed normally and will be routed to all servers. The`EXECUTE`
 
 ### Routing `SELECT` queries to primary
 
-In this example, MariaDB MaxScale is configured with the readwritesplit router\
+In this example, MariaDB MaxScale is configured with the readwritesplit router
 and the hint filter.
 
 ```
@@ -206,9 +206,9 @@ type=filter
 module=hintfilter
 ```
 
-Behind MariaDB MaxScale is a primary server and a replica server. If there is\
-replication lag between the primary and the replica, read queries sent to the replica\
-might return old data. To guarantee up-to-date data, we can add a routing hint\
+Behind MariaDB MaxScale is a primary server and a replica server. If there is
+replication lag between the primary and the replica, read queries sent to the replica
+might return old data. To guarantee up-to-date data, we can add a routing hint
 to the query.
 
 ```
@@ -216,9 +216,9 @@ INSERT INTO table1 VALUES ("John","Doe",1);
 SELECT * FROM table1; -- maxscale route to master
 ```
 
-The first INSERT query will be routed to the primary. The following SELECT query\
-would normally be routed to the replica but with the added routing hint it will be\
-routed to the primary. This way we can do an INSERT and a SELECT right after it\
+The first INSERT query will be routed to the primary. The following SELECT query
+would normally be routed to the replica but with the added routing hint it will be
+routed to the primary. This way we can do an INSERT and a SELECT right after it
 and still get up-to-date data.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-lua-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-lua-filter.md
@@ -6,34 +6,34 @@
 
 The luafilter is a filter that calls a set of functions in a Lua script.
 
-Read the [Lua language documentation](https://www.lua.org/docs.html) for\
+Read the [Lua language documentation](https://www.lua.org/docs.html) for
 information on how to write Lua scripts.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Filter Parameters
 
-The luafilter has two parameters. They control which scripts will be called by\
-the filter. Both parameters are optional but at least one should be defined. If\
-both `global_script` and `session_script` are defined, the entry points in both\
+The luafilter has two parameters. They control which scripts will be called by
+the filter. Both parameters are optional but at least one should be defined. If
+both `global_script` and `session_script` are defined, the entry points in both
 scripts will be called.
 
 #### `global_script`
 
-The global Lua script. The parameter value is a path to a readable Lua script\
+The global Lua script. The parameter value is a path to a readable Lua script
 which will be executed.
 
-This script will always be called with the same global Lua state and it can be\
+This script will always be called with the same global Lua state and it can be
 used to build a global view of the whole service.
 
 #### `session_script`
 
-The session level Lua script. The parameter value is a path to a readable Lua\
+The session level Lua script. The parameter value is a path to a readable Lua
 script which will be executed once for each session.
 
-Each session will have its own Lua state meaning that each session can have a\
+Each session will have its own Lua state meaning that each session can have a
 unique Lua environment. Use this script to do session specific tasks.
 
 ### Lua Script Calling Convention
@@ -41,38 +41,38 @@ unique Lua environment. Use this script to do session specific tasks.
 The entry points for the Lua script expect the following signatures:
 
 * `nil createInstance(name)` - global script only, called when the script is first loaded
-  * When the global script is loaded, it first executes on a global level\
-    before the luafilter calls the createInstance function in the Lua script\
+  * When the global script is loaded, it first executes on a global level
+    before the luafilter calls the createInstance function in the Lua script
     with the filter's name as its argument.
 * `nil newSession(string, string)` - new session is created
-  * After the session script is loaded, the newSession function in the Lua\
-    scripts is called. The first parameter is the username of the client and\
+  * After the session script is loaded, the newSession function in the Lua
+    scripts is called. The first parameter is the username of the client and
     the second parameter is the client's network address.
 * `nil closeSession()` - session is closed
   * The `closeSession` function in the Lua scripts will be called.
 * `(nil | bool | string) routeQuery()` - query is being routed
-  * The Luafilter calls the `routeQuery` functions of both the session and the\
-    global script. The query is passed as a string parameter to the\
-    routeQuery Lua function and the return values of the session specific\
-    function, if any were returned, are interpreted. If the first value is\
-    bool, it is interpreted as a decision whether to route the query or to\
-    send an error packet to the client. If it is a string, the current query\
-    is replaced with the return value and the query will be routed. If nil is\
+  * The Luafilter calls the `routeQuery` functions of both the session and the
+    global script. The query is passed as a string parameter to the
+    routeQuery Lua function and the return values of the session specific
+    function, if any were returned, are interpreted. If the first value is
+    bool, it is interpreted as a decision whether to route the query or to
+    send an error packet to the client. If it is a string, the current query
+    is replaced with the return value and the query will be routed. If nil is
     returned, the query is routed normally.
 * `nil clientReply()` - reply to a query is being routed
   * This function is called with the name of the server that returned the response.
 * `string diagnostic()` - global script only, print diagnostic information
-  * If the Lua function returns a string that is valid JSON, it will be\
-    decoded as JSON and displayed as such in the REST API. If the object does\
+  * If the Lua function returns a string that is valid JSON, it will be
+    decoded as JSON and displayed as such in the REST API. If the object does
     not decode into JSON, it will be stored as a JSON string.
 
-These functions, if found in the script, will be called whenever a call to the\
+These functions, if found in the script, will be called whenever a call to the
 matching entry point is made.
 
 **Script Template**
 
-Here is a script template that can be used to try out the luafilter. Copy it\
-into a file and add `global_script=<path to script>` into the filter\
+Here is a script template that can be used to try out the luafilter. Copy it
+into a file and add `global_script=<path to script>` into the filter
 configuration. Make sure the file is readable by the `maxscale` user.
 
 ```
@@ -103,29 +103,29 @@ end
 
 #### Functions Exposed by the Luafilter
 
-The luafilter exposes the following functions that can be called inside the Lua\
-script API endpoints. The callback function in which they can be called is\
-documented after the function signature. If the functions are called outside of\
+The luafilter exposes the following functions that can be called inside the Lua
+script API endpoints. The callback function in which they can be called is
+documented after the function signature. If the functions are called outside of
 the correct callback function, they raise a Lua error.
 
 * `string mxs_get_sql()` (use: `routeQuery`)
-* Returns the SQL of the query being executed. This returns an empty string\
-  for any query that is not a text protocol query (COM\_QUERY). Support for\
+* Returns the SQL of the query being executed. This returns an empty string
+  for any query that is not a text protocol query (COM\_QUERY). Support for
   prepared statements is not yet implemented.
 * `string mxs_get_type_mask()` (use: `routeQuery`)
-* Returns the type of the current query being executed as a string. The values\
-  are the string versions of the query types defined in query\_classifier.h\
+* Returns the type of the current query being executed as a string. The values
+  are the string versions of the query types defined in query\_classifier.h
   are separated by vertical bars (`|`).\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_operation()` (use: `routeQuery`)
-* Returns the current operation type as a string. The values are defined in\
+* Returns the current operation type as a string. The values are defined in
   query\_classifier.h.\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_canonical()` (use: `routeQuery`)
 * Returns the canonical version of a query by replacing all user-defined constant values with question marks.\
   This function can only be called from the `routeQuery` entry point.
 * `number mxs_get_session_id()` (use: `newSession`, `routeQuery`, `clientReply`, `closeSession`)
-* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return\
+* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return
   the value 0.
 * `string mxs_get_db()` (use: `newSession`, `routeQuery`, `clientReply`, `closeSession`)
 * Returns the current default database used by the connection.
@@ -180,10 +180,10 @@ end
 
 ### Limitations
 
-* `mxs_get_sql()` and `mxs_get_canonical()` do not work with queries done with\
+* `mxs_get_sql()` and `mxs_get_canonical()` do not work with queries done with
   the binary protocol.
-* The Lua code is not restricted in any way which means excessively slow\
-  execution of it can cause the MaxScale process to become slower or to be\
+* The Lua code is not restricted in any way which means excessively slow
+  execution of it can cause the MaxScale process to become slower or to be
   aborted due to a SystemD watchdog timeout.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-masking.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-masking.md
@@ -8,15 +8,15 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-With the _masking_ filter it is possible to obfuscate the returned\
+With the _masking_ filter it is possible to obfuscate the returned
 value of a particular column.
 
-For instance, suppose there is a table _person_ that, among other\
-columns, contains the column _ssn_ where the social security number\
+For instance, suppose there is a table _person_ that, among other
+columns, contains the column _ssn_ where the social security number
 of a person is stored.
 
-With the masking filter it is possible to specify that when the _ssn_\
-field is queried, a masked value is returned unless the user making\
+With the masking filter it is possible to specify that when the _ssn_
+field is queried, a masked value is returned unless the user making
 the query is a specific one. That is, when making the query
 
 ```
@@ -45,44 +45,44 @@ the _ssn_ would be masked, as in
 ...
 ```
 
-Note that the masking filter should be viewed as a best-effort solution\
-intended for protecting against accidental misuse rather than malicious\
+Note that the masking filter should be viewed as a best-effort solution
+intended for protecting against accidental misuse rather than malicious
 attacks.
 
 ### Security
 
-From MaxScale 2.3 onwards, the masking filter will reject statements\
+From MaxScale 2.3 onwards, the masking filter will reject statements
 that use functions in conjunction with columns that should be masked.\
-Allowing function usage provides a way for circumventing the masking,\
+Allowing function usage provides a way for circumventing the masking,
 unless a firewall filter is separately configured and installed.
 
-Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2308-masking.md#prevent_function_usage)\
+Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2308-masking.md#prevent_function_usage)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will check the\
-definition of user variables and reject statements that define a user\
+From MaxScale 2.3.5 onwards, the masking filter will check the
+definition of user variables and reject statements that define a user
 variable using a statement that refers to columns that should be masked.
 
-Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2308-masking.md#check_user_variables)\
+Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2308-masking.md#check_user_variables)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine unions\
-and if the second or subsequent SELECT refer to columns that should\
+From MaxScale 2.3.5 onwards, the masking filter will examine unions
+and if the second or subsequent SELECT refer to columns that should
 be masked, the statement will be rejected.
 
-Please see the configuration parameter [check\_unions](mariadb-maxscale-2308-masking.md#check_unions)\
+Please see the configuration parameter [check\_unions](mariadb-maxscale-2308-masking.md#check_unions)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine subqueries\
-and if a subquery refers to columns that should be masked, the statement\
+From MaxScale 2.3.5 onwards, the masking filter will examine subqueries
+and if a subquery refers to columns that should be masked, the statement
 will be rejected.
 
-Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2308-masking.md#check_subqueries)\
+Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2308-masking.md#check_subqueries)
 for how to change the default behaviour.
 
-Note that in order to ensure that it is not possible to get access to\
-masked data, the privileges of the users should be minimized. For instance,\
-if a user can create tables and perform inserts, he or she can execute\
+Note that in order to ensure that it is not possible to get access to
+masked data, the privileges of the users should be minimized. For instance,
+if a user can create tables and perform inserts, he or she can execute
 something like
 
 ```
@@ -93,16 +93,16 @@ SELECT revealed_ssn FROM cheat;
 
 to get access to the cleartext version of a masked field `ssn`.
 
-From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that\
+From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that
 cannot be fully parsed.
 
-Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2308-masking.md#require_fully_parsed)\
+Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2308-masking.md#require_fully_parsed)
 for how to change the default behaviour.
 
-From MaxScale 2.3.7 onwards, the masking filter will treat any strings\
+From MaxScale 2.3.7 onwards, the masking filter will treat any strings
 passed to functions as if they were fields. The reason is that as the\
-MaxScale query classifier is not aware of whether `ANSI_QUOTES` is\
-enabled or not, it is possible to bypass the masking by turning that\
+MaxScale query classifier is not aware of whether `ANSI_QUOTES` is
+enabled or not, it is possible to bypass the masking by turning that
 option on.
 
 ```
@@ -110,32 +110,32 @@ mysql> set @@sql_mode = 'ANSI_QUOTES';
 mysql> select concat("ssn") from managers;
 ```
 
-Before this change, the content of the field `ssn` would have been\
+Before this change, the content of the field `ssn` would have been
 returned in clear text even if the column should have been masked.
 
-Note that this change will mean that there may be false positives\
-if `ANSI_QUOTES` is not enabled and a string argument happens to\
+Note that this change will mean that there may be false positives
+if `ANSI_QUOTES` is not enabled and a string argument happens to
 be the same as the name of a field to be masked.
 
 Please see the configuration parameter\
-\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)\
+\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)
 for how to change the default behaviour.
 
 ### Limitations
 
-The masking filter can _only_ be used for masking columns of the following\
-types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no\
+The masking filter can _only_ be used for masking columns of the following
+types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no
 masking will be performed.
 
-Currently, the masking filter can only work on packets whose payload is less\
-than 16MB. If the masking filter encounters a packet whose payload is exactly\
-that, thus indicating a situation where the payload is delivered in multiple\
-packets, the value of the parameter `large_payloads` specifies how the masking\
+Currently, the masking filter can only work on packets whose payload is less
+than 16MB. If the masking filter encounters a packet whose payload is exactly
+that, thus indicating a situation where the payload is delivered in multiple
+packets, the value of the parameter `large_payloads` specifies how the masking
 filter should handle the situation.
 
 ### Configuration
 
-The masking filter is taken into use with the following kind of\
+The masking filter is taken into use with the following kind of
 configuration setup.
 
 ```
@@ -161,7 +161,7 @@ The masking filter has one mandatory parameter - `rules`.
 * Dynamic: Yes
 
 Specifies the path of the file where the masking rules are stored.\
-A relative path is interpreted relative to the _module configuration directory_\
+A relative path is interpreted relative to the _module configuration directory_
 of MariaDB MaxScale. The default module configuration directory is_/etc/maxscale.modules.d_.
 
 ```
@@ -176,8 +176,8 @@ rules=/path/to/rules-file
 * Values: `never`, `always`
 * Default: `never`
 
-With this optional parameter the masking filter can be instructed to log\
-a warning if a masking rule matches a column that is not of one of the\
+With this optional parameter the masking filter can be instructed to log
+a warning if a masking rule matches a column that is not of one of the
 allowed types.
 
 ```
@@ -192,17 +192,17 @@ warn_type_mismatch=always
 * Values: `ignore`, `abort`
 * Default: `abort`
 
-This optional parameter specifies how the masking filter should treat\
-payloads larger than `16MB`, that is, payloads that are delivered in\
+This optional parameter specifies how the masking filter should treat
+payloads larger than `16MB`, that is, payloads that are delivered in
 multiple MySQL protocol packets.
 
-The values that can be used are `ignore`, which means that columns in\
-such payloads are not masked, and `abort`, which means that if such\
-payloads are encountered, the client connection is closed. The default\
+The values that can be used are `ignore`, which means that columns in
+such payloads are not masked, and `abort`, which means that if such
+payloads are encountered, the client connection is closed. The default
 is `abort`.
 
-Note that the aborting behaviour is applied only to resultsets that\
-contain columns that should be masked. There are _no_ limitations on\
+Note that the aborting behaviour is applied only to resultsets that
+contain columns that should be masked. There are _no_ limitations on
 resultsets that do not contain such columns.
 
 ```
@@ -216,23 +216,23 @@ large_payload=ignore
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should behave\
-if a column that should be masked, is used in conjunction with some\
-function. As the masking filter works _only_ on the basis of the\
-information in the returned result-set, if the name of a column is\
-not present in the result-set, then the masking filter cannot mask a\
-value. This means that the masking filter basically can be bypassed\
+This optional parameter specifies how the masking filter should behave
+if a column that should be masked, is used in conjunction with some
+function. As the masking filter works _only_ on the basis of the
+information in the returned result-set, if the name of a column is
+not present in the result-set, then the masking filter cannot mask a
+value. This means that the masking filter basically can be bypassed
 with a query like:
 
 ```
 SELECT CONCAT(masked_column) FROM tbl;
 ```
 
-If the value of `prevent_function_usage` is `true`, then all\
-statements that contain functions referring to masked columns will\
-be rejected. As that means that also queries using potentially\
-harmless functions, such as `LENGTH(masked_column)`, are rejected\
-as well, this feature can be turned off. In that case, the firewall\
+If the value of `prevent_function_usage` is `true`, then all
+statements that contain functions referring to masked columns will
+be rejected. As that means that also queries using potentially
+harmless functions, such as `LENGTH(masked_column)`, are rejected
+as well, this feature can be turned off. In that case, the firewall
 filter should be setup to allow or reject the use of certain functions.
 
 ```
@@ -246,19 +246,19 @@ prevent_function_usage=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
-behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a\
+This optional parameter specifies how the masking filter should
+behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a
 statement that cannot be fully parsed,
 
-If true, then statements that cannot be fully parsed (due to a\
+If true, then statements that cannot be fully parsed (due to a
 parser limitation) will be blocked.
 
 ```
 require_fully_parsed=false
 ```
 
-Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered\
-less effective, as it with a statement that can not be fully parsed may be\
+Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered
+less effective, as it with a statement that can not be fully parsed may be
 possible to bypass the protection that they are intended to provide.
 
 **`treat_string_arg_as_field`**
@@ -268,9 +268,9 @@ possible to bypass the protection that they are intended to provide.
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should treat\
-strings used as arguments to functions. If true, they will be handled\
-as fields, which will cause fields to be masked even if `ANSI_QUOTES` has\
+This optional parameter specifies how the masking filter should treat
+strings used as arguments to functions. If true, they will be handled
+as fields, which will cause fields to be masked even if `ANSI_QUOTES` has
 been enabled and `"` is used instead of backtick.
 
 ```
@@ -284,7 +284,7 @@ treat_string_arg_as_field=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to user variables. If true, then a statement like
 
 ```
@@ -304,7 +304,7 @@ check_user_variables=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to UNIONs. If true, then a statement like
 
 ```
@@ -324,7 +324,7 @@ check_unions=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to subqueries. If true, then a statement like
 
 ```
@@ -341,7 +341,7 @@ check_subqueries=false
 
 The masking rules are expressed as a JSON object.
 
-The top-level object is expected to contain a key `rules` whose\
+The top-level object is expected to contain a key `rules` whose
 value is an array of rule objects.
 
 ```
@@ -350,8 +350,8 @@ value is an array of rule objects.
 }
 ```
 
-Each rule in the rules array is a JSON object, expected to\
-contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two\
+Each rule in the rules array is a JSON object, expected to
+contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two
 latter ones optional.
 
 ```
@@ -369,15 +369,15 @@ latter ones optional.
 
 #### `replace`
 
-The value of this key is an object that specifies the column\
-whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The\
+The value of this key is an object that specifies the column
+whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The
 value of these keys must be a string.
 
-If only `column` is specified, then a column with that name\
-matches irrespective of the table and database. If `table`\
-is specified, then the column matches only if it is in a table\
-with the specified name, and if `database` is specified when\
-the column matches only if it is in a database with the\
+If only `column` is specified, then a column with that name
+matches irrespective of the table and database. If `table`
+is specified, then the column matches only if it is in a table
+with the specified name, and if `database` is specified when
+the column matches only if it is in a database with the
 specified name.
 
 ```
@@ -397,10 +397,10 @@ specified name.
 }
 ```
 
-**NOTE** If a rule contains a table/database then if the resultset\
-does _not_ contain table/database information, it will always be\
-considered a match if the column matches. For instance, given the\
-rule above, if there is a table `person2`, also containing an `ssn`\
+**NOTE** If a rule contains a table/database then if the resultset
+does _not_ contain table/database information, it will always be
+considered a match if the column matches. For instance, given the
+rule above, if there is a table `person2`, also containing an `ssn`
 field, then a query like
 
 ```
@@ -413,24 +413,24 @@ will not return masked values, but a query like
 SELECT ssn FROM person UNION SELECT ssn FROM person2;
 ```
 
-will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is\
+will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is
 observed even with a nonsensical query like
 
 ```
 SELECT ssn FROM person2 UNION SELECT ssn FROM person2;
 ```
 
-even if nothing from `person2` should be masked. The reason is that\
-as the resultset contains no table information, the values must be\
-masked if the column name matches, as otherwise the masking could\
+even if nothing from `person2` should be masked. The reason is that
+as the resultset contains no table information, the values must be
+masked if the column name matches, as otherwise the masking could
 easily be circumvented with a query like
 
 ```
 SELECT ssn FROM person UNION SELECT ssn FROM person;
 ```
 
-The optional key `match` makes partial replacement of the original\
-value possible: only the matched part would be replaced\
+The optional key `match` makes partial replacement of the original
+value possible: only the matched part would be replaced
 with the fill character.\
 The `match` value must be a valid pcre2 regular expression.
 
@@ -446,14 +446,14 @@ The `match` value must be a valid pcre2 regular expression.
 
 #### `obfuscate`
 
-The obfuscate rule allows the obfuscation of the value\
+The obfuscate rule allows the obfuscation of the value
 by passing it through an obfuscation algorithm.\
 Current solution uses a non-reversible obfuscation approach.
 
-However, note that although it is in principle impossible to obtain the\
-original value from the obfuscated one, if the range of possible original\
-values is limited, it is straightforward to figure out the possible\
-original values by running all possible values through the obfuscation\
+However, note that although it is in principle impossible to obtain the
+original value from the obfuscated one, if the range of possible original
+values is limited, it is straightforward to figure out the possible
+original values by running all possible values through the obfuscation
 algorithm and then comparing the results.
 
 The minimal configuration is:
@@ -478,20 +478,20 @@ SELECT name from db1.tbl1;`
 
 #### `with`
 
-The value of this key is an object that specifies what the value of the matched\
-column should be replaced with for the `replace` rule. Currently, the object\
+The value of this key is an object that specifies what the value of the matched
+column should be replaced with for the `replace` rule. Currently, the object
 is expected to contain either the key `value` or the key `fill`.\
 The value of both must be a string with length greater than zero.\
 If both keys are specified, `value` takes precedence.\
 If `fill` is not specified, the default `X` is used as its value.
 
-If `value` is specified, then its value is used to replace the actual value\
-verbatim and the length of the specified value must match the actual returned\
+If `value` is specified, then its value is used to replace the actual value
+verbatim and the length of the specified value must match the actual returned
 value (from the server) exactly. If the lengths do not match, the value of`fill` is used to mask the actual value.
 
-When the value of `fill` (fill-value) is used for masking the returned value,\
-the fill-value is used as many times as necessary to match the length of the\
-return value. If required, only a part of the fill-value may be used in the end\
+When the value of `fill` (fill-value) is used for masking the returned value,
+the fill-value is used as many times as necessary to match the length of the
+return value. If required, only a part of the fill-value may be used in the end
 of the mask value to get the lengths to match.
 
 ```
@@ -534,8 +534,8 @@ of the mask value to get the lengths to match.
 
 #### `applies_to`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is applied to. Each string\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is applied to. Each string
 should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -551,13 +551,13 @@ should be a MariaDB account string, that is, `%` is a wildcard.
 }
 ```
 
-If this key is not specified, then the masking is performed for all\
+If this key is not specified, then the masking is performed for all
 users, except the ones exempted using the key `exempted`.
 
 #### `exempted`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is _not_ applied to. Each\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is _not_ applied to. Each
 string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -575,14 +575,14 @@ string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md) documentation for details\
+Read [Module Commands](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md) documentation for details
 about module commands.
 
 The masking filter supports the following module commands.
 
 #### `reload`
 
-Reload the rules from the rules file. The new rules are taken into use\
+Reload the rules from the rules file. The new rules are taken into use
 only if the loading succeeds without any errors.
 
 ```
@@ -594,8 +594,8 @@ MariaDB MaxScale configuration file.
 
 ### Example
 
-In the following we configure a masking filter _MyMasking_ that should always log a\
-warning if a masking rule matches a column that is of a type that cannot be masked,\
+In the following we configure a masking filter _MyMasking_ that should always log a
+warning if a masking rule matches a column that is of a type that cannot be masked,
 and that should abort the client connection if a resultset package is larger than\
 16MB. The rules for the masking filter are in the file `masking_rules.json`.
 
@@ -617,9 +617,9 @@ filters=MyMasking
 
 #### `masking_rules.json`
 
-The rules specify that the data of a column whose name is `ssn`, should\
-be replaced with the string _012345-ABCD_. If the length of the data is\
-not exactly the same as the length of the replacement value, then the\
+The rules specify that the data of a column whose name is `ssn`, should
+be replaced with the string _012345-ABCD_. If the length of the data is
+not exactly the same as the length of the replacement value, then the
 data should be replaced with as many _X_ characters as needed.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-maxrows.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-maxrows.md
@@ -8,11 +8,11 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Maxrows filter is capable of restricting the amount of rows that a SELECT,\
+The Maxrows filter is capable of restricting the amount of rows that a SELECT,
 a prepared statement or stored procedure could return to the client application.
 
-If a resultset from a backend server has more rows than the configured limit\
-or the resultset size exceeds the configured size,\
+If a resultset from a backend server has more rows than the configured limit
+or the resultset size exceeds the configured size,
 an empty result will be sent to the client.
 
 ### Configuration
@@ -42,7 +42,7 @@ Optional parameters are:
 * Dynamic: Yes
 * Default: (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 returned to the user.
 
 If a resultset is larger than this an empty result will be sent instead.
@@ -58,8 +58,8 @@ max_resultset_rows=1000
 * Dynamic: Yes
 * Default: `64Ki`
 
-Specifies the maximum size a resultset can have in order\
-to be sent to the client. A resultset larger than this, will\
+Specifies the maximum size a resultset can have in order
+to be sent to the client. A resultset larger than this, will
 not be sent: an empty resultset will be sent instead.
 
 ```
@@ -74,7 +74,7 @@ max_resultset_size=128Ki
 * Values: `empty`, `error`, `ok`
 * Default: `empty`
 
-Specifies what the filter sends to the client when the\
+Specifies what the filter sends to the client when the
 rows or size limit is hit, possible values:
 
 * an empty result set
@@ -95,8 +95,8 @@ ERROR 1415 (0A000): Row limit/size exceeded for query: select * from test.t4
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the Maxrows\
-filter can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the Maxrows
+filter can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -111,7 +111,7 @@ debug=2
 
 ### Example Configuration
 
-Here is an example of filter configuration where the maximum number of returned\
+Here is an example of filter configuration where the maximum number of returned
 rows is 10000 and maximum allowed resultset size is 256KB
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-maxscale-2308-ldi-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-maxscale-2308-ldi-filter.md
@@ -4,14 +4,14 @@
 
 ## LDI Filter
 
-The `ldi` (LOAD DATA INFILE) filter was introduced in MaxScale 23.08.0 and it\
-extends the MariaDB `LOAD DATA INFILE` syntax to support loading data from any\
+The `ldi` (LOAD DATA INFILE) filter was introduced in MaxScale 23.08.0 and it
+extends the MariaDB `LOAD DATA INFILE` syntax to support loading data from any
 object storage that supports the S3 API. This includes cloud offerings like AWS\
 S3 and Google Cloud Storage as well as locally run services like Minio.
 
-If the filename starts with either `S3://` or `gs://`, the path is interpreted\
-as a S3 object file. The prefix is case-insensitive. For example, the following\
-command would load the file `my-data.csv` from the bucket `my-bucket` into the\
+If the filename starts with either `S3://` or `gs://`, the path is interpreted
+as a S3 object file. The prefix is case-insensitive. For example, the following
+command would load the file `my-data.csv` from the bucket `my-bucket` into the
 table `t1`.
 
 ```
@@ -21,7 +21,7 @@ LOAD DATA INFILE 'S3://my-bucket/my-data.csv' INTO TABLE t1
 
 ### How to Upload Data
 
-Here is a minimal configuration for the filter that can be used to load data\
+Here is a minimal configuration for the filter that can be used to load data
 from AWS S3:
 
 ```
@@ -33,11 +33,11 @@ region=us-east-1
 ```
 
 The first step is to move the file to be loaded into the same region that\
-MaxScale and the MariaDB servers are in. One factor in the speed of the upload\
-is the network latency and minimizing it by moving the source and the\
+MaxScale and the MariaDB servers are in. One factor in the speed of the upload
+is the network latency and minimizing it by moving the source and the
 destination closer improves the data loading speed.
 
-The next step is to connect to MaxScale and prepare the session for an upload by\
+The next step is to connect to MaxScale and prepare the session for an upload by
 providing the service account access and secret keys.
 
 ```
@@ -52,41 +52,41 @@ LOAD DATA INFILE 'S3://my-bucket/my-data.csv' INTO TABLE t1;
 
 #### Data Uploads with MariaDB Xpand
 
-For MariaDB Xpand server, the upload is done using `xpand_import`. In this case,`xpand_import` must be installed locally on the MaxScale server and must be in\
+For MariaDB Xpand server, the upload is done using `xpand_import`. In this case,`xpand_import` must be installed locally on the MaxScale server and must be in
 the executable path of the `maxscale` user.
 
-In addition, the `@maxscale.ldi.import_user` and `@maxscale.ldi.import_password`\
-variables must be set to the username and password that are used to load data\
+In addition, the `@maxscale.ldi.import_user` and `@maxscale.ldi.import_password`
+variables must be set to the username and password that are used to load data
 into the Xpand cluster.
 
 ```
 SET @maxscale.ldi.import_user='<user>', @maxscale.ldi.import_password='<password>';
 ```
 
-If a `LOAD DATA LOCAL INFILE` command is executed with an Xpand cluster,\
+If a `LOAD DATA LOCAL INFILE` command is executed with an Xpand cluster,
 the data is redirected into `xpand_import` instead of directly to the\
-Xpand nodes. This will speed up data imports into Xpand. For this mode,\
-only the `@maxscale.ldi.import_user` and `@maxscale.ldi.import_password`\
+Xpand nodes. This will speed up data imports into Xpand. For this mode,
+only the `@maxscale.ldi.import_user` and `@maxscale.ldi.import_password`
 variables must be set, the other S3 related variables are ignored.
 
-If `xpand_import` is not installed locally, the `LOAD DATA INFILE` and`LOAD DATA LOCAL INFILE` commands will not use `xpand_import` and use\
+If `xpand_import` is not installed locally, the `LOAD DATA INFILE` and`LOAD DATA LOCAL INFILE` commands will not use `xpand_import` and use
 the normal `LOAD DATA LOCAL INFILE` that's used with MariaDB behavior.
 
 ### Common Problems With Data Loading
 
 #### Missing Files
 
-If you are using self-hosted object storage programs like Minio, a common\
-problem is that they do not necessarily support the newer virtual-hosted-style\
-requests that is used by AWS. This usually manifests as an error either about a\
+If you are using self-hosted object storage programs like Minio, a common
+problem is that they do not necessarily support the newer virtual-hosted-style
+requests that is used by AWS. This usually manifests as an error either about a
 missing file or a missing bucket.
 
-If the `host` parameter is set to a hostname, it's assumed that the object\
-storage supports the newer virtual-hosted-style requests. If this not the case,\
+If the `host` parameter is set to a hostname, it's assumed that the object
+storage supports the newer virtual-hosted-style requests. If this not the case,
 the filter must be configured with `protocol_version=1`.
 
-Conversely, if the `host` parameter is set to a plain IP address, it is assumed\
-that it does not support the newer virtual-hosted-style request. If the host\
+Conversely, if the `host` parameter is set to a plain IP address, it is assumed
+that it does not support the newer virtual-hosted-style request. If the host
 does support it, the filter must be configured with `protocol_version=2`.
 
 ### Configuration Parameters
@@ -120,7 +120,7 @@ This must be either configured in the MaxScale configuration file or set with`SE
 
 The S3 region where the data is located.
 
-The value can be overridden with `SET @maxscale.ldi.s3_region='<region>'` before\
+The value can be overridden with `SET @maxscale.ldi.s3_region='<region>'` before
 starting the data load.
 
 #### `host`
@@ -130,10 +130,10 @@ starting the data load.
 * Dynamic: Yes
 * Default: `s3.amazonaws.com`
 
-The location of the S3 object storage. By default the original AWS S3 host is\
+The location of the S3 object storage. By default the original AWS S3 host is
 used. The corresponding value for Google Cloud Storage is`storage.googleapis.com`.
 
-The value can be overridden with `SET @maxscale.ldi.s3_host='<host>'` before\
+The value can be overridden with `SET @maxscale.ldi.s3_host='<host>'` before
 starting the data load.
 
 #### `port`
@@ -143,11 +143,11 @@ starting the data load.
 * Dynamic: Yes
 * Default: 0
 
-The port on which the S3 object storage is listening. If unset or set to the\
+The port on which the S3 object storage is listening. If unset or set to the
 value of 0, the default S3 port is used.
 
-The value can be overridden with `SET @maxscale.ldi.s3_port=<port>` before\
-starting the data load. Note that unlike the other values, the value for this\
+The value can be overridden with `SET @maxscale.ldi.s3_port=<port>` before
+starting the data load. Note that unlike the other values, the value for this
 variable must be an SQL integer and not an SQL string.
 
 #### `no_verify`
@@ -177,14 +177,14 @@ HTTP instead of HTTPS.
 * Default: 0
 * Values: 0, 1, 2
 
-Which protocol version to use. By default the protocol version is derived from\
-the value of `host` but this automatic protocol version deduction will not\
-always produce the correct result. For the legacy path-style requests used by\
-older S3 storage buckets, the value must be set to 1. All new buckets use the\
+Which protocol version to use. By default the protocol version is derived from
+the value of `host` but this automatic protocol version deduction will not
+always produce the correct result. For the legacy path-style requests used by
+older S3 storage buckets, the value must be set to 1. All new buckets use the
 protocol version 2.
 
-For object storage programs like Minio, the value must be set to 1 as the bucket\
-name cannot be resolved via the subdomain like it is done for object stores in\
+For object storage programs like Minio, the value must be set to 1 as the bucket
+name cannot be resolved via the subdomain like it is done for object stores in
 the cloud.
 
 #### `import_user`
@@ -193,10 +193,10 @@ the cloud.
 * Mandatory: No
 * Dynamic: Yes
 
-The Xpand user that will be used to import the data. This parameter must be\
+The Xpand user that will be used to import the data. This parameter must be
 defined if the data is being uploaded to an Xpand cluster.
 
-The value can be overridden with `SET @maxscale.ldi.import_user='<user>'` before\
+The value can be overridden with `SET @maxscale.ldi.import_user='<user>'` before
 starting the data load.
 
 #### `import_password`
@@ -205,8 +205,8 @@ starting the data load.
 * Mandatory: No
 * Dynamic: Yes
 
-The password for the Xpand user that will be used to import the data. This\
-parameter must be defined if the data is being uploaded to an Xpand cluster. The\
+The password for the Xpand user that will be used to import the data. This
+parameter must be defined if the data is being uploaded to an Xpand cluster. The
 password can be encrypted with `maxpasswd` before use.
 
 The value can be overridden with `SET @maxscale.ldi.import_password='<password>'` before starting the data load.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-named-server-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-named-server-filter.md
@@ -6,25 +6,25 @@
 
 ### Overview
 
-The **namedserverfilter** is a MariaDB MaxScale filter module able to route\
-queries to servers based on regular expression (regex) matches. Since it is a\
+The **namedserverfilter** is a MariaDB MaxScale filter module able to route
+queries to servers based on regular expression (regex) matches. Since it is a
 filter instead of a router, the NamedServerFilter only sets routing suggestions.\
-It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the\
-data packets. This filter uses the _PCRE2_ library for regular expression\
+It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the
+data packets. This filter uses the _PCRE2_ library for regular expression
 matching.
 
 ### Configuration
 
-The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of\
-the modes may be used for a given filter instance. The legacy mode is meant for\
-backwards compatibility and allows only one regular expression and one server\
-name in the configuration. In indexed mode, up to 25 regex-server pairs are\
+The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of
+the modes may be used for a given filter instance. The legacy mode is meant for
+backwards compatibility and allows only one regular expression and one server
+name in the configuration. In indexed mode, up to 25 regex-server pairs are
 allowed in the form _match01_ - _target01_, _match02_ - _target02_ and so on.\
-Also, in indexed mode, the server names (targets) may contain a list of names or\
+Also, in indexed mode, the server names (targets) may contain a list of names or
 special tags `->master` or `->slave`.
 
-All parameters except the deprecated `match` and `target` parameters can\
-be modified at runtime. Any modifications to the filter configuration will\
+All parameters except the deprecated `match` and `target` parameters can
+be modified at runtime. Any modifications to the filter configuration will
 only affect sessions created after the change has completed.
 
 Below is a configuration example for the filter in indexed-mode. The legacy mode\
@@ -65,10 +65,10 @@ NamedServerFilter requires at least one _matchXY_ - _targetXY_ pair.
 * Dynamic: Yes
 * Default: None
 
-_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#regular-expressions)\
+_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#regular-expressions)
 against which the incoming SQL query is matched. _XY_ must be a number in the range\
-01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is\
-defined, the other must be defined as well. If a query matches the pattern, the filter\
+01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is
+defined, the other must be defined as well. If a query matches the pattern, the filter
 attaches a routing hint defined by the _target_-setting to the query. The _options_-parameter affects how the patterns are compiled.
 
 ```
@@ -84,7 +84,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-[Regular expression options](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Regular expression options](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 for `matchXY`.
 
 #### `targetXY`
@@ -103,8 +103,8 @@ accordingly. The target can be one of the following:
 * `->slave` (adds a `HINT_ROUTE_TO_SLAVE` hint)
 * `->all` (adds a `HINT_ROUTE_TO_ALL` hint)
 
-The support for service names was added in MaxScale 6.3.2. Older\
-versions of MaxScale did not accept service names in the `target`\
+The support for service names was added in MaxScale 6.3.2. Older
+versions of MaxScale did not accept service names in the `target`
 parameters.
 
 ```
@@ -118,9 +118,9 @@ target01=MyServer2
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines an IP address or mask which a connecting\
-client's IP address is matched against. Only sessions whose address matches this\
-setting will have this filter active and performing the regex matching. Traffic\
+This optional parameter defines an IP address or mask which a connecting
+client's IP address is matched against. Only sessions whose address matches this
+setting will have this filter active and performing the regex matching. Traffic
 from other client IPs is simply left as is and routed straight through.
 
 ```
@@ -137,7 +137,7 @@ source=192.168.10.%
 
 Note that using `source=%` to match any IP is not allowed.
 
-Since MaxScale 2.3 it's also possible to specify multiple addresses separated\
+Since MaxScale 2.3 it's also possible to specify multiple addresses separated
 by comma. Incoming client connections are subsequently checked against each.
 
 ```
@@ -151,9 +151,9 @@ source=192.168.21.3,192.168.10.%
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines a username the connecting client username is\
-matched against. Only sessions that are connected using this username will have\
-the match and routing hints applied to them. Traffic from other users is simply\
+This optional parameter defines a username the connecting client username is
+matched against. Only sessions that are connected using this username will have
+the match and routing hints applied to them. Traffic from other users is simply
 left as is and routed straight through.
 
 ```
@@ -164,30 +164,30 @@ user=john
 
 The maximum number of accepted _match_ - _target_ pairs is 25.
 
-In the configuration file, the indexed match and target settings may be in any order\
-and may skip numbers. During SQL-query matching, however, the regexes are tested\
-in ascending order: match01, match02, match03 and so on. As soon as a match is\
-found for a given query, the routing hints are written and the packet is\
-forwarded to the next filter or router. Any remaining match regexes are\
-ignored. This means the _match_ - _target_ pairs should be indexed in priority\
-order, or, if priority is not a factor, in order of decreasing match\
+In the configuration file, the indexed match and target settings may be in any order
+and may skip numbers. During SQL-query matching, however, the regexes are tested
+in ascending order: match01, match02, match03 and so on. As soon as a match is
+found for a given query, the routing hints are written and the packet is
+forwarded to the next filter or router. Any remaining match regexes are
+ignored. This means the _match_ - _target_ pairs should be indexed in priority
+order, or, if priority is not a factor, in order of decreasing match
 probability.
 
-Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching\
-the prepared sql against the _match_-parameters. If a match is found, the\
-routing hints are attached to any execution of that prepared statement. Text-\
-mode prepared statements are not supported in this way. To divert them, use\
+Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching
+the prepared sql against the _match_-parameters. If a match is found, the
+routing hints are attached to any execution of that prepared statement. Text-
+mode prepared statements are not supported in this way. To divert them, use
 regular expressions which match the specific "EXECUTE"-query.
 
 ### Examples
 
 #### Example 1 - Route queries targeting a specific table to a server
 
-This will route all queries matching the regular expression `*from *users` to\
+This will route all queries matching the regular expression `*from *users` to
 the server named _server2_. The filter will ignore character case in queries.
 
-A query like `SELECT * FROM users` would be routed to server2 where as a query\
-like `SELECT * FROM accounts` would be routed according to the normal rules of\
+A query like `SELECT * FROM users` would be routed to server2 where as a query
+like `SELECT * FROM accounts` would be routed according to the normal rules of
 the router.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-query-log-all-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-query-log-all-filter.md
@@ -31,13 +31,13 @@ filters=MyLogFilter
 
 ### Log Rotation
 
-The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`\
-command. This will cause the log files to be reopened when the next message is\
+The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`
+command. This will cause the log files to be reopened when the next message is
 written to the file. This applies to both unified and session type logging.
 
 ### Filter Parameters
 
-The QLA filter has one mandatory parameter, `filebase`, and a number of optional\
+The QLA filter has one mandatory parameter, `filebase`, and a number of optional
 parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 
 #### `filebase`
@@ -46,7 +46,7 @@ parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 * Mandatory: Yes
 * Dynamic: No
 
-The basename of the output file created for each session. A session index is\
+The basename of the output file created for each session. A session index is
 added to the filename for each written session file. For unified log files,_.unified_ is appended.
 
 ```
@@ -105,7 +105,7 @@ Limit logging to sessions with this client source address.
 * Mandatory: No
 * Dynamic: Yes
 
-Only log queries from users that match this pattern. If the `user` parameter is\
+Only log queries from users that match this pattern. If the `user` parameter is
 used, the value of `user_match` is ignored.
 
 Here is an example pattern that matches the users `alice` and `bob`:
@@ -120,7 +120,7 @@ user_match=/(^alice$)|(^bob$)/
 * Mandatory: No
 * Dynamic: Yes
 
-Exclude all queries from users that match this pattern. If the `user` parameter\
+Exclude all queries from users that match this pattern. If the `user` parameter
 is used, the value of `user_exclude` is ignored.
 
 Here is an example pattern that excludes the users `alice` and `bob`:
@@ -135,10 +135,10 @@ user_exclude=/(^alice$)|(^bob$)/
 * Mandatory: No
 * Dynamic: Yes
 
-Only log queries from hosts that match this pattern. If the `source` parameter\
+Only log queries from hosts that match this pattern. If the `source` parameter
 is used, the value of `source_match` is ignored.
 
-Here is an example pattern that matches the loopback interface as well as the\
+Here is an example pattern that matches the loopback interface as well as the
 address `192.168.0.109`:
 
 ```
@@ -151,10 +151,10 @@ source_match=/(^127[.]0[.]0[.]1)|(^192[.]168[.]0[.]109)/
 * Mandatory: No
 * Dynamic: Yes
 
-Exclude all queries from hosts that match this pattern. If the `source`\
+Exclude all queries from hosts that match this pattern. If the `source`
 parameter is used, the value of `source_exclude` is ignored.
 
-Here is an example pattern that excludes the loopback interface as well as the\
+Here is an example pattern that excludes the loopback interface as well as the
 address `192.168.0.109`:
 
 ```
@@ -205,14 +205,14 @@ Type of data to log in the log files.
 | error\_msg         | Error message from the server (if any) (v6.2)           |
 | server             | The server where the query was routed (if any) (v22.08) |
 
-The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,\
+The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,
 but can be specified to another unit using _duration\_unit_.
 
 The log entry is written when the last reply from the server is received.\
-Prior to version 6.2 the entry was written when the query was received from\
+Prior to version 6.2 the entry was written when the query was received from
 the client, or if _reply\_time_ was specified, on first reply from the server.
 
-**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_\
+**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_
 is set the error message may contain user defined constants. For example:
 
 ```
@@ -240,7 +240,7 @@ This option is available as of MaxScale version 6.2.
 * Dynamic: Yes
 * Default: `false`
 
-When this option is true the canonical form of the query is logged. In the\
+When this option is true the canonical form of the query is logged. In the
 canonical form all user defined constants are replaced with question marks.\
 This option is available as of MaxScale version 6.2.
 
@@ -267,7 +267,7 @@ Flush log files after every write.
 * Dynamic: Yes
 * Default: `","`
 
-Defines the separator string between elements of\
+Defines the separator string between elements of
 log entries. The value should be enclosed in quotes.
 
 #### `newline_replacement`
@@ -277,19 +277,19 @@ log entries. The value should be enclosed in quotes.
 * Dynamic: Yes
 * Default: `" "`
 
-Default value is `" "` (one space). SQL-queries may include line breaks, which, if\
-printed directly to the log, may break automatic parsing. This parameter defines\
-what should be written in the place of a newline sequence (\r, \n or \r\n). If\
-this is set as the empty string, then newlines are not replaced and printed as\
+Default value is `" "` (one space). SQL-queries may include line breaks, which, if
+printed directly to the log, may break automatic parsing. This parameter defines
+what should be written in the place of a newline sequence (\r, \n or \r\n). If
+this is set as the empty string, then newlines are not replaced and printed as
 is to the output. The value should be enclosed in quotes.
 
 ### Examples
 
 #### Example 1 - Query without primary key
 
-Imagine you have observed an issue with a particular table and you want to\
-determine if there are queries that are accessing that table but not using the\
-primary key of the table. Let's assume the table name is PRODUCTS and the\
+Imagine you have observed an issue with a particular table and you want to
+determine if there are queries that are accessing that table but not using the
+primary key of the table. Let's assume the table name is PRODUCTS and the
 primary key is called PRODUCT\_ID. Add a filter with the following definition:
 
 ```
@@ -309,7 +309,7 @@ password=mypasswd
 filters=ProductsSelectLogger
 ```
 
-The result of using this filter with the service used by the application would\
+The result of using this filter with the service used by the application would
 be a log file of all select queries querying PRODUCTS without using the\
 PRODUCT\_ID primary key in the predicates of the query. Executing `SELECT * FROM PRODUCTS` would log the following into `/var/logs/qla/SelectProducts`:
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-regex-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-regex-filter.md
@@ -6,13 +6,13 @@
 
 ### Overview
 
-The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite\
-query content using regular expression matches and text substitution. The\
+The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite
+query content using regular expression matches and text substitution. The
 regular expressions use the [PCRE2 syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html).
 
-PCRE2 library uses a different syntax than POSIX to refer to capture\
-groups in the replacement string. The main difference is the usage of the dollar\
-character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)\
+PCRE2 library uses a different syntax than POSIX to refer to capture
+groups in the replacement string. The main difference is the usage of the dollar
+character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)
 chapter in the PCRE2 manual.
 
 ### Configuration
@@ -68,7 +68,7 @@ The _options_-parameter affects how the patterns are compiled as [usual](../mari
 * Mandatory: Yes
 * Dynamic: Yes
 
-This is the text that should replace the part of the SQL-query matching the\
+This is the text that should replace the part of the SQL-query matching the
 pattern defined in _match_.
 
 ```
@@ -82,9 +82,9 @@ replace=ENGINE =
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
-the address from which the client connection to MariaDB MaxScale\
-originates. Only sessions that originate from this address will have the match\
+The optional source parameter defines an address that is used to match against
+the address from which the client connection to MariaDB MaxScale
+originates. Only sessions that originate from this address will have the match
 and replacement applied to them.
 
 ```
@@ -98,9 +98,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will have the match and\
+The optional user parameter defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will have the match and
 replacement applied to them.
 
 ```
@@ -114,9 +114,9 @@ user=john
 * Dynamic: Yes
 * Default: None
 
-The optional log\_file parameter defines a log file in which the filter writes\
-all queries that are not matched and matching queries with their replacement\
-queries. All sessions will log to this file so this should only be used for\
+The optional log\_file parameter defines a log file in which the filter writes
+all queries that are not matched and matching queries with their replacement
+queries. All sessions will log to this file so this should only be used for
 diagnostic purposes.
 
 ```
@@ -130,10 +130,10 @@ log_file=/tmp/regexfilter.log
 * Dynamic: Yes
 * Default: None
 
-The optional log\_trace parameter toggles the logging of non-matching and\
+The optional log\_trace parameter toggles the logging of non-matching and
 matching queries with their replacements into the log file on the _info_ level.\
-This is the preferred method of diagnosing the matching of queries since the log\
-level can be changed at runtime. For more details about logging levels and\
+This is the preferred method of diagnosing the matching of queries since the log
+level can be changed at runtime. For more details about logging levels and
 session specific logging, please read the [Configuration Guide](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#global-settings).
 
 ```
@@ -144,10 +144,10 @@ log_trace=true
 
 #### Example 1 - Replace MySQL 5.1 create table syntax with that for later versions
 
-MySQL 5.1 used the parameter TYPE = to set the storage engine that should be\
-used for a table. In later versions this changed to be ENGINE =. Imagine you\
-have an application that you can not change for some reason, but you wish to\
-migrate to a newer version of MySQL. The regexfilter can be used to transform\
+MySQL 5.1 used the parameter TYPE = to set the storage engine that should be
+used for a table. In later versions this changed to be ENGINE =. Imagine you
+have an application that you can not change for some reason, but you wish to
+migrate to a newer version of MySQL. The regexfilter can be used to transform
 the create table statements into the form that could be used by MySQL 5.5
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-rewrite-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-rewrite-filter.md
@@ -7,8 +7,8 @@
 ### Overview
 
 The rewrite filter allows modification of sql queries on the fly.\
-Reasons for modifying queries can be to rewrite a query for performance,\
-or to change a specific query when the client query is incorrect and\
+Reasons for modifying queries can be to rewrite a query for performance,
+or to change a specific query when the client query is incorrect and
 cannot be changed in a timely manner.
 
 The examples will use Rewrite Filter file format. See below.
@@ -23,7 +23,7 @@ Rewriter native syntax uses placeholders to grab and replace parts of text.
 
 The syntax for a plain placeholder is `@{N}` where N is a positive integer.
 
-The syntax for a placeholder regex is `@{N:regex}`. It allows more control\
+The syntax for a placeholder regex is `@{N:regex}`. It allows more control
 when needed.
 
 The below is a valid entry in rf format. For demonstration, all options are set.\
@@ -57,23 +57,23 @@ For a match, the two `@{2}` text grabs must be equal.
 
 The match template is used to match against the sql to be rewritten.
 
-The match template can be partial `from mytable`. But the actual underlying\
-regex match is always for the whole sql. If the match template does not\
-start or end with a placeholder, placeholders are automatically added so\
-that the above becomes `@{1}from mytable@{2}`. The automatically added\
+The match template can be partial `from mytable`. But the actual underlying
+regex match is always for the whole sql. If the match template does not
+start or end with a placeholder, placeholders are automatically added so
+that the above becomes `@{1}from mytable@{2}`. The automatically added
 placeholders cannot be used in the replace template.
 
-Matching the whole input also means that Native syntax does not support\
-(and is not intended to support) scan and replace. Only the first occurrence\
+Matching the whole input also means that Native syntax does not support
+(and is not intended to support) scan and replace. Only the first occurrence
 of the above `from mytable` can be modified in the replace template.\
-However, one can selectively choose to modify e.g. the first through\
+However, one can selectively choose to modify e.g. the first through
 third occurrence of `from mytable` by writing`from mytable @{1} from mytable @{2} from mytable @{3}`.
 
 For scan and replace use a different regex\_grammar (see below).
 
 **Replace template**
 
-The replace template uses the placeholders from the match template to\
+The replace template uses the placeholders from the match template to
 rewrite sql.
 
 ```
@@ -89,11 +89,11 @@ Input: select count(distinct author) from books where entity != "AI"
 Rewritten: select count(*) from (select distinct author from books where entity != "AI") as t123
 ```
 
-An important option for smooth matching is `ignore_whitespace`, which\
-is on (true) by default. It creates the match regex in such a way that\
-the amount and kind of whitespace does not affect matching. However,\
-to make `ignore_whitespace` always work, it is important to add\
-whitespace where allowed. If "id=42" is in the match template then\
+An important option for smooth matching is `ignore_whitespace`, which
+is on (true) by default. It creates the match regex in such a way that
+the amount and kind of whitespace does not affect matching. However,
+to make `ignore_whitespace` always work, it is important to add
+whitespace where allowed. If "id=42" is in the match template then
 only the exact "id=42" can match. But if "id = 42" is used, and`ignore_whitespace` is on, both "id=42" and "id = 42" will match.
 
 Another example, and what not to do:
@@ -110,7 +110,7 @@ Input: select name from mytable where id=42
 Rewritten: select name from mytable force index (myindex) where id=42
 ```
 
-That works, but because the match lacks specific detail about the\
+That works, but because the match lacks specific detail about the
 expected sql, things are likely to break. In this case`show indexes from my_table` would no longer work.
 
 The minimum detail in this case could be:
@@ -123,22 +123,22 @@ The minimum detail in this case could be:
 select @{2} from mytable force index (myindex)
 ```
 
-but if more detail is known, like something specific in the where clause,\
+but if more detail is known, like something specific in the where clause,
 that too should be added.
 
 **Placeholder Regex**
 
 Syntax: @{N:regex}
 
-In a placeholder regex the character `}` must be escaped to `\}`\
-(for literal matching). Plain parenthesis "()" indicate capturing\
+In a placeholder regex the character `}` must be escaped to `\}`
+(for literal matching). Plain parenthesis "()" indicate capturing
 groups, which are internally used by the Native grammar.\
 Thus plain parentheses in a placeholder regex will break matching.\
 However, non-capturing groups can be used: e.g. `@{1:(:?Jane|Joe)}`.\
 To match a literal parenthesis use an escape, e.g. `\(`.
 
 Suppose an application is misbehaving after an upgrade and a quick fix is needed.\
-This query `select zip from address_book where str_id = "AZ-124"` is correct,\
+This query `select zip from address_book where str_id = "AZ-124"` is correct,
 but if the id is an integer the where clause should be `id = 1234`.
 
 ```
@@ -159,7 +159,7 @@ For scan and replace the regex\_grammar must be set to something else than\
 Native. An example will illustrate the usage.
 
 Replace all occurrences of "wrong\_table\_name" with "correct\_table\_name".\
-Further, if the replacement was made then replace all occurrences\
+Further, if the replacement was made then replace all occurrences
 of wrong\_column\_name with correct\_column\_name.
 
 ```
@@ -264,7 +264,7 @@ Ignore whitespace differences in the match template and input sql.
 * Type: boolean
 * Default: false
 
-If a template matches and the replacement is done, continue to the\
+If a template matches and the replacement is done, continue to the
 next template and apply it to the result of the previous rewrite.
 
 **`what_if`**
@@ -272,7 +272,7 @@ next template and apply it to the result of the previous rewrite.
 * Type: boolean
 * Default: false
 
-Do not make the replacement, only log what would have\
+Do not make the replacement, only log what would have
 been replaced (NOTICE level).
 
 ### Rewrite file format
@@ -288,12 +288,12 @@ match template
 replace template
 ```
 
-The character `#` starts a single line comment when it is the\
+The character `#` starts a single line comment when it is the
 first character on a line.
 
 Empty lines are ignored.
 
-The rf format does not need any additional escaping to what the basic\
+The rf format does not need any additional escaping to what the basic
 format requires (see Placeholder Regex).
 
 Options are specified as follows:
@@ -304,11 +304,11 @@ case_sensitive: true
 
 The colon must stick to the option name.
 
-The separators `%` and `%%` must be the exact content of\
+The separators `%` and `%%` must be the exact content of
 their respective separator lines.
 
-The templates can span multiple lines. Whitespace does not\
-matter as long as `ignore_whitespace = true`. Always use space\
+The templates can span multiple lines. Whitespace does not
+matter as long as `ignore_whitespace = true`. Always use space
 where space is allowed to maximize the utility of`ignore_whitespace`.
 
 Example
@@ -328,10 +328,10 @@ and @{3} in (select user from approved_users)
 ### Json file format
 
 The json file format is harder to read and edit manually.\
-It will be needed if support for editing of rewrite templates\
+It will be needed if support for editing of rewrite templates
 is added to the GUI.
 
-All double quotes and escape characters have to be escaped in json,\
+All double quotes and escape characters have to be escaped in json,
 i.e '"' and '\\'.
 
 The same example as above is:
@@ -351,7 +351,7 @@ and @{3} in (select user from approved_users)"
 
 ### Reload template file
 
-The configuration is re-read if any dynamic value is updated\
+The configuration is re-read if any dynamic value is updated
 even if the value does not change.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-tee-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-tee-filter.md
@@ -7,17 +7,17 @@
 ### Overview
 
 The tee filter is a "plumbing" fitting in the MariaDB MaxScale filter toolkit.\
-It can be used in a filter pipeline of a service to make copies of requests from\
+It can be used in a filter pipeline of a service to make copies of requests from
 the client and send the copies to another service within MariaDB MaxScale.
 
-**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a\
-service which uses a tee filter will require a grant for the loopback address,\
+**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a
+service which uses a tee filter will require a grant for the loopback address,
 i.e. `127.0.0.1`.
 
 ### Configuration
 
-The configuration block for the TEE filter requires the minimal filter\
-parameters in its section within the MaxScale configuration file. The service to\
+The configuration block for the TEE filter requires the minimal filter
+parameters in its section within the MaxScale configuration file. The service to
 send the duplicates to must be defined.
 
 ```
@@ -37,7 +37,7 @@ filters=DataMartFilter
 
 ### Filter Parameters
 
-The tee filter requires a mandatory parameter to define the service to replicate\
+The tee filter requires a mandatory parameter to define the service to replicate
 statements to and accepts a number of optional parameters.
 
 #### `target`
@@ -47,8 +47,8 @@ statements to and accepts a number of optional parameters.
 * Dynamic: Yes
 * Default: none
 
-The target where the filter will duplicate all queries. The target can be either\
-a service or a server. The duplicate connection that is created to this target\
+The target where the filter will duplicate all queries. The target can be either
+a service or a server. The duplicate connection that is created to this target
 will be referred to as the "branch target" in this document.
 
 #### `service`
@@ -58,8 +58,8 @@ will be referred to as the "branch target" in this document.
 * Dynamic: Yes
 * Default: none
 
-The service where the filter will duplicate all queries. This parameter is\
-deprecated in favor of the `target` parameter and will be removed in a future\
+The service where the filter will duplicate all queries. This parameter is
+deprecated in favor of the `target` parameter and will be removed in a future
 release. Both `target` and `service` cannot be defined.
 
 #### `match`
@@ -109,7 +109,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
+The optional source parameter defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be replicated.
 
@@ -124,8 +124,8 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a user name that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
+The optional user parameter defines a user name that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
 sessions that are connected using this username are replicated.
 
 ```
@@ -139,63 +139,63 @@ user=john
 * Dynamic: Yes
 * Default: `false`
 
-Enable synchronous routing mode. When configured with `sync=true`, the filter\
-will queue new queries until the response from both the main and the branch\
-target has been received. This means that for `n` executed queries, `n - 1`\
-queries are guaranteed to be synchronized. Adding one extra statement\
-(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL\
+Enable synchronous routing mode. When configured with `sync=true`, the filter
+will queue new queries until the response from both the main and the branch
+target has been received. This means that for `n` executed queries, `n - 1`
+queries are guaranteed to be synchronized. Adding one extra statement
+(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL
 statements have been successfully executed on both targets.
 
-In the synchronous routing mode, a failure of the branch target will cause the\
+In the synchronous routing mode, a failure of the branch target will cause the
 client session to be closed.
 
 ### Limitations
 
-* All statements that are executed on the branch target are done in an\
-  asynchronous manner. This means that when the client receives the response\
-  there is no guarantee that the statement has completed on the branch\
-  target. The `sync` feature provides some synchronization guarantees that can\
+* All statements that are executed on the branch target are done in an
+  asynchronous manner. This means that when the client receives the response
+  there is no guarantee that the statement has completed on the branch
+  target. The `sync` feature provides some synchronization guarantees that can
   be used to verify successful execution on both targets.
-* Any errors on the branch target will cause the connection to it to be\
-  closed. If `target` is a service, it is up to the router to decide whether the\
-  connection is closed. For direct connections to servers, any network errors\
-  cause the connection to be closed. When the connection is closed, no new\
+* Any errors on the branch target will cause the connection to it to be
+  closed. If `target` is a service, it is up to the router to decide whether the
+  connection is closed. For direct connections to servers, any network errors
+  cause the connection to be closed. When the connection is closed, no new
   queries will be routed to the branch target.
 
-With `sync=true`, a failure of the branch target will cause the whole session\
+With `sync=true`, a failure of the branch target will cause the whole session
 to be closed.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md) documentation for
 details about module commands.
 
 The tee filter supports the following module commands.
 
 #### `tee disable [FILTER]`
 
-This command disables a tee filter instance. A disabled tee filter will not send\
+This command disables a tee filter instance. A disabled tee filter will not send
 any queries to the target service.
 
 #### `tee enable [FILTER]`
 
-Enable a disabled tee filter. This resumes the sending of queries to the target\
+Enable a disabled tee filter. This resumes the sending of queries to the target
 service.
 
 ### Examples
 
 #### Example 1 - Replicate all inserts into the orders table
 
-Assume an order processing system that has a table called orders. You also have\
-another database server, the datamart server, that requires all inserts into\
+Assume an order processing system that has a table called orders. You also have
+another database server, the datamart server, that requires all inserts into
 orders to be replicated to it. Deletes and updates are not, however, required.
 
-Set up a service in MariaDB MaxScale, called Orders, to communicate with the\
-order processing system with the tee filter applied to it. Also set up a service\
-to talk to the datamart server, using the DataMart service. The tee filter would\
+Set up a service in MariaDB MaxScale, called Orders, to communicate with the
+order processing system with the tee filter applied to it. Also set up a service
+to talk to the datamart server, using the DataMart service. The tee filter would
 have as its service entry the DataMart service, by adding a match parameter of\
-"insert into orders" would then result in all requests being sent to the order\
-processing system, and insert statements that include the orders table being\
+"insert into orders" would then result in all requests being sent to the order
+processing system, and insert statements that include the orders table being
 additionally sent to the datamart server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-throttle.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-throttle.md
@@ -8,13 +8,13 @@ This filter was added in MariaDB MaxScale 2.3
 
 ### Overview
 
-The throttle filter is used to limit the maximum query frequency (QPS - queries\
-per second) of a database session to a configurable value. The main use cases\
-are to prevent a rogue session (client side error) and a DoS attack from\
+The throttle filter is used to limit the maximum query frequency (QPS - queries
+per second) of a database session to a configurable value. The main use cases
+are to prevent a rogue session (client side error) and a DoS attack from
 overloading the system.
 
-The throttling is dynamic. The query frequency is not limited to an absolute\
-value. Depending on the configuration the throttle will allow some amount of\
+The throttling is dynamic. The query frequency is not limited to an absolute
+value. Depending on the configuration the throttle will allow some amount of
 high frequency queries, or especially short bursts with no frequency limitation.
 
 ### Configuration
@@ -35,27 +35,27 @@ filters = Throttle
 ```
 
 This configuration states that the query frequency will be throttled to around\
-500 qps, and that the time limit a query is allowed to stay at the maximum\
-frequency is 60 seconds. All values involving time are configured in\
-milliseconds. With the basic configuration the throttling will be nearly\
-immediate, i.e. a session will only be allowed very short bursts of high\
+500 qps, and that the time limit a query is allowed to stay at the maximum
+frequency is 60 seconds. All values involving time are configured in
+milliseconds. With the basic configuration the throttling will be nearly
+immediate, i.e. a session will only be allowed very short bursts of high
 frequency querying.
 
-When a session has been continuously throttled for `throttling_duration`\
-milliseconds, or 60 seconds in this example, MaxScale will disconnect the\
+When a session has been continuously throttled for `throttling_duration`
+milliseconds, or 60 seconds in this example, MaxScale will disconnect the
 session.
 
 #### Allowing high frequency bursts
 
-The two parameters `max_qps` and `sampling_duration` together define how a\
+The two parameters `max_qps` and `sampling_duration` together define how a
 session is throttled.
 
-Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not\
-an instantaneous measure, but one could say it has a granularity of 10 seconds,\
-we see that over the 10 seconds 10\*400 = 4000 queries are allowed before\
+Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not
+an instantaneous measure, but one could say it has a granularity of 10 seconds,
+we see that over the 10 seconds 10\*400 = 4000 queries are allowed before
 throttling kicks in.
 
-With these values, a fresh session can start off with a speed of 2000 qps, and\
+With these values, a fresh session can start off with a speed of 2000 qps, and
 maintain that speed for 2 seconds before throttling starts.
 
 If the client continues to query at high speed and throttling duration is set to\
@@ -71,8 +71,8 @@ If the client continues to query at high speed and throttling duration is set to
 
 Maximum queries per second.
 
-This is the frequency to which a session will be limited over a given time\
-period. QPS is not measured as an instantaneous value but over a configurable\
+This is the frequency to which a session will be limited over a given time
+period. QPS is not measured as an instantaneous value but over a configurable
 sampling duration (see `sampling_duration`).
 
 **`throttling_duration`**
@@ -81,7 +81,7 @@ sampling duration (see `sampling_duration`).
 * Mandatory: Yes
 * Dynamic: Yes
 
-This defines how long a session is allowed to be throttled before MaxScale\
+This defines how long a session is allowed to be throttled before MaxScale
 disconnects the session.
 
 #### `sampling_duration`
@@ -91,11 +91,11 @@ disconnects the session.
 * Dynamic: Yes
 * Default: 250ms
 
-Sampling duration defines the window of time over which QPS is measured. This\
-parameter directly affects the amount of time that high frequency queries are\
+Sampling duration defines the window of time over which QPS is measured. This
+parameter directly affects the amount of time that high frequency queries are
 allowed before throttling kicks in.
 
-The lower this value is, the more strict throttling becomes. Conversely, the\
+The lower this value is, the more strict throttling becomes. Conversely, the
 longer this time is, the longer bursts of high frequency querying is allowed.
 
 #### `continuous_duration`
@@ -105,8 +105,8 @@ longer this time is, the longer bursts of high frequency querying is allowed.
 * Dynamic: Yes
 * Default: 2s
 
-This value defines what continuous throttling means. Continuous throttling\
-starts as soon as the filter throttles the frequency. Continuous throttling ends\
+This value defines what continuous throttling means. Continuous throttling
+starts as soon as the filter throttles the frequency. Continuous throttling ends
 when no throttling has been performed in the past `continuous_duration` time.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-top-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-top-filter.md
@@ -6,11 +6,11 @@
 
 ### Overview
 
-The top filter is a filter module for MariaDB MaxScale that monitors every SQL\
-statement that passes through the filter. It measures the duration of that\
-statement, the time between the statement being sent and the first result being\
-returned. The top N times are kept, along with the SQL text itself and a list\
-sorted on the execution times of the query is written to a file upon closure of\
+The top filter is a filter module for MariaDB MaxScale that monitors every SQL
+statement that passes through the filter. It measures the duration of that
+statement, the time between the statement being sent and the first result being
+returned. The top N times are kept, along with the SQL text itself and a list
+sorted on the execution times of the query is written to a file upon closure of
 the client session.
 
 ### Configuration
@@ -33,7 +33,7 @@ filters=MyLogFilter
 
 #### Filter Parameters
 
-The top filter has one mandatory parameter, `filebase`, and a number of optional\
+The top filter has one mandatory parameter, `filebase`, and a number of optional
 parameters.
 
 **`filebase`**
@@ -42,15 +42,15 @@ parameters.
 * Mandatory: Yes
 * Dynamic: Yes
 
-The basename of the output file created for each session. The session ID is\
+The basename of the output file created for each session. The session ID is
 added to the filename for each file written. This is a mandatory parameter.
 
 ```
 filebase=/tmp/SqlQueryLog
 ```
 
-The filebase may also be set as the filter, the mechanism to set the filebase\
-via the filter option is superseded by the parameter. If both are set the\
+The filebase may also be set as the filter, the mechanism to set the filebase
+via the filter option is superseded by the parameter. If both are set the
 parameter setting will be used and the filter option ignored.
 
 **`count`**
@@ -73,7 +73,7 @@ count=30
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Limits](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 the queries logged by the filter.
 
 ```
@@ -89,7 +89,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Limits](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 the queries logged by the filter.
 
 **`options`**
@@ -100,7 +100,7 @@ the queries logged by the filter.
 * Values: `ignorecase`, `case`, `extended`
 * Default: `case`
 
-[Regular expression options](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)\
+[Regular expression options](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
 for `match` and `exclude`.
 
 **`source`**
@@ -110,7 +110,7 @@ for `match` and `exclude`.
 * Dynamic: Yes
 * Default: None
 
-Defines an address that is used to match against\
+Defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be logged.
 
@@ -125,9 +125,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-Defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will result in results being\
+Defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will result in results being
 generated.
 
 ```
@@ -138,8 +138,8 @@ user=john
 
 #### Example 1 - Heavily Contended Table
 
-You have an order system and believe the updates of the PRODUCTS table is\
-causing some performance issues for the rest of your application. You would like\
+You have an order system and believe the updates of the PRODUCTS table is
+causing some performance issues for the rest of your application. You would like
 to know which of the many updates in your application is causing the issue.
 
 Add a filter with the following definition:
@@ -154,12 +154,12 @@ exclude=UPDATE.*PRODUCTS_STOCK.*WHERE
 filebase=/var/logs/top/ProductsUpdate
 ```
 
-Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table\
+Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table
 from being included in the report.
 
 #### Example 2 - One Application Server is Slow
 
-One of your applications servers is slower than the rest, you believe it is\
+One of your applications servers is slower than the rest, you believe it is
 related to database access but you are not sure what is taking the time.
 
 Add a filter with the following definition:
@@ -173,7 +173,7 @@ source=192.168.0.32
 filebase=/var/logs/top/SlowAppServer
 ```
 
-In order to produce a comparison with an unaffected application server you can\
+In order to produce a comparison with an unaffected application server you can
 also add a second filter as a control.
 
 ```
@@ -198,14 +198,14 @@ password=mypasswd
 filters=SlowAppServer | ControlAppServer
 ```
 
-You will then have two sets of logs files written, one which profiles the top 20\
-queries of the slow application server and another that gives you the top 20\
-queries of your control application server. These two sets of files can then be\
+You will then have two sets of logs files written, one which profiles the top 20
+queries of the slow application server and another that gives you the top 20
+queries of your control application server. These two sets of files can then be
 compared to determine what if anything is different between the two.
 
 ### Output Report
 
-The following is an example report for a number of fictitious queries executed\
+The following is an example report for a number of fictitious queries executed
 against the employees example database available for MySQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-transaction-performance-monitoring-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-transaction-performance-monitoring-filter.md
@@ -4,22 +4,22 @@
 
 ## Transaction Performance Monitoring Filter
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Overview
 
-The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale\
+The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale
 that monitors every SQL statement that passes through the filter.\
 The filter groups a series of SQL statements into a transaction by detecting\
-'commit' or 'rollback' statements. It logs all committed transactions with necessary\
-information, such as timestamp, client, SQL statements, latency, etc., which\
+'commit' or 'rollback' statements. It logs all committed transactions with necessary
+information, such as timestamp, client, SQL statements, latency, etc., which
 can be used later for transaction performance analysis.
 
 ### Configuration
 
-The configuration block for the TPM filter requires the minimal filter\
+The configuration block for the TPM filter requires the minimal filter
 options in it's section within the maxscale.cnf file, stored in /etc/maxscale.cnf.
 
 ```
@@ -55,9 +55,9 @@ filename=/tmp/SqlQueryLog
 
 #### Source
 
-The optional `source` parameter defines an address that is used\
-to match against the address from which the client connection\
-to MaxScale originates. Only sessions that originate from this\
+The optional `source` parameter defines an address that is used
+to match against the address from which the client connection
+to MaxScale originates. Only sessions that originate from this
 address will be logged.
 
 ```
@@ -66,9 +66,9 @@ source=127.0.0.1
 
 #### User
 
-The optional `user` parameter defines a user name that is used\
+The optional `user` parameter defines a user name that is used
 to match against the user from which the client connection to\
-MaxScale originates. Only sessions that are connected using\
+MaxScale originates. Only sessions that are connected using
 this username are logged.
 
 ```
@@ -77,7 +77,7 @@ user=john
 
 #### Delimiter
 
-The optional `delimiter` parameter defines a delimiter that is used to\
+The optional `delimiter` parameter defines a delimiter that is used to
 distinguish columns in the log. The default delimiter is **`:::`**.
 
 ```
@@ -86,7 +86,7 @@ delimiter=:::
 
 #### Query\_delimiter
 
-The optional `query_delimiter` defines a delimiter that is used to\
+The optional `query_delimiter` defines a delimiter that is used to
 distinguish different SQL statements in a transaction.\
 The default query delimiter is **`@@@`**.
 
@@ -96,9 +96,9 @@ query_delimiter=@@@
 
 #### Named\_pipe
 
-**`named_pipe`** is the path to a named pipe, which TPM filter uses to\
+**`named_pipe`** is the path to a named pipe, which TPM filter uses to
 communicate with 3rd-party applications (e.g., [DBSeer](https://dbseer.org)).\
-Logging is enabled when the router receives the character '1' and logging is\
+Logging is enabled when the router receives the character '1' and logging is
 disabled when the router receives the character '0' from this named pipe.\
 The default named pipe is **`/tmp/tpmfilter`** and logging is **disabled** by default.
 
@@ -128,7 +128,7 @@ For each transaction, the TPM filter prints its log in the following format:
 
 #### Example 1 - Log Transactions for Performance Analysis
 
-You want to log every transaction with its SQL statements and latency\
+You want to log every transaction with its SQL statements and latency
 for future transaction performance analysis.
 
 Add a filter with the following definition:
@@ -151,7 +151,7 @@ password=mypasswd
 filters=PerformanceLogger
 ```
 
-After the filter reads the character '1' from its named pipe, the following\
+After the filter reads the character '1' from its named pipe, the following
 is an example log that is generated from the above TPM filter with the above configuration:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-building-mariadb-maxscale-from-source-code.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-building-mariadb-maxscale-from-source-code.md
@@ -4,7 +4,7 @@
 
 ## Building MariaDB MaxScale from Source Code
 
-MariaDB MaxScale can be built on any system that meets the requirements. The main\
+MariaDB MaxScale can be built on any system that meets the requirements. The main
 requirements are as follows:
 
 * CMake version 3.16 or later (Packaging requires CMake 3.25.1 or later)
@@ -26,7 +26,7 @@ requirements are as follows:
 * libssh
 * pcre2
 
-This is the minimum set of requirements that must be met to build the MaxScale\
+This is the minimum set of requirements that must be met to build the MaxScale
 core package. Some modules in MaxScale require optional extra dependencies.
 
 * libuuid (binlogrouter)
@@ -37,9 +37,9 @@ core package. Some modules in MaxScale require optional extra dependencies.
 * memcached (storage\_memcached for the cache filter)
 * hiredis (storage\_redis for the cache filter)
 
-Some of these dependencies are not available on all operating systems and are\
-downloaded automatically during the build step. To skip the building of modules\
-that need automatic downloading of the dependencies, use `-DBUNDLE=N` when\
+Some of these dependencies are not available on all operating systems and are
+downloaded automatically during the build step. To skip the building of modules
+that need automatic downloading of the dependencies, use `-DBUNDLE=N` when
 configuring CMake.
 
 ### Quickstart
@@ -65,7 +65,7 @@ For a definitive list of packages, consult the [install\_build\_deps.sh](https:/
 
 The tests and other parts of the build can be controlled via CMake arguments.
 
-Here is a small table with the names of the most common parameters and what\
+Here is a small table with the names of the most common parameters and what
 they control. These should all be given as parameters to the -D switch in _NAME_=_VALUE_ format (e.g. `-DBUILD_TESTS=Y`).
 
 | Argument Name          | Explanation                                                                                                                                                                |
@@ -77,25 +77,25 @@ they control. These should all be given as parameters to the -D switch in _NAME_
 | TARGET\_COMPONENT      | Which component to install, default is the 'core' package. Other targets are 'experimental', which installs experimental packages and 'all' which installs all components. |
 | TARBALL                | Build tar.gz packages, requires PACKAGE=Y                                                                                                                                  |
 
-**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a\
+**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a
 list of the CMake variables.
 
 ### Running unit tests
 
-To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,\
+To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,
 compile and then run the `make test` command.
 
 ## Building MariaDB MaxScale packages
 
-If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation\
-and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your\
+If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation
+and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your
 system.
 
-To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create\
+To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create
 a _maxscale-x.y.z.tar.gz_ file where _x.y.z_ is the version number.
 
-Some Debian and Ubuntu systems suffer from a bug where `make package` fails\
-with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to\
+Some Debian and Ubuntu systems suffer from a bug where `make package` fails
+with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to
 the LD\_LIBRARY\_PATH environment variable.
 
 ```
@@ -105,14 +105,14 @@ LD_LIBRARY_PATH=$PWD/server/core/ make package
 
 ### Installing optional components
 
-The MaxScale build system is split into multiple components. The main component\
-is the `core` MaxScale package which contains MaxScale and all the modules. This\
-is the default component that is build, installed and packaged. There is also\
-the `experimental` component that contains all experimental modules which are\
-not considered as part of the core MaxScale package and are either alpha or beta\
+The MaxScale build system is split into multiple components. The main component
+is the `core` MaxScale package which contains MaxScale and all the modules. This
+is the default component that is build, installed and packaged. There is also
+the `experimental` component that contains all experimental modules which are
+not considered as part of the core MaxScale package and are either alpha or beta
 quality modules.
 
-To build the experimental modules along with the MaxScale core components,\
+To build the experimental modules along with the MaxScale core components,
 invoke CMake with `-DTARGET_COMPONENT=core,experimental`.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-installing-mariadb-maxscale-using-a-tarball.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-installing-mariadb-maxscale-using-a-tarball.md
@@ -4,7 +4,7 @@
 
 ## Installing MariaDB MaxScale using a tarball
 
-MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`\
+MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`
 identifies the operating system, e.g. `maxscale-2.5.6.centos.7.tar.gz`.
 
 In order to use the tarball, the following libraries are required:
@@ -17,12 +17,12 @@ In order to use the tarball, the following libraries are required:
 * unixODBC
 
 The tarball has been built with the assumption that it will be installed in `/usr/local`.\
-However, it is possible to install it in any directory, but in that case MariaDB MaxScale\
+However, it is possible to install it in any directory, but in that case MariaDB MaxScale
 must be invoked with a flag.
 
 ### Installing as root in `/usr/local`
 
-If you have root access to the system you probably want to install MariaDB MaxScale under\
+If you have root access to the system you probably want to install MariaDB MaxScale under
 the user and group `maxscale`.
 
 The required steps are as follows:
@@ -37,14 +37,14 @@ $ cd maxscale
 $ sudo chown -R maxscale var
 ```
 
-Creating the symbolic link is necessary, since MariaDB MaxScale has been built\
+Creating the symbolic link is necessary, since MariaDB MaxScale has been built
 with the assumption that the plugin directory is `/usr/local/maxscale/lib/maxscale`.
 
 The symbolic link also makes it easy to switch between different versions of\
 MariaDB MaxScale that have been installed side by side in `/usr/local`;\
 just make the symbolic link point to another installation.
 
-In addition, the first time you install MariaDB MaxScale from a tarball\
+In addition, the first time you install MariaDB MaxScale from a tarball
 you need to create the following directories:
 
 ```
@@ -73,14 +73,14 @@ When the configuration file has been created, MariaDB MaxScale can be started.
 $ sudo bin/maxscale --user=maxscale -d
 ```
 
-The `-d` flag causes maxscale _not_ to turn itself into a daemon,\
+The `-d` flag causes maxscale _not_ to turn itself into a daemon,
 which is advisable the first time MariaDB MaxScale is started, as it makes it easier to spot problems.
 
 If you want to place the configuration file somewhere else but in `/etc`\
 you can invoke MariaDB MaxScale with the `--config` flag,\
 for instance, `--config=/usr/local/maxscale/etc/maxscale.cnf`.
 
-Note also that if you want to keep _everything_ under `/usr/local/maxscale`\
+Note also that if you want to keep _everything_ under `/usr/local/maxscale`
 you can invoke MariaDB MaxScale using the flag `--basedir`.
 
 ```
@@ -108,12 +108,12 @@ $ cd maxscale-x.y.z.OS
 $ bin/maxscale -d --basedir=.
 ```
 
-With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`\
-directories are found. Unless it is specified, MariaDB MaxScale assumes\
-the `lib` directory is found in `/usr/local/maxscale`,\
+With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`
+directories are found. Unless it is specified, MariaDB MaxScale assumes
+the `lib` directory is found in `/usr/local/maxscale`,
 and the `var` and `etc` directories in `/`.
 
-It is also possible to specify the directories and the location of\
+It is also possible to specify the directories and the location of
 the configuration file individually. Invoke MaxScale like
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md
@@ -6,9 +6,9 @@
 
 ## Introduction
 
-This document describes how to configure MariaDB MaxScale and presents some\
-possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,\
-and consists of an event processing core with various support functions and\
+This document describes how to configure MariaDB MaxScale and presents some
+possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,
+and consists of an event processing core with various support functions and
 plugin modules that tailor the behavior of the program.
 
 ## Concepts
@@ -28,9 +28,9 @@ plugin modules that tailor the behavior of the program.
 
 #### Server
 
-A server represents an individual database server to which a client can be\
-connected via MariaDB MaxScale. The status of a server varies during the lifetime\
-of the server and typically the status is updated by some monitor. However, it\
+A server represents an individual database server to which a client can be
+connected via MariaDB MaxScale. The status of a server varies during the lifetime
+of the server and typically the status is updated by some monitor. However, it
 is also possible to update the status of a server manually.
 
 | Status                   | Description                                                                                                                                                                                                                                                                                                               |
@@ -49,62 +49,62 @@ For more information on how to manually set these states via MaxCtrl, read the [
 
 #### Monitor
 
-A monitor module is capable of monitoring the state of a particular kind\
+A monitor module is capable of monitoring the state of a particular kind
 of cluster and making that state available to the routers of MaxScale.
 
-Examples of monitor modules are `mariadbmon` that is capable of monitoring\
-a regular primary-replica cluster and in addition of performing both _switchover_\
-and _failover_, `galeramon` that is capable of monitoring a Galera cluster,\
+Examples of monitor modules are `mariadbmon` that is capable of monitoring
+a regular primary-replica cluster and in addition of performing both _switchover_
+and _failover_, `galeramon` that is capable of monitoring a Galera cluster,
 and `csmon` that is capable of monitoring a Columnstore cluster.
 
-Monitor modules have sections of their own in the MaxScale configuration\
+Monitor modules have sections of their own in the MaxScale configuration
 file.
 
 #### Filter
 
-A filter module resides in front of routers in the request processing chain\
-of MaxScale. That is, a filter will see a request before it reaches the router\
-and before a response is sent back to the client. This allows filters to\
+A filter module resides in front of routers in the request processing chain
+of MaxScale. That is, a filter will see a request before it reaches the router
+and before a response is sent back to the client. This allows filters to
 reject, handle, alter or log information about a request.
 
 Examples of filters `cache` that provides query caching according to rules,`regexfilter` that can rewrite requests according to regular expressions, and`qlafilter` that logs information about requests.
 
-Filters have sections of their own in the MaxScale configuration file that are\
+Filters have sections of their own in the MaxScale configuration file that are
 referred to from _services_.
 
 #### Router
 
-A router module is capable of routing requests to backend servers according to\
-the characteristics of a request and/or the algorithm the router\
+A router module is capable of routing requests to backend servers according to
+the characteristics of a request and/or the algorithm the router
 implements. Examples of routers are `readconnroute` that provides _connection routing_, that is, the server is chosen according to specified rules when the
-session is created and all requests are subsequently routed to that server,\
-and `readwritesplit` that provides _statement routing_, that is, each\
+session is created and all requests are subsequently routed to that server,
+and `readwritesplit` that provides _statement routing_, that is, each
 individual request is routed to the most appropriate server.
 
-Routers do not have sections of their own in the MaxScale configuration file,\
+Routers do not have sections of their own in the MaxScale configuration file,
 but are referred to from _services_.
 
 #### Service
 
-A service abstracts a set of databases and makes them appear as a single one\
-to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular\
-way. If the service uses filters, then all requests will be pre-processed in\
+A service abstracts a set of databases and makes them appear as a single one
+to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular
+way. If the service uses filters, then all requests will be pre-processed in
 some way before they reach the router.
 
 Services have sections of their own in the MaxScale configuration file.
 
 #### Listener
 
-A listener defines a port MaxScale listens on. Connection requests arriving on\
-that port will be forwarded to the service the listener is associated with. A\
-listener may be associated with a single service, but several listeners may be\
+A listener defines a port MaxScale listens on. Connection requests arriving on
+that port will be forwarded to the service the listener is associated with. A
+listener may be associated with a single service, but several listeners may be
 associated with the same service.
 
 Listeners have sections of their own in the MaxScale configuration file.
 
 #### Include
 
-An [include section](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#include-1) defines common parameters used in other\
+An [include section](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#include-1) defines common parameters used in other
 configuration sections.
 
 ## Administration
@@ -114,33 +114,33 @@ The administration of MaxScale can be divided in two parts:
 * Writing the MaxScale configuration file, which is described in the following [section](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#configuration).
 * Performing runtime modifications using [MaxCtrl](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md)
 
-For detailed information about _MaxCtrl_ please refer to the specific\
+For detailed information about _MaxCtrl_ please refer to the specific
 documentation referred to above. In the following it will only be explained how\
 MaxCtrl relate to each other, as far as user credentials go.
 
-**Note**: By default all runtime configuration changes are saved on disk and\
-loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details\
+**Note**: By default all runtime configuration changes are saved on disk and
+loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details
 on how it works and how to disable it.
 
 MaxCtrl can connect using TCP/IP sockets. When connecting with MaxCtrl using\
-TCP/IP sockets, the user and password must be provided and are checked against a\
+TCP/IP sockets, the user and password must be provided and are checked against a
 separate user credentials database. By default, that database contains the user`admin` whose password is `mariadb`.
 
-Note that if MaxCtrl is invoked without explicitly providing a user and password\
-then it will by default use `admin` and `mariadb`. That means that when the\
+Note that if MaxCtrl is invoked without explicitly providing a user and password
+then it will by default use `admin` and `mariadb`. That means that when the
 default user is removed, the credentials must always be provided.
 
 ### Administration audit file
 
-The REST API calls to MaxScale can be logged\
+The REST API calls to MaxScale can be logged
 by enabling [admin\_audit](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#admin_audit).
 
-For more detail see the admin audit configuration values `admin_audit`,`admin_audit_file` and `admin_audit_exclude_methods` below\
+For more detail see the admin audit configuration values `admin_audit`,`admin_audit_file` and `admin_audit_exclude_methods` below
 and [Administration Tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-mariadb-maxscale-administration-tutorial.md#administration-audit-file).
 
 ### Static Configuration Parameters
 
-The following list of global configuration parameters can **NOT** be changed at\
+The following list of global configuration parameters can **NOT** be changed at
 runtime and can only be defined in a configuration file:
 
 * `admin_auth`
@@ -181,35 +181,35 @@ runtime and can only be defined in a configuration file:
 * `substitute_variables`
 * `threads_max`
 
-All other parameters that relate to objects can be altered at runtime or can be\
+All other parameters that relate to objects can be altered at runtime or can be
 changed by destroying and recreating the object in question.
 
 ## Configuration
 
-MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If\
-the command line argument `--configdir=<path>` is given, `maxscale.cnf` is\
-searched for in _\<path>_ instead. If the argument `--config=<file>` is given,\
+MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If
+the command line argument `--configdir=<path>` is given, `maxscale.cnf` is
+searched for in _\<path>_ instead. If the argument `--config=<file>` is given,
 configuration is read from the file _\<file>_.
 
-MaxScale also looks for a directory with the same name as the configuration\
-file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale\
+MaxScale also looks for a directory with the same name as the configuration
+file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale
 recursively reads all files with the ".cnf" suffix in the directory hierarchy.\
 Other files are ignored.
 
-After loading normal configuration files, MaxScale reads runtime-generated\
+After loading normal configuration files, MaxScale reads runtime-generated
 configuration files, if any, from the [persisted configuration files directory](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#persistdir).
 
 Different configuration sections can be arranged with little restrictions.\
-Global path settings such as `logdir`, `piddir` and `datadir` are only read from\
-the main configuration file. Other global settings are also best left in the\
-main file to ensure they are read before other configuration sections are\
+Global path settings such as `logdir`, `piddir` and `datadir` are only read from
+the main configuration file. Other global settings are also best left in the
+main file to ensure they are read before other configuration sections are
 parsed.
 
 The configuration file format used is [INI](https://en.wikipedia.org/wiki/INI_file), similar to the\
-MariaDB Server. The files contain sections and each section can contain multiple\
+MariaDB Server. The files contain sections and each section can contain multiple
 key-value pairs.
 
-Comments are defined by prefixing a row with a hash (#). Trailing comments are\
+Comments are defined by prefixing a row with a hash (#). Trailing comments are
 not supported.
 
 ```
@@ -217,8 +217,8 @@ not supported.
 some_parameter=123
 ```
 
-A parameter can be defined on multiple lines as shown below. A value spread over\
-multiple lines is simply concatenated. The additional lines of the value\
+A parameter can be defined on multiple lines as shown below. A value spread over
+multiple lines is simply concatenated. The additional lines of the value
 definition need to have at least one whitespace character in the beginning.
 
 ```
@@ -234,24 +234,24 @@ servers=server1,
 
 Section names may not contain whitespace and must not start with the characters`@@`.
 
-As the object names are used to form URLs in the MaxScale REST API, they must be\
+As the object names are used to form URLs in the MaxScale REST API, they must be
 safe for use in URLs. This means that only alphanumeric characters (i.e. `a-zA-Z` and `0-9`) and the special characters `_.~-` can be used.
 
 ### Dynamic Configuration
 
 By default all changes done at runtime via the MaxScale GUI, MaxCtrl or the REST\
-API will be saved on disk, inside the [persistdir](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#persistdir) directory. The\
-changes done at runtime will override the configuration found in the static\
+API will be saved on disk, inside the [persistdir](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#persistdir) directory. The
+changes done at runtime will override the configuration found in the static
 configuration files for that particular object.
 
-This means that if an object that is found in `/etc/maxscale.cnf` is modified at\
-runtime, all future changes to it must also be done at runtime. Any\
-modifications done to `/etc/maxscale.cnf` after a runtime change has been made\
+This means that if an object that is found in `/etc/maxscale.cnf` is modified at
+runtime, all future changes to it must also be done at runtime. Any
+modifications done to `/etc/maxscale.cnf` after a runtime change has been made
 are ignored for that object.
 
-To prevent the saving of runtime changes and to make all runtime changes\
-volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`\
-section. This will make MaxScale behave like the MariaDB server does: any\
+To prevent the saving of runtime changes and to make all runtime changes
+volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`
+section. This will make MaxScale behave like the MariaDB server does: any
 changes done with `SET GLOBAL` statements are lost if the process is restarted.
 
 ### Special Parameter Types
@@ -259,16 +259,16 @@ changes done with `SET GLOBAL` statements are lost if the process is restarted.
 #### Booleans
 
 Boolean type parameters interpret the values `true`, `yes`, `on` and `1` as\_true\_ values and `false`, `no`, `off` and `0` as _false_ values. Starting with\
-MaxScale 23.02, the REST API also accepts the same boolean values for boolean\
+MaxScale 23.02, the REST API also accepts the same boolean values for boolean
 type parameters.
 
 #### Sizes
 
-Where _specifically noted_, a number denoting a size can be suffixed by a subset\
-of the IEC binary prefixes or the SI prefixes. In the former case the number\
-will be interpreted as a certain multiple of 1024 and in the latter case as a\
-certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`\
-and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,\
+Where _specifically noted_, a number denoting a size can be suffixed by a subset
+of the IEC binary prefixes or the SI prefixes. In the former case the number
+will be interpreted as a certain multiple of 1024 and in the latter case as a
+certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`
+and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,
 the matching is case insensitive.
 
 For instance, the following entries
@@ -293,8 +293,8 @@ max_size=1T
 
 #### Durations
 
-A number denoting a duration can be suffixed by one of the case-insensitive\
-suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,\
+A number denoting a duration can be suffixed by one of the case-insensitive
+suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,
 minutes, seconds and milliseconds, respectively.
 
 For instance, the following entries
@@ -309,79 +309,79 @@ soft_ttl=3600000ms
 
 are equivalent.
 
-Note that if an explicit unit is not specified, then it is specific to the\
-configuration parameter whether the duration is interpreted as seconds or\
+Note that if an explicit unit is not specified, then it is specific to the
+configuration parameter whether the duration is interpreted as seconds or
 milliseconds.
 
 _Not_ providing an explicit unit has been deprecated in MaxScale 2.4.
 
 #### Regular Expressions
 
-Many modules have settings which accept a regular expression. In most cases, these\
+Many modules have settings which accept a regular expression. In most cases, these
 settings are named either _match_ or _exclude_, and are used to filter users or queries.\
-MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching\
+MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching
 regular expressions.
 
-When writing a regular expression (regex) type parameter to a MaxScale configuration file,\
-the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This\
-clarifies where the pattern begins and ends, even if it includes whitespace. Without\
-slashes the configuration loader trims the pattern from the ends. The slashes are removed\
-before compiling the pattern. For backwards compatibility, the slashes are not yet\
-mandatory. Omitting them is, however, deprecated and will be rejected in a future release\
-of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_\
-accept parameters in this type of regular expression form. Some other modules may not\
+When writing a regular expression (regex) type parameter to a MaxScale configuration file,
+the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This
+clarifies where the pattern begins and ends, even if it includes whitespace. Without
+slashes the configuration loader trims the pattern from the ends. The slashes are removed
+before compiling the pattern. For backwards compatibility, the slashes are not yet
+mandatory. Omitting them is, however, deprecated and will be rejected in a future release
+of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_
+accept parameters in this type of regular expression form. Some other modules may not
 handle the slashes yet correctly.
 
-PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses\
-regular expressions simply, only checking whether the pattern and subject match at some\
-point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to\
-accept any query with the text "SELECT" somewhere within. To force the pattern to only\
+PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses
+regular expressions simply, only checking whether the pattern and subject match at some
+point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to
+accept any query with the text "SELECT" somewhere within. To force the pattern to only
 match at the beginning of the query, set `match=/^SELECT/`. To only match the end, set`match=/SELECT$/`.
 
-Modules which accept regular expression parameters also often accept options which affect\
-how the patterns are compiled. Typically, this setting is called _options_ and accepts\
+Modules which accept regular expression parameters also often accept options which affect
+how the patterns are compiled. Typically, this setting is called _options_ and accepts
 values such as `ignorecase`, `case` and `extended`.
 
-* `ignorecase`: Causes the regular expression matcher to ignore letter case, and\
+* `ignorecase`: Causes the regular expression matcher to ignore letter case, and
   is often on by default. When enabled, `/SELECT/` would match both `SELECT` and`select`.
-* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this\
+* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this
   is not the same as the extended regular expression syntax that for example`grep -E` uses.
-* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not\
+* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not
   match `select`.
 
-These settings can also be defined in the pattern itself, so they can be\
-used even in modules without pattern compilation settings. The pattern\
-settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)\
+These settings can also be defined in the pattern itself, so they can be
+used even in modules without pattern compilation settings. The pattern
+settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)
 for more information.
 
 **Standard regular expression settings for filters**
 
-Many filters use the settings _match_, _exclude_ and _options_. Since these settings are\
-used in a similar way across these filters, the settings are explained here. The\
-documentation of the filters link here and describe any exceptions to this\
+Many filters use the settings _match_, _exclude_ and _options_. Since these settings are
+used in a similar way across these filters, the settings are explained here. The
+documentation of the filters link here and describe any exceptions to this
 generalized explanation.
 
-These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the\
+These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the
 patterns are compiled. _options_ works as explained above, accepting the values`ignorecase`, `case` and `extended`, with `ignorecase` being the default.
 
-The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is\
+The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is
 not defined, all queries are considered to match.
 
 If _exclude_ is defined, the filter only acts on queries not matching that pattern. If\_exclude\_ is not defined, nothing is excluded.
 
 If both are defined, the query needs to match _match_ but not match _exclude_.
 
-Even if a filter does not act on a query, the query is not lost. The query is simply\
+Even if a filter does not act on a query, the query is not lost. The query is simply
 passed on to the next module in the processing chain as if the filter was not there.
 
 #### Enumerations
 
-Enumeration type parameters have a pre-defined set of accepted values. For types\
-declared as `enum`, only one value is accepted. For `enum_mask` types, multiple\
+Enumeration type parameters have a pre-defined set of accepted values. For types
+declared as `enum`, only one value is accepted. For `enum_mask` types, multiple
 values can be defined by separating them with commas. All enumeration values in\
 MaxScale are case-sensitive.
 
-For example the `router_options` parameter in the `readconnroute` router is a\
+For example the `router_options` parameter in the `readconnroute` router is a
 mask type enumeration:
 
 ```
@@ -390,7 +390,7 @@ router_options=master,slave
 
 #### Path Lists
 
-A `pathlist` type parameter expects one or more filesystem paths separated by\
+A `pathlist` type parameter expects one or more filesystem paths separated by
 colons. The value must not include space between the separators.
 
 Here is an example path list parameter that points to `/tmp/something.log` and`/var/log/maxscale/maxscale.log`:
@@ -401,8 +401,8 @@ path_list_parameter=/tmp/something.log:/var/log/maxscale/maxscale.log
 
 ### Global Settings
 
-The global settings, in a section named `[MaxScale]`, allow various parameters\
-that affect MariaDB MaxScale as a whole to be tuned. This section must be\
+The global settings, in a section named `[MaxScale]`, allow various parameters
+that affect MariaDB MaxScale as a whole to be tuned. This section must be
 defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 
 #### `core_file`
@@ -411,9 +411,9 @@ defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 * Default: true
 * Dynamic: No
 
-This parameter specifies whether a core file should be generated if MaxScale\
-crashes. The default is `true` although usually a core file is not needed,\
-as MaxScale is capable of logging the full stack trace of all threads\
+This parameter specifies whether a core file should be generated if MaxScale
+crashes. The default is `true` although usually a core file is not needed,
+as MaxScale is capable of logging the full stack trace of all threads
 when it crashes.
 
 #### `auto_tune`
@@ -424,7 +424,7 @@ when it crashes.
 * Mandatory: No
 * Dynamic: No
 
-An _auto tunable_ parameter is a parameter whose value can be derived from a\
+An _auto tunable_ parameter is a parameter whose value can be derived from a
 particular server variable. With this parameter it can be specified whether`all` or a specific set of parameters should automatically be set.
 
 The current auto tunable parameters are:
@@ -434,13 +434,13 @@ The current auto tunable parameters are:
 | [connection\_keepalive](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#connection_keepalive) | 80% of the smallest [wait\_timeout](https://mariadb.com/docs/reference/mdb/system-variables/wait_timeout/) value of the servers used by the service |
 | [wait\_timeout](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#wait_timeout)                 | The smallest [wait\_timeout](https://mariadb.com/docs/reference/mdb/system-variables/wait_timeout/) value of the servers used by the service        |
 
-The values of the server variables are collected by monitors, which means that\
-if the servers of a service are not monitored by a monitor, then the parameters\
+The values of the server variables are collected by monitors, which means that
+if the servers of a service are not monitored by a monitor, then the parameters
 of that service will not be auto tuned.
 
-Note that even if `auto_tune` is set to `all`, the auto tunable parameters\
+Note that even if `auto_tune` is set to `all`, the auto tunable parameters
 can still be set in the configuration file and modified with _maxctrl_.\
-However, the specified value will be overwritten at the next auto tuning\
+However, the specified value will be overwritten at the next auto tuning
 round, but only if the servers of the service are monitored by a monitor.
 
 #### `threads`
@@ -450,20 +450,20 @@ round, but only if the servers of the service are monitored by a monitor.
 * Dynamic: No
 * Default: `auto`
 
-This parameter controls the number of worker threads that are handling the\
-events coming from the kernel. The default is `auto` which uses as many threads\
-as there are CPU cores. MaxScale versions older than 6 used one thread by\
+This parameter controls the number of worker threads that are handling the
+events coming from the kernel. The default is `auto` which uses as many threads
+as there are CPU cores. MaxScale versions older than 6 used one thread by
 default.
 
-You can explicitly enable automatic configuration of this value by setting the\
-value to `auto`. This way MariaDB MaxScale will detect the number of available\
+You can explicitly enable automatic configuration of this value by setting the
+value to `auto`. This way MariaDB MaxScale will detect the number of available
 processors and set the amount of threads to be equal to that number.
 
-Note that if MaxScale is running in a container where the CPU resources\
-have been limited, the use of `auto` may cause MaxScale to use more resources\
-than what is available. In such a situation `auto` should not be used, but instead\
-an explicit number that corresponds to the amount of CPU resources available in\
-the container. As a rule of thumb, an appropriate value for `threads` is the\_vCPU\_ of the container rounded up to the nearest integer. For instance, if\
+Note that if MaxScale is running in a container where the CPU resources
+have been limited, the use of `auto` may cause MaxScale to use more resources
+than what is available. In such a situation `auto` should not be used, but instead
+an explicit number that corresponds to the amount of CPU resources available in
+the container. As a rule of thumb, an appropriate value for `threads` is the\_vCPU\_ of the container rounded up to the nearest integer. For instance, if
 the _vCPU_ of the container is `0.5` then `1` is an appropriate value for`threads`, if the _vCPU_ is `2.3` then `3` is.
 
 The maximum value for `threads` is specified by [threads\_max](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#threads_max).
@@ -480,7 +480,7 @@ From 23.02 onwards it is possible to change the number threads at runtime.\
 Please see [Threads](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#threads-1) for more details.
 
 Additional threads will be created to execute other internal services within\
-MariaDB MaxScale. This setting is used to configure the number of threads that\
+MariaDB MaxScale. This setting is used to configure the number of threads that
 will be used to manage the user connections.
 
 #### `threads_max`
@@ -489,11 +489,11 @@ will be used to manage the user connections.
 * Default: 256
 * Dynamic: No
 
-This parameter specifies the hard limit for the number of worker threads,\
+This parameter specifies the hard limit for the number of worker threads,
 which is specified using [threads](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#threads).
 
-At startup, if the value of `threads` is larger than that of `threads_max`,\
-the value of `threads` will be reduced to that. At runtime, an attempt to\
+At startup, if the value of `threads` is larger than that of `threads_max`,
+the value of `threads` will be reduced to that. At runtime, an attempt to
 increase the value of `threads` beyond that of `threads_max` is an error.
 
 #### `rebalance_period`
@@ -503,19 +503,19 @@ increase the value of `threads` beyond that of `threads_max` is an error.
 * Dynamic: Yes
 * Default: `0s`
 
-This duration parameter controls how often the load of the worker threads\
-should be checked. The default value is 0, which means that no checks and\
+This duration parameter controls how often the load of the worker threads
+should be checked. The default value is 0, which means that no checks and
 no rebalancing will be performed.
 
 ```
 rebalance_period=10s
 ```
 
-Note that the value of `rebalance_period` should not be smaller than the\
+Note that the value of `rebalance_period` should not be smaller than the
 value of `rebalance_window` whose default value is 10.
 
-If the value of `rebalance_period` is significantly shorter than that\
-of `rebalance_window`, it may lead to oscillation where work is constantly\
+If the value of `rebalance_period` is significantly shorter than that
+of `rebalance_window`, it may lead to oscillation where work is constantly
 moved from one thread to another.
 
 #### `rebalance_threshold`
@@ -525,21 +525,21 @@ moved from one thread to another.
 * Dynamic: Yes
 * Default: `20`
 
-This integer parameter controls at which point MaxScale should start\
+This integer parameter controls at which point MaxScale should start
 moving work from one worker thread to another.
 
 If the difference in load between the thread with the maximum load and\
 the thread with the minimum load is larger than the value of this parameter,\
 then work will be moved from the former to the latter.
 
-Although the load of a thread can vary between 0 and 100, the value of this\
+Although the load of a thread can vary between 0 and 100, the value of this
 parameter must be between 5 and 100.
 
 ```
 rebalance_threshold=15
 ```
 
-Note that rebalancing will not be performed unless `rebalance_period`\
+Note that rebalancing will not be performed unless `rebalance_period`
 has been specified.
 
 #### `rebalance_window`
@@ -549,11 +549,11 @@ has been specified.
 * Dynamic: Yes
 * Default: `10`
 
-This integer parameter controls how many seconds of load should be\
-taken into account when deciding whether work should be moved from\
+This integer parameter controls how many seconds of load should be
+taken into account when deciding whether work should be moved from
 one thread to another.
 
-The default value is 10, which means that the load during the last 10\
+The default value is 10, which means that the load during the last 10
 seconds is considered when deciding whether work should be moved.
 
 The minimum value is 1 and the maximum 60.
@@ -565,8 +565,8 @@ The minimum value is 1 and the maximum 60.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether reverse domain name lookups are made to convert\
-client IP addresses to hostnames. If enabled, client IP addresses will not be\
+This parameter controls whether reverse domain name lookups are made to convert
+client IP addresses to hostnames. If enabled, client IP addresses will not be
 resolved to hostnames during authentication or for the REST API even if requested.
 
 If you have database users that use a hostname in the host part of the user\
@@ -582,8 +582,8 @@ an IP address.
 * Dynamic: Yes
 * Default: `10s`
 
-Duration, default 10s. This setting defines the connection timeout when\
-attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same\
+Duration, default 10s. This setting defines the connection timeout when
+attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same
 value is also used for read and write timeouts. Increasing this value causes\
 MaxScale to wait longer for a response from a server before user fetching fails.\
 Other servers may then be attempted.
@@ -592,10 +592,10 @@ Other servers may then be attempted.
 auth_connect_timeout=10s
 ```
 
-The value is given as [a duration](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,\
-the value is interpreted as seconds. In subsequent versions a value without a\
-unit may be rejected. Since the granularity of the timeout is seconds, a timeout\
-specified in milliseconds will be rejected even if the given value is longer\
+The value is given as [a duration](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,
+the value is interpreted as seconds. In subsequent versions a value without a
+unit may be rejected. Since the granularity of the timeout is seconds, a timeout
+specified in milliseconds will be rejected even if the given value is longer
 than a second.
 
 #### `auth_read_timeout`
@@ -613,14 +613,14 @@ Deprecated and ignored as of MaxScale 2.5.0. See _auth\_connect\_timeout_ above.
 * Dynamic: No
 * Default: `1`
 
-The number of times an interrupted internal query will be retried. The default\
-is to retry the query once. This feature was added in MaxScale 2.1.10 and was\
+The number of times an interrupted internal query will be retried. The default
+is to retry the query once. This feature was added in MaxScale 2.1.10 and was
 disabled by default until MaxScale 2.3.0.
 
-An interrupted query is any query that is interrupted by a network\
-error. Connection timeouts are included in network errors and thus is it\
-advisable to make sure that the value of `query_retry_timeout` is set to an\
-adequate value. Internal queries are only used to retrieve authentication data\
+An interrupted query is any query that is interrupted by a network
+error. Connection timeouts are included in network errors and thus is it
+advisable to make sure that the value of `query_retry_timeout` is set to an
+adequate value. Internal queries are only used to retrieve authentication data
 and monitor the servers.
 
 #### `query_retry_timeout`
@@ -630,16 +630,16 @@ and monitor the servers.
 * Dynamic: Yes
 * Default: `10s`
 
-The total timeout in seconds for any retried queries. The default value is 5\
+The total timeout in seconds for any retried queries. The default value is 5
 seconds.
 
-An interrupted query is retried for either the configured amount of attempts or\
+An interrupted query is retried for either the configured amount of attempts or
 until the configured timeout is reached.
 
-The value is specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `passive`
@@ -649,11 +649,11 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `false`
 
-Controls whether MaxScale is a passive node in a cluster of multiple MaxScale\
+Controls whether MaxScale is a passive node in a cluster of multiple MaxScale
 instances.
 
-This parameter is intended to be used with multiple MaxScale instances that use\
-failover functionality to manipulate the cluster in some form. Passive nodes\
+This parameter is intended to be used with multiple MaxScale instances that use
+failover functionality to manipulate the cluster in some form. Passive nodes
 only observe the clusters being monitored and take no direct actions.
 
 The following functionality is disabled when passive mode is enabled:
@@ -662,8 +662,8 @@ The following functionality is disabled when passive mode is enabled:
 * Automatic rejoin in the `mariadbmon` module
 * Launching of monitor scripts
 
-**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and\
-route any traffic sent to it. The **only** operations affected by the passive\
+**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and
+route any traffic sent to it. The **only** operations affected by the passive
 mode are the ones listed above.
 
 #### `ms_timestamp`
@@ -673,7 +673,7 @@ mode are the ones listed above.
 * Dynamic: Yes
 * Default: `false`
 
-Enable or disable the high precision timestamps in logfiles. Enabling this adds\
+Enable or disable the high precision timestamps in logfiles. Enabling this adds
 millisecond precision to all logfile timestamps.
 
 #### `syslog`
@@ -683,10 +683,10 @@ millisecond precision to all logfile timestamps.
 * Dynamic: Yes
 * Default: `false`
 
-Log messages to the system journal. This logs messages using the native SystemD\
+Log messages to the system journal. This logs messages using the native SystemD
 journal interface. The logs can be viewed with `journalctl`.
 
-MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be\
+MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be
 logged twice: once into the system journal and once into MaxScale's own logfile.
 
 #### `maxlog`
@@ -707,8 +707,8 @@ Log messages to MariaDB MaxScale's log file. The name of the log file is`maxscal
 
 Log messages whose syslog priority is _warning_.
 
-MaxScale logs warning level messages whenever a condition is encountered that\
-the user should be notified of but does not require immediate action or it\
+MaxScale logs warning level messages whenever a condition is encountered that
+the user should be notified of but does not require immediate action or it
 indicates a minor problem.
 
 #### `log_notice`
@@ -720,8 +720,8 @@ indicates a minor problem.
 
 Log messages whose syslog priority is _notice_.
 
-These messages contain information that is helpful for the user and they usually\
-do not indicate a problem. These are logged whenever something worth nothing\
+These messages contain information that is helpful for the user and they usually
+do not indicate a problem. These are logged whenever something worth nothing
 happens in either MaxScale or in the servers it monitors.
 
 #### `log_info`
@@ -734,10 +734,10 @@ happens in either MaxScale or in the servers it monitors.
 Log messages whose syslog priority is _info_.
 
 These messages provide detailed information about the internal workings of\
-MariaDB MaxScale. These messages should only be enabled when there is a need to\
-inspect the internal logic of MaxScale. A common use-case is to see why a\
-particular query was handled in a certain way. Almost all modules log some\
-messages on the info level and this can be very helpful when trying to solve\
+MariaDB MaxScale. These messages should only be enabled when there is a need to
+inspect the internal logic of MaxScale. A common use-case is to see why a
+particular query was handled in a certain way. Almost all modules log some
+messages on the info level and this can be very helpful when trying to solve
 routing related problems.
 
 #### `log_debug`
@@ -749,11 +749,11 @@ routing related problems.
 
 Log messages whose syslog priority is _debug_.
 
-These messages are intended for development purposes and are disabled by\
+These messages are intended for development purposes and are disabled by
 default. These are rarely useful outside of debugging core MaxScale issues.
 
-**Note:** If MariaDB MaxScale has been built in release mode, then debug\
-messages are excluded from the build and this setting will not have any\
+**Note:** If MariaDB MaxScale has been built in release mode, then debug
+messages are excluded from the build and this setting will not have any
 effect. If an attempt to enable these is made, a warning is logged.
 
 #### `log_warn_super_user`
@@ -763,10 +763,10 @@ effect. If an attempt to enable these is made, a warning is logged.
 * Dynamic: No
 * Default: `false`
 
-When enabled, a warning is logged whenever a client with SUPER-privilege\
-successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The\
-setting is intended for diagnosing situations where a client interferes with a\
-primary server switchover. Super-users bypass the _read\_only_-flag which\
+When enabled, a warning is logged whenever a client with SUPER-privilege
+successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The
+setting is intended for diagnosing situations where a client interferes with a
+primary server switchover. Super-users bypass the _read\_only_-flag which
 switchover uses to block writes to the primary.
 
 #### `log_augmentation`
@@ -776,9 +776,9 @@ switchover uses to block writes to the primary.
 * Dynamic: Yes
 * Default: `0`
 
-Enable or disable the augmentation of messages. If this is enabled, then each\
-logged message is appended with the name of the function where the message was\
-logged. This is primarily for development purposes and hence is disabled by\
+Enable or disable the augmentation of messages. If this is enabled, then each
+logged message is appended with the name of the function where the message was
+logged. This is primarily for development purposes and hence is disabled by
 default.
 
 ```
@@ -796,10 +796,10 @@ To disable the augmentation use the value 0 and to enable it use the value 1.
 * Dynamic: Yes
 * Default: `10, 1000ms, 10000ms`
 
-It is possible that a particular error (or warning) is logged over and over\
-again, if the cause for the error persistently remains. To prevent the log from\
-flooding, it is possible to specify how many times a particular error may be\
-logged within a time period, before the logging of that error is suppressed for\
+It is possible that a particular error (or warning) is logged over and over
+again, if the cause for the error persistently remains. To prevent the log from
+flooding, it is possible to specify how many times a particular error may be
+logged within a time period, before the logging of that error is suppressed for
 a while.
 
 ```
@@ -815,18 +815,18 @@ log_throttling=8, 2s, 15000ms
 In the example above, the logging of a particular error will be suppressed for\
 15 seconds if the error has been logged 8 times in 2 seconds.
 
-The default is `10, 1000ms, 10000ms`, which means that if the same error is\
-logged 10 times in one second, the logging of that error is suppressed for the\
+The default is `10, 1000ms, 10000ms`, which means that if the same error is
+logged 10 times in one second, the logging of that error is suppressed for the
 following 10 seconds.
 
-Whenever an error message that is being throttled is logged within the\
-triggering window (the second argument), the suppression window is\
-extended. This continues until there is a pause in the messages that is longer\
+Whenever an error message that is being throttled is logged within the
+triggering window (the second argument), the suppression window is
+extended. This continues until there is a pause in the messages that is longer
 than the triggering window.
 
-For example, with the default configuration the messages must pause for at least\
-one second in order for the throttling to eventually stop. This mechanism\
-prevents long-lasting error conditions from slowly filling up the log with short\
+For example, with the default configuration the messages must pause for at least
+one second in order for the throttling to eventually stop. This mechanism
+prevents long-lasting error conditions from slowly filling up the log with short
 bursts of messages.
 
 To disable log throttling, add an entry with an empty value
@@ -841,8 +841,8 @@ or one where any of the integers is 0.
 log_throttling=0, 0, 0
 ```
 
-The durations can be specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In\
+The durations can be specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In
 subsequent versions a value without a unit may be rejected.
 
 Note that _notice_, _info_ and _debug_ messages are never throttled.
@@ -854,7 +854,7 @@ Note that _notice_, _info_ and _debug_ messages are never throttled.
 * Dynamic: No
 * Default: `/var/log/maxscale`
 
-Set the directory where the logfiles are stored. The folder needs to be both\
+Set the directory where the logfiles are stored. The folder needs to be both
 readable and writable by the user running MariaDB MaxScale.
 
 ```
@@ -869,10 +869,10 @@ logdir=/var/log/maxscale/
 * Default: `/var/lib/maxscale`
 
 Set the directory where the data files used by MariaDB MaxScale are stored.\
-Modules can write to this directory and for example the binlogrouter uses this\
+Modules can write to this directory and for example the binlogrouter uses this
 folder as the default location for storing binary logs.
 
-This is also the directory where the password encryption key is read from that\
+This is also the directory where the password encryption key is read from that
 is generated by `maxkeys`.
 
 ```
@@ -886,10 +886,10 @@ datadir=/var/lib/maxscale/
 * Dynamic: No
 * Default: `""`
 
-The location where the `.secrets` file is read from. If `secretsdir` is not\
+The location where the `.secrets` file is read from. If `secretsdir` is not
 defined, the file is read from [datadir](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#datadir).
 
-This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6\
+This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6
 and 24.02.2.
 
 #### `libdir`
@@ -899,12 +899,12 @@ and 24.02.2.
 * Dynamic: No
 * Default: OS Dependent
 
-Set the directory where MariaDB MaxScale looks for modules. The library\
-directory is the only directory that MariaDB MaxScale uses when it searches for\
-modules. If you have custom modules for MariaDB MaxScale, make sure you have\
+Set the directory where MariaDB MaxScale looks for modules. The library
+directory is the only directory that MariaDB MaxScale uses when it searches for
+modules. If you have custom modules for MariaDB MaxScale, make sure you have
 them in this folder.
 
-The default value depends on the operating system. For RHEL versions the value\
+The default value depends on the operating system. For RHEL versions the value
 is `/usr/lib64/maxscale/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/`
 
 ```
@@ -920,14 +920,14 @@ libdir=/usr/lib64/maxscale/
 
 Sets the directory where static data assets are loaded.
 
-The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI\
-files have been manually moved somewhere else, this path must be configured to\
+The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI
+files have been manually moved somewhere else, this path must be configured to
 point to the parent directory of the `gui/` subdirectory.
 
-The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path\
-resolves to outside of this directory are not served by the MaxScale GUI: this\
+The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path
+resolves to outside of this directory are not served by the MaxScale GUI: this
 is done to prevent other files from being accessible via the MaxScale REST\
-API. This means that path to the GUI source directory can contain symbolic links\
+API. This means that path to the GUI source directory can contain symbolic links
 but all parts after the `/gui/` directory must reside inside it.
 
 #### `cachedir`
@@ -950,7 +950,7 @@ cachedir=/var/cache/maxscale/
 * Dynamic: No
 * Default: `/var/run/maxscale`
 
-Configure the directory for the PID file for MariaDB MaxScale. This file\
+Configure the directory for the PID file for MariaDB MaxScale. This file
 contains the Process ID for the running MariaDB MaxScale process.
 
 ```
@@ -964,8 +964,8 @@ piddir=/var/run/maxscale/
 * Dynamic: No
 * Default: `/usr/bin`
 
-Configure the directory where the executable files reside. All internal\
-processes which are launched will use this directory to look for executable\
+Configure the directory where the executable files reside. All internal
+processes which are launched will use this directory to look for executable
 files.
 
 ```
@@ -979,13 +979,13 @@ execdir=/usr/bin/
 * Dynamic: No
 * Default: OS Dependent
 
-Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C\
-used in MaxScale can use this directory to load authentication plugins. The\
-versions of the plugins must be binary compatible with the connector version\
+Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C
+used in MaxScale can use this directory to load authentication plugins. The
+versions of the plugins must be binary compatible with the connector version
 that MaxScale was built with.
 
-Starting with version 6.2.0, the plugins are bundled with MaxScale and the\
-default value now points to the bundled plugins. The location where the plugins\
+Starting with version 6.2.0, the plugins are bundled with MaxScale and the
+default value now points to the bundled plugins. The location where the plugins
 are stored depends on the operating system. For RHEL versions the value is`/usr/lib64/maxscale/plugin/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/plugin/`.
 
 Older versions of MaxScale used `/usr/lib/mysql/plugin/` as the default value.
@@ -1001,10 +1001,10 @@ connector_plugindir=/usr/lib64/maxscale/plugin/
 * Dynamic: No
 * Default: `/var/lib/maxscale/maxscale.cnf.d/`
 
-Configure the directory where persisted configurations are stored. When a new\
-object is created via MaxCtrl, it will be stored in this directory. Do not use\
-this directory for normal configuration files, use _/etc/maxscale.cnf.d/_\
-instead. The user MaxScale is running as must be able to write into this\
+Configure the directory where persisted configurations are stored. When a new
+object is created via MaxCtrl, it will be stored in this directory. Do not use
+this directory for normal configuration files, use _/etc/maxscale.cnf.d/_
+instead. The user MaxScale is running as must be able to write into this
 directory.
 
 ```
@@ -1018,16 +1018,16 @@ persistdir=/var/lib/maxscale/maxscale.cnf.d/
 * Dynamic: No
 * Default: `/etc/maxscale.modules.d/`
 
-Configure the directory where module configurations are stored. Path arguments\
-are resolved relative to this directory. This directory should be used to store\
+Configure the directory where module configurations are stored. Path arguments
+are resolved relative to this directory. This directory should be used to store
 module specific configurations.
 
-Any configuration parameter that is not an absolute path will be interpreted as\
-a relative path. The relative paths use the module configuration directory as\
+Any configuration parameter that is not an absolute path will be interpreted as
+a relative path. The relative paths use the module configuration directory as
 the working directory.
 
-For example, the configuration parameter `file=my_file.txt` would be interpreted\
-as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would\
+For example, the configuration parameter `file=my_file.txt` would be interpreted
+as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would
 be interpreted as `/home/user/my_file.txt`.
 
 ```
@@ -1041,7 +1041,7 @@ module_configdir=/etc/maxscale.modules.d/
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will\
+Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will
 look for the errmsg.sys file installed with MariaDB MaxScale from this folder.
 
 ```
@@ -1060,20 +1060,20 @@ Deprecated since MariaDB MaxScale 23.08.
 * Default: System Dependent
 
 Specifies the maximum size of the query classifier cache. The default limit is\
-15% of total system memory starting with MaxScale 2.3.7. In older versions the\
+15% of total system memory starting with MaxScale 2.3.7. In older versions the
 default limit was 40% of total system memory. This feature was added in MaxScale\
 2.3.0.
 
-When the query classifier cache has been enabled, MaxScale will, after a\
-statement has been parsed, store the classification result using the\
+When the query classifier cache has been enabled, MaxScale will, after a
+statement has been parsed, store the classification result using the
 canonicalized version of the statement as the key.
 
-If the classification result for a statement is needed, MaxScale will first\
-canonicalize the statement and check whether the result can be found in the\
-cache. If it can, the statement will not be parsed at all but the cached result\
+If the classification result for a statement is needed, MaxScale will first
+canonicalize the statement and check whether the result can be found in the
+cache. If it can, the statement will not be parsed at all but the cached result
 is used.
 
-The configuration parameter takes one integer that specifies the maximum size of\
+The configuration parameter takes one integer that specifies the maximum size of
 the cache. The size of the cache can be specified as explained [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#sizes).
 
 ```
@@ -1081,17 +1081,17 @@ the cache. The size of the cache can be specified as explained [here](mariadb-ma
 query_classifier_cache_size=1MB
 ```
 
-Note that MaxScale uses a separate cache for each worker thread. To obtain the\
-amount of memory available for each thread, divide the cache size with the value\
-of `threads`. If statements are evicted from the cache (visible in the\
+Note that MaxScale uses a separate cache for each worker thread. To obtain the
+amount of memory available for each thread, divide the cache size with the value
+of `threads`. If statements are evicted from the cache (visible in the
 diagnostic output), consider increasing the cache size.
 
-Note also that limit is not a hard limit, but an approximate one. Namely, although\
-the memory needed for storing the canonicalized statement and the classification\
-result is correctly accounted for, there is additional overhead whose size is not\
+Note also that limit is not a hard limit, but an approximate one. Namely, although
+the memory needed for storing the canonicalized statement and the classification
+result is correctly accounted for, there is additional overhead whose size is not
 exactly known and over which we do not have direct control.
 
-Using `maxctrl show threads` it is possible to check what the actual size of\
+Using `maxctrl show threads` it is possible to check what the actual size of
 the cache is and to see performance statistics.
 
 | Key                | Meaning                                                                                                                 |
@@ -1113,15 +1113,15 @@ Deprecated since MariaDB MaxScale 23.08.
 * Dynamic: No
 * Default: `false`
 
-Enable or disable the substitution of environment variables in the MaxScale\
-configuration file. If the substitution of variables is enabled and a\
+Enable or disable the substitution of environment variables in the MaxScale
+configuration file. If the substitution of variables is enabled and a
 configuration line like
 
 ```
 some_parameter=$SOME_VALUE
 ```
 
-is encountered, then `$SOME_VALUE` will be replaced with the actual value\
+is encountered, then `$SOME_VALUE` will be replaced with the actual value
 of the environment variable `SOME_VALUE`. Note: _Variable substitution will be made only if '$' is the first character of the value._ _Everything_ following '$' is interpreted as the name of the environment
 variable.
 
@@ -1131,9 +1131,9 @@ variable.
 substitute_variables=true
 ```
 
-The setting of `substitute_variables` will have an effect on all parameters\
-in the all other sections, irrespective of where the `[maxscale]` section\
-is placed in the configuration file. However, in the `[maxscale]` section,\
+The setting of `substitute_variables` will have an effect on all parameters
+in the all other sections, irrespective of where the `[maxscale]` section
+is placed in the configuration file. However, in the `[maxscale]` section,
 to ensure that substitution will take place, place the`substitute_variables=true` line first.
 
 #### `sql_mode`
@@ -1144,7 +1144,7 @@ to ensure that substitution will take place, place the`substitute_variables=true
 * Values: `default`, `oracle`
 * Default: `default`
 
-Specifies whether the query classifier parser should initially expect _MariaDB_\
+Specifies whether the query classifier parser should initially expect _MariaDB_
 or _PL/SQL_ kind of SQL.
 
 The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`oracle` : The parser expects PL/SQL.
@@ -1153,7 +1153,7 @@ The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`orac
 sql_mode=oracle
 ```
 
-**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume\
+**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume
 that `autocommit` initially is off.
 
 At runtime, MariaDB MaxScale will recognize statements like
@@ -1170,12 +1170,12 @@ set sql_mode=default;
 
 and change mode accordingly.
 
-**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also\
-behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave\
+**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also
+behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave
 as if `autocommit` had been turned on.
 
-Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of\
-the server, so the value of `sql_mode` should reflect the sql mode used\
+Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of
+the server, so the value of `sql_mode` should reflect the sql mode used
 when the server is started.
 
 #### `local_address`
@@ -1187,8 +1187,8 @@ when the server is started.
 
 What specific local address/interface to use when connecting to servers.
 
-This can be used for ensuring that MaxScale uses a particular interface\
-when connecting to servers, in case the computer MaxScale is running on\
+This can be used for ensuring that MaxScale uses a particular interface
+when connecting to servers, in case the computer MaxScale is running on
 has multiple interfaces.
 
 ```
@@ -1202,27 +1202,27 @@ local_address=192.168.1.254
 * Dynamic: Yes
 * Default: `30s`
 
-How often, in seconds, MaxScale at most may refresh the users from the\
+How often, in seconds, MaxScale at most may refresh the users from the
 backend server.
 
-MaxScale will at startup load the users from the backend server, but if\
-the authentication of a user fails, MaxScale assumes it is because a new\
-user has been created and will thus refresh the users. By default, MaxScale\
-will do that at most once per 30 seconds and with this configuration option\
-that can be changed. A value of 0 allows infinite refreshes and a negative\
+MaxScale will at startup load the users from the backend server, but if
+the authentication of a user fails, MaxScale assumes it is because a new
+user has been created and will thus refresh the users. By default, MaxScale
+will do that at most once per 30 seconds and with this configuration option
+that can be changed. A value of 0 allows infinite refreshes and a negative
 value disables the refreshing entirely.
 
 ```
 users_refresh_time=120s
 ```
 
-The value is specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds\
+In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds
 but, due to a bug, the default value was 0 which allowed infinite refreshes.
 
 #### `users_refresh_interval`
@@ -1232,12 +1232,12 @@ but, due to a bug, the default value was 0 which allowed infinite refreshes.
 * Dynamic: Yes
 * Default: `0s`
 
-How often, in seconds, MaxScale will automatically refresh the users from the\
+How often, in seconds, MaxScale will automatically refresh the users from the
 backend server.
 
-This configuration is used to periodically refresh the backend users, making sure\
-they are up to date. The default value for this setting is 0, meaning the users\
-are not periodically refreshed. However, they can still be refreshed in case of\
+This configuration is used to periodically refresh the backend users, making sure
+they are up to date. The default value for this setting is 0, meaning the users
+are not periodically refreshed. However, they can still be refreshed in case of
 failed authentication depending on `users_refresh_time`.
 
 ```
@@ -1251,13 +1251,13 @@ users_refresh_interval=2h
 * Dynamic: Yes
 * Default: `0`
 
-How many statements MaxScale should store for each session. This is for\
-debugging purposes, as in case of problems it is often of value to be able\
-to find out exactly what statements were sent before a particular\
+How many statements MaxScale should store for each session. This is for
+debugging purposes, as in case of problems it is often of value to be able
+to find out exactly what statements were sent before a particular
 problem turned up.
 
-**Note:** See also `dump_last_statements` using which the actual dumping\
-of the statements is enabled. Unless both of the parameters are defined,\
+**Note:** See also `dump_last_statements` using which the actual dumping
+of the statements is enabled. Unless both of the parameters are defined,
 the statement dumping mechanism doesn't work.
 
 ```
@@ -1272,10 +1272,10 @@ retain_last_statements=20
 * Values: `on_close`, `on_error`, `never`
 * Default: `never`
 
-With this configuration item it is specified in what circumstances MaxScale\
-should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never\
-logged, with `on_error` they are logged if the client closes the connection\
-improperly, and with `on_close` they are always logged when a client session\
+With this configuration item it is specified in what circumstances MaxScale
+should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never
+logged, with `on_error` they are logged if the client closes the connection
+improperly, and with `on_close` they are always logged when a client session
 is closed.
 
 ```
@@ -1283,7 +1283,7 @@ dump_last_statements=on_error
 ```
 
 Note that you need to specify with `retain_last_statements` how many statements\
-MaxScale should retain for each session. Unless it has been set to another value\
+MaxScale should retain for each session. Unless it has been set to another value
 than `0`, this configuration setting will not have an effect.
 
 #### `session_trace`
@@ -1293,8 +1293,8 @@ than `0`, this configuration setting will not have an effect.
 * Dynamic: Yes
 * Default: `0`
 
-How many log entries are stored in the session specific trace log. This log is\
-written to disk when a session ends abnormally and can be used for debugging\
+How many log entries are stored in the session specific trace log. This log is
+written to disk when a session ends abnormally and can be used for debugging
 purposes. Currently the session trace log is written to the log in the following situations:
 
 * When MaxScale receives a fatal signal and is about to crash.
@@ -1302,8 +1302,8 @@ purposes. Currently the session trace log is written to the log in the following
 * If the session is not closed gracefully (i.e. client doesn't send a COM\_QUIT packet)
 * Whenever readwritesplit receives a response that is was not expecting.
 
-It would be good to enable this if a session is disconnected and the log is not\
-detailed enough. In this case the info log might reveal the true cause of why\
+It would be good to enable this if a session is disconnected and the log is not
+detailed enough. In this case the info log might reveal the true cause of why
 the connection was closed.
 
 ```
@@ -1315,9 +1315,9 @@ Default is `0`.
 The session trace log is also exposed by REST API and is shown with`maxctrl show sessions`.
 
 The order in which the session trace messages are logged into the log changed in\
-MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal\
-log order" of older events coming first and newer events appearing later in the\
-file. Older versions of MaxScale logged the trace dump in the reverse order with\
+MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal
+log order" of older events coming first and newer events appearing later in the
+file. Older versions of MaxScale logged the trace dump in the reverse order with
 the newest messages first and oldest ones last.
 
 #### `session_trace_match`
@@ -1327,17 +1327,17 @@ the newest messages first and oldest ones last.
 * Dynamic: Yes
 * Default: None
 
-If both `session_trace` and `session_trace_match` are defined, and a trace log\
-entry of a session matches the regular expression, the trace log is written to\
+If both `session_trace` and `session_trace_match` are defined, and a trace log
+entry of a session matches the regular expression, the trace log is written to
 disk. The check for the match is done when the session is stopping.
 
-The most effective way to debug MaxScale related issues is to turn on `log_info`\
-and observe the events written into the MaxScale log. The only problem with this\
-approach is that it can cause a severe performance bottleneck and can easily\
-fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged\
+The most effective way to debug MaxScale related issues is to turn on `log_info`
+and observe the events written into the MaxScale log. The only problem with this
+approach is that it can cause a severe performance bottleneck and can easily
+fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged
 can be filtered to only what is needed.
 
-For example, the following configuration would only log the trace log messages\
+For example, the following configuration would only log the trace log messages
 from sessions that execute SQL queries with syntax errors:
 
 ```
@@ -1345,10 +1345,10 @@ session_trace=1000
 session_trace_match=/You have an error in your SQL syntax/
 ```
 
-This could be used to easily identify which applications execute the queries\
-without having to gather the info level log output from all the sessions that\
-connect to MaxScale. For every session that ends up logging a syntax error\
-message, the last 1000 lines of log output done by that session is written into\
+This could be used to easily identify which applications execute the queries
+without having to gather the info level log output from all the sessions that
+connect to MaxScale. For every session that ends up logging a syntax error
+message, the last 1000 lines of log output done by that session is written into
 the MaxScale log.
 
 #### `writeq_high_water`
@@ -1358,17 +1358,17 @@ the MaxScale log.
 * Dynamic: Yes
 * Default: `65536`
 
-High water mark for network write buffer. When the size of the outbound network\
-buffer in MaxScale for a single connection exceeds this value, network traffic\
-throttling for that connection is started. The parameter accepts [size type\
+High water mark for network write buffer. When the size of the outbound network
+buffer in MaxScale for a single connection exceeds this value, network traffic
+throttling for that connection is started. The parameter accepts [size type
 values](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#sizes). The default value was 16777216 bytes before 22.08.4.
 
-More specifically, if the client side write queue is above this value, it will\
-block traffic coming from backend servers. If the backend side write queue is\
+More specifically, if the client side write queue is above this value, it will
+block traffic coming from backend servers. If the backend side write queue is
 above this value, it will block traffic from client.
 
-The buffer that this parameter controls is the buffer internal to MaxScale and\
-is not the kernel TCP send buffer. This means that the total amount of buffered\
+The buffer that this parameter controls is the buffer internal to MaxScale and
+is not the kernel TCP send buffer. This means that the total amount of buffered
 data is determined by both the kernel TCP buffers and the value of`writeq_high_water`.
 
 Network throttling is only enabled when `writeq_high_water` is non-zero. In\
@@ -1381,8 +1381,8 @@ MaxScale 23.02 and earlier, also `writeq_low_water` had to be non-zero.
 * Dynamic: Yes
 * Default: `1024`
 
-Low water mark for network write buffer. Once the traffic throttling is enabled,\
-it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#sizes). The\
+Low water mark for network write buffer. Once the traffic throttling is enabled,
+it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#sizes). The
 default value was 8192 bytes before 22.08.4.
 
 The value of `writeq_high_water` must always be greater than the value of`writeq_low_water`.
@@ -1395,10 +1395,10 @@ The value of `writeq_high_water` must always be greater than the value of`writeq
 
 Persist changes done at runtime. This parameter was added in MaxScale 22.08.0.
 
-When `persist_runtime_changes` is enabled, runtime configuration changes done\
-with the GUI, MaxCtrl or via the REST API cause a new configuration file to be\
-saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is\
-enabled, these files will be applied on top of any existing values found in\
+When `persist_runtime_changes` is enabled, runtime configuration changes done
+with the GUI, MaxCtrl or via the REST API cause a new configuration file to be
+saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is
+enabled, these files will be applied on top of any existing values found in
 static configuration files whenever MaxScale is starting up.
 
 #### `load_persisted_configs`
@@ -1411,11 +1411,11 @@ static configuration files whenever MaxScale is starting up.
 Load persisted runtime changes on startup. This parameter was added in MaxScale\
 2.3.6.
 
-All runtime configuration changes are persisted in generated configuration files\
-located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on\
-startup after main configuration files have been read. To make runtime\
-configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores\
-the current runtime state of MaxScale. This makes problem analysis easier if an\
+All runtime configuration changes are persisted in generated configuration files
+located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on
+startup after main configuration files have been read. To make runtime
+configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores
+the current runtime state of MaxScale. This makes problem analysis easier if an
 unexpected outage happens.
 
 #### `max_auth_errors_until_block`
@@ -1425,14 +1425,14 @@ unexpected outage happens.
 * Dynamic: Yes
 * Default: `10`
 
-The maximum number of authentication failures that are tolerated before a host\
-is temporarily blocked. The default value is 10 failures. After a host is\
-blocked, connections from it are rejected for 60 seconds. To disable this\
+The maximum number of authentication failures that are tolerated before a host
+is temporarily blocked. The default value is 10 failures. After a host is
+blocked, connections from it are rejected for 60 seconds. To disable this
 feature, set the value to 0.
 
-Note that the configured value is not a hard limit. The number of tolerated\
-failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the\
-configured value of this parameter and `threads` is the number of configured\
+Note that the configured value is not a hard limit. The number of tolerated
+failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the
+configured value of this parameter and `threads` is the number of configured
 threads.
 
 #### `debug`
@@ -1442,16 +1442,16 @@ threads.
 * Dynamic: No
 * Default: `""`
 
-Define debug options from the --debug command line option. Either the command\
-line option or the parameter should be used, not both. The debug options are\
+Define debug options from the --debug command line option. Either the command
+line option or the parameter should be used, not both. The debug options are
 only for testing purposes and are not to be used in production.
 
 #### REST API Configuration
 
-The MaxScale REST API is an HTTP interface that provides JSON format data\
+The MaxScale REST API is an HTTP interface that provides JSON format data
 intended to be consumed by monitoring applications and visualization tools.
 
-The following options must be defined under the `[maxscale]` section in the\
+The following options must be defined under the `[maxscale]` section in the
 configuration file.
 
 #### `admin_host`
@@ -1480,8 +1480,8 @@ The port where the REST API listens on. The default value is port 8989.
 * Dynamic: No
 * Default: `true`
 
-Enable REST API authentication using HTTP Basic Access\
-authentication. This is not a secure method of authentication without HTTPS but\
+Enable REST API authentication using HTTP Basic Access
+authentication. This is not a secure method of authentication without HTTPS but
 it does add a small layer of security.
 
 For more information, read the [REST API documentation](../mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md).
@@ -1495,11 +1495,11 @@ For more information, read the [REST API documentation](../mariadb-maxscale-23-0
 
 The path to the TLS private key in PEM format for the admin interface.
 
-If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin\
+If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin
 interface will use encrypted HTTPS instead of plain HTTP.
 
-The REST-API only supports PKCS#8 PEM private keys and using a PKCS#1 PEM\
-private key will result in an error. If your private key is in PKCS#1 PEM\
+The REST-API only supports PKCS#8 PEM private keys and using a PKCS#1 PEM
+private key will result in an error. If your private key is in PKCS#1 PEM
 format, convert it to PKCS#8 PEM format first before starting up MaxScale.
 
 #### `admin_ssl_cert`
@@ -1509,7 +1509,7 @@ format, convert it to PKCS#8 PEM format first before starting up MaxScale.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS public certificate in PEM format. See `admin_ssl_key`\
+The path to the TLS public certificate in PEM format. See `admin_ssl_key`
 documentation for more details.
 
 #### `admin_ssl_ca_cert`
@@ -1523,11 +1523,11 @@ Deprecated since MariaDB MaxScale 22.08. See `admin_ssl_ca`.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS CA certificate in PEM format. If defined, the client\
-certificate, if provided, will be validated against it. This parameter is\
+The path to the TLS CA certificate in PEM format. If defined, the client
+certificate, if provided, will be validated against it. This parameter is
 optional starting with MaxScale 2.3.19.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,
 which is still accepted as an alias for `admin_ssl_ca`.
 
 #### `admin_ssl_version`
@@ -1538,7 +1538,7 @@ which is still accepted as an alias for `admin_ssl_ca`.
 * Values: `MAX`, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`, `TLSv10`, `TLSv11`, `TLSv12`, `TLSv13`
 * Default: `MAX`
 
-This parameter controls the enabled TLS versions in the REST API. Accepted\
+This parameter controls the enabled TLS versions in the REST API. Accepted
 values are:
 
 * `TLSv10`
@@ -1547,7 +1547,7 @@ values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -1555,19 +1555,19 @@ releases accept also the following alias values:
 * `TLSv1.2`
 * `TLSv1.3` (not supported on OpenSSL 1.0)
 
-The default value is `MAX` which negotiates the highest level of encryption that\
-both the client and server support. The list of supported TLS versions depends\
+The default value is `MAX` which negotiates the highest level of encryption that
+both the client and server support. The list of supported TLS versions depends
 on the operating system and what TLS versions the GnuTLS library supports.
 
 For example, to enable only TLSv1.1 and TLSv1.3, use`admin_ssl_version=TLSv1.1,TLSv1.3`.
 
 This parameter was added in MaxScale 2.5.7.
 
-Older versions of MaxScale interpreted `admin_ssl_version` as the minimum\
+Older versions of MaxScale interpreted `admin_ssl_version` as the minimum
 allowed TLS version. In those versions, `admin_ssl_version=TLSv1.2` allowed both\
-TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2\
-and all newer versions, the value is a enumeration of accepted TLS protocol\
-versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To\
+TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2
+and all newer versions, the value is a enumeration of accepted TLS protocol
+versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To
 retain the old behavior, specify all the accepted values with`admin_ssl_version=TLSv1.2,TLSv1.3`
 
 #### `admin_enabled`
@@ -1577,7 +1577,7 @@ retain the old behavior, specify all the accepted values with`admin_ssl_version=
 * Dynamic: No
 * Default: `true`
 
-Enable or disable the admin interface. This allows the admin interface to\
+Enable or disable the admin interface. This allows the admin interface to
 be completely disabled to prevent access to it.
 
 #### `admin_gui`
@@ -1590,9 +1590,9 @@ be completely disabled to prevent access to it.
 Enable or disable the admin graphical user interface.
 
 MaxScale provides a GUI for administrative operations via the REST API. When the\
-GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will\
-serve the GUI. When disabled, the REST API will respond with a 200 OK to the\
-request. By disabling the GUI, the root resource can be used as a low overhead\
+GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will
+serve the GUI. When disabled, the REST API will respond with a 200 OK to the
+request. By disabling the GUI, the root resource can be used as a low overhead
 health check.
 
 #### `admin_secure_gui`
@@ -1604,10 +1604,10 @@ health check.
 
 Whether to serve the GUI only over secure HTTPS connections.
 
-To be secure by default, the GUI is only served over HTTPS connections as\
+To be secure by default, the GUI is only served over HTTPS connections as
 it uses a token authentication scheme. This also controls whether the`/auth` endpoint requires an encrypted connection.
 
-To allow use of the GUI without having to configure TLS certificates for\
+To allow use of the GUI without having to configure TLS certificates for
 the MaxScale REST API, set this parameter to false.
 
 #### `admin_log_auth_failures`
@@ -1626,17 +1626,17 @@ Log authentication failures for the admin interface.
 * Dynamic: No
 * Default: `""`
 
-Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings\
-accept a PAM service name which is used during authentication if normal authentication\
+Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings
+accept a PAM service name which is used during authentication if normal authentication
 fails. `admin_pam_readwrite_service` should accept users who can do any\
-MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only\
-do read operations. Because REST-API does not support back and forth communication between\
-the client and MaxScale, the PAM services must be simple. They should only ask for the\
+MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only
+do read operations. Because REST-API does not support back and forth communication between
+the client and MaxScale, the PAM services must be simple. They should only ask for the
 password and nothing else.
 
-If only `admin_pam_readwrite_service` is configured, both read and write operations can be\
-authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read\
-operations can be authenticated by PAM. If both are set, the service used is determined by\
+If only `admin_pam_readwrite_service` is configured, both read and write operations can be
+authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read
+operations can be authenticated by PAM. If both are set, the service used is determined by
 the requested operation. Leave or set both empty to disable PAM for REST-API.
 
 #### `admin_jwt_algorithm`
@@ -1650,47 +1650,47 @@ the requested operation. Leave or set both empty to disable PAM for REST-API.
 The signature algorithm used by the MaxScale REST API when generating JSON Web\
 Tokens.
 
-For more information about the tokens and how they work, refer to [the REST API\
+For more information about the tokens and how they work, refer to [the REST API
 documentation](../mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md).
 
-If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale\
-will generate a random encryption key on startup and use that to sign the\
+If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale
+will generate a random encryption key on startup and use that to sign the
 messages. The symmetric key can also be retrieved from an [Encryption Key\
 Manager](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encryption-key-managers) if the `admin_jwt_key` parameter is defined.
 
-If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must\
-contain a private key and a public certificate of the correct type. If the wrong\
+If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must
+contain a private key and a public certificate of the correct type. If the wrong
 key type, key length or elliptic curve is used, MaxScale will refuse to start.
 
-Asymmetric key algorithms make it possible for the clients of the REST API to\
+Asymmetric key algorithms make it possible for the clients of the REST API to
 validate that the token was indeed generated by the correct entity.
 
-Symmetric algorithms make it easy to share the same tokens between\
-multiple MaxScale instances as the shared secret can be stored in a key\
+Symmetric algorithms make it easy to share the same tokens between
+multiple MaxScale instances as the shared secret can be stored in a key
 management system.
 
 The possible values for this parameter are:
 
 * `auto`
-* MaxScale will attempt to detect the best algorithm to use for\
+* MaxScale will attempt to detect the best algorithm to use for
   signatures. The algorithm used depends on the private key type: RSA keys use`PS256`, EC keys use the `ES256`, `ES384` or `ES512` depending on the curve,\
-  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot\
+  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot
   auto-detect the key type, it falls back to `HS256` as the default algorithm.
 * `HS256`, `HS384` or `HS512`
 * [HMAC with SHA-2\
-  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct\
+  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct
   size.
 * `RS256`, `RS384` or `RS512`
 * [Digital Signature with\
-  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires\
+  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires
   at least a 2048-bit RSA key.
 * `PS256`, `PS384` or `PS512`
 * [Digital Signature with\
-  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires\
+  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires
   at least a 2048-bit RSA key.
 * `ES256`, `ES384` or `ES512`
 * [Digital Signature with\
-  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires\
+  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires
   an EC key with the correct curve: P-256 for `ES256`, P-384 for `ES384` and\
   P-512 for `ES512`.
 * `ED25519` or `ED448`
@@ -1705,15 +1705,15 @@ The possible values for this parameter are:
 * Dynamic: No
 * Default: `""`
 
-The ID for the encryption key used to sign the JSON Web Tokens. If configured,\
-an [Encryption Key Manager](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured\
-and it must contain the key with the given ID. If no key is defined, MaxScale\
-will use a random encryption key whenever a symmetric signature algorithm is\
+The ID for the encryption key used to sign the JSON Web Tokens. If configured,
+an [Encryption Key Manager](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured
+and it must contain the key with the given ID. If no key is defined, MaxScale
+will use a random encryption key whenever a symmetric signature algorithm is
 used.
 
-Currently, the encryption key is only read on startup. This means that the\
+Currently, the encryption key is only read on startup. This means that the
 tokens will be signed by the latest key version that is available on startup:\
-rotating the encryption key in the key management system will not cause the JWTs\
+rotating the encryption key in the key management system will not cause the JWTs
 to be signed with newer versions of the key.
 
 #### `admin_jwt_max_age`
@@ -1725,11 +1725,11 @@ to be signed with newer versions of the key.
 
 The maximum lifetime of a token generated by the `/auth` endpoint.
 
-If a client requests for a token with a lifetime that exceeds the configured\
-value, the token lifetime is silently truncated to this value. This can be used\
+If a client requests for a token with a lifetime that exceeds the configured
+value, the token lifetime is silently truncated to this value. This can be used
 to control the maximum length of a MaxGUI session.
 
-This also acts as the effective maximum age of any database connection created\
+This also acts as the effective maximum age of any database connection created
 from the `/sql` endpoint.
 
 #### `admin_oidc_url`
@@ -1741,19 +1741,19 @@ from the `/sql` endpoint.
 
 The URL to a OpenID Connect server that is used for JWT validation.
 
-If defined, any tokens signed by this server are accepted as valid bearer tokens\
-for the MaxScale REST API. The `"sub"` field of the token is assumed to be the\
-username of an administrative user in MaxScale and the `"account"` claim is\
-assumed to be the type of the user: `"admin"` for administrative users with full\
+If defined, any tokens signed by this server are accepted as valid bearer tokens
+for the MaxScale REST API. The `"sub"` field of the token is assumed to be the
+username of an administrative user in MaxScale and the `"account"` claim is
+assumed to be the type of the user: `"admin"` for administrative users with full
 access to the REST-API and `"basic"` for users with read-only access to the\
 REST-API. This means that all users must be first created with `maxctrl create user` before the tokens are accepted if the OIDC provider is not able to add the`"account"` claim.
 
-Modifying `admin_oidc_url` will cause the certificates to be fetched\
-again. They are also fetched when the `maxctrl reload tls` command is\
-executed or when the `admin_ssl_cert` and `admin_ssl_key` settings are\
+Modifying `admin_oidc_url` will cause the certificates to be fetched
+again. They are also fetched when the `maxctrl reload tls` command is
+executed or when the `admin_ssl_cert` and `admin_ssl_key` settings are
 modified.
 
-MaxScale versions 22.08.16 and earlier only fetched the new certificates when\
+MaxScale versions 22.08.16 and earlier only fetched the new certificates when
 the `maxctrl reload tls` command was executed.
 
 #### `admin_verify_url`
@@ -1765,19 +1765,19 @@ the `maxctrl reload tls` command was executed.
 
 URL to a server to which the REST API token verification is delegated.
 
-If the URL is defined, any tokens passed to the REST API will be validated by\
-doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client\
+If the URL is defined, any tokens passed to the REST API will be validated by
+doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client
 and the custom `X-Referrer-Method` header is set to the HTTP method being used\
 (PUT, GET etc.).
 
-**Note**: When `admin_verify_url` is used and the remote server cannot\
-be accessed, all REST API access that uses tokens will be disabled. The\
-only way to use the REST API with tokens is to remove `admin_verify_url`\
-from the configuration which requires restarting MaxScale. The REST API\
-still accepts HTTP Basic Access authentication even if the remote server\
+**Note**: When `admin_verify_url` is used and the remote server cannot
+be accessed, all REST API access that uses tokens will be disabled. The
+only way to use the REST API with tokens is to remove `admin_verify_url`
+from the configuration which requires restarting MaxScale. The REST API
+still accepts HTTP Basic Access authentication even if the remote server
 cannot be reached.
 
-By delegating the authentication and authorization of the REST API to an\
+By delegating the authentication and authorization of the REST API to an
 external server, users can implement custom access control systems for the\
 MaxScale REST API.
 
@@ -1788,9 +1788,9 @@ MaxScale REST API.
 * Dynamic: No
 * Default: `maxscale`
 
-The issuer (`"iss"`) claim of all JWTs generated by MaxScale. This can be set\
-to a custom value to uniquely identify which MaxScale issued a JWT. This is\
-especially useful for cases where the MaxScale GUI is used from behind\
+The issuer (`"iss"`) claim of all JWTs generated by MaxScale. This can be set
+to a custom value to uniquely identify which MaxScale issued a JWT. This is
+especially useful for cases where the MaxScale GUI is used from behind
 a reverse proxy.
 
 #### `admin_audit`
@@ -1811,8 +1811,8 @@ Enable logging of incoming REST API calls.
 
 The file where the REST API auditing information is logged.
 
-If a non-default value is used, the directory where the file resides must\
-exist. For example, with `/var/log/maxscale/audit_files/audit.csv`, the\
+If a non-default value is used, the directory where the file resides must
+exist. For example, with `/var/log/maxscale/audit_files/audit.csv`, the
 directory `/var/log/maxscale/audit_files` must exist.
 
 #### `admin_audit_exclude_methods`
@@ -1826,9 +1826,9 @@ directory `/var/log/maxscale/audit_files` must exist.
 List of comma separated HTTP methods to exclude from logging\
 Currently MaxScale does not use `CONNECT` or `TRACE`.
 
-Resetting to log all methods can be done in the configuration file by\
+Resetting to log all methods can be done in the configuration file by
 writing `admin_audit_exclude_methods=` or at runtime with`maxctrl alter maxscale admin_audit_exclude_methods=`.\
-Remember that once a runtime change has been made, the entry for that\
+Remember that once a runtime change has been made, the entry for that
 setting is ignored in the main configuration file (usually maxscale.cnf).
 
 #### `config_sync_cluster`
@@ -1838,10 +1838,10 @@ setting is ignored in the main configuration file (usually maxscale.cnf).
 * Dynamic: Yes
 * Default: None
 
-This parameter controls which cluster (i.e. monitor) is used to synchronize\
+This parameter controls which cluster (i.e. monitor) is used to synchronize
 configuration changes between MaxScale instances. The first server labeled`Master` will be used for the synchronization.
 
-By default configuration synchronization is not enabled and it must be\
+By default configuration synchronization is not enabled and it must be
 explicitly enabled by defining a monitor name for `config_sync_cluster`.
 
 When `config_sync_cluster` is defined, `config_sync_user` and`config_sync_password` must also be defined.
@@ -1856,8 +1856,8 @@ Synchronization](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#c
 * Dynamic: Yes
 * Default: None
 
-The username for the account that is used to synchronize configuration changes\
-across MaxScale instances. Both this parameter and `config_sync_password` are\
+The username for the account that is used to synchronize configuration changes
+across MaxScale instances. Both this parameter and `config_sync_password` are
 required if `config_sync_cluster` is configured.
 
 This account must have the following grants:
@@ -1866,7 +1866,7 @@ This account must have the following grants:
 GRANT SELECT, INSERT, UPDATE, CREATE ON `mysql`.`maxscale_config`
 ```
 
-The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`\
+The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`
 grant is not needed by the user configured in `config_sync_user`. The following\
 SQL is used to create the table.
 
@@ -1880,7 +1880,7 @@ CREATE TABLE IF NOT EXISTS mysql.maxscale_config(
 ) ENGINE=InnoDB;
 ```
 
-If the database where the table is created is changed with `config_sync_db`, the\
+If the database where the table is created is changed with `config_sync_db`, the
 grants must be adjusted to target that database instead.
 
 #### `config_sync_password`
@@ -1890,8 +1890,8 @@ grants must be adjusted to target that database instead.
 * Dynamic: Yes
 * Default: None
 
-The password for `config_sync_user`. Both this parameter and `config_sync_user`\
-are required if `config_sync_cluster` is configured. This password can\
+The password for `config_sync_user`. Both this parameter and `config_sync_user`
+are required if `config_sync_cluster` is configured. This password can
 optionally be encrypted using `maxpasswd`.
 
 #### `config_sync_db`
@@ -1901,13 +1901,13 @@ optionally be encrypted using `maxpasswd`.
 * Dynamic: No
 * Default: `mysql`
 
-The database where the `maxscale_config` table is created. By default the table\
-is created in the `mysql` database. This parameter was added in MaxScale\
+The database where the `maxscale_config` table is created. By default the table
+is created in the `mysql` database. This parameter was added in MaxScale
 versions 6.4.6 and 22.08.5.
 
-As tables in the `mysql` database cannot have triggers on them, the database\
+As tables in the `mysql` database cannot have triggers on them, the database
 must be changed to a user-created one in order to create triggers on the table.\
-An example use-case for triggers on this table is to track all configuration\
+An example use-case for triggers on this table is to track all configuration
 changes done to MaxScale by inserting them into a separate table.
 
 #### `config_sync_interval`
@@ -1919,9 +1919,9 @@ changes done to MaxScale by inserting them into a separate table.
 
 How often to synchronize the configuration with the cluster.
 
-As the synchronization involves selecting the configuration version from the\
-database, this value should not be set to an unreasonably low value. The default\
-value of 5 second should provide a good compromise between responsiveness and\
+As the synchronization involves selecting the configuration version from the
+database, this value should not be set to an unreasonably low value. The default
+value of 5 second should provide a good compromise between responsiveness and
 how much load it places on the database.
 
 #### `config_sync_timeout`
@@ -1931,8 +1931,8 @@ how much load it places on the database.
 * Dynamic: Yes
 * Default: `10s`
 
-Timeout for all SQL operations done during the configuration synchronization. If\
-an operation exceeds this timeout, the configuration change is treated as failed\
+Timeout for all SQL operations done during the configuration synchronization. If
+an operation exceeds this timeout, the configuration change is treated as failed
 and an error is reported to the client that did the change.
 
 #### `key_manager`
@@ -1947,13 +1947,13 @@ The encryption key manager to use. The available encryption key managers are:
 * `none` - No key manager, encryption keys are not available.
 * `file` - [File-based key manager](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#file-based-key-manager)
 * `kmip` - [KMIP key manager](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#kmip-key-manager)
-* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This\
-  key manager is only included on systems with GCC 9 or newer which\
+* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This
+  key manager is only included on systems with GCC 9 or newer which
   means it cannot be used on Ubuntu 18.04.
 
-Refer to the [Encryption Key Managers](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for\
-more information on how to configure the key managers. The key managers each\
-have their configuration in their own namespace and must have their name as a\
+Refer to the [Encryption Key Managers](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for
+more information on how to configure the key managers. The key managers each
+have their configuration in their own namespace and must have their name as a
 prefix.
 
 For example to configure the `file` key manager, the following must be used:
@@ -1965,16 +1965,16 @@ file.keyfile=/path/to/keyfile
 
 ### Events
 
-MaxScale logs warnings and errors for various reasons and often it is self-\
-evident and generally applicable whether some occurrence should warrant a\
+MaxScale logs warnings and errors for various reasons and often it is self-
+evident and generally applicable whether some occurrence should warrant a
 warning or an error, or perhaps just an info-level message.
 
-However, there are events whose seriousness is not self-evident. For\
-instance, in some environments an authentication failure may simply indicate\
-that someone has made a typo, while in some other environment that can only\
+However, there are events whose seriousness is not self-evident. For
+instance, in some environments an authentication failure may simply indicate
+that someone has made a typo, while in some other environment that can only
 happen in case there has been a security breech.
 
-To handle events like these, MaxScale defines _events_ whose logging\
+To handle events like these, MaxScale defines _events_ whose logging
 facility and level can be controlled by the administrator. Given an event`X`, its facility and level are controlled in the following manner:
 
 ```
@@ -1982,21 +1982,21 @@ event.X.facility=LOG_LOCAL0
 event.X.level=LOG_ERR
 ```
 
-The above means that if event _X_ occurs, then that is logged using the\
+The above means that if event _X_ occurs, then that is logged using the
 facility `LOG_LOCAL0` and the level `LOG_ERR`.
 
-The valid values of facility`are the facility values reported by`man\
+The valid values of facility`are the facility values reported by`man
 syslog`, e.g.`LOG\_AUTH`,`LOG\_LOCAL0`and`LOG\_USER`. Likewise, the valid values for`level`are the ones also reported by`man syslog`, e.g.`LOG\_WARNING`,`LOG\_ERR`and`LOG\_CRIT\`.
 
-Note that MaxScale does not act upon the level, that is, even if the level\
-of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut\
+Note that MaxScale does not act upon the level, that is, even if the level
+of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut
 down if that event occurs.
 
 The default facility is `LOG_USER` and the default level is `LOG_WARNING`.
 
-Note that you may also have to configure `rsyslog` to ensure that the\
-event can be logged to the intended log file. For instance, if the facility\
-is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line\
+Note that you may also have to configure `rsyslog` to ensure that the
+event can be logged to the intended log file. For instance, if the facility
+is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line
 like
 
 ```
@@ -2018,22 +2018,22 @@ event.authentication_failure.level=LOG_CRIT
 
 ### Service
 
-A service represents the database service that MariaDB MaxScale offers to the\
-clients. In general a service consists of a set of backend database servers and\
-a routing algorithm that determines how MariaDB MaxScale decides to send\
+A service represents the database service that MariaDB MaxScale offers to the
+clients. In general a service consists of a set of backend database servers and
+a routing algorithm that determines how MariaDB MaxScale decides to send
 statements or route connections to those backend servers.
 
-A service may be considered as a virtual database server that MariaDB MaxScale\
+A service may be considered as a virtual database server that MariaDB MaxScale
 makes available to its clients.
 
 Several different services may be defined using the same set of backend servers.\
-For example a connection based routing service might be used by clients that\
-already performed internal read/write splitting, whilst a different statement\
-based router may be used by clients that are not written with this functionality\
-in place. Both sets of applications could access the same data in the same\
+For example a connection based routing service might be used by clients that
+already performed internal read/write splitting, whilst a different statement
+based router may be used by clients that are not written with this functionality
+in place. Both sets of applications could access the same data in the same
 databases.
 
-A service is identified by a service name, which is the name of the\
+A service is identified by a service name, which is the name of the
 configuration file section and a type parameter of service.
 
 ```
@@ -2041,9 +2041,9 @@ configuration file section and a type parameter of service.
 type=service
 ```
 
-In order for MariaDB MaxScale to forward any requests it must have at least one\
-service defined within the configuration file. The definition of a service alone\
-is not enough to allow MariaDB MaxScale to forward requests however, the service\
+In order for MariaDB MaxScale to forward any requests it must have at least one
+service defined within the configuration file. The definition of a service alone
+is not enough to allow MariaDB MaxScale to forward requests however, the service
 is merely present to link together the other configuration elements.
 
 #### `router`
@@ -2052,15 +2052,15 @@ is merely present to link together the other configuration elements.
 * Mandatory: Yes
 * Dynamic: No
 
-The router parameter of a service defines the name of the router module that\
+The router parameter of a service defines the name of the router module that
 will be used to implement the routing algorithm between the client of MariaDB\
-MaxScale and the backend databases. Additionally routers may also be passed a\
-comma separated list of options that are used to control the behavior of the\
-routing algorithm. The two parameters that control the routing choice are router\
-and router\_options. The router options are specific to a particular router and\
-are used to modify the behavior of the router. The read connection router can be\
-passed options of `master`, `slave` or `synced`, an example of configuring a service\
-to use this router and limiting the choice of servers to those in `slave` state\
+MaxScale and the backend databases. Additionally routers may also be passed a
+comma separated list of options that are used to control the behavior of the
+routing algorithm. The two parameters that control the routing choice are router
+and router\_options. The router options are specific to a particular router and
+are used to modify the behavior of the router. The read connection router can be
+passed options of `master`, `slave` or `synced`, an example of configuring a service
+to use this router and limiting the choice of servers to those in `slave` state
 would be as follows.
 
 ```
@@ -2068,7 +2068,7 @@ router=readconnroute
 router_options=slave
 ```
 
-To change the router to connect on to servers in the `master` state as well as\
+To change the router to connect on to servers in the `master` state as well as
 slave servers, the router options can be modified to include the `master` state.
 
 ```
@@ -2076,7 +2076,7 @@ router=readconnroute
 router_options=master,slave
 ```
 
-A more complete description of router options and what is available for a given\
+A more complete description of router options and what is available for a given
 router is included with the documentation of the router itself.
 
 #### `filters`
@@ -2086,17 +2086,17 @@ router is included with the documentation of the router itself.
 * Dynamic: Yes
 * Default: None
 
-The filters option allow a set of filters to be defined for a service; requests\
-from the client are passed through these filters before being sent to the router\
-for dispatch to the backend server. The filters parameter takes one or more\
-filter names, as defined within the filter definition section of the\
+The filters option allow a set of filters to be defined for a service; requests
+from the client are passed through these filters before being sent to the router
+for dispatch to the backend server. The filters parameter takes one or more
+filter names, as defined within the filter definition section of the
 configuration file. Multiple filters are separated using the | character.
 
 ```
 filters=counter | QLA
 ```
 
-The requests pass through the filters from left to right in the order defined in\
+The requests pass through the filters from left to right in the order defined in
 the configuration parameter.
 
 #### `targets`
@@ -2106,7 +2106,7 @@ the configuration parameter.
 * Dynamic: Yes
 * Default: None
 
-The `targets` parameter is a comma separated list of server and/or service names\
+The `targets` parameter is a comma separated list of server and/or service names
 that comprise the routing targets of the service. This parameter was added in\
 MaxScale 2.5.0.
 
@@ -2114,9 +2114,9 @@ MaxScale 2.5.0.
 targets=My-Service,server2
 ```
 
-This parameter allows nested service configurations to be defined without having\
-to configure listeners for all services. For example, one use-case is to use\
-multiple readwritesplit services behind a schemarouter service to have both the\
+This parameter allows nested service configurations to be defined without having
+to configure listeners for all services. For example, one use-case is to use
+multiple readwritesplit services behind a schemarouter service to have both the
 sharding of schemarouter with the high-availability of readwritesplit.
 
 **NOTE:** The `targets` parameter is mutually exclusive with the `cluster` and`servers` parameters.
@@ -2128,8 +2128,8 @@ sharding of schemarouter with the high-availability of readwritesplit.
 * Dynamic: Yes
 * Default: None
 
-The servers parameter in a service definition provides a comma separated list of\
-the backend servers that comprise the service. The server names are those used\
+The servers parameter in a service definition provides a comma separated list of
+the backend servers that comprise the service. The server names are those used
 in the name section of a block with a type parameter of server (see below).
 
 ```
@@ -2145,7 +2145,7 @@ servers=server1,server2,server3
 * Dynamic: Yes
 * Default: None
 
-The servers the service uses are defined by the monitor specified as value\
+The servers the service uses are defined by the monitor specified as value
 of this configuration parameter.
 
 ```
@@ -2160,7 +2160,7 @@ cluster=TheMonitor
 * Mandatory: Yes
 * Dynamic: Yes
 
-This setting defines the _user_ the service uses to fetch user account\
+This setting defines the _user_ the service uses to fetch user account
 information from backends. A _password_ is specified using [password](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#password).
 
 ```
@@ -2168,8 +2168,8 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
 #### `password`
@@ -2178,9 +2178,9 @@ regarding user account management and client authentication.
 * Mandatory: Yes
 * Dynamic: Yes
 
-This settings defines the _password_ the service uses to fetch user account\
-information from backends. The _password_ may be either a plain text password or\
-an [encrypted password](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified\
+This settings defines the _password_ the service uses to fetch user account
+information from backends. The _password_ may be either a plain text password or
+an [encrypted password](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified
 using [user](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#user).
 
 ```
@@ -2188,20 +2188,20 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
-From 23.08.0 onwards, MaxScale will remember the previous password when the\
-password is changed. If the fetching of the user account information fails\
-using the new password, it will be attempted using the previous one. The purpose\
-of this change is to make it a smoother operation to change the password of\
+From 23.08.0 onwards, MaxScale will remember the previous password when the
+password is changed. If the fetching of the user account information fails
+using the new password, it will be attempted using the previous one. The purpose
+of this change is to make it a smoother operation to change the password of
 the service user. The steps are as follows:
 
 1. `$ maxctrl alter service MyService password=TheNewPassword`
 2. `MariaDB [(none)]> set password for TheServiceUser = password('TheNewPassword');`
 
-Since the old password is remembered and used if the new password does not\
+Since the old password is remembered and used if the new password does not
 work, it is no longer necessary to perform those steps simultaneously.
 
 #### `enable_root_user`
@@ -2225,7 +2225,7 @@ Deprecated and ignored.
 * Dynamic: No
 * Default: None
 
-This parameter sets a custom version string that is sent in the MySQL Handshake\
+This parameter sets a custom version string that is sent in the MySQL Handshake
 from MariaDB MaxScale to clients.
 
 Example:
@@ -2234,13 +2234,13 @@ Example:
 version_string=10.11.2-MariaDB-RWsplit
 ```
 
-If not set, MaxScale will attempt to use a version string from the\
-backend databases by selecting the version string of the database with\
+If not set, MaxScale will attempt to use a version string from the
+backend databases by selecting the version string of the database with
 the lowest version number. If the selected version is from the MariaDB\
 10 series, a `5.5.5-` prefix will be added to it similarly to how the\
 MariaDB 10 series versions added it.
 
-If MaxScale has not been able to connect to a single database and the\
+If MaxScale has not been able to connect to a single database and the
 versions are unknown, the default value of `5.5.5-10.4.32 <MaxScale version>-maxscale` is used where `<MaxScale version>` is the version of\
 MaxScale.
 
@@ -2251,11 +2251,11 @@ MaxScale.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether only a single server or all of the servers are\
+This parameter controls whether only a single server or all of the servers are
 used when loading the users from the backend servers.
 
-By default MaxScale uses the first server labeled as `Master` as the source of\
-the authentication data. When this option is enabled, the authentication data is\
+By default MaxScale uses the first server labeled as `Master` as the source of
+the authentication data. When this option is enabled, the authentication data is
 loaded from all the servers and combined into one big data set.
 
 #### `strip_db_esc`
@@ -2265,7 +2265,7 @@ loaded from all the servers and combined into one big data set.
 * Dynamic: Yes
 * Default: `true`
 
-**Note:** This parameter has been deprecated in MaxScale 23.08. The stripping of\
+**Note:** This parameter has been deprecated in MaxScale 23.08. The stripping of
 escape characters is in all known cases the correct thing to do.
 
 This setting controls whether escape characters (`\`) are removed from database\
@@ -2273,12 +2273,12 @@ names when loading user grants from a backend server. When enabled, a grant\
 such as `grant select on` test\_`.* to 'user'@'%';` is read as `grant select on` test\_`.* to 'user'@'%';`
 
 This setting has no effect on database-level grants fetched from a MariaDB\
-Server. The database names of a MariaDB Server are compared using the LIKE\
-operator to properly handle wildcards and escaped wildcards. This setting may\
-affect database names in table and column level grants, although these typically\
+Server. The database names of a MariaDB Server are compared using the LIKE
+operator to properly handle wildcards and escaped wildcards. This setting may
+affect database names in table and column level grants, although these typically
 do not contain backlashes.
 
-Some visual database management tools automatically escape some characters and\
+Some visual database management tools automatically escape some characters and
 this might cause conflicts when MaxScale tries to authenticate users.
 
 #### `log_auth_warnings`
@@ -2288,8 +2288,8 @@ this might cause conflicts when MaxScale tries to authenticate users.
 * Dynamic: Yes
 * Default: `true`
 
-Enable or disable the logging of authentication failures and warnings. If\
-enabled, messages about failed authentication attempts will be logged with\
+Enable or disable the logging of authentication failures and warnings. If
+enabled, messages about failed authentication attempts will be logged with
 details about who tried to connect to MariaDB MaxScale and from where.
 
 #### `log_warning`
@@ -2299,10 +2299,10 @@ details about who tried to connect to MariaDB MaxScale and from where.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log warning messages even if the global\
+When enabled, this allows a service to log warning messages even if the global
 log level configuration disables them.
 
-Note that disabling the service level logging does not override the global\
+Note that disabling the service level logging does not override the global
 logging configuration: with `log_warning=false` in the service and`log_warning=true` globally, warnings will still be logged for all services.
 
 #### `log_notice`
@@ -2312,7 +2312,7 @@ logging configuration: with `log_warning=false` in the service and`log_warning=t
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log notice messages even if the global\
+When enabled, this allows a service to log notice messages even if the global
 log level configuration disables them.
 
 #### `log_info`
@@ -2322,7 +2322,7 @@ log level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log info messages even if the global log\
+When enabled, this allows a service to log info messages even if the global log
 level configuration disables them.
 
 #### `log_debug`
@@ -2332,10 +2332,10 @@ level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log debug messages even if the global log\
+When enabled, this allows a service to log debug messages even if the global log
 level configuration disables them.
 
-Debug messages are only enabled for debug builds. Enabling `log_debug` in a\
+Debug messages are only enabled for debug builds. Enabling `log_debug` in a
 release build does nothing.
 
 #### `wait_timeout`
@@ -2347,30 +2347,30 @@ release build does nothing.
 * Auto tune: [Yes](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#auto_tune)
 
 The wait\_timeout parameter is used to disconnect sessions to MariaDB\
-MaxScale that have been idle for too long. The session timeouts are disabled by\
-default. To enable them, define the timeout in seconds in the service's\
-configuration section. A value of zero is interpreted as no timeout, the same\
+MaxScale that have been idle for too long. The session timeouts are disabled by
+default. To enable them, define the timeout in seconds in the service's
+configuration section. A value of zero is interpreted as no timeout, the same
 as if the parameter is not defined.
 
-This parameter used to be called `connection_timeout` and this name is still\
+This parameter used to be called `connection_timeout` and this name is still
 accepted as an alias for `wait_timeout`. The old name has been deprecated in\
 MaxScale 23.08.
 
-Note that since the granularity of the timeout is seconds, a timeout specified\
+Note that since the granularity of the timeout is seconds, a timeout specified
 in milliseconds will be rejected, even if the duration is longer than a second.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `wait_timeout` for those is not used.
 
-The value of `wait_timeout` in MaxScale should be lower than the lowest`wait_timeout` value on the backend servers. This way idle clients are\
-disconnected by MaxScale before the backend servers have to close them. Any\
-client-side idle timeouts (e.g. maximum lifetime for connection pools) should be\
-lower than `wait_timeout` in both MaxScale and MariaDB. This way the client\
-application will end up closing the connection itself which most of the time\
+The value of `wait_timeout` in MaxScale should be lower than the lowest`wait_timeout` value on the backend servers. This way idle clients are
+disconnected by MaxScale before the backend servers have to close them. Any
+client-side idle timeouts (e.g. maximum lifetime for connection pools) should be
+lower than `wait_timeout` in both MaxScale and MariaDB. This way the client
+application will end up closing the connection itself which most of the time
 results in better and more helpful error messages.
 
-**Warning:** If a connection is idle for longer than the configured connection\
+**Warning:** If a connection is idle for longer than the configured connection
 timeout, it will be forcefully disconnected and a warning will be logged in the\
 MaxScale log file.
 
@@ -2388,13 +2388,13 @@ wait_timeout=300s
 * Dynamic: Yes
 * Default: `0`
 
-The maximum number of simultaneous connections MaxScale should permit to this\
-service. If the parameter is zero or is omitted, there is no limit. Any attempt\
-to make more connections after the limit is reached will result in a "Too many\
+The maximum number of simultaneous connections MaxScale should permit to this
+service. If the parameter is zero or is omitted, there is no limit. Any attempt
+to make more connections after the limit is reached will result in a "Too many
 connections" error being returned.
 
-**Warning**: In MaxScale 2.5, it is possible that the number of concurrent\
-connections temporarily exceeds the value of `max_connections`. This has been\
+**Warning**: In MaxScale 2.5, it is possible that the number of concurrent
+connections temporarily exceeds the value of `max_connections`. This has been
 fixed in MaxScale 6.
 
 Example:
@@ -2411,25 +2411,25 @@ max_connections=100
 * Dynamic: Yes
 * Default: `false`
 
-\*_Note:_ This parameter has been deprecated in MaxScale 23.08 as the feature is\
-now used automatically if needed. In addition, the session tracking no longer\
-needs to be enabled in MariaDB for the transaction state tracking to work\
+\*_Note:_ This parameter has been deprecated in MaxScale 23.08 as the feature is
+now used automatically if needed. In addition, the session tracking no longer
+needs to be enabled in MariaDB for the transaction state tracking to work
 correctly.
 
 Enable transaction state tracking by offloading it to the backend servers.\
-Getting the transaction state from the server will be more accurate for stored\
-procedures or multi-statement SQL that modifies the transaction state\
+Getting the transaction state from the server will be more accurate for stored
+procedures or multi-statement SQL that modifies the transaction state
 non-atomically.
 
-In general, it is better to avoid using this type of SQL as tracking the\
-transaction state via the server responses is not compatible with features such\
-as `transaction_replay` in readwritesplit. `session_track_trx_state` should only\
-be enabled if the default transaction tracking done by MaxScale does not produce\
+In general, it is better to avoid using this type of SQL as tracking the
+transaction state via the server responses is not compatible with features such
+as `transaction_replay` in readwritesplit. `session_track_trx_state` should only
+be enabled if the default transaction tracking done by MaxScale does not produce
 the desired outcome.
 
-This is only supported by MariaDB versions 10.3 or newer. The following must be\
-configured in the MariaDB server in order for this feature to work. Not\
-configuring the MariaDB server with it can result in the transaction state being\
+This is only supported by MariaDB versions 10.3 or newer. The following must be
+configured in the MariaDB server in order for this feature to work. Not
+configuring the MariaDB server with it can result in the transaction state being
 wrong in MaxScale which can result in data inconsistency.
 
 ```
@@ -2446,12 +2446,12 @@ session_track_transaction_info = CHARACTERISTICS
 
 How many statements MaxScale should store for each session of this service.\
 This overrides the value of the global setting with the same name. If`retain_last_statements` has been specified in the global section of the\
-MaxScale configuration file, then if it has _not_ been explicitly specified\
-for the service, the global value holds, otherwise the service specific\
-value rules. That is, it is possible to enable the setting globally and\
+MaxScale configuration file, then if it has _not_ been explicitly specified
+for the service, the global value holds, otherwise the service specific
+value rules. That is, it is possible to enable the setting globally and
 turn it off for a specific service, or just enable it for specific services.
 
-The value of this parameter can be changed at runtime using `maxctrl` and the\
+The value of this parameter can be changed at runtime using `maxctrl` and the
 new value will take effect for sessions created thereafter.
 
 ```
@@ -2466,38 +2466,38 @@ maxctrl alter service MyService retain_last_statements 5
 * Default: `300s`
 * Auto tune: [Yes](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#auto_tune)
 
-Keep idle connections alive by sending pings to backend servers. This feature\
-was introduced in MaxScale 2.5.0 where it was changed from a\
-readwritesplit-specific feature to a generic service feature. The default value\
+Keep idle connections alive by sending pings to backend servers. This feature
+was introduced in MaxScale 2.5.0 where it was changed from a
+readwritesplit-specific feature to a generic service feature. The default value
 for this parameter is 300 seconds. To disable this feature, set the value to 0.
 
-The keepalive interval is specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no\
+The keepalive interval is specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no
 explicit unit is provided, the value is interpreted as seconds in MaxScale\
-2.5. In subsequent versions a value without a unit may be rejected. Note that\
-since the granularity of the keepalive is seconds, a keepalive specified in\
+2.5. In subsequent versions a value without a unit may be rejected. Note that
+since the granularity of the keepalive is seconds, a keepalive specified in
 milliseconds will be rejected, even if the duration is longer than a second.
 
-The parameter value is the interval in seconds between each keepalive ping. A\
-keepalive ping will be sent to a backend server if the connection has been idle\
+The parameter value is the interval in seconds between each keepalive ping. A
+keepalive ping will be sent to a backend server if the connection has been idle
 for longer than the configured keepalive interval.
 
-Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client\
-has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings\
+Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client
+has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings
 regardless of the client state.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `connection_keepalive` for those is not used.
 
-If the value of `connection_keepalive` is changed at runtime, the change in the\
+If the value of `connection_keepalive` is changed at runtime, the change in the
 value takes effect immediately.
 
-As the connection keepalive pings must be done only when there's no ongoing\
-query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that\
-rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the\
+As the connection keepalive pings must be done only when there's no ongoing
+query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that
+rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the
 performance will be the same with or without `connection_keepalive`.
 
-If you want to avoid the performance cost and you don't need the connection\
+If you want to avoid the performance cost and you don't need the connection
 keepalive feature, you can disable it with `connection_keepalive=0s`.
 
 #### `force_connection_keepalive`
@@ -2507,16 +2507,16 @@ keepalive feature, you can disable it with `connection_keepalive=0s`.
 * Dynamic: Yes
 * Default: `false`
 
-By default, connection keepalive pings are only sent if the client is either\
-executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are\
-unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can\
-be used to emulate the pre-2.5.21 behavior if long-lived application connections\
+By default, connection keepalive pings are only sent if the client is either
+executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are
+unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can
+be used to emulate the pre-2.5.21 behavior if long-lived application connections
 rely on the old unconditional keepalive pings.
 
 _Note:_ if `force_connection_keepalive` is enabled and `connection_keepalive` in\
-MaxScale is set to a lower value than the `wait_timeout` on the database, the\
-client idle timeouts that `wait_timeout` control are no longer effective. This\
-happens because MaxScale unconditionally sends the pings which make the client\
+MaxScale is set to a lower value than the `wait_timeout` on the database, the
+client idle timeouts that `wait_timeout` control are no longer effective. This
+happens because MaxScale unconditionally sends the pings which make the client
 behave like it is not idle and thus the connections will never be killed due to`wait_timeout`.
 
 #### `net_write_timeout`
@@ -2526,17 +2526,17 @@ behave like it is not idle and thus the connections will never be killed due to`
 * Dynamic: Yes
 * Default: `0s`
 
-This parameter controls how long a network write to the client can stay\
+This parameter controls how long a network write to the client can stay
 buffered. This feature is disabled by default.
 
-When `net_write_timeout` is configured and data is buffered on the client\
-network connection, if the time since the last successful network write exceeds\
+When `net_write_timeout` is configured and data is buffered on the client
+network connection, if the time since the last successful network write exceeds
 the configured limit, the client connection will be disconnected.
 
-The value is specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `max_sescmd_history`
@@ -2546,45 +2546,45 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `50`
 
-`max_sescmd_history` sets a limit on how many distinct session commands are\
-stored in the session command history. When the history limit is exceeded, the\
-history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server\
+`max_sescmd_history` sets a limit on how many distinct session commands are
+stored in the session command history. When the history limit is exceeded, the
+history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server
 reconnections are no longer possible.
 
-The required history size can be estimated by counting the total number of\
-session state modifying commands (e.g `SET NAMES`) that are used by a\
-client. Note that connectors usually add some commands that aren't visible to\
-the application developer which means a safety margin should be added. A good\
-rule of thumb is to count the expected number of statements and double that\
-number. The default value of 50 is a value that'll work for most applications\
+The required history size can be estimated by counting the total number of
+session state modifying commands (e.g `SET NAMES`) that are used by a
+client. Note that connectors usually add some commands that aren't visible to
+the application developer which means a safety margin should be added. A good
+rule of thumb is to count the expected number of statements and double that
+number. The default value of 50 is a value that'll work for most applications
 that do not rely heavily on user variables.
 
-Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4\
-and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol\
-prepared statements opened by the client are also kept open by MaxScale and are\
+Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4
+and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol
+prepared statements opened by the client are also kept open by MaxScale and are
 restored whenever a reconnection to a server happens. The limits imposed by`max_sescmd_history` apply to other text protocol commands e.g. `SET NAMES`.\
-Note that text protocol prepared statements count as text protocol commands and\
-are thus potentially pruned when history pruning happens. If an application uses\
+Note that text protocol prepared statements count as text protocol commands and
+are thus potentially pruned when history pruning happens. If an application uses
 a lot of `PREPARE stmt FROM <sql>` commands, it is recommended that the value of`max_sescmd_history` is increased accordingly.
 
-In older versions of MaxScale, binary protocol prepared statements were limited\
-by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this\
-caused problems when the binary protocol prepared statement were pruned while\
-they were still open from the client's point of view. In older versions, the\
-recommended value of `max_sescmd_history` is the number of state modifying\
-commands plus the maximum number of open prepared statements that any application\
+In older versions of MaxScale, binary protocol prepared statements were limited
+by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this
+caused problems when the binary protocol prepared statement were pruned while
+they were still open from the client's point of view. In older versions, the
+recommended value of `max_sescmd_history` is the number of state modifying
+commands plus the maximum number of open prepared statements that any application
 may use.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
-In addition to limiting the number of commands to store, it also acts as a hard\
-limit on the number of packets that may be queued up on a backend before it is\
-closed. Packets are queued while the TCP socket is being opened and when\
-prepared statements are being prepared. In certain rare cases, a slow server may\
-fall behind and not catch up to the rest of the cluster and a backlog of packets\
-forms. In these cases, if more than `max_sescmd_history` packets are queued, the\
+In addition to limiting the number of commands to store, it also acts as a hard
+limit on the number of packets that may be queued up on a backend before it is
+closed. Packets are queued while the TCP socket is being opened and when
+prepared statements are being prepared. In certain rare cases, a slow server may
+fall behind and not catch up to the rest of the cluster and a backlog of packets
+forms. In these cases, if more than `max_sescmd_history` packets are queued, the
 connection to the server is closed.
 
 #### `prune_sescmd_history`
@@ -2594,24 +2594,24 @@ connection to the server is closed.
 * Dynamic: Yes
 * Default: `true`
 
-This option enables pruning of the session command history when it exceeds the\
-value configured in `max_sescmd_history`. When this option is enabled, only a\
-set number of statements are stored in the history. This limits the per-session\
+This option enables pruning of the session command history when it exceeds the
+value configured in `max_sescmd_history`. When this option is enabled, only a
+set number of statements are stored in the history. This limits the per-session
 memory use while still allowing safe reconnections.
 
-This parameter is intended to be used with pooled connections that remain in use\
-for a very long time. Most connection pool implementations do not reset the\
-session state and instead re-initialize it with new values. This causes the\
-session command history to grow at roughly a constant rate for the lifetime of\
+This parameter is intended to be used with pooled connections that remain in use
+for a very long time. Most connection pool implementations do not reset the
+session state and instead re-initialize it with new values. This causes the
+session command history to grow at roughly a constant rate for the lifetime of
 the pooled connection.
 
-Starting with MaxScale 23.08, the session command history is also simplified\
-before being stored. The simplification is done by removing repeated occurrences\
-of the same command and only executing the latest one of them. The order in\
-which the commands are executed still remains the same but inter-dependencies\
+Starting with MaxScale 23.08, the session command history is also simplified
+before being stored. The simplification is done by removing repeated occurrences
+of the same command and only executing the latest one of them. The order in
+which the commands are executed still remains the same but inter-dependencies
 between commands are not preserved.
 
-For example, the following set of commands demonstrates how the history\
+For example, the following set of commands demonstrates how the history
 simplification works and how inter-dependencies can be lost.
 
 ```
@@ -2620,34 +2620,34 @@ SET @my_home='My home is: ' || @my_planet;         -- Command #1 in the history
 SET @my_planet='Earth';                            -- Command #2 in the history
 ```
 
-In the example, the value of `@my_home` has a dependency on the value of`@my_planet` which is lost when the same statement is executed again and\
+In the example, the value of `@my_home` has a dependency on the value of`@my_planet` which is lost when the same statement is executed again and
 the history simplification removes the earlier one.
 
-This same problem can occur even in older versions of MaxScale that used\
-a sliding window of the history when the window moves past the statement\
-that later statement dependent on. If inter-dependent session commands\
+This same problem can occur even in older versions of MaxScale that used
+a sliding window of the history when the window moves past the statement
+that later statement dependent on. If inter-dependent session commands
 are being used, the history pruning should be disabled.
 
-Each client-side session that uses a pooled connection only executes a finite\
-amount of session commands. By retaining a shorter history that encompasses all\
-session commands the individual clients execute, the session state of a pooled\
+Each client-side session that uses a pooled connection only executes a finite
+amount of session commands. By retaining a shorter history that encompasses all
+session commands the individual clients execute, the session state of a pooled
 connection can be accurately recreated on another server.
 
-When the session command history pruning is enabled, there is a theoretical\
-possibility that upon server reconnection the session states of the connections\
-are inconsistent. This can only happen if the length of the stored history is\
-shorter than the list of relevant statements that affect the session state. In\
-practice the default value of 50 session commands is a fairly reasonable value\
+When the session command history pruning is enabled, there is a theoretical
+possibility that upon server reconnection the session states of the connections
+are inconsistent. This can only happen if the length of the stored history is
+shorter than the list of relevant statements that affect the session state. In
+practice the default value of 50 session commands is a fairly reasonable value
 and the risk of inconsistent session state is relatively low.
 
-In case the default history length is too short for safe pruning, set the value\
-of `max_sescmd_history` to the total number of commands that affect the session\
-state plus a safety margin of 10. The safety margin reserves some extra space\
-for new commands that might be executed due to changes in the client side\
+In case the default history length is too short for safe pruning, set the value
+of `max_sescmd_history` to the total number of commands that affect the session
+state plus a safety margin of 10. The safety margin reserves some extra space
+for new commands that might be executed due to changes in the client side
 application.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `disable_sescmd_history`
@@ -2657,17 +2657,17 @@ history. Currently only `readwritesplit` and `schemarouter` support it.
 * Dynamic: Yes
 * Default: `false`
 
-This option disables the session command history. This way no history is stored\
-and if a replica server fails, the router will not try to replace the failed\
-replica. Disabling session command history will allow long-lived connections\
+This option disables the session command history. This way no history is stored
+and if a replica server fails, the router will not try to replace the failed
+replica. Disabling session command history will allow long-lived connections
 without causing a constant growth in the memory consumption.
 
-This parameter should only be used when either the memory footprint must be as\
-small as possible or when the pruning of the session command history is not\
+This parameter should only be used when either the memory footprint must be as
+small as possible or when the pruning of the session command history is not
 acceptable.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `user_accounts_file`
@@ -2684,25 +2684,25 @@ Default value is empty, which disables the feature.
 user_accounts_file=/home/root/users.json
 ```
 
-In addition to querying the backends, MaxScale can read users from a file. This\
-feature is useful when backends have limitations on the type of users that can\
-be created, or if MaxScale needs to allow users to log in even\
-when backends are down (e.g. binlog router). The users read from the file are\
-only present on MaxScale, so logging into backends can still fail. The format of\
-the file is protocol-specific. The following only applies to MariaDB-protocol,\
+In addition to querying the backends, MaxScale can read users from a file. This
+feature is useful when backends have limitations on the type of users that can
+be created, or if MaxScale needs to allow users to log in even
+when backends are down (e.g. binlog router). The users read from the file are
+only present on MaxScale, so logging into backends can still fail. The format of
+the file is protocol-specific. The following only applies to MariaDB-protocol,
 which is also the only protocol supporting this feature.
 
-The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which\
-contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at\
-least the string fields _user_ and _host_, which define the user account to add\
+The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which
+contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at
+least the string fields _user_ and _host_, which define the user account to add
 or modify.
 
-The elements in the _user_-array may contain the following additional fields. If\
+The elements in the _user_-array may contain the following additional fields. If
 a field is not defined, it is assumed either empty (string) or false (boolean).
 
 * password: String. Password hash, similar to the equivalent column on server.
 * plugin: String. Authentication plugin used by client, similar to server.
-* authentication\_string: String. Additional authentication info, similar to\
+* authentication\_string: String. Additional authentication info, similar to
   server.
 * default\_role: String. Default role of user, similar to server.
 * super\_priv: Boolean. True if user has SUPER grant.
@@ -2712,17 +2712,17 @@ a field is not defined, it is assumed either empty (string) or false (boolean).
 
 The elements in the _db_-array must contain the following additional field:
 
-* db: String. Database which the user can access. Can contain % and \_\
+* db: String. Database which the user can access. Can contain % and \_
   wildcards.
 
-The elements in the _roles\_mapping_-array must contain the following additional\
+The elements in the _roles\_mapping_-array must contain the following additional
 field:
 
 * role: String. Role the user can access.
 
 When users are read from both servers and the file, the server takes priority.\
 That is, if user `'joe'@'%'` is defined on both, the file-version is discarded.\
-The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant\
+The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant
 and role lists.
 
 An example users file is below.
@@ -2781,9 +2781,9 @@ Defines when _user\_accounts\_file_ is read. The value is an enum, either\
 read from a server. The file contents are then added to the server-based data.\
 If reading from server fails (e.g. servers are down), the file is ignored.
 
-"file\_only\_always" means that users are not read from the servers at all and the\
-file contents is all that matters. The state of the servers is ignored. This\
-mode can be useful with the binlog router, as it allows clients to log in and\
+"file\_only\_always" means that users are not read from the servers at all and the
+file contents is all that matters. The state of the servers is ignored. This
+mode can be useful with the binlog router, as it allows clients to log in and
 fetch binary logs from MaxScale even when backend servers are down.
 
 ```
@@ -2797,36 +2797,36 @@ user_accounts_file_usage=file_only_always
 * Dynamic: Yes
 * Default: `-1s`
 
-Normally, MaxScale only pools backend connections when\
-a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections\
+Normally, MaxScale only pools backend connections when
+a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections
 instead of creating new connections to backends. If connection sharing is enabled,\
-MaxScale can pool backend connections also from running sessions, and\
-re-attach a pooled connection when a session is doing a query. This effectively\
+MaxScale can pool backend connections also from running sessions, and
+re-attach a pooled connection when a session is doing a query. This effectively
 allows multiple sessions to share backend connections.
 
-_idle\_session\_pool\_time_ defines the amount of time a session must be idle\
-before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in\
+_idle\_session\_pool\_time_ defines the amount of time a session must be idle
+before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in
 seconds or milliseconds.
 
-This feature has a significant drawback: when a backend connection is reused, it\
-needs to be restored to the correct state. This means reauthenticating and\
-replaying session commands. This can add a significant delay before the\
-connection is actually ready for a query. If the session command history size\
-exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for\
+This feature has a significant drawback: when a backend connection is reused, it
+needs to be restored to the correct state. This means reauthenticating and
+replaying session commands. This can add a significant delay before the
+connection is actually ready for a query. If the session command history size
+exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for
 the session.
 
-This feature should only be used when limiting the backend connection count is\
-a priority, even at the cost of query delay and throughput. This feature only\
+This feature should only be used when limiting the backend connection count is
+a priority, even at the cost of query delay and throughput. This feature only
 works when the following server settings are also set in MaxScale configuration:
 
 1. [max\_routing\_connections](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#max_routing_connections)
 2. [persistpoolmax](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#persistpoolmax)
 3. [persistmaxtime](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#persistmaxtime)
 
-Since reusing a backend connection is an expensive operation, MaxScale only\
-pools connections when another session requires them. _idle\_session\_pool\_time_\
-thus effectively limits the frequency at which a connection can be moved from\
-one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to\
+Since reusing a backend connection is an expensive operation, MaxScale only
+pools connections when another session requires them. _idle\_session\_pool\_time_
+thus effectively limits the frequency at which a connection can be moved from
+one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to
 move connections as soon as possible.
 
 ```
@@ -2838,57 +2838,57 @@ See below for more information on configuring connection sharing.
 **Details, limitations and suggestions for connection sharing**
 
 As noted above, when a connection is pooled and reused its state is lost.\
-Although session variables and prepared statements are restored by replaying\
+Although session variables and prepared statements are restored by replaying
 session commands, some state information cannot be transferred.
 
-The most common such state is a transaction. When a transaction is on,\
+The most common such state is a transaction. When a transaction is on,
 connection sharing is disabled for that session until the transaction completes.\
-Other similar situations may not be properly detected, and it's the\
-responsibility of the user to avoid introducing such state to the session when\
+Other similar situations may not be properly detected, and it's the
+responsibility of the user to avoid introducing such state to the session when
 using connection sharing. This means that the following should not be used:
 
-* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that\
+* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that
   introduces state into the connection.
-* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector\
+* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector
   must be used instead of the variable.
 * Stored procedures that cause session level side-effects.
 
-Several settings affect connection sharing and its effectiveness. Reusing a\
-connection is an expensive operation so its frequency should be minimized. The\
+Several settings affect connection sharing and its effectiveness. Reusing a
+connection is an expensive operation so its frequency should be minimized. The
 important configuration settings in addition to _idle\_session\_pool\_time_ are\
 MaxScale server settings [persistpoolmax](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#persistpoolmax),[persistmaxtime](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#persistmaxtime) and [max\_routing\_connections](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#max_routing_connections).\
-The service settings [max\_sescmd\_history](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These\
+The service settings [max\_sescmd\_history](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These
 settings should be tuned according to the use case.
 
-_persistpoolmax_ limits how many connections can be kept in a pool for a given\
-server. If the pool is full, no more connections are detached from sessions even\
-if they are idle and required. The pool size should be large enough to contain\
+_persistpoolmax_ limits how many connections can be kept in a pool for a given
+server. If the pool is full, no more connections are detached from sessions even
+if they are idle and required. The pool size should be large enough to contain
 any connections being transferred between sessions, but not be greater than _max\_routing\_connections_. Using the value of _max\_routing\_connections_ is a
 reasonable starting point.
 
-_persistmaxtime_ limits the time a connection may stay in the pool. This should\
-be high enough so that pooled connections are not unnecessarily closed. Cleaning\
+_persistmaxtime_ limits the time a connection may stay in the pool. This should
+be high enough so that pooled connections are not unnecessarily closed. Cleaning
 up clearly unneeded connections from the pool may be useful when _max\_routing\_connections_ is restrictively tuned. Because each MaxScale routing
-thread has its own connection pool, one thread can monopolize access to a\
-server. For example, if the pool of thread 1 has 100 connections to _ServerA_\
-with `max_routing_connections=100`, other threads can no longer connect to the\
-server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as\
-it would cause unneeded connections in the pool to be closed faster. Such\
-connection slots then become available to other routing threads. Reducing the\
-number of [routing threads](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool\
-fragmentation. This may reduce overall throughput, though. When using connection\
+thread has its own connection pool, one thread can monopolize access to a
+server. For example, if the pool of thread 1 has 100 connections to _ServerA_
+with `max_routing_connections=100`, other threads can no longer connect to the
+server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as
+it would cause unneeded connections in the pool to be closed faster. Such
+connection slots then become available to other routing threads. Reducing the
+number of [routing threads](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool
+fragmentation. This may reduce overall throughput, though. When using connection
 sharing, backend connections are only in the pool momentarily. Consequently,_persistmaxtime_ can be set quite low, e.g. 10s.
 
-If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is\
-disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find\
-a backend connection. This can be avoided with _prune\_sescmd\_history_. However,\
-pruning means that old session commands will not be replayed when a pooled\
-connection is reused. If the pruned commands are important\
+If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is
+disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find
+a backend connection. This can be avoided with _prune\_sescmd\_history_. However,
+pruning means that old session commands will not be replayed when a pooled
+connection is reused. If the pruned commands are important
 (e.g. statement preparations), the session may fail later on.
 
 If the number of clients actively running queries is greater than _max\_routing\_connections_, query throughput will suffer as clients will need to
-take turns. In this situation, it's imperative to minimize the number of\
-backend connections a single session uses. The settings to achieve this depend\
+take turns. In this situation, it's imperative to minimize the number of
+backend connections a single session uses. The settings to achieve this depend
 on the router. For ReadWriteSplit the following should be used:
 
 ```
@@ -2897,12 +2897,12 @@ lazy_connect=1
 transaction_replay=true
 ```
 
-The above settings mean that MaxScale can process roughly\
-(_number of replica servers_ X _max\_routing\_connections_) read queries\
-simultaneously. Write queries will still need to take turns as there is only one\
+The above settings mean that MaxScale can process roughly
+(_number of replica servers_ X _max\_routing\_connections_) read queries
+simultaneously. Write queries will still need to take turns as there is only one
 primary server.
 
-The following configuration snippet shows example server and service\
+The following configuration snippet shows example server and service
 configurations for connection sharing with ReadWriteSplit.
 
 ```
@@ -2929,11 +2929,11 @@ lazy_connect=1
 * Dynamic: Yes
 * Default: `60s`
 
-When connection sharing (as described above) is on, clients\
-may have to wait for their turn to use a backend connection. If too much time\
-passes without a connection becoming available, MaxScale returns an error to\
-the client, usually also ending the session. _multiplex\_timeout_ sets this\
-timeout. Increase it if queries are failing with "Timed out when waiting for a\
+When connection sharing (as described above) is on, clients
+may have to wait for their turn to use a backend connection. If too much time
+passes without a connection becoming available, MaxScale returns an error to
+the client, usually also ending the session. _multiplex\_timeout_ sets this
+timeout. Increase it if queries are failing with "Timed out when waiting for a
 connection". Decrease it if failing early is preferable to stalling.
 
 ```
@@ -2942,10 +2942,10 @@ multiplex_timeout=33s
 
 ### Server
 
-Server sections define the backend database servers MaxScale uses. A server is\
-identified by its section name in the configuration file. The only mandatory\
-parameter of a server is _type_, but _address_ and _port_ are also usually\
-defined. A server may be a member of one or more services. A server may only be\
+Server sections define the backend database servers MaxScale uses. A server is
+identified by its section name in the configuration file. The only mandatory
+parameter of a server is _type_, but _address_ and _port_ are also usually
+defined. A server may be a member of one or more services. A server may only be
 monitored by at most one monitor.
 
 ```
@@ -2962,7 +2962,7 @@ port=3000
 * Dynamic: Yes
 * Default: `""`
 
-The IP-address or hostname of the machine running the database server. MaxScale\
+The IP-address or hostname of the machine running the database server. MaxScale
 uses this address to connect to the server.
 
 Either _address_ or _socket_ must be defined, but not both.
@@ -2974,7 +2974,7 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: `3306`
 
-The port the backend server listens on for incoming connections. MaxScale uses\
+The port the backend server listens on for incoming connections. MaxScale uses
 this port to connect to the server.
 
 #### `socket`
@@ -2984,7 +2984,7 @@ this port to connect to the server.
 * Dynamic: Yes
 * Default: `""`
 
-The absolute path to a UNIX domain socket the MariaDB server is listening\
+The absolute path to a UNIX domain socket the MariaDB server is listening
 on.
 
 Either _address_ or _socket_ must be defined, but not both.
@@ -2996,9 +2996,9 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitorpasswd](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -3013,9 +3013,9 @@ monitorpw=mymonitorpasswd
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitoruser](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitoruser](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -3023,7 +3023,7 @@ monitoruser=mymonitoruser
 monitorpw=mymonitorpasswd
 ```
 
-`monitorpw` may be either a plain text password or an encrypted password. See\
+`monitorpw` may be either a plain text password or an encrypted password. See
 the section [encrypting passwords](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encrypting-passwords) for more information.
 
 #### `extra_port`
@@ -3033,19 +3033,19 @@ the section [encrypting passwords](mariadb-maxscale-2308-mariadb-maxscale-config
 * Dynamic: Yes
 * Default: `0`
 
-An alternative port used for administrative connections to the server. If this\
-setting is defined, MaxScale uses it for monitoring the server and to fetch user\
+An alternative port used for administrative connections to the server. If this
+setting is defined, MaxScale uses it for monitoring the server and to fetch user
 accounts. Client sessions will still use the normal port.
 
-Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on\
-the backend server has been reached. Extra-port connections have their own\
-connection limit, which is one by default. This needs to be increased to allow\
+Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on
+the backend server has been reached. Extra-port connections have their own
+connection limit, which is one by default. This needs to be increased to allow
 both monitor and user account manager to connect.
 
-If the connection to the extra-port fails due to connection number limit or if\
+If the connection to the extra-port fails due to connection number limit or if
 the port is not open on the server, normal port is used.
 
-For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)\
+For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)
 and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables#extra_max_connections).
 
 #### `persistpoolmax`
@@ -3056,15 +3056,15 @@ and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-
 * Default: `0`
 
 Sets the size of the server connection pool. Disabled by default. When enabled,\
-MaxScale places unused connections to the server to a pool and reuses them\
-later. Connections typically become unused when a session closes. If the size of\
+MaxScale places unused connections to the server to a pool and reuses them
+later. Connections typically become unused when a session closes. If the size of
 the pool reaches _persistpoolmax_, unused connections are closed instead.
 
-Every routing thread has its own pool. As of version 6.3.0, MaxScale will round\
+Every routing thread has its own pool. As of version 6.3.0, MaxScale will round
 up _persistpoolmax_ so that every thread has an equal size pool.
 
-When a MariaDB-protocol connection is taken from the pool to be used in a new\
-session, the state of the connection is dependent on the router. ReadWriteSplit\
+When a MariaDB-protocol connection is taken from the pool to be used in a new
+session, the state of the connection is dependent on the router. ReadWriteSplit
 restores the connection to match the session state. Other routers do not.
 
 #### `persistmaxtime`
@@ -3074,15 +3074,15 @@ restores the connection to match the session state. Other routers do not.
 * Dynamic: Yes
 * Default: `0s`
 
-The `persistmaxtime` parameter defaults to zero but can be set to a duration as\
-documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is\
-interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a\
-unit may be rejected. Note that since the granularity of the parameter is\
-seconds, a value specified in milliseconds will be rejected, even if the\
+The `persistmaxtime` parameter defaults to zero but can be set to a duration as
+documented [here](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is
+interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a
+unit may be rejected. Note that since the granularity of the parameter is
+seconds, a value specified in milliseconds will be rejected, even if the
 duration is longer than a second.
 
-A DCB placed in the persistent pool for a server will only be reused if the\
-elapsed time since it joined the pool is less than the given value. Otherwise,\
+A DCB placed in the persistent pool for a server will only be reused if the
+elapsed time since it joined the pool is less than the given value. Otherwise,
 the DCB will be discarded and the connection closed.
 
 #### `max_routing_connections`
@@ -3092,18 +3092,18 @@ the DCB will be discarded and the connection closed.
 * Dynamic: Yes
 * Default: `0`
 
-Maximum number of routing connections to this server. Connections held in a pool\
-also count towards this maximum. Does not limit monitor connections or user\
+Maximum number of routing connections to this server. Connections held in a pool
+also count towards this maximum. Does not limit monitor connections or user
 account fetching. A value of 0 (default) means no limit.
 
-Since every client session can generate a connection to a server, the server may\
-run out of memory when the number of clients is high enough. This setting limits\
-server memory use caused by MaxScale. The effect depends on if the service\
-setting [idle\_session\_pool\_time](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection\
+Since every client session can generate a connection to a server, the server may
+run out of memory when the number of clients is high enough. This setting limits
+server memory use caused by MaxScale. The effect depends on if the service
+setting [idle\_session\_pool\_time](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection
 sharing, is enabled or not.
 
 If connection sharing is not on, _max\_routing\_connections_ simply sets a limit.\
-Any sessions attempting to exceed this limit will fail to connect to the\
+Any sessions attempting to exceed this limit will fail to connect to the
 backend. The client can still connect to MaxScale, but queries will fail.
 
 If connection sharing is on, sessions exceeding the limit will be put on hold\
@@ -3121,37 +3121,37 @@ max_routing_connections=1234
 * Dynamic: Yes
 * Default: `false`
 
-If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-header when connecting client sessions to the server. The header contains the\
-original client IP address and port, as seen by MaxScale. The server will then\
-read the header and perform authentication as if the connection originated from\
-this address instead of MaxScale's IP address. With this feature, the user\
-accounts on the backend server can be simplified to only contain the actual\
+If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+header when connecting client sessions to the server. The header contains the
+original client IP address and port, as seen by MaxScale. The server will then
+read the header and perform authentication as if the connection originated from
+this address instead of MaxScale's IP address. With this feature, the user
+accounts on the backend server can be simplified to only contain the actual
 client hosts and not the MaxScale host.
 
-**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy\
-protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#proxy_protocol_networks) in MaxScale. This also needs\
-to be done whenever one MaxScale may connect to another Maxscale and the\
+**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy
+protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#proxy_protocol_networks) in MaxScale. This also needs
+to be done whenever one MaxScale may connect to another Maxscale and the
 connecting MaxScale has `proxy_protocol` enabled.
 
-PROXY protocol will be supported by MariaDB 10.3, which this feature has been\
-tested with. To use it, enable the PROXY protocol in MaxScale for every\
-compatible server and configure the MariaDB servers themselves to accept the\
-protocol headers from MaxScale's IP address. On the server side, the protocol\
-should be enabled only for trusted IPs, as it allows the sender to spoof the\
-connection origin. If a proxy header is sent to a server not expecting it, the\
-connection will fail. Usually PROXY protocol should be enabled for every\
+PROXY protocol will be supported by MariaDB 10.3, which this feature has been
+tested with. To use it, enable the PROXY protocol in MaxScale for every
+compatible server and configure the MariaDB servers themselves to accept the
+protocol headers from MaxScale's IP address. On the server side, the protocol
+should be enabled only for trusted IPs, as it allows the sender to spoof the
+connection origin. If a proxy header is sent to a server not expecting it, the
+connection will fail. Usually PROXY protocol should be enabled for every
 server in a cluster, as they typically have similar grants.
 
-Other SQL-servers may support PROXY protocol as well, but the implementation may\
-be highly restricting. Strict adherence to the protocol requires that the\
-backend server does not allow mixing of un-proxied and proxied connections from\
-a given IP. MaxScale requires normal connections to backends for monitoring and\
-authentication data queries, which would be blocked. To bypass this restriction,\
-the server monitor needs to be disabled and the service listener needs to be\
+Other SQL-servers may support PROXY protocol as well, but the implementation may
+be highly restricting. Strict adherence to the protocol requires that the
+backend server does not allow mixing of un-proxied and proxied connections from
+a given IP. MaxScale requires normal connections to backends for monitoring and
+authentication data queries, which would be blocked. To bypass this restriction,
+the server monitor needs to be disabled and the service listener needs to be
 configured to disregard authentication errors (`skip_authentication=true`).\
-Server states also need to be set manually in MaxCtrl. These steps are _not_\
-required for MariaDB 10.3, since its implementation is more flexible and allows\
+Server states also need to be set manually in MaxCtrl. These steps are _not_
+required for MariaDB 10.3, since its implementation is more flexible and allows
 both PROXY-headered and headerless connections from a proxy-enabled IP.
 
 #### `disk_space_threshold`
@@ -3161,30 +3161,30 @@ both PROXY-headered and headerless connections from a proxy-enabled IP.
 * Dynamic: No
 * Default: None
 
-This parameter specifies how full a disk may be, before MaxScale should start\
-logging warnings or take other actions (e.g. perform a switchover). This\
+This parameter specifies how full a disk may be, before MaxScale should start
+logging warnings or take other actions (e.g. perform a switchover). This
 functionality will only work with MariaDB server versions 10.1.32, 10.2.14 and\
 10.3.6 onwards, if the `DISKS` _information schema plugin_ has been installed.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-A limit is specified as a path followed by a colon and a percentage specifying\
+A limit is specified as a path followed by a colon and a percentage specifying
 how full the corresponding disk may be, before action is taken. E.g. an entry like
 
 ```
 /data:80
 ```
 
-specifies that the disk that has been mounted on `/data` may be used until 80%\
-of the total space has been consumed. Multiple entries can be specified by\
-separating them by a comma. If the path is specified using `*`, then the limit\
-applies to all disks. However, the value of `*` is only applied if there is not\
+specifies that the disk that has been mounted on `/data` may be used until 80%
+of the total space has been consumed. Multiple entries can be specified by
+separating them by a comma. If the path is specified using `*`, then the limit
+applies to all disks. However, the value of `*` is only applied if there is not
 an exact match.
 
-Note that if a particular disk has been mounted on several paths, only one path\
-need to be specified. If several are specified, then the one with the smallest\
+Note that if a particular disk has been mounted on several paths, only one path
+need to be specified. If several are specified, then the one with the smallest
 percentage will be applied.
 
 Examples:
@@ -3196,7 +3196,7 @@ disk_space_threshold=/data1:80,/data2:60,*:90
 ```
 
 The last line means that the disk mounted at `/data1` may be used up to\
-80%, the disk mounted at `/data2` may be used up to 60% and all other disks\
+80%, the disk mounted at `/data2` may be used up to 60% and all other disks
 mounted at any paths may be used up until 90% of maximum capacity, before\
 MaxScale starts to warn to take action.
 
@@ -3213,7 +3213,7 @@ Note that the path to be used, is one of the paths returned by:
 ...
 ```
 
-There is no default value, but this parameter must be explicitly specified\
+There is no default value, but this parameter must be explicitly specified
 if the disk space situation should be monitored.
 
 #### `rank`
@@ -3224,20 +3224,20 @@ if the disk space situation should be monitored.
 * Values: `primary`, `secondary`
 * Default: `primary`
 
-This parameter controls the order in which servers are used. Valid values for\
+This parameter controls the order in which servers are used. Valid values for
 this parameter are `primary` and `secondary`. The default value is`primary`.
 
-This behavior depends on the router implementation but the general rule of thumb\
+This behavior depends on the router implementation but the general rule of thumb
 is that primary servers will be used before secondary servers.
 
-Readconnroute will always use primary servers before secondary servers as long\
+Readconnroute will always use primary servers before secondary servers as long
 as they match the configured server type.
 
-Readwritesplit will pick servers that have the same rank as the current\
-primary. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md#server-ranks)\
+Readwritesplit will pick servers that have the same rank as the current
+primary. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md#server-ranks)
 for a detailed description of the behavior.
 
-The following example server configuration demonstrates how `rank` can be used\
+The following example server configuration demonstrates how `rank` can be used
 to exclude `DR-site` servers from routing.
 
 ```
@@ -3262,7 +3262,7 @@ address=192.168.0.22
 rank=secondary
 ```
 
-The `main-site-primary` and `main-site-replica` servers will be used as long as\
+The `main-site-primary` and `main-site-replica` servers will be used as long as
 they are available. When they are no longer available, the `DR-site-primary` and`DR-site-replica` will be used.
 
 #### `priority`
@@ -3272,11 +3272,11 @@ they are available. When they are no longer available, the `DR-site-primary` and
 * Dynamic: Yes
 * Default: 0
 
-Server priority. Currently only used by galeramon to choose the order in which\
-nodes are selected as the current primary server. Refer to the [Server Priorities](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-galera-monitor.md#interaction-with-server-priorities)\
+Server priority. Currently only used by galeramon to choose the order in which
+nodes are selected as the current primary server. Refer to the [Server Priorities](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-galera-monitor.md#interaction-with-server-priorities)
 section of the galeramon documentation for more information on how to use it.
 
-Starting with MaxScale 2.5.21, this parameter also accepts negative values. In\
+Starting with MaxScale 2.5.21, this parameter also accepts negative values. In
 older versions, the parameter only accepted non-negative values.
 
 #### `replication_custom_options`
@@ -3286,33 +3286,33 @@ older versions, the parameter only accepted non-negative values.
 * Dynamic: Yes
 
 Server-specific custom string added to "CHANGE MASTER TO"-commands sent by\
-MariaDB Monitor. Overrides `replication_custom_options` setting set in\
-the monitor. This setting affects the server where the command is ran at, not\
-the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-\
-command to server A telling it to replicate from server B, the setting value\
+MariaDB Monitor. Overrides `replication_custom_options` setting set in
+the monitor. This setting affects the server where the command is ran at, not
+the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-
+command to server A telling it to replicate from server B, the setting value
 from MaxScale configuration for server A would be used.
 
-See [MariaDB Monitor documentation](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md#replication_custom_options)\
+See [MariaDB Monitor documentation](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md#replication_custom_options)
 for more information.
 
 ### Monitor
 
-Monitor sections are used to define the monitoring module that watches a set of\
+Monitor sections are used to define the monitoring module that watches a set of
 servers. Each server can only be monitored by one monitor.
 
 Common monitor parameters [can be found here](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-common-monitor-parameters.md).
 
 ### Listener
 
-A listener defines a port MaxScale listens on for incoming connections. Accepted\
-connections are linked with a MaxScale service. Multiple listeners can feed the\
-same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface\
+A listener defines a port MaxScale listens on for incoming connections. Accepted
+connections are linked with a MaxScale service. Multiple listeners can feed the
+same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface
 only. _socket_ is also optional and is used for Unix socket connections.
 
-The network socket where the listener listens may have a backlog of\
+The network socket where the listener listens may have a backlog of
 connections. The size of this backlog is controlled by the\_net.ipv4.tcp\_max\_syn\_backlog\_ and _net.core.somaxconn_ kernel parameters.
 
-Increasing the size of the backlog by modifying the kernel parameters helps with\
+Increasing the size of the backlog by modifying the kernel parameters helps with
 sudden connection spikes and rejected connections. For more information see [listen(2)](https://man7.org/linux/man-pages/man2/listen.2.html).
 
 ```
@@ -3328,7 +3328,7 @@ port=3006
 * Mandatory: Yes
 * Dynamic: No
 
-The service to which the listener is associated. This is the name of a service\
+The service to which the listener is associated. This is the name of a service
 that is defined elsewhere in the configuration file.
 
 #### `protocol`
@@ -3341,11 +3341,11 @@ that is defined elsewhere in the configuration file.
 The name of the protocol module used for communication between the client and\
 MaxScale. The same protocol is also used for backend communication.
 
-Usually this does not need to be defined as the default protocol is the MariaDB\
+Usually this does not need to be defined as the default protocol is the MariaDB
 network protocol that is used by SQL connections.
 
-For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL\
-protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md) module\
+For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL
+protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md) module
 documentation.
 
 #### `address`
@@ -3355,8 +3355,8 @@ documentation.
 * Dynamic: No
 * Default: `"::"`
 
-This sets the address the listening socket is bound to. The address may be\
-specified as an IP address in 'dot notation' or as a hostname. If left undefined\
+This sets the address the listening socket is bound to. The address may be
+specified as an IP address in 'dot notation' or as a hostname. If left undefined
 the listener will bind to all network interfaces.
 
 #### `port`
@@ -3366,7 +3366,7 @@ the listener will bind to all network interfaces.
 * Dynamic: No
 * Default: `0`
 
-The port the listener listens on. If left undefined a default port for the\
+The port the listener listens on. If left undefined a default port for the
 protocol is used.
 
 #### `socket`
@@ -3376,10 +3376,10 @@ protocol is used.
 * Dynamic: No
 * Default: `""`
 
-If defined, the listener uses Unix domain sockets to listen for incoming\
+If defined, the listener uses Unix domain sockets to listen for incoming
 connections. The parameter value is the name of the socket to use.
 
-If you want to use both network ports and UNIX domain sockets with a service,\
+If you want to use both network ports and UNIX domain sockets with a service,
 define two separate listeners that connect to the same service.
 
 #### `authenticator`
@@ -3389,9 +3389,9 @@ define two separate listeners that connect to the same service.
 * Dynamic: No
 * Default: `""`
 
-The authenticator module to use. Each protocol module defines a default\
+The authenticator module to use. Each protocol module defines a default
 authentication module, which is used if the setting is left undefined.\
-MariaDB and PostgreSQL protocols support multiple authenticators and they can\
+MariaDB and PostgreSQL protocols support multiple authenticators and they can
 be used simultaneously by giving a comma-separated list e.g.`authenticator=PAMAuth,mariadbauth,gssapiauth`
 
 #### `authenticator_options`
@@ -3401,8 +3401,8 @@ be used simultaneously by giving a comma-separated list e.g.`authenticator=PAMAu
 * Dynamic: No
 * Default: `""`
 
-This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of\
-this parameter should be a comma-separated list of key-value pairs. See\
+This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of
+this parameter should be a comma-separated list of key-value pairs. See
 authenticator specific documentation for more details.
 
 #### `sql_mode`
@@ -3418,33 +3418,33 @@ If both are used this setting will override the global setting for this listener
 
 #### `proxy_protocol_networks`
 
-Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-when connecting. The proxy header contains the original client IP-address and\
+Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+when connecting. The proxy header contains the original client IP-address and
 port, and MaxScale will use that information in its internal bookkeeping.\
-This means the client is authenticated as if it was connecting from the host\
-in the proxy header. If proxy protocol is also enabled in MaxScale server\
-settings, MaxScale will relay the original client address and port to\
+This means the client is authenticated as if it was connecting from the host
+in the proxy header. If proxy protocol is also enabled in MaxScale server
+settings, MaxScale will relay the original client address and port to
 the server. See [server settings](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#proxy_protocol) for more information.
 
-This setting may be useful if a compatible load balancer is relaying client\
-connections to MaxScale. If proxy headers are used, both MaxScale and the\
+This setting may be useful if a compatible load balancer is relaying client
+connections to MaxScale. If proxy headers are used, both MaxScale and the
 backends will know where the client originally came from.
 
-The `proxy_protocol_networks`-setting works similarly to the equivalent setting\
+The `proxy_protocol_networks`-setting works similarly to the equivalent setting
 in [MariaDB Server](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/server-client-software/client-libraries/proxy-protocol-support).\
 The value can be a single IP or subnetwork, or a comma-separated list of them.\
-Subnetworks are given in CIDR-format, e.g. "192.168.0.0/16". "\*" is a valid\
-value, allowing anyone to send the header. "localhost" allows proxy headers\
+Subnetworks are given in CIDR-format, e.g. "192.168.0.0/16". "\*" is a valid
+value, allowing anyone to send the header. "localhost" allows proxy headers
 from domain socket connections.
 
-Only trusted IPs should be added to the list, as the proxy header may affect\
+Only trusted IPs should be added to the list, as the proxy header may affect
 authentication results.
 
 ```
 proxy_protocol_networks=192.168.0.1,198.168.0.0/16
 ```
 
-Similar to MariaDB Server, MaxScale will also accept normal connections even\
+Similar to MariaDB Server, MaxScale will also accept normal connections even
 if `proxy_protocol_networks` is configured for the listener.
 
 #### `connection_init_sql_file`
@@ -3454,10 +3454,10 @@ if `proxy_protocol_networks` is configured for the listener.
 * Dynamic: Yes
 * Default: `""`
 
-Path to a text file with sql queries. Any sessions created from the listener\
-will send the contents of the file to backends after authentication. Each\
-non-empty line in the file is interpreted as a query. Each query must succeed\
-for the backend connection to be usable for client queries. The queries should\
+Path to a text file with sql queries. Any sessions created from the listener
+will send the contents of the file to backends after authentication. Each
+non-empty line in the file is interpreted as a query. Each query must succeed
+for the backend connection to be usable for client queries. The queries should
 not return any data.
 
 ```
@@ -3478,28 +3478,28 @@ set @myvar2 = 4;
 * Dynamic: Yes
 * Default: `""`
 
-Path to a json-text file with user and group mapping, as well as server\
-credentials. Only affects MariaDB-protocol based listeners. Default value is\
+Path to a json-text file with user and group mapping, as well as server
+credentials. Only affects MariaDB-protocol based listeners. Default value is
 empty, which disables the feature.
 
 ```
 user_mapping_file=/home/root/mapping.json
 ```
 
-Should not be used together with [PAM Authenticator](../mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-pam-authenticator.md)\
-settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite\
-the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on\
+Should not be used together with [PAM Authenticator](../mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-pam-authenticator.md)
+settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite
+the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on
 backends and map them to backend users.
 
 This file functions very similar to [PAM-based mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
-Both user-to-user and group-to-user mappings can be defined. Also, the password\
-and authentication plugin for the mapped users can be added. The file is only\
-read during listener creation (typically MaxScale start) or when a listener is\
-modified during runtime. When a client logs into MaxScale, their username is\
+Both user-to-user and group-to-user mappings can be defined. Also, the password
+and authentication plugin for the mapped users can be added. The file is only
+read during listener creation (typically MaxScale start) or when a listener is
+modified during runtime. When a client logs into MaxScale, their username is
 searched from the mapping data. If the name matches either a name mapping or a\
-Linux group mapping, the username is replaced by the mapped name. The mapped\
-name is then used when logging into backends. If the file also contains\
-credentials for the mapped user, then those are used. Otherwise, MaxScale tries\
+Linux group mapping, the username is replaced by the mapped name. The mapped
+name is then used when logging into backends. If the file also contains
+credentials for the mapped user, then those are used. Otherwise, MaxScale tries
 to log in with an empty password and default MariaDB authentication.
 
 Three arrays are read from the file: _user\_map_, _group\_map_ and\_server\_credentials\_, none of which are mandatory.
@@ -3514,25 +3514,25 @@ Each array element in the _group\_map_-array must define the following fields:
 * original\_group: String. Incoming client Linux group.
 * mapped\_user: String. Username the client is mapped to.
 
-Each array element in the _server\_credentials_-array can define the following\
+Each array element in the _server\_credentials_-array can define the following
 fields:
 
 * mapped\_user: String. The mapped username this password is for.
-* password: String. Backend server password. Can be encrypted with\
+* password: String. Backend server password. Can be encrypted with
   maxpasswd.
-* plugin: String, optional. Authentication plugin to use. Must be enabled on\
-  the listener. Defaults to empty, which results in standard MariaDB\
+* plugin: String, optional. Authentication plugin to use. Must be enabled on
+  the listener. Defaults to empty, which results in standard MariaDB
   authentication.
 
-When a client successfully logs into MaxScale, MaxScale first searches for\
-name-based mapping. The incoming client does not need to be a Linux user for\
-name-based mapping to take place. If the name is not found, MaxScale checks if\
-the client is a Linux user with a group membership matching an element in the\
-group mapping array. If the client is a member of more than 100 groups, this\
+When a client successfully logs into MaxScale, MaxScale first searches for
+name-based mapping. The incoming client does not need to be a Linux user for
+name-based mapping to take place. If the name is not found, MaxScale checks if
+the client is a Linux user with a group membership matching an element in the
+group mapping array. If the client is a member of more than 100 groups, this
 check may fail.
 
-If a mapping is found, MaxScale searches the credentials array for a matching\
-username, and uses the password and plugin listed. The plugin need not be the\
+If a mapping is found, MaxScale searches the credentials array for a matching
+username, and uses the password and plugin listed. The plugin need not be the
 same as the one the original user used. Currently, "mysql\_native\_password" and\
 "pam" are supported as mapped plugins.
 
@@ -3578,35 +3578,35 @@ An example mapping file is below.
 * Dynamic: Yes
 * Mandatory: No
 
-Metadata that's sent to all connecting clients. The value must be a\
-comma-separated list of key-value arguments. The keys or values cannot contain\
+Metadata that's sent to all connecting clients. The value must be a
+comma-separated list of key-value arguments. The keys or values cannot contain
 commas in them.
 
-Any values that are set to `auto` will be substituted with the value of the\
-corresponding MariaDB system variable. Any system variables that do not\
-exist or have empty or null values will not be sent to the client. The system\
-variable values are read from the first `Master` server that's reachable from\
-the listener's service. If no `Master` server is reachable, the value is read\
-from the first `Slave` server and if no `Slave` servers are available, from the\
-first `Running` server. If no running servers are available, the system\
+Any values that are set to `auto` will be substituted with the value of the
+corresponding MariaDB system variable. Any system variables that do not
+exist or have empty or null values will not be sent to the client. The system
+variable values are read from the first `Master` server that's reachable from
+the listener's service. If no `Master` server is reachable, the value is read
+from the first `Slave` server and if no `Slave` servers are available, from the
+first `Running` server. If no running servers are available, the system
 variables are not sent.
 
-The exception to this is the `maxscale=auto` value where the `auto` will be\
-replaced with the MaxScale version string. This is useful for detecting whether\
-a client is connected to MaxScale. To make MaxScale completely transparent to\
+The exception to this is the `maxscale=auto` value where the `auto` will be
+replaced with the MaxScale version string. This is useful for detecting whether
+a client is connected to MaxScale. To make MaxScale completely transparent to
 the client application, the `maxscale=auto` value can be removed from`connection_metadata`.
 
-MaxScale will always send a metadata value for `threads_connected` that contains\
-the current number of connections to the service that the listener points to and\
-for `connection_id` that contains the 64-bit connection ID value. The values can\
+MaxScale will always send a metadata value for `threads_connected` that contains
+the current number of connections to the service that the listener points to and
+for `connection_id` that contains the 64-bit connection ID value. The values can
 be overridden by defining them with some value, for example,`connection_metadata=threads_connected=0,connection_id=0`.
 
-The metadata is implemented using [the session state information](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/4-server-response-packets/ok_packet#session-state-info)\
-that is embedded in the OK packets that are generated by MaxScale. The values\
-are encoded as system variables changes. This information can be accessed by all\
-connectors that support reading the session state information. One example of\
-this is the MariaDB Connector/C that implements it with the [mysql\_session\_track\_get\_first](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_first)\
-and [mysql\_session\_track\_get\_next](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_next)\
+The metadata is implemented using [the session state information](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/4-server-response-packets/ok_packet#session-state-info)
+that is embedded in the OK packets that are generated by MaxScale. The values
+are encoded as system variables changes. This information can be accessed by all
+connectors that support reading the session state information. One example of
+this is the MariaDB Connector/C that implements it with the [mysql\_session\_track\_get\_first](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_first)
+and [mysql\_session\_track\_get\_next](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_next)
 functions.
 
 The following example demonstrates the use of `connection_metadata`:
@@ -3615,20 +3615,20 @@ The following example demonstrates the use of `connection_metadata`:
 connection_metadata=redirect_url=localhost:3306,service_name=my-service,max_allowed_packet=auto
 ```
 
-The configuration has three variables, `redirect_url`, `service_name` and`max_allowed_packet` that have the values `localhost:3306`, `my-service` and`auto`. The `auto` value is special and gets replaced with the`max_allowed_packet` value from the MariaDB server. This means that the final\
+The configuration has three variables, `redirect_url`, `service_name` and`max_allowed_packet` that have the values `localhost:3306`, `my-service` and`auto`. The `auto` value is special and gets replaced with the`max_allowed_packet` value from the MariaDB server. This means that the final
 metadata that is sent to the client would be `redirect_url=localhost:3306`,`service_name=my-service` and `max_allowed_packet=16777216`.
 
 #### Version-specific Behavior
 
-If the `connection_metadata` variable list contains the `tx_isolation` variable\
+If the `connection_metadata` variable list contains the `tx_isolation` variable
 and the backend MariaDB server from which the variable is retrieved is MariaDB\
-11 or newer, the value is renamed to `transaction_isolation`. The `tx_isolation`\
+11 or newer, the value is renamed to `transaction_isolation`. The `tx_isolation`
 parameter was deprecated in favor of `transaction_isolation` in MariaDB 11\
 (MDEV-21921).
 
 ### Include
 
-An _include_ section defined common parameters used in other configuration\
+An _include_ section defined common parameters used in other configuration
 sections. Consider the following configuration.
 
 ```
@@ -3656,7 +3656,7 @@ servers=Server3, Server4
 ```
 
 The two monitor sections are identical except for the `servers` setting.\
-If they otherwise should remain identical, a change must be made in two\
+If they otherwise should remain identical, a change must be made in two
 places. With an `include` section the situation can be simplified.
 
 ```
@@ -3681,20 +3681,20 @@ type=monitor
 servers=Server3, Server3
 ```
 
-With an `include` section, all common settings can be defined in one\
+With an `include` section, all common settings can be defined in one
 place, and then included to any number of other sections using the`@include` parameter.
 
-The `@include` parameter takes a list of section names, so the settings\
+The `@include` parameter takes a list of section names, so the settings
 can be distributed across several `include` sections.
 
 ```
 @include=Some-Common-Attributes, Other-Common-Attributes
 ```
 
-It is permissible to specify in the _including_ section, parameters\
-that have already been specified in the _included_ section and they\
-will take precedence. For instance, if `Monitor2` in the example\
-above should have a longer backend connect timeout it can be\
+It is permissible to specify in the _including_ section, parameters
+that have already been specified in the _included_ section and they
+will take precedence. For instance, if `Monitor2` in the example
+above should have a longer backend connect timeout it can be
 specified as follows.
 
 ```
@@ -3705,9 +3705,9 @@ servers=Server3, Server3
 backend_connect_timeout = 5s
 ```
 
-Note that an included section **must** be an `include` section and\
-that an `include` section **cannot** include another `include`\
-section. For instance, both of the following sections would cause\
+Note that an included section **must** be an `include` section and
+that an `include` section **cannot** include another `include`
+section. For instance, both of the following sections would cause
 an error at startup.
 
 ```
@@ -3722,22 +3722,22 @@ type=monitor
 ...
 ```
 
-Note also that if an included parameter is changed using `maxctrl`,\
-it will be changed _only_ on the actual object the change is applied\
-on, not on the `include` section where the parameter is originally\
+Note also that if an included parameter is changed using `maxctrl`,
+it will be changed _only_ on the actual object the change is applied
+on, not on the `include` section where the parameter is originally
 specified.
 
 ## Available Protocols
 
-Protocol modules in MaxScale define what kind of clients can connect to a\
-listener and what type of backend servers are supported. Protocol is defined in\
-listener settings, and affects both the listener and any services the listener\
+Protocol modules in MaxScale define what kind of clients can connect to a
+listener and what type of backend servers are supported. Protocol is defined in
+listener settings, and affects both the listener and any services the listener
 is linked to.
 
 ### `MariaDB` or `MariaDBClient`
 
-Implements MariaDB protocol. The listener will accept MariaDB/MySQL connections\
-from clients and route the client queries through a linked MaxScale service\
+Implements MariaDB protocol. The listener will accept MariaDB/MySQL connections
+from clients and route the client queries through a linked MaxScale service
 to backend servers. The backends used by the service should be\
 MariaDB servers or compatible.
 
@@ -3748,54 +3748,54 @@ See [Change Data Capture Protocol](../mariadb-maxscale-23-08-protocols/mariadb-m
 ### `Postgresql` or `Postgresprotocol`
 
 Implements [Postgresql protocol](https://www.postgresql.org/docs/current/protocol.html).\
-The listener will accept Postgresql connections from clients and route the\
-client queries through a linked MaxScale service to backend servers. The\
+The listener will accept Postgresql connections from clients and route the
+client queries through a linked MaxScale service to backend servers. The
 backends used by the service should be PostgreSQL servers or compatible.
 
 ### `nosqlprotocol`
 
 Accepts MongoDB® connections, yet stores and fetches results to/from\
-MariaDB servers. See [NoSQL documentation](../mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md)\
+MariaDB servers. See [NoSQL documentation](../mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md)
 for more information.
 
 ## TLS/SSL encryption
 
-This section describes configuration parameters for both servers and listeners\
-that control the TLS/SSL encryption method and the various certificate files\
+This section describes configuration parameters for both servers and listeners
+that control the TLS/SSL encryption method and the various certificate files
 involved in it.
 
 To enable TLS/SSL for a listener, you must set the `ssl` parameter to`true` and provide at least the `ssl_cert` and `ssl_key` parameters.
 
-To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification\
+To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification
 enabled, the `ssl_cert` and `ssl_key` parameters must also be defined.
 
 Custom CA certificates can be defined with the `ssl_ca` parameter.
 
-After this, MaxScale connections between the server and/or the client will be\
-encrypted. Note that the database must also be configured to use TLS/SSL\
+After this, MaxScale connections between the server and/or the client will be
+encrypted. Note that the database must also be configured to use TLS/SSL
 connections if backend connection encryption is used.
 
-**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on\
+**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on
 the same port.
 
-If TLS encryption is enabled for a listener, any unencrypted connections to it\
-will be rejected. MaxScale does this to improve security by preventing\
+If TLS encryption is enabled for a listener, any unencrypted connections to it
+will be rejected. MaxScale does this to improve security by preventing
 accidental creation of unencrypted connections.
 
-The separation of secure and insecure connections differs from the MariaDB\
+The separation of secure and insecure connections differs from the MariaDB
 server which allows both secure and insecure connections on the same port. As\
-MaxScale is the gateway through which all connections go, in order to guarantee\
-a more secure system MaxScale enforces a stricter security policy than what the\
+MaxScale is the gateway through which all connections go, in order to guarantee
+a more secure system MaxScale enforces a stricter security policy than what the
 server does.
 
-TLS encryption must be enabled for listeners when they are created. For servers,\
+TLS encryption must be enabled for listeners when they are created. For servers,
 the TLS can be enabled after creation but it cannot be disabled or altered.
 
 Starting with MaxScale 2.5.20, if the TLS certificate given to MaxScale has the\
-X509v3 extended key usage information, MaxScale will check it and refuse to use\
-a certificate with the wrong usage. This means that a certificate with only\
-clientAuth can only be used with servers and a certificate with only serverAuth\
-can only be used with listeners. In order to use the same certificate for both\
+X509v3 extended key usage information, MaxScale will check it and refuse to use
+a certificate with the wrong usage. This means that a certificate with only
+clientAuth can only be used with servers and a certificate with only serverAuth
+can only be used with listeners. In order to use the same certificate for both
 listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 #### `ssl`
@@ -3807,12 +3807,12 @@ listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 This enables SSL connections when set to true. The legacy values `required` and`disabled` were removed in MaxScale 6.0.
 
-If enabled, the certificate files mentioned above must also be\
+If enabled, the certificate files mentioned above must also be
 supplied. MaxScale connections to will then be encrypted with TLS/SSL.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require\
-ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created\
+24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require
+ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created
 with `REQUIRE SSL` or `REQUIRE X509`.
 
 #### `ssl_key`
@@ -3822,8 +3822,8 @@ with `REQUIRE SSL` or `REQUIRE X509`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client private key MaxScale should use. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client private key MaxScale should use. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_cert`
@@ -3833,9 +3833,9 @@ parameter for listeners but an optional parameter for servers.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client certificate MaxScale should use with the server. The\
-certificate must match the key defined in `ssl_key`. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client certificate MaxScale should use with the server. The
+certificate must match the key defined in `ssl_key`. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_ca_cert`
@@ -3849,13 +3849,13 @@ Deprecated since MariaDB MaxScale 22.08. See `ssl_ca`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the Certificate Authority (CA) certificate for the CA that signed the\
-certificate referred to in the previous parameter. It will be used to verify\
-that the certificate is valid. This is a required parameter for both listeners\
+A string giving a file path that identifies an existing readable file. The file
+must be the Certificate Authority (CA) certificate for the CA that signed the
+certificate referred to in the previous parameter. It will be used to verify
+that the certificate is valid. This is a required parameter for both listeners
 and servers. The CA certificate can consist of a certificate chain.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,
 which is still accepted as an alias for `ssl_ca`.
 
 #### `ssl_version`
@@ -3874,7 +3874,7 @@ This parameter controls the allowed TLS version. Accepted values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -3886,18 +3886,18 @@ The default setting (MAX) allows all supported versions. MaxScale supports\
 TLSv1.0, TLSv1.1, TLSv1.2 and TLSv1.3 depending on the OpenSSL library version.\
 TLSv1.0 and TLSv1.1 are considered deprecated and should not be used, so setting`ssl_version=TLSv1.2,TLSv1.3` or `ssl_version=TLSv1.3` is recommended.
 
-In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this\
-setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would\
+In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this
+setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would
 only enable TLSv12. The interpretation changed in MaxScale versions 6.4.14,\
-22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while\
-allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`\
+22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while
+allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`
 enabled both TLSv1.2 and TLSv1.3.
 
 The interpretation changed again in MaxScale versions 6.4.16, 22.08.13,\
-23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an\
-enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior\
-from the previous releases where the newer versions were automatically enabled,\
-the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)\
+23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an
+enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior
+from the previous releases where the newer versions were automatically enabled,
+the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)
 parameter works.
 
 #### `ssl_cipher`
@@ -3907,8 +3907,8 @@ parameter works.
 * Dynamic: Yes
 * Default: `""`
 
-Set the list of TLS ciphers. By default, no explicit ciphers are defined and the\
-system defaults are used. Note that this parameter does not modify TLSv1.3\
+Set the list of TLS ciphers. By default, no explicit ciphers are defined and the
+system defaults are used. Note that this parameter does not modify TLSv1.3
 ciphers.
 
 #### `ssl_cert_verify_depth`
@@ -3918,8 +3918,8 @@ ciphers.
 * Dynamic: Yes
 * Default: `9`
 
-The maximum length of the certificate authority chain that will be accepted. The\
-default value is 9, same as the OpenSSL default. The configured value must be\
+The maximum length of the certificate authority chain that will be accepted. The
+default value is 9, same as the OpenSSL default. The configured value must be
 larger than 0.
 
 #### `ssl_verify_peer_certificate`
@@ -3929,11 +3929,11 @@ larger than 0.
 * Dynamic: Yes
 * Default: `false`
 
-Peer certificate verification. This functionality is disabled by default. In\
+Peer certificate verification. This functionality is disabled by default. In
 versions prior to 2.3.17 the feature was enabled by default.
 
-When this feature is enabled, the peer must send a certificate. The certificate\
-sent by the peer is verified against the configured Certificate Authority to\
+When this feature is enabled, the peer must send a certificate. The certificate
+sent by the peer is verified against the configured Certificate Authority to
 make sure the peer is who they claim to be. For listeners, this behaves as if`REQUIRE X509` was defined for all users. For servers, this behaves like the`--ssl-verify-server-cert` command line option for the `mysql` client.
 
 #### `ssl_verify_peer_host`
@@ -3945,10 +3945,10 @@ make sure the peer is who they claim to be. For listeners, this behaves as if`RE
 
 Peer host verification.
 
-When this feature is enabled, the peer hostname or IP is verified against the\
-certificate that is sent by the peer. If the IP address or the hostname does not\
-match the one in the certificate returned by the peer, the connection will be\
-closed. If the peer does not provide a certificate, the host verification is not\
+When this feature is enabled, the peer hostname or IP is verified against the
+certificate that is sent by the peer. If the IP address or the hostname does not
+match the one in the certificate returned by the peer, the connection will be
+closed. If the peer does not provide a certificate, the host verification is not
 done. To require peer certificates, use `ssl_verify_peer_certificate`.
 
 #### `ssl_crl`
@@ -3958,8 +3958,8 @@ done. To require peer certificates, use `ssl_verify_peer_certificate`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be a Certificate Revocation List in the PEM format that defines the revoked\
+A string giving a file path that identifies an existing readable file. The file
+must be a Certificate Revocation List in the PEM format that defines the revoked
 certificates. This parameter is only accepted by listeners.
 
 **Example SSL enabled server configuration**
@@ -3975,7 +3975,7 @@ ssl_key=/usr/local/mariadb/maxscale/ssl/key.max-client.pem
 ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
-This example configuration requires all connections to this server to be\
+This example configuration requires all connections to this server to be
 encrypted with SSL. The paths to the certificate files and the Certificate\
 Authority file are also provided.
 
@@ -3993,18 +3993,18 @@ ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
 This example configuration requires all connections to be encrypted with\
-SSL. The paths to the certificate files and the Certificate Authority file are\
+SSL. The paths to the certificate files and the Certificate Authority file are
 also provided.
 
 ## Module Types
 
 ### Routing Modules
 
-The main task of MariaDB MaxScale is to accept database connections from client\
-applications and route the connections or the statements sent over those\
+The main task of MariaDB MaxScale is to accept database connections from client
+applications and route the connections or the statements sent over those
 connections to the various services supported by MariaDB MaxScale.
 
-Currently a number of routing modules are available, these are designed for a\
+Currently a number of routing modules are available, these are designed for a
 range of different needs.
 
 Connection based load balancing:
@@ -4025,28 +4025,28 @@ Binary log server:
 
 ### Monitor Modules
 
-Monitor modules are used by MariaDB MaxScale to internally monitor the state of\
-the backend databases in order to set the server flags for each of those\
-servers. The router modules then use these flags to determine if the particular\
-server is a suitable destination for routing connections for particular query\
+Monitor modules are used by MariaDB MaxScale to internally monitor the state of
+the backend databases in order to set the server flags for each of those
+servers. The router modules then use these flags to determine if the particular
+server is a suitable destination for routing connections for particular query
 classifications. The monitors are run within separate threads of MariaDB\
 MaxScale and do not affect MariaDB MaxScale's routing performance.
 
 * [MariaDB Monitor](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md)
 * [Galera Monitor](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-galera-monitor.md)
 
-The use of monitors in MaxScale is not absolutely mandatory: it is possible to\
-run MariaDB MaxScale without a monitor module. In this case an external\
+The use of monitors in MaxScale is not absolutely mandatory: it is possible to
+run MariaDB MaxScale without a monitor module. In this case an external
 monitoring system must the status of each server via MaxCtrl or the REST\
 API. **Only do this if you know what you are doing.**
 
 ### Filter Modules
 
 Filters provide a means to manipulate or process requests as they pass through\
-MariaDB MaxScale between the client side protocol and the query router. A full\
+MariaDB MaxScale between the client side protocol and the query router. A full
 explanation of each filter's functionality can be found in its documentation.
 
-The [Filter Tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-filters.md) document shows how you\
+The [Filter Tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-filters.md) document shows how you
 can add a filter to a service and combine multiple filters in one service.
 
 * [Query Log All (QLA) Filter](../mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-query-log-all-filter.md)
@@ -4059,8 +4059,8 @@ can add a filter to a service and combine multiple filters in one service.
 
 Passwords stored in the maxscale.cnf file may optionally be encrypted for added security.\
 This is done by creation of an encryption key on installation of MariaDB MaxScale.\
-Encryption keys may be created manually by executing the maxkeys utility with the argument\
-of the filename to store the key. The default location MariaDB MaxScale stores\
+Encryption keys may be created manually by executing the maxkeys utility with the argument
+of the filename to store the key. The default location MariaDB MaxScale stores
 the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES CBC encryption.
 
 ```
@@ -4068,16 +4068,16 @@ the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES C
 maxkeys /var/lib/maxscale/
 ```
 
-Changing the encryption key for MariaDB MaxScale will invalidate any currently\
+Changing the encryption key for MariaDB MaxScale will invalidate any currently
 encrypted keys stored in the maxscale.cnf file.
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
 ### Creating Encrypted Passwords
 
-Encrypted passwords are created by executing the maxpasswd command with the location\
+Encrypted passwords are created by executing the maxpasswd command with the location
 of the .secrets file and the password you require to encrypt as an argument.
 
 ```
@@ -4086,9 +4086,9 @@ maxpasswd /var/lib/maxscale/ MaxScalePw001
 61DD955512C39A4A8BC4BB1E5F116705
 ```
 
-The output of the maxpasswd command is a hexadecimal string, this should be inserted\
+The output of the maxpasswd command is a hexadecimal string, this should be inserted
 into the maxscale.cnf file in place of the ordinary, plain text, password.\
-MariaDB MaxScale will determine this as an encrypted password and automatically decrypt\
+MariaDB MaxScale will determine this as an encrypted password and automatically decrypt
 it before sending it the database server.
 
 ```
@@ -4102,7 +4102,7 @@ password=61DD955512C39A4A8BC4BB1E5F116705
 
 ## Runtime Configuration Changes
 
-Read the following documents for different methods of altering the MaxScale\
+Read the following documents for different methods of altering the MaxScale
 configuration at runtime.
 
 * MaxCtrl
@@ -4113,88 +4113,88 @@ configuration at runtime.
 * [alter](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md#alter)
 * [REST API](../mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md) documentation
 
-All changes to the configuration done via MaxCtrl are persisted as individual\
-configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these\
-files will override any configurations found in the main configuration file or\
+All changes to the configuration done via MaxCtrl are persisted as individual
+configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these
+files will override any configurations found in the main configuration file or
 any auxiliary configuration files.
 
-Refer to the [Dynamic Configuration](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more\
+Refer to the [Dynamic Configuration](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more
 details on how this mechanism works and how to disable it.
 
 ### Configuration Synchronization
 
-The configuration synchronization mechanism is intended for synchronizing\
-configuration changes done on one MaxScale to all other MaxScales. This is done\
+The configuration synchronization mechanism is intended for synchronizing
+configuration changes done on one MaxScale to all other MaxScales. This is done
 by propagating the changes via the database cluster used by Maxscale.
 
-When configuring configuration synchronization for the first time, the same\
-static configuration files should be used on all MaxScale instances that use the\
+When configuring configuration synchronization for the first time, the same
+static configuration files should be used on all MaxScale instances that use the
 same cluster: the value of `config_sync_cluster` must be the same on all\
-MaxScale instances and the cluster (i.e. the monitor) pointed by it and its\
+MaxScale instances and the cluster (i.e. the monitor) pointed by it and its
 servers must be the same in every configuration.
 
-Whenever the MaxScale configuration is modified at runtime, the latest\
-configuration is stored in the database cluster in the `mysql.maxscale_config`\
-table. The table is created when the first modification to the configuration is\
+Whenever the MaxScale configuration is modified at runtime, the latest
+configuration is stored in the database cluster in the `mysql.maxscale_config`
+table. The table is created when the first modification to the configuration is
 done. A local copy of the configuration is stored in the data directory to allow\
-MaxScale to function even if a connection to the cluster cannot be made. By\
+MaxScale to function even if a connection to the cluster cannot be made. By
 default this file is stored at `/var/lib/maxscale/maxscale-config.json`.
 
-Whenever MaxScale starts up, it checks if a local version of this configuration\
-exists. If it does and it is a valid cached configuration, the static\
-configuration file as well as any other generated configuration files are\
-ignored. The exception is the `[maxscale]` section of the main static\
+Whenever MaxScale starts up, it checks if a local version of this configuration
+exists. If it does and it is a valid cached configuration, the static
+configuration file as well as any other generated configuration files are
+ignored. The exception is the `[maxscale]` section of the main static
 configuration file which is always read.
 
-Each configuration has a version number with the initial configuration being\
-version 0. Each time the configuration is modified, the version number is\
-incremented. This version number is used to detect when MaxScale needs to update\
+Each configuration has a version number with the initial configuration being
+version 0. Each time the configuration is modified, the version number is
+incremented. This version number is used to detect when MaxScale needs to update
 its configuration.
 
 #### Error Handling in Configuration Synchronization
 
-When doing a configuration change on the local MaxScale, if the configuration\
-change completes on MaxScale but fails to be committed to the database, MaxScale\
+When doing a configuration change on the local MaxScale, if the configuration
+change completes on MaxScale but fails to be committed to the database, MaxScale
 will attempt to revert the local configuration change. If this attempt fails,\
 MaxScale will discard the cached configuration and abort the process.
 
-When synchronizing with the cluster, if MaxScale fails to apply a configuration\
-retrieved from the cluster, it attempts to revert the configuration to the\
-previous version. If successful, the failed configuration update is ignored. If\
-the configuration update that fails cannot be reverted, the MaxScale\
-configuration will be in an indeterminate state. When this happens, MaxScale\
+When synchronizing with the cluster, if MaxScale fails to apply a configuration
+retrieved from the cluster, it attempts to revert the configuration to the
+previous version. If successful, the failed configuration update is ignored. If
+the configuration update that fails cannot be reverted, the MaxScale
+configuration will be in an indeterminate state. When this happens, MaxScale
 will discard the cached configuration and abort the process.
 
-When loading a locally cached configuration during startup, if any errors are\
-found in the cached configuration, it is discarded and the MaxScale process will\
-attempt to restart by exiting with code 75 from the main process. If MaxScale is\
+When loading a locally cached configuration during startup, if any errors are
+found in the cached configuration, it is discarded and the MaxScale process will
+attempt to restart by exiting with code 75 from the main process. If MaxScale is
 being used as a SystemD service, this will automatically trigger a restart of\
 MaxScale and no further actions are needed.
 
-The most common reason for a failed configuration update is missing files. For\
-example, if a configuration update adds encrypted connections to a server and\
-the TLS certificates it uses were not copied over to all MaxScale nodes before\
-the change was done, the operation will fail on all nodes that do not have these\
+The most common reason for a failed configuration update is missing files. For
+example, if a configuration update adds encrypted connections to a server and
+the TLS certificates it uses were not copied over to all MaxScale nodes before
+the change was done, the operation will fail on all nodes that do not have these
 files.
 
-If the synchronization of the configuration change fails at the step when the\
-database transaction is being committed, the new configuration can be\
-momentarily visible to the local MaxScale. This means the changes are not\
-guaranteed to be atomic on the local MaxScale but are atomic from the cluster's\
+If the synchronization of the configuration change fails at the step when the
+database transaction is being committed, the new configuration can be
+momentarily visible to the local MaxScale. This means the changes are not
+guaranteed to be atomic on the local MaxScale but are atomic from the cluster's
 point of view.
 
 #### Synchronization of Encrypted Passwords
 
-Starting with MaxScale 6.4.9, any passwords that are transmitted by the\
-configuration synchronization are encrypted if password encryption has been\
-enabled in MaxScale. This means that all MaxScale nodes in the same\
-configuration cluster must be configured to use password encryption and they\
+Starting with MaxScale 6.4.9, any passwords that are transmitted by the
+configuration synchronization are encrypted if password encryption has been
+enabled in MaxScale. This means that all MaxScale nodes in the same
+configuration cluster must be configured to use password encryption and they
 need to all use the same encryption keys that were created with `maxkeys`.
 
 #### Managing Configuration Synchronization
 
-The output of `maxctrl show maxscale` contains the `Config Sync` field with\
-information about the current configuration state of the local Maxscale as well\
+The output of `maxctrl show maxscale` contains the `Config Sync` field with
+information about the current configuration state of the local Maxscale as well
 as the state of any other nodes using this cluster.
 
 ```
@@ -4212,17 +4212,17 @@ as the state of any other nodes using this cluster.
 ├──────────────┼─────────────────────────────────────────────────────────────┤
 ```
 
-The `version` field is the logical configuration version and the `origin` is the\
-node that originates the latest configuration change. The `checksum` field is\
+The `version` field is the logical configuration version and the `origin` is the
+node that originates the latest configuration change. The `checksum` field is
 the checksum of the logical configuration and can be used to compare whether two\
-Maxscale instances are in the same configuration state. The `nodes` field\
-contains the status of each MaxScale instance mapped to the hostname of the\
-server. This field is updated whenever MaxScale reads the configuration from the\
-cluster and can thus be used to detect which MaxScales have updated their\
+Maxscale instances are in the same configuration state. The `nodes` field
+contains the status of each MaxScale instance mapped to the hostname of the
+server. This field is updated whenever MaxScale reads the configuration from the
+cluster and can thus be used to detect which MaxScales have updated their
 configuration.
 
-The `mysql.maxscale_config` table where the configuration changes are stored\
-must not be modified manually. The only case when the table should be modified\
+The `mysql.maxscale_config` table where the configuration changes are stored
+must not be modified manually. The only case when the table should be modified
 is when resetting the configuration synchronization.
 
 To reset the configuration synchronization:
@@ -4232,71 +4232,71 @@ To reset the configuration synchronization:
 3. Drop the `mysql.maxscale_config` table
 4. Start all MaxScale instances
 
-To disable configuration synchronization, remove `config_sync_cluster` from the\
-configuration file or set it to an empty string: `config_sync_cluster=""`. This\
+To disable configuration synchronization, remove `config_sync_cluster` from the
+configuration file or set it to an empty string: `config_sync_cluster=""`. This
 can be done at runtime with MaxCtrl by passing an empty string to`config_sync_cluster`:
 
 ```
 maxctrl alter maxscale config_sync_cluster ""
 ```
 
-If MaxScale cannot create a connection to the database cluster, configuration\
-changes are not possible until communication with the database is possible. To\
-override this behavior and force the changes to be done, use the `--skip-sync`\
-option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any\
-updates done with `--skip-sync` will overwritten by changes coming from the\
+If MaxScale cannot create a connection to the database cluster, configuration
+changes are not possible until communication with the database is possible. To
+override this behavior and force the changes to be done, use the `--skip-sync`
+option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any
+updates done with `--skip-sync` will overwritten by changes coming from the
 cluster.
 
 #### Limitations in Configuration Synchronization
 
-Only the MaxScale configuration is synchronized. Any external files (TLS\
-certificates, configuration files for modules or data generated by MaxScale) are\
-not synchronized. For example, the rule files for the cache filter must be\
+Only the MaxScale configuration is synchronized. Any external files (TLS
+certificates, configuration files for modules or data generated by MaxScale) are
+not synchronized. For example, the rule files for the cache filter must be
 synchronized separately if the filter itself is modified.
 
-Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers\
-and modifications to the administrative users will be synchronized. In older\
-versions servers had to be put into maintenance mode and users had to be\
+Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers
+and modifications to the administrative users will be synchronized. In older
+versions servers had to be put into maintenance mode and users had to be
 modified separately on each MaxScale.
 
-* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not\
+* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not
   synchronized.
-* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`\
-  option will not export the cluster configuration and instead exports only the\
-  static configuration files. To start a new MaxScale based off of a clustered\
-  configuration, copy the static configuration files as well as the JSON\
-  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale\
+* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`
+  option will not export the cluster configuration and instead exports only the
+  static configuration files. To start a new MaxScale based off of a clustered
+  configuration, copy the static configuration files as well as the JSON
+  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale
   instance.
 
 ### Backing Up Configuration Changes
 
-The combination of configuration files can be done either manually\
-(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line\
+The combination of configuration files can be done either manually
+(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line
 option. See `maxscale --help` for more information about how to use the`--export-config` flag.
 
-For example, to export the current runtime configuration, run the following\
+For example, to export the current runtime configuration, run the following
 command.
 
 ```
 maxscale --export-config=/tmp/maxscale.cnf.combined
 ```
 
-This will create the `/tmp/maxscale.cnf.combined` file and write the current\
-configuration into the it. This allows new MaxScale instances to be easily set\
-up without requiring copying of all runtime configuration files. The user\
-executing the command must be able to read all MaxScale configuration files as\
+This will create the `/tmp/maxscale.cnf.combined` file and write the current
+configuration into the it. This allows new MaxScale instances to be easily set
+up without requiring copying of all runtime configuration files. The user
+executing the command must be able to read all MaxScale configuration files as
 well as create and write the provided filename.
 
 ## Encryption Key Managers
 
-The encryption key managers are how MaxScale retrieves symmetric encryption keys\
-from a key management system. Some parts of MaxScale require the `key_manager`\
-to be configured in order to work. The key manager that is used is selected with\
-the [key\_manager](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is\
+The encryption key managers are how MaxScale retrieves symmetric encryption keys
+from a key management system. Some parts of MaxScale require the `key_manager`
+to be configured in order to work. The key manager that is used is selected with
+the [key\_manager](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is
 configured by placing the parameters in the `[maxscale]` section.
 
-The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key\
-management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration\
+The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key
+management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration
 files.
 
 ### File-based Key Manager
@@ -4304,13 +4304,13 @@ files.
 The encryption keys are stored in a text file stored on a local filesystem.
 
 The file uses the same format as the MariaDB server [File Key Management\
-Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file\
-consisting of an encryption key ID number and the hex-encoded encryption key\
+Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file
+consisting of an encryption key ID number and the hex-encoded encryption key
 separated by a semicolon. Read [Creating the Key\
-File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)\
+File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)
 for more details on how to create the file.
 
-For example, to configure encryption for the `nosqlprotocol` shared credentials\
+For example, to configure encryption for the `nosqlprotocol` shared credentials
 using the file-based encryption key:
 
 1. Create the key file with `(echo -n '1;' ; openssl rand -hex 32) | cat > /var/lib/maxscale/encryption.key`
@@ -4347,9 +4347,9 @@ nosqlprotocol.authentication_password=my_password
 * Mandatory: Yes
 * Dynamic: Yes
 
-Path to the file that contains the encryption keys. The user MaxScale runs as\
-(almost always `maxscale`) must be able to read this file. Encryption keys are\
-read from disk only during startup or when any global MaxScale parameter is\
+Path to the file that contains the encryption keys. The user MaxScale runs as
+(almost always `maxscale`) must be able to read this file. Encryption keys are
+read from disk only during startup or when any global MaxScale parameter is
 modified at runtime.
 
 ### KMIP Key Manager
@@ -4361,7 +4361,7 @@ The KMIP key manager has been verified to work with the PyKMIP server.
 #### Limitations
 
 * Key versioning is not supported
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the KMIP server.
 
 #### Parameters
@@ -4408,17 +4408,17 @@ The CA certificate to use. By default the system default certificates are used.
 
 ### HashiCorp Vault Key Manager
 
-Encryption keys are read from a local or remote Vault server using the secret\
-engine included in the Vault. This key manager supports versioned keys. Only\
+Encryption keys are read from a local or remote Vault server using the secret
+engine included in the Vault. This key manager supports versioned keys. Only
 version 2 key-value stores are supported.
 
 The encryption keys use the same format as the MariaDB [HashiCorp Vault Key\
 Management Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/hashicorp-key-management-plugin):\
-The key-value secret for each encryption key ID must contain the field `data`\
-which must contain a hex-encoded string that is either 32, 48 or 64 characters\
+The key-value secret for each encryption key ID must contain the field `data`
+which must contain a hex-encoded string that is either 32, 48 or 64 characters
 long.
 
-An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit\
+An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit
 encryption key using `openssl` and stores it using the key ID `1`:
 
 ```
@@ -4438,7 +4438,7 @@ version            1
 
 #### Limitations
 
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the Vault server.
 
 #### Parameters
@@ -4449,7 +4449,7 @@ version            1
 * Mandatory: Yes
 * Dynamic: Yes
 
-The authentication token used to connect to the Vault server. This can be\
+The authentication token used to connect to the Vault server. This can be
 encrypted using `maxpasswd`, similar to how other passwords are encrypted.
 
 **`vault.host`**
@@ -4482,7 +4482,7 @@ The CA certificate to use. By default the system default certificates are used.
 * Default: true
 * Dynamic: Yes
 
-Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating\
+Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating
 with the Vault server.
 
 **`vault.mount`**
@@ -4491,7 +4491,7 @@ with the Vault server.
 * Default: `secret`
 * Dynamic: Yes
 
-The Key-Value mount where the secret is stored. By default the `secret` mount is\
+The Key-Value mount where the secret is stored. By default the `secret` mount is
 used which is present by default in most Vault installations.
 
 **`vault.timeout`**
@@ -4504,30 +4504,30 @@ The connection and request timeout used with the Vault server.
 
 ## Threads
 
-For routing, MaxScale uses asynchronous I/O and a fixed number of threads\
+For routing, MaxScale uses asynchronous I/O and a fixed number of threads
 (aka _routing workers_), whose number up until 23.02 was fixed at startup.\
-From 23.02 onwards the number of threads can be altered at runtime, which\
-is convenient, for instance, if MaxScale is running in a container whose\
+From 23.02 onwards the number of threads can be altered at runtime, which
+is convenient, for instance, if MaxScale is running in a container whose
 properties are changed during the lifetime of the container.
 
 A thread can be in three different states:
 
-* **Active**: The thread is routing client traffic and is listening\
+* **Active**: The thread is routing client traffic and is listening
   for new connections.
-* **Draining**: The thread is routing client traffic but is **not**\
+* **Draining**: The thread is routing client traffic but is **not**
   listening for new connections.
-* **Dormant**: The thread is not routing client traffic (all sessions\
-  have ended), and is not listening for new connections, and is waiting\
+* **Dormant**: The thread is not routing client traffic (all sessions
+  have ended), and is not listening for new connections, and is waiting
   to be terminated.
 
-All threads start as _Active_ and may become _Draining_ if the number of\
-threads is reduced. A draining thread will eventually become _Dormant_,\
+All threads start as _Active_ and may become _Draining_ if the number of
+threads is reduced. A draining thread will eventually become _Dormant_,
 unless the number of threads is increased while the thread is still _Draining_.
 
-Note that it is not possible to terminate a specific thread, but it is only\
-possible to specify the _number_ of threads that MaxScale should use, and\
-that the threads will be terminated from the end. This has implications\
-if the number of threads is reduced by more than 1, as a _Dormant_ thread\
+Note that it is not possible to terminate a specific thread, but it is only
+possible to specify the _number_ of threads that MaxScale should use, and
+that the threads will be terminated from the end. This has implications
+if the number of threads is reduced by more than 1, as a _Dormant_ thread
 will not be terminated before it is the last thread.
 
 In the following, MaxScale has been started with `threads=4`.
@@ -4556,8 +4556,8 @@ $ bin/maxctrl show threads
 ...
 ```
 
-we will see that the threads 2 and 3 are now _Draining_. The reason is\
-that threads 2 and 3 still handle client sessions. If some client sessions\
+we will see that the threads 2 and 3 are now _Draining_. The reason is
+that threads 2 and 3 still handle client sessions. If some client sessions
 now end, the situation may become like
 
 ```
@@ -4569,13 +4569,13 @@ now end, the situation may become like
 ...
 ```
 
-That is, thread 2 is _Dormant_ and thread 3 is _Draining_. All client sessions\
-that were handled by thread 2 have ended and the thread is ready to be\
-terminated. However, as thread 3 is still _Draining_, thread 2 will not be\
+That is, thread 2 is _Dormant_ and thread 3 is _Draining_. All client sessions
+that were handled by thread 2 have ended and the thread is ready to be
+terminated. However, as thread 3 is still _Draining_, thread 2 will not be
 terminated but stay _Dormant_.
 
-If the sessions handled by thread 3 end, then it will become _Dormant_ at\
-which point first thread 3 will be terminatad and immediately after that\
+If the sessions handled by thread 3 end, then it will become _Dormant_ at
+which point first thread 3 will be terminatad and immediately after that
 thread 2.
 
 ```
@@ -4600,7 +4600,7 @@ $ bin/maxctrl show threads
 ...
 ```
 
-that is, the number of threads was 4 but has been reduced to 2, and while\
+that is, the number of threads was 4 but has been reduced to 2, and while
 thread 2 has become drained it stays as _Dormant_ since thread 3 is still _Draining_, it is possible to make thread 2 _Active_ again by increasing the
 number of threads to 3.
 
@@ -4630,8 +4630,8 @@ $ bin/maxctrl show threads
 
 ## Error Reporting
 
-MariaDB MaxScale is designed to be executed as a service, therefore all error\
-reports, including configuration errors, are written to the MariaDB MaxScale\
+MariaDB MaxScale is designed to be executed as a service, therefore all error
+reports, including configuration errors, are written to the MariaDB MaxScale
 error log file. By default, MariaDB MaxScale will log to a file in`/var/log/maxscale` and the system log.
 
 ## Limitations
@@ -4640,31 +4640,31 @@ The current limitations of MaxScale are listed in the [Limitations](../mariadb-m
 
 ## Performance Optimization
 
-* Tune `query_classifier_cache_size` to allow maximal use of the query\
-  classifier cache. Increase the value and/or system memory until the set of\
-  unique SQL patterns fits into memory. By default at most 15% of the system\
-  memory is used for this cache. To detect if the SQL statements fit into\
-  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to\
-  see how many evictions take place. If it keeps increasing, increase the size\
-  of the query classifier cache. Using the query classifier cache with a CPU\
-  bound workload gives a roughly 20% improvement in performance compared to when\
+* Tune `query_classifier_cache_size` to allow maximal use of the query
+  classifier cache. Increase the value and/or system memory until the set of
+  unique SQL patterns fits into memory. By default at most 15% of the system
+  memory is used for this cache. To detect if the SQL statements fit into
+  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to
+  see how many evictions take place. If it keeps increasing, increase the size
+  of the query classifier cache. Using the query classifier cache with a CPU
+  bound workload gives a roughly 20% improvement in performance compared to when
   it is turned off.
-* A faster CPU with more CPU cores is better. This is true for most applications\
+* A faster CPU with more CPU cores is better. This is true for most applications
   but especially for MaxScale as it is mostly limited by the speed of the\
   CPU. Using `threads=auto` is recommended (the default starting with MaxScale\
   6\).
-* Network throughput between the client, MaxScale and the database nodes governs\
-  how much traffic can be handled. The client-to-MaxScale network is likely to\
-  be saturated first: having multiple MaxScales in front of the cluster is an\
+* Network throughput between the client, MaxScale and the database nodes governs
+  how much traffic can be handled. The client-to-MaxScale network is likely to
+  be saturated first: having multiple MaxScales in front of the cluster is an
   easy way of solving this problem.
-* Certain MaxScale modules store data on disk. A faster disk improves their\
-  performance but depending on the module, this might not be a big enough of a\
-  problem to worry about. Filters like the `qlafilter` that write information to\
+* Certain MaxScale modules store data on disk. A faster disk improves their
+  performance but depending on the module, this might not be a big enough of a
+  problem to worry about. Filters like the `qlafilter` that write information to
   disk for every SQL query can cause performance bottlenecks.
 
 ### MaxScale Diagnostics using MaxCtrl
 
-From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with\
+From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with
 information about the system MaxScale is running on. The fields are:
 
 | Field                                   | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -4683,34 +4683,34 @@ In addition there is an `os` object that contains what the Linux command `uname`
 
 **`threads`**
 
-If `threads` has not been specified at all in the MaxScale configuration file,\
-or if its value is `auto`, then MaxScale will use as many routing threads as\
-there are physical cores on the machine. This is the right choice, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
+If `threads` has not been specified at all in the MaxScale configuration file,
+or if its value is `auto`, then MaxScale will use as many routing threads as
+there are physical cores on the machine. This is the right choice, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
 in any way.
 
-However, if the number of cores available to MaxScale have been restricted or\
-if MaxScale is running in a container whose CPU quota and period have been\
-limited, then it will lead to MaxScale using more routing threads than what\
+However, if the number of cores available to MaxScale have been restricted or
+if MaxScale is running in a container whose CPU quota and period have been
+limited, then it will lead to MaxScale using more routing threads than what
 is appropriate in the environment where it is running.
 
-If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`\
-should be specified explicitly in the MaxScale configuration file and its value\
-should be that of `machine.cores_virtual` rounded up to the nearest integer. If\
+If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`
+should be specified explicitly in the MaxScale configuration file and its value
+should be that of `machine.cores_virtual` rounded up to the nearest integer. If
 that value is `1` it may be beneficial to check whether `2` gives better performance.
 
 **`query_classifier_cache_size`**
 
-If `query_classifier_cache_size` has not been specified in the MaxScale\
-configuration file, then MaxScale will use at most 15% of the amount of physical\
-memory in the machine for the cache. This is a good starting point, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
-in any way. Note that the amount specifies how much memory the cache at maximum\
+If `query_classifier_cache_size` has not been specified in the MaxScale
+configuration file, then MaxScale will use at most 15% of the amount of physical
+memory in the machine for the cache. This is a good starting point, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
+in any way. Note that the amount specifies how much memory the cache at maximum
 is allowed to use, not what would immediately be allocated for the cache.
 
-However, if the amount of memory available to MaxScale has been restricted,\
-which may be the case if MaxScale is running in a container, this may cause the\
-cache to grow beyond what is available, which will lead to a crash or MaxScale\
+However, if the amount of memory available to MaxScale has been restricted,
+which may be the case if MaxScale is running in a container, this may cause the
+cache to grow beyond what is available, which will lead to a crash or MaxScale
 being killed.
 
 If the value of `machine.memory_available` is less than that of`machine.memory_physical`, then `query_classifier_cache_size` should be explicitly\
@@ -4749,7 +4749,7 @@ $ maxctrl show maxscale
 As can be seen, `maxscale.threads` is larger than `machine.cores_virtual` and thus,`threads=4` should explicitly be specified in the MaxScale configuration file.
 
 `maxscale.query_classifier_cache_size` is the default 15% of `machine.memory_physical`\
-but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be\
+but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be
 added to the configuration file.
 
 ```
@@ -4761,12 +4761,12 @@ query_classifier_cache_size=3100000000
 
 ## Troubleshooting
 
-For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)\
+For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 article on the MariaDB documentation.
 
 ### Systemd Watchdog
 
-If MaxScale is running as a systemd service, the systemd Watchdog will be\
+If MaxScale is running as a systemd service, the systemd Watchdog will be
 enabled by default. To configure it, change the `WatchdogSec` option in the\
 Service section of the maxscale systemd configuration file located in`/lib/systemd/system/maxscale.service`:
 
@@ -4774,8 +4774,8 @@ Service section of the maxscale systemd configuration file located in`/lib/syste
 WatchdogSec=30s
 ```
 
-It is not recommended to use a watchdog timeout less than 30 seconds. When\
-enabled MaxScale will check that all threads are running and notify systemd\
+It is not recommended to use a watchdog timeout less than 30 seconds. When
+enabled MaxScale will check that all threads are running and notify systemd
 with a "keep-alive ping".
 
 Systemd reference: [systemd.service.html](https://www.freedesktop.org/software/systemd/man/systemd.service.html)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-installation-guide.md
@@ -4,15 +4,15 @@
 
 ## MariaDB MaxScale Installation Guide
 
-We recommend to install MaxScale on a separate server, to ensure that there\
-can be no competition of resources between MaxScale and a MariaDB Server that\
+We recommend to install MaxScale on a separate server, to ensure that there
+can be no competition of resources between MaxScale and a MariaDB Server that
 it manages.
 
 ### Install MariaDB MaxScale From MariaDB Repositories
 
-The recommended approach is to use [the MariaDB package\
-repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
-to install MaxScale. After enabling the repository by following the\
+The recommended approach is to use [the MariaDB package
+repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
+to install MaxScale. After enabling the repository by following the
 instructions, MaxScale can be installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install maxscale`.
@@ -21,9 +21,9 @@ instructions, MaxScale can be installed with the following commands.
 
 ### Install MariaDB MaxScale From a RPM/DEB Package
 
-Download the correct MaxScale package for your CPU architecture and operating\
-system from [the MariaDB Downloads\
-page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be\
+Download the correct MaxScale package for your CPU architecture and operating
+system from [the MariaDB Downloads
+page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be
 installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install /path/to/maxscale-*.rpm`
@@ -33,7 +33,7 @@ installed with the following commands.
 ### Install MariaDB MaxScale Using a Tarball
 
 MaxScale can also be installed using a tarball.\
-That may be required if you are using a Linux distribution for which there\
+That may be required if you are using a Linux distribution for which there
 exist no installation package or if you want to install many different\
 MaxScale versions side by side. For instructions on how to do that, please refer to [Install MariaDB MaxScale using a Tarball](mariadb-maxscale-2308-installing-mariadb-maxscale-using-a-tarball.md).
 
@@ -46,20 +46,20 @@ To do this, refer to the separate document [Building MariaDB MaxScale from Sourc
 
 #### Memory allocation behavior
 
-MaxScale assumes that memory allocations always succeed and in general does\
-not check for memory allocation failures. This assumption is compatible with\
-the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)\
+MaxScale assumes that memory allocations always succeed and in general does
+not check for memory allocation failures. This assumption is compatible with
+the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)
 having the value `0`, which is also the default on most systems.
 
-With `vm.overcommit_memory` being `0`, memory _allocations_ made by an\
-application never fail, but instead the application may be killed by the\
-so-called OOM (out-of-memory) killer if, by the time the application\
-actually attempts to _use_ the allocated memory, there is not available\
+With `vm.overcommit_memory` being `0`, memory _allocations_ made by an
+application never fail, but instead the application may be killed by the
+so-called OOM (out-of-memory) killer if, by the time the application
+actually attempts to _use_ the allocated memory, there is not available
 free memory on the system.
 
-If the value is `2`, then a memory allocation made by an application may\
-fail and unless the application is prepared for that possibility, it will\
-likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory\
+If the value is `2`, then a memory allocation made by an application may
+fail and unless the application is prepared for that possibility, it will
+likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory
 allocation failures, it will crash in this situation.
 
 The current value of `vm.overcommit_memory` can be checked with
@@ -76,36 +76,36 @@ cat /proc/sys/vm/overcommit_memory
 
 ### Configuring MariaDB MaxScale
 
-[The MaxScale Tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-setting-up-mariadb-maxscale.md) covers the first\
-steps in configuring your MariaDB MaxScale installation. Follow this tutorial\
+[The MaxScale Tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-setting-up-mariadb-maxscale.md) covers the first
+steps in configuring your MariaDB MaxScale installation. Follow this tutorial
 to learn how to configure and start using MaxScale.
 
-For a detailed list of all configuration parameters, refer to the [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/) and the module specific documents\
+For a detailed list of all configuration parameters, refer to the [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/) and the module specific documents
 listed in the [Documentation Contents](https://mariadb.com/kb/en/mariadb-maxscale-2308-maxscale-2308-contents/#routers).
 
 ### Encrypting Passwords
 
-Read the [Encrypting Passwords](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#encrypting-passwords)\
-section of the configuration guide to set up password encryption for the\
+Read the [Encrypting Passwords](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#encrypting-passwords)
+section of the configuration guide to set up password encryption for the
 configuration file.
 
 ### Administration Of MariaDB MaxScale
 
 There are various administration tasks that may be done with MariaDB MaxScale.\
-A command line tools is available, [maxctrl](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md), that will\
+A command line tools is available, [maxctrl](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md), that will
 interact with a running MariaDB MaxScale and allow the status of MariaDB\
-MaxScale to be monitored and give some control of the MariaDB MaxScale\
+MaxScale to be monitored and give some control of the MariaDB MaxScale
 functionality.
 
-[The administration tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-mariadb-maxscale-administration-tutorial.md)\
+[The administration tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-mariadb-maxscale-administration-tutorial.md)
 covers the common administration tasks that need to be done with MariaDB MaxScale.
 
 ### Copying or Backing Up MaxScale
 
-The main configuration file for MaxScale is in `/etc/maxscale.cnf` and\
+The main configuration file for MaxScale is in `/etc/maxscale.cnf` and
 additional user-created configuration files are in`/etc/maxscale.cnf.d/`. Objects created or modified at runtime are stored in`/var/lib/maxscale/maxscale.cnf.d/`. Some modules also store internal data in`/var/lib/maxscale/` named after the module or the configuration object.
 
-The simplest way to back up the configuration and runtime data of a MaxScale\
+The simplest way to back up the configuration and runtime data of a MaxScale
 installation is to create an archive from the following files and directories:
 
 * `/etc/maxscale.cnf`
@@ -118,7 +118,7 @@ This can be done with the following command:
 tar -caf maxscale-backup.tar.gz /etc/maxscale.cnf /etc/maxscale.cnf.d/ /var/lib/maxscale/
 ```
 
-If MaxScale is configured to store data in custom locations, these should be\
+If MaxScale is configured to store data in custom locations, these should be
 included in the backup as well.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-maxgui-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-maxgui-guide.md
@@ -10,27 +10,27 @@ _MaxGUI_ is a browser-based interface for MaxScale REST-API and query execution.
 
 ## Enabling MaxGUI
 
-To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale\
+To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale
 configuration file. Once enabled, MaxGUI will be available on port 8989:`http://127.0.0.1:8989/`
 
 ### Securing the GUI
 
 To make MaxGUI secure, set `admin_secure_gui=true` and configure both the`admin_ssl_key` and `admin_ssl_cert` parameters.
 
-See [Configuration Guide](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-rest-api-tutorial.md#configuration-and-hardening)\
+See [Configuration Guide](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-rest-api-tutorial.md#configuration-and-hardening)
 for instructions on how to harden your MaxScale installation for production use.
 
 ## Authentication
 
-MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`\
+MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`
 with `mariadb` as the password.
 
-Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the\
-authentication method for persisting the user's session. If the _Remember me_\
-checkbox is ticked, the session will persist for 24 hours. Otherwise, the\
+Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the
+authentication method for persisting the user's session. If the _Remember me_
+checkbox is ticked, the session will persist for 24 hours. Otherwise, the
 session will expire as soon as MaxGUI is closed.
 
-To log out, simply click the username section in the top right corner of the\
+To log out, simply click the username section in the top right corner of the
 page header to access the logout menu.
 
 ## Pages
@@ -44,7 +44,7 @@ By default, the refresh interval is 10 seconds.
 
 ### Detail
 
-This page shows information on each [MaxScale object](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#objects) and allow to edit its\
+This page shows information on each [MaxScale object](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#objects) and allow to edit its
 parameter, relationships and perform other manipulation operations.
 
 Access this page by clicking on the MaxScale object name on the [dashboard page](mariadb-maxscale-2308-mariadb-maxscale-maxgui-guide.md#dashboard)
@@ -54,8 +54,8 @@ Access this page by clicking on the MaxScale object name on the [dashboard page]
 This page visualizes MaxScale configuration and clusters.
 
 * Configuration: Visualizing MaxScale configuration.
-* Cluster: Visualizing a replication cluster into a tree graph and provides\
-  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the\
+* Cluster: Visualizing a replication cluster into a tree graph and provides
+  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the
   moment, it supports only servers monitored by Monitor using [mariadbmon](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md) module.
 
 Access this page by clicking the graph icon on the sidebar navigation.
@@ -68,30 +68,30 @@ Access this page by clicking the gear icon on the sidebar navigation.
 
 ### Logs Archive
 
-Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar\
+Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar
 navigation.
 
 ### Workspace
 
-The "Workspace" page offers a versatile set of tools for effectively managing\
+The "Workspace" page offers a versatile set of tools for effectively managing
 data and database interactions. It includes the following key tasks:
 
 #### 1. Run Queries
 
-Execute queries on various servers, services, or listeners to retrieve data and\
-perform database operations. Visualize query results using different graph\
-types such as line, bar, or scatter graphs. Export query results in formats\
+Execute queries on various servers, services, or listeners to retrieve data and
+perform database operations. Visualize query results using different graph
+types such as line, bar, or scatter graphs. Export query results in formats
 like CSV or JSON for further analysis and sharing.
 
 #### 2. Data Migration
 
-The "Data Migration" feature facilitates seamless transitions from PostgreSQL\
-to MariaDB. Transfer data and database structures between the two systems while\
+The "Data Migration" feature facilitates seamless transitions from PostgreSQL
+to MariaDB. Transfer data and database structures between the two systems while
 ensuring data integrity and consistency throughout the process.
 
 #### 3. Create an ERD
 
-Generating Entity-Relationship Diagrams (ERDs) to gain insights regarding data\
+Generating Entity-Relationship Diagrams (ERDs) to gain insights regarding data
 structure, optimizing database design for both efficiency and clarity.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-common-monitor-parameters.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-common-monitor-parameters.md
@@ -4,7 +4,7 @@
 
 ## Common Monitor Parameters
 
-This document settings supported by all monitors. These should be defined\
+This document settings supported by all monitors. These should be defined
 in the monitor section of the configuration file.
 
 ### Parameters
@@ -23,7 +23,7 @@ The monitor module this monitor should use. Typically `mariadbmon` or`galeramon`
 * Mandatory: Yes
 * Dynamic: Yes
 
-Username used by the monitor to connect to the backend servers. If a server defines\
+Username used by the monitor to connect to the backend servers. If a server defines
 the `monitoruser` parameter, that value will be used instead.
 
 #### `password`
@@ -32,10 +32,10 @@ the `monitoruser` parameter, that value will be used instead.
 * Mandatory: Yes
 * Dynamic: Yes
 
-Password for the user defined with the `user` parameter. If a server defines\
+Password for the user defined with the `user` parameter. If a server defines
 the `monitorpw` parameter, that value will be used instead.
 
-**Note:** In older versions of MaxScale this parameter was called `passwd`. The\
+**Note:** In older versions of MaxScale this parameter was called `passwd`. The
 use of `passwd` was deprecated in MaxScale 2.3.0.
 
 #### `servers`
@@ -57,17 +57,17 @@ servers=MyServer1,MyServer2
 * Dynamic: Yes
 * Default: `2s`
 
-Defines how often the monitor updates the status of the servers. Choose a lower\
+Defines how often the monitor updates the status of the servers. Choose a lower
 value if servers should be queried more often. The smallest possible value is\
-100 milliseconds. If querying the servers takes longer than `monitor_interval`,\
+100 milliseconds. If querying the servers takes longer than `monitor_interval`,
 the effective update rate is reduced.
 
 ```
 monitor_interval=2s
 ```
 
-The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.
 
 #### `backend_connect_timeout`
@@ -78,10 +78,10 @@ versions a value without a unit may be rejected.
 * Default: `3s`
 
 This parameter controls the timeout for connecting to a monitored server.\
-The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -96,10 +96,10 @@ backend_connect_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for writing to a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 seconds.
 
 ```
@@ -114,10 +114,10 @@ backend_write_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for reading from a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -131,9 +131,9 @@ backend_read_timeout=3s
 * Dynamic: Yes
 * Default: `1`
 
-This parameter defines the maximum times a backend connection is attempted every\
-monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds\
-to perform. If none of the attempts are successful, the backend is considered to\
+This parameter defines the maximum times a backend connection is attempted every
+monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds
+to perform. If none of the attempts are successful, the backend is considered to
 be unreachable and down.
 
 ```
@@ -151,18 +151,18 @@ This parameter duplicates the `disk_space_threshold`[server parameter](https://m
 If the parameter has _not_ been specified for a server, then the one specified\
 for the monitor is applied.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-That is, if the disk configuration is the same on all servers monitored by\
-the monitor, it is sufficient (and more convenient) to specify the disk\
-space threshold in the monitor section, but if the disk configuration is\
-different on all or some servers, then the disk space threshold can be\
+That is, if the disk configuration is the same on all servers monitored by
+the monitor, it is sufficient (and more convenient) to specify the disk
+space threshold in the monitor section, but if the disk configuration is
+different on all or some servers, then the disk space threshold can be
 specified individually for each server.
 
-For example, suppose `server1`, `server2` and `server3` are identical\
-in all respects. In that case we can specify `disk_space_threshold`\
+For example, suppose `server1`, `server2` and `server3` are identical
+in all respects. In that case we can specify `disk_space_threshold`
 in the monitor.
 
 ```
@@ -185,8 +185,8 @@ disk_space_threshold=/data:80
 ...
 ```
 
-However, if the servers are heterogeneous with the disk used for the\
-data directory mounted on different paths, then the disk space threshold\
+However, if the servers are heterogeneous with the disk used for the
+data directory mounted on different paths, then the disk space threshold
 must be specified separately for each server.
 
 ```
@@ -211,8 +211,8 @@ servers=server1,server2,server3
 ...
 ```
 
-If _most_ of the servers have the data directory disk mounted on\
-the same path, then the disk space threshold can be specified on\
+If _most_ of the servers have the data directory disk mounted on
+the same path, then the disk space threshold can be specified on
 the monitor and separately on the server with a different setup.
 
 ```
@@ -236,7 +236,7 @@ disk_space_threshold=/data:80
 ...
 ```
 
-Above, `server1` has the disk used for the data directory mounted\
+Above, `server1` has the disk used for the data directory mounted
 at `/DbData` while both `server2` and `server3` have it mounted on`/data` and thus the setting in the monitor covers them both.
 
 #### `disk_space_check_interval`
@@ -246,15 +246,15 @@ at `/DbData` while both `server2` and `server3` have it mounted on`/data` and th
 * Dynamic: Yes
 * Default: `0s`
 
-With this parameter it can be specified the minimum amount of time\
-between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+With this parameter it can be specified the minimum amount of time
+between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.\
-The default value is 0, which means that by default the disk space\
+The default value is 0, which means that by default the disk space
 will not be checked.
 
-Note that as the checking is made as part of the regular monitor interval\
-cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,\
+Note that as the checking is made as part of the regular monitor interval
+cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,
 the checking will still take place at `monitor_interval` intervals.
 
 #### `script`
@@ -264,9 +264,9 @@ the checking will still take place at `monitor_interval` intervals.
 * Dynamic: Yes
 * Default: None
 
-This command will be executed on a server state change. The parameter should\
-be an absolute path to a command or the command should be in the executable\
-path. The user running MaxScale should have execution rights to the file itself\
+This command will be executed on a server state change. The parameter should
+be an absolute path to a command or the command should be in the executable
+path. The user running MaxScale should have execution rights to the file itself
 and the directory it resides in. The script may have placeholders which\
 MaxScale will substitute with useful information when launching the script.
 
@@ -280,15 +280,15 @@ The placeholders and their substitution results are:
 * `$MASTERLIST` -> list of IPs and ports of all primary servers
 * `$SYNCEDLIST` -> list of IPs and ports of all synced Galera nodes
 * `$PARENT` -> IP and port of the parent of the server which initiated the event.\
-  For primary-replica setups, this will be the primary if the initiating server is a\
+  For primary-replica setups, this will be the primary if the initiating server is a
   replica.
-* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who\
-  initiated the event. For primary-replica setups, this will be a list of replica\
+* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who
+  initiated the event. For primary-replica setups, this will be a list of replica
   servers if the initiating server is a primary.
 
-The expanded variable value can be an empty string if no servers match the\
-variable's requirements. For example, if no primaries are available `$MASTERLIST`\
-will expand into an empty string. The list-type substitutions will only contain\
+The expanded variable value can be an empty string if no servers match the
+variable's requirements. For example, if no primaries are available `$MASTERLIST`
+will expand into an empty string. The list-type substitutions will only contain
 servers monitored by the current monitor.
 
 ```
@@ -303,17 +303,17 @@ The above script could be executed as:
 
 See section [Script example](mariadb-maxscale-2308-common-monitor-parameters.md#script-example) below for an example script.
 
-Any output by the executed script will be logged into the MaxScale log. Each\
+Any output by the executed script will be logged into the MaxScale log. Each
 outputted line will be logged as a separate log message.
 
-The log level on which the messages are logged depends on the format of the\
-messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the\
-corresponding level. If the message is not prefixed with one of the keywords,\
-the message will be logged on the notice level. Whitespace before, after or\
-between the keyword and the colon is ignored and the matching is\
+The log level on which the messages are logged depends on the format of the
+messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the
+corresponding level. If the message is not prefixed with one of the keywords,
+the message will be logged on the notice level. Whitespace before, after or
+between the keyword and the colon is ignored and the matching is
 case-insensitive.
 
-Currently, the script must not execute any of the following MaxCtrl\
+Currently, the script must not execute any of the following MaxCtrl
 calls as they cause a deadlock:
 
 * `alter monitor` to the monitor executing the script
@@ -327,14 +327,14 @@ calls as they cause a deadlock:
 * Dynamic: Yes
 * Default: `90s`
 
-The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If the script execution exceeds the configured timeout, it is stopped by sending\
-a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be\
+If the script execution exceeds the configured timeout, it is stopped by sending
+a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be
 sent to it once the execution time is greater than twice the configured timeout.
 
 #### `events`
@@ -345,15 +345,15 @@ sent to it once the execution time is greater than twice the configured timeout.
 * Values: `master_down`, `master_up`, `slave_down`, `slave_up`, `server_down`, `server_up`, `lost_master`, `lost_slave`, `new_master`, `new_slave`
 * Default: All events
 
-A list of event names which cause the script to be executed. If this option is\
-not defined, all events cause the script to be executed. The list must contain a\
+A list of event names which cause the script to be executed. If this option is
+not defined, all events cause the script to be executed. The list must contain a
 comma separated list of event names.
 
 ```
 events=master_down,slave_down
 ```
 
-The following table contains all the possible event types and their\
+The following table contains all the possible event types and their
 descriptions.
 
 | Event Name   | Description                                  |
@@ -376,38 +376,38 @@ descriptions.
 * Dynamic: Yes
 * Default: `28800s`
 
-The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the max age is seconds, a max age specified in milliseconds will be rejected,\
+The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the max age is seconds, a max age specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-When the monitor starts, it reads any stored journal files. If the journal file\
-is older than the value of _journal\_max\_age_, it will be removed and the monitor\
+When the monitor starts, it reads any stored journal files. If the journal file
+is older than the value of _journal\_max\_age_, it will be removed and the monitor
 starts with no prior knowledge of the servers.
 
 ### Monitor Crash Safety
 
-Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the\
-latest server states. This change makes the monitors crash-safe when options\
-that introduce states are used. It also allows the monitors to retain stateful\
+Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the
+latest server states. This change makes the monitors crash-safe when options
+that introduce states are used. It also allows the monitors to retain stateful
 information when MaxScale is restarted.
 
-For MySQL monitor, options that introduce states into the monitoring process are\
-the `detect_stale_master` and `detect_stale_slave` options, both of which are\
-enabled by default. Galeramon has the `disable_master_failback` parameter which\
+For MySQL monitor, options that introduce states into the monitoring process are
+the `detect_stale_master` and `detect_stale_slave` options, both of which are
+enabled by default. Galeramon has the `disable_master_failback` parameter which
 introduces a state.
 
-The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the\
-name of the monitor section in the configuration file. If MaxScale crashes or is\
-shut down in an uncontrolled fashion, the journal will be read when MaxScale is\
-started. To skip the recovery process, manually delete the journal file before\
+The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the
+name of the monitor section in the configuration file. If MaxScale crashes or is
+shut down in an uncontrolled fashion, the journal will be read when MaxScale is
+started. To skip the recovery process, manually delete the journal file before
 starting MaxScale.
 
 ### Script example
 
-Below is an example monitor configuration which launches a script with all\
-supported substitutions. The example script reads the results and prints it to\
+Below is an example monitor configuration which launches a script with all
+supported substitutions. The example script reads the results and prints it to
 file and sends it as email.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md
@@ -6,11 +6,11 @@
 
 ### Overview
 
-MariaDB Monitor monitors a Primary-Replica replication cluster. It probes the\
-state of the backends and assigns server roles such as primary and replica, which\
-are used by the routers when deciding where to route a query. It can also modify\
-the replication cluster by performing failover, switchover and rejoin. Backend\
-server versions older than MariaDB/MySQL 5.5 are not supported. Failover and\
+MariaDB Monitor monitors a Primary-Replica replication cluster. It probes the
+state of the backends and assigns server roles such as primary and replica, which
+are used by the routers when deciding where to route a query. It can also modify
+the replication cluster by performing failover, switchover and rejoin. Backend
+server versions older than MariaDB/MySQL 5.5 are not supported. Failover and
 other similar operations require MariaDB 10.0.2 or later.
 
 Up until MariaDB MaxScale 2.2.0, this monitor was called _MySQL Monitor_.
@@ -45,7 +45,7 @@ set), then the FILE-grant is required with MariaDB Server versions 10.4.7,\
 GRANT FILE ON *.* TO 'maxscale'@'maxscalehost';
 ```
 
-MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it\
+MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it
 allows the monitor to log in even if server connection limit has been reached.
 
 ```
@@ -54,7 +54,7 @@ GRANT CONNECTION ADMIN ON *.* TO 'maxscale'@'maxscalehost';
 
 #### Cluster Manipulation Grants
 
-If [cluster manipulation operations](mariadb-maxscale-2308-mariadb-monitor.md#cluster-manipulation-operations) are used,\
+If [cluster manipulation operations](mariadb-maxscale-2308-mariadb-monitor.md#cluster-manipulation-operations) are used,
 the following additional grants are required:
 
 ```
@@ -68,7 +68,7 @@ MariaDB 10.5.2 and later require read access to _mysql.global\_priv_:
 GRANT SELECT ON mysql.global_priv TO 'maxscale'@'maxscalehost';
 ```
 
-As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of\
+As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of
 its former sub-privileges. These must be given separately.
 
 ```
@@ -87,59 +87,59 @@ GRANT REPLICATION SLAVE ON *.* TO 'replication'@'replicationhost';
 
 ### Primary selection
 
-Only one backend can be primary at any given time. A primary must be running\
-(successfully connected to by the monitor) and its _read\_only_-setting must be\
-off. A primary may not be replicating from another server in the monitored\
-cluster unless the primary is part of a multiprimary group. Primary selection\
-prefers to select the server with the most replicas, possibly in multiple\
-replication layers. Only replicas reachable by a chain of running relays or\
-directly connected to the primary count. When multiple servers are tied for\
-primary status, the server which appears earlier in the `servers`-setting of the\
+Only one backend can be primary at any given time. A primary must be running
+(successfully connected to by the monitor) and its _read\_only_-setting must be
+off. A primary may not be replicating from another server in the monitored
+cluster unless the primary is part of a multiprimary group. Primary selection
+prefers to select the server with the most replicas, possibly in multiple
+replication layers. Only replicas reachable by a chain of running relays or
+directly connected to the primary count. When multiple servers are tied for
+primary status, the server which appears earlier in the `servers`-setting of the
 monitor is selected.
 
-Servers in a cyclical replication topology (multiprimary group) are interpreted\
-as having all the servers in the group as replicas. Even from a multiprimary group\
+Servers in a cyclical replication topology (multiprimary group) are interpreted
+as having all the servers in the group as replicas. Even from a multiprimary group
 only one server is selected as the overall primary.
 
-After a primary has been selected, the monitor prefers to stick with the choice\
-even if other potential primaries with more replica servers are available. Only if\
-the current primary is clearly unsuitable does the monitor try to select another\
+After a primary has been selected, the monitor prefers to stick with the choice
+even if other potential primaries with more replica servers are available. Only if
+the current primary is clearly unsuitable does the monitor try to select another
 primary. An existing primary turns invalid if:
 
 1. It is unwritable (read\_only is on).
-2. It has been down for more than failcount monitor passes and has no running\
-   replicas. Running replicas behind a downed relay count. A replica in this\
-   context is any server with at least a partially running replication connection\
-   (either io or sql thread is running). The replicas must also be down for more\
+2. It has been down for more than failcount monitor passes and has no running
+   replicas. Running replicas behind a downed relay count. A replica in this
+   context is any server with at least a partially running replication connection
+   (either io or sql thread is running). The replicas must also be down for more
    than failcount monitor passes to allow new master selection.
-3. It did not previously replicate from another server in the cluster but it\
+3. It did not previously replicate from another server in the cluster but it
    is now replicating.
-4. It was previously part of a multiprimary group but is no longer, or the\
+4. It was previously part of a multiprimary group but is no longer, or the
    multiprimary group is replicating from a server not in the group.
 
-Cases 1 and 2 cover the situations in which the DBA, an external script or even\
-another MaxScale has modified the cluster such that the old primary can no longer\
-act as primary. Cases 3 and 4 are less severe. In these cases the topology has\
-changed significantly and the primary should be re-selected, although the old\
+Cases 1 and 2 cover the situations in which the DBA, an external script or even
+another MaxScale has modified the cluster such that the old primary can no longer
+act as primary. Cases 3 and 4 are less severe. In these cases the topology has
+changed significantly and the primary should be re-selected, although the old
 primary may still be the best choice.
 
-The primary change described above is different from failover and switchover\
+The primary change described above is different from failover and switchover
 described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2308-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
-A primary change only modifies the server roles inside MaxScale but does not\
+A primary change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a primary change on their own.
 
-As a general rule, it's best to avoid situations where the cluster has multiple\
+As a general rule, it's best to avoid situations where the cluster has multiple
 standalone servers, separate primary-replica pairs or separate multiprimary groups.\
-Due to primary invalidation rule 2, a standalone primary can easily lose the\
-primary status to another valid primary if it goes down. The new primary probably\
-does not have the same data as the previous one. Non-standalone primaries are less\
-vulnerable, as a single running replica or multiprimary group member will keep the\
+Due to primary invalidation rule 2, a standalone primary can easily lose the
+primary status to another valid primary if it goes down. The new primary probably
+does not have the same data as the previous one. Non-standalone primaries are less
+vulnerable, as a single running replica or multiprimary group member will keep the
 primary valid even when down.
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers.
 
 ```
@@ -153,8 +153,8 @@ password=mypwd
 
 From MaxScale 2.2.1 onwards, the module name is `mariadbmon` instead of`mysqlmon`. The old name can still be used.
 
-The grants required by `user` depend on which monitor features are used. A full\
-list of the grants can be found in the [Required Grants](mariadb-maxscale-2308-mariadb-monitor.md#required-grants)\
+The grants required by `user` depend on which monitor features are used. A full
+list of the grants can be found in the [Required Grants](mariadb-maxscale-2308-mariadb-monitor.md#required-grants)
 section.
 
 ### Common Monitor Parameters
@@ -163,9 +163,9 @@ For a list of optional parameters that all monitors support, read the [Monitor C
 
 ### MariaDB Monitor optional parameters
 
-These are optional parameters specific to the MariaDB Monitor. Failover,\
-switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2308-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are\
-described in the [Rebuild server-section](mariadb-maxscale-2308-mariadb-monitor.md#rebuild-server). ColumnStore\
+These are optional parameters specific to the MariaDB Monitor. Failover,
+switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2308-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are
+described in the [Rebuild server-section](mariadb-maxscale-2308-mariadb-monitor.md#rebuild-server). ColumnStore
 parameters are described in the [ColumnStore commands-section](mariadb-maxscale-2308-mariadb-monitor.md#settings).
 
 #### `assume_unique_hostnames`
@@ -175,31 +175,31 @@ parameters are described in the [ColumnStore commands-section](mariadb-maxscale-
 * Dynamic: Yes
 * Default: `true`
 
-When active, the monitor assumes that server hostnames and\
-ports are consistent between the server definitions in the MaxScale\
-configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers\
-themselves. Specifically, the monitor assumes that if server A is replicating\
-from server B, then A must have a replica connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this\
-is not the case, e.g. an IP is used in the server while a hostname is given in\
-the file, the monitor may misinterpret the topology. In MaxScale 2.4.1, the\
-monitor attempts name resolution on the addresses if a simple string comparison\
-does not find a match. Using exact matching addresses is, however, more\
+When active, the monitor assumes that server hostnames and
+ports are consistent between the server definitions in the MaxScale
+configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers
+themselves. Specifically, the monitor assumes that if server A is replicating
+from server B, then A must have a replica connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this
+is not the case, e.g. an IP is used in the server while a hostname is given in
+the file, the monitor may misinterpret the topology. In MaxScale 2.4.1, the
+monitor attempts name resolution on the addresses if a simple string comparison
+does not find a match. Using exact matching addresses is, however, more
 reliable.
 
-This setting must be ON to use any cluster operation features such as failover\
-or switchover, because MaxScale uses the addresses and ports in the\
+This setting must be ON to use any cluster operation features such as failover
+or switchover, because MaxScale uses the addresses and ports in the
 configuration file when issuing "CHANGE MASTER TO"-commands.
 
-If the network configuration is such that the addresses MaxScale uses to connect\
-to backends are different from the ones the servers use to connect to each\
-other, `assume_unique_hostnames` should be set to OFF. In this mode, MaxScale\
-uses server id:s it queries from the servers and the `Master_Server_Id` fields\
-of the replica connections to deduce which server is replicating from which. This\
-is not perfect though, since MaxScale doesn't know the id:s of servers it has\
-never connected to (e.g. server has been down since MaxScale was started). Also,\
-the `Master_Server_Id`-field may have an incorrect value if the replica connection\
-has not been established. MaxScale will only trust the value if the monitor has\
-seen the replica connection IO thread connected at least once. If this is not the\
+If the network configuration is such that the addresses MaxScale uses to connect
+to backends are different from the ones the servers use to connect to each
+other, `assume_unique_hostnames` should be set to OFF. In this mode, MaxScale
+uses server id:s it queries from the servers and the `Master_Server_Id` fields
+of the replica connections to deduce which server is replicating from which. This
+is not perfect though, since MaxScale doesn't know the id:s of servers it has
+never connected to (e.g. server has been down since MaxScale was started). Also,
+the `Master_Server_Id`-field may have an incorrect value if the replica connection
+has not been established. MaxScale will only trust the value if the monitor has
+seen the replica connection IO thread connected at least once. If this is not the
 case, the replica connection is ignored.
 
 #### `master_conditions`
@@ -212,9 +212,9 @@ case, the replica connection is ignored.
 
 Designate additional conditions for\_Master\_-status, i.e. qualified for read and write queries.
 
-Normally, if a suitable primary candidate server is found as described in [Primary selection](mariadb-maxscale-2308-mariadb-monitor.md#primary-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a primary server. This\
+Normally, if a suitable primary candidate server is found as described in [Primary selection](mariadb-maxscale-2308-mariadb-monitor.md#primary-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a primary server. This
 setting is an enum\_mask, allowing multiple conditions to be set simultaneously.\
-Conditions 2, 3 and 4 refer to replica servers. A single replica must\
+Conditions 2, 3 and 4 refer to replica servers. A single replica must
 fulfill all of the given conditions for the primary to be viable.
 
 If the primary candidate fails _master\_conditions_ but fulfills\_slave\_conditions\_, it may be designated _Slave_ instead.
@@ -222,28 +222,28 @@ If the primary candidate fails _master\_conditions_ but fulfills\_slave\_conditi
 The available conditions are:
 
 1. none : No additional conditions
-2. connecting\_slave : At least one immediate replica (not behind relay) is\
+2. connecting\_slave : At least one immediate replica (not behind relay) is
    attempting to replicate or is replicating from the primary (Slave\_IO\_Running is\
-   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A replica with incorrect\
-   replication credentials does not count. If the replica is currently down, results\
+   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A replica with incorrect
+   replication credentials does not count. If the replica is currently down, results
    from the last successful monitor tick are used.
-3. connected\_slave : Same as above, with the difference that the replication\
-   connection must be up (Slave\_IO\_Running is 'Yes'). If the replica is currently\
+3. connected\_slave : Same as above, with the difference that the replication
+   connection must be up (Slave\_IO\_Running is 'Yes'). If the replica is currently
    down, results from the last successful monitor tick are used.
-4. running\_slave : Same as connecting\_slave, with the addition that the\
+4. running\_slave : Same as connecting\_slave, with the addition that the
    replica must also be Running.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2308-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate primary is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2308-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate primary is selected also by the
    primary MaxScale.
-6. disk\_space\_ok : The candidate primary must not be low on disk space. This\
+6. disk\_space\_ok : The candidate primary must not be low on disk space. This
    option only takes effect if [disk space check](mariadb-maxscale-2308-common-monitor-parameters.md#disk_space_threshold) is enabled. Added in\
    MaxScale 23.08.5.
 
-The default value of this setting is`master_requirements=primary_monitor_master,disk_space_ok` to ensure that both\
-monitors use the same primary server when cooperating and that the primary is\
+The default value of this setting is`master_requirements=primary_monitor_master,disk_space_ok` to ensure that both
+monitors use the same primary server when cooperating and that the primary is
 not out of disk space.
 
-For example, to require that the primary must have a replica which is both\
+For example, to require that the primary must have a replica which is both
 connected and running, set
 
 ```
@@ -258,32 +258,32 @@ master_conditions=connected_slave,running_slave
 * Values: `none`, `linked_master`, `running_master`, `writable_master`, `primary_monitor_master`
 * Default: `none`
 
-Designate additional conditions for _Slave_-status,\
+Designate additional conditions for _Slave_-status,
 i.e qualified for read queries.
 
-Normally, a server is _Slave_ if it is at least attempting to replicate from the\
+Normally, a server is _Slave_ if it is at least attempting to replicate from the
 primary candidate or a relay (Slave\_IO\_Running is 'Yes' or 'Connecting',\
-Slave\_SQL\_Running is 'Yes', valid replication credentials). The primary candidate\
-does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a replica\
-server. This setting is an enum\_mask, allowing multiple conditions to be set\
+Slave\_SQL\_Running is 'Yes', valid replication credentials). The primary candidate
+does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a replica
+server. This setting is an enum\_mask, allowing multiple conditions to be set
 simultaneously.
 
 The available conditions are:
 
 1. none : No additional conditions. This is the default value.
-2. linked\_master : The replica must be connected to the primary (Slave\_IO\_Running\
-   and Slave\_SQL\_Running are 'Yes') and the primary must be Running. The same\
+2. linked\_master : The replica must be connected to the primary (Slave\_IO\_Running
+   and Slave\_SQL\_Running are 'Yes') and the primary must be Running. The same
    applies to any relays between the replica and the primary.
 3. running\_master : The primary must be running. Relays may be down.
 4. writable\_master : The primary must be writable, i.e. labeled Master.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2308-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate primary is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2308-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate primary is selected also by the
    primary MaxScale.
-6. disk\_space\_ok : The replica must not be low on disk space. This\
+6. disk\_space\_ok : The replica must not be low on disk space. This
    option only takes effect if [disk space check](mariadb-maxscale-2308-common-monitor-parameters.md#disk_space_threshold) is enabled. Added in\
    MaxScale 23.08.5.
 
-For example, to require that the primary server of the cluster must be running\
+For example, to require that the primary server of the cluster must be running
 and writable for any servers to have _Slave_-status, set
 
 ```
@@ -297,8 +297,8 @@ slave_conditions=running_master,writable_master
 * Dynamic: Yes
 * Default: `5`
 
-Number of consecutive monitor passes a primary server must be down before it is\
-considered failed. If automatic failover is enabled (`auto_failover=true`), it\
+Number of consecutive monitor passes a primary server must be down before it is
+considered failed. If automatic failover is enabled (`auto_failover=true`), it
 may be performed at this time. A value of 0 or 1 enables immediate failover.
 
 If automatic failover is not possible, the monitor will try to\
@@ -307,8 +307,8 @@ for more details. Changing the primary may break replication as queries could be
 routed to a server without previous events. To prevent this, avoid having\
 multiple valid primary servers in the cluster.
 
-The worst-case delay between the primary failure and the start of the failover\
-can be estimated by summing up the timeout values and `monitor_interval` and\
+The worst-case delay between the primary failure and the start of the failover
+can be estimated by summing up the timeout values and `monitor_interval` and
 multiplying that by `failcount`:
 
 ```
@@ -322,19 +322,19 @@ multiplying that by `failcount`:
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-disable the _read\_only_-flag on the primary when seen. The flag is\
-checked every monitor tick. The monitor user requires the SUPER-privilege for\
+If set to ON, the monitor attempts to
+disable the _read\_only_-flag on the primary when seen. The flag is
+checked every monitor tick. The monitor user requires the SUPER-privilege for
 this feature to work.
 
-Typically, the primary server should never be in read-only-mode. Such a situation\
-may arise due to misconfiguration or accident, or perhaps if MaxScale crashed\
+Typically, the primary server should never be in read-only-mode. Such a situation
+may arise due to misconfiguration or accident, or perhaps if MaxScale crashed
 during switchover.
 
-When this feature is enabled, setting the primary manually to _read\_only_ will no\
-longer cause the monitor to search for another primary. The primary will instead\
-for a moment lose its \[Master]-status (no writes), until the monitor again\
-enables writes on the primary. When starting from scratch, the monitor still\
+When this feature is enabled, setting the primary manually to _read\_only_ will no
+longer cause the monitor to search for another primary. The primary will instead
+for a moment lose its \[Master]-status (no writes), until the monitor again
+enables writes on the primary. When starting from scratch, the monitor still
 prefers to select a writable server as primary if possible.
 
 #### `enforce_read_only_slaves`
@@ -344,18 +344,18 @@ prefers to select a writable server as primary if possible.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-enable the _read\_only_-flag on any writable replica server. The flag is checked\
-every monitor tick. The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this\
+If set to ON, the monitor attempts to
+enable the _read\_only_-flag on any writable replica server. The flag is checked
+every monitor tick. The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this
 feature to work. While the _read\_only_-flag is ON, only users with the\
-SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If\
-temporary write access is required, this feature should be disabled before\
-attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly\
+SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If
+temporary write access is required, this feature should be disabled before
+attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly
 re-enable it.
 
-_read\_only_ won't be enabled on the master server, even if it has\
-lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2308-mariadb-monitor.md#master_conditions) and is\
+_read\_only_ won't be enabled on the master server, even if it has
+lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2308-mariadb-monitor.md#master_conditions) and is
 marked \[Slave].
 
 #### `enforce_read_only_servers`
@@ -365,12 +365,12 @@ marked \[Slave].
 * Dynamic: Yes
 * Default: `false`
 
-Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2308-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in\
+Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2308-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in
 maintenance (a superset of the servers altered by _enforce\_read\_only\_slaves_).
 
-The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid\
-primary or primary candidate, _read\_only_ is not set on any server as it is\
+The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid
+primary or primary candidate, _read\_only_ is not set on any server as it is
 unclear which servers should be altered.
 
 #### `maintenance_on_low_disk_space`
@@ -380,16 +380,16 @@ unclear which servers should be altered.
 * Dynamic: Yes
 * Default: `true`
 
-If a running server that is not the primary\
+If a running server that is not the primary
 or a relay primary is out of disk space the server is set to maintenance mode.\
-Such servers are not used for router sessions and are ignored when performing a\
-failover or other cluster modification operation. See the general monitor\
-parameters [disk\_space\_threshold](mariadb-maxscale-2308-common-monitor-parameters.md#disk_space_threshold) and [disk\_space\_check\_interval](mariadb-maxscale-2308-common-monitor-parameters.md#disk_space_check_interval)\
+Such servers are not used for router sessions and are ignored when performing a
+failover or other cluster modification operation. See the general monitor
+parameters [disk\_space\_threshold](mariadb-maxscale-2308-common-monitor-parameters.md#disk_space_threshold) and [disk\_space\_check\_interval](mariadb-maxscale-2308-common-monitor-parameters.md#disk_space_check_interval)
 on how to enable disk space monitoring.
 
-Once a server has been put to maintenance mode, the disk space situation\
-of that server is no longer updated. The server will not be taken out of\
-maintenance mode even if more disk space becomes available. The maintenance\
+Once a server has been put to maintenance mode, the disk space situation
+of that server is no longer updated. The server will not be taken out of
+maintenance mode even if more disk space becomes available. The maintenance
 flag must be removed manually:
 
 ```
@@ -404,22 +404,22 @@ maxctrl clear server server2 Maint
 * Values: `none`, `majority_of_all`, `majority_of_running`
 * Default: `none`
 
-Using this setting is recommended when multiple MaxScales are monitoring the\
-same backend cluster. When enabled, the monitor attempts to acquire exclusive\
-locks on the backend servers. The monitor considers itself the primary monitor\
-if it has a majority of locks. The majority can be either over all configured\
-servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2308-mariadb-monitor.md#cooperative-monitoring)\
+Using this setting is recommended when multiple MaxScales are monitoring the
+same backend cluster. When enabled, the monitor attempts to acquire exclusive
+locks on the backend servers. The monitor considers itself the primary monitor
+if it has a majority of locks. The majority can be either over all configured
+servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2308-mariadb-monitor.md#cooperative-monitoring)
 for more details on how this feature works and which value to use.
 
 Allowed values:
 
 1. `none` Default value, no locking.
-2. `majority_of_all` Primary monitor requires a majority of locks, even counting\
+2. `majority_of_all` Primary monitor requires a majority of locks, even counting
    servers which are \[Down].
 3. `majority_of_running` Primary monitor requires a majority of locks over\
    \[Running] servers.
 
-This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has\
+This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has
 acquired the locks. Generally, it's best not to mix cooperative monitoring with\_passive\_. Either set `passive=false` or do not set it at all.
 
 #### `script_max_replication_lag`
@@ -429,38 +429,38 @@ acquired the locks. Generally, it's best not to mix cooperative monitoring with\
 * Dynamic: Yes
 * Default: `-1`
 
-Defines a replication lag limit in seconds for\
-launching the monitor script configured in the _script_-parameter. If the\
+Defines a replication lag limit in seconds for
+launching the monitor script configured in the _script_-parameter. If the
 replication lag of a server goes above this limit, the script is ran with the\
-$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the\
+$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
-Negative values disable this feature. For more information on monitor scripts,\
+Negative values disable this feature. For more information on monitor scripts,
 see [general monitor documentation](https://mariadb.com/kb/en/node:mariadb-maxscale-2308-common-monitor-parameters#script).
 
 ### Cluster manipulation operations
 
-Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster\
+Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster
 modification. The operations implemented are:
 
 * [failover](mariadb-maxscale-2308-mariadb-monitor.md#failover), which replaces a failed primary with a replica
 * [switchover](mariadb-maxscale-2308-mariadb-monitor.md#switchover), which swaps a running primary with a replica
-* [switchover-force](mariadb-maxscale-2308-mariadb-monitor.md#switchover-force), which swaps a running primary with a replica, ignoring\
+* [switchover-force](mariadb-maxscale-2308-mariadb-monitor.md#switchover-force), which swaps a running primary with a replica, ignoring
   most errors. Can break replication.
 * [async-switchover](mariadb-maxscale-2308-mariadb-monitor.md#queued-switchover), which schedules a switchover and returns
 * [rejoin](mariadb-maxscale-2308-mariadb-monitor.md#rejoin), which directs servers to replicate from the primary
-* [reset-replication](mariadb-maxscale-2308-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and\
+* [reset-replication](mariadb-maxscale-2308-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
-See [operation details](mariadb-maxscale-2308-mariadb-monitor.md#operation-details) for more information on the\
+See [operation details](mariadb-maxscale-2308-mariadb-monitor.md#operation-details) for more information on the
 implementation of the commands.
 
-The cluster operations require that the monitor user (`user`) has the following\
+The cluster operations require that the monitor user (`user`) has the following
 privileges:
 
-* SUPER, to modify replica connections, set globals such as read\_only and kill\
+* SUPER, to modify replica connections, set globals such as read\_only and kill
   connections from other super-users
-* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list\
+* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list
   replica connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
@@ -468,19 +468,19 @@ privileges:
 * SELECT on mysql.user, to see which users have SUPER
 * SELECT on mysql.global\_priv so see to see which users have READ\_ONLY ADMIN
 
-A list of the grants can be found in the [Required Grants](mariadb-maxscale-2308-mariadb-monitor.md#required-grants)\
+A list of the grants can be found in the [Required Grants](mariadb-maxscale-2308-mariadb-monitor.md#required-grants)
 section.
 
-The privilege system was changed in MariaDB Server 10.5. The effects of this on\
-the MaxScale monitor user are minor, as the SUPER-privilege contains many of the\
-required privileges and is still required to kill connections from other\
+The privilege system was changed in MariaDB Server 10.5. The effects of this on
+the MaxScale monitor user are minor, as the SUPER-privilege contains many of the
+required privileges and is still required to kill connections from other
 super-users.
 
-In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required\
+In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required
 grants. The monitor requires:
 
 * READ\_ONLY ADMIN, to set read\_only
-* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication\
+* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication
   connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
@@ -490,19 +490,19 @@ grants. The monitor requires:
 * SELECT on mysql.user, to see which users have SUPER
 * SELECT on mysql.global\_priv so see to see which users have READ\_ONLY ADMIN
 
-In addition, the monitor needs to know which username and password a\
+In addition, the monitor needs to know which username and password a
 replica should use when starting replication. These are given in`replication_user` and `replication_password`.
 
-The user can define files with SQL statements which are executed on any server\
+The user can define files with SQL statements which are executed on any server
 being demoted or promoted by cluster manipulation commands. See the sections on`promotion_sql_file` and `demotion_sql_file` for more information.
 
-The monitor can manipulate scheduled server events when promoting or demoting a\
+The monitor can manipulate scheduled server events when promoting or demoting a
 server. See the section on `handle_events` for more information.
 
-All cluster operations can be activated manually through MaxCtrl. See\
+All cluster operations can be activated manually through MaxCtrl. See
 section [Manual activation](mariadb-maxscale-2308-mariadb-monitor.md#manual-activation) for more details.
 
-See [Limitations and requirements](mariadb-maxscale-2308-mariadb-monitor.md#limitations-and-requirements) for\
+See [Limitations and requirements](mariadb-maxscale-2308-mariadb-monitor.md#limitations-and-requirements) for
 information on possible issues with failover and switchover.
 
 #### Operation details
@@ -513,22 +513,22 @@ information on possible issues with failover and switchover.
 call command mariadbmon failover MONITOR
 ```
 
-**Failover** replaces a failed primary with a running replica. It does the\
+**Failover** replaces a failed primary with a running replica. It does the
 following:
 
-1. Select the most up-to-date replica of the old primary to be the new primary. The\
+1. Select the most up-to-date replica of the old primary to be the new primary. The
    selection criteria is as follows in descending priority:
 2. gtid\_IO\_pos (latest event in relay log)
 3. gtid\_current\_pos (most processed events)
 4. log\_slave\_updates is on
 5. disk space is not low
-6. If the new primary has unprocessed relay log items, cancel and try again\
+6. If the new primary has unprocessed relay log items, cancel and try again
    later.
 7. Prepare the new primary:
-8. Remove the replica connection the new primary used to replicate from the\
+8. Remove the replica connection the new primary used to replicate from the
    old primary.
 9. Disable the read\_only-flag.
-10. Enable scheduled server events (if event handling is on). Only events\
+10. Enable scheduled server events (if event handling is on). Only events
     that were enabled on the old primary are enabled.
 11. Run the commands in `promotion_sql_file`.
 12. Start replication from external primary if one existed.
@@ -538,7 +538,7 @@ following:
 16. START SLAVE
 17. Check that all replicas are replicating.
 
-Failover is considered successful if steps 1 to 3 succeed, as the cluster then\
+Failover is considered successful if steps 1 to 3 succeed, as the cluster then
 has at least a valid primary server.
 
 **Switchover**
@@ -547,26 +547,26 @@ has at least a valid primary server.
 call command mariadbmon switchover MONITOR [NEW_PRIMARY] [OLD_PRIMARY]
 ```
 
-**Switchover** swaps a running primary with a running replica. It does the\
+**Switchover** swaps a running primary with a running replica. It does the
 following:
 
 1. Prepare the old primary for demotion:
 2. If `backend_read_timeout` is short, extend it and reconnect.
 3. Stop any external replication.
 4. Enable the read\_only-flag to stop writes from normal users.
-5. Kill connections from super and read-only admin users since\
-   read\_only does not affect them. During this step, all writes are\
+5. Kill connections from super and read-only admin users since
+   read\_only does not affect them. During this step, all writes are
    blocked with "FLUSH TABLES WITH READ LOCK".
 6. Disable scheduled server events (if event handling is on).
 7. Run the commands in `demotion_sql_file`.
 8. Flush the binary log ("flush logs") so that all events are on disk.
 9. Wait a moment to check that gtid is stable.
 10. Wait for the new primary to catch up with the old primary.
-11. Promote new primary and redirect replicas as in failover steps 3 and 4. Also\
+11. Promote new primary and redirect replicas as in failover steps 3 and 4. Also
     redirect the demoted old primary.
 12. Check that all replicas are replicating.
 
-Similar to failover, switchover is considered successful if the new primary was\
+Similar to failover, switchover is considered successful if the new primary was
 successfully promoted.
 
 **Switchover-force**
@@ -575,11 +575,11 @@ successfully promoted.
 call command mariadbmon switchover-force MONITOR [NEW_PRIMARY] [OLD_PRIMARY]
 ```
 
-**Switchover-force** performs the same steps as a normal switchover but ignores\
-any errors on the old primary. Switchover-force also does not expect the new\
-primary to reach the gtid-position of the old, as the old primary\
-could be receiving more events constantly. Thus, switchover-force may lose\
-events and replication can break on multiple (or even all) replicas. This is\
+**Switchover-force** performs the same steps as a normal switchover but ignores
+any errors on the old primary. Switchover-force also does not expect the new
+primary to reach the gtid-position of the old, as the old primary
+could be receiving more events constantly. Thus, switchover-force may lose
+events and replication can break on multiple (or even all) replicas. This is
 an unsafe command and should only be used as a last resort.
 
 **Rejoin**
@@ -588,8 +588,8 @@ an unsafe command and should only be used as a last resort.
 call command mariadbmon rejoin MONITOR OLD_PRIMARY
 ```
 
-**Rejoin** joins a standalone server to the cluster or redirects a replica\
-replicating from a server other than the primary. A standalone server is joined\
+**Rejoin** joins a standalone server to the cluster or redirects a replica
+replicating from a server other than the primary. A standalone server is joined
 by:
 
 1. Run the commands in `demotion_sql_file`.
@@ -606,9 +606,9 @@ STOP SLAVE, RESET SLAVE, CHANGE MASTER TO and START SLAVE commands.
 maxctrl call command mariadbmon reset-replication MONITOR [NEW_PRIMARY]
 ```
 
-**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets\
-gtid:s. This destructive command is meant for situations where the gtid:s in the\
-cluster are out of sync while the actual data is known to be in sync. The\
+**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets
+gtid:s. This destructive command is meant for situations where the gtid:s in the
+cluster are out of sync while the actual data is known to be in sync. The
 operation proceeds as follows:
 
 1. Reset gtid:s and delete binary logs on all servers:
@@ -616,38 +616,38 @@ operation proceeds as follows:
 3. Enable the read\_only-flag.
 4. Disable scheduled server events (if event handling is on).
 5. Delete binary logs (RESET MASTER).
-6. Set the sequence number of gtid\_slave\_pos to zero. This also affects\
+6. Set the sequence number of gtid\_slave\_pos to zero. This also affects
    gtid\_current\_pos.
 7. Prepare new primary:
 8. Disable the read\_only-flag.
-9. Enable scheduled server events (if event handling is on). Events are\
-   only enabled if the cluster had a primary server when starting the\
-   reset-replication operation. Only events that were enabled on the previous\
+9. Enable scheduled server events (if event handling is on). Events are
+   only enabled if the cluster had a primary server when starting the
+   reset-replication operation. Only events that were enabled on the previous
    primary are enabled on the new.
-10. Direct other servers to replicate from the new primary as in the other\
+10. Direct other servers to replicate from the new primary as in the other
     operations.
 
 #### Manual activation
 
 Cluster operations can be activated manually through the REST API or MaxCtrl.\
-The commands are only performed when MaxScale is in active mode. The commands\
-generally match their automatic versions. The exception is _rejoin_, in which\
-the manual command allows rejoining even when the joining server has empty\
-gtid:s. This rule allows the user to force a rejoin on a server without binary\
+The commands are only performed when MaxScale is in active mode. The commands
+generally match their automatic versions. The exception is _rejoin_, in which
+the manual command allows rejoining even when the joining server has empty
+gtid:s. This rule allows the user to force a rejoin on a server without binary
 logs.
 
-All commands require the monitor instance name as the first parameter. Failover\
-selects the new primary server automatically and does not require additional\
+All commands require the monitor instance name as the first parameter. Failover
+selects the new primary server automatically and does not require additional
 parameters. Rejoin requires the name of the joining server as second parameter.\
 Replication reset accepts the name of the new primary server as second parameter.\
 If not given, the current primary is selected.
 
-Switchover takes one to three parameters. If only the monitor name is given,\
-switchover will autoselect both the replica to promote and the current primary as\
-the server to be demoted. If two parameters are given, the second parameter is\
-interpreted as the replica to promote. If three parameters are given, the third\
-parameter is interpreted as the current primary. The user-given current primary is\
-compared to the primary server currently deduced by the monitor and if the two\
+Switchover takes one to three parameters. If only the monitor name is given,
+switchover will autoselect both the replica to promote and the current primary as
+the server to be demoted. If two parameters are given, the second parameter is
+interpreted as the replica to promote. If three parameters are given, the third
+parameter is interpreted as the current primary. The user-given current primary is
+compared to the primary server currently deduced by the monitor and if the two
 are unequal, an error is given.
 
 Example commands are below:
@@ -663,28 +663,28 @@ maxctrl call command mariadbmon switchover MyMonitor NewPrimaryServ OldPrimarySe
 maxctrl call command mariadbmon switchover-force MyMonitor NewPrimaryServ
 ```
 
-The commands follow the standard module command syntax. All require the monitor\
-configuration name (MyMonitor) as the first parameter. For switchover, the\
-last two parameters define the server to promote (NewPrimaryServ) and the server\
-to demote (OldPrimaryServ). For rejoin, the server to join (OldPrimaryServ) is\
+The commands follow the standard module command syntax. All require the monitor
+configuration name (MyMonitor) as the first parameter. For switchover, the
+last two parameters define the server to promote (NewPrimaryServ) and the server
+to demote (OldPrimaryServ). For rejoin, the server to join (OldPrimaryServ) is
 required. Replication reset requires the server to promote (NewPrimaryServ).
 
-It is safe to perform manual operations even with automatic failover, switchover\
-or rejoin enabled since automatic operations cannot happen simultaneously\
+It is safe to perform manual operations even with automatic failover, switchover
+or rejoin enabled since automatic operations cannot happen simultaneously
 with manual ones.
 
-When a cluster modification is initiated via the REST-API, the URL path is of the\
+When a cluster modification is initiated via the REST-API, the URL path is of the
 form:
 
 ```
 /v1/maxscale/modules/mariadbmon/<operation>?<monitor-name>&<server-name1>&<server-name2>
 ```
 
-* `<operation>` is the name of the command e.g. failover, switchover,\
+* `<operation>` is the name of the command e.g. failover, switchover,
   rejoin or reset-replication.
 * `<monitor-name>` is the monitor name from the MaxScale configuration file.
-* `<server-name1>` and `<server-name2>` are server names as described\
-  above for MaxCtrl. Only switchover accepts both, failover doesn't need any\
+* `<server-name1>` and `<server-name2>` are server names as described
+  above for MaxCtrl. Only switchover accepts both, failover doesn't need any
   and both rejoin and reset-replication accept one.
 
 Given a MaxScale configuration file like
@@ -697,7 +697,7 @@ servers=server1, server2, server3, server 4
 ...
 ```
 
-with the assumption that `server2` is the current primary, then the URL\
+with the assumption that `server2` is the current primary, then the URL
 path for making `server4` the new primary would be:
 
 ```
@@ -714,9 +714,9 @@ Example REST-API paths for other commands are listed below.
 
 **Queued switchover**
 
-Most cluster modification commands wait until the operation either succeeds or\
-fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the\
-module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,\
+Most cluster modification commands wait until the operation either succeeds or
+fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the
+module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,
 whether queued or not.
 
 ```
@@ -733,123 +733,123 @@ maxctrl call command mariadbmon fetch-cmd-result Cluster1
 
 #### Automatic activation
 
-Failover can activate automatically if `auto_failover` is on. The activation\
+Failover can activate automatically if `auto_failover` is on. The activation
 begins when the primary has been down at least `failcount` monitor iterations.\
-Before modifying the cluster, the monitor checks that all prerequisites for the\
-failover are fulfilled. If the cluster does not seem ready, an error is printed\
+Before modifying the cluster, the monitor checks that all prerequisites for the
+failover are fulfilled. If the cluster does not seem ready, an error is printed
 and the cluster is rechecked during the next monitor iteration.
 
-Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the primary\
-server is low on disk space but otherwise the operating logic is quite similar\
+Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the primary
+server is low on disk space but otherwise the operating logic is quite similar
 to automatic failover.
 
-Rejoin stands for starting replication on a standalone server or redirecting a\
-replica replicating from the wrong primary (any server that is not the cluster\
-primary). The rejoined servers are directed to replicate from the current cluster\
-primary server, forcing the replication topology to a 1-primary-N-replicas\
+Rejoin stands for starting replication on a standalone server or redirecting a
+replica replicating from the wrong primary (any server that is not the cluster
+primary). The rejoined servers are directed to replicate from the current cluster
+primary server, forcing the replication topology to a 1-primary-N-replicas
 configuration.
 
-A server is categorized as standalone if the server has no replica connections,\
-not even stopped ones. A server is replicating from the wrong primary if the\
-replica IO thread is connected but the primary server id seen by the replica does not\
-match the cluster primary id. Alternatively, the IO thread may be stopped or\
-connecting but the primary server host or port information differs from the\
-cluster primary info. These criteria mean that a STOP SLAVE does not yet set a\
+A server is categorized as standalone if the server has no replica connections,
+not even stopped ones. A server is replicating from the wrong primary if the
+replica IO thread is connected but the primary server id seen by the replica does not
+match the cluster primary id. Alternatively, the IO thread may be stopped or
+connecting but the primary server host or port information differs from the
+cluster primary info. These criteria mean that a STOP SLAVE does not yet set a
 replica as standalone.
 
-With `auto_rejoin` active, the monitor will try to rejoin any servers matching\
-the above requirements. Rejoin does not obey `failcount` and will attempt to\
-rejoin any valid servers immediately. When activating rejoin manually, the\
+With `auto_rejoin` active, the monitor will try to rejoin any servers matching
+the above requirements. Rejoin does not obey `failcount` and will attempt to
+rejoin any valid servers immediately. When activating rejoin manually, the
 user-designated server must fulfill the same requirements.
 
 #### Limitations and requirements
 
-Switchover and failover are meant for simple topologies (one primary and\
-several replicas). Using these commands with complicated topologies\
-(multiple primaries, relays, circular replication) may give unpredictable results\
+Switchover and failover are meant for simple topologies (one primary and
+several replicas). Using these commands with complicated topologies
+(multiple primaries, relays, circular replication) may give unpredictable results
 and should be tested before use on a production system.
 
-The server cluster is assumed to be well-behaving with no significant\
-replication lag (within `failover_timeout`/`switchover_timeout`) and all\
+The server cluster is assumed to be well-behaving with no significant
+replication lag (within `failover_timeout`/`switchover_timeout`) and all
 commands that modify the cluster (such as "STOP SLAVE", "CHANGE MASTER",\
-"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`\
+"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`
 and `backend_write_timeout`).
 
-The backends must all use GTID-based replication, and the domain id should not\
-change during a switchover or failover. Replicas should not have extra\
+The backends must all use GTID-based replication, and the domain id should not
+change during a switchover or failover. Replicas should not have extra
 local events so that GTIDs are compatible across the cluster.
 
-Failover cannot be performed if MaxScale was started only after the primary\
-server went down. This is because MaxScale needs reliable information on the\
-gtid domain of the cluster and the replication topology in general to properly\
+Failover cannot be performed if MaxScale was started only after the primary
+server went down. This is because MaxScale needs reliable information on the
+gtid domain of the cluster and the replication topology in general to properly
 select the new primary. `enforce_simple_topology=1` relaxes this requirement.
 
-Failover may lose events. If a primary goes down before sending new events to at\
-least one replica, those events are lost when a new primary is chosen. If the old\
-primary comes back online, the other servers have likely moved on with a\
+Failover may lose events. If a primary goes down before sending new events to at
+least one replica, those events are lost when a new primary is chosen. If the old
+primary comes back online, the other servers have likely moved on with a
 diverging history and the old primary can no longer join the replication cluster.
 
 To reduce the chance of losing data, use [semisynchronous replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication).\
-In semisynchronous mode, the primary waits for a replica to receive an event before\
-returning an acknowledgement to the client. This does not yet guarantee a clean\
-failover. If the primary fails after preparing a transaction but before receiving\
-replica acknowledgement, it will still commit the prepared transaction as part of\
-its crash recovery. If the replicas never saw this transaction, the\
-old primary has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
+In semisynchronous mode, the primary waits for a replica to receive an event before
+returning an acknowledgement to the client. This does not yet guarantee a clean
+failover. If the primary fails after preparing a transaction but before receiving
+replica acknowledgement, it will still commit the prepared transaction as part of
+its crash recovery. If the replicas never saw this transaction, the
+old primary has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
 for more information. This situation is much less likely in MariaDB Server\
-10.6.2 and later, as the improved crash recovery logic will delete such\
+10.6.2 and later, as the improved crash recovery logic will delete such
 transactions.
 
-Even a controlled shutdown of the primary may lose events. The server does not by\
-default wait for all data to be replicated to the replicas when shutting down and\
-instead simply closes all connections. Before shutting down the primary with the\
-intention of having a replica promoted, run _switchover_ first to ensure that all\
+Even a controlled shutdown of the primary may lose events. The server does not by
+default wait for all data to be replicated to the replicas when shutting down and
+instead simply closes all connections. Before shutting down the primary with the
+intention of having a replica promoted, run _switchover_ first to ensure that all
 data is replicated. For more information on server shutdown, see [Binary Log Dump Threads and the Shutdown Process](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-threads).
 
-Switchover requires that the cluster is "frozen" for the duration of the\
-operation. This means that no data modifying statements such as INSERT or UPDATE\
-are executed and the GTID position of the primary server is stable. When\
-switchover begins, the monitor sets the global _read\_only_ flag on the old\
+Switchover requires that the cluster is "frozen" for the duration of the
+operation. This means that no data modifying statements such as INSERT or UPDATE
+are executed and the GTID position of the primary server is stable. When
+switchover begins, the monitor sets the global _read\_only_ flag on the old
 primary backend to stop any updates. _read\_only_ does not affect users with the\
-SUPER-privilege so any such user can issue writes during a switchover. These\
-writes have a high chance of breaking replication, because the write may not be\
-replicated to all replicas before they switch to the new primary. To prevent this,\
-any users who commonly do updates should NOT have the SUPER-privilege. For even\
+SUPER-privilege so any such user can issue writes during a switchover. These
+writes have a high chance of breaking replication, because the write may not be
+replicated to all replicas before they switch to the new primary. To prevent this,
+any users who commonly do updates should NOT have the SUPER-privilege. For even
 more security, the only SUPER-user session during a switchover should be the\
-MaxScale monitor user. This also applies to users running scheduled server\
-events. Although the monitor by default disables events on the master, an\
-event may already be executing. If the event definer has SUPER-privilege, the\
+MaxScale monitor user. This also applies to users running scheduled server
+events. Although the monitor by default disables events on the master, an
+event may already be executing. If the event definer has SUPER-privilege, the
 event can write to the database even through _read\_only_.
 
-When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest\
-of the cluster. If the current cluster primary does not have binary logs from the\
-moment the rejoining server lost connection, the rejoining server cannot\
-continue replication. This is an issue if the primary has changed and\
+When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest
+of the cluster. If the current cluster primary does not have binary logs from the
+moment the rejoining server lost connection, the rejoining server cannot
+continue replication. This is an issue if the primary has changed and
 the new primary does not have _log\_slave\_updates_ on.
 
-If an automatic cluster operation such as auto-failover or auto-rejoin fails,\
-all cluster modifying operations are disabled for `failcount` monitor iterations,\
-after which the operation may be retried. Similar logic applies if the cluster is\
+If an automatic cluster operation such as auto-failover or auto-rejoin fails,
+all cluster modifying operations are disabled for `failcount` monitor iterations,
+after which the operation may be retried. Similar logic applies if the cluster is
 unsuitable for such operations, e.g. replication is not using GTID.
 
 #### External primary support
 
-The monitor detects if a server in the cluster is replicating from an external\
-primary (a server that is not monitored by the monitor). If the replicating\
-server is the cluster primary server, then the cluster itself is considered to\
+The monitor detects if a server in the cluster is replicating from an external
+primary (a server that is not monitored by the monitor). If the replicating
+server is the cluster primary server, then the cluster itself is considered to
 have an external primary.
 
-If a failover/switchover happens, the new primary server is set to replicate from\
-the cluster external primary server. The username and password for the replication\
-are defined in `replication_user` and `replication_password`. The address and\
-port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster\
-primary server. In the case of switchover, the old primary also stops replicating\
+If a failover/switchover happens, the new primary server is set to replicate from
+the cluster external primary server. The username and password for the replication
+are defined in `replication_user` and `replication_password`. The address and
+port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster
+primary server. In the case of switchover, the old primary also stops replicating
 from the external server to preserve the topology.
 
-After failover the new primary is replicating from the external primary. If the\
-failed old primary comes back online, it is also replicating from the external\
-server. To normalize the situation, either have _auto\_rejoin_ on or manually\
-execute a rejoin. This will redirect the old primary to the current cluster\
+After failover the new primary is replicating from the external primary. If the
+failed old primary comes back online, it is also replicating from the external
+server. To normalize the situation, either have _auto\_rejoin_ on or manually
+execute a rejoin. This will redirect the old primary to the current cluster
 primary.
 
 #### Configuration parameters
@@ -861,18 +861,18 @@ primary.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic primary failover. When automatic failover is enabled, MaxScale\
-will elect a new primary server for the cluster if the old primary goes down. A\
-server is assumed _Down_ if it cannot be connected to, even if this is caused by\
+Enable automatic primary failover. When automatic failover is enabled, MaxScale
+will elect a new primary server for the cluster if the old primary goes down. A
+server is assumed _Down_ if it cannot be connected to, even if this is caused by
 incorrect credentials. Failover triggers if the primary stays down for [failcount](mariadb-maxscale-2308-mariadb-monitor.md#failcount) monitor intervals. Failover will not take place if\
 MaxScale is set [passive](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#passive).
 
-As failover alters replication, it requires more privileges than normal\
+As failover alters replication, it requires more privileges than normal
 monitoring. See [here](mariadb-maxscale-2308-mariadb-monitor.md#cluster-manipulation-grants) for a list of grants.
 
-Failover is designed to be used with simple primary-replica topologies. More\
-complicated topologies, such as multilayered or circular replication, are not\
-guaranteed to always work correctly. Test before using failover with such\
+Failover is designed to be used with simple primary-replica topologies. More
+complicated topologies, such as multilayered or circular replication, are not
+guaranteed to always work correctly. Test before using failover with such
 setups.
 
 **`auto_rejoin`**
@@ -882,20 +882,20 @@ setups.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic joining of servers to the cluster. When enabled, MaxScale will\
-attempt to direct servers to replicate from the current cluster primary if they\
-are not currently doing so. Replication will be started on any standalone\
+Enable automatic joining of servers to the cluster. When enabled, MaxScale will
+attempt to direct servers to replicate from the current cluster primary if they
+are not currently doing so. Replication will be started on any standalone
 servers. Servers that are replicating from another server will be redirected.\
-This effectively enforces a 1-primary-N-replicas topology. The current primary\
-itself is not redirected, so it can continue to replicate from an external\
-primary. Rejoin is also not performed on any server that is replicating from\
-multiple sources, as this indicates a complicated topology (this rule is\
+This effectively enforces a 1-primary-N-replicas topology. The current primary
+itself is not redirected, so it can continue to replicate from an external
+primary. Rejoin is also not performed on any server that is replicating from
+multiple sources, as this indicates a complicated topology (this rule is
 overridden by [enforce\_simple\_topology](mariadb-maxscale-2308-mariadb-monitor.md#enforce_simple_topology)).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2308-mariadb-monitor.md#auto_failover) to redirect\
-the former primary when it comes back online. Sometimes this kind of rejoin will\
-fail as the old primary may have transactions that were never replicated to the\
-current one. See [limitations](mariadb-maxscale-2308-mariadb-monitor.md#limitations-and-requirements) for more\
+This feature is often paired with [auto\_failover](mariadb-maxscale-2308-mariadb-monitor.md#auto_failover) to redirect
+the former primary when it comes back online. Sometimes this kind of rejoin will
+fail as the old primary may have transactions that were never replicated to the
+current one. See [limitations](mariadb-maxscale-2308-mariadb-monitor.md#limitations-and-requirements) for more
 information.
 
 As an example, consider the following series of events:
@@ -905,9 +905,9 @@ As an example, consider the following series of events:
 3. Replica A comes back
 4. Old primary comes back
 
-Replica A is still trying to replicate from the downed primary, since it wasn't\
-online during failover. If _auto\_rejoin_ is on, Replica A will quickly be\
-redirected to Replica B, the current primary. The old primary will also rejoin the\
+Replica A is still trying to replicate from the downed primary, since it wasn't
+online during failover. If _auto\_rejoin_ is on, Replica A will quickly be
+redirected to Replica B, the current primary. The old primary will also rejoin the
 cluster if possible.
 
 **`switchover_on_low_disk_space`**
@@ -940,18 +940,18 @@ switchover_on_low_disk_space=true
 * Default: `false`
 
 This setting tells the monitor to assume that the servers should be arranged in a\
-1-primary-N-replicas topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual\
+1-primary-N-replicas topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual
 settings.
 
-By default, mariadbmon will not rejoin servers with more than one replication\
-stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the\
-cluster and any extra replication sources will be removed. This is done to make\
+By default, mariadbmon will not rejoin servers with more than one replication
+stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the
+cluster and any extra replication sources will be removed. This is done to make
 automated failover with multi-source external replication possible.
 
-This setting also allows the monitor to perform a failover to a cluster where the primary\
-server has not been seen \[Running]. This is usually the case when the primary goes down\
-before MaxScale is started. When using this feature, the monitor will guess the GTID\
-domain id of the primary from the replicas. For reliable results, the GTID:s of the cluster\
+This setting also allows the monitor to perform a failover to a cluster where the primary
+server has not been seen \[Running]. This is usually the case when the primary goes down
+before MaxScale is started. When using this feature, the monitor will guess the GTID
+domain id of the primary from the replicas. For reliable results, the GTID:s of the cluster
 should be simple.
 
 ```
@@ -965,19 +965,19 @@ enforce_simple_topology=true
 * Dynamic: Yes
 * Default: None
 
-The username and password of the replication user. These are given as the values\
-for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is\
+The username and password of the replication user. These are given as the values
+for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is
 executed.
 
-Both `replication_user` and `replication_password` parameters must be defined if\
-a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication\
+Both `replication_user` and `replication_password` parameters must be defined if
+a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication
 user.
 
-The credentials used for replication must have the `REPLICATION SLAVE`\
+The credentials used for replication must have the `REPLICATION SLAVE`
 privilege.
 
-`replication_password` uses the same encryption scheme as other password\
-parameters. If password encryption is in use, `replication_password` must be\
+`replication_password` uses the same encryption scheme as other password
+parameters. If password encryption is in use, `replication_password` must be
 encrypted with the same key to avoid erroneous decryption.
 
 **`replication_master_ssl`**
@@ -987,25 +987,25 @@ encrypted with the same key to avoid erroneous decryption.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable\
-encryption for the replication stream. This setting should only be enabled if the backend\
-servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication\
+If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable
+encryption for the replication stream. This setting should only be enabled if the backend
+servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication
 user should require an encrypted connection (`e.g. ALTER USER repl@'%' REQUIRE SSL;`).
 
-If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing\
+If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing
 settings when redirecting a replica connection.
 
 **`replication_custom_options`**
 
 Type: string
 
-A custom string added to "CHANGE MASTER TO"-commands sent by the monitor\
-whenever setting up replication (e.g. during switchover). Useful for defining\
-ssl certificates or other specialized replication options. MaxScale does not\
-check the contents of the string, so care should be taken to ensure that\
-only valid options are set and that the contents do not interfere with\
-the options MaxScale sets on its own (e.g. MASTER\_HOST). This setting can\
-also be configured for an individual server. If configured for both\
+A custom string added to "CHANGE MASTER TO"-commands sent by the monitor
+whenever setting up replication (e.g. during switchover). Useful for defining
+ssl certificates or other specialized replication options. MaxScale does not
+check the contents of the string, so care should be taken to ensure that
+only valid options are set and that the contents do not interfere with
+the options MaxScale sets on its own (e.g. MASTER\_HOST). This setting can
+also be configured for an individual server. If configured for both
 the monitor and a server, the server setting takes priority.
 
 ```
@@ -1022,19 +1022,19 @@ replication_custom_options=MASTER_SSL_CERT = '/tmp/certs/client-cert.pem',
 * Dynamic: Yes
 * Default: `90s`
 
-Time limit for failover and switchover operations. The default\
-values are 90 seconds for both. `switchover_timeout` is also used as the time\
-limit for a rejoin operation. Rejoin should rarely time out, since it is a\
+Time limit for failover and switchover operations. The default
+values are 90 seconds for both. `switchover_timeout` is also used as the time
+limit for a rejoin operation. Rejoin should rarely time out, since it is a
 faster operation than switchover.
 
-The timeouts are specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeouts is seconds, a timeout specified in milliseconds will be rejected,\
+The timeouts are specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeouts is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If no successful failover/switchover takes place within the configured time\
-period, a message is logged and automatic failover is disabled. This prevents\
+If no successful failover/switchover takes place within the configured time
+period, a message is logged and automatic failover is disabled. This prevents
 further automatic modifications to the misbehaving cluster.
 
 **`verify_master_failure`**
@@ -1046,24 +1046,24 @@ further automatic modifications to the misbehaving cluster.
 
 Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and [master\_failure\_timeout](mariadb-maxscale-2308-mariadb-monitor.md#master_failure_timeout) defines the timeout.
 
-The primary failure timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The primary failure timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-Failure verification is performed by checking whether the replica servers are\
-still connected to the primary and receiving events. An event is either a change\
-in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat\
-event. Effectively, if a replica has received an event within`master_failure_timeout` duration, the primary is not considered down when\
-deciding whether to failover, even if MaxScale cannot connect to the primary.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of\
+Failure verification is performed by checking whether the replica servers are
+still connected to the primary and receiving events. An event is either a change
+in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat
+event. Effectively, if a replica has received an event within`master_failure_timeout` duration, the primary is not considered down when
+deciding whether to failover, even if MaxScale cannot connect to the primary.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of
 the replica connection to be effective.
 
 If every replica loses its connection to the primary (_Slave\_IO\_Running_ is not\
-"Yes"), primary failure is considered verified regardless of timeout. This allows\
+"Yes"), primary failure is considered verified regardless of timeout. This allows
 faster failover when the primary properly disconnects.
 
-For automatic failover to activate, the `failcount` requirement must also be\
+For automatic failover to activate, the `failcount` requirement must also be
 met.
 
 **`master_failure_timeout`**
@@ -1073,10 +1073,10 @@ met.
 * Dynamic: Yes
 * Default: `10s`
 
-`master_failure_timeout` is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+`master_failure_timeout` is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 **`servers_no_promotion`**
@@ -1086,11 +1086,11 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: None
 
-This is a comma-separated list of server names that will not be chosen for\
-primary promotion during a failover or autoselected for switchover. This does not\
-affect switchover if the user selects the server to promote. Using this setting\
-can disrupt new primary selection for failover such that an non-optimal server is\
-chosen. At worst, this will cause replication to break. Alternatively, failover\
+This is a comma-separated list of server names that will not be chosen for
+primary promotion during a failover or autoselected for switchover. This does not
+affect switchover if the user selects the server to promote. Using this setting
+can disrupt new primary selection for failover such that an non-optimal server is
+chosen. At worst, this will cause replication to break. Alternatively, failover
 may fail if all valid promotion candidates are in the exclusion list.
 
 ```
@@ -1105,30 +1105,30 @@ servers_no_promotion=backup_dc_server1,backup_dc_server2
 * Default: None
 
 These optional settings are paths to text files with SQL statements in them.\
-During promotion or demotion, the contents are read line-by-line and executed on\
-the backend. Use these settings to execute custom statements on the servers to\
+During promotion or demotion, the contents are read line-by-line and executed on
+the backend. Use these settings to execute custom statements on the servers to
 complement the built-in operations.
 
-Empty lines or lines starting with '#' are ignored. Any results returned by the\
-statements are ignored. All statements must succeed for the failover, switchover\
-or rejoin to continue. The monitor user may require additional privileges and\
+Empty lines or lines starting with '#' are ignored. Any results returned by the
+statements are ignored. All statements must succeed for the failover, switchover
+or rejoin to continue. The monitor user may require additional privileges and
 grants for the custom commands to succeed.
 
-When promoting a replica to primary during switchover or failover, the`promotion_sql_file` is read and executed on the new primary server after its\
-read-only flag is disabled. The commands are ran _before_ starting replication\
+When promoting a replica to primary during switchover or failover, the`promotion_sql_file` is read and executed on the new primary server after its
+read-only flag is disabled. The commands are ran _before_ starting replication
 from an external primary if any.
 
-`demotion_sql_file` is ran on an old primary during demotion to replica, before the\
-old primary starts replicating from the new primary. The file is also ran before\
-rejoining a standalone server to the cluster, as the standalone server is\
-typically a former primary server. When redirecting a replica replicating from a\
+`demotion_sql_file` is ran on an old primary during demotion to replica, before the
+old primary starts replicating from the new primary. The file is also ran before
+rejoining a standalone server to the cluster, as the standalone server is
+typically a former primary server. When redirecting a replica replicating from a
 wrong primary, the sql-file is not executed.
 
-Since the queries in the files are ran during operations which modify\
-replication topology, care is required. If `promotion_sql_file` contains data\
-modification (DML) queries, the new primary server may not be able to\
-successfully replicate from an external primary. `demotion_sql_file` should never\
-contain DML queries, as these may not replicate to the replica servers before\
+Since the queries in the files are ran during operations which modify
+replication topology, care is required. If `promotion_sql_file` contains data
+modification (DML) queries, the new primary server may not be able to
+successfully replicate from an external primary. `demotion_sql_file` should never
+contain DML queries, as these may not replicate to the replica servers before
 replica threads are stopped, breaking replication.
 
 ```
@@ -1143,122 +1143,122 @@ demotion_sql_file=/home/root/scripts/demotion.sql
 * Dynamic: Yes
 * Default: `true`
 
-If enabled, the monitor continuously queries the\
-servers for enabled scheduled events and uses this information when performing\
+If enabled, the monitor continuously queries the
+servers for enabled scheduled events and uses this information when performing
 cluster operations, enabling and disabling events as appropriate.
 
 When a server is being demoted, any events with "ENABLED" status are set to\
 "SLAVESIDE\_DISABLED". When a server is being promoted to primary, events that are either\
-"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled\
-on the old primary server last time it was successfully queried. Events are considered\
-identical if they have the same schema and name. When a standalone server is rejoined to\
+"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled
+on the old primary server last time it was successfully queried. Events are considered
+identical if they have the same schema and name. When a standalone server is rejoined to
 the cluster, its events are also disabled since it is now a replica.
 
-The monitor does not check whether the same events were disabled and enabled during a\
+The monitor does not check whether the same events were disabled and enabled during a
 switchover or failover/rejoin. All events that meet the criteria above are altered.
 
-The monitor does not enable or disable the event scheduler itself. For the\
-events to run on the new primary server, the scheduler should be enabled by the\
+The monitor does not enable or disable the event scheduler itself. For the
+events to run on the new primary server, the scheduler should be enabled by the
 admin. Enabling it in the server configuration file is recommended.
 
-Events running at high frequency may cause replication to break in a failover\
-scenario. If an old primary which was failed over restarts, its event scheduler\
-will be on if set in the server configuration file. Its events will also\
-remember their "ENABLED"-status and run when scheduled. This may happen before\
-the monitor rejoins the server and disables the events. This should only be an\
-issue for events running more often than the monitor interval or events that run\
+Events running at high frequency may cause replication to break in a failover
+scenario. If an old primary which was failed over restarts, its event scheduler
+will be on if set in the server configuration file. Its events will also
+remember their "ENABLED"-status and run when scheduled. This may happen before
+the monitor rejoins the server and disables the events. This should only be an
+issue for events running more often than the monitor interval or events that run
 immediately after the server has restarted.
 
 ### Cooperative monitoring
 
-As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means\
-that multiple monitors (typically in different MaxScale instances) can monitor\
-the same backend server cluster and only one will be the primary monitor. Only\
+As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means
+that multiple monitors (typically in different MaxScale instances) can monitor
+the same backend server cluster and only one will be the primary monitor. Only
 the primary monitor may perform _switchover_, _failover_ or _rejoin_ operations.\
-The primary also decides which server is the primary. Cooperative monitoring is\
+The primary also decides which server is the primary. Cooperative monitoring is
 enabled with the [cooperative\_monitoring\_locks](mariadb-maxscale-2308-mariadb-monitor.md#cooperative_monitoring_locks)-setting.\
 Even with this setting, only one monitor per server per MaxScale is allowed.\
-This limitation can be circumvented by defining multiple copies of a server in\
+This limitation can be circumvented by defining multiple copies of a server in
 the configuration file.
 
-Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)\
-for coordinating between monitors. When cooperating, the monitor regularly\
-checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and\
-acquires it if free. If the monitor acquires a majority of locks, it is the\
+Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)
+for coordinating between monitors. When cooperating, the monitor regularly
+checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and
+acquires it if free. If the monitor acquires a majority of locks, it is the
 primary. If a monitor cannot claim majority locks, it is a secondary monitor.
 
 The primary monitor of a cluster also acquires the lock _maxscale\_mariadbmonitor\_master_ on the primary server. Secondary monitors check
 which server this lock is taken on and only accept that server as the primary.\
-This arrangement is required so that multiple monitors can agree on which server\
-is the primary regardless of replication topology. If a secondary monitor does\
-not see the primary-lock taken, then it won't mark any server as \[Master],\
+This arrangement is required so that multiple monitors can agree on which server
+is the primary regardless of replication topology. If a secondary monitor does
+not see the primary-lock taken, then it won't mark any server as \[Master],
 causing writes to fail.
 
-The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor\
-needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three\
-servers needs two locks for majority, a cluster of four needs three, and a\
+The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor
+needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three
+servers needs two locks for majority, a cluster of four needs three, and a
 cluster of five needs three.\
-This scheme is resistant against split-brain situations in the sense\
-that multiple monitors cannot be primary simultaneously. However, a split may\
-cause both monitors to consider themselves secondary, in which case a primary\
+This scheme is resistant against split-brain situations in the sense
+that multiple monitors cannot be primary simultaneously. However, a split may
+cause both monitors to consider themselves secondary, in which case a primary
 server won't be detected.
 
-Even without a network split, `cooperative_monitoring_locks=majority_of_all`\
-will lead to neither monitor claiming lock majority once too many servers go\
-down. This scenario is depicted in the image below. Only two out of four servers\
-are running when three are needed for majority. Although both MaxScales see both\
-running servers, neither is certain they have majority and the cluster stays in\
+Even without a network split, `cooperative_monitoring_locks=majority_of_all`
+will lead to neither monitor claiming lock majority once too many servers go
+down. This scenario is depicted in the image below. Only two out of four servers
+are running when three are needed for majority. Although both MaxScales see both
+running servers, neither is certain they have majority and the cluster stays in
 read-only mode. If the primary server is down, no failover is performed either.
 
-Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only\
-servers currently \[Running] are considered. This scheme adapts to multiple\
+Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only
+servers currently \[Running] are considered. This scheme adapts to multiple
 servers going down, ensuring that claiming lock majority is always possible.\
-However, it can lead to multiple monitors claiming primary status in a\
-split-brain situation. As an example, consider a cluster with servers 1 to 4\
-with MaxScales A and B, as in the image below. MaxScale A can connect to\
-servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to\
-a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B\
+However, it can lead to multiple monitors claiming primary status in a
+split-brain situation. As an example, consider a cluster with servers 1 to 4
+with MaxScales A and B, as in the image below. MaxScale A can connect to
+servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to
+a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B
 does the opposite, claiming servers 3 and 4 and assuming 1 and 2 are down.\
-Both MaxScales claim two locks out of two available and assume that they have\
-lock majority. Both MaxScales may then promote their own primaries and route\
+Both MaxScales claim two locks out of two available and assume that they have
+lock majority. Both MaxScales may then promote their own primaries and route
 writes to different servers.
 
-The recommended strategy depends on which failure scenario is more likely and/or\
-more destructive. If it's unlikely that multiple servers are ever down\
-simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other\
-hand, if split-brain is unlikely but multiple servers may be down\
+The recommended strategy depends on which failure scenario is more likely and/or
+more destructive. If it's unlikely that multiple servers are ever down
+simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other
+hand, if split-brain is unlikely but multiple servers may be down
 simultaneously, then _majority\_of\_running_ would keep the cluster operational.
 
-To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the\
-monitor has lock majority on the cluster. If cooperative monitoring is disabled,\
-the field value is _null_. Lock information for individual servers is listed in\
-the server-specific field **lock\_held**. Again, _null_ indicates that locks are\
+To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the
+monitor has lock majority on the cluster. If cooperative monitoring is disabled,
+the field value is _null_. Lock information for individual servers is listed in
+the server-specific field **lock\_held**. Again, _null_ indicates that locks are
 not in use or the lock status is unknown.
 
-If a MaxScale instance tries to acquire the locks but fails to get majority\
-(perhaps another MaxScale was acquiring locks simultaneously) it will release\
-any acquired locks and try again after a random number of monitor ticks. This\
+If a MaxScale instance tries to acquire the locks but fails to get majority
+(perhaps another MaxScale was acquiring locks simultaneously) it will release
+any acquired locks and try again after a random number of monitor ticks. This
 prevents multiple MaxScales from fighting over the locks continuously as one\
-MaxScale will eventually wait less time than the others. Conflict probability\
+MaxScale will eventually wait less time than the others. Conflict probability
 can be further decreased by configuring each monitor with a different\_monitor\_interval\_.
 
 The flowchart below illustrates the lock handling logic.
 
 #### Releasing locks
 
-Monitor cooperation depends on the server locks. The locks are\
-connection-specific. The owning connection can manually release a lock, allowing\
+Monitor cooperation depends on the server locks. The locks are
+connection-specific. The owning connection can manually release a lock, allowing
 another connection to claim it. Also, if the owning connection closes, the\
-MariaDB Server process releases the lock. How quickly a lost connection is\
-detected affects how quickly the primary monitor status moves from one monitor\
+MariaDB Server process releases the lock. How quickly a lost connection is
+detected affects how quickly the primary monitor status moves from one monitor
 and MaxScale to another.
 
-If the primary MaxScale or its monitor is stopped normally, the monitor\
+If the primary MaxScale or its monitor is stopped normally, the monitor
 connections are properly closed, releasing the locks. This allows the secondary\
-MaxScale to quickly claim the locks. However, if the primary simply vanishes\
+MaxScale to quickly claim the locks. However, if the primary simply vanishes
 (broken network), the connection may just look idle. In this case, the\
-MariaDB Server may take a long time before it considers the monitor connection\
-lost. This time ultimately depends on TCP keepalive settings on the machines\
+MariaDB Server may take a long time before it considers the monitor connection
+lost. This time ultimately depends on TCP keepalive settings on the machines
 running MariaDB Server.
 
 On MariaDB Server 10.3.3 and later, the TCP keepalive settings can be configured\
@@ -1267,15 +1267,15 @@ for information on settings _tcp\_keepalive\_interval_, _tcp\_keepalive\_probes_
 level, as described [here](https://www.tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html).
 
 As of MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6 and 24.02.2, configuring\
-TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_\
-variable when acquiring a lock. This causes the MariaDB Server to close the\
-monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout\
+TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_
+variable when acquiring a lock. This causes the MariaDB Server to close the
+monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout
 settings, and is logged at MaxScale startup.
 
-A monitor can also be ordered to manually release its locks via the module\
-command _release-locks_. This is useful for manually changing the primary\
-monitor. After running the release-command, the monitor will not attempt to\
-reacquire the locks for one minute, even if it wasn't the primary monitor to\
+A monitor can also be ordered to manually release its locks via the module
+command _release-locks_. This is useful for manually changing the primary
+monitor. After running the release-command, the monitor will not attempt to
+reacquire the locks for one minute, even if it wasn't the primary monitor to
 begin with. This command can cause the cluster to become temporarily unusable by\
 MaxScale. Only use it when there is another monitor ready to claim the locks.
 
@@ -1285,38 +1285,38 @@ maxctrl call command mariadbmon release-locks MyMonitor1
 
 ### Backup operations
 
-Backup operations manipulate the contents of a MariaDB Server, saving it or\
+Backup operations manipulate the contents of a MariaDB Server, saving it or
 overwriting it. MariaDB-Monitor supports three backup operations:
 
-1. rebuild-server: Replace the contents of a database server with the\
+1. rebuild-server: Replace the contents of a database server with the
    contents of another.
-2. create-backup: Copy the contents of a database server to a storage\
+2. create-backup: Copy the contents of a database server to a storage
    location.
-3. restore-from-backup: Overwrite the contents of a database server with a\
+3. restore-from-backup: Overwrite the contents of a database server with a
    backup.
 
-These operations do not modify server config files, only files in the data\
+These operations do not modify server config files, only files in the data
 directory _/var/lib/mysql_ are affected.
 
 All of these operations are monitor commands and best launched with MaxCtrl.\
-The operations are asynchronous, which means MaxCtrl won't wait for the\
-operation to complete and instead immediately returns "OK". To see the current\
-status of an operation, either check MaxScale log or use the\
-fetch-cmd-result-command\
+The operations are asynchronous, which means MaxCtrl won't wait for the
+operation to complete and instead immediately returns "OK". To see the current
+status of an operation, either check MaxScale log or use the
+fetch-cmd-result-command
 (e.g. `maxctrl call command mariadbmon fetch-cmd-result MyMonitor`).
 
-To perform backup operations, MaxScale requires ssh-access on all affected\
+To perform backup operations, MaxScale requires ssh-access on all affected
 machines. The _ssh\_user_ and _ssh\_keyfile_-settings define the SSH credentials\
-MaxScale uses to access the servers. MaxScale must be able to run commands with\_sudo\_ on both the source and target servers. See [settings](mariadb-maxscale-2308-mariadb-monitor.md#settings) and [sudoers.d configuration](mariadb-maxscale-2308-mariadb-monitor.md#sudoersd-configuration) below\
+MaxScale uses to access the servers. MaxScale must be able to run commands with\_sudo\_ on both the source and target servers. See [settings](mariadb-maxscale-2308-mariadb-monitor.md#settings) and [sudoers.d configuration](mariadb-maxscale-2308-mariadb-monitor.md#sudoersd-configuration) below
 for more information.
 
 The following tools need to be installed on the backends:
 
 1. mariadb-backup. Backs up and restores MariaDB Server contents. Installed e.g.\
-   with `yum install MariaDB-backup`. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/) for more\
+   with `yum install MariaDB-backup`. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/) for more
    information.
 2. pigz. Compresses and decompresses the backup stream. Installed e.g. with`yum install pigz`.
-3. socat. Streams data from one machine to another. Is likely already\
+3. socat. Streams data from one machine to another. Is likely already
    installed. If not, can be installed e.g. with `yum install socat`.
 
 mariadb-backup needs server credentials to log in and authenticate to the\
@@ -1326,91 +1326,91 @@ for more details.
 
 #### Rebuild server
 
-The rebuild server-operation replaces the contents of a database server with the\
-contents of another server. The source server is effectively cloned and all data\
-on the target server is lost. This is useful when a replica server has diverged\
+The rebuild server-operation replaces the contents of a database server with the
+contents of another server. The source server is effectively cloned and all data
+on the target server is lost. This is useful when a replica server has diverged
 from the primary server, or when adding a new server to the cluster.\
-MaxScale performs this operation by running mariadb-backup on both the\
+MaxScale performs this operation by running mariadb-backup on both the
 source and target servers.
 
-When launched, the rebuild operation proceeds as below. If any step fails, the\
+When launched, the rebuild operation proceeds as below. If any step fails, the
 operation is stopped and the target server will be left in an unspecified state.
 
-1. Log in to both servers with ssh and check that the tools listed above are\
+1. Log in to both servers with ssh and check that the tools listed above are
    present (e.g. `mariadb-backup -v` should succeed).
-2. Check that the port used for transferring the backup is free on the source\
-   server. If not, kill the process holding it. This requires running lsof and\
+2. Check that the port used for transferring the backup is free on the source
+   server. If not, kill the process holding it. This requires running lsof and
    kill.
-3. Test the connection by streaming a short message from the source host to the\
+3. Test the connection by streaming a short message from the source host to the
    target.
-4. Launch mariadb-backup on the source machine, compress the stream and listen\
+4. Launch mariadb-backup on the source machine, compress the stream and listen
    for an incoming connection. This is performed with a command like`mariadb-backup --backup --safe-slave-backup --stream=xbstream | pigz -c | socat - TCP-LISTEN:<port>`.
-5. Stop MariaDB-server on the target machine and delete all contents of the data\
+5. Stop MariaDB-server on the target machine and delete all contents of the data
    directory /var/lib/mysql.
-6. On the target machine, connect to the source machine, read the backup stream,\
-   decompress it and write to the data directory. This is performed with a command\
-   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can\
+6. On the target machine, connect to the source machine, read the backup stream,
+   decompress it and write to the data directory. This is performed with a command
+   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can
    take a long time if there is much data to transfer.
-7. Check that the data directory on the target machine is not empty,\
+7. Check that the data directory on the target machine is not empty,
    i.e. that the transfer at least appears to have succeeded.
-8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if\
+8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if
    the source server performed writes during data transfer.
-9. On the target server, change ownership of datadir contents to the\
+9. On the target server, change ownership of datadir contents to the
    mysql-user and start MariaDB-server.
-10. Read gtid from the data directory. Have the target server start replicating\
+10. Read gtid from the data directory. Have the target server start replicating
     from the primary if it is not one already.
 
 The rebuild-operation is a monitor module command and takes three arguments:\
 the monitor name, target server name and source server name.\
 The source server can be left out, in which case it is autoselected.\
-When autoselecting, the monitor prefers to pick an up-to-date replica server to\
+When autoselecting, the monitor prefers to pick an up-to-date replica server to
 avoid increasing load on a primary server.\
-Due to the `--safe-slave-backup`-option, the replica will stop\
+Due to the `--safe-slave-backup`-option, the replica will stop
 replicating until the backup data has been transferred.
 
 ```
 maxctrl call command mariadbmon async-rebuild-server MyMonitor MyTargetServer MySourceServer
 ```
 
-The operation does not launch if the target server is already replicating or if\
+The operation does not launch if the target server is already replicating or if
 the source server is not a primary or replica.
 
-Steps 6 and 8 can take a long time depending on the size of the database and if\
-writes are ongoing. During these steps, the monitor will continue monitoring the\
-cluster normally. After each monitor tick the monitor checks if the\
-rebuild-operation can proceed. No other monitor operations, either manual or\
+Steps 6 and 8 can take a long time depending on the size of the database and if
+writes are ongoing. During these steps, the monitor will continue monitoring the
+cluster normally. After each monitor tick the monitor checks if the
+rebuild-operation can proceed. No other monitor operations, either manual or
 automatic, can run until the rebuild completes.
 
 #### Create backup
 
-The create backup-operation copies the contents of a database server to the\
-backup storage. The source server is not modified but may slow down during\
-backup creation. MaxScale performs this operation by running\
-mariadb-backup on both the source and storage servers. The storage location is\
+The create backup-operation copies the contents of a database server to the
+backup storage. The source server is not modified but may slow down during
+backup creation. MaxScale performs this operation by running
+mariadb-backup on both the source and storage servers. The storage location is
 defined by the _backup\_storage\_address_ and _backup\_storage\_path_ settings.\
-Normal ssh-settings are used to access the storage server. The backup storage\
+Normal ssh-settings are used to access the storage server. The backup storage
 machine does not need to have a MariaDB Server installed.
 
-Backup creation runs somewhat similar to rebuild-server. The main difference\
-is that the backup data is simply saved to a directory and not prepared or\
-used to start a MariaDB Server. If any step fails, the operation is stopped\
+Backup creation runs somewhat similar to rebuild-server. The main difference
+is that the backup data is simply saved to a directory and not prepared or
+used to start a MariaDB Server. If any step fails, the operation is stopped
 and the backup storage directory will be left in an unspecified state.
 
 1. Init. See rebuild-server.
 2. Check listen port on backup storage machine. See rebuild-server.
-3. Check that the backup storage main directory exists. Check that it does not\
-   contain a backup with the same name as the one being created. Create the final\
+3. Check that the backup storage main directory exists. Check that it does not
+   contain a backup with the same name as the one being created. Create the final
    backup directory.
-4. Test the connection by streaming a short message from the source host to the\
+4. Test the connection by streaming a short message from the source host to the
    backup storage.
 5. Serve backup on source. Similar to rebuild-server step 4.
-6. Transfer backup directly to the final storage directory. Similar to\
+6. Transfer backup directly to the final storage directory. Similar to
    rebuild-server step 5.
 7. Check that the copied backup data looks ok.
 
-Backup creation is a monitor module command and takes three\
-arguments: the monitor name, source server name and backup name. Backup name\
-defines the subdirectory where the backup is saved and should be a valid\
+Backup creation is a monitor module command and takes three
+arguments: the monitor name, source server name and backup name. Backup name
+defines the subdirectory where the backup is saved and should be a valid
 directory name. The command
 
 ```
@@ -1420,55 +1420,55 @@ maxctrl call command mariadbmon async-create-backup MyMonitor MySourceServer wed
 would save the backup of MySourceServer to `<backup_storage_path>/wednesday_161122` on the host defined in _backup\_storage\_address_. _ssh\_user_ needs to have read and write access
 to the main storage directory. The source server must be a primary or replica.
 
-Similar to rebuild-server, the monitor will continue monitoring the servers\
+Similar to rebuild-server, the monitor will continue monitoring the servers
 while the backup is transferred.
 
 #### Restore from backup
 
-The restore-operation is the reverse of create-backup. It overwrites the\
+The restore-operation is the reverse of create-backup. It overwrites the
 contents of an existing MariaDB Server with a backup from the backup storage.\
-The backup is not removed and can be used again. MaxScale performs this\
-operation by transferring the backup contents as a tar archive and overwriting\
-the target server data directory. The backup storage is defined in monitor\
+The backup is not removed and can be used again. MaxScale performs this
+operation by transferring the backup contents as a tar archive and overwriting
+the target server data directory. The backup storage is defined in monitor
 settings similar to create-backup.
 
-The restore-operation runs somewhat similar to rebuild-server. The main\
+The restore-operation runs somewhat similar to rebuild-server. The main
 difference is that the backup data is copied with _tar_ instead of mariadb-backup.\
-If any step fails, the operation is stopped and the target server will be\
+If any step fails, the operation is stopped and the target server will be
 left in an unspecified state.
 
 1. Init. See rebuild-server.
 2. Check listen port on target machine. See rebuild-server.
-3. Check that the backup storage main directory exists and that it contains\
+3. Check that the backup storage main directory exists and that it contains
    a backup with the name requested.
-4. Test the connection by streaming a short message from the backup storage to\
+4. Test the connection by streaming a short message from the backup storage to
    the target machine.
-5. On the backup storage machine, compress the backup with tar and serve it\
-   with socat, listening for an incoming connection. This is performed with\
+5. On the backup storage machine, compress the backup with tar and serve it
+   with socat, listening for an incoming connection. This is performed with
    a command like `tar -zc -C <backup_dir> . | socat - TCP-LISTEN:<port>`.
-6. Stop MariaDB-server on the target machine and delete all contents of the data\
+6. Stop MariaDB-server on the target machine and delete all contents of the data
    directory /var/lib/mysql.
-7. On the target machine, connect to the source machine, read the backup stream,\
-   decompress it and write to the data directory. This is performed with a command\
+7. On the target machine, connect to the source machine, read the backup stream,
+   decompress it and write to the data directory. This is performed with a command
    like `socat -u TCP:<host>:<port> STDOUT | sudo tar -xz -C /var/lib/mysql/`.\
    This step can take a long time if there is much data to transfer.
 8. From here on, the operation proceeds as from rebuild-server step 7.
 
-Server restoration is a monitor module command and takes three\
-arguments: the monitor name, target server name and backup name. Backup name\
-defines the subdirectory where the backup is read from and should be an\
+Server restoration is a monitor module command and takes three
+arguments: the monitor name, target server name and backup name. Backup name
+defines the subdirectory where the backup is read from and should be an
 existing directory on the backup storage host. The command
 
 ```
 maxctrl call command mariadbmon async-restore-from-backup MyMonitor MyTargetServer wednesday_161122
 ```
 
-would erase the contents of MyTargetServer and replace them with the backup\
+would erase the contents of MyTargetServer and replace them with the backup
 contained in `<backup_storage_path>/wednesday_161122` on the host defined in _backup\_storage\_address_. _ssh\_user_ needs to have read access
-to the main storage directory and the backup. The target server must not be\
+to the main storage directory and the backup. The target server must not be
 a primary or replica.
 
-Similar to rebuild-server, the monitor will continue monitoring the servers\
+Similar to rebuild-server, the monitor will continue monitoring the servers
 while the backup is transferred and prepared.
 
 #### Settings
@@ -1489,7 +1489,7 @@ Ssh username. Used when logging in to backend servers to run commands.
 * Dynamic: Yes
 * Default: None
 
-Path to file with an ssh private key. Used when logging in to backend servers to\
+Path to file with an ssh private key. Used when logging in to backend servers to
 run commands.
 
 **`ssh_check_host_key`**
@@ -1499,7 +1499,7 @@ run commands.
 * Dynamic: Yes
 * Default: `true`
 
-Boolean, default: true. When logging in to backends, require that the server is\
+Boolean, default: true. When logging in to backends, require that the server is
 already listed in the known\_hosts-file of the user running MaxScale.
 
 **`ssh_timeout`**
@@ -1509,10 +1509,10 @@ already listed in the known\_hosts-file of the user running MaxScale.
 * Dynamic: Yes
 * Default: `10s`
 
-The rebuild operation consists of multiple ssh\
-commands. Most of the commands are assumed to complete quickly. If these\
-commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust\
-this setting if rebuild fails due to ssh commands timing out. This setting does\
+The rebuild operation consists of multiple ssh
+commands. Most of the commands are assumed to complete quickly. If these
+commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust
+this setting if rebuild fails due to ssh commands timing out. This setting does
 not affect steps 5 and 6, as these are assumed to take significant time.
 
 **`ssh_port`**
@@ -1531,9 +1531,9 @@ SSH port. Used for running remote commands on servers.
 * Dynamic: Yes
 * Default: `4444`
 
-The port which the source server listens on for a\
-connection. The port must not be blocked by a firewall or listened on by any\
-other program. If another process is listening on the port when rebuild is\
+The port which the source server listens on for a
+connection. The port must not be blocked by a firewall or listened on by any
+other program. If another process is listening on the port when rebuild is
 starting, MaxScale will attempt to kill the process.
 
 **`backup_storage_address`**
@@ -1543,8 +1543,8 @@ starting, MaxScale will attempt to kill the process.
 * Dynamic: Yes
 * Default: None
 
-Address of the backup storage. Does not need to have MariaDB Server\
-running or be monitored by the monitor. Connected to with ssh. Must have enough\
+Address of the backup storage. Does not need to have MariaDB Server
+running or be monitored by the monitor. Connected to with ssh. Must have enough
 disk space to store all backups.
 
 ```
@@ -1558,7 +1558,7 @@ backup_storage_address=192.168.1.11
 * Dynamic: Yes
 * Default: None
 
-Path to main backup storage directory on backup storage host. _ssh\_user_\
+Path to main backup storage directory on backup storage host. _ssh\_user_
 needs to have full access to this directory to save and read backups.
 
 ```
@@ -1567,10 +1567,10 @@ backup_storage_path=/home/maxscale_ssh_user/backup_storage
 
 #### sudoers.d configuration
 
-If giving MaxScale general sudo-access is out of the question, MaxScale must be\
-allowed to run the specific commands required by the backup operations. This can\
-be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the\
-power to run commands as root. The contents of the file may need to be tweaked\
+If giving MaxScale general sudo-access is out of the question, MaxScale must be
+allowed to run the specific commands required by the backup operations. This can
+be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the
+power to run commands as root. The contents of the file may need to be tweaked
 due to changes in install locations.
 
 ```
@@ -1588,31 +1588,31 @@ johnny ALL= NOPASSWD: /bin/tar -xz -C /var/lib/mysql/
 
 ### ColumnStore commands
 
-Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative\
+Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative
 commands against a ColumnStore cluster. The commands interact with the\
-ColumnStore REST-API present in recent ColumnStore versions and have been tested\
-with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the\
-commands affect monitor configuration or replication topology. MariaDB Monitor\
+ColumnStore REST-API present in recent ColumnStore versions and have been tested
+with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the
+commands affect monitor configuration or replication topology. MariaDB Monitor
 simply relays the commands to the backend cluster.
 
-MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop\
-the cluster, and set cluster read-only or readwrite. MaxScale only communicates\
+MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop
+the cluster, and set cluster read-only or readwrite. MaxScale only communicates
 with the first server in the `servers`-list.
 
-Most of the commands are asynchronous, i.e. they do not wait for the operation\
+Most of the commands are asynchronous, i.e. they do not wait for the operation
 to complete on the ColumnStore backend before returning to the command prompt.\
-MariaDB Monitor itself, however, runs the command in the background and does not\
-perform normal monitoring until the operation completes or fails. After an\
-operation has started the user should use _fetch-cmd-result_ to check its\
-status. The examples below show how to run the commands using MaxCtrl. If a\
-command takes a timeout-parameter, the timeout can be given in seconds (s),\
+MariaDB Monitor itself, however, runs the command in the background and does not
+perform normal monitoring until the operation completes or fails. After an
+operation has started the user should use _fetch-cmd-result_ to check its
+status. The examples below show how to run the commands using MaxCtrl. If a
+command takes a timeout-parameter, the timeout can be given in seconds (s),
 minutes (m) or hours (h).
 
 ColumnStore command settings are listed [here](mariadb-maxscale-2308-mariadb-monitor.md#settings). At least`cs_admin_api_key` must be set.
 
 #### Get status
 
-Fetch cluster status. Returns the result as is. Status fetching has an automatic\
+Fetch cluster status. Returns the result as is. Status fetching has an automatic
 timeout of ten seconds.
 
 ```
@@ -1726,7 +1726,7 @@ maxctrl call command mariadbmon fetch-cmd-result MyMonitor
 
 **`cs_admin_port`**
 
-Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes\
+Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes
 are assumed to listen on the same port.
 
 ```
@@ -1750,9 +1750,9 @@ String, default: _/cmapi/0.4.0_. Base path sent with the REST-API request.
 
 #### `fetch-cmd-result`
 
-Fetches the result of the last manual command. Requires monitor name as\
-parameter. Most commands only return a generic success message or an error\
-description. ColumnStore commands may return more data. Scheduling another\
+Fetches the result of the last manual command. Requires monitor name as
+parameter. Most commands only return a generic success message or an error
+description. ColumnStore commands may return more data. Scheduling another
 command clears a stored result.
 
 ```
@@ -1762,11 +1762,11 @@ maxctrl call command mariadbmon fetch-cmd-result MariaDB-Monitor
 
 #### `cancel-cmd`
 
-Cancels the latest operation, whether manual or automatic, if possible. Requires\
-monitor name as parameter. A scheduled manual command is simply canceled\
-before it can run. If a command is already running, it stops as soon as\
+Cancels the latest operation, whether manual or automatic, if possible. Requires
+monitor name as parameter. A scheduled manual command is simply canceled
+before it can run. If a command is already running, it stops as soon as
 possible. The _cancel-cmd_ itself does not wait for a running operation to stop.\
-Use _fetch-cmd-result_ or check the log to see if the operation has truly\
+Use _fetch-cmd-result_ or check the log to see if the operation has truly
 completed. Canceling is most useful for stopping a stalled rebuild operation.
 
 ```
@@ -1780,48 +1780,48 @@ OK
 
 See the [Limitations and requirements-section](mariadb-maxscale-2308-mariadb-monitor.md#limitations_and_requirements).
 
-Before performing failover or switchover, the monitor checks that\
-prerequisites are fulfilled, printing any errors and warnings found. This should\
+Before performing failover or switchover, the monitor checks that
+prerequisites are fulfilled, printing any errors and warnings found. This should
 catch and explain most issues with failover or switchover not working.\
-If the operations are attempted and still fail, then most likely one of\
-the commands the monitor issued to a server failed or timed out. The log should\
+If the operations are attempted and still fail, then most likely one of
+the commands the monitor issued to a server failed or timed out. The log should
 explain which query failed.
 
-A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the\
-monitor will retry most such queries if the failure was caused by a timeout. The retrying\
-continues until the total time for a failover or switchover has been spent. If the log\
-shows warnings or errors about commands timing out, increasing the backend timeout\
+A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the
+monitor will retry most such queries if the failure was caused by a timeout. The retrying
+continues until the total time for a failover or switchover has been spent. If the log
+shows warnings or errors about commands timing out, increasing the backend timeout
 settings of the monitor should help. Other settings to look at are `query_retries` and`query_retry_timeout`. These are general MaxScale settings described in the [Configuration guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md). Setting`query_retries` to 2 is a reasonable first try.
 
-If switchover causes the old primary (now replica) to fail replication, then most\
-likely a user or perhaps a scheduled event performed a write while monitor\
+If switchover causes the old primary (now replica) to fail replication, then most
+likely a user or perhaps a scheduled event performed a write while monitor
 had set `read_only=1`. This is possible if the user performing the write has\
-"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick\
-out SUPER-users but this is not certain to succeed. Remove these privileges\
-from any users that regularly do writes to prevent them from interfering with\
+"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick
+out SUPER-users but this is not certain to succeed. Remove these privileges
+from any users that regularly do writes to prevent them from interfering with
 switchover.
 
-The server configuration files should have `log-slave-updates=1` to ensure that\
-a newly promoted primary has binary logs of previous events. This allows the new\
+The server configuration files should have `log-slave-updates=1` to ensure that
+a newly promoted primary has binary logs of previous events. This allows the new
 primary to replicate past events to any lagging replicas.
 
-To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the\
-backends by monitors and authenticators. The printed queries may include\
+To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the
+backends by monitors and authenticators. The printed queries may include
 usernames and passwords.
 
 #### Replica detection shows external primaries
 
 If a replica is shown in _maxctrl_ as "Slave of External Server" instead of\
-"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection\
-does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default\
-assumes that the replica connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact\
-same "Master\_Host" as used the MaxScale configuration file server definitions. This is\
+"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection
+does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default
+assumes that the replica connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact
+same "Master\_Host" as used the MaxScale configuration file server definitions. This is
 controlled by the setting [assume\_unique\_hostnames](mariadb-maxscale-2308-mariadb-monitor.md#assume_unique_hostnames).
 
 ### Using the MariaDB Monitor With Binlogrouter
 
-Since MaxScale 2.2 it's possible to detect a replication setup\
-which includes Binlog Server: the required action is to add the\
+Since MaxScale 2.2 it's possible to detect a replication setup
+which includes Binlog Server: the required action is to add the
 binlog server to the list of servers only if _master\_id_ identity is set.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor.md
@@ -6,8 +6,8 @@
 
 ### Overview
 
-The Xpand Monitor is a monitor that monitors a Xpand cluster. It is\
-capable of detecting the cluster setup and creating corresponding server\
+The Xpand Monitor is a monitor that monitors a Xpand cluster. It is
+capable of detecting the cluster setup and creating corresponding server
 instances within MaxScale.
 
 ### Required Grants
@@ -21,7 +21,7 @@ GRANT SELECT ON system.nodeinfo TO 'maxscale'@'maxscalehost';
 GRANT SELECT ON system.softfailed_nodes TO 'maxscale'@'maxscalehost';
 ```
 
-Further, if you want be able to _softfail_ and _unsoftfail_ a node via MaxScale,\
+Further, if you want be able to _softfail_ and _unsoftfail_ a node via MaxScale,
 then the monitor user must have `SUPER` privileges:
 
 ```
@@ -30,19 +30,19 @@ GRANT SUPER ON *.* TO 'maxscale'@'maxscalehost';
 
 ### Configuration
 
-A minimal configuration for a monitor requires one server in the Xpand\
-cluster, and a username and a password to connect to the server. Note that\
-by default the Xpand monitor will only use that server in order to\
-dynamically find out the configuration of the cluster; after startup it\
-will completely rely upon information obtained at runtime. To change the\
+A minimal configuration for a monitor requires one server in the Xpand
+cluster, and a username and a password to connect to the server. Note that
+by default the Xpand monitor will only use that server in order to
+dynamically find out the configuration of the cluster; after startup it
+will completely rely upon information obtained at runtime. To change the
 default behaviour, please see the parameter [dynamic\_node\_detection](mariadb-maxscale-2308-xpand-monitor.md#dynamic_node_detection).
 
-To ensure that the Xpand monitor will be able to start, it is advisable\
-to provide _more_ than one server to cater for the case that not all nodes\
+To ensure that the Xpand monitor will be able to start, it is advisable
+to provide _more_ than one server to cater for the case that not all nodes
 are always up when MaxScale starts.
 
-**Note:** All services that use servers monitored by xpandmon should use\
-the `cluster` parameter to define the set of servers they use. This will\
+**Note:** All services that use servers monitored by xpandmon should use
+the `cluster` parameter to define the set of servers they use. This will
 guarantee that the services use servers that are valid members of the\
 XPand cluster.
 
@@ -71,12 +71,12 @@ Xpand node will be named like
 @@<name-of-xpand-monitor>:node-<id>
 ```
 
-where `<name-of-xpand-monitor>` is the name of the Xpand monitor\
-instance, as defined in the MaxScale configuration file, and `<id>` is the\
+where `<name-of-xpand-monitor>` is the name of the Xpand monitor
+instance, as defined in the MaxScale configuration file, and `<id>` is the
 id of the Xpand node.
 
-For instance, with the Xpand monitor defined as above and a Xpand\
-cluster consisting of 3 nodes whose ids are `1`, `2` and `3` respectively,\
+For instance, with the Xpand monitor defined as above and a Xpand
+cluster consisting of 3 nodes whose ids are `1`, `2` and `3` respectively,
 the names of the created server objects will be:
 
 ```
@@ -86,7 +86,7 @@ the names of the created server objects will be:
 ```
 
 When dynamic servers are created, the values for the configuration settings`max_routing_connections`, `persistmaxtime`, `persistpoolmax` and`proxy_protocol` are copied from the settings of the bootstrap servers.\
-Note that the values of these settings must be **identical** on every\
+Note that the values of these settings must be **identical** on every
 bootstrap server.
 
 ### Common Monitor Parameters
@@ -104,8 +104,8 @@ These are optional parameters specific to the Xpand Monitor.
 * Dynamic: Yes
 * Default: `60s`
 
-Defines how often the monitor checks the state of the entire cluster. The\
-default value is 60 seconds, which should not be lowered as that may have\
+Defines how often the monitor checks the state of the entire cluster. The
+default value is 60 seconds, which should not be lowered as that may have
 an adverse effect on the Cluster itself.
 
 ```
@@ -119,7 +119,7 @@ cluster_monitor_interval=120s
 * Dynamic: Yes
 * Default: `2`
 
-Defines how many times the health check may fail before the monitor\
+Defines how many times the health check may fail before the monitor
 considers a particular node to be down.
 
 ```
@@ -133,11 +133,11 @@ health_check_threshold=3
 * Dynamic: Yes
 * Default: `true`
 
-By default, the Xpand monitor will only use the bootstrap nodes\
-in order to connect to the Xpand cluster and then find out the\
+By default, the Xpand monitor will only use the bootstrap nodes
+in order to connect to the Xpand cluster and then find out the
 cluster configuration dynamically at runtime.
 
-That behaviour can be turned off with this optional parameter, in\
+That behaviour can be turned off with this optional parameter, in
 which case all Xpand nodes must manually be defined as shown below.
 
 ```
@@ -171,14 +171,14 @@ See also [health\_check\_port](mariadb-maxscale-2308-xpand-monitor.md#health_che
 * Dynamic: Yes
 * Default: `3581`
 
-With this optional parameter it can be specified what health check\
+With this optional parameter it can be specified what health check
 port to use, if `dynamic_node_detection` has been disabled.
 
 ```
 health_check_port=4711
 ```
 
-Note that this parameter is _ignored_ unless `dynamic_node_detection`\
+Note that this parameter is _ignored_ unless `dynamic_node_detection`
 is `false`. Note also that the port must be the same for all nodes.
 
 #### `region_name`
@@ -190,9 +190,9 @@ is `false`. Note also that the port must be the same for all nodes.
 
 Mutually exclusive with `region_oid`.
 
-`region_name` specifies the name of the region the instance MaxScale is\
-running in. Should be specified only if Xpand Multi-Region HA cluster,\
-which is available from Xpand 23.08 onwards, is used. With `region_name`\
+`region_name` specifies the name of the region the instance MaxScale is
+running in. Should be specified only if Xpand Multi-Region HA cluster,
+which is available from Xpand 23.08 onwards, is used. With `region_name`
 specified, MaxScale will only consider nodes from that region.
 
 #### `region_oid`
@@ -204,9 +204,9 @@ specified, MaxScale will only consider nodes from that region.
 
 Mutually exclusive with `region_name`.
 
-`region_oid` specifies the oid of the region the instance MaxScale is\
-running in. Should be specified only if Xpand Multi-Region HA cluster,\
-which is available from Xpand 23.08 onwards, is used. With `region_oid`\
+`region_oid` specifies the oid of the region the instance MaxScale is
+running in. Should be specified only if Xpand Multi-Region HA cluster,
+which is available from Xpand 23.08 onwards, is used. With `region_oid`
 specified, MaxScale will only consider nodes from that region.
 
 ### Commands
@@ -216,8 +216,8 @@ The Xpand monitor supports the following module commands.
 #### `softfail`
 
 With the `softfail` module command, a node can be _softfailed_ via\
-MaxScale. The command requires as argument the name of the Xpand\
-monitor instance (as defined in the configuration file) and the name\
+MaxScale. The command requires as argument the name of the Xpand
+monitor instance (as defined in the configuration file) and the name
 of the node to be softfailed.
 
 For instance, with a configuration file like
@@ -229,56 +229,56 @@ module=xpandmon
 ...
 ```
 
-then the node whose server name is `@@TheXpandMonitor:node-1` can\
+then the node whose server name is `@@TheXpandMonitor:node-1` can
 be softfailed like
 
 ```
 $ maxctrl call command xpandmon softfail TheXpandMonitor @@TheXpandMonitor:node-1
 ```
 
-If the softfailing of a node is successfully initiated, then the status\
-of the corresponding MaxScale server object will be set to `Draining`,\
+If the softfailing of a node is successfully initiated, then the status
+of the corresponding MaxScale server object will be set to `Draining`,
 which will prevent new connections from being created to the node.
 
-When the number of connections through MaxScale to the node has dropped\
-to 0, its state will change to `Drained`. Note that the state `Drained`\
-only tells that there are no connections to the node, not what the state\
+When the number of connections through MaxScale to the node has dropped
+to 0, its state will change to `Drained`. Note that the state `Drained`
+only tells that there are no connections to the node, not what the state
 of the softfailing operation is.
 
 #### `unsoftfail`
 
 With the `unsoftfail` module command, a node can be _unsoftfailed_ via\
-MaxScale. The command requires as argument the name of the Xpand\
-monitor instance (as defined in the configuration file) and the name\
+MaxScale. The command requires as argument the name of the Xpand
+monitor instance (as defined in the configuration file) and the name
 of the node to be unsoftfailed.
 
-With a setup similar to the `softfail` case, a node can be unsoftfailed\
+With a setup similar to the `softfail` case, a node can be unsoftfailed
 like:
 
 ```
 $ maxctrl call command xpandmon unsoftfail TheXpandMonitor @@TheXpandMonitor:node-1
 ```
 
-If a node is successfully softfailed, then a `Draining` status of\
+If a node is successfully softfailed, then a `Draining` status of
 the corresponding MaxScale server object will be cleared.
 
 ### SOFTFAILed nodes
 
-During the cluster check, which is performed once per`cluster_monitor_interval`, the monitor will also check whether any\
-nodes are being softfailed. The status of the corresponding server\
-object of a node being softfailed will be set to `Draining`,\
+During the cluster check, which is performed once per`cluster_monitor_interval`, the monitor will also check whether any
+nodes are being softfailed. The status of the corresponding server
+object of a node being softfailed will be set to `Draining`,
 which will prevent new connections from being created to that node.
 
-When the number of connections through MaxScale to the node has dropped\
-to 0, its state will change to `Drained`. Note that the state `Drained`\
-only tells that there are no connections to the node, not what the state\
+When the number of connections through MaxScale to the node has dropped
+to 0, its state will change to `Drained`. Note that the state `Drained`
+only tells that there are no connections to the node, not what the state
 of the softfailing operation is.
 
-If a node that was softfailed is UNSOFTFAILed then the `Draining`\
+If a node that was softfailed is UNSOFTFAILed then the `Draining`
 status will be cleared.
 
-If the softfailing and unsoftfailing is initiated using the `softfail`\
-and `unsoftfail` commands of the Xpand monitor, then there will be\
+If the softfailing and unsoftfailing is initiated using the `softfail`
+and `unsoftfail` commands of the Xpand monitor, then there will be
 no delay between the softfailing or unsoftfailing being initiated and the`Draining` status being turned on/off.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-change-data-capture-cdc-protocol.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-change-data-capture-cdc-protocol.md
@@ -4,11 +4,11 @@
 
 ## Change Data Capture (CDC) Protocol
 
-CDC is a new protocol that allows compatible clients to authenticate and\
-register for Change Data Capture events. The new protocol must be use in\
+CDC is a new protocol that allows compatible clients to authenticate and
+register for Change Data Capture events. The new protocol must be use in
 conjunction with AVRO router which currently converts MariaDB binlog events into\
-AVRO records. Change Data Capture protocol is used by clients in order to\
-interact with stored AVRO file and also allows registered clients to be notified\
+AVRO records. Change Data Capture protocol is used by clients in order to
+interact with stored AVRO file and also allows registered clients to be notified
 with the new events coming from MariaDB 10.0/10.1 database.
 
 ### Creating Users
@@ -51,12 +51,12 @@ In the future, optional flags could be implemented.
 
 #### Authentication
 
-The authentication starts when the client sends the hexadecimal representation\
+The authentication starts when the client sends the hexadecimal representation
 of the username concatenated with a colon (`:`) and the SHA1 of the password.
 
 `bin2hex(username + ':' + SHA1(password))`
 
-For example the user _foobar_ with a password of _foopasswd_ should send the\
+For example the user _foobar_ with a password of _foopasswd_ should send the
 following hexadecimal string
 
 ```
@@ -87,9 +87,9 @@ Server returns `OK` on success and `ERR` on failure.
 
 `REQUEST-DATA DATABASE.TABLE[.VERSION] [GTID]`
 
-This command fetches data from specified table in a database and returns the\
-output in the requested format (AVRO or JSON). Data records are sent to clients\
-and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new\
+This command fetches data from specified table in a database and returns the
+output in the requested format (AVRO or JSON). Data records are sent to clients
+and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new
 schema and data will be sent as well.
 
 The data will be streamed until the client closes the connection.
@@ -106,7 +106,7 @@ REQUEST-DATA db2.table4 0-11-345
 
 ### Example Client
 
-MaxScale includes an example CDC client application written in Python 3. You can\
+MaxScale includes an example CDC client application written in Python 3. You can
 find the source code for it [in the MaxScale repository](https://github.com/mariadb-corporation/MaxScale/tree/2.0/server/modules/protocol/examples/cdc.py).
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-change-data-capture-cdc-users.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-change-data-capture-cdc-users.md
@@ -4,13 +4,13 @@
 
 ## Change Data Capture (CDC) users
 
-Change Data Capture (CDC) is a new MaxScale protocol that allows compatible\
-clients to authenticate and register for Change Data Capture events. The new\
+Change Data Capture (CDC) is a new MaxScale protocol that allows compatible
+clients to authenticate and register for Change Data Capture events. The new
 protocol must be use in conjunction with AVRO router which currently converts\
-MariaDB binlog events into AVRO records. Clients connect to CDC listener and\
+MariaDB binlog events into AVRO records. Clients connect to CDC listener and
 authenticate using credentials provided in a format described in the [CDC Protocol documentation](mariadb-maxscale-2308-change-data-capture-cdc-protocol.md).
 
-**Note**: If no users are found in that file or if it doesn't exist, the only\
+**Note**: If no users are found in that file or if it doesn't exist, the only
 available user will be the _service user_:
 
 ```
@@ -30,7 +30,7 @@ Starting with MaxScale 2.1, users can also be created through maxctrl:
 maxctrl call command cdc add_user <service> <name> <password>
 ```
 
-The should be the service name where the user is created. Older\
+The should be the service name where the user is created. Older
 versions of MaxScale should use the _cdc\_users.py_ script.
 
 ```
@@ -43,7 +43,7 @@ The output of this command should be appended to the _cdcusers_ file at`/var/lib
 bash$ cdc_users.py user1 pass1 >> /var/lib/maxscale/avro-service/cdcusers
 ```
 
-Users can be deleted by removing the related rows in 'cdcusers' file. For\
+Users can be deleted by removing the related rows in 'cdcusers' file. For
 more details on the format of the _cdcusers_ file, read the [CDC Protocol documentation](mariadb-maxscale-2308-change-data-capture-cdc-protocol.md).
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-maxscale-2308-mariadb-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-maxscale-2308-mariadb-protocol-module.md
@@ -6,7 +6,7 @@
 
 The `mariadbprotocol` module implements the MariaDB client-server protocol.
 
-The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all\
+The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all
 aliases to `mariadbprotocol`.
 
 * [MariaDB Protocol Module](mariadb-maxscale-2308-maxscale-2308-mariadb-protocol-module.md#mariadb-protocol-module)
@@ -15,7 +15,7 @@ aliases to `mariadbprotocol`.
 
 ### Configuration
 
-Protocol level parameters are defined in the listeners. They must be defined\
+Protocol level parameters are defined in the listeners. They must be defined
 using the scoped parameter syntax where the protocol name is used as the prefix.
 
 ```
@@ -36,8 +36,8 @@ For the MariaDB protocol module, the prefix is always `mariadbprotocol`.
 * Dynamic: Yes
 * Default: true
 
-Whether the use of the replication protocol is allowed through this listener. If\
-disabled with `mariadbprotocol.allow_replication=false`, all attempts to start\
+Whether the use of the replication protocol is allowed through this listener. If
+disabled with `mariadbprotocol.allow_replication=false`, all attempts to start
 replication will be rejected with a ER\_FEATURE\_DISABLED error (error number\
 1289\).
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md
@@ -4,21 +4,21 @@
 
 ## NoSQL Protocol Module
 
-The `nosqlprotocol` module allows a MariaDB server or cluster to be\
+The `nosqlprotocol` module allows a MariaDB server or cluster to be
 used as the backend of an application using a MongoDB® client library.\
 Internally, all documents are stored in a table containing two columns;\
 an `id` column for the object id and a `doc` column for the document itself.
 
-When the MongoDB® client application issues MongoDB protocol _commands_,\
-either directly or indirectly via the client library, they are transparently\
+When the MongoDB® client application issues MongoDB protocol _commands_,
+either directly or indirectly via the client library, they are transparently
 converted into the equivalent SQL and executed against the MariaDB backend.\
-The MariaDB responses are then in turn converted into the format expected by\
+The MariaDB responses are then in turn converted into the format expected by
 the MongoDB® client library and application.
 
 ## Configuring
 
-There are a number of [parameters](mariadb-maxscale-2308-nosql-protocol-module.md#parameters) with which the behavior\
-of _nosqlprotocol_ can be adjusted. A minimal configuration looks\
+There are a number of [parameters](mariadb-maxscale-2308-nosql-protocol-module.md#parameters) with which the behavior
+of _nosqlprotocol_ can be adjusted. A minimal configuration looks
 like:
 
 ```
@@ -35,13 +35,13 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-`nosqlprotocol.user` and `nosqlprotocol.password` specify the\
-credentials that will be used when accessing the backend database or\
+`nosqlprotocol.user` and `nosqlprotocol.password` specify the
+credentials that will be used when accessing the backend database or
 cluster. Note that the same credentials will be used for _all_ connecting\
 MongoDB® clients.
 
-Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which\
-the client requests will be sent. _Nosqlprotocol_ places no limitations\
+Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which
+the client requests will be sent. _Nosqlprotocol_ places no limitations
 on what filters, routers or backends can be used.
 
 To configure the same listener with MaxCtrl, the parameters must be passed in a\
@@ -51,7 +51,7 @@ JSON object in the following manner:
 maxctrl create listener TheService MongoDB-Listener --protocol=nosqlprotocol 'nosqlprotocol={"user":"the_user", "password": "the_password"}'
 ```
 
-All the parameters that the nosqlprotocol module takes must be passed in the\
+All the parameters that the nosqlprotocol module takes must be passed in the
 same JSON object.
 
 A complete example can be found at the [end](mariadb-maxscale-2308-nosql-protocol-module.md#example) of this document.
@@ -61,18 +61,18 @@ A complete example can be found at the [end](mariadb-maxscale-2308-nosql-protoco
 Nosqlprotocol supports _SCRAM_ _authentication_ as implemented by MongoDB®.\
 The mechanisms `SCRAM-SHA-1` and `SCRAM-SHA-256` are both supported.
 
-If nosqlprotocol has been setup so that no authentication is required, then\
-when connecting only the host and port should be provided, but neither a\
+If nosqlprotocol has been setup so that no authentication is required, then
+when connecting only the host and port should be provided, but neither a
 username nor a password.
 
-For instance, if the _MongoDB Node.JS Driver_ is used, then the connection\
+For instance, if the _MongoDB Node.JS Driver_ is used, then the connection
 string should look like:
 
 ```
 const uri = "mongodb://127.0.0.1:17017"
 ```
 
-Similarly, if the _Mongo Shell_ is used, only the host and port should\
+Similarly, if the _Mongo Shell_ is used, only the host and port should
 be provided:
 
 ```
@@ -84,26 +84,26 @@ MongoDB shell version v4.4.1
 
 ### NoSQL and MariaDB Users
 
-A MariaDB user consists of a name and a host part. A user `'user'@'%'`\
-and a user `'user'@'127.0.0.1'` are completely different. The host part\
-specifies where a user may connect from, with `%` being a wildcard that\
-matches all hosts. What data a user is allowed to access and modify is\
+A MariaDB user consists of a name and a host part. A user `'user'@'%'`
+and a user `'user'@'127.0.0.1'` are completely different. The host part
+specifies where a user may connect from, with `%` being a wildcard that
+matches all hosts. What data a user is allowed to access and modify is
 specified by what _privileges_ are granted to the user.
 
-A NoSQL user is somewhat different. It is created in the context of a\
-particular database, so there may be a user `userx` in the database `dbA`\
-and different user with the same name `userx` in the database `dbB`. What\
-hosts a user may connect from can be restricted, but that is a property of\
-the user and not an implicit part of it. What data a user is allowed to\
-access and modify is specified by the _roles_ that have been assigned to\
+A NoSQL user is somewhat different. It is created in the context of a
+particular database, so there may be a user `userx` in the database `dbA`
+and different user with the same name `userx` in the database `dbB`. What
+hosts a user may connect from can be restricted, but that is a property of
+the user and not an implicit part of it. What data a user is allowed to
+access and modify is specified by the _roles_ that have been assigned to
 the user.
 
-From the above it should be clear that there is not a 1-to-1\
-correspondence between the concept of a user in NoSQL and the concept\
+From the above it should be clear that there is not a 1-to-1
+correspondence between the concept of a user in NoSQL and the concept
 of a user in MariaDB, but that some additional conventions are needed.
 
-To make it possible to have different NoSQL users with the same name,\
-the database in whose context the user is created is prepended to the\
+To make it possible to have different NoSQL users with the same name,
+the database in whose context the user is created is prepended to the
 user name, separated with a dot, when the MariaDB user is created.
 
 This is perhaps easiest to illustrate using an example:
@@ -119,7 +119,7 @@ MariaDB [(none)]> select user, host from mysql.user;
 2 rows in set (0.001 sec)
 ```
 
-Currently there are two user accounts defined. Even though there is\
+Currently there are two user accounts defined. Even though there is
 a user `bob`, creating a NoSQL user `bob` succeeds.
 
 ```
@@ -143,20 +143,20 @@ MariaDB [(none)]> select user, host from mysql.user;
 3 rows in set (0.001 sec)
 ```
 
-The MariaDB user corresponding to the NoSQL user `bob`, created in the\
+The MariaDB user corresponding to the NoSQL user `bob`, created in the
 context of the database `test`, has `test` as a prefix.
 
 #### The `mariadb` database
 
-The fact that NoSQL users have the database embedded in the MariaDB\
-name may be inconvenient if the same data is accessed both as NoSQL\
-via nosqlprotocol and as SQL directly from MariaDB. It also makes\
+The fact that NoSQL users have the database embedded in the MariaDB
+name may be inconvenient if the same data is accessed both as NoSQL
+via nosqlprotocol and as SQL directly from MariaDB. It also makes
 it impossible to use an existing MariaDB account from NoSQL.
 
-To provide a solution for this problem, the database `mariadb` is treated\
-in a specific fashion. A user created in the context of the `mariadb`\
+To provide a solution for this problem, the database `mariadb` is treated
+in a specific fashion. A user created in the context of the `mariadb`
 database is created in the MariaDB server without the database prefix.\
-If we now try to create a user `bob` in the `mariadb` database it will fail,\
+If we now try to create a user `bob` in the `mariadb` database it will fail,
 because the user `'bob'@'%'` exists already.
 
 ```
@@ -199,7 +199,7 @@ we will see that `alice` was created without a database prefix.
 
 When creating a user nosqlprotocol accepts all roles as predefined by\
 MongoDB®, but not all of them are translated into GRANT privileges.\
-The following table shows what privilege(s) a particular role is\
+The following table shows what privilege(s) a particular role is
 converted to.
 
 | Role      | Privileges                                    |
@@ -216,21 +216,21 @@ The following roles are shorthands for several other roles.
 | dbOwner | dbAdmin, readWrite, userAdmin |
 | root    | dbAdmin, readWrite, userAdmin |
 
-`dbOwner` differs from `root` in that the privileges of the former\
-apply only to a particular database, while the privileges of the\
-latter apply to _all_ databases. However, the role `root` can\
+`dbOwner` differs from `root` in that the privileges of the former
+apply only to a particular database, while the privileges of the
+latter apply to _all_ databases. However, the role `root` can
 only be assigned to a user in the `admin` database.
 
-In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in\
-the `admin` database. If so, then the privilege is granted on `*.*`,\
+In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in
+the `admin` database. If so, then the privilege is granted on `*.*`,
 otherwise on `<db>.*`.
 
-If the `root` role is assigned to a user in the `admin` database,\
+If the `root` role is assigned to a user in the `admin` database,
 then the privileges are granted on `*.*`, otherwise on `<db>.*`.
 
-Other pre-defined roles are recognized and stored in the local\
-nosqlprotocol account database, but they do not affect what privileges\
-are granted to the MariaDB user. Currently user-defined roles are\
+Other pre-defined roles are recognized and stored in the local
+nosqlprotocol account database, but they do not affect what privileges
+are granted to the MariaDB user. Currently user-defined roles are
 not supported.
 
 ### Client Authentication
@@ -243,11 +243,11 @@ Authenticationwise nosqlprotocol can be used in three different ways:
 
 #### Anonymously
 
-If there is an anonymous user on the MariaDB server and if nosqlprotocol\
-is configured without a user/password, then all nosqlprotocol clients will\
+If there is an anonymous user on the MariaDB server and if nosqlprotocol
+is configured without a user/password, then all nosqlprotocol clients will
 access the MariaDB server as anonymous users.
 
-Note that the anonymous MariaDB user is only intended for testing and\
+Note that the anonymous MariaDB user is only intended for testing and
 should in general not be used, but deleted.
 
 #### Shared Credentials
@@ -261,18 +261,18 @@ nosqlprotocol.password=thepassword
 ```
 
 then each MongoDB® client will use those credentials when accessing the\
-MariaDB server. Note that from the perspective of the MariaDB server, it\
+MariaDB server. Note that from the perspective of the MariaDB server, it
 is not possible to distinguish between different MongoDB® clients.
 
 #### Unique Credentials
 
-If nosqlprotocol authentication has been taken into use and a MongoDB®\
-client authenticates, either when connecting or later, then the credentials\
+If nosqlprotocol authentication has been taken into use and a MongoDB®
+client authenticates, either when connecting or later, then the credentials
 of MongoDB® client will be used when accessing the MariaDB server.
 
-Note that even if nosqlprotocol authentication has been enabled, authentication\
-is not required, and if the MongoDB® client has not authenticated itself, the\
-credentials specified with `nosqlprotocol.[user|password]` (or the anonymous\
+Note that even if nosqlprotocol authentication has been enabled, authentication
+is not required, and if the MongoDB® client has not authenticated itself, the
+credentials specified with `nosqlprotocol.[user|password]` (or the anonymous
 user) will be used when accessing the MariaDB server.
 
 #### Enforce Authentication
@@ -283,14 +283,14 @@ To enforce authentication, specify
 nosqlprotocol.authentication_required=true
 ```
 
-in the configuration. If authentication is required, then any command\
-that requires access to the MariaDB server will fail, unless the client\
+in the configuration. If authentication is required, then any command
+that requires access to the MariaDB server will fail, unless the client
 has authenticated.
 
 ### Authorization
 
-By default nosqlprotocol does no authorization. However, a nosqlprotocol\
-client is _always_ subject to the authorization performed by the MariaDB\
+By default nosqlprotocol does no authorization. However, a nosqlprotocol
+client is _always_ subject to the authorization performed by the MariaDB
 server.
 
 When nosqlprotocol authorization is enabled by adding
@@ -299,8 +299,8 @@ When nosqlprotocol authorization is enabled by adding
 nosqlprotocol.authorization_enabled=true
 ```
 
-to the configuration file, some commands will be subject to authorization,\
-by nosqlprotocol. The following table lists the commands and what role they\
+to the configuration file, some commands will be subject to authorization,
+by nosqlprotocol. The following table lists the commands and what role they
 require.
 
 | Command                                                                                   | Role      |
@@ -315,27 +315,27 @@ require.
 | [updateUser](mariadb-maxscale-2308-nosql-protocol-module.md#updateUser)                   | userAdmin |
 | [usersInfo](mariadb-maxscale-2308-nosql-protocol-module.md#usersInfo)                     | userAdmin |
 
-It is important to note that even if nosqlprotocol authorization\
-is enabled, the MariaDB server has the final word. That is, even if the\
-roles of a user would be sufficient for a particular operation, if the\
-granted privileges are not, the operation will not succeed. There may\
-be a mismatch between roles and grants, for instance, if the wrong roles\
-were specified when the user was added, or if the grants have been\
+It is important to note that even if nosqlprotocol authorization
+is enabled, the MariaDB server has the final word. That is, even if the
+roles of a user would be sufficient for a particular operation, if the
+granted privileges are not, the operation will not succeed. There may
+be a mismatch between roles and grants, for instance, if the wrong roles
+were specified when the user was added, or if the grants have been
 altered directly and not via nosqlprotocol.
 
 ### Bootstrapping the Authentication/Authorization
 
-The authentication/authorization can be bootstrapped explicitly\
-or implicitly. Bootstrapping explicitly provides more control, while\
+The authentication/authorization can be bootstrapped explicitly
+or implicitly. Bootstrapping explicitly provides more control, while
 bootstrapping implicitly is much more convenient.
 
 #### Explicit bootstrapping
 
-In order to enable authorization you need to have NoSQL users and\
-those can be created with [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser) or added\
+In order to enable authorization you need to have NoSQL users and
+those can be created with [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser) or added
 with [mxsAddUser](mariadb-maxscale-2308-nosql-protocol-module.md#addUser).
 
-If you want to _create_ a user, then you first need to configure\
+If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
 
 ```
@@ -343,7 +343,7 @@ nosqlprotocol.user = user_with_privileges_for_creating_a_user
 nosqlprotocol.password = the_users_password
 ```
 
-At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that\
+At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that
 as those are their default values, they do not have to be specified.
 
 Start MaxScale and connect to it with the MongoDB® command line client
@@ -363,8 +363,8 @@ switched to db admin
 { "ok" : 1 }
 ```
 
-Alternatively you can add an existing user. Note that it should be\
-added to the `mariadb` database, unless it was created with the\
+Alternatively you can add an existing user. Note that it should be
+added to the `mariadb` database, unless it was created with the
 convention of having the database as a prefix, e.g. `db.bob`.
 
 ```
@@ -383,12 +383,12 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but\
-as they will be ignored with `nosqlprotocol.authentication_required=true`\
+The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but
+as they will be ignored with `nosqlprotocol.authentication_required=true`
 being present, it is not mandatory.
 
-If you now try to create a user when not having been authenticated or\
-when authenticated as a user without the `userAdmin` role, the result\
+If you now try to create a user when not having been authenticated or
+when authenticated as a user without the `userAdmin` role, the result
 will be:
 
 ```
@@ -403,105 +403,105 @@ switched to db test
 }
 ```
 
-**NOTE** When a client authenticates, the password will not be\
-transferred in cleartext over the network, so, even without SSL,\
-it is not possible to gain access to a password by monitoring the\
+**NOTE** When a client authenticates, the password will not be
+transferred in cleartext over the network, so, even without SSL,
+it is not possible to gain access to a password by monitoring the
 network traffic.
 
-However, when a user is created or added (or the password is changed),\
-the password will be transferred in _cleartext_. To prevent eavesdropping,\
+However, when a user is created or added (or the password is changed),
+the password will be transferred in _cleartext_. To prevent eavesdropping,
 create/add users when connecting over a domain socket, or use [TLS/SSL](mariadb-maxscale-2308-nosql-protocol-module.md#tlsssl)
 
 #### Implicit bootstrapping
 
-With implicit bootstrapping, you should first create the MariaDB\
-user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2308-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat\
-different in MariaDB and NoSQL, which means that certain factors\
-must be taken into account when creating the MariaDB user. Then\
+With implicit bootstrapping, you should first create the MariaDB
+user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2308-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat
+different in MariaDB and NoSQL, which means that certain factors
+must be taken into account when creating the MariaDB user. Then
 at first startup, nosqlprotocol will create the corresponding\
-NoSQL user, which will enable the authenticated and authorized\
+NoSQL user, which will enable the authenticated and authorized
 use of nosqlprotocol.
 
 When MaxScale is started, if the following hold
 
-* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration\
+* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration
   section of the nosqlprotocol listener,
 * `nosqlprotocol.user` and `nosqlprotocol.password` are provided, and
 * there are no NoSQL users in the NoSQL account database.
 
 then, MaxScale will
 
-* wait until the primary of the service pointed to by the listener\
+* wait until the primary of the service pointed to by the listener
   is available,
-* connect using the credentials specified in `nosqlprotocol.user`\
+* connect using the credentials specified in `nosqlprotocol.user`
   and `nosqlprotocol.password`,
 * execute `SHOW GRANTS`,
 * translate the privileges into the equivalent NoSQL roles, and
 * create a corresponding NoSQL user into the NoSQL account database.
 
-Immediately thereafter it is possible to connect to the nosqlprotocol\
+Immediately thereafter it is possible to connect to the nosqlprotocol
 port with a MongoDB® client using the specified credentials.
 
-Note that after the bootstrapping, nosqlprotocol will not use\
+Note that after the bootstrapping, nosqlprotocol will not use
 the `user` and `password` settings and they can be removed.
 
 **Grants**
 
-When a NoSQL user is created using [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser)\
-the MariaDB grants are obtained from the specified NoSQL roles\
+When a NoSQL user is created using [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser)
+the MariaDB grants are obtained from the specified NoSQL roles
 as explained [here](mariadb-maxscale-2308-nosql-protocol-module.md#Roles_and_privileges).
 
 When implicitly creating a NoSQL user from an existing user in\
-MariaDB, the inverse operation must be performed. There are\
-many factors that affect what NoSQL roles the grants of a user\
+MariaDB, the inverse operation must be performed. There are
+many factors that affect what NoSQL roles the grants of a user
 are translated into:
 
 * whether the user is a regular or admin user,
 * whether the privileges are on `*.*` or some specific `db.*`, and
 * the privileges themselves, e.g. `SELECT`, `DELETE`, etc.
 
-In NoSQL, every user resides in a specific database. Note that\
-this does **not** mean that database would have to exist\
+In NoSQL, every user resides in a specific database. Note that
+this does **not** mean that database would have to exist
 in MariaDB.
 
-When it comes to users, the database effectively means a scope,\
-which in the case of nosqlprotocol is handled by prefixing the\
+When it comes to users, the database effectively means a scope,
+which in the case of nosqlprotocol is handled by prefixing the
 corresponding MariaDB user name with the database/scope name.
 
-When creating a user to be used from NoSQL, there are three\
+When creating a user to be used from NoSQL, there are three
 options for the user's name:
 
 * The name can be of the format `some_db.user_name` where`some_db` can be anything (subject to the naming rules of\
-  MariaDB), except `admin` or `mariadb`. In this case, the\
-  user will be a regular user, who can access data in\
+  MariaDB), except `admin` or `mariadb`. In this case, the
+  user will be a regular user, who can access data in
   databases that she has been granted access to.
-* The name can be of the format `admin.user_name` where `admin`\
-  is exactly just that. In this case, the user will be an\
+* The name can be of the format `admin.user_name` where `admin`
+  is exactly just that. In this case, the user will be an
   admin user, who can access any database.
-* The name can be of the format `user_name`. In this case, the\
-  user will be a regular user that from the NoSQL side appears\
-  to reside in the `mariadb` database. The primary purpose of\
-  this alternative is to enable the use of existing users from\
+* The name can be of the format `user_name`. In this case, the
+  user will be a regular user that from the NoSQL side appears
+  to reside in the `mariadb` database. The primary purpose of
+  this alternative is to enable the use of existing users from
   the NoSQL side.
 
-What database the privileges can be specified `ON` depends on\
+What database the privileges can be specified `ON` depends on
 what kind of user is being created.
 
-* If it is a regular user, the privileges must be granted on a\
+* If it is a regular user, the privileges must be granted on a
   specific database, such as `\`dbA\`\`.\*\`. Note that there is no\
   dependency between this database and the (conceptual) database\
   the user resides in.
 * If it is an admin user, the privileges must be granted on\
   the `*.*` database.
 
-In NoSQL, a role can be database specific or generic. However,\
-a generic role can _only_ be assigned to a user in the _admin_\
-database. In practice this means that if the privileges are\
-on `*.*`, then the user must reside in the _admin_ database\
+In NoSQL, a role can be database specific or generic. However,
+a generic role can _only_ be assigned to a user in the _admin_
+database. In practice this means that if the privileges are
+on `*.*`, then the user must reside in the _admin_ database
 (e.g. `admin.bob`) or it is treated as an error.
 
-The following table shows what privileges are required for a\
-role to be assigned. Note that `ALL PRIVILEGES` can be used as\
+The following table shows what privileges are required for a
+role to be assigned. Note that `ALL PRIVILEGES` can be used as
 well.
 
 | ALTER | CREATE | CREATE USER | DROP | DELETE | INDEX | INSERT | SHOW DATABASES(1) | SELECT | UPDATE | WITH GRANT OPTION | Role                    |
@@ -513,19 +513,19 @@ well.
 
 1. Only required if the user is an admin user.
 
-The `AnyDatabase` version will be assigned, if the user is\
+The `AnyDatabase` version will be assigned, if the user is
 an _admin_ user.
 
-If certain roles are assigned, then other roles will be\
+If certain roles are assigned, then other roles will be
 assigned as well.
 
-* If the roles `dbAdmin`, `readWrite` and `userAdmin` are\
+* If the roles `dbAdmin`, `readWrite` and `userAdmin` are
   assigned, then `dbOwner` will be assigned as well.
-* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`\
-  and `userAdminAnyDatabase` are assigned, then `root` will\
+* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`
+  and `userAdminAnyDatabase` are assigned, then `root` will
   be assigned as well.
 
-Once the user has been created and the desired privileges have\
+Once the user has been created and the desired privileges have
 been granted, the NoSQL listener should be configured as follows:
 
 ```
@@ -544,7 +544,7 @@ At MaxScale startup, the NoSQL user will then be created.
 
 **Admin User**
 
-We want the initial NoSQL user to be an administrator, with\
+We want the initial NoSQL user to be an administrator, with
 full rights.
 
 ```
@@ -552,8 +552,8 @@ CREATE USER 'admin.nosql_admin'@'%' IDENTIFIED BY 'nosql_password';
 GRANT ALL PRIVILEGES ON *.* TO 'admin.nosql_admin'@'%' WITH GRANT OPTION;
 ```
 
-As we want an admin user, the name is prefixed with `admin`,\
-which will have that effect. And since it is an admin user, the\
+As we want an admin user, the name is prefixed with `admin`,
+which will have that effect. And since it is an admin user, the
 privileges are granted ON `*.*`.
 
 Thereafter, we specify the following in the configuration file,
@@ -571,16 +571,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'admin.nosql_admin'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -590,9 +590,9 @@ $ mongo --quiet --port 17017 -u nosql_admin -p nosql_password admin
 >
 ```
 
-Note that when connecting the user is passed as `nosql_admin` and _not_\
-as `admin.nosql_admin`. The fact that we want to authenticate against\
-the `admin` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `nosql_admin` and _not_
+as `admin.nosql_admin`. The fact that we want to authenticate against
+the `admin` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -631,13 +631,13 @@ argument.
 }
 ```
 
-As can be seen, the user has the _any_ roles on the `admin`\
-database, which means that all databases can be accessed and\
+As can be seen, the user has the _any_ roles on the `admin`
+database, which means that all databases can be accessed and
 modified, and that new users can be created.
 
 **Test User**
 
-We want the initial NoSQL user to be a user with limited rights,\
+We want the initial NoSQL user to be a user with limited rights,
 intended to be used for testing.
 
 ```
@@ -645,11 +645,11 @@ CREATE USER 'test.test_user'@'%' IDENTIFIED BY 'test_password';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX ON `test`.* TO 'test.test_user'@'%';
 ```
 
-As we want a user with limited rights, the name is _not_ prefixed\
+As we want a user with limited rights, the name is _not_ prefixed
 with `admin`. The privileges are granted specifically on database`test.*`. Indeed, if `*.*` had been used, the creation of the initial\
-NoSQL user would have failed with an error. Here, the user is created\
-in the same database that the user is given access to, but it could\
-have been another one. Further, several `GRANT` statements could have\
+NoSQL user would have failed with an error. Here, the user is created
+in the same database that the user is given access to, but it could
+have been another one. Further, several `GRANT` statements could have
 been used, had we wanted to give access to several databases.
 
 Thereafter, we specify the following in the configuration file,
@@ -667,16 +667,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'test.test_user'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -686,9 +686,9 @@ $ mongo --quiet --port 17017 -u test_user -p test_password test
 >
 ```
 
-Note that when connecting the user is passed as `test_user` and _not_\
-as `test.test_user`. The fact that we want to authenticate against\
-the `test` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `test_user` and _not_
+as `test.test_user`. The fact that we want to authenticate against
+the `test` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -715,44 +715,44 @@ argument.
 }
 ```
 
-As can be seen, the user has the `readWrite` role on the `test` database,\
+As can be seen, the user has the `readWrite` role on the `test` database,
 which means that only the `test` database can be accessed and modified.
 
 #### TLS/SSL
 
-Since `nosqlprotocol` is a regular protocol module used in a listener,\
-the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](https://mariadb.com/kb/en/Getting-Started/Configuration-Guide#tsl-encryption)\
+Since `nosqlprotocol` is a regular protocol module used in a listener,
+the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](https://mariadb.com/kb/en/Getting-Started/Configuration-Guide#tsl-encryption)
 for details.
 
 ### NoSQL Account Database
 
-So as to be able to connect to the MariaDB server on behalf of\
-clients, nosqlprotocol must know their password. As the password\
-is not transferred to nosqlprotocol during the authentication in\
-a way that could be used when logging into MariaDB, the password\
-must be stored when the user is created with [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser)\
+So as to be able to connect to the MariaDB server on behalf of
+clients, nosqlprotocol must know their password. As the password
+is not transferred to nosqlprotocol during the authentication in
+a way that could be used when logging into MariaDB, the password
+must be stored when the user is created with [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser)
 or added with [mxsAddUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsAddUser).
 
-Note that the password is not stored in cleartext but as three\
-different hashes; hashed with sha1 for use with MariaDB, salted\
-and hashed with sha1 for use with the `SCRAM-SHA-1` authentication\
-mechanism (if that is enabled for the user) and salted and hashed\
-with sha256 for use with the `SCRAM-SHA-256` authentication mechanism\
+Note that the password is not stored in cleartext but as three
+different hashes; hashed with sha1 for use with MariaDB, salted
+and hashed with sha1 for use with the `SCRAM-SHA-1` authentication
+mechanism (if that is enabled for the user) and salted and hashed
+with sha256 for use with the `SCRAM-SHA-256` authentication mechanism
 (if that is enabled for the user).
 
-The account information can be stored _privately_, in which case it\
-can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can\
-share the information and a user created/added on one instance\
+The account information can be stored _privately_, in which case it
+can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can
+share the information and a user created/added on one instance
 can be used on another.
 
 #### Private
 
-In the private case, the account information of nosqlprotocol is\
-stored in an [sqlite3](https://sqlite.org/index.html) database\
-whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,\
-where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the\
-listener section in the MaxScale configuration file, and `-v1`\
-a suffix for making schema evolution easier, should there be\
+In the private case, the account information of nosqlprotocol is
+stored in an [sqlite3](https://sqlite.org/index.html) database
+whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,
+where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the
+listener section in the MaxScale configuration file, and `-v1`
+a suffix for making schema evolution easier, should there be
 a need for that.
 
 For instance, given a configuration like
@@ -767,41 +767,41 @@ protocol=nosqlprotocol
 
 the account information will be stored in the file`<libdir>/nosqlprotocol/NoSQL-Listener-v1.db`.
 
-Note that since the database name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the database name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
-To retain the accounts, the database file should also be\
+To retain the accounts, the database file should also be
 renamed.
 
-At first startup, the `nosqlprotocol` directory and\
-the file `NoSQL-Listener-v1.db` will be created. They will\
-be created with file permissions that only allow MaxScale\
-access. At subsequent startups the permissions will be checked\
-and MaxScale will refuse to start if the permissions allow\
+At first startup, the `nosqlprotocol` directory and
+the file `NoSQL-Listener-v1.db` will be created. They will
+be created with file permissions that only allow MaxScale
+access. At subsequent startups the permissions will be checked
+and MaxScale will refuse to start if the permissions allow
 access to others.
 
 **We strongly recommend that no manual modifications are made**\
 **to the database.**
 
-Note that we make **no** guarantees that the way in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the way in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ### Shared
 
-In the shared case, the account information of nosqlprotocol\
+In the shared case, the account information of nosqlprotocol
 is stored in the cluster of the service in front of which the\
-NoSQL listener resides. The primary of the cluster will be used\
+NoSQL listener resides. The primary of the cluster will be used
 both for reading and writing data.
 
 A table whose name is the same as the listener's name in the\
-MaxScale configuration will be created in the database\
-specified with the [authentication\_db](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_db)\
-parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of\
+MaxScale configuration will be created in the database
+specified with the [authentication\_db](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_db)
+parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of
 the listener section in the MaxScale configuration file.
 
 For instance, given a configuration like
@@ -816,61 +816,61 @@ protocol=nosqlprotocol
 
 the account information will be stored in the table`nosqlprotocol.NoSQL-Listener`.
 
-Note that since the table name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the table name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
 To retain the accounts, the table should also be renamed.
 
-`nosqlprotocol` will create the table when needed, so the\
-user specified with [authentication\_user](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_user)\
+`nosqlprotocol` will create the table when needed, so the
+user specified with [authentication\_user](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_user)
 must have sufficient grants to be able to do that.
 
-`nosqlprotocol` will store in the table, data that allow\
-any MaxScale to authenticate a MongoDB® client, irrespective\
+`nosqlprotocol` will store in the table, data that allow
+any MaxScale to authenticate a MongoDB® client, irrespective
 of which MaxScale instance was used when the user was created.
 
-`nosqlprotocol` also stores in the table the SHA1 of a user's\
+`nosqlprotocol` also stores in the table the SHA1 of a user's
 password, to be able to authenticate against the MariaDB server.\
-Therefore it is **strongly** suggested to enable encryption key\
-management in MaxScale and to provide an authentication\
-key ID with [authentication\_key\_id](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_key_id) so\
+Therefore it is **strongly** suggested to enable encryption key
+management in MaxScale and to provide an authentication
+key ID with [authentication\_key\_id](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_key_id) so
 that the data will be encrypted.
 
-If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_password) must also\
-be provided. With [authentication\_db](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_db) the\
-database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_key_id) an\
-encryption key ID, using which the sensitive data is encrypted,\
+If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_password) must also
+be provided. With [authentication\_db](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_db) the
+database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2308-nosql-protocol-module.md#authentication_key_id) an
+encryption key ID, using which the sensitive data is encrypted,
 can optionally be provided.
 
-Note that we make **no** guarantees that the table in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the table in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ## Wire Protocol
 
-_Nosqlprotocol_ fully supports wire protocol version 6 and only provides\
-rudimentary support for earlier wire protocol versions, but reports at\
-startup that it would support versions 0 to 6. The reason is that some\
-client libraries are buggy and use an old wire protocol version if the\
-server claims to support only version 6. Consequently, one should use a\
+_Nosqlprotocol_ fully supports wire protocol version 6 and only provides
+rudimentary support for earlier wire protocol versions, but reports at
+startup that it would support versions 0 to 6. The reason is that some
+client libraries are buggy and use an old wire protocol version if the
+server claims to support only version 6. Consequently, one should use a
 client library version that at least supports wire protocol version 6.
 
 ## Client Library
 
-As the goal of _nosqlprotocol_ is to implement, to the extent that it\
-is feasible, the wire protocol and the database commands the way MongoDB®\
+As the goal of _nosqlprotocol_ is to implement, to the extent that it
+is feasible, the wire protocol and the database commands the way MongoDB®
 implements them, it should be possible to use any language specific driver.
 
-However, during the development of _nosqlprotocol_, the _only_ client library\
+However, during the development of _nosqlprotocol_, the _only_ client library
 that has been verified to work is version 3.6 of _MongoDB Node.JS Driver_.
 
 ## Parameters
 
-Using the following parameters, the behavior of _nosqlprotocol_ can be\
+Using the following parameters, the behavior of _nosqlprotocol_ can be
 adjusted. As they are not generic listener parameters, but specific to _nosqlprotocol_ they must be qualified with the `nosqlprotocol`-prefix.
 
 For instance:
@@ -892,7 +892,7 @@ nosqlprotocol.on_unknown_command=return_error
 * Mandatory: No
 * Default: `""`
 
-Specifies the _user_ to be used when connecting to the backend, if the MongoDB®\
+Specifies the _user_ to be used when connecting to the backend, if the MongoDB®
 client is not authenticated.
 
 ### `password`
@@ -901,8 +901,8 @@ client is not authenticated.
 * Mandatory: No
 * Default: `""`
 
-Specifies the _password_ to be used when connecting to the backend, is the MongoDB®\
-client is not authenticated. Note that the same _user_/_password_ combination will be\
+Specifies the _password_ to be used when connecting to the backend, is the MongoDB®
+client is not authenticated. Note that the same _user_/_password_ combination will be
 used for all unauthenticated MongoDB® clients connecting to the same listener port.
 
 ### `authentication_required`
@@ -911,11 +911,11 @@ used for all unauthenticated MongoDB® clients connecting to the same listener p
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the client always must authenticate. If authentication is required,\
-it does not matter whether `user` and `password` have been specified, the client must\
+Specifies whether the client always must authenticate. If authentication is required,
+it does not matter whether `user` and `password` have been specified, the client must
 authenticate.
 
-Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsAddUser),\
+Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsAddUser),
 with authentication being optional and authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -927,7 +927,7 @@ MariaDB server.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the NoSQL account information should be stored in a shared\
+Specifies whether the NoSQL account information should be stored in a shared
 manner or privately.
 
 ### `authentication_db`
@@ -936,10 +936,10 @@ manner or privately.
 * Mandatory: No
 * Default: `"NoSQL"`
 
-Specifies the database of the table where the NoSQL account information\
-is stored, if `authentication_shared` is `true`. If the database does not\
-exist, nosqlprotocol will attempt to create it, so either is should be\
-manually created or the used specified with `authentication_user` should\
+Specifies the database of the table where the NoSQL account information
+is stored, if `authentication_shared` is `true`. If the database does not
+exist, nosqlprotocol will attempt to create it, so either is should be
+manually created or the used specified with `authentication_user` should
 have the grants required to do so.
 
 ### `authentication_key_id`
@@ -948,11 +948,11 @@ have the grants required to do so.
 * Mandatory: No
 * Default: `""`
 
-The encryption key ID, using which the NoSQL account information should be\
-encrypted with when stored in the MariaDB server. If an encryption key ID is\
+The encryption key ID, using which the NoSQL account information should be
+encrypted with when stored in the MariaDB server. If an encryption key ID is
 given, the encryption key manager in MaxScale must also be enabled.
 
-The encryption key must be a 256-bit key. Keys of shorter length are rejected\
+The encryption key must be a 256-bit key. Keys of shorter length are rejected
 as invalid encryption keys.
 
 ### `authentication_user`
@@ -960,7 +960,7 @@ as invalid encryption keys.
 * Type: string
 * Mandatory: Yes, if `authentication_shared` is true.
 
-Specifies the _user_ to be used when modifying and accessing the NoSQL\
+Specifies the _user_ to be used when modifying and accessing the NoSQL
 account information stored in the MariaDB server.
 
 ### `authentication_password`
@@ -977,9 +977,9 @@ Specifies the _password_ of `authentication_user`.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether nosqlprotocol itself should perform authorization in the context\
-of the commands [mxsAddUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users\
-have been created with [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsAddUser)\
+Specifies whether nosqlprotocol itself should perform authorization in the context
+of the commands [mxsAddUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users
+have been created with [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2308-nosql-protocol-module.md#mxsAddUser)
 with authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -992,8 +992,8 @@ MariaDB server.
 * Default: `"%"`
 
 Specifies the _host_ to be used when a MariaDB user is created via nosqlprotocol.\
-By default all users are created as `...@'%'`, which means that it is possible to\
-connect to the MariaDB server from any host using the credentials of the created\
+By default all users are created as `...@'%'`, which means that it is possible to
+connect to the MariaDB server from any host using the credentials of the created
 user. For tighter security, the IP-address of the MaxScale host can be specified.
 
 NOTE: This value does **not** specify from which host it is allowed to connect to\
@@ -1019,8 +1019,8 @@ Enumeration values:
 * Mandatory: No
 * Default: `false`
 
-Specifies whether an unknown command should be logged. This is primarily\
-for debugging purposes, to find out whether a client uses a command that\
+Specifies whether an unknown command should be logged. This is primarily
+for debugging purposes, to find out whether a client uses a command that
 currently is not supported.
 
 ### `auto_create_databases`
@@ -1042,7 +1042,7 @@ Note that setting this parameter to `true`, without also setting`auto_create_tab
 Specifies whether tables should automatically be created, as needed.
 
 Note that this applies only if the relevant database already exists.\
-If a database should also be created if needed, then `auto_create_databases`\
+If a database should also be created if needed, then `auto_create_databases`
 must also be set to `true`.
 
 ### `id_length`
@@ -1063,16 +1063,16 @@ Specifies the length of the id column in tables that are automatically created.
 
 Enumeration values:
 
-* `default`: Each document is inserted using a separate `INSERT`, either in a\
-  multi-statement or in a compound statement. Whether an error causes the remaining\
-  insertions to be aborted, depends on the value of `ordered` specified in the\
+* `default`: Each document is inserted using a separate `INSERT`, either in a
+  multi-statement or in a compound statement. Whether an error causes the remaining
+  insertions to be aborted, depends on the value of `ordered` specified in the
   insert command.
-* `atomic`: If the value of `ordered` in the insert command is `true`\
-  (the default) then all documents are inserted using a single `INSERT` statement,\
-  that is, either all insertions succeed or none will. If `ordered` is false, then\
+* `atomic`: If the value of `ordered` in the insert command is `true`
+  (the default) then all documents are inserted using a single `INSERT` statement,
+  that is, either all insertions succeed or none will. If `ordered` is false, then
   the behavior is as in the `default` case.
 
-What combination of `ordered_insert_behavior` and `ordered` (in the insert command\
+What combination of `ordered_insert_behavior` and `ordered` (in the insert command
 document) is used, has an impact on the performance. Please see the discussion at [insert](mariadb-maxscale-2308-nosql-protocol-module.md#insert).
 
 ### `cursor_timeout`
@@ -1081,7 +1081,7 @@ document) is used, has an impact on the performance. Please see the discussion a
 * Mandatory: No
 * Default: `60s`
 
-Specifies how long a cursor can be idle, that is, not accessed, before it is\
+Specifies how long a cursor can be idle, that is, not accessed, before it is
 automatically closed.
 
 ### `debug`
@@ -1106,7 +1106,7 @@ So, specify
 nosqlprotocol.debug=in,out,back
 ```
 
-to have the incoming command, the corresponding SQL sent to the backend\
+to have the incoming command, the corresponding SQL sent to the backend
 and the resulting response sent to the client logged.
 
 ### `internal_cache`
@@ -1115,7 +1115,7 @@ and the resulting response sent to the client logged.
 * Mandatory: No
 * Default: ''
 
-Specifies what internal cache to use if any. Currently, the only\
+Specifies what internal cache to use if any. Currently, the only
 permissible value is `cache`, which refers to the [cache filter](../mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md).
 
 Please see [caching](mariadb-maxscale-2308-nosql-protocol-module.md#caching) for more information.
@@ -1123,15 +1123,15 @@ Please see [caching](mariadb-maxscale-2308-nosql-protocol-module.md#caching) for
 ## Databases and Tables
 
 By default, _nosqlprotocol_ automatically creates databases as needed.\
-The default behavior can be changed by setting `auto_create_databases` to\
+The default behavior can be changed by setting `auto_create_databases` to
 false. In that case, databases must manually be created.
 
 Each MongoDB® _collection_ corresponds to a MariaDB table with the same name.\
-However, it is always possible to access a collection irrespective of whether\
+However, it is always possible to access a collection irrespective of whether
 the corresponding table exists or not; it will simply appear to be empty.
 
-Inserting documents into a collection, whose corresponding table does not\
-exist, succeeds, provided `auto_create_tables` is `true`, as the table will\
+Inserting documents into a collection, whose corresponding table does not
+exist, succeeds, provided `auto_create_tables` is `true`, as the table will
 in that case be created.
 
 When _nosqlprotocol_ creates a table, it uses a statement like
@@ -1142,19 +1142,19 @@ CREATE TABLE name (id VARCHAR(35) AS (JSON_COMPACT(JSON_EXTRACT(doc, "$._id"))) 
                    CONSTRAINT id_not_null CHECK(id IS NOT NULL));
 ```
 
-where the length of the `VARCHAR` is specified by the value of `id_length`,\
+where the length of the `VARCHAR` is specified by the value of `id_length`,
 whose default and minimum is 35.
 
-_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain\
+_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain
 a similar constraint.
 
-Note that _nosqlprotocol_ does not in any way verify that the table\
-corresponding to a collection being accessed or modified does indeed\
-have the expected columns `id` and `doc` of the expected types, but it\
-simply uses the table, which will fail if the layout is not the expected\
+Note that _nosqlprotocol_ does not in any way verify that the table
+corresponding to a collection being accessed or modified does indeed
+have the expected columns `id` and `doc` of the expected types, but it
+simply uses the table, which will fail if the layout is not the expected
 one.
 
-To reduce the risk for confusion, the recommendation is to use a specific\
+To reduce the risk for confusion, the recommendation is to use a specific
 database for tables that contain documents.
 
 ## Operators
@@ -1190,7 +1190,7 @@ The following operators are currently supported.
 
 **`$type`**
 
-When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset\
+When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset
 of types can be used in `$type` queries:
 
 | Type           | Number | Alias    | MariaDB Type |
@@ -1237,10 +1237,10 @@ As arguments, only the operators `$eq` and `$ne` are supported.
 
 ## Database Commands
 
-The following commands are supported. At each command is specified\
+The following commands are supported. At each command is specified
 what fields are relevant for the command.
 
-**All** non-listed fields are ignored; their presence or absence have no\
+**All** non-listed fields are ignored; their presence or absence have no
 impact, unless otherwise explicitly specified.
 
 ### Aggregation Commands
@@ -1311,7 +1311,7 @@ The `projection` parameter takes a document of the following form:
 { <field1>: <value>, <field2>: <value> ... }
 ```
 
-If a `projection` document is not provided or if it is empty, the entire document\
+If a `projection` document is not provided or if it is empty, the entire document
 will be returned.
 
 | Projection     | Description                         |
@@ -1325,23 +1325,23 @@ For fields in an embedded documents, the field can be specified using:
 
 * dot notation; e.g. `"field.nestedfield": <value>`
 
-In particular, specifying fields in embedded documents using nested form\
+In particular, specifying fields in embedded documents using nested form
 is not supported.
 
 **`_id` Field Projection**
 
-The `_id` field is included in the returned documents by default unless you\
+The `_id` field is included in the returned documents by default unless you
 explicitly specify `_id: 0` in the projection to suppress the field.
 
 **Inclusion or Exclusion**
 
-A `projection` cannot contain both include and exclude specifications,\
+A `projection` cannot contain both include and exclude specifications,
 with the exception of the `_id` field:
 
 * In projections that explicitly include fields, the `_id` field is the only field that can be explicitly excluded.
 * In projections that explicitly excludes fields, the `_id` field is the only field that can be explicitly include; however, the `_id` field is included by default.
 
-_NOTE_ Currently `_id` is the only field that can be excluded, and _only_\
+_NOTE_ Currently `_id` is the only field that can be excluded, and _only_
 if other fields are explicitly included._NOTE_ Currently exclusion of other fields but `_id` is not supported.
 
 **Filtering by `_id`**
@@ -1370,7 +1370,7 @@ and in the latter
 ... WHERE (JSON_EXTRACT(doc, '$._id') = 4711)
 ```
 
-That is, in the former case the _indexed_ column `id` will be used, in the\
+That is, in the former case the _indexed_ column `id` will be used, in the
 latter it will not.
 
 #### findAndModify
@@ -1410,9 +1410,9 @@ The following fields are relevant.
 
 #### insert
 
-The `insert` command inserts one or more documents into the table whose\
-name is the same as that of the collection. If the option `auto_create_tables`\
-is `true`, then the table is created if it does not already exist. If the\
+The `insert` command inserts one or more documents into the table whose
+name is the same as that of the collection. If the option `auto_create_tables`
+is `true`, then the table is created if it does not already exist. If the
 value is `false`, then the insert will fail unless the table already exists.
 
 The following fields are relevant.
@@ -1429,9 +1429,9 @@ The impact of `ordered` is dependent upon the value of `ordered_insert_behavior`
 
 **`default`**
 
-In this case `ordered` has the same impact as in MongoDB®. That is, if the value\
-is `true`, then when an insert of a document fails, return without inserting any\
-remaining documents listed in the inserts array. If `false`, then when an insert\
+In this case `ordered` has the same impact as in MongoDB®. That is, if the value
+is `true`, then when an insert of a document fails, return without inserting any
+remaining documents listed in the inserts array. If `false`, then when an insert
 of a document fails, continue to insert the remaining documents.
 
 **`atomic`**
@@ -1443,7 +1443,7 @@ then the behavior is identical with that of `default`.
 
 **Performance**
 
-What combination of `ordered_insert_behavior` and `ordered` is used, has an\
+What combination of `ordered_insert_behavior` and `ordered` is used, has an
 impact on the performance.
 
 | ordered\_insert\_behavior | ordered = true                                                                                                                        | ordered = false                                                                                                                        |
@@ -1451,8 +1451,8 @@ impact on the performance.
 | default                   | All documents are inserted within a compound statement, in a transaction containing as many INSERT statements as there are documents. | All documents are inserted in a single multi-statement transaction containing as many INSERT IGNORE statements as there are documents. |
 | atomic                    | All documents are inserted using a single INSERT statement.                                                                           | Same as above                                                                                                                          |
 
-Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,\
-being roughly twice as slow. The performance of 'default + true' is halfway between\
+Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,
+being roughly twice as slow. The performance of 'default + true' is halfway between
 the two.
 
 #### resetError
@@ -1485,10 +1485,10 @@ Each document contains the following fields:
 | u     | document | The modifications to apply. See behavior below for details.                                                                                                        |
 | multi | boolean  | Optional. If true, updates all documents that meet the query criteria. If false limit the update to one document that meets the query criteria. Defaults to false. |
 
-Note that currently it is possible to set `multi` to `true` in conjunction\
+Note that currently it is possible to set `multi` to `true` in conjunction
 with a _replacement-style_ update, even though MongoDB® rejects that.
 
-All other fields are ignored, with the exception of `upsert` that if present\
+All other fields are ignored, with the exception of `upsert` that if present
 with the value of `true` will cause the command to fail.
 
 **Behavior**
@@ -1514,7 +1514,7 @@ In this case, the update command updates only the corresponding fields in the do
 
 **Update with a Replacement Document**
 
-The update statement field `u` field can accept a _replacement document_,\
+The update statement field `u` field can accept a _replacement document_,
 i.e. the document contains only `field:value` expressions. For example:
 
 ```
@@ -1529,12 +1529,12 @@ updates: [
 ```
 
 In this case, the update command replaces the matching document with the update document.\
-The update command can only replace a single matching document; i.e. the multi field\
+The update command can only replace a single matching document; i.e. the multi field
 cannot be true.
 
-**Note** If the replacement document contains an `_id` field, it will be ignored and the\
-document id will remain non-changed while the document otherwise is replaced. This is\
-different from MongoDB® where the presence of the `_id` field in the replacement document\
+**Note** If the replacement document contains an `_id` field, it will be ignored and the
+document id will remain non-changed while the document otherwise is replaced. This is
+different from MongoDB® where the presence of the `_id` field in the replacement document
 causes an error, if the value is not the same as it is in the document being replaced.
 
 ### Authentication Commands
@@ -1549,7 +1549,7 @@ The following fields are relevant.
 
 If you are not logged in and using authentication, `logout` has no effect.
 
-Note that in order to be logged out, the logging out must be done while\
+Note that in order to be logged out, the logging out must be done while
 using the same database that was used when you logged on.
 
 Always returns
@@ -1562,7 +1562,7 @@ Always returns
 
 #### createUser
 
-Creates a new MariaDB user and adds an entry to the local nosqlprotocol\
+Creates a new MariaDB user and adds an entry to the local nosqlprotocol
 account database.
 
 The following fields are relevant.
@@ -1576,8 +1576,8 @@ The following fields are relevant.
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is\
-the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the\
+The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is
+the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the
 following command
 
 ```
@@ -1587,19 +1587,19 @@ following command
 
 the MariaDB user `'myDatabase.user1'@'%'` will be created.
 
-The elements of the `roles` array are converted into privileges\
+The elements of the `roles` array are converted into privileges
 as explained in [here](mariadb-maxscale-2308-nosql-protocol-module.md#roles_and_privileges).
 
 In practice the creation is performed as follows:_First the MariaDB user is created._ Then the privileges are granted.
 
 * Finally the local nosqlprotocol account database is updated.
 
-If the granting of privileges fails, an attempt will be made to\
+If the granting of privileges fails, an attempt will be made to
 drop the user.
 
 #### dropAllUsersFromDatabase
 
-Drops all users from the local nosqlprotocol account database and\
+Drops all users from the local nosqlprotocol account database and
 the corresponding MariaDB users.
 
 The following fields are relevant.
@@ -1621,13 +1621,13 @@ The following fields are relevant.
 | -------- | ------ | ----------------------------------- |
 | dropUser | string | The name of the user to be dropped. |
 
-The user will first be dropped from the MariaDB server and if\
+The user will first be dropped from the MariaDB server and if
 that succeeds also from the local nosqlprotocol account database.
 
 #### grantRolesToUser
 
-This command _adds_ more roles to a NoSQL user, which may imply\
-that additional privileges are granted to the corresponding MariaDB\
+This command _adds_ more roles to a NoSQL user, which may imply
+that additional privileges are granted to the corresponding MariaDB
 user.
 
 | Field            | Type   | Description                                    |
@@ -1636,12 +1636,12 @@ user.
 | roles            | array  | An array of additional roles.                  |
 
 Note that roles assigned to different databases will result in separate\
-GRANT statements, which means that it is possible that some succeed and\
+GRANT statements, which means that it is possible that some succeed and
 others do not.
 
 #### revokeRolesFromUser
 
-This command _removes_ roles from an NoSQL user, which may imply\
+This command _removes_ roles from an NoSQL user, which may imply
 that privileges are revoked from the corresponding MariaDB user.
 
 | Field               | Type   | Description                                |
@@ -1649,8 +1649,8 @@ that privileges are revoked from the corresponding MariaDB user.
 | revokeRolesFromUser | string | The name of the user to remove roles from. |
 | roles               | array  | An array of roles to remove.               |
 
-Note that roles to be removed from different databases will result in\
-separate REVOKE statements, which means that it is possible that some\
+Note that roles to be removed from different databases will result in
+separate REVOKE statements, which means that it is possible that some
 succeed and others do not.
 
 #### updateUser
@@ -1665,8 +1665,8 @@ This command updates the information about a particular user.
 | roles      | array    | Optional. The roles granted to the user. Note that the existing ones are replaced and not amended with these roles.                                                                                                                                                |
 | mechanisms | array    | Optional. The specific SCRAM mechanisms for user credentials. Note that if a new pwd is provided, then the array can contain all supported SCRAM mechanisms. If a new pwd is not provided, then the array must be a subset of the existing mechanisms of the user. |
 
-Changes to `customData` or `mechanisism` are made only to the local\
-nosqlprotocol database, but changes to `pwd` or `roles` require\
+Changes to `customData` or `mechanisism` are made only to the local
+nosqlprotocol database, but changes to `pwd` or `roles` require
 the MariaDB server to be updated.
 
 #### usersInfo
@@ -1690,11 +1690,11 @@ The returned information depends the value of `usersInfo`:
 | { usersInfo: \[{ user: , db: }, ...]} | Returns information about specified users.                                          |
 | { usersInfo: \[ , ... ]}              | Returns information about specified users in the database where the command is run. |
 
-Note that users may always view their own information. Otherwise the user must\
+Note that users may always view their own information. Otherwise the user must
 have the `userAdmin` or `userAdminAnyDatabase` role.
 
 If `showCredentials` is true, the returned object(s) will contain a`mariadb: { password: "*..."}` field, where `password` is the`SHA1(SHA1())` value of the password used when logging to MariaDB.\
-That is, the same string that is found in the `password` column in\
+That is, the same string that is found in the `password` column in
 the `mysql.user` table.
 
 ### Replication Commands
@@ -1756,8 +1756,8 @@ The following fields are relevant.
 | capped | boolean | Optional. If specified, the value must be false as capped collections are not supported. |
 | viewOn | string  | Optional. If specified, the command will fail as views are not supported.                |
 
-Currently, _capped collections_ and _views_ are not supported. Consequently,\
-specifying that the collection should be capped or that it should be a\
+Currently, _capped collections_ and _views_ are not supported. Consequently,
+specifying that the collection should be capped or that it should be a
 view on another collection, will cause the command to fail.
 
 #### createIndexes
@@ -1768,9 +1768,9 @@ The following fields are relevant.
 | ------------- | ------ | ------------------------------------------- |
 | createIndexes | string | The collection for which to create indexes. |
 
-**NOTE** Currently it is not possible to create indexes, but the command\
-will nonetheless return success, provide the index specification passes\
-some rudimentary sanity checks. Note also that the collection will be\
+**NOTE** Currently it is not possible to create indexes, but the command
+will nonetheless return success, provide the index specification passes
+some rudimentary sanity checks. Note also that the collection will be
 created if it does not exist.
 
 #### drop
@@ -1797,9 +1797,9 @@ The following fields are relevant.
 | ----------- | ---- | ----------- |
 | dropIndexes | any  | Ignored.    |
 
-**NOTE** Currently it is not possible to create indexes and thus there\
-will never be any indexes that could be dropped. However, provided the\
-specified collection exists, dropping indexes will always succeed except\
+**NOTE** Currently it is not possible to create indexes and thus there
+will never be any indexes that could be dropped. However, provided the
+specified collection exists, dropping indexes will always succeed except
 for an attempt to drop the built-in `_id_` index.
 
 #### fsync
@@ -1840,8 +1840,8 @@ The following fields are relevant.
 | filter          | document | The field name is honored, other fields are not but cause warnings to be logged.                                                                 |
 | nameOnly        | boolean  | Optional. A flag to indicate whether the command should return just the collection names and type or return both the name and other information. |
 
-Note that the command lists all collections (that is, tables) that are found\
-in the current database. The listed collections may or may not be suitable\
+Note that the command lists all collections (that is, tables) that are found
+in the current database. The listed collections may or may not be suitable
 for being accessed using _nosqlprotocol_.
 
 #### listDatabases
@@ -1861,9 +1861,9 @@ The following fields are relevant.
 | ----------- | ------ | --------------------------- |
 | listIndexes | string | The name of the collection. |
 
-**NOTE** As it currently is not possible to actually create indexes,\
-although an attempt to do so using `createIndexes` will succeed, the\
-result will always only contain information about the built-in\
+**NOTE** As it currently is not possible to actually create indexes,
+although an attempt to do so using `createIndexes` will succeed, the
+result will always only contain information about the built-in
 index `_id_`.
 
 #### renameCollection
@@ -1971,8 +1971,8 @@ The following fields are relevant.
 | -------- | ------ | --------------------------------------- |
 | validate | string | The name of the collection to validate. |
 
-The command does not actually perform any validation but for checking\
-that the collection exists. The response will contain in `nrecords`\
+The command does not actually perform any validation but for checking
+that the collection exists. The response will contain in `nrecords`
 the current number of documents/rows it contains.
 
 #### whatsmyuri
@@ -2009,11 +2009,11 @@ The following document will always be returned:
 
 **mxsAddUser**
 
-The `mxsAddUser` command adds an _existing_ MariaDB user to the local\
+The `mxsAddUser` command adds an _existing_ MariaDB user to the local
 nosqlprotocol account database. Use [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createUser) if the\
 MariaDB user should be created as well.
 
-Note that the `mxsAddUser` command does not check that the user exists\
+Note that the `mxsAddUser` command does not check that the user exists
 or that the specified roles are compatible with the grants of the user.
 
 **Syntax**
@@ -2049,17 +2049,17 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The value of `mxsAddUser` should be the name (without the host part) of\
-an existing user in the MariaDB server and the value of `pwd` should be\
+The value of `mxsAddUser` should be the name (without the host part) of
+an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2308-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2308-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the addition of the user succeeds, the command returns a document\
+If the addition of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2085,7 +2085,7 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsCreateDatabase**
 
-The 'mxsCreateDatabase' command creates a new database and must be run\
+The 'mxsCreateDatabase' command creates a new database and must be run
 against the `admin` database.
 
 **Syntax**
@@ -2110,7 +2110,7 @@ The command takes the following fields:
 
 **Returns**
 
-If database creation succeeds, the command returns a document with the\
+If database creation succeeds, the command returns a document with the
 single field `ok` whose value is `1`.
 
 ```
@@ -2161,7 +2161,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains diagnostics of the command\
+The command returns a document that contains diagnostics of the command
 provided as argument. For example:
 
 ```
@@ -2186,19 +2186,19 @@ provided as argument. For example:
 }
 ```
 
-`kind` specifies of what kind the command is; an _immediate_ command is one for\
-which MaxScale autonomously can generate the response, a _single_ command is one\
-where the command will cause a single SQL statement to be sent to the backend, and\
-a _multi_ command is one where potentially multiple SQL statements will be sent to\
+`kind` specifies of what kind the command is; an _immediate_ command is one for
+which MaxScale autonomously can generate the response, a _single_ command is one
+where the command will cause a single SQL statement to be sent to the backend, and
+a _multi_ command is one where potentially multiple SQL statements will be sent to
 the backend.
 
-If the command is _immediate_ then there will be a field `response` containing\
-the actual response of the command, if the command is _single_ then there will be\
-a field `sql` containing the actual statement that would have been sent to the backend,\
-and if the command is _multi_ then there will be a field `sql` containing an array\
+If the command is _immediate_ then there will be a field `response` containing
+the actual response of the command, if the command is _single_ then there will be
+a field `sql` containing the actual statement that would have been sent to the backend,
+and if the command is _multi_ then there will be a field `sql` containing an array
 of statements that would have been sent to the backend.
 
-If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that\
+If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that
 the value of `ok` will always be 1.
 
 #### mxsGetConfig
@@ -2207,7 +2207,7 @@ the value of `ok` will always be 1.
 
 **mxsGetConfig**
 
-The `mxsGetConfig` command returns the current configuration of the session\
+The `mxsGetConfig` command returns the current configuration of the session
 and must be run against the 'admin' database.
 
 **Syntax**
@@ -2231,7 +2231,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the current configuration of\
+The command returns a document that contains the current configuration of
 the session. For example:
 
 ```
@@ -2253,8 +2253,8 @@ the session. For example:
 
 **mxsRemoveUser**
 
-The `mxsRemoveUser` removes a user from the local nosqlprotocol account\
-database. Use [dropUser](mariadb-maxscale-2308-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped\
+The `mxsRemoveUser` removes a user from the local nosqlprotocol account
+database. Use [dropUser](mariadb-maxscale-2308-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped
 as well.
 
 **Syntax**
@@ -2279,7 +2279,7 @@ The command has the following fields:
 
 **Returns**
 
-If the removal of the user succeeds, the command returns a document\
+If the removal of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2305,10 +2305,10 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsSetConfig**
 
-The `mxsSetConfig` command changes the configuration of the session\
+The `mxsSetConfig` command changes the configuration of the session
 and must be run against the 'admin' database.
 
-Note that the changes only affect the current session and are **not**\
+Note that the changes only affect the current session and are **not**
 persisted.
 
 **Syntax**
@@ -2340,7 +2340,7 @@ The document takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the changed configuration of\
+The command returns a document that contains the changed configuration of
 the session. For example:
 
 ```
@@ -2372,12 +2372,12 @@ the session. For example:
 
 **mxsUpdateUser**
 
-The `mxsUpdateUser` command updates a user in the local nosqlprotocol\
-account database. Use [updateUser](mariadb-maxscale-2308-nosql-protocol-module.md#updateUser) to update MariaDB user\
+The `mxsUpdateUser` command updates a user in the local nosqlprotocol
+account database. Use [updateUser](mariadb-maxscale-2308-nosql-protocol-module.md#updateUser) to update MariaDB user
 as well.
 
-Note that the `mxsUpdateUser` command does not check that the changed\
-data is compatible e.g. with the grants of the corresponding MariaDB\
+Note that the `mxsUpdateUser` command does not check that the changed
+data is compatible e.g. with the grants of the corresponding MariaDB
 user.
 
 **Syntax**
@@ -2413,13 +2413,13 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. If a new password is not provided, the specified mechanisms must be a subset of the current mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2308-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2308-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the updating of the user succeeds, the command returns a document\
+If the updating of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2441,23 +2441,23 @@ If there is a failure of some kind, the command returns an error document
 
 ## Object Id
 
-When a document is created, an id of type `ObjectId` will be autogenerated by\
-the MongoDB® client library. If the id is provided explicitly, by assigning a\
-value to the `_id` field, the value must be an `ObjectId`, a string or an\
+When a document is created, an id of type `ObjectId` will be autogenerated by
+the MongoDB® client library. If the id is provided explicitly, by assigning a
+value to the `_id` field, the value must be an `ObjectId`, a string or an
 integer.
 
 ## Caching
 
 The conversion of the BSON used in the communication between the client and\
-MaxScale, to the SQL used in the communication between MaxScale and the server\
-carries a not insignificant cost, as does the conversion of result sets\
-returned by the server to the BSON returned by MaxScale to the client. The\
-regular [cache filter](../mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md) provides no remedy for this, as\
-it is located after the protocol and uses SQL as the key and stores result\
+MaxScale, to the SQL used in the communication between MaxScale and the server
+carries a not insignificant cost, as does the conversion of result sets
+returned by the server to the BSON returned by MaxScale to the client. The
+regular [cache filter](../mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md) provides no remedy for this, as
+it is located after the protocol and uses SQL as the key and stores result
 sets as values.
 
-From 23.08 onwards, the nosqlprotocol has a built-in cache that when used\
-under certain conditions diminishes the conversion cost. The cache is\
+From 23.08 onwards, the nosqlprotocol has a built-in cache that when used
+under certain conditions diminishes the conversion cost. The cache is
 enabled by adding the following line to the NoSQL listener.
 
 ```
@@ -2466,8 +2466,8 @@ enabled by adding the following line to the NoSQL listener.
 nosqlprotocol.internal_cache=cache
 ```
 
-This effectively causes the [cache filter](../mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md) to be used\
-inside the NoSQL protocol module. The internal cache can be configured just\
+This effectively causes the [cache filter](../mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md) to be used
+inside the NoSQL protocol module. The internal cache can be configured just
 like the cache filter is, by using the following nested configuration syntax.
 
 ```
@@ -2480,27 +2480,27 @@ nosqlprotocol.cache.hard_ttl=40s
 ...
 ```
 
-A limitation is that _only_ the default storage `storage_inmemory` is\
+A limitation is that _only_ the default storage `storage_inmemory` is
 supported; `storage_redis` and `storage_memcached` cannot be used.
 
-The cache works on both the SQL and the BSON layer. When a NoSQL request\
-that potentially is cacheable arrives, a lookup for the BSON response is\
-made. If it is found, the response is returned to the client. That is, in\
-this case neither BSON -> SQL, nor a Result Set -> BSON translation will\
+The cache works on both the SQL and the BSON layer. When a NoSQL request
+that potentially is cacheable arrives, a lookup for the BSON response is
+made. If it is found, the response is returned to the client. That is, in
+this case neither BSON -> SQL, nor a Result Set -> BSON translation will
 be made.
 
-If the request is not potentially cacheable or the response is not\
-available, the request is processed normally, which may mean that the\
-request is translated into SQL. If the SQL is a SELECT, a second lookup\
-will be made for the corresponding result set. If that is found, the\
+If the request is not potentially cacheable or the response is not
+available, the request is processed normally, which may mean that the
+request is translated into SQL. If the SQL is a SELECT, a second lookup
+will be made for the corresponding result set. If that is found, the
 result set is processed, but the roundtrip to the server will be saved.
 
-So, when a result set is received from the server, it will be cached and\
-if the generated NoSQL response is also cacheable, it will be cached as\
-well. The benefit of this approach is that two `Find` NoSQL requests\
-may effectively return the same documents, even though one but not the\
-other NoSQL response is cacheable. Both will benefit the result set being\
-in the cache. Since the used storage follows an LRU-approach when evicting\
+So, when a result set is received from the server, it will be cached and
+if the generated NoSQL response is also cacheable, it will be cached as
+well. The benefit of this approach is that two `Find` NoSQL requests
+may effectively return the same documents, even though one but not the
+other NoSQL response is cacheable. Both will benefit the result set being
+in the cache. Since the used storage follows an LRU-approach when evicting
 data from the cache, the less valuable result will be evicted first.
 
 ### Cached Commands
@@ -2509,25 +2509,25 @@ The responses of the following commands are cached.
 
 * [count](mariadb-maxscale-2308-nosql-protocol-module.md#count)
 * [distinct](mariadb-maxscale-2308-nosql-protocol-module.md#distinct)
-* [find](mariadb-maxscale-2308-nosql-protocol-module.md#find), provided all found documents can be returned in one response,\
+* [find](mariadb-maxscale-2308-nosql-protocol-module.md#find), provided all found documents can be returned in one response,
   i.e., if `singleBatch` is `true` or `batchSize` is large enough.
 
 ## Compatibility
 
-Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)\
+Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)
 test-suite pass.
 
 ## Example
 
-The following is a minimal setup for getting _nosqlprotocol_ up and\
-running. It is assumed the reader knows how to configure MaxScale for\
+The following is a minimal setup for getting _nosqlprotocol_ up and
+running. It is assumed the reader knows how to configure MaxScale for
 normal use. If not, please start with the [MaxScale tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-setting-up-mariadb-maxscale.md).\
-Note that as _nosqlprotocol_ is the first component in the MaxScale\
+Note that as _nosqlprotocol_ is the first component in the MaxScale
 routing chain, it can be used with all routers and filters.
 
 ### Configuring MaxScale
 
-In the following it is assumed that MaxScale already has been configured\
+In the following it is assumed that MaxScale already has been configured
 for normal use and that there exists a _service_ `[TheService]`.
 
 ```
@@ -2544,10 +2544,10 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-The values `the_user` and `the_password` must be replaced with the\
+The values `the_user` and `the_password` must be replaced with the
 actual credentials to be used for every MongoDB® client that connects.
 
-If MaxScale is now started, the following entry should appear in the\
+If MaxScale is now started, the following entry should appear in the
 log file.
 
 ```
@@ -2558,8 +2558,8 @@ log file.
 
 The mongo Shell is a powerful tool with which to access and manipulate a\
 MongoDB database. It is part of the MongoDB® package. Having the native\
-MongoDB database installed is convenient, as it makes it easy to ascertain\
-whether a problem is due to _nosqlprotocol_ not fully implementing something\
+MongoDB database installed is convenient, as it makes it easy to ascertain
+whether a problem is due to _nosqlprotocol_ not fully implementing something
 or due to the API not being used in the correct fashion.
 
 With the _mongo shell_, all that is needed is to invoke it with the port\_nosqlprotocol\_ is listening on:
@@ -2576,7 +2576,7 @@ MongoDB server version: 4.4.1
 >
 ```
 
-If the shell prompt appears, then a connection was successfully\
+If the shell prompt appears, then a connection was successfully
 established and the shell can be used.
 
 ```
@@ -2584,13 +2584,13 @@ established and the shell can be used.
 { "n" : 1, "ok" : 1 }
 ```
 
-The `db` variable is implicitly available, and refers by default to\
+The `db` variable is implicitly available, and refers by default to
 the `test` database.
 
 The command inserted a document into the collection called `collection`.\
-The table corresponding to that collection is created implicitly because\
-the default value of `auto_create_tables` is `true`. Here, the object id\
-is specified explicitly, but there is no need for that, as one will be\
+The table corresponding to that collection is created implicitly because
+the default value of `auto_create_tables` is `true`. Here, the object id
+is specified explicitly, but there is no need for that, as one will be
 created if needed.
 
 To check whether the documents was inserted into the collection, the`find` command can be issued:
@@ -2625,18 +2625,18 @@ MariaDB [(none)]> select * from test.collection;
 +------+------------------------------------+
 ```
 
-The collection `collection` is represented by a table `collection` with\
-the two columns `id` and `doc`. `id` is a virtual column whose content is\
+The collection `collection` is represented by a table `collection` with
+the two columns `id` and `doc`. `id` is a virtual column whose content is
 the value of the `_id` field of the document in the `doc` column.
 
-All MongoDB® commands that _mongdbprotocol_ support (but for the ones that\
-do not require database access), basically access or manipulate the\
+All MongoDB® commands that _mongdbprotocol_ support (but for the ones that
+do not require database access), basically access or manipulate the
 content in the `doc` column using the [JSON functions](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements-and-structure/sql-statements/built-in-functions/special-functions/json-functions/) of MariaDB.
 
-From within the mongo shell itself it is easy to find out just what SQL\
+From within the mongo shell itself it is easy to find out just what SQL
 a particular MongoDB command is translated into.
 
-For instance, the SQL that the insert command with which the document was\
+For instance, the SQL that the insert command with which the document was
 added can be found out like:
 
 ```
@@ -2661,18 +2661,18 @@ Similarly, the SQL of the `find` command can be find out like:
 }
 ```
 
-The returned SQL can be directly pasted at the `mysql` prompt, which is\
+The returned SQL can be directly pasted at the `mysql` prompt, which is
 quite convenient in case the MongoDB® command does not behave as expected.
 
 ### MongoDB® Node.JS Driver
 
-As all client libraries implement and depend on the MongoDB® wire protocol,\
-all client libraries should work with _nosqlprotocol_. However, the\
-only client library that has been used and that has been verified to work\
+As all client libraries implement and depend on the MongoDB® wire protocol,
+all client libraries should work with _nosqlprotocol_. However, the
+only client library that has been used and that has been verified to work
 is version 3.6 of the _MongoDB Node.JS Driver_.
 
-In principle, the only thing that needs to be altered in an existing\
-program using the library is to change the uri string that typically\
+In principle, the only thing that needs to be altered in an existing
+program using the library is to change the uri string that typically
 is something like
 
 ```
@@ -2687,8 +2687,8 @@ const uri = "mongodb://<maxscale-ip>:17017";
 
 with the assumption that the default _nosqlprotocol_ port is used.
 
-In practice, additional modifications may be needed since _nosqlprotocol_\
-does not implement all commands and does not in all cases implement the\
+In practice, additional modifications may be needed since _nosqlprotocol_
+does not implement all commands and does not in all cases implement the
 full functionality of the commands that it supports.
 
 #### Inserting a Document

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md
@@ -4,14 +4,14 @@
 
 ## MaxCtrl
 
-MaxCtrl is a command line administrative client for MaxScale which uses\
-the MaxScale REST API for communication. It has replaced the legacy MaxAdmin\
+MaxCtrl is a command line administrative client for MaxScale which uses
+the MaxScale REST API for communication. It has replaced the legacy MaxAdmin
 command line client that is no longer supported or included.
 
-By default, the MaxScale REST API listens on port 8989 on the local host. The\
+By default, the MaxScale REST API listens on port 8989 on the local host. The
 default credentials for the REST API are `admin:mariadb`. The users used by the\
-REST API are the same that are used by the MaxAdmin network interface. This\
-means that any users created for the MaxAdmin network interface should work with\
+REST API are the same that are used by the MaxAdmin network interface. This
+means that any users created for the MaxAdmin network interface should work with
 the MaxScale REST API and MaxCtrl.
 
 For more information about the MaxScale REST API, refer to the [REST API documentation](../mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md) and the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md).
@@ -22,10 +22,10 @@ For more information about the MaxScale REST API, refer to the [REST API documen
 
 ## .maxctrl.cnf
 
-If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the\
-section `[maxctrl]` as defaults for command line arguments. For instance,\
-to avoid having to specify the user and password on the command line,\
-create the file `.maxctrl.cnf` in your home directory, with the following\
+If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the
+section `[maxctrl]` as defaults for command line arguments. For instance,
+to avoid having to specify the user and password on the command line,
+create the file `.maxctrl.cnf` in your home directory, with the following
 content:
 
 ```
@@ -34,11 +34,11 @@ u = my-name
 p = my-password
 ```
 
-Note that all access rights to the file must be removed from everybody else\
-but the owner. MaxCtrl refuses to use the file unless the rights have been\
+Note that all access rights to the file must be removed from everybody else
+but the owner. MaxCtrl refuses to use the file unless the rights have been
 removed.
 
-Another file from which to read the defaults can be specified with the `-c`\
+Another file from which to read the defaults can be specified with the `-c`
 flag.
 
 ## Commands

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md
@@ -4,17 +4,17 @@
 
 ## Module commands
 
-Introduced in MaxScale 2.1, the module commands are special, module-specific\
+Introduced in MaxScale 2.1, the module commands are special, module-specific
 commands. They allow the modules to expand beyond the capabilities of the module\
 API. Currently, only MaxCtrl implements an interface to the module commands.
 
-All registered module commands can be shown with `maxctrl list commands` and\
+All registered module commands can be shown with `maxctrl list commands` and
 they can be executed with `maxctrl call command <module> <name> ARGS...` whereis the name of the module and is the name of the command._ARGS_ is a command specific list of arguments.
 
 ### Developer reference
 
-The module command API is defined in the _modulecmd.h_ header. It consists of\
-various functions to register and call module commands. Read the function\
+The module command API is defined in the _modulecmd.h_ header. It consists of
+various functions to register and call module commands. Read the function
 documentation in the header for more details.
 
 The following example registers the module command _my\_command_ for module _my\_module_.
@@ -54,11 +54,11 @@ int main(int argc, char **argv)
 }
 ```
 
-The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of\
-arguments the command expects. The first argument is a boolean and the second\
+The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of
+arguments the command expects. The first argument is a boolean and the second
 argument is an optional string.
 
-Arguments are passed to the parsing function as an array of void pointers. They\
+Arguments are passed to the parsing function as an array of void pointers. They
 are interpreted as the types the command expects.
 
 When the module command is executed, the _argv_ parameter for the _my\_simple\_cmd_ contains the parsed arguments received from the caller of the

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-admin-user-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-admin-user-resource.md
@@ -15,7 +15,7 @@ MaxScale's configuration.
 GET /v1/users/inet/:name
 ```
 
-Get a single network user. The _:name_ in the URI must be a valid network\
+Get a single network user. The _:name_ in the URI must be a valid network
 user name.
 
 **Response**
@@ -138,7 +138,7 @@ Get all administrative users.
 POST /v1/users/inet
 ```
 
-Create a new network user. The request body must define at least the\
+Create a new network user. The request body must define at least the
 following fields.
 
 * `data.id`
@@ -150,11 +150,11 @@ following fields.
 * `data.attributes.account`
 * Set to `admin` for administrative users and `basic` to read-only users
 
-Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic\
-account performs one of the aforementioned request, the REST API will respond\
+Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic
+account performs one of the aforementioned request, the REST API will respond
 with a `401 Unauthorized` error.
 
-Here is an example request body defining the network user _my-user_ with the\
+Here is an example request body defining the network user _my-user_ with the
 password _my-password_ that is allowed to execute only read-only operations.
 
 ```
@@ -182,7 +182,7 @@ Status: 204 No Content
 POST /v1/users/unix
 ```
 
-This enables an existing UNIX account on the system for administrative\
+This enables an existing UNIX account on the system for administrative
 operations. The request body must define at least the following fields.
 
 * `data.id`
@@ -246,8 +246,8 @@ Status: 204 No Content
 PATCH /v1/users/inet/:name
 ```
 
-Update network user. Currently, only the password can be updated. This\
-means that the request body must define the `data.attributes.password`\
+Update network user. Currently, only the password can be updated. This
+means that the request body must define the `data.attributes.password`
 field.
 
 Here is an example request body that updates the password.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-filter-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-filter-resource.md
@@ -4,7 +4,7 @@
 
 ## Filter Resource
 
-A filter resource represents an instance of a filter inside MaxScale. Multiple\
+A filter resource represents an instance of a filter inside MaxScale. Multiple
 services can use the same filter and a single service can use multiple filters.
 
 ### Resource Operations
@@ -190,7 +190,7 @@ GET /v1/filters
 POST /v1/filters
 ```
 
-Create a new filter. The posted object must define at\
+Create a new filter. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -202,8 +202,8 @@ least the following fields.
 
 All of the filter parameters should be defined at creation time in the`data.attributes.parameters` object.
 
-As the service to filter relationship is ordered (filters are applied in the\
-order they are listed), filter to service relationships cannot be defined at\
+As the service to filter relationship is ordered (filters are applied in the
+order they are listed), filter to service relationships cannot be defined at
 creation time.
 
 The following example defines a request body which creates a new filter.
@@ -235,8 +235,8 @@ Filter is created:
 PATCH /v1/filters/:name
 ```
 
-Filter parameters can be updated at runtime if the module supports it. Refer to\
-the individual module documentation for more details on whether it supports\
+Filter parameters can be updated at runtime if the module supports it. Refer to
+the individual module documentation for more details on whether it supports
 runtime configuration and which parameters can be updated.
 
 The following example modifies a filter by changing the `match` parameter to`.*users.*`.
@@ -268,10 +268,10 @@ DELETE /v1/filters/:filter
 The _:filter_ in the URI must map to the name of the filter to be destroyed.
 
 A filter can only be destroyed if no service uses it. This means that the`data.relationships` object for the filter must be empty. Note that the service\
-→ filter relationship cannot be modified from the filters resource and must be\
+→ filter relationship cannot be modified from the filters resource and must be
 done via the services resource.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the filter by first removing it from all services that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-listener-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-listener-resource.md
@@ -4,7 +4,7 @@
 
 ## Listener Resource
 
-A listener resource represents a listener of a service in MaxScale. All\
+A listener resource represents a listener of a service in MaxScale. All
 listeners point to a service in MaxScale.
 
 ### Resource Operations
@@ -212,10 +212,10 @@ Creates a new listener. The request body must define the following fields.
 * `data.type`
 * Type of the object, must be `listeners`
 * `data.attributes.parameters.port` OR `data.attributes.parameters.socket`
-* The TCP port or UNIX Domain Socket the listener listens on. Only one of the\
+* The TCP port or UNIX Domain Socket the listener listens on. Only one of the
   fields can be defined.
 * `data.relationships.services.data`
-* The service relationships data, must define a JSON object with an `id` value\
+* The service relationships data, must define a JSON object with an `id` value
   that defines the service to use and a `type` value set to `services`.
 
 The following is the minimal required JSON object for defining a new listener.
@@ -241,7 +241,7 @@ The following is the minimal required JSON object for defining a new listener.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) for\
+Refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) for
 a full list of listener parameters.
 
 **Response**
@@ -256,15 +256,15 @@ Listener is created:
 PATCH /v1/listeners/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the listener.
 
 All parameters marked as modifiable at runtime can be modified. Currently, all\
-TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters\
+TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters
 can be modified at runtime.
 
-Parameters that affect the network address or the port the listener listens on\
-cannot be modified at runtime. To modify these parameters, recreate the\
+Parameters that affect the network address or the port the listener listens on
+cannot be modified at runtime. To modify these parameters, recreate the
 listener.
 
 **Response**
@@ -279,7 +279,7 @@ Listener is modified:
 DELETE /v1/listeners/:name
 ```
 
-The _:name_ must be a valid listener name. When a listener is destroyed, the\
+The _:name_ must be a valid listener name. When a listener is destroyed, the
 network port it listens on is available for reuse.
 
 **Response**
@@ -298,7 +298,7 @@ Listener cannot be deleted:
 PUT /v1/listeners/:name/stop
 ```
 
-Stops a started listener. When a listener is stopped, new connections are no\
+Stops a started listener. When a listener is stopped, new connections are no
 longer accepted and are queued until the listener is started again.
 
 **Parameters**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md
@@ -8,28 +8,28 @@ This document describes the version 1 of the MaxScale REST API.
 
 ### Note About Syntax
 
-Although JSON does not define a syntax for comments, some of the JSON examples\
-have C-style inline comments in them. These comments use `//` to mark the start\
+Although JSON does not define a syntax for comments, some of the JSON examples
+have C-style inline comments in them. These comments use `//` to mark the start
 of the comment and extend to the end of the current line.
 
 ### Configuration
 
-Read the [REST API](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#rest-api-configuration)\
+Read the [REST API](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#rest-api-configuration)
 section of the configuration guide for more details on how to configure the REST API.
 
 ### Authentication
 
-The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)\
-authentication with the MaxScale administrative interface users. The default\
+The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)
+authentication with the MaxScale administrative interface users. The default
 user is `admin:mariadb`.
 
-It is highly recommended to enable HTTPS on the MaxScale REST API to make the\
-communication between the client and MaxScale secure. Without it, the passwords\
-can be intercepted from the network traffic. Refer to the [Configuration Guide](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#admin_ssl_key) for more\
+It is highly recommended to enable HTTPS on the MaxScale REST API to make the
+communication between the client and MaxScale secure. Without it, the passwords
+can be intercepted from the network traffic. Refer to the [Configuration Guide](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#admin_ssl_key) for more
 details on how to enable HTTPS for the MaxScale REST API.
 
-For more details on how administrative interface users are created and managed,\
-refer to the [MaxCtrl](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md) documentation as well as the\
+For more details on how administrative interface users are created and managed,
+refer to the [MaxCtrl](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md) documentation as well as the
 documentation of the [users](mariadb-maxscale-2308-admin-user-resource.md) resource.
 
 #### JSON Web Tokens
@@ -40,7 +40,7 @@ MaxScale supports authentication via [JSON Web Tokens](https://tools.ietf.org/ht
 GET /v1/auth
 ```
 
-The `/v1/auth` endpoint can be used to generate new tokens which are returned in\
+The `/v1/auth` endpoint can be used to generate new tokens which are returned in
 the following form.
 
 ```
@@ -51,41 +51,41 @@ the following form.
 }
 ```
 
-Note that by default the `/auth` endpoint requires the connection to be\
-encrypted (HTTPS) and attempts to use it without encryption will be treated as\
+Note that by default the `/auth` endpoint requires the connection to be
+encrypted (HTTPS) and attempts to use it without encryption will be treated as
 an error. To allow use of the `/auth` endpoint without encryption, use`admin_secure_gui=false`.
 
-If the token is used to authenticate users in a web browser, the token can be\
-optionally stored in cookies. This can be enabled with the `persist=yes`\
+If the token is used to authenticate users in a web browser, the token can be
+optionally stored in cookies. This can be enabled with the `persist=yes`
 parameter in the request:
 
 ```
 GET /v1/auth?persist=yes
 ```
 
-When the token is stored in the cookies, it will be stored in the `token_sig`\
+When the token is stored in the cookies, it will be stored in the `token_sig`
 cookie using the `SameSite=Strict` and `HttpOnly` cookie options. This means the\
-JavaScript context of the browser will not have access to it. This is done to\
+JavaScript context of the browser will not have access to it. This is done to
 prevent CSRF attacks.
 
-By default, the generated tokens are valid for 8 hours. The token validity\
+By default, the generated tokens are valid for 8 hours. The token validity
 period can be set with the `max-age` request parameter:
 
 ```
 GET /v1/auth?max-age=28800
 ```
 
-When `max-age` is combined with `persist`, the `Max-Age` cookie option is\
+When `max-age` is combined with `persist`, the `Max-Age` cookie option is
 also set to the same value.
 
-The maximum lifetime of the tokens is controlled by the `admin_jwt_max_age`\
-parameter. If the configured value is less than 8 hours, the default token\
-lifetime is also lowered to it. A request for a token with a lifetime longer\
-than `admin_jwt_max_age` will be accepted but the token will have its lifetime\
+The maximum lifetime of the tokens is controlled by the `admin_jwt_max_age`
+parameter. If the configured value is less than 8 hours, the default token
+lifetime is also lowered to it. A request for a token with a lifetime longer
+than `admin_jwt_max_age` will be accepted but the token will have its lifetime
 set to `admin_jwt_max_age`.
 
-To use the token for authentication, the generated token must be presented in\
-the Authorization header with the Bearer authentication scheme. For example, the\
+To use the token for authentication, the generated token must be presented in
+the Authorization header with the Bearer authentication scheme. For example, the
 token above would be used in the following manner:
 
 ```
@@ -96,24 +96,24 @@ If MaxScale is restarted, all generated tokens are invalidated.
 
 **`/auth` Request Parameters**
 
-The `/auth` endpoint supports the following request parameters that must be\
+The `/auth` endpoint supports the following request parameters that must be
 given in the HTTP query string.
 
 * `max-age`
-* Sets the token maximum age in seconds. The default is `max-age=28800`. Only\
-  positive values between 1 and 2147483646 are accepted and if a non-positive\
+* Sets the token maximum age in seconds. The default is `max-age=28800`. Only
+  positive values between 1 and 2147483646 are accepted and if a non-positive
   or a non-integer value is found, the parameter is ignored.
 * `persist`
 * Store the generated token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the
   response is 204 No Content instead of 200 OK.\
-  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie\
-  which prevents access to from JavaScript. This is done to mitigate any\
+  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie
+  which prevents access to from JavaScript. This is done to mitigate any
   attacks that might leak the token.
 
 ### Resources
 
-The MaxScale REST API provides the following resources. All resources conform to\
+The MaxScale REST API provides the following resources. All resources conform to
 the [JSON API](https://jsonapi.org/format/) specification.
 
 * [maxscale](mariadb-maxscale-2308-maxscale-resource.md)
@@ -126,45 +126,45 @@ the [JSON API](https://jsonapi.org/format/) specification.
 * [users](mariadb-maxscale-2308-admin-user-resource.md)
 * [sql](mariadb-maxscale-2308-sql-resource.md)
 
-In addition to the named resources, the REST API will respond with a HTTP 200 OK\
-response to GET requests on the root resource (`/`) as well as the namespace\
-root resource (`/v1/`). These can be used for HTTP health checks to determine\
+In addition to the named resources, the REST API will respond with a HTTP 200 OK
+response to GET requests on the root resource (`/`) as well as the namespace
+root resource (`/v1/`). These can be used for HTTP health checks to determine
 whether MaxScale is running.
 
 ### API Versioning
 
 All of the current resources are in the `/v1/` namespace of the MaxScale REST\
-API. Further additions to the namespace can be added that do not break backwards\
+API. Further additions to the namespace can be added that do not break backwards
 compatibility of any existing resources. What this means in practice is that:
 
 * No resources or URLs will be removed
 * The API will be JSON API compliant
 
-Note that this means that the contents of individual resources can change. New\
-fields can be added, old ones can be removed and the meaning of existing fields\
-can change. The aim is to be as backwards compatible as reasonably possible\
+Note that this means that the contents of individual resources can change. New
+fields can be added, old ones can be removed and the meaning of existing fields
+can change. The aim is to be as backwards compatible as reasonably possible
 without sacrificing the clarity and functionality of the API.
 
-Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the\
+Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the
 prefix is not used, the latest API version is used.
 
 #### Resource Relationships
 
-All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other\
+All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other
 objects. This closely resembles the JSON API definition of links.
 
-In the _relationships_ objects, all resources have a _self_ link that points to\
-the resource itself. This allows easy access to the objects pointed by the\
+In the _relationships_ objects, all resources have a _self_ link that points to
+the resource itself. This allows easy access to the objects pointed by the
 relationships as the reply URL is included in the response itself.
 
-To create a relationship between two objects, define it in the initial POST\
-request. To modify the relationships of existing objects, perform a PATCH\
-request with the new definition of the relevant relationship. To completely\
-remove all relationships from an object, the `data` field of the corresponding\
+To create a relationship between two objects, define it in the initial POST
+request. To modify the relationships of existing objects, perform a PATCH
+request with the new definition of the relevant relationship. To completely
+remove all relationships from an object, the `data` field of the corresponding
 relationship object must be set to an empty array.
 
-The following lists the resources and the types of links each resource can have\
-in addition to the _self_ link. Examples of these relationships can be seen in\
+The following lists the resources and the types of links each resource can have
+in addition to the _self_ link. Examples of these relationships can be seen in
 the resource documentation.
 
 * `services` - Service resource
@@ -174,7 +174,7 @@ the resource documentation.
   List of services used by the service
 * `filters`\
   List of filters used by the service\
-  NOTE: This is an ordered relationship where the order of the filters\
+  NOTE: This is an ordered relationship where the order of the filters
   defines the order in which they process queries.
 * `listeners`\
   List of listeners used by the service
@@ -197,57 +197,57 @@ the resource documentation.
 ### Common Request Parameters
 
 All parameters that use boolean values use the same rules that are used for the [boolean values](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#booleans) in the\
-MaxScale configuration. For example, both `pretty=off` and `pretty=false`\
+MaxScale configuration. For example, both `pretty=off` and `pretty=false`
 disable the `pretty` option.
 
-All the resources that return JSON content also support the following\
+All the resources that return JSON content also support the following
 parameters. Parameters are given in the HTTP query string:`https://localhost:8989/v1/servers?pretty=true&fields[servers]=state`.
 
 * `pretty`
 * Pretty-print output.\
-  If this parameter is set to `true` then the returned objects are formatted\
-  in a more human readable format. If the parameter is set to `false` then the\
-  returned objects are formatted in a compact format. All resources support\
+  If this parameter is set to `true` then the returned objects are formatted
+  in a more human readable format. If the parameter is set to `false` then the
+  returned objects are formatted in a compact format. All resources support
   this parameter. The default value for this parameter is `true`.
 * `fields[TYPE]=field1,field2...`
 * Return a [Sparse Fieldset](https://jsonapi.org/format/#fetching-sparse-fieldsets)\
-  This parameter controls which fields are returned in the REST API\
-  response. The `TYPE` value in the `fields` parameter must be the resource\
-  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated\
-  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which\
-  fields of the object to return. Only fields in objects in the `attributes`\
-  and `relationships` objects are inspected. This means that if the path\
-  marked by the JSON Pointer contains an array in it, it will not advance past\
+  This parameter controls which fields are returned in the REST API
+  response. The `TYPE` value in the `fields` parameter must be the resource
+  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated
+  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which
+  fields of the object to return. Only fields in objects in the `attributes`
+  and `relationships` objects are inspected. This means that if the path
+  marked by the JSON Pointer contains an array in it, it will not advance past
   this array.\
-  For example, to return only the server state output from the `/servers`\
-  endpoint, the `fields[servers]=state` parameter can be used. This would\
-  return only the `data.attributes.state` part of the resource. To return the\
-  nested value `data.attributes.statistics.connections`, the corresponding\
+  For example, to return only the server state output from the `/servers`
+  endpoint, the `fields[servers]=state` parameter can be used. This would
+  return only the `data.attributes.state` part of the resource. To return the
+  nested value `data.attributes.statistics.connections`, the corresponding
   parameter would be `fields[servers]=statistics/connections`.
 * `filter=json_ptr=expr`
 * Filter the output of the result\
-  This parameter controls which rows are returned in a REST API response that\
-  returns an array in the `data` member (i.e. a request to a resource\
+  This parameter controls which rows are returned in a REST API response that
+  returns an array in the `data` member (i.e. a request to a resource
   collection). Requests to individual resources are not filtered.\
-  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a\
-  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2308-rest-api.md#filter-expressions). The comparison is done for each\
-  individual object in the `data` array of the result. If given only a JSON\
-  value, the stored value is compared for equality. If an expression is used,\
+  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a
+  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2308-rest-api.md#filter-expressions). The comparison is done for each
+  individual object in the `data` array of the result. If given only a JSON
+  value, the stored value is compared for equality. If an expression is used,
   the expression is evaluated and only rows that match are returned.\
-  For example, if the object stored in `data[0]` has a value pointed by the\
-  given JSON pointer and that value compares equal to the given JSON value,\
-  the array row is kept in the result. Examples for filtering expression can\
+  For example, if the object stored in `data[0]` has a value pointed by the
+  given JSON pointer and that value compares equal to the given JSON value,
+  the array row is kept in the result. Examples for filtering expression can
   be found [here](mariadb-maxscale-2308-rest-api.md#filter-expression-examples).\
-  A practical use for this parameter is to return only sessions for a\
-  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can\
-  be used. Note the double quotes around the `"RW-Split-Router"`, they are\
+  A practical use for this parameter is to return only sessions for a
+  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
+  be used. Note the double quotes around the `"RW-Split-Router"`, they are
   required to correctly convert strings into JSON values.
 * `filter[json_path]=expr`
 * Filter based on a JSONPath and a filtering expression.\
-  Similar to the `filter` parameter that takes a JSON Pointer, this version of\
-  the `filter` controls which rows are returned in a REST API response for a\
+  Similar to the `filter` parameter that takes a JSON Pointer, this version of
+  the `filter` controls which rows are returned in a REST API response for a
   resource collection. Requests to individual resources are never filtered.\
-  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)\
+  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)
   expression that MaxScale supports. The currently supported syntax is:
   * dot notation: `$.store.book`
   * bracket notation: `$['store']['book']`
@@ -257,53 +257,53 @@ parameters. Parameters are given in the HTTP query string:`https://localhost:898
   * object wildcards: `$.store.bicycle.*`
   * optional root object: `store.book`
 
-The root object being optional is an extension to the JSONPath specification\
+The root object being optional is an extension to the JSONPath specification
 that MaxScale implements.\
-The `expr` value must be a [filter-expression](mariadb-maxscale-2308-rest-api.md#filter-expressions). Similarly to the other `filter`\
-parameter, the comparison is done for each individual object in the `data`\
+The `expr` value must be a [filter-expression](mariadb-maxscale-2308-rest-api.md#filter-expressions). Similarly to the other `filter`
+parameter, the comparison is done for each individual object in the `data`
 array of the result.\
-If the JSONPath expression returns multiple objects, the comparison is done\
-for each element and if any of them matches, the object is considered to\
+If the JSONPath expression returns multiple objects, the comparison is done
+for each element and if any of them matches, the object is considered to
 match. In other words, wildcard JSONPath expressions are ORed together.\
-If multiple `filter[json_path]=expr` parameters are found in the request,\
-all returned values must match all of them. In other words, the filter\
-parameters are all combined into an AND expression. For example, the\
-following filter will only return all values whose `id` field is `"srv1` and\
+If multiple `filter[json_path]=expr` parameters are found in the request,
+all returned values must match all of them. In other words, the filter
+parameters are all combined into an AND expression. For example, the
+following filter will only return all values whose `id` field is `"srv1` and
 the `attributes.parameters.port` field is 3306:`filter[id]=eq("srv1")&filter[attributes.parameters.port]=eq(3306)`
 
 * `page[size]`
-* The number of elements that are returned for resource collections. By\
-  default all elements in the resource collection are returned. The value must\
-  be a valid positive integer, otherwise the parameter is ignored. If\
-  pagination is used, the `links` object will have pagination links to the\
+* The number of elements that are returned for resource collections. By
+  default all elements in the resource collection are returned. The value must
+  be a valid positive integer, otherwise the parameter is ignored. If
+  pagination is used, the `links` object will have pagination links to the
   next page if more elements are available.
 * `page[number]`
-* How many pages of results to skip. The first page of results starts from 0\
-  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This\
-  should be considered pseudo-pagination as the results are not guaranteed to\
+* How many pages of results to skip. The first page of results starts from 0
+  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This
+  should be considered pseudo-pagination as the results are not guaranteed to
   be consistent between requests.
 * `sync`
 * Control configuration synchronization.\
-  If this parameter is set to `false` then the configuration synchronization\
-  is disabled for this request. This can be used to perform configuration\
-  changes when MaxScale is unable to reach the cluster used to synchronize the\
-  configuration. The modifications to the local configuration will be\
-  overwritten when the next modification to the cluster's configuration is\
+  If this parameter is set to `false` then the configuration synchronization
+  is disabled for this request. This can be used to perform configuration
+  changes when MaxScale is unable to reach the cluster used to synchronize the
+  configuration. The modifications to the local configuration will be
+  overwritten when the next modification to the cluster's configuration is
   done which means this should only be used to perform temporary fixes.
 
 #### Filter Expressions
 
-MaxScale 24.02 added support for expressions in the `filter` request\
-parameter. Each resource in a resource collection that evaluates to a true value\
-will be kept in the returned result. All rows that evaluate to false are\
+MaxScale 24.02 added support for expressions in the `filter` request
+parameter. Each resource in a resource collection that evaluates to a true value
+will be kept in the returned result. All rows that evaluate to false are
 removed.
 
-Equality and inequality is defined for all JSON types but ordering is defined\
-only for numbers and strings. The logical operators allow one or more\
+Equality and inequality is defined for all JSON types but ordering is defined
+only for numbers and strings. The logical operators allow one or more
 sub-expressions.
 
-The following table lists the supported operations in the filter expressions. In\
-it, the stored value is marked as `S` and the literal JSON value in the\
+The following table lists the supported operations in the filter expressions. In
+it, the stored value is marked as `S` and the literal JSON value in the
 expression as `V`. For the logical operators, the sub-expression is marked as`expr`.
 
 | Expression   | Logic          | Types               |
@@ -320,25 +320,25 @@ expression as `V`. For the logical operators, the sub-expression is marked as`ex
 
 **Filter Expression Examples**
 
-Ranges of values can be defined using an `and()` expression with the range\
-limits defined with the ordering operators `ge()` and `le()`. To filter the\
-sessions in MaxScale to ones that have an ID between 50 and 100, the following\
+Ranges of values can be defined using an `and()` expression with the range
+limits defined with the ordering operators `ge()` and `le()`. To filter the
+sessions in MaxScale to ones that have an ID between 50 and 100, the following
 filtering expression can be used.
 
 ```
 filter=id=and(ge(50),le(100))
 ```
 
-Limiting the result to only the given values can be done with an `or()`\
-expression that uses `eq()` expressions to select the rows to return. To only\
-return sessions with IDs 1, 5, 10 the following filtering expression can be\
+Limiting the result to only the given values can be done with an `or()`
+expression that uses `eq()` expressions to select the rows to return. To only
+return sessions with IDs 1, 5, 10 the following filtering expression can be
 used.
 
 ```
 filter=id=or(eq(1),eq(5),eq(10))
 ```
 
-Similarly, excluding certain rows from the result can be done by simply\
+Similarly, excluding certain rows from the result can be done by simply
 replacing `or()` with `not()`. This expression would exclude sessions with the\
 IDs 1, 5 and 10 from the result.
 
@@ -350,22 +350,22 @@ filter=id=not(eq(1),eq(5),eq(10))
 
 #### Request Headers
 
-REST makes use of the HTTP protocols in its aim to provide a natural way to\
-understand the workings of an API. The following request headers are understood\
+REST makes use of the HTTP protocols in its aim to provide a natural way to
+understand the workings of an API. The following request headers are understood
 by this API.
 
 **Authorization**
 
 Credentials for authentication. This header should consist of a HTTP Basic\
-Access authentication type payload which is the base64 encoded value of the\
+Access authentication type payload which is the base64 encoded value of the
 username and password joined by a colon e.g. `Base64("maxuser:maxpwd")`.
 
 **Content-Type**
 
-All PUT and POST requests must use the `Content-Type: application/json` media\
-type and the request body must be a complete and valid JSON representation of a\
-resource. All PATCH requests must use the `Content-Type: application/json` media\
-type and the request body must be a JSON document containing a partial\
+All PUT and POST requests must use the `Content-Type: application/json` media
+type and the request body must be a complete and valid JSON representation of a
+resource. All PATCH requests must use the `Content-Type: application/json` media
+type and the request body must be a JSON document containing a partial
 definition of the modified resource.
 
 **Host**
@@ -374,59 +374,59 @@ The address and port of the server.
 
 **If-Match**
 
-The request is performed only if the provided ETag value matches the one on the\
-server. This field should be used with PATCH requests to prevent concurrent\
+The request is performed only if the provided ETag value matches the one on the
+server. This field should be used with PATCH requests to prevent concurrent
 updates to the same resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Modified-Since**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **If-None-Match**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Unmodified-Since**
 
-The request is performed only if the requested resource has not been modified\
+The request is performed only if the requested resource has not been modified
 since the provided date.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **X-HTTP-Method-Override**
 
-Some clients only support GET and PUT requests. By providing the string value of\
-the intended method in the `X-HTTP-Method-Override` header, a client can, for\
-example, perform a POST, PATCH or DELETE request with the PUT method\
+Some clients only support GET and PUT requests. By providing the string value of
+the intended method in the `X-HTTP-Method-Override` header, a client can, for
+example, perform a POST, PATCH or DELETE request with the PUT method
 (e.g. `X-HTTP-Method-Override: PATCH`).
 
-If this header is defined in the request, the current method of the request is\
-replaced with the one in the header. The HTTP method must be in uppercase and it\
+If this header is defined in the request, the current method of the request is
+replaced with the one in the header. The HTTP method must be in uppercase and it
 must be one of the methods that the requested resource supports.
 
 #### Response Headers
 
 **Allow**
 
-All resources return the Allow header with the supported HTTP methods. For\
-example the resource `/services` will always return the `Accept: GET, PATCH, PUT`\
+All resources return the Allow header with the supported HTTP methods. For
+example the resource `/services` will always return the `Accept: GET, PATCH, PUT`
 header.
 
 **Accept-Patch**
 
-All PATCH capable resources return the `Accept-Patch: application/json-patch`\
+All PATCH capable resources return the `Accept-Patch: application/json-patch`
 header.
 
 **Date**
@@ -436,12 +436,12 @@ English and it uses the server's local timezone.
 
 **ETag**
 
-An identifier for a specific version of a resource. The value of this header\
-changes whenever a resource is modified via the REST API. It will not change if\
-an internal MaxScale event (e.g. server changing state or statistics being\
+An identifier for a specific version of a resource. The value of this header
+changes whenever a resource is modified via the REST API. It will not change if
+an internal MaxScale event (e.g. server changing state or statistics being
 updated) causes a change.
 
-When the client sends the `If-Match` or `If-None-Match` header, the provided\
+When the client sends the `If-Match` or `If-None-Match` header, the provided
 value should be the value of the `ETag` header of an earlier GET.
 
 **Last-Modified**
@@ -450,29 +450,29 @@ The date when the resource was last modified in "HTTP-date" format.
 
 **Location**
 
-If an out of date resource location is requested, a HTTP return code of 3XX with\
-the `Location` header is returned. The value of the header contains the new\
+If an out of date resource location is requested, a HTTP return code of 3XX with
+the `Location` header is returned. The value of the header contains the new
 location of the requested resource as a relative URI.
 
 **WWW-Authenticate**
 
-The requested authentication method. For example, `WWW-Authenticate: Basic`\
+The requested authentication method. For example, `WWW-Authenticate: Basic`
 would require basic HTTP authentication.
 
 **Mxs-Warning**
 
-This header is used for sending generic warnings to clients about actions that\
-were successful and valid but could cause problems in the future. Currently\
-these are used to indicate when a configuration change was made to a static\
-object and an overriding configuration is created or when a static object is\
+This header is used for sending generic warnings to clients about actions that
+were successful and valid but could cause problems in the future. Currently
+these are used to indicate when a configuration change was made to a static
+object and an overriding configuration is created or when a static object is
 being deleted at runtime.
 
-The content of the header is the human-readable warning that should be displayed\
+The content of the header is the human-readable warning that should be displayed
 to a user.
 
 ### Response Codes
 
-Every HTTP response starts with a line with a return code which indicates the\
+Every HTTP response starts with a line with a return code which indicates the
 outcome of the request. The API uses some of the standard HTTP values:
 
 #### 2xx Success
@@ -482,37 +482,37 @@ outcome of the request. The API uses some of the standard HTTP values:
 * 201 Created
 * A new resource was created.
 * 202 Accepted
-* The request has been accepted for processing, but the processing has not\
+* The request has been accepted for processing, but the processing has not
   been completed.
 * 204 No Content
 * Successful HTTP requests, response has no body.
 
 #### 3xx Redirection
 
-This class of status code indicates the client must take additional action to\
+This class of status code indicates the client must take additional action to
 complete the request.
 
 * 301 Moved Permanently
 * This and all future requests should be directed to the given URI.
 * 302 Found
-* The response to the request can be found under another URI using the same\
+* The response to the request can be found under another URI using the same
   method as in the original request.
 * 303 See Other
-* The response to the request can be found under another URI using a GET\
+* The response to the request can be found under another URI using a GET
   method.
 * 304 Not Modified
-* Indicates that the resource has not been modified since the version\
+* Indicates that the resource has not been modified since the version
   specified by the request headers If-Modified-Since or If-None-Match.
 * 307 Temporary Redirect
-* The request should be repeated with another URI but future requests should\
+* The request should be repeated with another URI but future requests should
   use the original URI.
 * 308 Permanent Redirect
 * The request and all future requests should be repeated using another URI.
 
 #### 4xx Client Error
 
-The 4xx class of status code is when the client seems to have erred. Except when\
-responding to a HEAD request, the body of the response _MAY_ contains a JSON\
+The 4xx class of status code is when the client seems to have erred. Except when
+responding to a HEAD request, the body of the response _MAY_ contains a JSON
 representation of the error.
 
 ```
@@ -523,7 +523,7 @@ representation of the error.
 }
 ```
 
-The _error_ field contains a short error description and the _description_ field\
+The _error_ field contains a short error description and the _description_ field
 contains a more detailed version of the error message.
 
 * 400 Bad Request
@@ -531,41 +531,41 @@ contains a more detailed version of the error message.
 * 401 Unauthorized
 * Authentication is required. The response includes a WWW-Authenticate header.
 * 403 Forbidden
-* The request was a valid request, but the client does not have the necessary\
+* The request was a valid request, but the client does not have the necessary
   permissions for the resource.
 * 404 Not Found
 * The requested resource could not be found.
 * 405 Method Not Allowed
 * A request method is not supported for the requested resource.
 * 406 Not Acceptable
-* The requested resource is capable of generating only content not acceptable\
+* The requested resource is capable of generating only content not acceptable
   according to the Accept headers sent in the request.
 * 409 Conflict
-* Indicates that the request could not be processed because of conflict in the\
+* Indicates that the request could not be processed because of conflict in the
   request, such as an edit conflict be tween multiple simultaneous updates.
 * 411 Length Required
-* The request did not specify the length of its content, which is required by\
+* The request did not specify the length of its content, which is required by
   the requested resource.
 * 412 Precondition Failed
-* The server does not meet one of the preconditions that the requester put on\
+* The server does not meet one of the preconditions that the requester put on
   the request.
 * 413 Payload Too Large
 * The request is larger than the server is willing or able to process.
 * 414 URI Too Long
 * The URI provided was too long for the server to process.
 * 415 Unsupported Media Type
-* The request entity has a media type which the server or resource does not\
+* The request entity has a media type which the server or resource does not
   support.
 * 422 Unprocessable Entity
-* The request was well-formed but was unable to be followed due to semantic\
+* The request was well-formed but was unable to be followed due to semantic
   errors.
 * 423 Locked
 * The resource that is being accessed is locked.
 * 428 Precondition Required
-* The origin server requires the request to be conditional. This error code is\
+* The origin server requires the request to be conditional. This error code is
   returned when none of the `Modified-Since` or `Match` type headers are used.
 * 431 Request Header Fields Too Large
-* The server is unwilling to process the request because either an individual\
+* The server is unwilling to process the request because either an individual
   header field, or all the header fields collectively, are too large.
 
 #### 5xx Server Error
@@ -573,30 +573,30 @@ contains a more detailed version of the error message.
 The server failed to fulfill an apparently valid request.
 
 * 500 Internal Server Error
-* A generic error message, given when an unexpected condition was encountered\
+* A generic error message, given when an unexpected condition was encountered
   and no more specific message is suitable.
 * 501 Not Implemented
-* The server either does not recognize the request method, or it lacks the\
+* The server either does not recognize the request method, or it lacks the
   ability to fulfill the request.
 * 502 Bad Gateway
-* The server was acting as a gateway or proxy and received an invalid response\
+* The server was acting as a gateway or proxy and received an invalid response
   from the upstream server.
 * 503 Service Unavailable
-* The server is currently unavailable (because it is overloaded or down for\
+* The server is currently unavailable (because it is overloaded or down for
   maintenance). Generally, this is a temporary state.
 * 504 Gateway Timeout
-* The server was acting as a gateway or proxy and did not receive a timely\
+* The server was acting as a gateway or proxy and did not receive a timely
   response from the upstream server.
 * 505 HTTP Version Not Supported
 * The server does not support the HTTP protocol version used in the request.
 * 506 Variant Also Negotiates
-* Transparent content negotiation for the request results in a circular\
+* Transparent content negotiation for the request results in a circular
   reference.
 * 507 Insufficient Storage
-* The server is unable to store the representation needed to complete the\
+* The server is unable to store the representation needed to complete the
   request.
 * 508 Loop Detected
-* The server detected an infinite loop while processing the request (sent in\
+* The server detected an infinite loop while processing the request (sent in
   lieu of 208 Already Reported).
 * 510 Not Extended
 * Further extensions to the request are required for the server to fulfil it.
@@ -607,23 +607,23 @@ The following response headers are not currently in use. Future versions of the\
 API could return them.
 
 * 206 Partial Content
-* The server is delivering only part of the resource (byte serving) due to a\
+* The server is delivering only part of the resource (byte serving) due to a
   range header sent by the client.
 * 300 Multiple Choices
-* Indicates multiple options for the resource from which the client may choose\
+* Indicates multiple options for the resource from which the client may choose
   (via agent-driven content negotiation).
 * 407 Proxy Authentication Required
 * The client must first authenticate itself with the proxy.
 * 408 Request Timeout
-* The server timed out waiting for the request. According to HTTP\
-  specifications: "The client did not produce a request within the time that\
-  the server was prepared to wait. The client MAY repeat the request without\
+* The server timed out waiting for the request. According to HTTP
+  specifications: "The client did not produce a request within the time that
+  the server was prepared to wait. The client MAY repeat the request without
   modifications at any later time."
 * 410 Gone
-* Indicates that the resource requested is no longer available and will not be\
+* Indicates that the resource requested is no longer available and will not be
   available again.
 * 416 Range Not Satisfiable
-* The client has asked for a portion of the file (byte serving), but the\
+* The client has asked for a portion of the file (byte serving), but the
   server cannot supply that portion.
 * 417 Expectation Failed
 * The server cannot meet the requirements of the Expect request-header field.
@@ -632,10 +632,10 @@ API could return them.
 * 424 Failed Dependency
 * The request failed due to failure of a previous request.
 * 426 Upgrade Required
-* The client should switch to a different protocol such as TLS/1.0, given in\
+* The client should switch to a different protocol such as TLS/1.0, given in
   the Upgrade header field.
 * 429 Too Many Requests
-* The user has sent too many requests in a given amount of time. Intended for\
+* The user has sent too many requests in a given amount of time. Intended for
   use with rate-limiting schemes.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-server-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-server-resource.md
@@ -765,7 +765,7 @@ Response contains a resource collection with all servers.
 POST /v1/servers
 ```
 
-Create a new server by defining the resource. The posted object must define at\
+Create a new server by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -773,10 +773,10 @@ least the following fields.
 * `data.type`
 * Type of the object, must be `servers`
 * `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-* The [address](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#address) or [socket](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#socket) to use. Only\
+* The [address](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#address) or [socket](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#socket) to use. Only
   one of the fields can be defined.
 * `data.attributes.parameters.port`
-* The [port](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#port) to use. Needs\
+* The [port](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#port) to use. Needs
   to be defined if the `address` field is defined.
 
 The following is the minimal required JSON object for defining a new server.
@@ -796,7 +796,7 @@ The following is the minimal required JSON object for defining a new server.
 }
 ```
 
-The relationships of a server can also be defined at creation time. This allows\
+The relationships of a server can also be defined at creation time. This allows
 new servers to be created and immediately taken into use.
 
 ```
@@ -836,7 +836,7 @@ new servers to be created and immediately taken into use.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)
 for a full list of server parameters.
 
 **Response**
@@ -855,19 +855,19 @@ Invalid JSON body:
 PATCH /v1/servers/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 server.
 
 #### Modifiable Fields
 
-In addition to the server [parameters](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#server-1), the _services_\
-and _monitors_ fields of the _relationships_ object can be modified. Removal,\
-addition and modification of the links will change which service and monitors\
+In addition to the server [parameters](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#server-1), the _services_
+and _monitors_ fields of the _relationships_ object can be modified. Removal,
+addition and modification of the links will change which service and monitors
 use this server.
 
 For example, removing the first value in the _services_ list in the_relationships_ object from the following JSON document will remove the_server1_ from the service _RW-Split-Router_.
 
-Removing a service from a server is analogous to removing the server from the\
+Removing a service from a server is analogous to removing the server from the
 service. Both unlink the two objects from each other.
 
 Request for `PATCH /v1/servers/server1` that modifies the address of the server:
@@ -905,9 +905,9 @@ Request for `PATCH /v1/servers/server1` that modifies the server relationships:
 }
 ```
 
-If parts of the resource are not defined (e.g. the `attributes` field in the\
-above example), those parts of the resource are not modified. All parts that are\
-defined are interpreted as the new definition of those part of the resource. In\
+If parts of the resource are not defined (e.g. the `attributes` field in the
+above example), those parts of the resource are not modified. All parts that are
+defined are interpreted as the new definition of those part of the resource. In
 the above example, the `relationships` of the resource are completely redefined.
 
 **Response**
@@ -926,15 +926,15 @@ Invalid JSON body:
 PATCH /v1/servers/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _services_, for service\
+The _:type_ in the URI must be either _services_, for service
 relationships, or _monitors_, for monitor relationships.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the particular type from the server.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 service relationship for a server.
 
 ```
@@ -973,11 +973,11 @@ Invalid JSON body:
 DELETE /v1/servers/:name
 ```
 
-A server can only be deleted if it is not used by any services or\
+A server can only be deleted if it is not used by any services or
 monitors.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the server by first unlinking it from all services and monitors that use\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the server by first unlinking it from all services and monitors that use
 it.
 
 **Response**
@@ -996,7 +996,7 @@ Server is in use:
 PUT /v1/servers/:name/set
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the following values.
 
 | Value       | State Description                |
@@ -1008,19 +1008,19 @@ request. The value of `state` must be one of the following values.
 | synced      | Server is a Galera node          |
 | drain       | Server is drained of connections |
 
-For example, to set the server _db-server-1_ into maintenance mode, a request to\
+For example, to set the server _db-server-1_ into maintenance mode, a request to
 the following URL must be made:
 
 ```
 PUT /v1/servers/db-server-1/set?state=maintenance
 ```
 
-This endpoint also supports the `force=yes` parameter that will cause all\
-connections to the server to be closed if `state=maintenance` is also set. By\
-default setting a server into maintenance mode will cause connections to be\
+This endpoint also supports the `force=yes` parameter that will cause all
+connections to the server to be closed if `state=maintenance` is also set. By
+default setting a server into maintenance mode will cause connections to be
 closed only after the next request is sent.
 
-The following example forcefully closes all connections to server _db-server-1_\
+The following example forcefully closes all connections to server _db-server-1_
 and sets it into maintenance mode:
 
 ```
@@ -1043,7 +1043,7 @@ Missing or invalid parameter:
 PUT /v1/servers/:name/clear
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the values defined in the_set_ endpoint documentation.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-service-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-service-resource.md
@@ -4,7 +4,7 @@
 
 ## Service Resource
 
-A service resource represents a service inside MaxScale. A service is a\
+A service resource represents a service inside MaxScale. A service is a
 collection of network listeners, filters, a router and a set of backend servers.
 
 ### Resource Operations
@@ -728,7 +728,7 @@ Get all services.
 POST /v1/services
 ```
 
-Create a new service by defining the resource. The posted object must define at\
+Create a new service by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -742,24 +742,24 @@ least the following fields.
 * `data.attributes.parameters.password`
 * The [password](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#password) to use
 
-The `data.attributes.parameters` object is used to define router and service\
-parameters. All configuration parameters that can be defined in the\
-configuration file can also be added to the parameters object. The exceptions to\
-this are the `type`, `router`, `servers` and `filters` parameters which must not\
+The `data.attributes.parameters` object is used to define router and service
+parameters. All configuration parameters that can be defined in the
+configuration file can also be added to the parameters object. The exceptions to
+this are the `type`, `router`, `servers` and `filters` parameters which must not
 be defined.
 
-As with other REST API resources, the `data.relationships` field defines the\
-relationships of the service to other resources. Services can have two types of\
+As with other REST API resources, the `data.relationships` field defines the
+relationships of the service to other resources. Services can have two types of
 relationships: `servers` and `filters` relationships.
 
-If the request body defines a valid `relationships` object, the service is\
-linked to those resources. For servers, this is equivalent to adding the list of\
-server names into the [servers](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#servers) parameter. For\
-filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#filters) parameter in the\
-order they appear. For other services, this is equivalent to adding the list of\
+If the request body defines a valid `relationships` object, the service is
+linked to those resources. For servers, this is equivalent to adding the list of
+server names into the [servers](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#servers) parameter. For
+filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#filters) parameter in the
+order they appear. For other services, this is equivalent to adding the list of
 server names into the [targets](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#targets) parameter.
 
-The following example defines a new service with both a server and a filter\
+The following example defines a new service with both a server and a filter
 relationship.
 
 ```
@@ -808,21 +808,21 @@ Service is created:
 DELETE /v1/services/:name
 ```
 
-A service can only be destroyed if the service uses no servers or filters and\
-all the listeners pointing to the service have been destroyed. This means that\
-the `data.relationships` must be an empty object and `data.attributes.listeners`\
+A service can only be destroyed if the service uses no servers or filters and
+all the listeners pointing to the service have been destroyed. This means that
+the `data.relationships` must be an empty object and `data.attributes.listeners`
 must be an empty array in order for the service to qualify for destruction.
 
-If there are open client connections that use the service when it is destroyed,\
-they are allowed to gracefully close before the service is destroyed. This means\
-that the destruction of a service can be acknowledged via the REST API before\
+If there are open client connections that use the service when it is destroyed,
+they are allowed to gracefully close before the service is destroyed. This means
+that the destruction of a service can be acknowledged via the REST API before
 the destruction process has fully completed.
 
-To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2308-session-resource.md) resource should be used. If a session for\
+To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2308-session-resource.md) resource should be used. If a session for
 the service is still open, it has not yet been destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the service by first unlinking it from all servers and filters that it\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the service by first unlinking it from all servers and filters that it
 uses.
 
 **Response**
@@ -837,15 +837,15 @@ Service is destroyed:
 PATCH /v1/services/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the service.
 
-All standard service parameters can be modified. Refer to the [service](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#service) documentation on\
+All standard service parameters can be modified. Refer to the [service](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#service) documentation on
 the details of these parameters.
 
-In addition to the standard service parameters, router parameters can be updated\
-at runtime if the router module supports it. Refer to the individual router\
-documentation for more details on whether the router supports it and which\
+In addition to the standard service parameters, router parameters can be updated
+at runtime if the router module supports it. Refer to the individual router
+documentation for more details on whether the router supports it and which
 parameters can be updated at runtime.
 
 The following example modifies a service by changing the `user` parameter to `admin`.
@@ -874,22 +874,22 @@ Service is modified:
 PATCH /v1/services/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _servers_, _services_ or _filters_,\
+The _:type_ in the URI must be either _servers_, _services_ or _filters_,
 depending on which relationship is being modified.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of this type for the service.
 
-_Note:_ The order of the values in the `filters` relationship will define the\
-order the filters are set up in. The order in which the filters appear in the\
-array will be the order in which the filters are applied to each query. Refer\
-to the [filters](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#filters) parameter\
+_Note:_ The order of the values in the `filters` relationship will define the
+order the filters are set up in. The order in which the filters appear in the
+array will be the order in which the filters are applied to each query. Refer
+to the [filters](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#filters) parameter
 for more details.
 
-The following is an example request and request body that defines a single\
-server relationship for a service that is equivalent to a `servers=my-server`\
+The following is an example request and request body that defines a single
+server relationship for a service that is equivalent to a `servers=my-server`
 parameter.
 
 ```
@@ -985,7 +985,7 @@ This endpoint is deprecated, use the [this](mariadb-maxscale-2308-listener-resou
 GET /v1/services/:name/listeners/:listener
 ```
 
-This endpoint is deprecated, use the [this](mariadb-maxscale-2308-listener-resource.md#get-a-listener)\
+This endpoint is deprecated, use the [this](mariadb-maxscale-2308-listener-resource.md#get-a-listener)
 listeners endpoint instead.
 
 #### Create a new listener

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-session-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-session-resource.md
@@ -4,8 +4,8 @@
 
 ## Session Resource
 
-A session is an abstraction of a client connection, any number of related backend\
-connections, a router module session and possibly filter module sessions. Each\
+A session is an abstraction of a client connection, any number of related backend
+connections, a router module session and possibly filter module sessions. Each
 session is created on a service and each service can have multiple sessions.
 
 ### Resource Operations
@@ -16,11 +16,11 @@ session is created on a service and each service can have multiple sessions.
 GET /v1/sessions/:id
 ```
 
-Get a single session. _:id_ must be a valid session ID. The session ID is the\
+Get a single session. _:id_ must be a valid session ID. The session ID is the
 same that is exposed to the client as the connection ID.
 
-This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to\
-perform reverse DNS on the client IP address. As this requires communicating with\
+This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to
+perform reverse DNS on the client IP address. As this requires communicating with
 an external server, the operation may be expensive.
 
 **Response**
@@ -211,10 +211,10 @@ Get all sessions.
 PATCH /v1/sessions/:id
 ```
 
-The request body must be a JSON object which represents the new configuration of\
+The request body must be a JSON object which represents the new configuration of
 the session. The `:id` must be a valid session ID that is active.
 
-The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean\
+The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean
 parameters control whether the associated logging level is enabled:
 
 ```
@@ -229,11 +229,11 @@ parameters control whether the associated logging level is enabled:
 }
 ```
 
-The filters that a session uses can be updated by re-defining the filter\
-relationship of the session. This causes new filter sessions to be opened\
-immediately. The old filter session are closed and replaced with the new filter\
-session the next time the session is idle. The order in which the filters are\
-defined in the request body is the order in which the filters are installed,\
+The filters that a session uses can be updated by re-defining the filter
+relationship of the session. This causes new filter sessions to be opened
+immediately. The old filter session are closed and replaced with the new filter
+session the next time the session is idle. The order in which the filters are
+defined in the request body is the order in which the filters are installed,
 similar to how the filter relationship for services behaves.
 
 ```
@@ -265,14 +265,14 @@ Session is modified:
 POST /v1/sessions/:id/restart
 ```
 
-This endpoint causes the session to re-read the configuration from the\
-service. As a result of this, all backend connections will be closed and then\
-opened again. All router and filter sessions will be created again which means\
-that for modules that perform something whenever a new module session is opened,\
+This endpoint causes the session to re-read the configuration from the
+service. As a result of this, all backend connections will be closed and then
+opened again. All router and filter sessions will be created again which means
+that for modules that perform something whenever a new module session is opened,
 this behaves as if a new session was started.
 
-This endpoint can be used to apply configuration changes that were done after\
-the session was started. This can be useful for situations where the client\
+This endpoint can be used to apply configuration changes that were done after
+the session was started. This can be useful for situations where the client
 connections live for a long time and connections are not recycled often enough.
 
 **Response**
@@ -287,7 +287,7 @@ Session is was restarted:
 POST /v1/sessions/restart
 ```
 
-This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint\
+This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint
 except that it applies to all sessions.
 
 **Response**
@@ -309,8 +309,8 @@ This endpoint causes the session to be forcefully closed.
 This endpoint supports the following request parameters.
 
 * `ttl`
-* The time after which the session is killed. If this parameter is not given,\
-  the session is killed immediately. This can be used to give the session time\
+* The time after which the session is killed. If this parameter is not given,
+  the session is killed immediately. This can be used to give the session time
   to finish the work it is performing before the connection is closed.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-sql-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-sql-resource.md
@@ -11,35 +11,35 @@ The SQL resource represents a database connection.
 The following endpoints provide a simple REST API interface for executing\
 SQL queries on servers and services in MaxScale.
 
-This endpoint also supports executing SQL queries using an ODBC driver. The\
-results returned by connections that use ODBC drivers can differ from the ones\
+This endpoint also supports executing SQL queries using an ODBC driver. The
+results returned by connections that use ODBC drivers can differ from the ones
 returned by normal SQL connections to objects in MaxScale.
 
-This document uses the `:id` value in the URL to represent a connection ID and\
-the `:query_id` to represent a query ID. These values do not need to be manually\
+This document uses the `:id` value in the URL to represent a connection ID and
+the `:query_id` to represent a query ID. These values do not need to be manually
 added as the relevant links are returned in the request body of each endpoint.
 
-The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A\
-connection token can be acquired with a `POST /v1/sql` request and can be used\
-with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in\
+The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A
+connection token can be acquired with a `POST /v1/sql` request and can be used
+with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in
 the `token` parameter of the request:
 
 ```
 POST /v1/sql/query?token=eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhZG1pbiIsImV4cCI6MTU4MzI1NDE1MSwiaWF0IjoxNTgzMjI1MzUxLCJpc3MiOiJtYXhzY2FsZSJ9.B1BqhjjKaCWKe3gVXLszpOPfeu8cLiwSb4CMIJAoyqw
 ```
 
-In addition to request parameters, the token can be stored in cookies in which\
-case they are automatically used by the REST API. For more information about\
+In addition to request parameters, the token can be stored in cookies in which
+case they are automatically used by the REST API. For more information about
 token storage in cookies, see the documentation for `POST /v1/sql`.
 
 ### Request Parameters
 
-All of the endpoints that operate on a single connection support the following\
-request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an\
+All of the endpoints that operate on a single connection support the following
+request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an
 exception as they ignore the current connection token.
 
 * `token`
-* The connection token to use for the request. If provided, the value is\
+* The connection token to use for the request. If provided, the value is
   unconditionally used even if a cookie with a valid token exists.
 
 #### Get one SQL connection
@@ -135,24 +135,24 @@ POST /v1/sql
 The request body must be a JSON object consisting of the following fields:
 
 * `target`
-* The object to connect to. This is a mandatory value and the\
+* The object to connect to. This is a mandatory value and the
   given value must be the name of a valid server, service or listener in\
   MaxScale or the value `odbc` if an ODBC connection is being made.
 * `user`
-* The username to use when creating the connection. This is a mandatory value\
+* The username to use when creating the connection. This is a mandatory value
   when connecting to an object in MaxScale.
 * `password`
-* The password for the user. This is a mandatory value when connecting to an\
+* The password for the user. This is a mandatory value when connecting to an
   object in MaxScale.
 * `db`
-* The default database for the connection. By default the connection will have\
+* The default database for the connection. By default the connection will have
   no default database. This is ignored by ODBC connections.
 * `timeout`
-* Connection timeout in seconds. The default connection timeout is 10\
-  seconds. This controls how long the SQL connection creation can take before\
+* Connection timeout in seconds. The default connection timeout is 10
+  seconds. This controls how long the SQL connection creation can take before
   an error is returned. This is accepted by all connection types.
 * `connection_string`
-* Connection string that defines the ODBC connection. This is a required value\
+* Connection string that defines the ODBC connection. This is a required value
   for ODBC type connections and is ignored by all other connection types.
 
 Here is an example request body:
@@ -167,7 +167,7 @@ Here is an example request body:
 }
 ```
 
-And here is an example request that uses an ODBC driver to connect to a remote\
+And here is an example request that uses an ODBC driver to connect to a remote
 server:
 
 ```
@@ -177,16 +177,16 @@ server:
 }
 ```
 
-The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token\
-is stored in cookies instead of the metadata object and the response body will\
+The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token
+is stored in cookies instead of the metadata object and the response body will
 not contain the token.
 
-The location of the newly created connection will be stored at `links.self` in\
+The location of the newly created connection will be stored at `links.self` in
 the response body as well as in the `Location` header.
 
-The token must be given to all subsequent requests that use the connection. It\
-must be either given in the `token` parameter of a request or it must be stored\
-in the cookies. If both a `token` parameter and a cookie exist at the same time,\
+The token must be given to all subsequent requests that use the connection. It
+must be either given in the `token` parameter of a request or it must be stored
+in the cookies. If both a `token` parameter and a cookie exist at the same time,
 the `token` parameter will be used instead of the cookie.
 
 **Request Parameters**
@@ -195,12 +195,12 @@ This endpoint supports the following request parameters.
 
 * `persist`
 * Store the connection token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie
   where the `<id>` part is replaced by the ID of the connection.
 * `max-age`
-* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or\
-  a non-integer value is found, the parameter is ignored. Once the token age\
-  exceeds the configured maximum value, the token can no longer be used and a\
+* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or
+  a non-integer value is found, the parameter is ignored. Once the token age
+  exceeds the configured maximum value, the token can no longer be used and a
   new connection must be created.
 
 **Response**
@@ -260,12 +260,12 @@ Missing or invalid connection token:
 POST /v1/sql/:id/reconnect
 ```
 
-Reconnects an existing connection. This can also be used if the connection to\
+Reconnects an existing connection. This can also be used if the connection to
 the backend server was lost due to a network error.
 
 The connection will use the same credentials that were passed to the `POST /v1/sql` endpoint. The new connection will still have the same ID in the REST\
-API but will be treated as a new connection by the database. A reconnection\
-re-initializes the connection and resets the session state. Reconnections cannot\
+API but will be treated as a new connection by the database. A reconnection
+re-initializes the connection and resets the session state. Reconnections cannot
 take place while a transaction is open.
 
 **Response**
@@ -288,17 +288,17 @@ Missing or invalid connection token:
 POST /v1/sql/:id/clone
 ```
 
-Clones an existing connection. This is done by opening a new connection using\
+Clones an existing connection. This is done by opening a new connection using
 the credentials and configuration from the given connection.
 
 **Request Parameters**
 
-This endpoint supports the same request parameters as the `POST /v1/sql`\
+This endpoint supports the same request parameters as the `POST /v1/sql`
 endpoint.
 
 **Response**
 
-The response is identical to the one in the `POST /v1/sql` endpoint. In\
+The response is identical to the one in the `POST /v1/sql` endpoint. In
 addition, this endpoint can return the following responses.
 
 Connection is already in use:
@@ -315,7 +315,7 @@ Missing or invalid connection token:
 POST /v1/sql/:id/queries
 ```
 
-The request body must be a JSON object with the value of the `sql` field set to\
+The request body must be a JSON object with the value of the `sql` field set to
 the SQL to be executed:
 
 ```
@@ -328,23 +328,23 @@ the SQL to be executed:
 The request body must be a JSON object consisting of the following fields:
 
 * `sql`
-* The SQL to be executed. If the SQL contain multiple statements, multiple\
+* The SQL to be executed. If the SQL contain multiple statements, multiple
   results are returned in the response body.
 * `max_rows`
-* The maximum number of rows returned in the response. By default this is 1000\
-  rows. Setting the value to 0 means no limit. Any extra rows in the result\
+* The maximum number of rows returned in the response. By default this is 1000
+  rows. Setting the value to 0 means no limit. Any extra rows in the result
   will be discarded.
 
-By default, the complete result is returned in the response body. If the SQL\
-query returns more than one result, the `results` array will contain all the\
-results. If the `async=true` request option is used, the query is queued for\
+By default, the complete result is returned in the response body. If the SQL
+query returns more than one result, the `results` array will contain all the
+results. If the `async=true` request option is used, the query is queued for
 execution.
 
-The `results` array can have three types of objects: resultsets, errors, and OK\
+The `results` array can have three types of objects: resultsets, errors, and OK
 responses.
 
-* A resultset consists of the `data` field with the result data stored as a two\
-  dimensional array. The names of the fields are stored in an array in the`fields` field. These types of results will be returned for any operation that\
+* A resultset consists of the `data` field with the result data stored as a two
+  dimensional array. The names of the fields are stored in an array in the`fields` field. These types of results will be returned for any operation that
   returns rows (i.e. `SELECT` statements)
 
 ```
@@ -382,7 +382,7 @@ responses.
 }
 ```
 
-* An error consists of an object with the `errno` field set to the MariaDB error\
+* An error consists of an object with the `errno` field set to the MariaDB error
   code, the `message` field set to the human-readable error message and the`sqlstate` field set to the current SQLSTATE of the connection.
 
 ```
@@ -408,9 +408,9 @@ responses.
 }
 ```
 
-* An OK response is returned for any result that completes successfully but not\
-  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`\
-  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field\
+* An OK response is returned for any result that completes successfully but not
+  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`
+  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field
   contains the number of warnings raised by the operation.
 
 ```
@@ -436,17 +436,17 @@ responses.
 }
 ```
 
-It is also possible for the fields of the error response to be present in the\
-resultset response if the result ended with an error but still generated some\
-data. Usually this happens when query execution is interrupted but a partial\
+It is also possible for the fields of the error response to be present in the
+resultset response if the result ended with an error but still generated some
+data. Usually this happens when query execution is interrupted but a partial
 result was generated by the server.
 
 **Request Parameters**
 
 * `async`
-* If set to `true`, the query is queued for asynchronous execution and the\
-  results must be retrieved later from the URL stored in `links.self` field\
-  of the response. The HTTP response code is set to HTTP 202 Accepted if the\
+* If set to `true`, the query is queued for asynchronous execution and the
+  results must be retrieved later from the URL stored in `links.self` field
+  of the response. The HTTP response code is set to HTTP 202 Accepted if the
   query was successfully queued for execution.
 
 **Response**
@@ -512,7 +512,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 #### Get Asynchronous Query Results
@@ -521,10 +521,10 @@ Fatal connection error:
 GET /v1/sql/:id/queries/:query_id
 ```
 
-The results are only available if a `POST /v1/sql/:id/queries` was executed with\
-the `async` field set to `true`. The result of any asynchronous query can be\
-read multiple times. Only the latest result is stored: executing a new query\
-will cause the latest result to be erased. Results can be explicitly erased\
+The results are only available if a `POST /v1/sql/:id/queries` was executed with
+the `async` field set to `true`. The result of any asynchronous query can be
+read multiple times. Only the latest result is stored: executing a new query
+will cause the latest result to be erased. Results can be explicitly erased
 with a `DELETE` request.
 
 **Response**
@@ -574,7 +574,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 #### Erase Asynchronous Query Results
@@ -583,7 +583,7 @@ Fatal connection error:
 DELETE /v1/sql/:id/queries/:query_id
 ```
 
-Erases the latest result of an asynchronously executed query. All asynchronous\
+Erases the latest result of an asynchronously executed query. All asynchronous
 results are erased when the connection that owns them is closed.
 
 **Response**
@@ -606,12 +606,12 @@ Missing connection token:
 POST /v1/sql/:id/cancel
 ```
 
-This endpoint cancels the current query being executed by this connection. If no\
+This endpoint cancels the current query being executed by this connection. If no
 query is being done and the connection is idle, no action is taken.
 
-If the connection is busy but it is not executing a query, an attempt to cancel\
-is still made: in this case the results of this operation are undefined for ODBC\
-connections, for MariaDB connections this will cause a `KILL QUERY` command to\
+If the connection is busy but it is not executing a query, an attempt to cancel
+is still made: in this case the results of this operation are undefined for ODBC
+connections, for MariaDB connections this will cause a `KILL QUERY` command to
 be executed.
 
 **Response**
@@ -634,9 +634,9 @@ Missing connection token:
 GET /v1/sql/odbc/drivers
 ```
 
-Get the list of configured ODBC drivers found by the driver manager. The list of\
-drivers includes all drivers known to the driver manager for which an installed\
-library was found (i.e. `Driver` or `Driver64` in `/etc/odbcinst.ini` points to\
+Get the list of configured ODBC drivers found by the driver manager. The list of
+drivers includes all drivers known to the driver manager for which an installed
+library was found (i.e. `Driver` or `Driver64` in `/etc/odbcinst.ini` points to
 a file).
 
 **Response**
@@ -671,14 +671,14 @@ The response contains a resource collection with all available drivers.
 POST /v1/sql/:id/etl/prepare
 ```
 
-The ETL operation requires two connections: an ODBC connection to a remote\
-server (source connection) and a connection to a server in MaxScale (destination\
+The ETL operation requires two connections: an ODBC connection to a remote
+server (source connection) and a connection to a server in MaxScale (destination
 connection). All ETL operations must be done on the ODBC connection.
 
 The ETL operations require that the MariaDB ODBC driver is installed on the\
-MaxScale server. This driver is often available in the package manager of your\
-operating system but it can also be downloaded from the MariaDB\
-website. Installation instructions for installing the driver manually can be\
+MaxScale server. This driver is often available in the package manager of your
+operating system but it can also be downloaded from the MariaDB
+website. Installation instructions for installing the driver manually can be
 found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#installing-mariadb-connectorodbc-on-linux).
 
 The request body must be a JSON object consisting of the following fields:
@@ -686,12 +686,12 @@ The request body must be a JSON object consisting of the following fields:
 * `target`
 
 The target connection ID that defines the destination server. This must be the\
-ID of a connection (i.e. `data.attributes.id` ) to a server in MaxScale\
+ID of a connection (i.e. `data.attributes.id` ) to a server in MaxScale
 created via the `POST /v1/sql/` endpoint.
 
 * `type`
 
-The type of the ETL data source. The value must be a string with one of the\
+The type of the ETL data source. The value must be a string with one of the
 following values:
 
 ```
@@ -719,48 +719,48 @@ following values:
 
 * `tables`
 
-An array of objects, each of which must define a `table` and a `schema`\
+An array of objects, each of which must define a `table` and a `schema`
 field. The `table` field defines the name of the table to be imported and the`schema` field defines the schema it is in. If the objects contain a value for`create`, `select` or `insert`, the SQL generation for that part is skipped.
 
 * `connection_string`
 
-Extra connection string that is appended to the destination server's\
-connection string. This connection will always use the MariaDB ODBC\
+Extra connection string that is appended to the destination server's
+connection string. This connection will always use the MariaDB ODBC
 driver. The list of supported options can be found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#parameters).
 
 * `threads`
 
-The number of parallel connections used during the ETL operation. By default\
+The number of parallel connections used during the ETL operation. By default
 the ETL operation will use up to 16 connections.
 
 * `timeout`
 
-The connection and query timeout in seconds. By default a timeout of 30\
+The connection and query timeout in seconds. By default a timeout of 30
 seconds is used.
 
 * `create_mode`
 
-A string with either `normal`, `ignore` or `replace` which controls how tables\
+A string with either `normal`, `ignore` or `replace` which controls how tables
 are handled that already exist on the destination server.
 
-If left undefined or set to `normal`, the tables are created using a normal`CREATE TABLE` statement. This will cause an error to be reported if the table\
-already exist and will prevent the ETL from proceeding past the object\
+If left undefined or set to `normal`, the tables are created using a normal`CREATE TABLE` statement. This will cause an error to be reported if the table
+already exist and will prevent the ETL from proceeding past the object
 creation stage.
 
-If set to `ignore` the tables are created with `CREATE TABLE IF NOT EXISTS`\
-which will ignore any existing tables and assume that they are compatible with\
-the rest of the ETL operation. This mode can be used to continuously load data\
+If set to `ignore` the tables are created with `CREATE TABLE IF NOT EXISTS`
+which will ignore any existing tables and assume that they are compatible with
+the rest of the ETL operation. This mode can be used to continuously load data
 from an external source into MariaDB.
 
-If set to `replace`, the tables are created with `CREATE OR REPLACE TABLE`\
-which will cause existing tables to be dropped if they exist. This is not a\
+If set to `replace`, the tables are created with `CREATE OR REPLACE TABLE`
+which will cause existing tables to be dropped if they exist. This is not a
 reversible process so caution should be taken when this mode is used.
 
 * `catalog`
 
 The catalog for the tables. This is only used when `type` is set to`generic`. In all other cases this value is ignored.
 
-Here is an example payload that prepares the table `test.t1` for extraction from\
+Here is an example payload that prepares the table `test.t1` for extraction from
 a MariaDB server.
 
 ```
@@ -776,9 +776,9 @@ a MariaDB server.
 }
 ```
 
-The token for the source connection is provided the same way it is\
-provided for all other `/v1/sql` endpoints: in the `token` request\
-parameter or in the cookies. The destination connection token is\
+The token for the source connection is provided the same way it is
+provided for all other `/v1/sql` endpoints: in the `token` request
+parameter or in the cookies. The destination connection token is
 provided either in the `target_token` request parameter or as a cookie.
 
 ### Request Parameters
@@ -786,8 +786,8 @@ provided either in the `target_token` request parameter or as a cookie.
 This endpoints supports the following additional request parameters.
 
 * `target_token`
-* The connection token for the destination connection. If provided, the value\
-  is unconditionally used even if a cookie with a valid token exists for the\
+* The connection token for the destination connection. If provided, the value
+  is unconditionally used even if a cookie with a valid token exists for the
   destination connection.
 
 **Response**
@@ -796,7 +796,7 @@ ETL operation prepared:
 
 `Status: 202 Accepted`
 
-Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the\
+Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the
 following result.
 
 ```
@@ -838,32 +838,32 @@ Invalid payload or missing connection token:
 POST /v1/sql/:id/etl/start
 ```
 
-The behavior of this endpoint is identical to the preparation but instead of\
-preparing the operation, this endpoint will execute the prepared ETL and load\
+The behavior of this endpoint is identical to the preparation but instead of
+preparing the operation, this endpoint will execute the prepared ETL and load
 the data into MariaDB.
 
-The intended way of doing an ETL operation is to first prepare it using the`/v1/sql/:id/etl/prepare` endpoint to retrieve the SQL statements that define\
-the ETL operation. Then if the ETL preparation is successful, the`data.attributes.results.tables` value from the response is used as the `tables`\
+The intended way of doing an ETL operation is to first prepare it using the`/v1/sql/:id/etl/prepare` endpoint to retrieve the SQL statements that define
+the ETL operation. Then if the ETL preparation is successful, the`data.attributes.results.tables` value from the response is used as the `tables`
 value for the ETL start operation, done on the `/v1/sql/:id/etl/start` endpoint.
 
-If any of the `create`, `select` or `insert` fields for a table in the `tables`\
-list have not been defined, the SQL will be automatically generated by querying\
-the source server, similarly to how the preparation generates the SQL\
-statements. This means that the preparation step is optional if there is no need\
+If any of the `create`, `select` or `insert` fields for a table in the `tables`
+list have not been defined, the SQL will be automatically generated by querying
+the source server, similarly to how the preparation generates the SQL
+statements. This means that the preparation step is optional if there is no need
 to adjust the automatically generated SQL.
 
-The ETL operation can be canceled using the `/v1/sql/:id/cancel` endpoint which\
-will roll back the ETL operation. Any tables that were created during the ETL\
-operation are not deleted on the destination server and must be manually cleaned\
+The ETL operation can be canceled using the `/v1/sql/:id/cancel` endpoint which
+will roll back the ETL operation. Any tables that were created during the ETL
+operation are not deleted on the destination server and must be manually cleaned
 up.
 
-If the ETL fails to extract the SQL from the source server or an error was\
-encountered during table creation, the response will have the `"ok"` field set\
-to false. Both the top-level object as well as the individual tables can have\
+If the ETL fails to extract the SQL from the source server or an error was
+encountered during table creation, the response will have the `"ok"` field set
+to false. Both the top-level object as well as the individual tables can have
 the `"error"` field set to the error message. This field is filled during the\
 ETL operation which means errors are visible even if the ETL is still ongoing.
 
-During the ETL operation, tables that have been fully processed will have a`"execution_time"` field. This field has the total time in seconds it took to\
+During the ETL operation, tables that have been fully processed will have a`"execution_time"` field. This field has the total time in seconds it took to
 execute the data loading step.
 
 **Response**
@@ -872,7 +872,7 @@ ETL operation started:
 
 `Status: 202 Accepted`
 
-Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the\
+Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the
 following result.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avrorouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avrorouter.md
@@ -4,14 +4,14 @@
 
 ## Avrorouter
 
-The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes\
+The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes
 binary logs from a local directory and transforms them into a set of Avro files.\
 These files can then be queried by clients for various purposes.
 
 This router is intended to be used in tandem with the [Binlog Server](mariadb-maxscale-2308-binlogrouter.md).\
 The Binlog Server can connect to a primary server and request binlog records.\
-These records can then consumed by the avrorouter directly from the binlog cache\
-of the Binlog Server. This allows MariaDB MaxScale to automatically transform\
+These records can then consumed by the avrorouter directly from the binlog cache
+of the Binlog Server. This allows MariaDB MaxScale to automatically transform
 binlog events on the primary to local Avro format files.
 
 ```mermaid
@@ -68,25 +68,25 @@ flowchart LR
 ```
 _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog events are converted to Avro-formatted change data and streamed to CDC clients, Kafka, and Hadoop._
 
-The avrorouter can also consume binary logs straight from the primary. This will\
-remove the need to configure the Binlog Server but it will increase the disk space\
+The avrorouter can also consume binary logs straight from the primary. This will
+remove the need to configure the Binlog Server but it will increase the disk space
 requirement on the primary server by at least a factor of two.
 
-The converted Avro files can be requested with the CDC protocol. This protocol\
-should be used to communicate with the avrorouter and currently it is the only\
-supported protocol. The clients can request either Avro or JSON format data\
+The converted Avro files can be requested with the CDC protocol. This protocol
+should be used to communicate with the avrorouter and currently it is the only
+supported protocol. The clients can request either Avro or JSON format data
 streams from a database table.
 
 ### Direct Replication Mode
 
-MaxScale 2.4.0 added a direct replication mode that connects the avrorouter\
-directly to a MariaDB server. This mode is an improvement over the binlogrouter\
-based replication as it provides a more space-efficient and faster conversion\
-process. This is the recommended method of using the avrorouter as it is faster,\
+MaxScale 2.4.0 added a direct replication mode that connects the avrorouter
+directly to a MariaDB server. This mode is an improvement over the binlogrouter
+based replication as it provides a more space-efficient and faster conversion
+process. This is the recommended method of using the avrorouter as it is faster,
 more efficient and less prone to errors caused by missing DDL events.
 
-To enable the direct replication mode, add either the `servers` or the `cluster`\
-parameter to the avrorouter service. The avrorouter will then use one of the\
+To enable the direct replication mode, add either the `servers` or the `cluster`
+parameter to the avrorouter service. The avrorouter will then use one of the
 servers as the replication source.
 
 Here is a minimal avrorouter direct replication configuration:
@@ -114,12 +114,12 @@ protocol=CDC
 port=4001
 ```
 
-In direct replication mode, the avrorouter stores the latest replicated GTID in\
-the `last_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove\
+In direct replication mode, the avrorouter stores the latest replicated GTID in
+the `last_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove
 the file.
 
-Additionally, the avrorouter will attempt to automatically create any missing\
-schema files for tables that have data events for them but the DDL for those\
+Additionally, the avrorouter will attempt to automatically create any missing
+schema files for tables that have data events for them but the DDL for those
 tables is not contained in the binlogs.
 
 ### Configuration
@@ -135,13 +135,13 @@ For information about common service parameters, refer to the [Configuration Gui
 * Dynamic: No
 * Default: `""`
 
-The GTID where avrorouter starts the replication from in direct replication\
-mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where\
-the first number is the replication domain, the second the server\_id value of\
+The GTID where avrorouter starts the replication from in direct replication
+mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where
+the first number is the replication domain, the second the server\_id value of
 the server and the last is the GTID sequence number.
 
-This parameter has no effect in the traditional mode. If this parameter is\
-defined, the replication will start from the implicit GTID that the primary first\
+This parameter has no effect in the traditional mode. If this parameter is
+defined, the replication will start from the implicit GTID that the primary first
 serves.
 
 **`server_id`**
@@ -151,7 +151,7 @@ serves.
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
 used when replicating from the primary in direct replication mode.
 
 **`codec`**
@@ -165,7 +165,7 @@ used when replicating from the primary in direct replication mode.
 The compression codec to use. By default, the avrorouter does not use compression.
 
 This parameter takes one of the following two values; _null_ or\_deflate\_. These are the mandatory compression algorithms required by the\
-Avro specification. For more information about the compression types,\
+Avro specification. For more information about the compression types,
 refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specification/#required-codecs).
 
 **`match` and `exclude`**
@@ -175,13 +175,13 @@ refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specificat
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#standard-regular-expression-settings-for-filters)\
+These [regular expression settings](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#standard-regular-expression-settings-for-filters)
 filter events for processing depending on table names. Avrorouter does not support the\_options\_-parameter for regular expressions.
 
-To prevent excessive matching of similarly named tables, surround each table\
-name with the `^` and `$` tokens. For example, to match the `test.clients` table\
-but not `test.clients_old` table use `match=^test[.]clients$`. For multiple\
-tables, surround each table in parentheses and add a pipe character between\
+To prevent excessive matching of similarly named tables, surround each table
+name with the `^` and `$` tokens. For example, to match the `test.clients` table
+but not `test.clients_old` table use `match=^test[.]clients$`. For multiple
+tables, surround each table in parentheses and add a pipe character between
 them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 
 **`binlogdir`**
@@ -191,8 +191,8 @@ them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location of the binary log files. This is the first mandatory parameter\
-and it defines where the module will read binlog files from. Read access to\
+The location of the binary log files. This is the first mandatory parameter
+and it defines where the module will read binlog files from. Read access to
 this directory is required.
 
 **`avrodir`**
@@ -202,14 +202,14 @@ this directory is required.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location where the Avro files are stored. This is the second mandatory\
-parameter and it governs where the converted files are stored. This directory\
-will be used to store the Avro files, plain-text Avro schemas and other files\
-needed by the avrorouter. The user running MariaDB MaxScale will need both read and\
+The location where the Avro files are stored. This is the second mandatory
+parameter and it governs where the converted files are stored. This directory
+will be used to store the Avro files, plain-text Avro schemas and other files
+needed by the avrorouter. The user running MariaDB MaxScale will need both read and
 write access to this directory.
 
-The avrorouter will also use the _avrodir_ to store various internal\
-files. These files are named _avro.index_ and _avro-conversion.ini_. By default,\
+The avrorouter will also use the _avrodir_ to store various internal
+files. These files are named _avro.index_ and _avro-conversion.ini_. By default,
 the default data directory, _/var/lib/maxscale/_, is used. Before version 2.1 of\
 MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 
@@ -220,7 +220,7 @@ MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 * Dynamic: No
 * Default: `mysql-bin`
 
-The base name of the binlog files. The binlog files are assumed to follow the\
+The base name of the binlog files. The binlog files are assumed to follow the
 naming schema _._ where is the binlog number and is the value of this router option.
 
 For example, with the following parameters:
@@ -240,11 +240,11 @@ The first binlog file the avrorouter would look for is `/var/lib/mysql/binlogs/m
 * Default: `1`
 
 The starting index number of the binlog file. The default value is 1.\
-For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_\
+For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_
 the index would be 5.
 
-If you need to start from a binlog file other than 1, you need to set the value\
-of this option to the correct index. The avrorouter will always start from the\
+If you need to start from a binlog file other than 1, you need to set the value
+of this option to the correct index. The avrorouter will always start from the
 beginning of the binary log file.
 
 #### `cooperative_replication`
@@ -254,39 +254,39 @@ beginning of the binary log file.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
-cluster. This is a boolean parameter and is disabled by default. It was\
+Controls whether multiple instances cooperatively replicate from the same
+cluster. This is a boolean parameter and is disabled by default. It was
 added in MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`),\
-the replication is only active if the monitor owns the cluster it is\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`),
+the replication is only active if the monitor owns the cluster it is
 monitoring.
 
-With this feature, multiple MaxScale instances can replicate from the same set\
-of servers and only one of them actively processes the replication stream. This\
-allows the avrorouter instances to be made highly-available without having to\
+With this feature, multiple MaxScale instances can replicate from the same set
+of servers and only one of them actively processes the replication stream. This
+allows the avrorouter instances to be made highly-available without having to
 have them all process the events at the same time.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID processed by that\
-instance. This means that if the instance hasn't replicated events that have\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID processed by that
+instance. This means that if the instance hasn't replicated events that have
 been purged from the binary logs, the replication cannot continue.
 
 **Avro File Related Parameters**
 
 These options control how large the Avro file data blocks can get.\
-Increasing or lowering the block size could have a positive effect\
-depending on your use case. For more information about the Avro file\
+Increasing or lowering the block size could have a positive effect
+depending on your use case. For more information about the Avro file
 format and how it organizes data, refer to the [Avro documentation](https://avro.apache.org/docs/current/).
 
-The avrorouter will flush a block and start a new one when either `group_trx`\
-transactions or `group_rows` row events have been processed. Changing these\
-options will also allow more frequent updates to stored data but this\
+The avrorouter will flush a block and start a new one when either `group_trx`
+transactions or `group_rows` row events have been processed. Changing these
+options will also allow more frequent updates to stored data but this
 will cause a small increase in file size and search times.
 
-It is highly recommended to keep the block sizes relatively large to allow\
-larger chunks of memory to be flushed to disk at one time. This will make\
+It is highly recommended to keep the block sizes relatively large to allow
+larger chunks of memory to be flushed to disk at one time. This will make
 the conversion process noticeably faster.
 
 **`group_trx`**
@@ -296,7 +296,7 @@ the conversion process noticeably faster.
 * Dynamic: No
 * Default: `1`
 
-Controls the number of transactions that are grouped into a single Avro\
+Controls the number of transactions that are grouped into a single Avro
 data block.
 
 **`group_rows`**
@@ -306,7 +306,7 @@ data block.
 * Dynamic: No
 * Default: `1000`
 
-Controls the number of row events that are grouped into a single Avro\
+Controls the number of row events that are grouped into a single Avro
 data block.
 
 **`block_size`**
@@ -316,10 +316,10 @@ data block.
 * Dynamic: Yes
 * Default: `16KiB`
 
-The Avro data block size in bytes. The default is 16 kilobytes. Increase this\
-value if individual events in the binary logs are very large. The value is a\
+The Avro data block size in bytes. The default is 16 kilobytes. Increase this
+value if individual events in the binary logs are very large. The value is a
 size type parameter which means that it can also be defined with an SI suffix.\
-Refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)
 for more details about size type parameters and how to use them.
 
 **`max_file_size`**
@@ -329,17 +329,17 @@ for more details about size type parameters and how to use them.
 * Dynamic: No
 * Default: 0
 
-If the size of a single Avro data file exceeds this limit, the avrorouter will\
-rotate to a new file. This is done by closing the existing file and creating a\
-new one with the next version number. By default the avrorouter does not rotate\
-files based on their size. Setting the value to 0 disables file rotation based on\
+If the size of a single Avro data file exceeds this limit, the avrorouter will
+rotate to a new file. This is done by closing the existing file and creating a
+new one with the next version number. By default the avrorouter does not rotate
+files based on their size. Setting the value to 0 disables file rotation based on
 size.
 
-This uses the size of the file as reported by the operating system. The check\
-for the file size is done after a transaction has been processed which means\
+This uses the size of the file as reported by the operating system. The check
+for the file size is done after a transaction has been processed which means
 that large transactions can still cause the file size to exceed the given limit.
 
-File rotation only works with the direct replication mode. The legacy file based\
+File rotation only works with the direct replication mode. The legacy file based
 replication mode does not support this.
 
 **`max_data_age`**
@@ -349,17 +349,17 @@ replication mode does not support this.
 * Dynamic: No
 * Default: 0s
 
-When enabled, the avrorouter will automatically purge any files that only have\
-data that is older than the given limit. This means that all data files with at\
-least one event that is newer than the configured limit will not be removed,\
-even if the age of all the other events is above the limit. The purge operation\
-is only done when a file rotation takes place (either manual or automatic) or\
+When enabled, the avrorouter will automatically purge any files that only have
+data that is older than the given limit. This means that all data files with at
+least one event that is newer than the configured limit will not be removed,
+even if the age of all the other events is above the limit. The purge operation
+is only done when a file rotation takes place (either manual or automatic) or
 when a schema change is detected.
 
-This parameter is best combined with `max_file_size` to provide automatic\
+This parameter is best combined with `max_file_size` to provide automatic
 removal of stale data.
 
-Automatic file purging only works with the direct replication mode. The legacy\
+Automatic file purging only works with the direct replication mode. The legacy
 file based replication mode does not support this.
 
 **Example configuration**
@@ -382,94 +382,94 @@ avrodir=/var/lib/maxscale
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md) documentation for
 details about module commands.
 
 The avrorouter supports the following module commands.
 
 #### `avrorouter::convert SERVICE {start | stop}`
 
-Start or stop the binary log to Avro conversion. The first parameter is the name\
-of the service to stop and the second parameter tells whether to start the\
+Start or stop the binary log to Avro conversion. The first parameter is the name
+of the service to stop and the second parameter tells whether to start the
 conversion process or to stop it.
 
 #### `avrorouter::purge SERVICE`
 
 This command will delete all files created by the avrorouter. This includes all\
-.avsc schema files and .avro data files as well as the internal state tracking\
+.avsc schema files and .avro data files as well as the internal state tracking
 files. Use this to completely reset the conversion process.
 
-**Note:** Once the command has completed, MaxScale must be restarted to restart\
+**Note:** Once the command has completed, MaxScale must be restarted to restart
 the conversion process. Issuing a `convert start` command **will not work**.
 
-**WARNING:** You will lose any and all converted data when this command is\
+**WARNING:** You will lose any and all converted data when this command is
 executed.
 
 ### Files Created by the Avrorouter
 
-The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store\
-the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains\
-the last converted position and GTID in the binlogs. If you need to reset the\
+The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store
+the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains
+the last converted position and GTID in the binlogs. If you need to reset the
 conversion process, delete these two files and restart MaxScale.
 
 ### Resetting the Conversion Process
 
-To reset the binlog conversion process, issue the `purge` module command by\
-executing it via MaxCtrl and stop MaxScale. If manually created schema files\
+To reset the binlog conversion process, issue the `purge` module command by
+executing it via MaxCtrl and stop MaxScale. If manually created schema files
 were used, they need to be recreated once MaxScale is stopped. After stopping\
-MaxScale and optionally creating the schema files, the conversion process can be\
+MaxScale and optionally creating the schema files, the conversion process can be
 started by starting MaxScale.
 
 ### Stopping the Avrorouter
 
-The safest way to stop the avrorouter when used with the binlogrouter is to\
+The safest way to stop the avrorouter when used with the binlogrouter is to
 follow the following steps:
 
 * Issue `STOP SLAVE` on the binlogrouter
 * Wait for the avrorouter to process all files
 * Stop MaxScale with `systemctl stop maxscale`
 
-This guarantees that the conversion process halts at a known good position in\
+This guarantees that the conversion process halts at a known good position in
 the latest binlog file.
 
 ### Example Client
 
 The avrorouter comes with an example client program, _cdc.py_, written in Python 3.\
-This client can connect to a MaxScale configured with the CDC protocol and the\
+This client can connect to a MaxScale configured with the CDC protocol and the
 avrorouter.
 
-Before using this client, you will need to install the Python 3 interpreter and\
-add users to the service with the _cdc\_users.py_ script. Fore more details about\
-the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-change-data-capture-cdc-protocol.md)\
+Before using this client, you will need to install the Python 3 interpreter and
+add users to the service with the _cdc\_users.py_ script. Fore more details about
+the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-change-data-capture-cdc-protocol.md)
 and [CDC Users](../mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-change-data-capture-cdc-users.md) documentation.
 
-Read the output of `cdc.py --help` for a full list of supported options\
+Read the output of `cdc.py --help` for a full list of supported options
 and a short usage description of the client program.
 
 ### Avro Schema Generator
 
-The avrorouter needs to have access to the CREATE TABLE statement for all tables\
-for which there are data events in the binary logs. If the CREATE TABLE\
-statements for the tables aren't present in the current binary logs, the schema\
+The avrorouter needs to have access to the CREATE TABLE statement for all tables
+for which there are data events in the binary logs. If the CREATE TABLE
+statements for the tables aren't present in the current binary logs, the schema
 files must be created.
 
-In the direct replication mode, avrorouter will automatically create the missing\
-schema files by connecting to the database and executing a `SHOW CREATE TABLE`\
-statement. If a connection cannot be made or the service user lacks the\
-permission, an error will be logged and the data events for that table will not\
+In the direct replication mode, avrorouter will automatically create the missing
+schema files by connecting to the database and executing a `SHOW CREATE TABLE`
+statement. If a connection cannot be made or the service user lacks the
+permission, an error will be logged and the data events for that table will not
 be processed.
 
-For the legacy binlog mode, the files must be generated with a schema file\
+For the legacy binlog mode, the files must be generated with a schema file
 generator. There are currently two methods to generate the .avsc schema files.
 
 #### Simple Schema Generator
 
-The `cdc_one_schema.py` generates a schema file for a single table by reading a\
-tab separated list of field and type names from the standard input. This is the\
-recommended schema generation tool as it does not directly communicate with the\
+The `cdc_one_schema.py` generates a schema file for a single table by reading a
+tab separated list of field and type names from the standard input. This is the
+recommended schema generation tool as it does not directly communicate with the
 database thus making it more flexible.
 
-The only requirement to run the script is that a Python interpreter is\
+The only requirement to run the script is that a Python interpreter is
 installed.
 
 To use this script, pipe the output of the `mysql` command line into the`cdc_one_schema.py` script:
@@ -478,15 +478,15 @@ To use this script, pipe the output of the `mysql` command line into the`cdc_one
 mysql -ss -u <user> -p -h <host> -P <port> -e 'DESCRIBE `<database>`.`<table>`'|./cdc_one_schema.py <database> <table>
 ```
 
-Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with\
-appropriate values and run the command. Note that the `-ss` parameter is\
-mandatory as that will generate the tab separated output instead of the default\
+Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with
+appropriate values and run the command. Note that the `-ss` parameter is
+mandatory as that will generate the tab separated output instead of the default
 pretty-printed output.
 
-An .avsc file named after the database and table name will be generated in the\
+An .avsc file named after the database and table name will be generated in the
 current working directory. Copy this file to the location pointed by the`avrodir` parameter of the avrorouter.
 
-Alternatively, you can also copy the output of the `mysql` command to a file and\
+Alternatively, you can also copy the output of the `mysql` command to a file and
 feed it into the script if you cannot execute the SQL command directly:
 
 ```
@@ -509,31 +509,31 @@ usage: cdc_schema.py [--help] [-h HOST] [-P PORT] [-u USER] [-p PASSWORD] DATABA
 The _cdc\_schema.py_ executable is installed as a part of MaxScale. This is a\
 Python 3 script that generates Avro schema files from an existing database.
 
-The script will generate the .avsc schema files into the current directory. Run\
-the script for all required databases copy the generated .avsc files to the\
+The script will generate the .avsc schema files into the current directory. Run
+the script for all required databases copy the generated .avsc files to the
 directory where the avrorouter stores the .avro files (the value of `avrodir`).
 
 #### Go Schema Generator
 
-The _cdc\_schema.go_ example Go program is provided with MaxScale. This file\
-can be used to create Avro schemas for the avrorouter by connecting to a\
-database and reading the table definitions. You can find the file in MaxScale's\
+The _cdc\_schema.go_ example Go program is provided with MaxScale. This file
+can be used to create Avro schemas for the avrorouter by connecting to a
+database and reading the table definitions. You can find the file in MaxScale's
 share directory in `/usr/share/maxscale/`.
 
-You'll need to install the Go compiler and run `go get` to resolve Go\
-dependencies before you can use the _cdc\_schema_ program. After resolving the\
-dependencies you can run the program with `go run cdc_schema.go`. The program\
-will create .avsc files in the current directory. These files should be moved\
-to the location pointed by the _avrodir_ option of the avrorouter if they are\
+You'll need to install the Go compiler and run `go get` to resolve Go
+dependencies before you can use the _cdc\_schema_ program. After resolving the
+dependencies you can run the program with `go run cdc_schema.go`. The program
+will create .avsc files in the current directory. These files should be moved
+to the location pointed by the _avrodir_ option of the avrorouter if they are
 to be used by the router itself.
 
-Read the output of `go run cdc_schema.go -help` for more information on how\
+Read the output of `go run cdc_schema.go -help` for more information on how
 to run the program.
 
 ### Examples
 
-The [Avrorouter Tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-avrorouter-tutorial.md) shows you how\
-the Avrorouter works with the Binlog Server to convert binlogs from a primary server\
+The [Avrorouter Tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-avrorouter-tutorial.md) shows you how
+the Avrorouter works with the Binlog Server to convert binlogs from a primary server
 into easy to process Avro data.
 
 Here is a simple configuration example which reads binary logs locally from`/var/lib/mysql/` and stores them as Avro files in `/var/lib/maxscale/avro/`.\
@@ -563,7 +563,7 @@ Python script. It queries the table _test.mytable_ for all change records.
 cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytable
 ```
 
-You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change\
+You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change
 records to a Kafka broker.
 
 ```
@@ -571,28 +571,28 @@ cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytab
 cdc_kafka_producer.py --kafka-broker 127.0.0.1:9092 --kafka-topic test.mytable
 ```
 
-For more information on how to use these scripts, see the output of `cdc.py -h`\
+For more information on how to use these scripts, see the output of `cdc.py -h`
 and `cdc_kafka_producer.py -h`.
 
 ### Building Avrorouter
 
-To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development\
+To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development
 headers. When configuring MaxScale with CMake, you will need to add`-DBUILD_CDC=Y` to build the CDC module set.
 
-The Avro C library needs to be build with position independent code enabled. You\
-can do this by adding the following flags to the CMake invocation when\
+The Avro C library needs to be build with position independent code enabled. You
+can do this by adding the following flags to the CMake invocation when
 configuring the Avro C library.
 
 ```
 -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC
 ```
 
-For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-building-mariadb-maxscale-from-source-code.md)\
+For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-building-mariadb-maxscale-from-source-code.md)
 document.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for an avrorouter service contains the following\
+The `router_diagnostics` output for an avrorouter service contains the following
 fields.
 
 * `infofile`: File where the avrorouter stores the conversion process state.
@@ -612,8 +612,8 @@ The avrorouter does not support the following data types, conversions or SQL sta
 * Fields CAST from integer types to string types
 * [CREATE TABLE ... AS SELECT statements](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/tables/create-table)
 
-The avrorouter does not do any crash recovery. This means that the avro files\
-need to be removed or truncated to valid block lengths before starting the\
+The avrorouter does not do any crash recovery. This means that the avro files
+need to be removed or truncated to valid block lengths before starting the
 avrorouter.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-binlogrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-binlogrouter.md
@@ -4,28 +4,28 @@
 
 ## Binlogrouter
 
-The binlogrouter is a router that acts as a replication proxy for MariaDB\
-primary-replica replication. The router connects to a primary, retrieves the binary\
-logs and stores them locally. Replica servers can connect to MaxScale like they\
-would connect to a normal primary server. If the primary server goes down,\
-replication between MaxScale and the replicas can still continue up to the latest\
-point to which the binlogrouter replicated to. The primary can be changed without\
-disconnecting the replicas and without them noticing that the primary server has\
+The binlogrouter is a router that acts as a replication proxy for MariaDB
+primary-replica replication. The router connects to a primary, retrieves the binary
+logs and stores them locally. Replica servers can connect to MaxScale like they
+would connect to a normal primary server. If the primary server goes down,
+replication between MaxScale and the replicas can still continue up to the latest
+point to which the binlogrouter replicated to. The primary can be changed without
+disconnecting the replicas and without them noticing that the primary server has
 changed. This allows for a more highly available replication setup.
 
-In addition to the high availability benefits, the binlogrouter creates only one\
-connection to the primary whereas with normal replication each individual replica\
-will create a separate connection. This reduces the amount of work the primary\
-database has to do which can be significant if there are a large number of\
+In addition to the high availability benefits, the binlogrouter creates only one
+connection to the primary whereas with normal replication each individual replica
+will create a separate connection. This reduces the amount of work the primary
+database has to do which can be significant if there are a large number of
 replicating replicas.
 
 ### Supported SQL Commands
 
-The binlogrouter supports a subset of the SQL constructs that the MariaDB server\
+The binlogrouter supports a subset of the SQL constructs that the MariaDB server
 supports. The following commands are supported:
 
 * `CHANGE MASTER TO`
-* The binlogrouter supports the same syntax as the MariaDB server but only the\
+* The binlogrouter supports the same syntax as the MariaDB server but only the
   following values are allowed:
   * `MASTER_HOST`
   * `MASTER_PORT`
@@ -42,7 +42,7 @@ supports. The following commands are supported:
   * `MASTER_SSL_CIPHER`
   * `MASTER_SSL_VERIFY_SERVER_CERT`
 
-NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported\
+NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported
 as binlogrouter only supports GTID based replication.
 
 * `STOP SLAVE`
@@ -50,56 +50,56 @@ as binlogrouter only supports GTID based replication.
 * `START SLAVE`
 * Starts replication, same as MariaDB.
 * `RESET SLAVE`
-* Resets replication. Note that the `RESET SLAVE ALL` form that is supported\
+* Resets replication. Note that the `RESET SLAVE ALL` form that is supported
   by MariaDB isn't supported by the binlogrouter.
 * `SHOW BINARY LOGS`
-* Lists the current files and their sizes. These will be different from the\
-  ones listed by the original primary where the binlogrouter is replicating\
+* Lists the current files and their sizes. These will be different from the
+  ones listed by the original primary where the binlogrouter is replicating
   from.
 * `PURGE { BINARY | MASTER } LOGS TO <filename>`
-* Purges binary logs up to but not including the given file. The file name\
-  must be one of the names shown in `SHOW BINARY LOGS`. The version of this\
+* Purges binary logs up to but not including the given file. The file name
+  must be one of the names shown in `SHOW BINARY LOGS`. The version of this
   command which accepts a timestamp is not currently supported.\
-  Automatic purging is supported using the configuration\
+  Automatic purging is supported using the configuration
   parameter [expire\_log\_duration](mariadb-maxscale-2308-binlogrouter.md#expire_log_duration).\
-  The files are purged in the order they were created. If a file to be purged\
-  is detected to be in use, the purge stops. This means that the purge will\
+  The files are purged in the order they were created. If a file to be purged
+  is detected to be in use, the purge stops. This means that the purge will
   stop at the oldest file that a replica is still reading.\
-  NOTE: You should still take precaution not to purge files that a potential\
-  replica will need in the future. MaxScale can only detect that a file is\
+  NOTE: You should still take precaution not to purge files that a potential
+  replica will need in the future. MaxScale can only detect that a file is
   in active use when a replica is connected, and requesting events from it.
 * `SHOW MASTER STATUS`
-* Shows the name and position of the file to which the binlogrouter will write\
-  the next replicated data. The name and position do not correspond to the\
+* Shows the name and position of the file to which the binlogrouter will write
+  the next replicated data. The name and position do not correspond to the
   name and position in the primary.
 * `SHOW SLAVE STATUS`
-* Shows the replica status information similar to what a normal MariaDB replica\
-  server shows. Some of the values are replaced with constants values that\
+* Shows the replica status information similar to what a normal MariaDB replica
+  server shows. Some of the values are replaced with constants values that
   never change. The following values are not constant:
-  * `Slave_IO_State`: Set to `Waiting for primary to send event` when\
+  * `Slave_IO_State`: Set to `Waiting for primary to send event` when
     replication is ongoing.
   * `Master_Host`: Address of the current primary.
   * `Master_User`: The user used to replicate.
   * `Master_Port`: The port the primary is listening on.
-  * `Master_Log_File`: The name of the latest file that the binlogrouter is\
+  * `Master_Log_File`: The name of the latest file that the binlogrouter is
     writing to.
-  * `Read_Master_Log_Pos`: The current position where the last event was\
+  * `Read_Master_Log_Pos`: The current position where the last event was
     written in the latest binlog.
-  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's\
+  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's
     not.
-  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's\
+  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's
     not.
   * `Exec_Master_Log_Pos`: Same as `Read_Master_Log_Pos`.
   * `Gtid_IO_Pos`: The latest replicated GTID.
 * `SELECT { Field } ...`
-* The binlogrouter implements a small subset of the MariaDB SELECT syntax as\
-  it is mainly used by the replicating replicas to query various parameters. If\
-  a field queried by a client is not known to the binlogrouter, the value\
-  will be returned back as-is. The following list of functions and variables\
+* The binlogrouter implements a small subset of the MariaDB SELECT syntax as
+  it is mainly used by the replicating replicas to query various parameters. If
+  a field queried by a client is not known to the binlogrouter, the value
+  will be returned back as-is. The following list of functions and variables
   are understood by the binlogrouter and are replaced with actual values:
-  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of\
+  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of
     these return the latest GTID replicated from the primary.
-  * `version()` or `@@version`: The version string returned by MaxScale when\
+  * `version()` or `@@version`: The version string returned by MaxScale when
     a client connects to it.
   * `UNIX_TIMESTAMP()`: The current timestamp.
   * `@@version_comment`: Always `pinloki`.
@@ -127,27 +127,27 @@ as binlogrouter only supports GTID based replication.
   * `@@tx_isolation`: Always `REPEATABLE-READ`
   * `@@wait_timeout`: Always `28800`
 * `SET`
-* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should\
+* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should
   start replicating. E.g. `SET @@global.gtid_slave_pos="0-1000-1234,1-1001-5678"`
 * `SHOW VARIABLES LIKE '...'`
-* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`\
-  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`\
-  is not currently supported. In addition, the `LIKE` operator in\
+* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`
+  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`
+  is not currently supported. In addition, the `LIKE` operator in
   binlogrouter only supports exact matches.\
-  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID\
-  coordinates of the binlogrouter. In addition to these, the `server_id`\
+  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID
+  coordinates of the binlogrouter. In addition to these, the `server_id`
   variable will return the configured server ID of the binlogrouter.
 
 ### Semi-sync replication
 
-If the server from which the binlogrouter replicates from is using semi-sync\
+If the server from which the binlogrouter replicates from is using semi-sync
 replication, the binlogrouter will acknowledge the replicated events.
 
 ### Configuration Parameters
 
 The binlogrouter is configured similarly to how normal routers are configured in\
-MaxScale. It requires at least one listener where clients can connect to and one\
-server from which the database user information can be retrieved. An example\
+MaxScale. It requires at least one listener where clients can connect to and one
+server from which the database user information can be retrieved. An example
 configuration can be found in the [example](mariadb-maxscale-2308-binlogrouter.md#example) section of this document.
 
 #### `datadir`
@@ -166,7 +166,7 @@ Directory where binary log files are stored.
 * Dynamic: No
 * Default: `1234`
 
-The server ID that MaxScale uses when connecting to the master and when serving\
+The server ID that MaxScale uses when connecting to the master and when serving
 binary logs to the slaves.
 
 #### `net_timeout`
@@ -187,26 +187,26 @@ Network connection and read timeout in seconds for the connection to the master.
 
 Automatically select the master server to replicate from.
 
-When this feature is enabled, the primary which binlogrouter will replicate\
+When this feature is enabled, the primary which binlogrouter will replicate
 from will be selected from the servers defined by a monitor `cluster=TheMonitor`.\
-Alternatively servers can be listed in `servers`. The servers should be monitored\
-by a monitor. Only servers with the `Master` status are used. If multiple primary\
+Alternatively servers can be listed in `servers`. The servers should be monitored
+by a monitor. Only servers with the `Master` status are used. If multiple primary
 servers are available, the first available primary server will be used.
 
-If a `CHANGE MASTER TO` command is received while `select_master` is on, the\
+If a `CHANGE MASTER TO` command is received while `select_master` is on, the
 command will be honored and `select_master` turned off until the next reboot.\
 This allows the Monitor to perform failover, and more importantly, switchover.\
-It also allows the user to manually redirect the Binlogrouter. The current\
+It also allows the user to manually redirect the Binlogrouter. The current
 primary is "sticky", meaning that the same primary will be chosen on reboot.
 
-**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is\
-monitoring a binlogrouter. The binlogrouter does not support all the SQL\
-commands that the monitor will send and the rejoin will fail. This restriction\
+**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is
+monitoring a binlogrouter. The binlogrouter does not support all the SQL
+commands that the monitor will send and the rejoin will fail. This restriction
 will be lifted in a future version.
 
 The GTID the replication will start from, will be based on the latest replicated\
-GTID. If no GTID has been replicated, the router will start replication from the\
-start. Manual configuration of the GTID can be done by first configuring the\
+GTID. If no GTID has been replicated, the router will start replication from the
+start. Manual configuration of the GTID can be done by first configuring the
 replication manually with `CHANGE MASTER TO`.
 
 #### `expire_log_duration`
@@ -218,9 +218,9 @@ replication manually with `CHANGE MASTER TO`.
 
 Duration after which a binary log file can be automatically removed.
 
-The duration is measured from the last modification of the log file. Files are\
-purged in the order they were created. The automatic purge works in a similar\
-manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if\
+The duration is measured from the last modification of the log file. Files are
+purged in the order they were created. The automatic purge works in a similar
+manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if
 an eligible file is in active use, i.e. being read by a replica.
 
 #### `expire_log_minimum_files`
@@ -230,7 +230,7 @@ an eligible file is in active use, i.e. being read by a replica.
 * Dynamic: No
 * Default: `2`
 
-The minimum number of log files the automatic purge keeps. At least one file\
+The minimum number of log files the automatic purge keeps. At least one file
 is always kept.
 
 #### `ddl_only`
@@ -241,9 +241,9 @@ is always kept.
 
 When enabled, only DDL events are written to the binary logs. This means that`CREATE`, `ALTER` and `DROP` events are written but `INSERT`, `UPDATE` and`DELETE` events are not.
 
-This mode can be used to keep a record of all the schema changes that occur on a\
-database. As only the DDL events are stored, it becomes very easy to set up an\
-empty server with no data in it by simply pointing it at a binlogrouter instance\
+This mode can be used to keep a record of all the schema changes that occur on a
+database. As only the DDL events are stored, it becomes very easy to set up an
+empty server with no data in it by simply pointing it at a binlogrouter instance
 that has `ddl_only` enabled.
 
 #### `encryption_key_id`
@@ -254,23 +254,23 @@ that has `ddl_only` enabled.
 * Default: `""`
 
 Encryption key ID used to encrypt the binary logs. If configured, an [Encryption\
-Key Manager](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#encryption-key-managers)\
-must also be configured and it must contain the key with the given ID. If the\
-encryption key manager supports versioning, new binary logs will be encrypted\
-using the latest encryption key. Old binlogs will remain encrypted with older\
-key versions and remain readable as long as the key versions used to encrypt\
+Key Manager](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#encryption-key-managers)
+must also be configured and it must contain the key with the given ID. If the
+encryption key manager supports versioning, new binary logs will be encrypted
+using the latest encryption key. Old binlogs will remain encrypted with older
+key versions and remain readable as long as the key versions used to encrypt
 them are available.
 
-Once binary log encryption has been enabled, the encryption key ID cannot be\
-changed and the key must remain available to MaxScale in order for replication\
-to work. If an encryption key is not available or the key manager fails to\
-retrieve it, the replication from the currently selected primary server will\
-stop. If the replication is restarted manually, the encryption key retrieval is\
+Once binary log encryption has been enabled, the encryption key ID cannot be
+changed and the key must remain available to MaxScale in order for replication
+to work. If an encryption key is not available or the key manager fails to
+retrieve it, the replication from the currently selected primary server will
+stop. If the replication is restarted manually, the encryption key retrieval is
 attempted again.
 
-Re-encryption of binlogs using another encryption key is not possible. However,\
-this is possible if the data is replicated to a second MaxScale server that uses\
-a different encryption key. The same approach can also be used to decrypt\
+Re-encryption of binlogs using another encryption key is not possible. However,
+this is possible if the data is replicated to a second MaxScale server that uses
+a different encryption key. The same approach can also be used to decrypt
 binlogs.
 
 #### `encryption_cipher`
@@ -281,7 +281,7 @@ binlogs.
 * Values: `AES_CBC`, `AES_CTR`, `AES_GCM`
 * Default: `AES_GCM`
 
-The encryption cipher to use. The encryption key size also affects which mode is\
+The encryption cipher to use. The encryption key size also affects which mode is
 used: only 128, 192 and 256 bit encryption keys are currently supported.
 
 Possible values are:
@@ -299,16 +299,16 @@ Possible values are:
 * Default: false
 * Dynamic: Yes
 
-Enable [semi-synchronous](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
-replication when replicating from a MariaDB server. If enabled, the binlogrouter\
-will send acknowledgment for each received event. Note that the [rpl\_semi\_sync\_master\_enabled](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication#rpl_semi_sync_master_enabled)\
-parameter must be enabled in the MariaDB server where the replication is done\
+Enable [semi-synchronous](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
+replication when replicating from a MariaDB server. If enabled, the binlogrouter
+will send acknowledgment for each received event. Note that the [rpl\_semi\_sync\_master\_enabled](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication#rpl_semi_sync_master_enabled)
+parameter must be enabled in the MariaDB server where the replication is done
 from for the semi-synchronous replication to take place.
 
 ### New installation
 
 1. Configure and start MaxScale.
-2. If you have not configured `select_master=true` (automatic\
+2. If you have not configured `select_master=true` (automatic
    primary selection), issue a `CHANGE MASTER TO` command to binlogrouter.
 
 ```
@@ -330,29 +330,29 @@ SHOW SLAVE STATUS \G
 
 ### Upgrading from legacy versions
 
-Binlogrouter does not read any of the data that a version prior to 2.5\
-has saved. By default binlogrouter will request the replication stream\
-from the blank state (from the start of time), which is basically meant\
-for new systems. If a system is live, the entire replication data probably\
-does not exist, and if it does, it is not necessary for binlogrouter to read\
+Binlogrouter does not read any of the data that a version prior to 2.5
+has saved. By default binlogrouter will request the replication stream
+from the blank state (from the start of time), which is basically meant
+for new systems. If a system is live, the entire replication data probably
+does not exist, and if it does, it is not necessary for binlogrouter to read
 and store all the data.
 
 #### Before you start
 
 * Note that binlogrouter only supports GTID based replication.
-* Make sure that the configured data directory for the new binlogrouter\
+* Make sure that the configured data directory for the new binlogrouter
   is different from the old one, or move old data away.\
   See [datadir](mariadb-maxscale-2308-binlogrouter.md#datadir).
-* If the primary contains binlogs from the blank state, and there\
+* If the primary contains binlogs from the blank state, and there
   is a large amount of data, consider purging old binlogs.\
   See [Using and Maintaining the Binary Log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log).
 
 #### Deployment
 
-The method described here inflicts the least downtime. Assuming you have\
+The method described here inflicts the least downtime. Assuming you have
 configured MaxScale version 2.5 or newer, and it is ready to go:
 
-1. Redirect each replica that replicates from Binlogrouter to replicate from the\
+1. Redirect each replica that replicates from Binlogrouter to replicate from the
    primary.
 
 ```
@@ -375,7 +375,7 @@ master_user=USER,master_password="PASSWORD", master_use_gtid=slave_pos;
 ```
 
 1. Run `maxctrl list servers`. Make sure all your servers are accounted for.\
-   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and\
+   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and
    issue this command to Binlogrouter:
 
 ```
@@ -384,8 +384,8 @@ SET @@global.gtid_slave_pos = "0-1000-1234,1-1001-5678";
 START SLAVE
 ```
 
-**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos\
-if any binlog files have been purged on the primary. The server will only stream\
+**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos
+if any binlog files have been purged on the primary. The server will only stream
 from the start of time if the first binlog file is present.\
 See [select\_master](mariadb-maxscale-2308-binlogrouter.md#select_master).
 
@@ -403,7 +403,7 @@ SHOW SLAVE STATUS \G
 
 ### Galera cluster
 
-When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2308-binlogrouter.md#select_master) must be\
+When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2308-binlogrouter.md#select_master) must be
 set to true, and the servers must be monitored by the [Galera Monitor](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-galera-monitor.md).\
 Configuring binlogrouter is the same as described above.
 
@@ -468,8 +468,8 @@ port=3306
 
 ### Limitations
 
-* Old-style replication with binlog name and file offset is not supported\
-  and the replication must be started by setting up the GTID to replicate\
+* Old-style replication with binlog name and file offset is not supported
+  and the replication must be started by setting up the GTID to replicate
   from.
 * Only replication from MariaDB servers (including Galera) is supported.
 * Old encrypted binary logs are not re-encrypted with newer key versions ([MXS-4140](https://jira.mariadb.org/browse/MXS-4140))

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-cat.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-cat.md
@@ -6,8 +6,8 @@
 
 The `cat` router is a special router that concatenates result sets.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Configuration
@@ -16,28 +16,28 @@ The router has no special parameters. To use it, define a service with`router=ca
 
 ### Behavior
 
-The order the servers are defined in is the order in which the servers are\
-queried. This means that the results are ordered based on the `servers`\
-parameter of the service. The result will only be completed once all servers\
+The order the servers are defined in is the order in which the servers are
+queried. This means that the results are ordered based on the `servers`
+parameter of the service. The result will only be completed once all servers
 have executed this.
 
-All commands executed via this router will be executed on all servers. This\
-means that an INSERT through the `cat` router will send it to all servers. In\
-the case of commands that do not return resultsets, the response of the last\
-server is sent to the client. This means that if one of the earlier servers\
+All commands executed via this router will be executed on all servers. This
+means that an INSERT through the `cat` router will send it to all servers. In
+the case of commands that do not return resultsets, the response of the last
+server is sent to the client. This means that if one of the earlier servers
 returns a different result, the client will not see it.
 
-As the intended use-case of the router is to mainly reduce multiple result sets\
-into one, it has no mechanisms to prevent writes from being executed on slave\
-servers (which would cause data corruption or replication failure). Take great\
+As the intended use-case of the router is to mainly reduce multiple result sets
+into one, it has no mechanisms to prevent writes from being executed on slave
+servers (which would cause data corruption or replication failure). Take great
 care when performing administrative operations though this router.
 
-If a connection to one of the servers is lost, the client connection will also\
+If a connection to one of the servers is lost, the client connection will also
 be closed.
 
 ### Example
 
-Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-servers.md) tutorial and the\
+Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-servers.md) tutorial and the
 credentials from the [MaxScale Tutorial](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-setting-up-mariadb-maxscale.md).
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-hintrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-hintrouter.md
@@ -8,27 +8,27 @@ HintRouter was introduced in 2.2 and is still beta.
 
 ### Overview
 
-The **HintRouter** module is a simple router intended to operate in conjunction\
-with the NamedServerFilter. The router looks at the hints embedded in a packet\
-buffer and attempts to route the packet according to the hint. The user can also\
-set a default action to be taken when a query has no hints or when the hints\
+The **HintRouter** module is a simple router intended to operate in conjunction
+with the NamedServerFilter. The router looks at the hints embedded in a packet
+buffer and attempts to route the packet according to the hint. The user can also
+set a default action to be taken when a query has no hints or when the hints
 could not be applied.
 
-If a packet has multiple hints attached, the router will read them in order and\
-attempt routing. Any successful routing ends the process and any further hints\
+If a packet has multiple hints attached, the router will read them in order and
+attempt routing. Any successful routing ends the process and any further hints
 are ignored for the packet.
 
 ### Configuration
 
-The HintRouter is a rather simple router and only accepts a few configuration\
+The HintRouter is a rather simple router and only accepts a few configuration
 settings.
 
 ```
 default_action=<master|slave|named|all>
 ```
 
-This setting defines what happens when a query has no routing hint or applying\
-the routing hint(s) fails. If also the default action fails, the routing will\
+This setting defines what happens when a query has no routing hint or applying
+the routing hint(s) fails. If also the default action fails, the routing will
 end in error and the session closes. The different values are:
 
 | Value  | Description                                                                |
@@ -38,40 +38,40 @@ end in error and the session closes. The different values are:
 | named  | Route to a named server. The name is given in the default\_server-setting. |
 | all    | Default value. Route to all connected servers.                             |
 
-Note that setting default action to anything other than `all` means that session\
+Note that setting default action to anything other than `all` means that session
 variable write commands are by default not routed to all backends.
 
 ```
 default_server=<server-name>
 ```
 
-Defines the default backend name if `default_action=named`. `<server-name>` must\
+Defines the default backend name if `default_action=named`. `<server-name>` must
 be a valid backend name.
 
 ```
 max_slaves=<limit>
 ```
 
-`<limit>` should be an integer, -1 by default. Defines how many backend replica\
-servers a session should attempt to connect to. Having less replicas defined in\
-the services and/or less successful connections during session creation is not\
-an error. The router will attempt to distribute replicas evenly between sessions\
-by assigning them in a round robin fashion. The session will always try to\
-connect to a primary regardless of this setting, although not finding one is not\
+`<limit>` should be an integer, -1 by default. Defines how many backend replica
+servers a session should attempt to connect to. Having less replicas defined in
+the services and/or less successful connections during session creation is not
+an error. The router will attempt to distribute replicas evenly between sessions
+by assigning them in a round robin fashion. The session will always try to
+connect to a primary regardless of this setting, although not finding one is not
 an error.
 
-Negative values activate default mode, in which case this value is set to the\
-number of backends in the service - 1, so that the sessions are connected to all\
+Negative values activate default mode, in which case this value is set to the
+number of backends in the service - 1, so that the sessions are connected to all
 replicas.
 
-If the hints or the `default_action` point to a named server, this setting is\
-probably best left to default to ensure that the specific server is connected to\
-at session creation. The router will not attempt to connect to additional\
+If the hints or the `default_action` point to a named server, this setting is
+probably best left to default to ensure that the specific server is connected to
+at session creation. The router will not attempt to connect to additional
 servers after session creation.
 
 ### Examples
 
-A minimal configuration doesn't require any parameters as all settings have\
+A minimal configuration doesn't require any parameters as all settings have
 reasonable defaults.
 
 ```
@@ -81,7 +81,7 @@ router=hintrouter
 servers=replica1,replica2,replica3
 ```
 
-If packets should be routed to the primary server by default and only a few\
+If packets should be routed to the primary server by default and only a few
 connections are required, the configuration might be as follows.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-kafkacdc.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-kafkacdc.md
@@ -6,10 +6,10 @@
 
 ### Overview
 
-The KafkaCDC module reads data changes in MariaDB via replication and converts\
+The KafkaCDC module reads data changes in MariaDB via replication and converts
 them into JSON objects that are then streamed to a Kafka broker.
 
-DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the\
+DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the
 following format (example created by `CREATE TABLE test.t1(id INT)`):
 
 ```
@@ -69,10 +69,10 @@ following format (example created by `CREATE TABLE test.t1(id INT)`):
 }
 ```
 
-The `domain`, `server_id` and `sequence` fields contain the GTID that this event\
-belongs to. The `event_number` field is the sequence number of events inside the\
-transaction starting from 1. The `timestamp` field is the UNIX timestamp when\
-the event occurred. The `event_type` field contains the type of the event, one\
+The `domain`, `server_id` and `sequence` fields contain the GTID that this event
+belongs to. The `event_number` field is the sequence number of events inside the
+transaction starting from 1. The `timestamp` field is the UNIX timestamp when
+the event occurred. The `event_type` field contains the type of the event, one
 of:
 
 * `insert`: the event is the data that was added to MariaDB
@@ -80,13 +80,13 @@ of:
 * `update_before`: the event contains the data before an update statement modified it
 * `update_after`: the event contains the data after an update statement modified it
 
-All remaining fields contains data from the table. In the example event this\
+All remaining fields contains data from the table. In the example event this
 would be the fields `id` and `data`.
 
 The sending of these schema objects is optional and can be disabled using`send_schema=false`.
 
-DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that\
-follow the format specified in the DDL event. The objects are in the following\
+DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that
+follow the format specified in the DDL event. The objects are in the following
 format (example created by `INSERT INTO test.t1 VALUES (1)`):
 
 ```
@@ -103,28 +103,28 @@ format (example created by `INSERT INTO test.t1 VALUES (1)`):
 }
 ```
 
-The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These\
+The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These
 contain the table name and schema the event targets.
 
-The router stores table metadata in the MaxScale data directory. The\
-default value is `/var/lib/maxscale/<service name>`. If data for a table\
-is replicated before a DDL event for it is replicated, the CREATE TABLE\
+The router stores table metadata in the MaxScale data directory. The
+default value is `/var/lib/maxscale/<service name>`. If data for a table
+is replicated before a DDL event for it is replicated, the CREATE TABLE
 will be queried from the primary server.
 
-During shutdown, the Kafka event queue is flushed. This can take up to 60\
+During shutdown, the Kafka event queue is flushed. This can take up to 60
 seconds if the network is slow or there are network problems.
 
 ### Configuration
 
-* In order for `kafkacdc` to work, the binary logging on the source server must\
-  be configured to use row-based replication and the row image must be set to\
+* In order for `kafkacdc` to work, the binary logging on the source server must
+  be configured to use row-based replication and the row image must be set to
   full by configuring `binlog_format=ROW` and `binlog_row_image=FULL`.
-* The `servers` parameter defines the set of servers where the data is\
-  replicated from. The replication will be done from the first primary server\
+* The `servers` parameter defines the set of servers where the data is
+  replicated from. The replication will be done from the first primary server
   that is found.
-* The `user` and `password` of the service will be used to connect to the\
+* The `user` and `password` of the service will be used to connect to the
   primary. This user requires the `REPLICATION SLAVE` grant.
-* The KafkaCDC service must not be configured to use listeners. If a listener is\
+* The KafkaCDC service must not be configured to use listeners. If a listener is
   configured, all attempts to start a session will fail.
 
 ### Parameters
@@ -135,7 +135,7 @@ seconds if the network is slow or there are network problems.
 * Mandatory: Yes
 * Dynamic: No
 
-The list of Kafka brokers to use in `host:port` format. Multiple values\
+The list of Kafka brokers to use in `host:port` format. Multiple values
 can be separated with commas. This is a mandatory parameter.
 
 #### `topic`
@@ -144,7 +144,7 @@ can be separated with commas. This is a mandatory parameter.
 * Mandatory: Yes
 * Dynamic: No
 
-The Kafka topic where the replicated events will be sent. This is a\
+The Kafka topic where the replicated events will be sent. This is a
 mandatory parameter.
 
 #### `enable_idempotence`
@@ -154,22 +154,22 @@ mandatory parameter.
 * Dynamic: No
 * Default: `false`
 
-Enable idempotent producer mode. This feature requires Kafka version 0.11 or\
+Enable idempotent producer mode. This feature requires Kafka version 0.11 or
 newer to work and is disabled by default.
 
-When enabled, the Kafka producer enters a strict mode which avoids event\
-duplication due to broker outages or other network errors. In HA scenarios where\
-there are more than two MaxScale instances, event duplication can still happen\
+When enabled, the Kafka producer enters a strict mode which avoids event
+duplication due to broker outages or other network errors. In HA scenarios where
+there are more than two MaxScale instances, event duplication can still happen
 as there is no synchronization between the MaxScale instances.
 
-The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),\
+The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),
 describes the parameter as follows:
 
-When set to true, the producer will ensure that messages are successfully\
-produced exactly once and in the original produce order. The following\
-configuration properties are adjusted automatically (if not modified by the\
-user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must\
-be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),\
+When set to true, the producer will ensure that messages are successfully
+produced exactly once and in the original produce order. The following
+configuration properties are adjusted automatically (if not modified by the
+user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must
+be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),
 acks=all, queuing.strategy=fifo.
 
 #### `timeout`
@@ -188,12 +188,12 @@ The connection and read timeout for the replication stream.
 * Dynamic: No
 * Default: `""`
 
-The initial GTID position from where the replication is started. By default the\
-replication is started from the beginning. The value of this parameter is only\
-used if no previously replicated events with GTID positions can be retrieved\
+The initial GTID position from where the replication is started. By default the
+replication is started from the beginning. The value of this parameter is only
+used if no previously replicated events with GTID positions can be retrieved
 from Kafka.
 
-Once the replication has started and a GTID position has been recorded, this\
+Once the replication has started and a GTID position has been recorded, this
 parameter will be ignored. To reset the recorded GTID position, delete the`current_gtid.txt` file located in `/var/lib/maxscale/<SERVICE>/` where`<SERVICE>` is the name of the KafkaCDC service.
 
 #### `server_id`
@@ -203,8 +203,8 @@ parameter will be ignored. To reset the recorded GTID position, delete the`curre
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
-used when replicating from the primary in direct replication mode. The default\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
+used when replicating from the primary in direct replication mode. The default
 value is 1234. This parameter was added in MaxScale 2.5.7.
 
 #### `match`
@@ -218,13 +218,13 @@ Only include data from tables that match this pattern.
 
 For example, if configured with `match=accounts[.].*`, only data from the`accounts` database is sent to Kafka.
 
-The pattern is matched against the combined database and table name separated by\
-a period. This means that the event for the table `t1` in the `test` database\
-would appear as `test.t1`. The behavior is the same even if the database or the\
-table name contains a period. This means that an event for the `test.table`\
+The pattern is matched against the combined database and table name separated by
+a period. This means that the event for the table `t1` in the `test` database
+would appear as `test.t1`. The behavior is the same even if the database or the
+table name contains a period. This means that an event for the `test.table`
 table in the `my.data` database would appear as `my.data.test.table`.
 
-Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are\
+Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are
 filtered out using the `exclude` parameter.
 
 ```
@@ -249,11 +249,11 @@ exclude=db1 [.](accounts|users)
 
 Exclude data from tables that match this pattern.
 
-For example, if configured with `exclude=mydb[.].*`, all data from the tables in\
+For example, if configured with `exclude=mydb[.].*`, all data from the tables in
 the `mydb` database is not sent to Kafka.
 
-The pattern matching works the same way for both of the `exclude` and `match`\
-parameters. See [match](mariadb-maxscale-2308-kafkacdc.md#match) for an explanation on how the patterns are\
+The pattern matching works the same way for both of the `exclude` and `match`
+parameters. See [match](mariadb-maxscale-2308-kafkacdc.md#match) for an explanation on how the patterns are
 matched against the database and table names.
 
 #### `cooperative_replication`
@@ -263,22 +263,22 @@ matched against the database and table names.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
+Controls whether multiple instances cooperatively replicate from the same
 cluster. This is a boolean parameter and is disabled by default. It was added in\
 MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`), the\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`), the
 replication is only active if the monitor owns the cluster it is monitoring.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID that was delivered\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID that was delivered
 to Kafka.
 
-This means that multiple MaxScale instances can replicate from the same set of\
-servers and the event is only processed once. This feature does not provide\
-exactly-once semantics for the Kafka event delivery. However, it does provide\
-high-availability for the `kafkacdc` instances which allows automated failover\
+This means that multiple MaxScale instances can replicate from the same set of
+servers and the event is only processed once. This feature does not provide
+exactly-once semantics for the Kafka event delivery. However, it does provide
+high-availability for the `kafkacdc` instances which allows automated failover
 between multiple MaxScale instances.
 
 #### `send_schema`
@@ -288,12 +288,12 @@ between multiple MaxScale instances.
 * Dynamic: Yes
 * Default: true
 
-Send JSON schema object into the stream whenever the table schema changes. These\
-events, as described [here](mariadb-maxscale-2308-kafkacdc.md#overview), can be used to detect whenever the\
+Send JSON schema object into the stream whenever the table schema changes. These
+events, as described [here](mariadb-maxscale-2308-kafkacdc.md#overview), can be used to detect whenever the
 format of the data being sent changes.
 
-If this information in these schema change events is not needed or the code that\
-processes the Kafka stream can't handle them, they can be disabled with this\
+If this information in these schema change events is not needed or the code that
+processes the Kafka stream can't handle them, they can be disabled with this
 parameter.
 
 #### `read_gtid_from_kafka`
@@ -303,10 +303,10 @@ parameter.
 * Dynamic: No
 * Default: `true`
 
-On startup, the latest GTID is by default read from the Kafka cluster. This\
+On startup, the latest GTID is by default read from the Kafka cluster. This
 makes it possible to recover the replication position stored by another\
-MaxScale. Sometimes this is not desirable and the GTID should only be read from\
-the local file or started anew. Examples of these are when the GTIDs are reset\
+MaxScale. Sometimes this is not desirable and the GTID should only be read from
+the local file or started anew. Examples of these are when the GTIDs are reset
 or the replication topology has changed.
 
 #### `kafka_ssl`
@@ -316,7 +316,7 @@ or the replication topology has changed.
 * Dynamic: No
 * Default: `false`
 
-Enable SSL for Kafka connections. This is a boolean parameter and is disabled by\
+Enable SSL for Kafka connections. This is a boolean parameter and is disabled by
 default.
 
 #### `kafka_ssl_ca`
@@ -326,7 +326,7 @@ default.
 * Dynamic: No
 * Default: `""`
 
-Path to the certificate authority file in PEM format. If this is not provided,\
+Path to the certificate authority file in PEM format. If this is not provided,
 the default system certificates will be used.
 
 #### `kafka_ssl_cert`
@@ -338,8 +338,8 @@ the default system certificates will be used.
 
 Path to the public certificate in PEM format.
 
-The client must provide a certificate if the Kafka server performs authentication\
-of the client certificates. This feature is enabled by default in Kafka and is\
+The client must provide a certificate if the Kafka server performs authentication
+of the client certificates. This feature is enabled by default in Kafka and is
 controlled by [ssl.endpoint.identification.algorithm](https://kafka.apache.org/documentation/#brokerconfigs_ssl.endpoint.identification.algorithm).
 
 If `kafka_ssl_cert` is provided, `kafka_ssl_key` must also be provided.
@@ -385,8 +385,8 @@ If `kafka_sasl_password` is provided, `kafka_sasl_user` must also be provided.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-The SASL mechanism used. The default value is `PLAIN` which uses plaintext\
-authentication. It is recommended to enable SSL whenever plaintext\
+The SASL mechanism used. The default value is `PLAIN` which uses plaintext
+authentication. It is recommended to enable SSL whenever plaintext
 authentication is used.
 
 Allowed values are:
@@ -400,7 +400,7 @@ Kafka broker.
 
 ### Example Configuration
 
-The following configuration defines the minimal setup for streaming replication\
+The following configuration defines the minimal setup for streaming replication
 events from MariaDB into Kafka as JSON:
 
 ```
@@ -432,8 +432,8 @@ topic=my-cdc-topic
 
 ### Limitations
 
-* The KafkaCDC module provides at-least-once semantics for the generated\
-  events. This means that each replication event is delivered to kafka at least\
+* The KafkaCDC module provides at-least-once semantics for the generated
+  events. This means that each replication event is delivered to kafka at least
   once but there can be duplicate events in case of failures.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-kafkaimporter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-kafkaimporter.md
@@ -7,8 +7,8 @@
 ### Overview
 
 The KafkaImporter module reads messages from Kafka and streams them into a\
-MariaDB server. The messages are inserted into a table designated by either the\
-topic name or the message key (see [table\_name\_in](mariadb-maxscale-2308-kafkaimporter.md#table_name_in) for\
+MariaDB server. The messages are inserted into a table designated by either the
+topic name or the message key (see [table\_name\_in](mariadb-maxscale-2308-kafkaimporter.md#table_name_in) for
 details). By default the table will be automatically created with the following\
 SQL:
 
@@ -19,31 +19,31 @@ CREATE TABLE IF NOT EXISTS my_table (
 );
 ```
 
-The payload of the message is inserted into the `data` field from which the `id`\
-field is calculated. The payload must be a valid JSON object and it must either\
-contain a unique `_id` field or it must not exist or the value must be a JSON\
-null. This is similar to the MongoDB document format where the `_id` field is\
+The payload of the message is inserted into the `data` field from which the `id`
+field is calculated. The payload must be a valid JSON object and it must either
+contain a unique `_id` field or it must not exist or the value must be a JSON
+null. This is similar to the MongoDB document format where the `_id` field is
 the primary key of the document collection.
 
-If a message is read from Kafka and the insertion into the table fails due to a\
-violation of one of the constraints, the message is ignored. Similarly, messages\
-with duplicate `_id` value are also ignored: this is done to avoid inserting the\
-same document multiple times whenever the connection to either Kafka or MariaDB\
+If a message is read from Kafka and the insertion into the table fails due to a
+violation of one of the constraints, the message is ignored. Similarly, messages
+with duplicate `_id` value are also ignored: this is done to avoid inserting the
+same document multiple times whenever the connection to either Kafka or MariaDB
 is lost.
 
-The limitations on the data can be removed by either creating the table before\
-the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`\
-does nothing, or by altering the structure of the existing table. The minimum\
-requirement that must be met is that the table contains the `data` field to\
+The limitations on the data can be removed by either creating the table before
+the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`
+does nothing, or by altering the structure of the existing table. The minimum
+requirement that must be met is that the table contains the `data` field to
 which string values can be inserted into.
 
-The database server where the data is inserted is chosen from the set of servers\
-available to the service. The first server labeled as the `Master` with the best\
+The database server where the data is inserted is chosen from the set of servers
+available to the service. The first server labeled as the `Master` with the best
 rank will be chosen. This means that a monitor must be configured for the\
 MariaDB server where the data is to be inserted.
 
-In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 24.08.2\
-the `_id` field is not required to be present. Older versions of MaxScale used\
+In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 24.08.2
+the `_id` field is not required to be present. Older versions of MaxScale used
 the following SQL where the `_id` field was mandatory:
 
 ```
@@ -84,9 +84,9 @@ The comma separated list of topics to subscribe to.
 * Dynamic: Yes
 * Default: `100`
 
-Maximum number of uncommitted records. The KafkaImporter will buffer records\
-into batches and commit them once either enough records are gathered (controlled\
-by this parameter) or when the KafkaImporter goes idle. Any uncommitted records\
+Maximum number of uncommitted records. The KafkaImporter will buffer records
+into batches and commit them once either enough records are gathered (controlled
+by this parameter) or when the KafkaImporter goes idle. Any uncommitted records
 will be read again if a reconnection to either Kafka or MariaDB occurs.
 
 #### `kafka_sasl_mechanism`
@@ -97,7 +97,7 @@ will be read again if a reconnection to either Kafka or MariaDB occurs.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-SASL mechanism to use. The Kafka broker must be configured with the same\
+SASL mechanism to use. The Kafka broker must be configured with the same
 authentication scheme.
 
 #### `kafka_sasl_user`
@@ -116,7 +116,7 @@ SASL username used for authentication. If this parameter is defined,`kafka_sasl_
 * Dynamic: Yes
 * Default: `""`
 
-SASL password for the user. If this parameter is defined, `kafka_sasl_user` must\
+SASL password for the user. If this parameter is defined, `kafka_sasl_user` must
 also be provided.
 
 #### `kafka_ssl`
@@ -135,7 +135,7 @@ Enable SSL for Kafka connections.
 * Dynamic: Yes
 * Default: `""`
 
-SSL Certificate Authority file in PEM format. If this parameter is not\
+SSL Certificate Authority file in PEM format. If this parameter is not
 defined, the system default CA certificate is used.
 
 #### `kafka_ssl_cert`
@@ -169,14 +169,14 @@ The Kafka message part that is used to locate the table to insert the data into.
 Enumeration Values:
 
 * `topic`: The topic named is used as the fully qualified table name.
-* `key`: The message key is used as the fully qualified table name. If the Kafka\
+* `key`: The message key is used as the fully qualified table name. If the Kafka
   message does not have a key, the message is ignored.
 
-For example, all messages with a fully qualified table name of `my_db.my_table`\
-will be inserted into the table `my_table` located in the `my_db` database. If\
-the table or database names have special characters that must be escaped to make\
-them valid identifiers, the name must also contain those escape characters. For\
-example, to insert into a table named `my table` in the database `my database`,\
+For example, all messages with a fully qualified table name of `my_db.my_table`
+will be inserted into the table `my_table` located in the `my_db` database. If
+the table or database names have special characters that must be escaped to make
+them valid identifiers, the name must also contain those escape characters. For
+example, to insert into a table named `my table` in the database `my database`,
 the name would be:
 
 ```
@@ -201,20 +201,20 @@ Timeout for both Kafka and MariaDB network communication.
 
 The storage engine used for tables that are created by the KafkaImporter.
 
-This defines the `ENGINE` table option and must be the name of a valid storage\
-engine in MariaDB. When the storage engine is something other than `InnoDB`, the\
+This defines the `ENGINE` table option and must be the name of a valid storage
+engine in MariaDB. When the storage engine is something other than `InnoDB`, the
 table is created without the generated column and the check constraints:
 
 ```
 CREATE TABLE IF NOT EXISTS my_table (data JSON NOT NULL);
 ```
 
-This is done to avoid conflicts where the custom engine does not support all the\
+This is done to avoid conflicts where the custom engine does not support all the
 features that InnoDB supports.
 
 ### Limitations
 
-* The backend servers used by this service must be MariaDB version 10.2 or\
+* The backend servers used by this service must be MariaDB version 10.2 or
   newer.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-mirror.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-mirror.md
@@ -6,11 +6,11 @@
 
 ### Overview
 
-The `mirror` router is designed for data consistency and database behavior\
-verification during system upgrades. It allows statement duplication to multiple\
+The `mirror` router is designed for data consistency and database behavior
+verification during system upgrades. It allows statement duplication to multiple
 servers in a manner similar to that of the [Tee filter](../mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-tee-filter.md) with exporting of collected query metrics.
 
-For each executed query the router exports a JSON object that describes the\
+For each executed query the router exports a JSON object that describes the
 query results and has the following fields:
 
 | Key       | Description                                              |
@@ -21,7 +21,7 @@ query results and has the following fields:
 | query\_id | Query sequence number, starts from 1                     |
 | results   | Array of query result objects                            |
 
-The objects in the `results` array describe an individual query result and have\
+The objects in the `results` array describe an individual query result and have
 the following fields:
 
 | Key      | Description                                |
@@ -41,12 +41,12 @@ the following fields:
 * Mandatory: Yes
 * Dynamic: Yes
 
-The main target from which results are returned to the client. This is a\
+The main target from which results are returned to the client. This is a
 mandatory parameter and must define one of the targets configured in the`targets` parameter of the service.
 
-If the connection to the main target cannot be created or is lost mid-session,\
-the client connection will be closed. Connection failures to other targets are\
-not fatal errors and any open connections to them will be closed. The router\
+If the connection to the main target cannot be created or is lost mid-session,
+the client connection will be closed. Connection failures to other targets are
+not fatal errors and any open connections to them will be closed. The router
 does not create new connections after the initial connections are created.
 
 #### `exporter`
@@ -56,7 +56,7 @@ does not create new connections after the initial connections are created.
 * Dynamic: Yes
 * Values: `log`, `file`, `kafka`
 
-The exporter where the data is exported. This is a mandatory parameter. Possible\
+The exporter where the data is exported. This is a mandatory parameter. Possible
 values are:
 
 * `log`
@@ -64,7 +64,7 @@ values are:
 * `file`
 * Exports metrics to a file. Configured with the [file](mariadb-maxscale-2308-mirror.md#file) parameter.
 * `kafka`
-* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2308-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2308-mirror.md#kafka_topic)\
+* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2308-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2308-mirror.md#kafka_topic)
   parameters.
 
 #### `file`
@@ -74,12 +74,12 @@ values are:
 * Mandatory: No
 * Dynamic: Yes
 
-The output file where the metrics will be written. The file must be writable by\
+The output file where the metrics will be written. The file must be writable by
 the user that is running MaxScale, usually the `maxscale` user.
 
-When the `file` parameter is altered at runtime, the old file is closed before\
-the new file is opened. This makes it a convenient way of rotating the file\
-where the metrics are exported. Note that the file name alteration must change\
+When the `file` parameter is altered at runtime, the old file is closed before
+the new file is opened. This makes it a convenient way of rotating the file
+where the metrics are exported. Note that the file name alteration must change
 the value for it to take effect.
 
 This is a mandatory parameter when configured with `exporter=file`.
@@ -91,7 +91,7 @@ This is a mandatory parameter when configured with `exporter=file`.
 * Mandatory: No
 * Dynamic: Yes
 
-The Kafka broker list. Must be given as a comma-separated list of broker hosts\
+The Kafka broker list. Must be given as a comma-separated list of broker hosts
 with optional ports in `host:port` format.
 
 This is a mandatory parameter when configured with `exporter=kafka`.
@@ -118,12 +118,12 @@ This is a mandatory parameter when configured with `exporter=kafka`.
 What to do when a backend network connection fails. Accepted values are:
 
 * `ignore`
-* Ignore the failing backend if it's not the backend that the `main` parameter\
+* Ignore the failing backend if it's not the backend that the `main` parameter
   points to.
 * `close`
 * Close the client connection when the first backend fails.
 
-This parameter was added in MaxScale 6.0. Older versions always ignored\
+This parameter was added in MaxScale 6.0. Older versions always ignored
 failing backends.
 
 #### `report`
@@ -141,7 +141,7 @@ When to report the result of the queries. Accepted values are:
 * `on_conflict`
 * Only report when one or more backends returns a conflicting result.
 
-This parameter was added in MaxScale 6.0. Older versions always reported the\
+This parameter was added in MaxScale 6.0. Older versions always reported the
 result.
 
 ### Example Configuration
@@ -186,8 +186,8 @@ port=3306
 * Broken network connections are not recreated.
 * Prepared statements are not supported.
 * Contents of non-SQL statements are not added to the exported metrics.
-* Data synchronization in dynamic environments (e.g. when replication is in use)\
-  is not guaranteed. This means that result mismatches can be reported when the\
+* Data synchronization in dynamic environments (e.g. when replication is in use)
+  is not guaranteed. This means that result mismatches can be reported when the
   data is only eventually consistent.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readconnroute.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readconnroute.md
@@ -4,32 +4,32 @@
 
 ## Readconnroute
 
-This document provides an overview of the **readconnroute** router module\
-and its intended use case scenarios. It also displays all router\
+This document provides an overview of the **readconnroute** router module
+and its intended use case scenarios. It also displays all router
 configuration parameters with their descriptions.
 
 ### Overview
 
-The readconnroute router provides simple and lightweight load balancing across a\
+The readconnroute router provides simple and lightweight load balancing across a
 set of servers.
 
-Note that \*_readconnroute_ balances _connections_ and not _statements_. When a\
-client connects, the router selects the server that matches the value of`router_options` and has the least number of connections. Once the connection is\
-opened, it will not be changed for the duration of the session. If the\
-connection between MaxScale and the server breaks, the connection can not be\
-re-established and the client session will be closed. The fact that the server\
+Note that \*_readconnroute_ balances _connections_ and not _statements_. When a
+client connects, the router selects the server that matches the value of`router_options` and has the least number of connections. Once the connection is
+opened, it will not be changed for the duration of the session. If the
+connection between MaxScale and the server breaks, the connection can not be
+re-established and the client session will be closed. The fact that the server
 is fixed when the client connects also means that routing hints are ignored.
 
-Connections from other MaxScale instances or connections done directly on a\
+Connections from other MaxScale instances or connections done directly on a
 database are not taken into account. Only connections done through the same\
 Maxscale instance are taken into account.
 
-**Warning:** `readconnroute` will not prevent writes from being done even if you\
-define `router_options=slave`. The client application is responsible for\
-making sure that it only performs read-only queries in such\
-cases. `readconnroute` is simple by design: it selects a server for each\
-client connection and routes all queries there. If something more complex is\
-required, the [readwritesplit](mariadb-maxscale-2308-readwritesplit.md) router is usually the right\
+**Warning:** `readconnroute` will not prevent writes from being done even if you
+define `router_options=slave`. The client application is responsible for
+making sure that it only performs read-only queries in such
+cases. `readconnroute` is simple by design: it selects a server for each
+client connection and routes all queries there. If something more complex is
+required, the [readwritesplit](mariadb-maxscale-2308-readwritesplit.md) router is usually the right
 choice.
 
 ### Configuration
@@ -44,8 +44,8 @@ For more details about the standard service parameters, refer to the [Configurat
 * Values: `master`, `slave`, `synced`, `running`
 * Default: `running`
 
-**`router_options`** can contain a comma separated list of valid server\
-roles. These roles are used as the valid types of servers the router will\
+**`router_options`** can contain a comma separated list of valid server
+roles. These roles are used as the valid types of servers the router will
 form connections to when new sessions are created.
 
 Examples:
@@ -64,20 +64,20 @@ Here is a list of all possible values for the `router_options`.
 | synced  | A Galera cluster node which is in a synced state with the cluster.                                                                                                                                                           |
 | running | A server that is up and running. All servers that MariaDB MaxScale can connect to are labeled as running.                                                                                                                    |
 
-If no `router_options` parameter is configured in the service definition,\
-the router will use the default value of `running`. This means that it will\
-load balance connections across all running servers defined in the `servers`\
+If no `router_options` parameter is configured in the service definition,
+the router will use the default value of `running`. This means that it will
+load balance connections across all running servers defined in the `servers`
 parameter of the service.
 
-When a connection is being created and the candidate server is being chosen, the\
-list of servers is processed in from first entry to last. This means that if two\
-servers with equal rank and number of connections are found, the one that's\
+When a connection is being created and the candidate server is being chosen, the
+list of servers is processed in from first entry to last. This means that if two
+servers with equal rank and number of connections are found, the one that's
 listed first in the _servers_ parameter for the service is chosen.
 
-When using `router_options=slave`, only servers with the `Slave` status are\
-used. If there are no servers with the `Slave` status but there is a `Master`\
-status, it will be used as the fallback server. Note that the use of`router_options=slave` does not prevent writes from being done and the client\
-application is responsible for making sure that no writes are done on a `Slave`\
+When using `router_options=slave`, only servers with the `Slave` status are
+used. If there are no servers with the `Slave` status but there is a `Master`
+status, it will be used as the fallback server. Note that the use of`router_options=slave` does not prevent writes from being done and the client
+application is responsible for making sure that no writes are done on a `Slave`
 server.
 
 #### `master_accept_reads`
@@ -88,8 +88,8 @@ server.
 * Default: true
 
 This option can be used to prevent queries from being sent to the current primary.\
-If `router_options` does not contain `master`, the readconnroute instance is\
-usually meant for reading. Setting `master_accept_reads=false` excludes the primary\
+If `router_options` does not contain `master`, the readconnroute instance is
+usually meant for reading. Setting `master_accept_reads=false` excludes the primary
 from server selection (and thus from receiving reads).
 
 If `router_options` contains `master`, the setting of `master_accept_reads` has no effect.
@@ -103,22 +103,22 @@ By default `master_accept_reads=true`.
 * Dynamic: Yes
 * Default: 0s
 
-The maximum acceptable replication lag. The value is in seconds and is specified\
-as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). The\
+The maximum acceptable replication lag. The value is in seconds and is specified
+as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). The
 default value is `0s`, which means that the lag is ignored.
 
-The replication lag of a server must be less than the configured value in order\
-for it to be used for routing. To configure the router to not allow any lag, use\
+The replication lag of a server must be less than the configured value in order
+for it to be used for routing. To configure the router to not allow any lag, use
 the smallest duration larger than 0, that is, `max_replication_lag=1s`.
 
 ### Examples
 
-The most common use for the readconnroute is to provide either a read or\
-write port for an application. This provides a more lightweight routing\
-solution than the more complex readwritesplit router but requires the\
+The most common use for the readconnroute is to provide either a read or
+write port for an application. This provides a more lightweight routing
+solution than the more complex readwritesplit router but requires the
 application to be able to use distinct write and read ports.
 
-To configure a read-only service that tolerates primary failures, we first\
+To configure a read-only service that tolerates primary failures, we first
 need to add a new section in to the configuration file.
 
 ```
@@ -129,11 +129,11 @@ servers=replica1,replica2,replica3
 router_options=slave
 ```
 
-Here the `router_options` designates replicas as the only valid server\
-type. With this configuration, the queries are load balanced across the\
+Here the `router_options` designates replicas as the only valid server
+type. With this configuration, the queries are load balanced across the
 replica servers.
 
-For more complex examples of the readconnroute router, take a look at the\
+For more complex examples of the readconnroute router, take a look at the
 examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
 
 ### Router Diagnostics

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
@@ -4,54 +4,54 @@
 
 ## Readwritesplit
 
-This document provides a short overview of the **readwritesplit** router module\
-and its intended use case scenarios. It also displays all router configuration\
-parameters with their descriptions. A list of current limitations of the module\
+This document provides a short overview of the **readwritesplit** router module
+and its intended use case scenarios. It also displays all router configuration
+parameters with their descriptions. A list of current limitations of the module
 is included and use examples are provided.
 
 ### Overview
 
-The **readwritesplit** router is designed to increase the read-only processing\
-capability of a cluster while maintaining consistency. This is achieved by\
-splitting the query load into read and write queries. Read queries, which do not\
-modify data, are spread across multiple nodes while all write queries will be\
-sent to a single node. For more details on how the load balancing works, refer\
+The **readwritesplit** router is designed to increase the read-only processing
+capability of a cluster while maintaining consistency. This is achieved by
+splitting the query load into read and write queries. Read queries, which do not
+modify data, are spread across multiple nodes while all write queries will be
+sent to a single node. For more details on how the load balancing works, refer
 to [slave\_selection\_criteria](mariadb-maxscale-2308-readwritesplit.md#slave_selection_criteria) and [master\_accept\_reads](mariadb-maxscale-2308-readwritesplit.md#master_accept_reads).
 
-The router is designed to be used with a traditional Primary-Replica replication\
-cluster. It automatically detects changes in the primary server and will use the\
-current primary server of the cluster. With a Galera cluster, one can achieve a\
+The router is designed to be used with a traditional Primary-Replica replication
+cluster. It automatically detects changes in the primary server and will use the
+current primary server of the cluster. With a Galera cluster, one can achieve a
 resilient setup and easy primary failover by using one of the Galera nodes as a\
-Write-Primary node, where all write queries are routed, and spreading the read\
+Write-Primary node, where all write queries are routed, and spreading the read
 load over all the nodes.
 
 ### Interaction with servers in `Maintenance` and `Draining` state
 
-When a server that readwritesplit uses is put into maintenance mode, any ongoing\
-requests are allowed to finish before the connection is closed. If the server\
-that is put into maintenance mode is a primary, open transaction are allowed to\
-complete before the connection is closed. Note that this means neither idle\
-session nor long-running transactions will be closed by readwritesplit. To\
+When a server that readwritesplit uses is put into maintenance mode, any ongoing
+requests are allowed to finish before the connection is closed. If the server
+that is put into maintenance mode is a primary, open transaction are allowed to
+complete before the connection is closed. Note that this means neither idle
+session nor long-running transactions will be closed by readwritesplit. To
 forcefully close the connections, use the following command:
 
 ```
 maxctrl set server <server> maintenance --force
 ```
 
-If a server is put into the `Draining` state while a connection is open, the\
-connection will be used normally. Whenever a new connection needs to be created,\
-whether that be due to a network error or when a new session being opened, only\
+If a server is put into the `Draining` state while a connection is open, the
+connection will be used normally. Whenever a new connection needs to be created,
+whether that be due to a network error or when a new session being opened, only
 servers that are neither `Draining` nor `Drained` will be used.
 
 ### Configuration
 
-Readwritesplit router-specific settings are specified in the configuration file\
-of MariaDB MaxScale in its specific section. The section can be freely named but\
+Readwritesplit router-specific settings are specified in the configuration file
+of MariaDB MaxScale in its specific section. The section can be freely named but
 the name is used later as a reference in a listener section.
 
 For more details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md).
 
-Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be\
+Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be
 taken into use by new sessions.
 
 ### Parameters
@@ -63,45 +63,45 @@ taken into use by new sessions.
 * Dynamic: Yes
 * Default: 255
 
-`max_slave_connections` sets the maximum number of replicas a router session uses\
-at any moment. The default is to use at most 255 replica connections per client\
-connection. In older versions the default was to use all available replicas with\
+`max_slave_connections` sets the maximum number of replicas a router session uses
+at any moment. The default is to use at most 255 replica connections per client
+connection. In older versions the default was to use all available replicas with
 no limit.
 
 For MaxScale 2.5.12 and newer, the minimum value is 0.
 
-For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions\
-suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that\
-causes the parameter to accept any values but only function when a value greater\
+For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions
+suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that
+causes the parameter to accept any values but only function when a value greater
 than one was given.
 
-Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be\
+Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be
 removed in a future release.
 
-For example, if you have configured MaxScale with one primary and three replicas\
-and set `max_slave_connections=2`, for each client connection a connection to\
-the primary and two replica connections would be opened. The read query load\
-balancing is then done between these two replicas and writes are sent to the\
+For example, if you have configured MaxScale with one primary and three replicas
+and set `max_slave_connections=2`, for each client connection a connection to
+the primary and two replica connections would be opened. The read query load
+balancing is then done between these two replicas and writes are sent to the
 primary.
 
-By tuning this parameter, you can control how dynamic the load balancing is at\
-the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of\
-possible replica servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more\
-resources but load balancing will almost always give the best single query\
+By tuning this parameter, you can control how dynamic the load balancing is at
+the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of
+possible replica servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more
+resources but load balancing will almost always give the best single query
 response time and performance. Longer sessions are less affected by a high`max_slave_connections` as the relative cost of opening a connection is lower.
 
 **Behavior of `max_slave_connections=0`**
 
-When readwritesplit is configured with `max_slave_connections=0`, readwritesplit\
-will behave slightly differently in that it will route all reads to the current\
-master server. This is a convenient way to force all of the traffic to go to a\
-single node while still being able to leverage the replay and reconnection\
+When readwritesplit is configured with `max_slave_connections=0`, readwritesplit
+will behave slightly differently in that it will route all reads to the current
+master server. This is a convenient way to force all of the traffic to go to a
+single node while still being able to leverage the replay and reconnection
 features of readwritesplit.
 
-In this mode, the behavior of `master_failure_mode=fail_on_write` also changes\
-slightly. If the current `Master` server fails and a read is done when there's\
-no other `Master` server available, the connection will be closed. This is done\
-to prevent an extra slave connection from being opened that would not be closed\
+In this mode, the behavior of `master_failure_mode=fail_on_write` also changes
+slightly. If the current `Master` server fails and a read is done when there's
+no other `Master` server available, the connection will be closed. This is done
+to prevent an extra slave connection from being opened that would not be closed
 if a new `Master` server would arrive.
 
 #### `slave_connections`
@@ -111,17 +111,17 @@ if a new `Master` server would arrive.
 * Dynamic: Yes
 * Default: 255
 
-This parameter controls how many replica connections each new session starts\
+This parameter controls how many replica connections each new session starts
 with. The default value is 255 which is the same as the default value of`max_slave_connections`.
 
-In contrast to `max_slave_connections`, `slave_connections` serves as a\
-soft limit on how many replica connections are created. The number of replica\
-connections can exceed `slave_connections` if the load balancing algorithm\
+In contrast to `max_slave_connections`, `slave_connections` serves as a
+soft limit on how many replica connections are created. The number of replica
+connections can exceed `slave_connections` if the load balancing algorithm
 finds an unconnected replica server better than all other replicas.
 
-Setting this parameter to 1 allows faster connection creation and improved\
-resource usage due to the smaller amount of initial backend\
-connections. It is recommended to use `slave_connections=1` when the\
+Setting this parameter to 1 allows faster connection creation and improved
+resource usage due to the smaller amount of initial backend
+connections. It is recommended to use `slave_connections=1` when the
 lifetime of the client connections is short.
 
 #### `max_replication_lag`
@@ -131,38 +131,38 @@ lifetime of the client connections is short.
 * Dynamic: Yes
 * Default: 0s
 
-**NOTE** Up until 23.02, this parameter was called `max_slave_replication_lag`,\
+**NOTE** Up until 23.02, this parameter was called `max_slave_replication_lag`,
 which has been deprecated but still works as an alias for `max_replication_lag`.
 
-Specify how many seconds a replica is allowed to be behind the primary. The lag of\
-a replica must be less than the configured value in order for it to be used for\
+Specify how many seconds a replica is allowed to be behind the primary. The lag of
+a replica must be less than the configured value in order for it to be used for
 routing. If set to `0s` (the default value), the feature is disabled.
 
-The replica lag must be less than `max_replication_lag`. This means that it\
-is possible to define, with `max_replication_lag=1s`, that all replicas must\
+The replica lag must be less than `max_replication_lag`. This means that it
+is possible to define, with `max_replication_lag=1s`, that all replicas must
 be up to date in order for them to be used for routing.
 
-Note that this feature does not guarantee that writes done on the primary are\
-visible for reads done on the replica. This is mainly due to the method of\
+Note that this feature does not guarantee that writes done on the primary are
+visible for reads done on the replica. This is mainly due to the method of
 replication lag measurement. For a feature that guarantees this, refer to [causal\_reads](mariadb-maxscale-2308-readwritesplit.md#causal_reads).
 
-The lag is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). Note that since\
-the granularity of the lag is seconds, a lag specified in milliseconds will be\
+The lag is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). Note that since
+the granularity of the lag is seconds, a lag specified in milliseconds will be
 rejected, even if the duration is longer than a second.
 
-The Readwritesplit-router does not detect the replication lag itself. A monitor\
-such as the MariaDB-monitor for a Primary-Replica cluster is required. This option\
-only affects Primary-Replica clusters. Galera clusters do not have a concept of\
-replica lag even if the application of write sets might have lag. When a server is\
-disqualified from routing because of replication lag, a warning is logged. Similarly,\
-when the server has caught up enough to be a valid routing target, another warning\
-is logged. These messages are only logged when a query is being routed and the\
+The Readwritesplit-router does not detect the replication lag itself. A monitor
+such as the MariaDB-monitor for a Primary-Replica cluster is required. This option
+only affects Primary-Replica clusters. Galera clusters do not have a concept of
+replica lag even if the application of write sets might have lag. When a server is
+disqualified from routing because of replication lag, a warning is logged. Similarly,
+when the server has caught up enough to be a valid routing target, another warning
+is logged. These messages are only logged when a query is being routed and the
 replication state changes.
 
-Starting with MaxScale versions 23.08.7, 24.02.3 and 24.08.1, readwritesplit\
-will discard connections to any servers that have excessive replication lag. The\
-connection will be discarded if a server is lagging behind by more than twice\
-the amount of `max_replication_lag` and the server is behind by more than 300\
+Starting with MaxScale versions 23.08.7, 24.02.3 and 24.08.1, readwritesplit
+will discard connections to any servers that have excessive replication lag. The
+connection will be discarded if a server is lagging behind by more than twice
+the amount of `max_replication_lag` and the server is behind by more than 300
 seconds (`replication lag > MAX(300, 2 * max_replication_lag)`).
 
 #### `use_sql_variables_in`
@@ -173,8 +173,8 @@ seconds (`replication lag > MAX(300, 2 * max_replication_lag)`).
 * Values: `master`, `all`
 * Default: `all`
 
-This parameter controls how `SELECT` statements that use SQL user variables are\
-handled. Here is an example of such a query that uses it to return an increasing\
+This parameter controls how `SELECT` statements that use SQL user variables are
+handled. Here is an example of such a query that uses it to return an increasing
 row number for a resultset:
 
 ```
@@ -182,31 +182,31 @@ SET @rownum := 0;
 SELECT @rownum := @rownum + 1 AS rownum, user, host FROM mysql.user;
 ```
 
-By default MaxScale will route both the `SET` and `SELECT` statements to all\
+By default MaxScale will route both the `SET` and `SELECT` statements to all
 nodes. Any future reads of the user variables can also be performed on any node.
 
 The possible values for this parameter are:
 
 * `all` (default)
-* Modifications to user variables inside `SELECT` statements as well as reads\
+* Modifications to user variables inside `SELECT` statements as well as reads
   of user variables are routed to all servers.\
-  Versions before MaxScale 22.08 returned an error if a user variable was\
-  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was\
-  used. MaxScale 22.08 will instead route the query to all servers and discard\
+  Versions before MaxScale 22.08 returned an error if a user variable was
+  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was
+  used. MaxScale 22.08 will instead route the query to all servers and discard
   the extra results.
 * `master`
-* Modifications to user variables inside `SELECT` statements as well as reads\
-  of user variables are routed to the primary server. This forces more of the\
-  traffic onto the primary server but it reduces the amount of data that is\
-  discarded for any `SELECT` statement that also modifies a user\
-  variable. With this mode, the state of user variables is not deterministic\
-  if they are modified inside of a `SELECT` statement. `SET` statements that\
+* Modifications to user variables inside `SELECT` statements as well as reads
+  of user variables are routed to the primary server. This forces more of the
+  traffic onto the primary server but it reduces the amount of data that is
+  discarded for any `SELECT` statement that also modifies a user
+  variable. With this mode, the state of user variables is not deterministic
+  if they are modified inside of a `SELECT` statement. `SET` statements that
   modify user variables are still routed to all servers.
 
-DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user\
-variables are still treated as writes and are only routed to the primary\
-server. For example, after the following query the value of `@myid` is no longer\
-the same on all servers and the `SELECT` statement can return different values\
+DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user
+variables are still treated as writes and are only routed to the primary
+server. For example, after the following query the value of `@myid` is no longer
+the same on all servers and the `SELECT` statement can return different values
 depending where it ends up being executed:
 
 ```
@@ -217,13 +217,13 @@ SELECT @myid; -- Might return 1 or 0
 
 #### `connection_keepalive`
 
-**Note:** This parameter has been moved into the MaxScale core. For the\
-current documentation, read the [connection\_keepalive](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#connection_keepalive)\
+**Note:** This parameter has been moved into the MaxScale core. For the
+current documentation, read the [connection\_keepalive](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#connection_keepalive)
 section in the configuration guide.
 
 Send keepalive pings to backend servers. This feature was introduced in MaxScale\
-2.2.0. The default value is 300 seconds starting with 2.3.2 and for older\
-versions the feature was disabled by default. This parameter was converted into\
+2.2.0. The default value is 300 seconds starting with 2.3.2 and for older
+versions the feature was disabled by default. This parameter was converted into
 a service parameter in MaxScale 2.5.0.
 
 #### `master_reconnection`
@@ -236,26 +236,26 @@ a service parameter in MaxScale 2.5.0.
 Allow the primary server to change mid-session. This feature was introduced in\
 MaxScale 2.3.0 and is disabled by default. This feature requires that`disable_sescmd_history` is not used.
 
-When a readwritesplit session starts, it will pick a primary server as the\
-current primary server of that session. By default, when this primary server is\
+When a readwritesplit session starts, it will pick a primary server as the
+current primary server of that session. By default, when this primary server is
 lost or changes to another server, the connection will be closed.
 
-When `master_reconnection` is enabled, readwritesplit can sometimes recover a\
+When `master_reconnection` is enabled, readwritesplit can sometimes recover a
 lost connection to the primary server. This largely depends on the value of`master_failure_mode`.
 
-With `master_failure_mode=fail_instantly`, the primary server is only allowed to\
-change to another server. This change must happen without a loss of the primary\
+With `master_failure_mode=fail_instantly`, the primary server is only allowed to
+change to another server. This change must happen without a loss of the primary
 server.
 
-With `master_failure_mode=fail_on_write`, the loss of the primary server is no\
-longer a fatal error: if a replacement primary server appears before any write\
-queries are received, readwritesplit will transparently reconnect to the new\
+With `master_failure_mode=fail_on_write`, the loss of the primary server is no
+longer a fatal error: if a replacement primary server appears before any write
+queries are received, readwritesplit will transparently reconnect to the new
 primary server.
 
-In both cases the change in the primary server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet\
+In both cases the change in the primary server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet
 been exceeded and the session does not have an open transaction.
 
-The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance\
+The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance
 without any risk to the consistency of the database.
 
 #### `slave_selection_criteria`
@@ -266,17 +266,17 @@ without any risk to the consistency of the database.
 * Values: `least_current_operations`, `adaptive_routing`, `least_behind_master`, `least_router_connections`, `least_global_connections`
 * Default: `least_current_operations`
 
-This option controls how the readwritesplit router chooses the replicas it\
-connects to and how the load balancing is done. The default behavior is to route\
+This option controls how the readwritesplit router chooses the replicas it
+connects to and how the load balancing is done. The default behavior is to route
 read queries to the replica server with the lowest amount of ongoing queries i.e.`least_current_operations`.
 
-All of the load balancing methods use MaxScale's own accounting. Connections and\
-queries done directly on the database and not through MaxScale are not taken\
-into account by readwritesplit. For example, if server A has 100 queries running\
+All of the load balancing methods use MaxScale's own accounting. Connections and
+queries done directly on the database and not through MaxScale are not taken
+into account by readwritesplit. For example, if server A has 100 queries running
 all of which are routed through MaxScale and server B has 115 queries but only\
-95 of those were routed through MaxScale, server B is considered a better\
-candidate even if the absolute number of active queries on it is higher. This is\
-because MaxScale only tracks the connections and queries routed through the same\
+95 of those were routed through MaxScale, server B is considered a better
+candidate even if the absolute number of active queries on it is higher. This is
+because MaxScale only tracks the connections and queries routed through the same
 process.
 
 The option syntax:
@@ -293,64 +293,64 @@ Where `<criteria>` is one of the following values.
 * `least_global_connections`, the replica with least connections from MariaDB MaxScale
 * `least_router_connections`, the replica with least connections from this service
 
-`least_current_operations` uses the current number of active operations\
-(i.e. SQL queries) as the load balancing metric and it optimizes for maximal\
-query throughput. Each query gets routed to the server with the least active\
-operations which results in faster servers processing more traffic. If two\
-servers have an equal number of active operations, the one that was least\
+`least_current_operations` uses the current number of active operations
+(i.e. SQL queries) as the load balancing metric and it optimizes for maximal
+query throughput. Each query gets routed to the server with the least active
+operations which results in faster servers processing more traffic. If two
+servers have an equal number of active operations, the one that was least
 recently used is chosen.
 
-`adaptive_routing` uses the server response time and current estimated server\
-load as the load balancing metric. The server that is estimated to finish an\
-additional query first is chosen. A modified average response time for each\
-server is continuously updated to allow slow servers at least some traffic and\
-quickly react to changes in server load conditions. If a server has not received\
-any traffic, the network lag to the server as measured by the monitor is used as\
-the proxy of the true response time. This selection criteria is designed for\
-heterogeneous clusters: servers of differing hardware, differing network\
-distances, or when other loads are running on the servers (including a\
-backup). If the servers are queried by other clients than MaxScale, the load\
+`adaptive_routing` uses the server response time and current estimated server
+load as the load balancing metric. The server that is estimated to finish an
+additional query first is chosen. A modified average response time for each
+server is continuously updated to allow slow servers at least some traffic and
+quickly react to changes in server load conditions. If a server has not received
+any traffic, the network lag to the server as measured by the monitor is used as
+the proxy of the true response time. This selection criteria is designed for
+heterogeneous clusters: servers of differing hardware, differing network
+distances, or when other loads are running on the servers (including a
+backup). If the servers are queried by other clients than MaxScale, the load
 caused by them is indirectly taken into account.
 
-`least_behind_master` uses the measured replication lag as the load balancing\
-metric. This means that servers that are more up-to-date are favored which\
-increases the likelihood of the data being read being up-to-date. However, this\
-is not as effective as `causal_reads` would be as there's no guarantee that\
-writes done by the same connection will be routed to a server that has\
+`least_behind_master` uses the measured replication lag as the load balancing
+metric. This means that servers that are more up-to-date are favored which
+increases the likelihood of the data being read being up-to-date. However, this
+is not as effective as `causal_reads` would be as there's no guarantee that
+writes done by the same connection will be routed to a server that has
 replicated those changes. The recommended approach is to use`LEAST_CURRENT_OPERATIONS` or `ADAPTIVE_ROUTING` in combination with`causal_reads`
 
-**NOTE**: `least_global_connections` and `least_router_connections` should not\
-be used, they are legacy options that exist only for backwards\
-compatibility. Using them will result in skewed load balancing as the algorithm\
-uses a metric that's too coarse (number of connections) to load balance\
+**NOTE**: `least_global_connections` and `least_router_connections` should not
+be used, they are legacy options that exist only for backwards
+compatibility. Using them will result in skewed load balancing as the algorithm
+uses a metric that's too coarse (number of connections) to load balance
 something that's finer (individual SQL queries).
 
-The `least_global_connections` and `least_router_connections` use the\
-connections from MariaDB MaxScale to the server, not the amount of connections\
+The `least_global_connections` and `least_router_connections` use the
+connections from MariaDB MaxScale to the server, not the amount of connections
 reported by the server itself.
 
-Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,\
-lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid\
+Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,
+lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid
 values.
 
-Starting with MaxScale 23.08.1, the legacy uppercase values have been\
-deprecated. All runtime modifications of the parameter will now be persisted in\
-lowercase. The uppercase values are still accepted but will be removed in a\
+Starting with MaxScale 23.08.1, the legacy uppercase values have been
+deprecated. All runtime modifications of the parameter will now be persisted in
+lowercase. The uppercase values are still accepted but will be removed in a
 future MaxScale release.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#max_sescmd_history)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#max_sescmd_history)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#disable_sescmd_history)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#disable_sescmd_history)
 in MaxScale 6.0.
 
 #### `prune_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#prune_sescmd_history)\
+This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#prune_sescmd_history)
 in MaxScale 6.0.
 
 #### `master_accept_reads`
@@ -360,12 +360,12 @@ in MaxScale 6.0.
 * Dynamic: Yes
 * Default: false
 
-**`master_accept_reads`** allows the primary server to be used for reads. This is\
-a useful option to enable if you are using a small number of servers and wish to\
+**`master_accept_reads`** allows the primary server to be used for reads. This is
+a useful option to enable if you are using a small number of servers and wish to
 use the primary for reads as well.
 
-By default, no reads are sent to the primary as long as there is a valid replica\
-server available. If no replicas are available, reads are sent to the primary\
+By default, no reads are sent to the primary as long as there is a valid replica
+server available. If no replicas are available, reads are sent to the primary
 regardless of the value of `master_accept_reads`.
 
 ```
@@ -380,18 +380,18 @@ master_accept_reads=true
 * Dynamic: Yes
 * Default: false
 
-This option is disabled by default since MaxScale 2.2.1. In older versions, this\
+This option is disabled by default since MaxScale 2.2.1. In older versions, this
 option was enabled by default.
 
-When a client executes a multi-statement query, it will be treated as if it were\
-a DML statement and routed to the primary. If the option is enabled, all queries\
-after a multi-statement query will be routed to the primary to guarantee a\
+When a client executes a multi-statement query, it will be treated as if it were
+a DML statement and routed to the primary. If the option is enabled, all queries
+after a multi-statement query will be routed to the primary to guarantee a
 consistent session state.
 
-If the feature is disabled, queries are routed normally after a multi-statement\
+If the feature is disabled, queries are routed normally after a multi-statement
 query.
 
-**Warning:** Enable the strict mode only if you know that the clients will send\
+**Warning:** Enable the strict mode only if you know that the clients will send
 statements that cause inconsistencies in the session state.
 
 ```
@@ -406,8 +406,8 @@ strict_multi_stmt=true
 * Dynamic: Yes
 * Default: false
 
-Similar to `strict_multi_stmt`, this option allows all queries after a CALL\
-operation on a stored procedure to be routed to the primary. This option is\
+Similar to `strict_multi_stmt`, this option allows all queries after a CALL
+operation on a stored procedure to be routed to the primary. This option is
 disabled by default and was added in MaxScale 2.1.9.
 
 All warnings and restrictions that apply to `strict_multi_stmt` also apply to`strict_sp_calls`.
@@ -419,14 +419,14 @@ All warnings and restrictions that apply to `strict_multi_stmt` also apply to`st
 * Dynamic: Yes
 * Default: false
 
-By default, all temporary tables are lost when a reconnection of the primary\
-node occurs. This means that when `master_reconnection` is enabled, the use of\
+By default, all temporary tables are lost when a reconnection of the primary
+node occurs. This means that when `master_reconnection` is enabled, the use of
 temporary tables might appear to disappear when a reconnection happens.
 
-If `strict_tmp_tables` is enabled, reconnections are prevented as long as a\
-temporary tables exist. In this case if the primary node is lost and temporary\
-table exist, the session is closed. If a session creates temporary tables but\
-does not drop them, this behavior will effectively disable reconnections until\
+If `strict_tmp_tables` is enabled, reconnections are prevented as long as a
+temporary tables exist. In this case if the primary node is lost and temporary
+table exist, the session is closed. If a session creates temporary tables but
+does not drop them, this behavior will effectively disable reconnections until
 the session is closed.
 
 #### `master_failure_mode`
@@ -437,10 +437,10 @@ the session is closed.
 * Values: `fail_instantly`, `fail_on_write`, `error_on_write`
 * Default: `fail_instantly`
 
-This option controls how the failure of a primary server is handled. By default,\
+This option controls how the failure of a primary server is handled. By default,
 the router will close the client connection as soon as the primary is lost.
 
-The following table describes the values for this option and how they treat the\
+The following table describes the values for this option and how they treat the
 loss of a primary server.
 
 | Value            | Description                                                                                                                      |
@@ -449,22 +449,22 @@ loss of a primary server.
 | fail\_on\_write  | The client connection is closed if a write query is received when no primary is available.                                       |
 | error\_on\_write | If no primary is available and a write query is received, an error is returned stating that the connection is in read-only mode. |
 
-These also apply to new sessions created after the primary has failed. This means\
-that in `fail_on_write` or `error_on_write` mode, connections are accepted as\
+These also apply to new sessions created after the primary has failed. This means
+that in `fail_on_write` or `error_on_write` mode, connections are accepted as
 long as replica servers are available.
 
-When configured with `fail_on_write` or `error_on_write`, sessions that are idle\
-will not be closed even if all backend connections for that session have\
-failed. This is done in the hopes that before the next query from the idle\
-session arrives, a reconnection to one of the replicas is made. However, this can\
-leave idle connections around unless the client application actively closes\
-them. To prevent this, use the [connection\_timeout](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#connection_timeout)\
+When configured with `fail_on_write` or `error_on_write`, sessions that are idle
+will not be closed even if all backend connections for that session have
+failed. This is done in the hopes that before the next query from the idle
+session arrives, a reconnection to one of the replicas is made. However, this can
+leave idle connections around unless the client application actively closes
+them. To prevent this, use the [connection\_timeout](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#connection_timeout)
 parameter.
 
-**Note:** If `master_failure_mode` is set to `error_on_write` and the connection\
-to the primary is lost, by default, clients will not be able to execute write\
-queries without reconnecting to MariaDB MaxScale once a new primary is\
-available. If [master\_reconnection](mariadb-maxscale-2308-readwritesplit.md#master_reconnection) is enabled, the\
+**Note:** If `master_failure_mode` is set to `error_on_write` and the connection
+to the primary is lost, by default, clients will not be able to execute write
+queries without reconnecting to MariaDB MaxScale once a new primary is
+available. If [master\_reconnection](mariadb-maxscale-2308-readwritesplit.md#master_reconnection) is enabled, the
 session can recover if one of the replicas is promoted as the primary.
 
 #### `retry_failed_reads`
@@ -477,13 +477,13 @@ session can recover if one of the replicas is promoted as the primary.
 This option controls whether autocommit selects are retried in case of failure.\
 This option is enabled by default.
 
-When a simple autocommit select is being executed outside of a transaction and\
-the replica server where the query is being executed fails, readwritesplit can\
-retry the read on a replacement server. This makes the failure of a replica\
+When a simple autocommit select is being executed outside of a transaction and
+the replica server where the query is being executed fails, readwritesplit can
+retry the read on a replacement server. This makes the failure of a replica
 transparent to the client.
 
-If a part of the result was already delivered to the client, the query will not\
-be retried. The retrying of queries with partially delivered results is only\
+If a part of the result was already delivered to the client, the query will not
+be retried. The retrying of queries with partially delivered results is only
 possible when `transaction_replay` is enabled.
 
 #### `delayed_retry`
@@ -493,34 +493,34 @@ possible when `transaction_replay` is enabled.
 * Dynamic: Yes
 * Default: false
 
-Retry queries over a period of time. This parameter takes a boolean value, was\
+Retry queries over a period of time. This parameter takes a boolean value, was
 added in Maxscale 2.3.0 and is disabled by default.
 
-When this feature is enabled, a failure to route a query due to a connection\
-problem will not immediately result in an error. The routing of the query is\
-delayed until either a valid candidate server is available or the retry timeout\
-is reached. If a candidate server becomes available before the timeout is\
-reached, the query is routed normally and no connection error is returned. If no\
-candidates are found and the timeout is exceeded, the router returns to normal\
+When this feature is enabled, a failure to route a query due to a connection
+problem will not immediately result in an error. The routing of the query is
+delayed until either a valid candidate server is available or the retry timeout
+is reached. If a candidate server becomes available before the timeout is
+reached, the query is routed normally and no connection error is returned. If no
+candidates are found and the timeout is exceeded, the router returns to normal
 behavior and returns an error.
 
-When combined with the `master_reconnection` parameter, failures of writes done\
-outside of transactions can be hidden from the client connection. This allows a\
+When combined with the `master_reconnection` parameter, failures of writes done
+outside of transactions can be hidden from the client connection. This allows a
 primary to be replaced while writes are being sent.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, `delayed_retry` will no longer attempt to retry a query if it was\
-already sent to the database. If a query is received while a valid target server\
-is not available, the execution of the query is delayed until a valid target is\
-found or the delayed retry timeout is hit. If a query was already sent, it will\
+24.08.1, `delayed_retry` will no longer attempt to retry a query if it was
+already sent to the database. If a query is received while a valid target server
+is not available, the execution of the query is delayed until a valid target is
+found or the delayed retry timeout is hit. If a query was already sent, it will
 not be replayed to prevent duplicate execution of statements.
 
-In older versions of MaxScale, duplicate execution of a statement can occur if\
-the connection to the server is lost or the server crashes but the server comes\
-back up before the timeout for the retrying is exceeded. At this point, if the\
-server managed to read the client's statement, it will be executed. For this\
+In older versions of MaxScale, duplicate execution of a statement can occur if
+the connection to the server is lost or the server crashes but the server comes
+back up before the timeout for the retrying is exceeded. At this point, if the
+server managed to read the client's statement, it will be executed. For this
 reason, it is recommended to only enable `delayed_retry` for older versions of\
-MaxScale when the possibility of duplicate statement execution is an acceptable\
+MaxScale when the possibility of duplicate statement execution is an acceptable
 risk.
 
 #### `delayed_retry_timeout`
@@ -532,10 +532,10 @@ risk.
 
 The duration to wait until an error is returned to the client when`delayed_retry` is enabled. The default value is 10 seconds.
 
-The timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `transaction_replay`
@@ -545,20 +545,20 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Replay interrupted transactions. This parameter was added in MaxScale 2.3.0 and\
-is disabled by default. Enabling this parameter enables both `delayed_retry` and`master_reconnection` and sets `master_failure_mode` to `fail_on_write`, thereby\
+Replay interrupted transactions. This parameter was added in MaxScale 2.3.0 and
+is disabled by default. Enabling this parameter enables both `delayed_retry` and`master_reconnection` and sets `master_failure_mode` to `fail_on_write`, thereby
 overriding any configured values for these parameters.
 
-When the server where the transaction is in progress fails, readwritesplit can\
-migrate the transaction to a replacement server. This can completely hide the\
+When the server where the transaction is in progress fails, readwritesplit can
+migrate the transaction to a replacement server. This can completely hide the
 failure of a primary node without any visible effects to the client.
 
 If no replacement node becomes available, the client connection is closed.
 
 To control how long a transaction replay can take, use`transaction_replay_timeout`.
 
-Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2308-readwritesplit.md#transaction-replay-limitations) section for\
-a more detailed explanation of what should and should not be done with\
+Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2308-readwritesplit.md#transaction-replay-limitations) section for
+a more detailed explanation of what should and should not be done with
 transaction replay.
 
 #### `transaction_replay_max_size`
@@ -568,20 +568,20 @@ transaction replay.
 * Dynamic: Yes
 * Default: 1 MiB
 
-The limit on transaction size for transaction replay in bytes. Any transaction\
-that exceeds this limit will not be replayed. The default value is 1 MiB. This\
-limit applies at a session level which means that the total peak memory\
-consumption can be `transaction_replay_max_size` times the number of client\
+The limit on transaction size for transaction replay in bytes. Any transaction
+that exceeds this limit will not be replayed. The default value is 1 MiB. This
+limit applies at a session level which means that the total peak memory
+consumption can be `transaction_replay_max_size` times the number of client
 connections.
 
-The amount of memory needed to store a particular transaction will be slightly\
-larger than the length in bytes of the SQL used in the transaction. If the limit\
+The amount of memory needed to store a particular transaction will be slightly
+larger than the length in bytes of the SQL used in the transaction. If the limit
 is ever exceeded, a message will be logged at the info level.
 
-Starting with MaxScale 6.4.10, the number of times that this limit has been\
+Starting with MaxScale 6.4.10, the number of times that this limit has been
 exceeded is shown in `maxctrl show service` as `trx_max_size_exceeded`.
 
-Read [the configuration guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#sizes)\
+Read [the configuration guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#sizes)
 for more details on size type parameters in MaxScale.
 
 #### `transaction_replay_attempts`
@@ -591,13 +591,13 @@ for more details on size type parameters in MaxScale.
 * Dynamic: Yes
 * Default: 5
 
-The upper limit on how many times a transaction replay is attempted before\
+The upper limit on how many times a transaction replay is attempted before
 giving up. The default value is 5.
 
-A transaction replay failure can happen if the server where the transaction is\
-being replayed fails while the replay is in progress. In practice this parameter\
-controls how many server and network failures a single transaction replay\
-tolerates. If a transaction is replayed successfully, the counter for failed\
+A transaction replay failure can happen if the server where the transaction is
+being replayed fails while the replay is in progress. In practice this parameter
+controls how many server and network failures a single transaction replay
+tolerates. If a transaction is replayed successfully, the counter for failed
 attempts is reset.
 
 #### `transaction_replay_timeout`
@@ -607,30 +607,30 @@ attempts is reset.
 * Dynamic: Yes
 * Default: 0s
 
-The time how long transactions are attempted for. This feature is disabled by\
-default and was added in MaxScale 6.2.1. To explicitly disable this feature, set\
+The time how long transactions are attempted for. This feature is disabled by
+default and was added in MaxScale 6.2.1. To explicitly disable this feature, set
 the value to 0 seconds.
 
-The timeout is [a duration type](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations)\
+The timeout is [a duration type](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations)
 and the value must include a unit for the duration.
 
-When `transaction_replay_timeout` is enabled, the time a transaction replay can\
-take is controlled solely by this parameter. This is a more convenient and\
-predictable method of controlling how long a transaction replay can be attempted\
+When `transaction_replay_timeout` is enabled, the time a transaction replay can
+take is controlled solely by this parameter. This is a more convenient and
+predictable method of controlling how long a transaction replay can be attempted
 before the connection is closed.
 
-If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set\
+If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set
 to the same value.
 
-By default the time how long a transaction can be retried is controlled by`delayed_retry_timeout` and `transaction_replay_attempts`. This can result in a\
-maximum replay time limit of `delayed_retry_timeout` multiplied by`transaction_replay_attempts`, by default this is 50 seconds. The minimum replay\
-time limit can be as low as `transaction_replay_attempts` seconds (5 seconds by\
-default) in cases where the connection fails after it was created. Usually this\
-happens due to problems like the max\_connections limit being hit on the database\
+By default the time how long a transaction can be retried is controlled by`delayed_retry_timeout` and `transaction_replay_attempts`. This can result in a
+maximum replay time limit of `delayed_retry_timeout` multiplied by`transaction_replay_attempts`, by default this is 50 seconds. The minimum replay
+time limit can be as low as `transaction_replay_attempts` seconds (5 seconds by
+default) in cases where the connection fails after it was created. Usually this
+happens due to problems like the max\_connections limit being hit on the database
 server.
 
-With the introduction of `transaction_replay_timeout`, these problems are\
-avoided. Starting with MaxScale 6.2.1, this is the recommended method of\
+With the introduction of `transaction_replay_timeout`, these problems are
+avoided. Starting with MaxScale 6.2.1, this is the recommended method of
 controlling the timeouts for transaction replay.
 
 #### `transaction_replay_retry_on_deadlock`
@@ -640,15 +640,15 @@ controlling the timeouts for transaction replay.
 * Dynamic: Yes
 * Default: false
 
-Enable automatic retrying of transactions that end up in a deadlock. This\
-parameter was added in MaxScale 2.4.6 and the feature is disabled by\
-default. MaxScale versions from 2.4.0 to 2.4.5 always tried to replay deadlocked\
+Enable automatic retrying of transactions that end up in a deadlock. This
+parameter was added in MaxScale 2.4.6 and the feature is disabled by
+default. MaxScale versions from 2.4.0 to 2.4.5 always tried to replay deadlocked
 transactions.
 
-If this feature is enabled and a transaction returns a deadlock error\
-(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),\
-the transaction is automatically retried. If the retrying of the transaction\
-results in another deadlock error, it is retried until it either succeeds or a\
+If this feature is enabled and a transaction returns a deadlock error
+(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),
+the transaction is automatically retried. If the retrying of the transaction
+results in another deadlock error, it is retried until it either succeeds or a
 transaction checksum error is encountered.
 
 #### `transaction_replay_safe_commit`
@@ -658,19 +658,19 @@ transaction checksum error is encountered.
 * Dynamic: Yes
 * Default: true
 
-If a transaction is ending and the `COMMIT` statement at the end of it is\
-interrupted, there is a risk of duplicating the transaction if it is\
-replayed. This parameter prevents the retrying of transactions that are about to\
+If a transaction is ending and the `COMMIT` statement at the end of it is
+interrupted, there is a risk of duplicating the transaction if it is
+replayed. This parameter prevents the retrying of transactions that are about to
 commit.
 
-This parameter was added in MaxScale 23.08.0 and is enabled by default. The\
-older version of MaxScale always attempted to replay the transaction even if\
+This parameter was added in MaxScale 23.08.0 and is enabled by default. The
+older version of MaxScale always attempted to replay the transaction even if
 there was a risk of duplicating the transaction.
 
-If the data that is about to be modified is read before it is modified and it is\
-locked in an appropriate manner (e.g. with `SELECT ... FOR UPDATE` or with the`SERIALIZABLE` isolation level), it is safe to replay a transaction that was\
-about to commit. This is because the checksum of the transaction will mismatch\
-if the original transaction ended up committing on the server. Disabling this\
+If the data that is about to be modified is read before it is modified and it is
+locked in an appropriate manner (e.g. with `SELECT ... FOR UPDATE` or with the`SERIALIZABLE` isolation level), it is safe to replay a transaction that was
+about to commit. This is because the checksum of the transaction will mismatch
+if the original transaction ended up committing on the server. Disabling this
 feature can enable more robust delivery of transactions but it requires that the\
 SQL is correctly formed and compatible with this behavior.
 
@@ -684,8 +684,8 @@ SQL is correctly formed and compatible with this behavior.
 Retry transactions that end in checksum mismatch. This parameter was added in\
 MaxScale 6.2.1 is disabled by default.
 
-When enabled, any replayed transactions that end with a checksum mismatch are\
-retried until they either succeeds or one of the transaction replay limits is\
+When enabled, any replayed transactions that end with a checksum mismatch are
+retried until they either succeeds or one of the transaction replay limits is
 reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_replay_attempts`).
 
 #### `transaction_replay_checksum`
@@ -696,30 +696,30 @@ reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_re
 * Values: `full`, `result_only`, `no_insert_id`
 * Default: `full`
 
-Selects which transaction checksum method is used to verify the result of the\
+Selects which transaction checksum method is used to verify the result of the
 replayed transaction.
 
-Note that only `transaction_replay_checksum=full` is guaranteed to retain the\
+Note that only `transaction_replay_checksum=full` is guaranteed to retain the
 consistency of the replayed transaction.
 
 Possible values are:
 
 * `full` (default)
-* All responses from the server are included in the checksum. This retains the\
-  full consistency guarantee of the replayed transaction as it must match\
+* All responses from the server are included in the checksum. This retains the
+  full consistency guarantee of the replayed transaction as it must match
   exactly the one that was already returned to the client.
 * `result_only`
-* Only resultsets and errors are included in the checksum. OK packets\
-  (i.e. successful queries that do not return results) are ignored. This mode\
+* Only resultsets and errors are included in the checksum. OK packets
+  (i.e. successful queries that do not return results) are ignored. This mode
   is intended to be used in cases where the extra information (auto-generated\
-  ID, warnings etc.) returned in the OK packet is not used by the\
+  ID, warnings etc.) returned in the OK packet is not used by the
   application.\
-  This mode is safe to use only if the auto-generated ID is not actually used\
-  by any following queries. An example of such behavior would be a transaction\
+  This mode is safe to use only if the auto-generated ID is not actually used
+  by any following queries. An example of such behavior would be a transaction
   that ends with an `INSERT` into a table with an `AUTO_INCREMENT` field.
 * `no_insert_id`
-* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the\
-  result of the query is not used by any subsequent statement in the\
+* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the
+  result of the query is not used by any subsequent statement in the
   transaction.
 
 #### `optimistic_trx`
@@ -729,21 +729,21 @@ Possible values are:
 * Dynamic: Yes
 * Default: false
 
-Enable optimistic transaction execution. This parameter controls whether normal\
-transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across\
+Enable optimistic transaction execution. This parameter controls whether normal
+transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across
 replicas. This feature is disabled by default and enabling it implicitly enables`transaction_replay`, `delayed_retry` and `master_reconnection` parameters.
 
-When this mode is enabled, all transactions are first attempted on replica\
-servers. If the transaction contains no statements that modify data, it is\
-completed on the replica. If the transaction contains statements that modify data,\
-it is rolled back on the replica server and restarted on the primary. The rollback\
-is initiated the moment a data modifying statement is intercepted by\
+When this mode is enabled, all transactions are first attempted on replica
+servers. If the transaction contains no statements that modify data, it is
+completed on the replica. If the transaction contains statements that modify data,
+it is rolled back on the replica server and restarted on the primary. The rollback
+is initiated the moment a data modifying statement is intercepted by
 readwritesplit so only read-only statements are executed on replica servers.
 
-As with `transaction_replay` and transactions that are replayed, if the results\
-returned by the primary server are not identical to the ones returned by the\
-replica up to the point where the first data modifying statement was executed, the\
-connection is closed. If the execution of ROLLBACK statement on the replica fails,\
+As with `transaction_replay` and transactions that are replayed, if the results
+returned by the primary server are not identical to the ones returned by the
+replica up to the point where the first data modifying statement was executed, the
+connection is closed. If the execution of ROLLBACK statement on the replica fails,
 the connection to that replica is closed.
 
 All limitations that apply to `transaction_replay` also apply to`optimistic_trx`.
@@ -759,12 +759,12 @@ All limitations that apply to `transaction_replay` also apply to`optimistic_trx`
 Enable causal reads. This parameter is disabled by default and was introduced in\
 MaxScale 2.3.0.
 
-If a client connection modifies the database and `causal_reads` is enabled, any\
-subsequent reads performed on replica servers will be done in a manner that\
+If a client connection modifies the database and `causal_reads` is enabled, any
+subsequent reads performed on replica servers will be done in a manner that
 prevents replication lag from affecting the results.
 
-The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2308-readwritesplit.md#implementation-of-causal_reads) for more\
-information on what a sync consists of and why minimizing the number of them is\
+The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2308-readwritesplit.md#implementation-of-causal_reads) for more
+information on what a sync consists of and why minimizing the number of them is
 important.
 
 | Mode            | Level of Causality | Latency                                                  |
@@ -776,19 +776,19 @@ important.
 | universal       | Cluster            | High, one sync per read plus a roundtrip to the primary. |
 | fast\_universal | Cluster            | Low, one roundtrip to the primary.                       |
 
-The `fast`, `fast_global` and `fast_universal` modes should only be used when\
-low latency is more important than proper distribution of reads. These modes\
-should only be used when the workload is mostly read-only with only occasional\
-writes. If used with a mixed or a write-heavy workload, the traffic will end up\
+The `fast`, `fast_global` and `fast_universal` modes should only be used when
+low latency is more important than proper distribution of reads. These modes
+should only be used when the workload is mostly read-only with only occasional
+writes. If used with a mixed or a write-heavy workload, the traffic will end up
 being routed almost exclusively to the primary server.
 
-**Note:** This feature requires MariaDB 10.2.16 or newer to function. In\
+**Note:** This feature requires MariaDB 10.2.16 or newer to function. In
 addition to this, the `session_track_system_variables` parameter must include`last_gtid` in its list of tracked system variables.
 
-**Note:** This feature also enables multi-statement execution of SQL in the\
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)\
+**Note:** This feature also enables multi-statement execution of SQL in the
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
-Connector/C. The _Implementation of causal\_reads_ section explains why this is\
+Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.
 
 The possible values for this parameter are:
@@ -796,98 +796,98 @@ The possible values for this parameter are:
 * `none` (default)
 * Read causality is disabled.
 * `local`
-* Writes are locally visible. Writes are guaranteed to be visible only to the\
-  connection that does it. Unrelated modifications done by other connections\
-  are not visible. This mode improves read scalability at the cost of latency\
-  and reduces the overall load placed on the primary server without breaking\
+* Writes are locally visible. Writes are guaranteed to be visible only to the
+  connection that does it. Unrelated modifications done by other connections
+  are not visible. This mode improves read scalability at the cost of latency
+  and reduces the overall load placed on the primary server without breaking
   causality guarantees.
 * `global`
-* Writes are globally visible. If one connection writes a value, all\
-  connections to the same service will see it. In general this mode is slower\
-  than the `local` mode due to the extra synchronization it has to do. This\
-  guarantees global happens-before ordering of reads when all transactions are\
-  inside a single GTID domain.This mode gives similar benefits as the `local`\
+* Writes are globally visible. If one connection writes a value, all
+  connections to the same service will see it. In general this mode is slower
+  than the `local` mode due to the extra synchronization it has to do. This
+  guarantees global happens-before ordering of reads when all transactions are
+  inside a single GTID domain.This mode gives similar benefits as the `local`
   mode in that it improves read scalability at the cost of latency.\
-  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads\
-  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this\
-  was fixed and all the GTID coordinates are passed alongside all requests\
+  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads
+  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this
+  was fixed and all the GTID coordinates are passed alongside all requests
   which makes multi-domain GTIDs safe to use. However, this does mean that the\
-  GTID coordinates will never be reset: if replication is reset and GTID\
-  coordinates go "backwards", readwritesplit will not consider these as being\
-  newer than the ones already stored. To reset the stored GTID coordinates in\
+  GTID coordinates will never be reset: if replication is reset and GTID
+  coordinates go "backwards", readwritesplit will not consider these as being
+  newer than the ones already stored. To reset the stored GTID coordinates in
   readwritesplit, MaxScale must be restarted.\
-  MaxScale 6.4.11 added the new `reset-gtid` module command to\
+  MaxScale 6.4.11 added the new `reset-gtid` module command to
   readwritesplit. This allows the global GTID state used by`causal_reads=global` to be reset without having to restart MaxScale.
 * `fast`
-* This mode is similar to the `local` mode where it will only affect the\
-  connection that does the write but where the `local` mode waits for a replica\
-  server to catch up, the `fast` mode will only use servers that are known to\
-  have replicated the write. This means that if no replica has replicated the\
-  write, the primary where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication\
-  state is only updated by the mariadbmon monitor whenever the servers are\
-  monitored. This means that a smaller `monitor_interval` provides faster\
+* This mode is similar to the `local` mode where it will only affect the
+  connection that does the write but where the `local` mode waits for a replica
+  server to catch up, the `fast` mode will only use servers that are known to
+  have replicated the write. This means that if no replica has replicated the
+  write, the primary where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication
+  state is only updated by the mariadbmon monitor whenever the servers are
+  monitored. This means that a smaller `monitor_interval` provides faster
   replication state updates and possibly better overall usage of servers.\
-  This mode is the inverse of the `local` mode in the sense that it improves\
-  read latency at the cost of read scalability while still retaining the\
-  causality guarantees for reads. This functionality can also be considered an\
+  This mode is the inverse of the `local` mode in the sense that it improves
+  read latency at the cost of read scalability while still retaining the
+  causality guarantees for reads. This functionality can also be considered an
   improved version of the functionality that the [CCRFilter](../mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-consistent-critical-read-filter.md) module provides.
 * `fast_global`
 * This mode is identical to the `fast` mode except that it uses the global\
-  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`\
-  is ignored in this mode. Currently the replication state is only updated by\
-  the mariadbmon monitor whenever the servers are monitored. This means that a\
-  smaller `monitor_interval` provides faster replication state updates and\
+  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`
+  is ignored in this mode. Currently the replication state is only updated by
+  the mariadbmon monitor whenever the servers are monitored. This means that a
+  smaller `monitor_interval` provides faster replication state updates and
   possibly better overall usage of servers.
 * `universal`
-* The universal mode guarantees that all SELECT statements always see the\
-  latest observable transaction state on a database cluster. The basis of this\
-  is the `@@gtid_binlog_pos` variable which is read from the current primary\
-  server before each read. This guarantees that if a transaction was visible\
-  at the time the read is received by readwritesplit, the transaction is\
-  guaranteed to be complete on the replica server where the read is\
+* The universal mode guarantees that all SELECT statements always see the
+  latest observable transaction state on a database cluster. The basis of this
+  is the `@@gtid_binlog_pos` variable which is read from the current primary
+  server before each read. This guarantees that if a transaction was visible
+  at the time the read is received by readwritesplit, the transaction is
+  guaranteed to be complete on the replica server where the read is
   done. Versions 22.08.16, 23.02.13, 23.08.9, 24.02.5 and older used`@@gtid_current_pos` as the GTID value\
-  ([MXS-5588](https://jira.mariadb.org/browse/MXS-5588)) but this caused\
+  ([MXS-5588](https://jira.mariadb.org/browse/MXS-5588)) but this caused
   problems with Galera clusters.\
-  This mode is the most consistent of all the modes. It provides consistency\
-  regardless of where a write originated from but it comes at the cost of\
-  increased latency. For every read, a round trip to the current primary server\
-  is done. This means that the latency of any given SELECT statement increases\
-  by roughly twice the network latency between MaxScale and the database\
-  cluster. In addition, an extra SELECT statement is always executed on the\
+  This mode is the most consistent of all the modes. It provides consistency
+  regardless of where a write originated from but it comes at the cost of
+  increased latency. For every read, a round trip to the current primary server
+  is done. This means that the latency of any given SELECT statement increases
+  by roughly twice the network latency between MaxScale and the database
+  cluster. In addition, an extra SELECT statement is always executed on the
   primary which places some load on the server.
 * `fast_universal`
-* A mix of `fast` and `universal`. This mode that guarantees that all SELECT\
-  statements always see the latest observable transaction state but unlike the`universal` mode that waits on the server to catch up, this mode behaves\
-  like `fast` and routes the query to the current primary if no replicas are\
+* A mix of `fast` and `universal`. This mode that guarantees that all SELECT
+  statements always see the latest observable transaction state but unlike the`universal` mode that waits on the server to catch up, this mode behaves
+  like `fast` and routes the query to the current primary if no replicas are
   available that have caught up.\
-  This mode provides the same consistency guarantees of `universal` with a\
-  constant latency overhead of one extra roundtrip. However, this also puts\
-  the most load on the primary node as even a moderate write load can cause\
+  This mode provides the same consistency guarantees of `universal` with a
+  constant latency overhead of one extra roundtrip. However, this also puts
+  the most load on the primary node as even a moderate write load can cause
   the GTIDs of replicas to lag too far behind.
 
-Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean\
+Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean
 parameter. False values translated to `none` and true values translated to`local`. The use of boolean parameters is deprecated but still accepted in\
 MaxScale 2.5.0.
 
 **Implementation of `causal_reads`**
 
-This feature is based on the `MASTER_GTID_WAIT` function and the tracking of\
-server-side status variables. By tracking the latest GTID that each statement\
-generates, readwritesplit can then perform a synchronization operation with the\
+This feature is based on the `MASTER_GTID_WAIT` function and the tracking of
+server-side status variables. By tracking the latest GTID that each statement
+generates, readwritesplit can then perform a synchronization operation with the
 help of the `MASTER_GTID_WAIT` function.
 
-If the replica has not caught up to the primary within the configured time, as\
-specified by [causal\_reads\_timeout](mariadb-maxscale-2308-readwritesplit.md#causal_reads_timeout), it will\
-be retried on the primary. In MaxScale 2.3.0 an error was returned to the client\
+If the replica has not caught up to the primary within the configured time, as
+specified by [causal\_reads\_timeout](mariadb-maxscale-2308-readwritesplit.md#causal_reads_timeout), it will
+be retried on the primary. In MaxScale 2.3.0 an error was returned to the client
 when the replica timed out.
 
-The exception to this rule is the `fast` mode which does not do any\
-synchronization at all. This can be done as any reads that would go to\
+The exception to this rule is the `fast` mode which does not do any
+synchronization at all. This can be done as any reads that would go to
 out-of-date servers will be re-routed to the current primary.
 
 **Normal SQL**
 
-A practical example can be given by the following set of SQL commands executed\
+A practical example can be given by the following set of SQL commands executed
 with `autocommit=1`.
 
 ```
@@ -895,17 +895,17 @@ INSERT INTO test.t1 (id) VALUES (1);
 SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-As the statements are not executed inside a transaction, from the load balancer's\
-point of view, the latter statement can be routed to a replica server. The problem\
-with this is that if the value that was inserted on the primary has not yet\
-replicated to the server where the SELECT statement is being performed, it can\
+As the statements are not executed inside a transaction, from the load balancer's
+point of view, the latter statement can be routed to a replica server. The problem
+with this is that if the value that was inserted on the primary has not yet
+replicated to the server where the SELECT statement is being performed, it can
 appear as if the value we just inserted is not there.
 
-By prefixing these types of SELECT statements with a command that guarantees\
-consistent results for the reads, read scalability can be improved without\
+By prefixing these types of SELECT statements with a command that guarantees
+consistent results for the reads, read scalability can be improved without
 sacrificing consistency.
 
-The set of example SQL above will be translated by MaxScale into the following\
+The set of example SQL above will be translated by MaxScale into the following
 statements.
 
 ```
@@ -919,18 +919,18 @@ SET @maxscale_secret_variable=(
     END); SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-The `SET` command will synchronize the replica to a certain logical point in the\
-replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more\
-details). If the synchronization fails, the query will not run and it will be\
+The `SET` command will synchronize the replica to a certain logical point in the
+replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more
+details). If the synchronization fails, the query will not run and it will be
 retried on the server where the transaction was originally done.
 
 **Prepared Statements**
 
-Binary protocol prepared statements are handled in a different manner. Instead\
-of adding the synchronization SQL into the original SQL query, it is sent as a\
+Binary protocol prepared statements are handled in a different manner. Instead
+of adding the synchronization SQL into the original SQL query, it is sent as a
 separate packet before the prepared statement is executed.
 
-We'll use the same example SQL but use a binary protocol prepared statement for\
+We'll use the same example SQL but use a binary protocol prepared statement for
 the SELECT:
 
 ```
@@ -948,24 +948,24 @@ COM_QUERY:         IF (MASTER_GTID_WAIT('0-3000-8', 10) <> 0) THEN KILL (SELECT 
 COM_STMT_EXECUTE:  ? = 123
 ```
 
-Both the synchronization query and the execution of the prepared statement are\
-sent at the same time. This is done to remove the need to wait for the result of\
-the synchronization query before routing the execution of the prepared\
-statement. This keeps the performance of causal\_reads for prepared statements\
+Both the synchronization query and the execution of the prepared statement are
+sent at the same time. This is done to remove the need to wait for the result of
+the synchronization query before routing the execution of the prepared
+statement. This keeps the performance of causal\_reads for prepared statements
 the same as it is for normal SQL queries.
 
-As a result of this, each time the synchronization query times out, the\
-connection will be killed by the `KILL` statement and readwritesplit will retry\
-the query on the primary. This is done to prevent the execution of the prepared\
+As a result of this, each time the synchronization query times out, the
+connection will be killed by the `KILL` statement and readwritesplit will retry
+the query on the primary. This is done to prevent the execution of the prepared
 statement that follows the synchronization query from being processed by the\
 MariaDB server.
 
-It is recommend that the session command history is enabled whenever prepared\
-statements are used with `causal_reads`. This allows new connections to be\
+It is recommend that the session command history is enabled whenever prepared
+statements are used with `causal_reads`. This allows new connections to be
 created whenever a causal read times out.
 
-Starting with MaxScale 2.5.17, a failed causal read inside of a read-only\
-transaction started with `START TRANSACTION READ ONLY` will return the following\
+Starting with MaxScale 2.5.17, a failed causal read inside of a read-only
+transaction started with `START TRANSACTION READ ONLY` will return the following
 error:
 
 ```
@@ -974,25 +974,25 @@ SQLSTATE: 25006
 Message:  Causal read timed out while in a read-only transaction, cannot retry command.
 ```
 
-Older versions of MaxScale attempted to retry the command on the current primary\
+Older versions of MaxScale attempted to retry the command on the current primary
 server which would cause the connection to be closed and a warning to be logged.
 
 **Limitations of Causal Reads**
 
-* This feature does not work with Galera or any other non-standard\
-  replication mechanisms. As Galera does not update the `gtid_slave_pos`\
-  variable when events are replicated via the Galera library, the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)\
-  function used by MaxScale to synchronize reads will wait until the\
-  timeout. With Galera this is not a serious issue as it, by nature, is a\
+* This feature does not work with Galera or any other non-standard
+  replication mechanisms. As Galera does not update the `gtid_slave_pos`
+  variable when events are replicated via the Galera library, the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)
+  function used by MaxScale to synchronize reads will wait until the
+  timeout. With Galera this is not a serious issue as it, by nature, is a
   mostly-synchronous replication mechanism.
-* If the combination of the original SQL statement and the modifications\
-  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),\
+* If the combination of the original SQL statement and the modifications
+  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),
   the causal read will not be attempted and a non-causal read is done instead.\
-  This applies only to text protocol queries as the binary protocol queries use\
+  This applies only to text protocol queries as the binary protocol queries use
   a different synchronization mechanism.
-* SQL like `INSERT ... RETURNING` that commits a transaction and returns a\
+* SQL like `INSERT ... RETURNING` that commits a transaction and returns a
   resultset will only work with causal reads if the connector supports the\
-  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB\
+  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB
   connectors and whether they support the protocol feature.
 
 | Connector         | Supported | Version |
@@ -1011,13 +1011,13 @@ server which would cause the connection to be closed and a warning to be logged.
 * Dynamic: Yes
 * Default: 10s
 
-The timeout for the replica synchronization done by `causal_reads`. The\
+The timeout for the replica synchronization done by `causal_reads`. The
 default value is 10 seconds.
 
-The timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `lazy_connect`
@@ -1027,25 +1027,25 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Lazy connection creation causes connections to backend servers to be opened only\
-when they are needed. This reduces the load that is placed on the backend\
-servers when the client connections are short. This parameter is a boolean type\
+Lazy connection creation causes connections to backend servers to be opened only
+when they are needed. This reduces the load that is placed on the backend
+servers when the client connections are short. This parameter is a boolean type
 and is disabled by default.
 
-By default readwritesplit opens as many connections as it can when the session\
-is first opened. This makes the execution of the first query faster when all\
-available connections are already created. When `lazy_connect` is enabled, this\
-initial connection creation is skipped. If the client executes only read\
-queries, no connection to the primary is made. If only write queries are made,\
+By default readwritesplit opens as many connections as it can when the session
+is first opened. This makes the execution of the first query faster when all
+available connections are already created. When `lazy_connect` is enabled, this
+initial connection creation is skipped. If the client executes only read
+queries, no connection to the primary is made. If only write queries are made,
 only the primary connection is used.
 
-In MaxScale 23.08.2, if a [session command](mariadb-maxscale-2308-readwritesplit.md#routing-to-every-session-backend)\
-is received as the first command, the default behavior is to execute it on a\
-replica. If [master\_accept\_reads](mariadb-maxscale-2308-readwritesplit.md#master_accept_reads) is enabled, the query is\
-executed on the primary server, if one is available. In practice this means that\
+In MaxScale 23.08.2, if a [session command](mariadb-maxscale-2308-readwritesplit.md#routing-to-every-session-backend)
+is received as the first command, the default behavior is to execute it on a
+replica. If [master\_accept\_reads](mariadb-maxscale-2308-readwritesplit.md#master_accept_reads) is enabled, the query is
+executed on the primary server, if one is available. In practice this means that
 workloads which are mostly reads with infrequent writes should disable`master_accept_reads` if they also use `lazy_connect`.
 
-Older versions of MaxScale always tried to execute all session commands on the\
+Older versions of MaxScale always tried to execute all session commands on the
 primary node if one was available.
 
 #### `reuse_prepared_statements`
@@ -1055,22 +1055,22 @@ primary node if one was available.
 * Dynamic: Yes
 * Default: false
 
-Reuse identical prepared statements inside the same client connection. This is a\
-boolean parameter and is disabled by default. This feature only applies to\
+Reuse identical prepared statements inside the same client connection. This is a
+boolean parameter and is disabled by default. This feature only applies to
 binary protocol prepared statements.
 
-When this parameter is enabled and the connection prepares an identical prepared\
-statement multiple times, instead of preparing it on the server the existing\
-prepared statement handle is reused. This also means that whenever prepared\
+When this parameter is enabled and the connection prepares an identical prepared
+statement multiple times, instead of preparing it on the server the existing
+prepared statement handle is reused. This also means that whenever prepared
 statements are closed by the client, they will be left open by readwritesplit.
 
-Enabling this feature will increase memory usage of a session. The amount of\
-memory stored per prepared statement is proportional to the length of the\
+Enabling this feature will increase memory usage of a session. The amount of
+memory stored per prepared statement is proportional to the length of the
 prepared SQL statement and the number of parameters the statement has.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a readwritesplit service contains the\
+The `router_diagnostics` output for a readwritesplit service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -1091,48 +1091,48 @@ following fields.
 
 ### Server Ranks
 
-The general rule with server ranks is that primary servers will be used before\
-secondary servers. Readwritesplit is an exception to this rule. The following\
+The general rule with server ranks is that primary servers will be used before
+secondary servers. Readwritesplit is an exception to this rule. The following
 rules govern how readwritesplit behaves with servers that have different ranks.
 
-* Sessions will use the current primary server as long as possible. This means\
-  that sessions with a secondary primary will not use the primary primary as long\
+* Sessions will use the current primary server as long as possible. This means
+  that sessions with a secondary primary will not use the primary primary as long
   as the secondary primary is available.
-* All replica connections will use the same rank as the primary connection. Any\
+* All replica connections will use the same rank as the primary connection. Any
   stale connections with a different rank than the primary will be discarded.
-* If no primary connection is available and `master_reconnection` is enabled, a\
-  connection to the best primary is created. If the new primary has a different\
-  priority than existing connections have, the connections with a different rank\
+* If no primary connection is available and `master_reconnection` is enabled, a
+  connection to the best primary is created. If the new primary has a different
+  priority than existing connections have, the connections with a different rank
   will be discarded.
-* If open connections exist, these will be used for routing. This means that if\
-  the primary is lost but the session still has replica servers with the same rank,\
+* If open connections exist, these will be used for routing. This means that if
+  the primary is lost but the session still has replica servers with the same rank,
   they will remain in use.
 * If no open connections exist, the servers with the best rank will used.
 
 ### Routing hints
 
-The readwritesplit router supports routing hints. For a detailed guide on hint\
-syntax and functionality, please read [this](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-hint-syntax.md)\
+The readwritesplit router supports routing hints. For a detailed guide on hint
+syntax and functionality, please read [this](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-hint-syntax.md)
 document.
 
-**Note**: Routing hints will always have the highest priority when a routing\
-decision is made. This means that it is possible to cause inconsistencies in\
-the session state and the actual data in the database by adding routing hints\
-to DDL/DML statements which are then directed to replica servers. Only use routing\
+**Note**: Routing hints will always have the highest priority when a routing
+decision is made. This means that it is possible to cause inconsistencies in
+the session state and the actual data in the database by adding routing hints
+to DDL/DML statements which are then directed to replica servers. Only use routing
 hints when you are sure that they can cause no harm.
 
-An exception to this rule is `transaction_replay`: when it is enabled, all\
-routing hints inside transaction are ignored. This is done to prevent changes\
-done inside a re-playable transaction from affecting servers outside of the\
-transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed\
+An exception to this rule is `transaction_replay`: when it is enabled, all
+routing hints inside transaction are ignored. This is done to prevent changes
+done inside a re-playable transaction from affecting servers outside of the
+transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed
 routing hints to override the transaction logic.
 
 #### Known Limitations of Routing Hints
 
-* If a `SELECT` statement with a `maxscale route to slave` hint is received\
-  while autocommit is disabled, the query will be routed to a replica server. This\
-  causes some metadata locks to be acquired on the database in question which\
-  will block DDL statements on the server until either the connection is closed\
+* If a `SELECT` statement with a `maxscale route to slave` hint is received
+  while autocommit is disabled, the query will be routed to a replica server. This
+  causes some metadata locks to be acquired on the database in question which
+  will block DDL statements on the server until either the connection is closed
   or autocommit is enabled again.
 
 ### Module Commands
@@ -1141,11 +1141,11 @@ The readwritesplit router implements the following module commands.
 
 #### `reset-gtid`
 
-The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is\
-reverted to an earlier state and the GTIDs recorded in MaxScale are no longer\
+The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is
+reverted to an earlier state and the GTIDs recorded in MaxScale are no longer
 valid.
 
-The first and only argument to the command is the router name. For example, to\
+The first and only argument to the command is the router name. For example, to
 reset the GTID state of a readwritesplit named `My-RW-Router`, the following\
 MaxCtrl command should be used:
 
@@ -1159,12 +1159,12 @@ Examples of the readwritesplit router in use can be found in the [Tutorials](htt
 
 ### Readwritesplit routing decisions
 
-Here is a small explanation which shows what kinds of queries are routed to\
+Here is a small explanation which shows what kinds of queries are routed to
 which type of server.
 
 #### Routing to Primary
 
-Routing to primary is important for data consistency and because majority of\
+Routing to primary is important for data consistency and because majority of
 writes are written to binlog and thus become replicated to replicas.
 
 The following operations are routed to primary:
@@ -1185,32 +1185,32 @@ The following operations are routed to primary:
 * `@@last_insert_id`
 * `@@identity`
 
-In addition to these, if the **readwritesplit** service is configured with the`max_replication_lag` parameter, and if all replicas suffer from too much\
-replication lag, then statements will be routed to the primary. (There might be\
-other similar configuration parameters in the future which limit the number of\
+In addition to these, if the **readwritesplit** service is configured with the`max_replication_lag` parameter, and if all replicas suffer from too much
+replication lag, then statements will be routed to the primary. (There might be
+other similar configuration parameters in the future which limit the number of
 statements that will be routed to replicas.)
 
 **Transaction Isolation Level Tracking**
 
-If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB\
-server, readwritesplit will track the transaction isolation level and lock the\
-session to the primary when the isolation level is set to serializable. This\
-retains the correctness of the isolation level which can otherwise cause\
+If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB
+server, readwritesplit will track the transaction isolation level and lock the
+session to the primary when the isolation level is set to serializable. This
+retains the correctness of the isolation level which can otherwise cause
 problems.
 
-Starting with MaxScale 23.08, once the transaction isolation level is set to\
-something other than `SERIALIZABLE`, the session is no longer locked to the\
-primary and returns to its normal state. Older versions of MaxScale remain\
-locked to the primary even if the session goes out of the `SERIALIZABLE`\
+Starting with MaxScale 23.08, once the transaction isolation level is set to
+something other than `SERIALIZABLE`, the session is no longer locked to the
+primary and returns to its normal state. Older versions of MaxScale remain
+locked to the primary even if the session goes out of the `SERIALIZABLE`
 isolation level.
 
 #### Routing to Replicas
 
-The ability to route some statements to replicas is important because it also\
-decreases the load targeted to _primary_. Moreover, it is possible to have multiple\
+The ability to route some statements to replicas is important because it also
+decreases the load targeted to _primary_. Moreover, it is possible to have multiple
 replicas to share the load in contrast to single primary.
 
-Queries which can be routed to replicas must be auto committed and belong to one\
+Queries which can be routed to replicas must be auto committed and belong to one
 of the following group:
 
 * Read-only statements (i.e. `SELECT`) that only use read-only built-in functions
@@ -1221,10 +1221,10 @@ The list of supported built-in functions can be found [here](https://github.com/
 
 #### Routing to every session backend
 
-A third class of statements includes those which modify session data, such as\
-session system variables, user-defined variables, the default database, etc. We\
-call them session commands, and they must be replicated as they affect the\
-future results of read and write operations. They must be executed on all\
+A third class of statements includes those which modify session data, such as
+session system variables, user-defined variables, the default database, etc. We
+call them session commands, and they must be replicated as they affect the
+future results of read and write operations. They must be executed on all
 servers that could execute statements on behalf of this client.
 
 Session commands include for example:
@@ -1234,26 +1234,26 @@ Session commands include for example:
 * Binary protocol prepared statements
 * Other miscellaneous commands (COM\_QUIT, COM\_PING etc.)
 
-**NOTE**: if variable assignment is embedded in a write statement it is routed\
-to _primary_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be\
+**NOTE**: if variable assignment is embedded in a write statement it is routed
+to _primary_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be
 routed to _primary_ only.
 
-The router stores all of the executed session commands so that in case of a\
-replica failure, a replacement replica can be chosen and the session command history\
-can be repeated on that new replica. This means that the router stores each\
-executed session command for the duration of the session. Applications that use\
-long-running sessions might cause MariaDB MaxScale to consume a growing amount\
-of memory unless the sessions are closed. This can be solved by adjusting the\
+The router stores all of the executed session commands so that in case of a
+replica failure, a replacement replica can be chosen and the session command history
+can be repeated on that new replica. This means that the router stores each
+executed session command for the duration of the session. Applications that use
+long-running sessions might cause MariaDB MaxScale to consume a growing amount
+of memory unless the sessions are closed. This can be solved by adjusting the
 value of `max_sescmd_history`.
 
 #### Routing to previous target
 
-In the following cases, a query is routed to the same server where the previous\
-query was executed. If no previous target is found, the query is routed to the\
+In the following cases, a query is routed to the same server where the previous
+query was executed. If no previous target is found, the query is routed to the
 current primary.
 
-* If a query uses the `FOUND_ROWS()` function, it will be routed to the server\
-  where the last query was executed. This is done with the assumption that a\
+* If a query uses the `FOUND_ROWS()` function, it will be routed to the server
+  where the last query was executed. This is done with the assumption that a
   query with `SQL_CALC_FOUND_ROWS` was previously executed.
 * COM\_STMT\_FETCH\_ROWS will always be routed to the same server where the\
   COM\_STMT\_EXECUTE was routed.
@@ -1268,90 +1268,90 @@ Read queries are routed to the primary server in the following situations:
 
 #### Prepared Statement Limitations
 
-If a prepared statement targets a temporary table on the primary, the replica\
-servers will fail to execute it. This will cause all replica connections to be\
+If a prepared statement targets a temporary table on the primary, the replica
+servers will fail to execute it. This will cause all replica connections to be
 closed (MXS-1816).
 
 #### Transaction Replay Limitations
 
-When transaction replay is enabled, readwritesplit calculates a checksum of the\
-server responses for each transaction. This is used to determine whether a\
+When transaction replay is enabled, readwritesplit calculates a checksum of the
+server responses for each transaction. This is used to determine whether a
 replayed transaction was identical to the original transaction. Starting with\
-MaxScale 23.08, a 128-bit xxHash checksum is stored for each statement that is\
-in the transaction. Older versions of MaxScale used a single 160-bit SHA1\
+MaxScale 23.08, a 128-bit xxHash checksum is stored for each statement that is
+in the transaction. Older versions of MaxScale used a single 160-bit SHA1
 checksum for the whole transaction.
 
-If the results from the replacement server are not identical when the\
-transaction is replayed, the client connection is closed. This means that any\
-transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot\
+If the results from the replacement server are not identical when the
+transaction is replayed, the client connection is closed. This means that any
+transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot
 be replayed successfully but it will still be attempted.
 
-If a transaction reads data before updating it, the rows should be locked by\
-using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when\
+If a transaction reads data before updating it, the rows should be locked by
+using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when
 multiple transactions are being replayed that modify the same set of rows.
 
-If the connection to the server where the transaction is being executed is\
-lost when the final `COMMIT` is being executed, it is impossible to know\
-whether the transaction was successfully committed. This means that there\
-is a possibility for duplicate transaction execution which can result in\
+If the connection to the server where the transaction is being executed is
+lost when the final `COMMIT` is being executed, it is impossible to know
+whether the transaction was successfully committed. This means that there
+is a possibility for duplicate transaction execution which can result in
 data duplication in certain cases.
 
-In MaxScale 23.08, the `transaction_replay_safe_commit` variable controls\
-whether a replay is attempted or not whenever a `COMMIT` is interrupted. By\
-default the transaction will not be replayed. Older versions of MaxScale always\
+In MaxScale 23.08, the `transaction_replay_safe_commit` variable controls
+whether a replay is attempted or not whenever a `COMMIT` is interrupted. By
+default the transaction will not be replayed. Older versions of MaxScale always
 replayed the transaction.
 
-Data duplication can happen if the transaction consists of the following\
+Data duplication can happen if the transaction consists of the following
 statement types:
 
 * INSERT of rows into a table that does not have an auto-increment primary key
 * A "blind update" of one or more rows e.g. `UPDATE t SET c = c + 1 WHERE id = 123`
 * A "blind delete" e.g. `DELETE FROM t LIMIT 100`
 
-This is not an exhaustive list and any operations that do not check the row\
+This is not an exhaustive list and any operations that do not check the row
 contents before performing the operation on them might face this problem.
 
-In all cases the problem of duplicate transaction execution can be avoided by\
-including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that\
-in the case that the transaction fails when it is being committed, the row is\
+In all cases the problem of duplicate transaction execution can be avoided by
+including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that
+in the case that the transaction fails when it is being committed, the row is
 only modified if it matches the expected contents.
 
-Similarly, a connection loss during `COMMIT` can also result in transaction\
-replay failure. This happens due to the same reason as duplicate transaction\
-execution but the retried transaction will not be committed. This can be\
-considered a success case as the transaction replay detected that the results of\
-the two transactions are different. In these cases readwritesplit will abort the\
+Similarly, a connection loss during `COMMIT` can also result in transaction
+replay failure. This happens due to the same reason as duplicate transaction
+execution but the retried transaction will not be committed. This can be
+considered a success case as the transaction replay detected that the results of
+the two transactions are different. In these cases readwritesplit will abort the
 transaction and close the client connection.
 
-Statements that result in an implicit commit do not reset the transaction when\
-transaction\_replay is enabled. This means that if the transaction is replayed,\
-the transaction will be committed twice due to the implicit commit being\
-present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the\
+Statements that result in an implicit commit do not reset the transaction when
+transaction\_replay is enabled. This means that if the transaction is replayed,
+the transaction will be committed twice due to the implicit commit being
+present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the
 transaction to be correctly reset.
 
-In older versions of MaxScale, if a connection to a server is lost while a\
-statement is being executed and the result was partially delivered to the\
-client, readwritesplit would immediately close the session without attempting to\
-replay the failing statement. Starting with MaxScale 23.08, this limitation no\
+In older versions of MaxScale, if a connection to a server is lost while a
+statement is being executed and the result was partially delivered to the
+client, readwritesplit would immediately close the session without attempting to
+replay the failing statement. Starting with MaxScale 23.08, this limitation no
 longer applies if the statement was done inside of a transaction and`transaction_replay` is enabled\
 ([MXS-4549](https://jira.mariadb.org/browse/MXS-4549)).
 
-If the connection to the server where a transaction is being executed is lost\
-while a `ROLLBACK` is being executed, readwritesplit will still attempt to\
-replay the transaction in the hopes that the real response can be delivered to\
-the client. However, this does mean that it is possible that a rolled back\
-transaction which gets replayed ends up with a conflict and is reported as a\
-replay failure when in reality a rolled back transaction could be safely\
+If the connection to the server where a transaction is being executed is lost
+while a `ROLLBACK` is being executed, readwritesplit will still attempt to
+replay the transaction in the hopes that the real response can be delivered to
+the client. However, this does mean that it is possible that a rolled back
+transaction which gets replayed ends up with a conflict and is reported as a
+replay failure when in reality a rolled back transaction could be safely
 ignored.
 
 **Limitations in Session State Modifications**
 
-Any changes to the session state (e.g. autocommit state, SQL mode) done inside a\
-transaction will remain in effect even if the connection to the server where the\
-transaction is being executed fails. When readwritesplit creates a new\
-connection to a server to replay the transaction, it will first restore the\
-session state by executing all session commands that were executed. This means\
-that if the session state is changed mid-transaction in a way that affects the\
+Any changes to the session state (e.g. autocommit state, SQL mode) done inside a
+transaction will remain in effect even if the connection to the server where the
+transaction is being executed fails. When readwritesplit creates a new
+connection to a server to replay the transaction, it will first restore the
+session state by executing all session commands that were executed. This means
+that if the session state is changed mid-transaction in a way that affects the
 results, transaction replay will fail.
 
 The following partial transaction demonstrates the problem by using [SQL\_MODE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) inside a transaction.
@@ -1364,7 +1364,7 @@ SET SQL_MODE='ANSI_QUOTES'; -- A session command
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-If this transaction has to be replayed the actual SQL that gets executed is the\
+If this transaction has to be replayed the actual SQL that gets executed is the
 following.
 
 ```
@@ -1375,38 +1375,38 @@ SELECT "hello world";       -- Returns an error
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-First the session state is restored by executing all commands that changed the\
+First the session state is restored by executing all commands that changed the
 state after which the actual transaction is replayed. Due to the fact that the\
-SQL\_MODE was changed mid-transaction, one of the queries will now return an\
+SQL\_MODE was changed mid-transaction, one of the queries will now return an
 error instead of the result we expected leading to a transaction replay failure.
 
 **Limitations in Service-to-Service Routing**
 
-In a service-to-service configuration (i.e. a service using another service in\
-its `targets` list ), if the topmost service starts a transaction, all\
-lower-level readwritesplit services will also behave as if a transaction is\
-open. If a connection to a backend database fails during this, it can result in\
-unnecessary transaction replays which in turn can end up with checksum\
-conflicts. The recommended approach is to not use any commands inside a\
+In a service-to-service configuration (i.e. a service using another service in
+its `targets` list ), if the topmost service starts a transaction, all
+lower-level readwritesplit services will also behave as if a transaction is
+open. If a connection to a backend database fails during this, it can result in
+unnecessary transaction replays which in turn can end up with checksum
+conflicts. The recommended approach is to not use any commands inside a
 transaction that would be routed to more than one node.
 
 **Limitations in multi-statement handling**
 
-When a multi-statement query is executed through the readwritesplit router, it\
-will always be routed to the primary. See [strict\_multi\_stmt](mariadb-maxscale-2308-readwritesplit.md#strict_multi_stmt) for more\
+When a multi-statement query is executed through the readwritesplit router, it
+will always be routed to the primary. See [strict\_multi\_stmt](mariadb-maxscale-2308-readwritesplit.md#strict_multi_stmt) for more
 details.
 
-If the multi-statement query creates a temporary table, it will not be\
-detected and reads to this table can be routed to replica servers. To\
-prevent this, always execute the temporary table creation as an individual\
+If the multi-statement query creates a temporary table, it will not be
+detected and reads to this table can be routed to replica servers. To
+prevent this, always execute the temporary table creation as an individual
 statement.
 
 **Limitations in client session handling**
 
-Some of the queries that a client sends are routed to all backends instead of\
-just to one. These queries include `USE <db name>` and `SET autocommit=0`, among\
-many others. Readwritesplit sends a copy of these queries to each backend server\
-and forwards the primary's reply to the client. Below is a list of MySQL commands\
+Some of the queries that a client sends are routed to all backends instead of
+just to one. These queries include `USE <db name>` and `SET autocommit=0`, among
+many others. Readwritesplit sends a copy of these queries to each backend server
+and forwards the primary's reply to the client. Below is a list of MySQL commands
 which are classified as session commands.
 
 ```
@@ -1428,19 +1428,19 @@ SELECT ..INTO variable|OUTFILE|DUMPFILE
 SET autocommit=1|0
 ```
 
-Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were\
+Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were
 not supported and caused the session to be closed.
 
-There is a possibility for misbehavior. If `USE mytable` is executed in one of\
-the replicas and fails, it may be due to replication lag rather than the database\
-not existing. Thus, the same command may produce different result in different\
-backend servers. The replicas which fail to execute a session command will be\
-dropped from the active list of replicas for this session to guarantee a\
-consistent session state across all the servers used by the session. In\
-addition, the server will not be used again for routing for the duration of the\
+There is a possibility for misbehavior. If `USE mytable` is executed in one of
+the replicas and fails, it may be due to replication lag rather than the database
+not existing. Thus, the same command may produce different result in different
+backend servers. The replicas which fail to execute a session command will be
+dropped from the active list of replicas for this session to guarantee a
+consistent session state across all the servers used by the session. In
+addition, the server will not be used again for routing for the duration of the
 session.
 
-The above-mentioned behavior for user variables can be partially controlled with\
+The above-mentioned behavior for user variables can be partially controlled with
 the configuration parameter `use_sql_variables_in`:
 
 ```
@@ -1449,10 +1449,10 @@ use_sql_variables_in=[master|all] (default: all)
 
 **WARNING**
 
-If a SELECT query modifies a user variable when the `use_sql_variables_in`\
-parameter is set to `all`, it will not be routed and the client will receive an\
-error. A log message is written into the log further explaining the reason for\
-the error. Here is an example use of a SELECT query which modifies a user\
+If a SELECT query modifies a user variable when the `use_sql_variables_in`
+parameter is set to `all`, it will not be routed and the client will receive an
+error. A log message is written into the log further explaining the reason for
+the error. Here is an example use of a SELECT query which modifies a user
 variable and how MariaDB MaxScale responds to it.
 
 ```
@@ -1463,7 +1463,7 @@ MySQL [(none)]> SELECT @id := @id + 1 FROM test.t1;
 ERROR 1064 (42000): Routing query to backend failed. See the error log for further details.
 ```
 
-Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user\
+Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user
 variables to the primary.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-schemarouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-schemarouter.md
@@ -4,16 +4,16 @@
 
 ## SchemaRouter
 
-The SchemaRouter provides an easy and manageable sharding solution by\
-building a single logical database server from multiple separate ones. Each\
-database is shown to the client and queries targeting unique databases are\
-routed to their respective servers. In addition to providing simple\
-database-based sharding, the schemarouter also enables cross-node\
-session variable usage by routing all queries that modify the session to all\
+The SchemaRouter provides an easy and manageable sharding solution by
+building a single logical database server from multiple separate ones. Each
+database is shown to the client and queries targeting unique databases are
+routed to their respective servers. In addition to providing simple
+database-based sharding, the schemarouter also enables cross-node
+session variable usage by routing all queries that modify the session to all
 nodes.
 
-By default the SchemaRouter assumes that each database and table is only located\
-on one server. If it finds the same database or table on multiple servers, it\
+By default the SchemaRouter assumes that each database and table is only located
+on one server. If it finds the same database or table on multiple servers, it
 will close the session with the following error:
 
 ```
@@ -22,14 +22,14 @@ ERROR 5000 (DUPDB): Error: duplicate tables found on two different shards.
 
 The exception to this rule are the system tables `mysql`, `information_schema`,`performance_schema`, `sys` that are never treated as duplicates.
 
-If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2308-schemarouter.md#ignore_tables_regex) parameter to controls which\
+If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2308-schemarouter.md#ignore_tables_regex) parameter to controls which
 duplicate tables are allowed. To disable the duplicate database detection, use`ignore_tables_regex=.*`.
 
-Schemarouter compares table and database names case-insensitively. This means\
+Schemarouter compares table and database names case-insensitively. This means
 that the tables `test.t1` and `test.T1` are assumed to refer to the same table.
 
-The main limitation of SchemaRouter is that aside from session variable writes\
-and some specific queries, a query can only target one server. This means that\
+The main limitation of SchemaRouter is that aside from session variable writes
+and some specific queries, a query can only target one server. This means that
 queries which depend on results from multiple servers give incorrect results.\
 See [Limitations](mariadb-maxscale-2308-schemarouter.md#limitations) for more information.
 
@@ -37,51 +37,51 @@ From 2.3.0 onwards, SchemaRouter is capable of limited table family sharding.
 
 ### Changes in Version 6
 
-* The `auth_all_servers` parameter is no longer automatically enabled by the\
-  schemarouter. To retain the old behavior that was present in 2.5, explicitly\
+* The `auth_all_servers` parameter is no longer automatically enabled by the
+  schemarouter. To retain the old behavior that was present in 2.5, explicitly
   define `auth_all_servers=true` for all schemarouter services.
 
 ### Routing Logic
 
-* If a command modifies the session state by modifying any session or user\
-  variables, the query is routed to all nodes. These statements include `SET`\
-  statements as well as any other statements that modify the behavior of the\
+* If a command modifies the session state by modifying any session or user
+  variables, the query is routed to all nodes. These statements include `SET`
+  statements as well as any other statements that modify the behavior of the
   client.
-* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers\
-  that contain the database. This same logic applies when a client connects with\
-  a default database: the default database is set only on servers that actually\
+* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers
+  that contain the database. This same logic applies when a client connects with
+  a default database: the default database is set only on servers that actually
   contain it.
-* If a query targets one or more tables that the schemarouter has discovered\
-  during the database mapping phase, the query is only routed if a server is\
-  found that contains all of the tables that the query uses. If no such server\
-  is found, the query is routed to the server that was previously used or to the\
-  first available backend if none have been used. If a query uses a table but\
-  doesn't define the database it is in, it is assumed to be located on the\
+* If a query targets one or more tables that the schemarouter has discovered
+  during the database mapping phase, the query is only routed if a server is
+  found that contains all of the tables that the query uses. If no such server
+  is found, the query is routed to the server that was previously used or to the
+  first available backend if none have been used. If a query uses a table but
+  doesn't define the database it is in, it is assumed to be located on the
   default database of the connection.
-* If a query targets a table or a database that is present on all nodes\
-  (e.g. `information_schema`) and the connection is using a default database,\
-  the query is routed based on the default database. This makes it possible to\
-  control where queries that do match a specific node are routed. If the\
-  connection is not using a default database, the query is routed based solely\
+* If a query targets a table or a database that is present on all nodes
+  (e.g. `information_schema`) and the connection is using a default database,
+  the query is routed based on the default database. This makes it possible to
+  control where queries that do match a specific node are routed. If the
+  connection is not using a default database, the query is routed based solely
   on the tables it contains.
-* If a query uses a table that is unknown to the schemarouter or executes a\
-  command that doesn't target a table, the query is routed to a server contains\
-  the current active default database. If the connection does not have a default\
-  database, the query is routed to the backend that was last used or to the\
-  first available backend if none have been used. If the query contains a\
+* If a query uses a table that is unknown to the schemarouter or executes a
+  command that doesn't target a table, the query is routed to a server contains
+  the current active default database. If the connection does not have a default
+  database, the query is routed to the backend that was last used or to the
+  first available backend if none have been used. If the query contains a
   routing hint that directs it to a server, the query is routed there.
 
-This means that all administrative commands, replication related command as\
-well as certain transaction control statements (XA transaction) are routed to\
-the first available server in certain cases. To avoid problems, use routing\
+This means that all administrative commands, replication related command as
+well as certain transaction control statements (XA transaction) are routed to
+the first available server in certain cases. To avoid problems, use routing
 hints to direct where these statements should go.
 
-* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`\
-  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the\
-  queries to the first available backend. This means that cross-shard\
-  transactions are technically possible but, without external synchronization,\
+* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`
+  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the
+  queries to the first available backend. This means that cross-shard
+  transactions are technically possible but, without external synchronization,
   the transactions are not guaranteed to be globally consistent.
-* `LOAD DATA LOCAL INFILE` commands are routed to the first available server\
+* `LOAD DATA LOCAL INFILE` commands are routed to the first available server
   that contains the tables listed in the query.
 
 #### Custom SQL Commands
@@ -98,24 +98,24 @@ db1.t2   |MyServer1    |
 db2.t1   |MyServer2    |
 ```
 
-The schemarouter will also intercept the `SHOW DATABASES` command and generate\
-it based on its internal data. This means that newly created databases will not\
-show up immediately and will only be visible when the cached data has been\
+The schemarouter will also intercept the `SHOW DATABASES` command and generate
+it based on its internal data. This means that newly created databases will not
+show up immediately and will only be visible when the cached data has been
 updated.
 
 #### Database Mapping
 
-The schemarouter maps each of the servers to know where each database and table\
-is located. As each user has access to a different set of tables and databases,\
-the result is unique to the username and the set of servers that the service\
-uses. These results are cached by the schemarouter. The lifetime of the cached\
+The schemarouter maps each of the servers to know where each database and table
+is located. As each user has access to a different set of tables and databases,
+the result is unique to the username and the set of servers that the service
+uses. These results are cached by the schemarouter. The lifetime of the cached
 result is controlled by the `refresh_interval` parameter.
 
-When a server needs to be mapped, the schemarouter will route a query to each of\
-the servers using the client's credentials. While this query is being executed,\
-all other sessions that would otherwise share the cached result will wait for\
-the update to complete. This waiting functionality was added in MaxScale 2.4.19,\
-older versions did not wait for existing updates to finish and would perform\
+When a server needs to be mapped, the schemarouter will route a query to each of
+the servers using the client's credentials. While this query is being executed,
+all other sessions that would otherwise share the cached result will wait for
+the update to complete. This waiting functionality was added in MaxScale 2.4.19,
+older versions did not wait for existing updates to finish and would perform
 parallel database mapping queries.
 
 ### Configuration
@@ -131,24 +131,24 @@ user=myuser
 password=mypwd
 ```
 
-The module generates the list of databases based on the servers parameter\
-using the connecting client's credentials. The user and password parameters\
-define the credentials that are used to fetch the authentication data from\
-the database servers. The credentials used only require the same grants as\
+The module generates the list of databases based on the servers parameter
+using the connecting client's credentials. The user and password parameters
+define the credentials that are used to fetch the authentication data from
+the database servers. The credentials used only require the same grants as
 mentioned in the configuration documentation.
 
-The list of databases is built by sending a SHOW DATABASES query to all the\
-servers. This requires the user to have at least USAGE and SELECT grants on\
+The list of databases is built by sending a SHOW DATABASES query to all the
+servers. This requires the user to have at least USAGE and SELECT grants on
 the databases that need be sharded.
 
-If you are connecting directly to a database or have different users on some\
-of the servers, you need to get the authentication data from all the\
-servers. You can control this with the `auth_all_servers` parameter. With\
-this parameter, MariaDB MaxScale forms a union of all the users and their\
-grants from all the servers. By default, the schemarouter will fetch the\
+If you are connecting directly to a database or have different users on some
+of the servers, you need to get the authentication data from all the
+servers. You can control this with the `auth_all_servers` parameter. With
+this parameter, MariaDB MaxScale forms a union of all the users and their
+grants from all the servers. By default, the schemarouter will fetch the
 authentication data from all servers.
 
-For example, if two servers have the database `shard` and the following\
+For example, if two servers have the database `shard` and the following
 rights are granted only on one server, all queries targeting the database`shard` would be routed to the server where the grants were given.
 
 ```
@@ -159,9 +159,9 @@ CREATE USER 'john'@'%' IDENTIFIED BY 'password';
 GRANT SELECT,USAGE ON shard.* TO 'john'@'%';
 ```
 
-This would in effect allow the user 'john' to only see the database 'shard'\
+This would in effect allow the user 'john' to only see the database 'shard'
 on this server. Take notice that these grants are matched against MariaDB\
-MaxScale's hostname instead of the client's hostname. Only user\
+MaxScale's hostname instead of the client's hostname. Only user
 authentication uses the client's hostname and all other grants use MariaDB\
 MaxScale's hostname.
 
@@ -174,7 +174,7 @@ MaxScale's hostname.
 * Dynamic: Yes
 * Default: `""`
 
-List of full table names (e.g. db1.t1) to ignore when checking for duplicate\
+List of full table names (e.g. db1.t1) to ignore when checking for duplicate
 tables. By default no tables are ignored.
 
 This parameter was once called `ignore_databases`.
@@ -186,11 +186,11 @@ This parameter was once called `ignore_databases`.
 * Dynamic: No
 * Default: `""`
 
-A [PCRE2 regular expression](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#regular-expressions)\
+A [PCRE2 regular expression](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#regular-expressions)
 that is matched against database names when checking for duplicate databases.\
 By default no tables are ignored.
 
-The following configuration ignores duplicate tables in the databases `db1` and `db2`,\
+The following configuration ignores duplicate tables in the databases `db1` and `db2`,
 and all tables starting with "t" in `db3`.
 
 ```
@@ -207,12 +207,12 @@ This parameter was once called `ignore_databases_regex`.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#max_sescmd_history)\
+This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#max_sescmd_history)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#disable_sescmd_history)\
+This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#disable_sescmd_history)
 in MaxScale 6.0.
 
 #### `refresh_databases`
@@ -222,11 +222,11 @@ in MaxScale 6.0.
 * Dynamic: No
 * Default: `false`
 
-Enable database map refreshing mid-session. These are triggered by a failure to\
+Enable database map refreshing mid-session. These are triggered by a failure to
 change the database i.e. `USE ...` queries. This feature is disabled by default.
 
-Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0\
-release of MaxScale this parameter now works again but it is disabled by default\
+Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0
+release of MaxScale this parameter now works again but it is disabled by default
 to retain the same behavior as in older releases.
 
 #### `refresh_interval`
@@ -236,13 +236,13 @@ to retain the same behavior as in older releases.
 * Dynamic: Yes
 * Default: `300s`
 
-The minimum interval between database map refreshes in seconds. The default\
+The minimum interval between database map refreshes in seconds. The default
 value is 300 seconds.
 
-The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `max_staleness`
@@ -252,28 +252,28 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: 150s
 
-The time how long stale database map entries can be used while an update is in\
-progress. When a database map entry goes stale, the next connection to be\
-created will start an update of the database map. While this update is ongoing,\
-other connections can use the stale entry for up to `max_staleness` seconds. If\
-this limit is exceeded and the update still hasn't completed, new connections\
+The time how long stale database map entries can be used while an update is in
+progress. When a database map entry goes stale, the next connection to be
+created will start an update of the database map. While this update is ongoing,
+other connections can use the stale entry for up to `max_staleness` seconds. If
+this limit is exceeded and the update still hasn't completed, new connections
 will instead block and wait for the update to finish.
 
-This feature was added in MaxScale 23.08.0. Older versions of MaxScale\
-always waited for the update to complete when the database map entry\
+This feature was added in MaxScale 23.08.0. Older versions of MaxScale
+always waited for the update to complete when the database map entry
 went stale.
 
 ### Table Family Sharding
 
 This functionality was introduced in 2.3.0.
 
-If the same database exists on multiple servers, but the database contains different\
-tables in each server, SchemaRouter is capable of routing queries to the right server,\
+If the same database exists on multiple servers, but the database contains different
+tables in each server, SchemaRouter is capable of routing queries to the right server,
 depending on which table is being addressed.
 
-As an example, suppose the database `db` exists on servers _server1_ and _server2_, but\
-that the database on _server1_ contains the table `tbl1` and on _server2_ contains the\
-table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table\
+As an example, suppose the database `db` exists on servers _server1_ and _server2_, but
+that the database on _server1_ contains the table `tbl1` and on _server2_ contains the
+table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table
 names must be qualified with the database names for table-level sharding to work.\
 Specifically, the query series below is not supported.
 
@@ -284,7 +284,7 @@ SELECT * FROM tbl1; // May be routed to an incorrect backend if using table shar
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a schemarouter service contains the\
+The `router_diagnostics` output for a schemarouter service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -299,72 +299,72 @@ following fields.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-module-commands.md) documentation for
 details about module commands.
 
 The schemarouter supports the following module commands.
 
 #### `invalidate SERVICE`
 
-Invalidates the database map cache of the given service. This can be used to schedule\
-the updates to the database maps to happen at off-peak hours by configuring a\
+Invalidates the database map cache of the given service. This can be used to schedule
+the updates to the database maps to happen at off-peak hours by configuring a
 high value for `refresh_interval` and invalidating the cache externally.
 
 #### `clear SERVICE`
 
-Clears the database map cache of the given service. This forces new connections\
+Clears the database map cache of the given service. This forces new connections
 to use a freshly retrieved entry.
 
-If the set of databases and tables in each shard is very large, the update can\
-take some time. If there are stale cache entries and `max_staleness` is\
-configured to be higher than the time it takes to update the database map, the\
-invalidation will only slow down one client connection that ends up doing the\
-update. When the cache is cleared completely, all clients will have to wait for\
-the update to complete. In general, cache invalidation should be preferred over\
+If the set of databases and tables in each shard is very large, the update can
+take some time. If there are stale cache entries and `max_staleness` is
+configured to be higher than the time it takes to update the database map, the
+invalidation will only slow down one client connection that ends up doing the
+update. When the cache is cleared completely, all clients will have to wait for
+the update to complete. In general, cache invalidation should be preferred over
 cache clearing.
 
 ### Limitations
 
-* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the\
-  first explicit database in the query, the current database in use or to the first\
+* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the
+  first explicit database in the query, the current database in use or to the first
   available database, depending on which succeeds.
-* Without a default database, queries that do not use fully qualified table\
-  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will\
-  be routed to the first available server. This includes queries such as explicit\
-  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`\
-  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`\
-  statements that do not directly refer to a table. `CREATE` commands should be\
-  done directly on the node or the router should be equipped with the hint filter\
-  and a routing hint should be used. Queries that modify the session state\
-  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the\
-  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,\
-  otherwise routing hints are required to correctly route the transaction control\
-  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the\
-  routing of transaction control commands to route them to all servers used by the\
+* Without a default database, queries that do not use fully qualified table
+  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will
+  be routed to the first available server. This includes queries such as explicit
+  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`
+  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`
+  statements that do not directly refer to a table. `CREATE` commands should be
+  done directly on the node or the router should be equipped with the hint filter
+  and a routing hint should be used. Queries that modify the session state
+  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the
+  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,
+  otherwise routing hints are required to correctly route the transaction control
+  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the
+  routing of transaction control commands to route them to all servers used by the
   schemarouter.
-* SELECT queries that modify session variables are not supported because uniform results\
-  can not be guaranteed. If such a query is executed, the behavior of the router is\
+* SELECT queries that modify session variables are not supported because uniform results
+  can not be guaranteed. If such a query is executed, the behavior of the router is
   undefined. To work around this limitation, the query must be executed in separate parts.
-* If a query targets a database the SchemaRouter has not mapped to a server, the\
-  query will be routed to the first available server. This possibly returns an\
+* If a query targets a database the SchemaRouter has not mapped to a server, the
+  query will be routed to the first available server. This possibly returns an
   error about database rights instead of a missing database.
-* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the\
+* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the
   correct backend if the statement is known and only requires one backend server. EXECUTE\
-  IMMEDIATE is not supported and is routed to the first available backend and may give\
+  IMMEDIATE is not supported and is routed to the first available backend and may give
   wrong results. Similarly, preparing a statement from a variable (e.g. `PREPARE stmt FROM @a`) is not supported and may be routed wrong.
-* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only\
-  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are\
+* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only
+  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are
   ignored. Starting with MaxScale 22.08, the database names will always be in lowercase.
-* `SHOW TABLES` is routed to the server with the current database. If using\
-  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table\
+* `SHOW TABLES` is routed to the server with the current database. If using
+  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table
   sharding. Use `SHOW SHARDS` to get results from the router itself. Starting with\
   MaxScale 22.08, the database names will always be in lowercase.
-* `USE db1` is routed to the server with `db1`. If the database is divided to multiple\
+* `USE db1` is routed to the server with `db1`. If the database is divided to multiple
   servers, only one server will get the command.
 
 ### Examples
 
-[Here](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-simple-sharding-with-two-servers.md) is a small tutorial on how\
+[Here](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-simple-sharding-with-two-servers.md) is a small tutorial on how
 to set up a sharded database.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-smartrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-smartrouter.md
@@ -6,20 +6,20 @@
 
 ### Overview
 
-SmartRouter is the query router of the SmartQuery framework. Based on the type\
-of the query, each query is routed to the server or cluster that can best\
+SmartRouter is the query router of the SmartQuery framework. Based on the type
+of the query, each query is routed to the server or cluster that can best
 handle it.
 
 For workloads where both transactional and analytical queries are needed,\
-SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into\
-a single entry point in MaxScale. This allows a MaxScale client to freely mix\
-transactional and analytical queries using the same connection. This is known\
+SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into
+a single entry point in MaxScale. This allows a MaxScale client to freely mix
+transactional and analytical queries using the same connection. This is known
 as Hybrid Transactional and Analytical Processing, HTAP.
 
 ### Configuration
 
-SmartRouter is configured as a service that either routes to other MaxScale\
-routers or plain servers. Although one can configure SmartRouter to use a plain\
+SmartRouter is configured as a service that either routes to other MaxScale
+routers or plain servers. Although one can configure SmartRouter to use a plain
 server directly, we refer to the configured "servers" as clusters.
 
 For details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md).
@@ -30,10 +30,10 @@ For details about the standard service parameters, refer to the [Configuration G
 * Mandatory: Yes
 * Dynamic: No
 
-One of the clusters must be designated as the **`master`**. All writes go to the\
+One of the clusters must be designated as the **`master`**. All writes go to the
 primary cluster, which for all practical purposes should be a primary-replica\
-ReadWriteSplit. This document does not go into details about setting up\
-primary-replica clusters, but suffice to say, that when setting up the ColumnStore\
+ReadWriteSplit. This document does not go into details about setting up
+primary-replica clusters, but suffice to say, that when setting up the ColumnStore
 servers they should be configured to be replicas of a MariaDB server running an\
 InnoDB engine.\
 The ReadWriteSplit [documentation](mariadb-maxscale-2308-readwritesplit.md) has more on primary-replica setup.
@@ -89,8 +89,8 @@ service = SmartQuery
 port = <port>
 ```
 
-Note that the SmartQuery listener listens on a port, while the Row and Column\
-service listeners listen on Unix domain sockets. The reason is that there is a\
+Note that the SmartQuery listener listens on a port, while the Row and Column
+service listeners listen on Unix domain sockets. The reason is that there is a
 significant performance benefit when SmartRouter accesses the services over a\
 Unix domain socket compared to accessing them over a TCP/IP socket.
 
@@ -98,31 +98,31 @@ A complete configuration example can be found at the end of this document.
 
 ### Cluster selection - how queries are routed
 
-SmartRouter keeps track of the performance, or the execution time, of queries to\
+SmartRouter keeps track of the performance, or the execution time, of queries to
 the clusters. Measurements are stored with the canonical of a query as the key.\
-The canonical of a query is the sql with all user-defined constants replaced with\
-question marks. When SmartRouter sees a read-query whose canonical has not been\
-seen before, it will send the query to all clusters. The first response from a\
-cluster will designate that cluster as the best one for that canonical. Also,\
-when the first response is received, the other queries are cancelled. The\
-response is sent to the client once all clusters have responded to the query\
+The canonical of a query is the sql with all user-defined constants replaced with
+question marks. When SmartRouter sees a read-query whose canonical has not been
+seen before, it will send the query to all clusters. The first response from a
+cluster will designate that cluster as the best one for that canonical. Also,
+when the first response is received, the other queries are cancelled. The
+response is sent to the client once all clusters have responded to the query
 or the cancel.
 
-There is obviously overhead when a new canonical is seen. This means that\
-queries after a MaxScale start will be slightly slower than normal. The\
-execution time of a query depends on the database engine, and on the contents\
-of the tables being queried. As a result, MaxScale will periodically re-measure\
+There is obviously overhead when a new canonical is seen. This means that
+queries after a MaxScale start will be slightly slower than normal. The
+execution time of a query depends on the database engine, and on the contents
+of the tables being queried. As a result, MaxScale will periodically re-measure
 queries.
 
-The performance behavior of queries under dynamic conditions, and their effect\
-on different storage engines is being studied at MariaDB. As we learn more, we\
+The performance behavior of queries under dynamic conditions, and their effect
+on different storage engines is being studied at MariaDB. As we learn more, we
 will be able to better categorize queries and move that knowledge into\
 SmartRouter.
 
 ### Limitations
 
 * `LOAD DATA LOCAL INFILE` is not supported.
-* The performance data is not persisted. The measurements will be performed\
+* The performance data is not persisted. The measurements will be performed
   anew after each startup.
 
 ### Complete configuration example

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-automatic-failover-with-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-automatic-failover-with-mariadb-monitor.md
@@ -4,24 +4,24 @@
 
 ## Automatic Failover With MariaDB Monitor
 
-The [MariaDB Monitor](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md) is not only capable\
-of monitoring the state of a MariaDB primary-replica cluster but is also\
-capable of performing _failover_ and _switchover_. In addition, in some\
-circumstances it is capable of _rejoining_ a primary that has gone down and\
+The [MariaDB Monitor](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md) is not only capable
+of monitoring the state of a MariaDB primary-replica cluster but is also
+capable of performing _failover_ and _switchover_. In addition, in some
+circumstances it is capable of _rejoining_ a primary that has gone down and
 later reappears.
 
-Note that the failover (and switchover and rejoin) functionality is only\
-supported in conjunction with GTID-based replication and initially only\
+Note that the failover (and switchover and rejoin) functionality is only
+supported in conjunction with GTID-based replication and initially only
 for simple topologies, that is, 1 primary and several replicas.
 
-The failover, switchover and rejoin functionality are inherent parts of\
-the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin\
+The failover, switchover and rejoin functionality are inherent parts of
+the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin
 are enabled by default.
 
-The following examples have been written with the assumption that there\
-are four servers - `server1`, `server2`, `server3` and `server4` - of\
+The following examples have been written with the assumption that there
+are four servers - `server1`, `server2`, `server3` and `server4` - of
 which `server1` is the initial primary and the other servers are replicas.\
-In addition there is a monitor called _TheMonitor_ that monitors those\
+In addition there is a monitor called _TheMonitor_ that monitors those
 servers.
 
 Somewhat simplified, the MaxScale configuration file would look like:
@@ -50,7 +50,7 @@ servers=server1,server2,server3,server4
 
 ## Manual Failover
 
-If everything is in order, the state of the cluster will look something\
+If everything is in order, the state of the cluster will look something
 like this:
 
 ```
@@ -68,7 +68,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If the primary now for any reason goes down, then the cluster state will\
+If the primary now for any reason goes down, then the cluster state will
 look like this:
 
 ```
@@ -88,7 +88,7 @@ $ maxctrl list servers
 
 Note that the status for `server1` is _Down_.
 
-Since failover is by default _not_ enabled, the failover mechanism must be\
+Since failover is by default _not_ enabled, the failover mechanism must be
 invoked manually:
 
 ```
@@ -103,11 +103,11 @@ There are quite a few arguments, so let's look at each one separately:
 * `failover` is the command we want to invoke, and
 * `TheMonitor` is the first and only argument to that command, the name of the monitor as specified in the configuration file.
 
-The MariaDB Monitor will now autonomously deduce which replica is the most\
-appropriate one to be promoted to primary, promote it to primary and modify\
+The MariaDB Monitor will now autonomously deduce which replica is the most
+appropriate one to be promoted to primary, promote it to primary and modify
 the other replicas accordingly.
 
-If we now check the cluster state we will see that one of the remaining\
+If we now check the cluster state we will see that one of the remaining
 replicas has been made into primary.
 
 ```
@@ -125,7 +125,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, it will not be rejoined to the cluster, as\
+If `server1` now reappears, it will not be rejoined to the cluster, as
 shown by the following output:
 
 ```
@@ -143,15 +143,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Had `auto_rejoin=true` been specified in the monitor section, then an\
+Had `auto_rejoin=true` been specified in the monitor section, then an
 attempt to rejoin `server1` would have been made.
 
-In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a\
+In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a
 subsequent version a command to that effect will be provided.
 
 ## Automatic Failover
 
-To enable automatic failover, simply add `auto_failover=true` to the\
+To enable automatic failover, simply add `auto_failover=true` to the
 monitor section in the configuration file.
 
 ```
@@ -180,7 +180,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now goes down, failover will automatically be performed and\
+If `server1` now goes down, failover will automatically be performed and
 an existing replica promoted to new primary.
 
 ```
@@ -198,12 +198,12 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴────────────────────────┘
 ```
 
-If you are continuously monitoring the server states, you may notice for a\
+If you are continuously monitoring the server states, you may notice for a
 brief period that the state of `server1` is _Down_ and the state of`server2` is still _Slave, Running_.
 
 ## Rejoin
 
-To enable automatic rejoin, simply add `auto_rejoin=true` to the\
+To enable automatic rejoin, simply add `auto_rejoin=true` to the
 monitor section in the configuration file.
 
 ```
@@ -215,7 +215,7 @@ auto_rejoin=true
 ...
 ```
 
-When automatic rejoin is enabled, the MariaDB Monitor will attempt to\
+When automatic rejoin is enabled, the MariaDB Monitor will attempt to
 rejoin a failed primary as a replica, if it reappears.
 
 When everything is running fine, the cluster state looks like follows:
@@ -235,8 +235,8 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Assuming `auto_failover=true` has been specified in the configuration\
-file, when `server1` goes down for some reason, failover will be performed\
+Assuming `auto_failover=true` has been specified in the configuration
+file, when `server1` goes down for some reason, failover will be performed
 and we end up with the following cluster state:
 
 ```
@@ -254,15 +254,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, the MariaDB Monitor will detect that and\
+If `server1` now reappears, the MariaDB Monitor will detect that and
 attempt to rejoin the old primary as a replica.
 
-Whether rejoining will succeed depends upon the actual state of the old\
-primary. For instance, if the old primary was modified and the changes had\
-not been replicated to the new primary, before the old primary went down,\
+Whether rejoining will succeed depends upon the actual state of the old
+primary. For instance, if the old primary was modified and the changes had
+not been replicated to the new primary, before the old primary went down,
 then automatic rejoin will not be possible.
 
-If rejoining can be performed, then the cluster state will end up looking\
+If rejoining can be performed, then the cluster state will end up looking
 like:
 
 ```
@@ -282,11 +282,11 @@ $ maxctrl list servers
 
 ## Switchover
 
-Switchover is for cases when you explicitly want to move the primary\
+Switchover is for cases when you explicitly want to move the primary
 role from one server to another.
 
-If we continue from the cluster state at the end of the previous example\
-and want to make `server1` primary again, then we must issue the following\
+If we continue from the cluster state at the end of the previous example
+and want to make `server1` primary again, then we must issue the following
 command:
 
 ```
@@ -303,7 +303,7 @@ There are quite a few arguments, so let's look at each one separately:
 * `server1` is the second argument to the command, the name of the server we want to make into _primary_, and
 * `server2` is the third argument to the command, the name of the _current primary_.
 
-If the command executes successfully, we will end up with the following\
+If the command executes successfully, we will end up with the following
 cluster state:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-avrorouter-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-avrorouter-tutorial.md
@@ -4,12 +4,12 @@
 
 ## Avrorouter Tutorial
 
-This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avrorouter.md), how to set it up and how it interacts\
+This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avrorouter.md), how to set it up and how it interacts
 with the binlogrouter.
 
-The first part configures the services and sets them up for the binary log to Avro\
-file conversion. The second part of this tutorial uses the client listener\
-interface for the avrorouter and shows how to communicate with the service\
+The first part configures the services and sets them up for the binary log to Avro
+file conversion. The second part of this tutorial uses the client listener
+interface for the avrorouter and shows how to communicate with the service
 over the network.
 
 ```mermaid
@@ -70,8 +70,8 @@ _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog
 
 ### Preparing the primary server
 
-The primary server where we will be replicating from needs to have binary logging\
-enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_\
+The primary server where we will be replicating from needs to have binary logging
+enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_
 file of the primary.
 
 ```
@@ -83,9 +83,9 @@ _You can find out more about replication formats from the_[_MariaDB documentatio
 
 ### Configuring MaxScale
 
-We start by adding two new services into the configuration file. The first\
-service is the binlogrouter service which will read the binary logs from the\
-primary server. The second service will read the binlogs as they are streamed\
+We start by adding two new services into the configuration file. The first
+service is the binlogrouter service which will read the binary logs from the
+primary server. The second service will read the binlogs as they are streamed
 from the primary and convert them into Avro format files.
 
 ```
@@ -121,13 +121,13 @@ protocol=CDC
 port=4001
 ```
 
-The `source` parameter in the _avro-service_ points to the _replication-service_\
-we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog\
-number to start from. With these parameters, the avrorouter will start reading\
+The `source` parameter in the _avro-service_ points to the _replication-service_
+we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog
+number to start from. With these parameters, the avrorouter will start reading
 events from binlog `binlog.000015`.
 
-Note that the _filestem_ and _start\_index_ must point to the file that is the\
-first binlog that the binlogrouter will replicate. For example, if the first\
+Note that the _filestem_ and _start\_index_ must point to the file that is the
+first binlog that the binlogrouter will replicate. For example, if the first
 file you are replicating is `my-binlog-file.001234`, set the parameters to`filestem=my-binlog-file` and `start_index=1234`.
 
 For more information on the avrorouter options, read the [Avrorouter\
@@ -135,31 +135,31 @@ Documentation](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avroroute
 
 ## Preparing the data in the primary server
 
-Before starting the MaxScale process, we need to make sure that the binary logs\
-of the primary server contain the DDL statements that define the table\
-layouts. What this means is that the `CREATE TABLE` statements need to be in the\
+Before starting the MaxScale process, we need to make sure that the binary logs
+of the primary server contain the DDL statements that define the table
+layouts. What this means is that the `CREATE TABLE` statements need to be in the
 binary logs before the conversion process is started.
 
-If the binary logs contain data modification events for tables that aren't\
-created in the binary logs, the Avro schema of the table needs to be manually\
+If the binary logs contain data modification events for tables that aren't
+created in the binary logs, the Avro schema of the table needs to be manually
 created. There are multiple ways to do this:
 
-* Dump the database to a replica, configure it to replicate from the primary and\
-  point MaxScale to this replica (this is the recommended method as it requires no\
+* Dump the database to a replica, configure it to replicate from the primary and
+  point MaxScale to this replica (this is the recommended method as it requires no
   extra steps)
-* Use the [cdc\_schema Go utility](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avrorouter.md#avro-schema-generator)\
+* Use the [cdc\_schema Go utility](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avrorouter.md#avro-schema-generator)
   and copy the generated .avsc files to the avrodir
-* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)\
+* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)
   and copy the generated .avsc files to the avrodir
 
-If you used the schema generator scripts, all Avro schema files for tables that\
-are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of\
+If you used the schema generator scripts, all Avro schema files for tables that
+are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of
 the _test.t1_ table would be `test.t1.0000001.avsc`.
 
 ## Starting MariaDB MaxScale
 
-The next step is to start MariaDB MaxScale and set up the binlogrouter. We do\
-that by connecting to the MySQL listener of the _replication\_router_ service and\
+The next step is to start MariaDB MaxScale and set up the binlogrouter. We do
+that by connecting to the MySQL listener of the _replication\_router_ service and
 executing a few commands.
 
 ```
@@ -173,22 +173,22 @@ CHANGE MASTER TO MASTER_HOST='172.18.0.1',
 START SLAVE;
 ```
 
-**NOTE:** GTID replication is not currently supported and file-and-position\
+**NOTE:** GTID replication is not currently supported and file-and-position
 replication must be used.
 
 This will start the replication of binary logs from the primary server at\
-172.18.0.1 listening on port 3000. The first file that the binlogrouter\
-replicates is `binlog.000015`. This is the same file that was configured as the\
+172.18.0.1 listening on port 3000. The first file that the binlogrouter
+replicates is `binlog.000015`. This is the same file that was configured as the
 starting file in the avrorouter.
 
 For more details about the SQL commands, refer to the [Binlogrouter](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-binlogrouter.md) documentation.
 
-After the binary log streaming has started, the avrorouter will automatically\
+After the binary log streaming has started, the avrorouter will automatically
 start processing the binlogs.
 
 ## Creating and Processing Data
 
-Next, create a simple test table and populated it with some data by executing\
+Next, create a simple test table and populated it with some data by executing
 the following statements.
 
 ```
@@ -196,21 +196,21 @@ CREATE TABLE test.t1 (id INT);
 INSERT INTO test.t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 ```
 
-To use the _cdc.py_ command line client to connect to the CDC service, we must first\
+To use the _cdc.py_ command line client to connect to the CDC service, we must first
 create a user. This can be done via maxctrl by executing the following command.
 
 ```
 maxctrl call command cdc add_user avro-service maxuser maxpwd
 ```
 
-This will create the _maxuser:maxpwd_ credentials which can then be used to\
+This will create the _maxuser:maxpwd_ credentials which can then be used to
 request a JSON data stream of the `test.t1` table that was created earlier.
 
 ```
 cdc.py -u maxuser -p maxpwd -h 127.0.0.1 -P 4001 test.t1
 ```
 
-The output is a stream of JSON events describing the changes done to the\
+The output is a stream of JSON events describing the changes done to the
 database.
 
 ```
@@ -227,8 +227,8 @@ database.
 {"domain": 0, "server_id": 3000, "sequence": 11, "event_number": 10, "timestamp": 1537429419, "event_type": "insert", "id": 10}
 ```
 
-The first record is always the JSON format schema for the table describing the\
-types and names of the fields. All records that follow it represent the changes\
+The first record is always the JSON format schema for the table describing the
+types and names of the fields. All records that follow it represent the changes
 that have happened on the database.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-servers.md
@@ -4,7 +4,7 @@
 
 ## Configuring Servers
 
-The first step is to define the servers that make up the cluster. These servers\
+The first step is to define the servers that make up the cluster. These servers
 will be used by the services and are monitored by the monitor.
 
 ```
@@ -28,10 +28,10 @@ The `address` and `port` parameters tell where the server is located.
 
 ### Enabling TLS
 
-To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`\
+To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`
 to the server section. To enable server certificate verification, add`ssl_verify_peer_certificate=true`.
 
-The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line\
+The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line
 client.
 
 For more information about TLS, refer to the [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-the-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-the-galera-monitor.md
@@ -20,19 +20,19 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
-This monitor module will assign one node within the Galera Cluster as the\
-current primary and other nodes as replica. Only those nodes that are active\
-members of the cluster are considered when making the choice of primary node. The\
+This monitor module will assign one node within the Galera Cluster as the
+current primary and other nodes as replica. Only those nodes that are active
+members of the cluster are considered when making the choice of primary node. The
 primary node will be the node with the lowest value of `wsrep_local_index`.
 
 ### Monitor User
 
-The monitor user does not require any special grants to monitor a Galera\
+The monitor user does not require any special grants to monitor a Galera
 cluster. To create a user for the monitor, execute the following SQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-the-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-the-mariadb-monitor.md
@@ -4,7 +4,7 @@
 
 ## Configuring the MariaDB Monitor
 
-This document describes how to configure a MariaDB primary-replica cluster monitor\
+This document describes how to configure a MariaDB primary-replica cluster monitor
 to be used with MaxScale.
 
 ### Configuring the Monitor
@@ -21,14 +21,14 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
 ### Monitor User
 
-The monitor user requires the REPLICATION CLIENT privileges to do basic\
+The monitor user requires the REPLICATION CLIENT privileges to do basic
 monitoring. To create a user with the proper grants, execute the following SQL.
 
 ```
@@ -36,7 +36,7 @@ CREATE USER 'monitor_user'@'%' IDENTIFIED BY 'my_password';
 GRANT REPLICATION CLIENT ON *.* TO 'monitor_user'@'%';
 ```
 
-**Note:** If the automatic failover of the MariaDB Monitor will used, the user\
+**Note:** If the automatic failover of the MariaDB Monitor will used, the user
 will require additional grants. Execute the following SQL to grant them.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-the-xpand-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-the-xpand-monitor.md
@@ -4,19 +4,19 @@
 
 ## Configuring the Xpand Monitor
 
-This document describes how to configure the Xpand monitor for use\
+This document describes how to configure the Xpand monitor for use
 with a Xpand cluster.
 
 ### Configuring the Monitor
 
-Contrary to the other monitors of MaxScale, the Xpand monitor will\
-autonomously figure out the cluster configuration and for each Xpand\
+Contrary to the other monitors of MaxScale, the Xpand monitor will
+autonomously figure out the cluster configuration and for each Xpand
 node create the corresponding MaxScale server object.
 
-In order to do that, a _sufficient_ number of "bootstrap" server instances\
-must be specified in the MaxScale configuration file for the Xpand\
-monitor to start with. One server instance is in principle sufficient, but\
-if the corresponding node happens to be down when MaxScale starts, the\
+In order to do that, a _sufficient_ number of "bootstrap" server instances
+must be specified in the MaxScale configuration file for the Xpand
+monitor to start with. One server instance is in principle sufficient, but
+if the corresponding node happens to be down when MaxScale starts, the
 monitor will not be able to function.
 
 ```
@@ -33,8 +33,8 @@ port=3306
 protocol=mariadbbackend
 ```
 
-The server configuration is identical with that of any other server, but since\
-these servers are _only_ used for bootstrapping the Xpand monitor it is\
+The server configuration is identical with that of any other server, but since
+these servers are _only_ used for bootstrapping the Xpand monitor it is
 adviceable to use names that clearly will identify them as such.
 
 The actual Xpand monitor configuration looks as follows:
@@ -50,20 +50,20 @@ monitor_interval=2s
 cluster_monitor_interval=60s
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to use for bootstrapping and the username and password to use\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to use for bootstrapping and the username and password to use
 when connecting to the servers.
 
-The `monitor_interval` parameter specifies how frequently the monitor should\
-ping the health check port of each server and the `cluster_monitor_interval`\
-specifies how frequently the monitor should do a complete cluster check, that\
-is, access the `system` tables of the Cluster for checking the Cluster\
-configuration. The default values are `2000` and `60000`, that is, 2 seconds\
+The `monitor_interval` parameter specifies how frequently the monitor should
+ping the health check port of each server and the `cluster_monitor_interval`
+specifies how frequently the monitor should do a complete cluster check, that
+is, access the `system` tables of the Cluster for checking the Cluster
+configuration. The default values are `2000` and `60000`, that is, 2 seconds
 and 1 minute, respectively.
 
-For each detected Xpand node a corresponding MaxScale server object will be\
-created, whose name is `@@<Monitor-Name>:node-<id>, where _Monitor-Name_ is the name of the monitor, in this example`Xpand\` and _id_ is the node id\
-of the Xpand node. So, with a cluster of three nodes, the created servers\
+For each detected Xpand node a corresponding MaxScale server object will be
+created, whose name is `@@<Monitor-Name>:node-<id>, where _Monitor-Name_ is the name of the monitor, in this example`Xpand\` and _id_ is the node id
+of the Xpand node. So, with a cluster of three nodes, the created servers
 might be named like.
 
 ```
@@ -72,9 +72,9 @@ might be named like.
 @@Xpand:node-7`
 ```
 
-Note that as these are created at runtime and may disappear at any moment,\
-depending on changes happening in and made to the Xpand cluster, they\
-should never be referred to directly from service configurations. Instead,\
+Note that as these are created at runtime and may disappear at any moment,
+depending on changes happening in and made to the Xpand cluster, they
+should never be referred to directly from service configurations. Instead,
 services should refer to the monitor, as shown in the following:
 
 ```
@@ -86,9 +86,9 @@ password=service_password
 cluster=Xpand
 ```
 
-Instead of listing the servers of the service explicitly using the `servers`\
-parameter as usually is the case, the service refers to the Xpand monitor\
-using the `cluster` parameter. This will cause the service to use the Xpand\
+Instead of listing the servers of the service explicitly using the `servers`
+parameter as usually is the case, the service refers to the Xpand monitor
+using the `cluster` parameter. This will cause the service to use the Xpand
 nodes that the Xpand monitor discovers at runtime.
 
 For additional details, please consult the monitor [documentation](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-connection-routing-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-connection-routing-with-mariadb-maxscale.md
@@ -4,8 +4,8 @@
 
 ## Connection Routing with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that has two ports available, one for\
-write connections and another for read connections. The read connections are load-\
+The goal of this tutorial is to configure a system that has two ports available, one for
+write connections and another for read connections. The read connections are load-
 balanced across replica servers.
 
 ### Setting up MariaDB MaxScale
@@ -15,11 +15,11 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring services
 
-We want two services and ports to which the client application can connect. One service\
-routes client connections to the primary server, the other load balances between replica\
+We want two services and ports to which the client application can connect. One service
+routes client connections to the primary server, the other load balances between replica
 servers. To achieve this, we need to define two services in the configuration file.
 
-Create the following two sections in your configuration file. The section names are the\
+Create the following two sections in your configuration file. The section names are the
 names of the services and should be meaningful. For this tutorial, we use the names_Write-Service_ and _Read-Service_.
 
 ```
@@ -40,18 +40,18 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readconnroute_ for\
+_router_ defines the routing module used. Here we use _readconnroute_ for
 connection-level routing.
 
-A service needs a list of servers to route queries to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers to route queries to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _router\_options_-parameter tells the _readconnroute_-module which servers it should\
-route a client connection to. For the write service we use the `master`-type and for the\
+The _router\_options_-parameter tells the _readconnroute_-module which servers it should
+route a client connection to. For the write service we use the `master`-type and for the
 read service the `slave`-type.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2308-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2308-encrypting-passwords.md).
@@ -59,7 +59,7 @@ For increased security, see [password encryption](mariadb-maxscale-2308-encrypti
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one per service is enough.
 
 ```
@@ -74,13 +74,13 @@ service=Read-Service
 port=3307
 ```
 
-The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set\
+The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set
 it to _Read-Service_.
 
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-encrypting-passwords.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-encrypting-passwords.md
@@ -4,24 +4,24 @@
 
 ## Encrypting Passwords
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
-There are two options for representing the password, either plain text or\
-encrypted passwords may be used. In order to use encrypted passwords a set of\
-keys must be generated that will be used by the encryption and decryption\
+There are two options for representing the password, either plain text or
+encrypted passwords may be used. In order to use encrypted passwords a set of
+keys must be generated that will be used by the encryption and decryption
 process. To generate the keys, use the `maxkeys` command.
 
 ```
 maxkeys
 ```
 
-By default the key file will be generated in `/var/lib/maxscale`. If a different\
-directory is required, it can be given as the first argument to the program. For\
+By default the key file will be generated in `/var/lib/maxscale`. If a different
+directory is required, it can be given as the first argument to the program. For
 more information, see `maxkeys --help`.
 
-Once the keys have been created the `maxpasswd` command can be used to generate\
+Once the keys have been created the `maxpasswd` command can be used to generate
 the encrypted password.
 
 ```
@@ -29,10 +29,10 @@ maxpasswd plainpassword
 96F99AA1315BDC3604B006F427DD9484
 ```
 
-The username and password, either encrypted or plain text, are stored in the\
+The username and password, either encrypted or plain text, are stored in the
 service section using the `user` and `password` parameters.
 
-If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For\
+If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For
 more information, see `maxkeys --help`.
 
 Here is an example configuration that uses an encrypted password.
@@ -47,7 +47,7 @@ user=maxscale
 password=96F99AA1315BDC3604B006F427DD9484
 ```
 
-If the key file is not in the default location, the [datadir](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#datadir) parameter must be\
+If the key file is not in the default location, the [datadir](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#datadir) parameter must be
 set to the directory that contains it.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-mariadb-maxscale-administration-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-mariadb-maxscale-administration-tutorial.md
@@ -4,47 +4,47 @@
 
 ## MariaDB MaxScale Administration Tutorial
 
-The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator\
-to a few of the common administration tasks. This is intended to be an\
-introduction for administrators who are new to MariaDB MaxScale and not a\
+The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator
+to a few of the common administration tasks. This is intended to be an
+introduction for administrators who are new to MariaDB MaxScale and not a
 reference to all the tasks that may be performed.
 
 ### Administration audit file
 
-The REST API calls that MaxCtrl and MaxGui issue to MaxScale can be logged\
+The REST API calls that MaxCtrl and MaxGui issue to MaxScale can be logged
 by enabling [admin\_audit](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#admin_audit).
 
 The generated file is a csv file that can be opened in most spread sheet programs.
 
 \[Rotating Log Files]\(#Rotating Log Files) also applies to the audit file.\
-The admin audit file will never be overwritten as a result of a rotate, unlike the\
+The admin audit file will never be overwritten as a result of a rotate, unlike the
 regular log file (in case a rotate is issued, but the file name has not been moved).\
-There is also the option to change the audit file name, which effectively rotates it\
+There is also the option to change the audit file name, which effectively rotates it
 independently of the regular log file.
 
 For e.g. `maxctrl alter maxscale admin_audit_file=/var/log/maxscale/admin_audit.march.csv`.
 
 ### Starting and Stopping MariaDB MaxScale
 
-MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,\
+MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,
 use `systemctl start maxscale`. To stop it, use `systemctl stop maxscale`.
 
 The systemd service file for MaxScale is located in`/lib/systemd/system/maxscale.service`.
 
 #### Additional Options for MaxScale
 
-Additional command line options and other systemd configuration options\
-can be given to MariaDB MaxScale by creating a drop-in file for the\
-service unit file. You can do this with the `systemctl edit maxscale.service`\
-command. For more information about systemd drop-in\
-files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)\
+Additional command line options and other systemd configuration options
+can be given to MariaDB MaxScale by creating a drop-in file for the
+service unit file. You can do this with the `systemctl edit maxscale.service`
+command. For more information about systemd drop-in
+files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)
 and [the systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html).
 
 ### Checking The Status Of The MariaDB MaxScale Services
 
-It is possible to use the maxctrl command to obtain statistics about the\
-services that are running within MaxScale. The maxctrl command `list services`\
-will give very basic information regarding services. This command may be either\
+It is possible to use the maxctrl command to obtain statistics about the
+services that are running within MaxScale. The maxctrl command `list services`
+will give very basic information regarding services. This command may be either
 run in interactive mode or passed on the maxctrl command line.
 
 ```
@@ -64,16 +64,16 @@ $ maxctrl list services
 └────────────────────────┴────────────────┴─────────────┴───────────────────┴────────────────────────────────────┘
 ```
 
-Network listeners count as a user of the service, therefore there will always be\
-one user per network port in which the service listens. More details can be\
+Network listeners count as a user of the service, therefore there will always be
+one user per network port in which the service listens. More details can be
 obtained by using the "show service" command.
 
 ### What Clients Are Connected To MariaDB MaxScale
 
-To determine what client are currently connected to MariaDB MaxScale, you can\
-use the `list sessions` command within maxctrl. This will give you IP address\
-and the ID of the session for that connection. As with any maxctrl\
-command this can be passed on the command line or typed interactively in\
+To determine what client are currently connected to MariaDB MaxScale, you can
+use the `list sessions` command within maxctrl. This will give you IP address
+and the ID of the session for that connection. As with any maxctrl
+command this can be passed on the command line or typed interactively in
 maxctrl.
 
 ```
@@ -87,32 +87,32 @@ $ maxctrl list sessions
 
 ### Rotating Log Files
 
-Log rotation applies to the MaxScale log file, admin audit file and\
+Log rotation applies to the MaxScale log file, admin audit file and
 qlafilter files.
 
 MariaDB MaxScale logs messages of different priority into a single log file.\
-With the exception if error messages that are always logged, whether messages of\
-a particular priority should be logged or not can be enabled via the maxctrl\
-interface or in the configuration file. By default, MaxScale keeps on writing to\
-the same log file. To prevent the file from growing indefinitely, the\
+With the exception if error messages that are always logged, whether messages of
+a particular priority should be logged or not can be enabled via the maxctrl
+interface or in the configuration file. By default, MaxScale keeps on writing to
+the same log file. To prevent the file from growing indefinitely, the
 administrator must take action.
 
-The name of the log file is maxscale.log. When the log is rotated, MaxScale\
+The name of the log file is maxscale.log. When the log is rotated, MaxScale
 closes the current log file and opens a new one using the same name.
 
-Log file rotation is achieved by use of the `rotate logs` command\
+Log file rotation is achieved by use of the `rotate logs` command
 in maxctrl.
 
 ```
 maxctrl rotate logs
 ```
 
-As there currently is only the maxscale log, that is the only one that will be\
+As there currently is only the maxscale log, that is the only one that will be
 rotated.
 
-This may be integrated into the Linux _logrotate_ mechanism by adding a\
-configuration file to the /etc/logrotate.d directory. If we assume we want to\
-rotate the log files once per month and wish to keep 5 log files worth of\
+This may be integrated into the Linux _logrotate_ mechanism by adding a
+configuration file to the /etc/logrotate.d directory. If we assume we want to
+rotate the log files once per month and wish to keep 5 log files worth of
 history, the configuration file would look as follows.
 
 ```
@@ -131,7 +131,7 @@ endscript
 }
 ```
 
-MariaDB MaxScale will also rotate all of its log files if it receives the USR1\
+MariaDB MaxScale will also rotate all of its log files if it receives the USR1
 signal. Using this the logrotate configuration script can be rewritten as
 
 ```
@@ -147,41 +147,41 @@ endscript
 }
 ```
 
-In older versions MaxScale renamed the log file, behavior which is not fully\
-compliant with the assumptions of logrotate and may lead to issues, depending on\
-the used logrotate configuration file. From version 2.1 onward, MaxScale will\
-not itself rename the log file, but when the log is rotated, MaxScale will\
-simply close and reopen the same log file. That will make the behavior fully\
+In older versions MaxScale renamed the log file, behavior which is not fully
+compliant with the assumptions of logrotate and may lead to issues, depending on
+the used logrotate configuration file. From version 2.1 onward, MaxScale will
+not itself rename the log file, but when the log is rotated, MaxScale will
+simply close and reopen the same log file. That will make the behavior fully
 compliant with logrotate.
 
 ### Taking Objects Temporarily Out of Use
 
 #### Putting Servers into Maintenance
 
-MariaDB MaxScale supports the concept of maintenance mode for servers within a\
-cluster. This allows for planned, temporary removal of a database from the\
+MariaDB MaxScale supports the concept of maintenance mode for servers within a
+cluster. This allows for planned, temporary removal of a database from the
 cluster without the need to change the MariaDB MaxScale configuration.
 
 ```
 maxctrl set server db-server-3 maintenance
 ```
 
-To achieve this, you can use the `set server` command in maxctrl to set the\
-maintenance mode flag for the server. This may be done interactively within\
+To achieve this, you can use the `set server` command in maxctrl to set the
+maintenance mode flag for the server. This may be done interactively within
 maxctrl or by passing the command on the command line.
 
-This will cause MariaDB MaxScale to stop routing any new requests to the server,\
-however if there are currently requests executing on the server these will not\
-be interrupted. Connections to servers in maintenance mode are closed as soon as\
-the next request arrives. To close them immediately, use the `--force` option\
+This will cause MariaDB MaxScale to stop routing any new requests to the server,
+however if there are currently requests executing on the server these will not
+be interrupted. Connections to servers in maintenance mode are closed as soon as
+the next request arrives. To close them immediately, use the `--force` option
 for `maxctrl set server`.
 
 ```
 maxctrl clear server db-server-3 maintenance
 ```
 
-Clearing the maintenance mode for a server will bring it back into use. If\
-multiple MariaDB MaxScale instances are configured to use the node then\
+Clearing the maintenance mode for a server will bring it back into use. If
+multiple MariaDB MaxScale instances are configured to use the node then
 maintenance mode must be set within each MariaDB MaxScale instance.
 
 ### Stopping and Starting Services
@@ -190,16 +190,16 @@ maintenance mode must be set within each MariaDB MaxScale instance.
 maxctrl stop service db-service
 ```
 
-Services can be stopped to temporarily halt their use. Stopping a service will\
-cause it to stop accepting new connections until it is started. New connections\
-are not refused if the service is stopped and are queued instead. This means\
+Services can be stopped to temporarily halt their use. Stopping a service will
+cause it to stop accepting new connections until it is started. New connections
+are not refused if the service is stopped and are queued instead. This means
 that connecting clients will wait until the service is started again.
 
 ```
 maxctrl start service db-service
 ```
 
-Starting a service will cause it to accept all queued connections that were\
+Starting a service will cause it to accept all queued connections that were
 created while it was stopped.
 
 #### Stopping and Starting Monitors
@@ -208,35 +208,35 @@ created while it was stopped.
 maxctrl stop monitor db-monitor
 ```
 
-Stopping a monitor will cause it to stop monitoring the state of the servers\
-assigned to it. This is useful when the state of the servers is assigned\
+Stopping a monitor will cause it to stop monitoring the state of the servers
+assigned to it. This is useful when the state of the servers is assigned
 manually with `maxctrl set server`.
 
 ```
 maxctrl start monitor db-monitor
 ```
 
-Starting a monitor will make it resume monitoring of the servers. Any manually\
+Starting a monitor will make it resume monitoring of the servers. Any manually
 assigned states will be overwritten by the monitor.
 
 ### Runtime Configuration Modification
 
-The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,\
+The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,
 modify or destroy objects (servers, services, monitors etc.) inside\
-MaxScale. The exact syntax for each of the commands and any additional options\
+MaxScale. The exact syntax for each of the commands and any additional options
 that they take can be seen with `maxctrl --help <command>`.
 
-Not all parameters can be modified at runtime. Refer to the module documentation\
-for more information on which parameters can be modified at runtime. If a\
-parameter cannot be modified at runtime, the object can be destroyed and\
+Not all parameters can be modified at runtime. Refer to the module documentation
+for more information on which parameters can be modified at runtime. If a
+parameter cannot be modified at runtime, the object can be destroyed and
 recreated in order to change it.
 
-All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime\
-persist through restarts. Any changes done to objects in the main configuration\
+All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime
+persist through restarts. Any changes done to objects in the main configuration
 file are ignored if a persisted entry is found for it.
 
-For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete\
-configuration for the object. To remove all runtime changes for all objects,\
+For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete
+configuration for the object. To remove all runtime changes for all objects,
 remove all files found in `/var/lib/maxscale/maxscale.cnf.d`.
 
 #### Core Parameter Configuration
@@ -247,7 +247,7 @@ Modify global MaxScale parameters:
 maxctrl alter maxscale auth_connect_timeout 5s
 ```
 
-Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) for a full list\
+Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) for a full list
 of parameters that can be modified at runtime.
 
 #### Managing Servers
@@ -270,8 +270,8 @@ maxctrl alter server db-server-1 port 3307
 maxctrl destroy server db-server-1
 ```
 
-A server can only be destroyed if it is not used by any services or monitors. To\
-automatically remove the server from the services and monitors that use it, use\
+A server can only be destroyed if it is not used by any services or monitors. To
+automatically remove the server from the services and monitors that use it, use
 the `--force` flag.
 
 **Drain a Server**
@@ -280,9 +280,9 @@ the `--force` flag.
 maxctrl set server db-server-1 drain
 ```
 
-When a server is set into the `drain` state, no new connections to it are\
-created. Unlike to the `maintenance` state which immediately stops all new\
-requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them\
+When a server is set into the `drain` state, no new connections to it are
+created. Unlike to the `maintenance` state which immediately stops all new
+requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them
 in order to be gracefully closed once the client disconnects.
 
 To remove the `drain` state, use `clear server` command:
@@ -291,7 +291,7 @@ To remove the `drain` state, use `clear server` command:
 maxctrl clear server db-server-1 drain
 ```
 
-Servers with the `Master` state cannot be drained. To drain them, first perform\
+Servers with the `Master` state cannot be drained. To drain them, first perform
 a switchover to another node and then drain the server.
 
 #### Managing Monitors
@@ -326,7 +326,7 @@ maxctrl unlink monitor db-monitor db-server-1
 maxctrl destroy monitor db-monitor
 ```
 
-A monitor can only be destroyed if it is not monitoring any servers. To\
+A monitor can only be destroyed if it is not monitoring any servers. To
 automatically remove the servers from the monitor, use the `--force` flag.
 
 #### Managing Services
@@ -349,7 +349,7 @@ maxctrl alter service db-service user new-db-user
 maxctrl link service db-service db-server1
 ```
 
-Any servers added to services will only be used by new sessions. Existing\
+Any servers added to services will only be used by new sessions. Existing
 sessions will use the servers that were available when they connected.
 
 **Remove Servers from a Service**
@@ -358,8 +358,8 @@ sessions will use the servers that were available when they connected.
 maxctrl unlink service db-service db-server1
 ```
 
-Similarly to adding servers, removing servers from a service will only affect\
-new sessions. Existing sessions keep using the servers even if they are removed\
+Similarly to adding servers, removing servers from a service will only affect
+new sessions. Existing sessions keep using the servers even if they are removed
 from a service.
 
 **Change the Filters of a Service**
@@ -368,9 +368,9 @@ from a service.
 maxctrl alter service-filters my-regexfilter my-qlafilter
 ```
 
-The order of the filters is significant: the first filter will be the first to\
-receive the query. The new set of filters will only be used by new\
-sessions. Existing sessions will keep using the filters that were configured\
+The order of the filters is significant: the first filter will be the first to
+receive the query. The new set of filters will only be used by new
+sessions. Existing sessions will keep using the filters that were configured
 when they connected.
 
 **Destroy a Service**
@@ -379,9 +379,9 @@ when they connected.
 maxctrl destroy service db-service
 ```
 
-The service can only be destroyed if it uses no servers or clusters and has no\
-listeners associated with it. To force destruction of a service even if it does\
-use servers or has listeners, use the `--force` flag. This will also destroy any\
+The service can only be destroyed if it uses no servers or clusters and has no
+listeners associated with it. To force destruction of a service even if it does
+use servers or has listeners, use the `--force` flag. This will also destroy any
 listeners associated with the service.
 
 #### Managing Filters
@@ -398,11 +398,11 @@ maxctrl create filter regexfilter match=ENGINE=MyISAM replace=ENGINE=InnoDB
 maxctrl destroy filter my-regexfilter
 ```
 
-A filter can only be destroyed if it is not used by any services. To\
-automatically remove the filter from all services using it, use the `--force`\
+A filter can only be destroyed if it is not used by any services. To
+automatically remove the filter from all services using it, use the `--force`
 flag.
 
-Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters\
+Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters
 of a filter, destroy it and recreate it with the modified parameters.
 
 #### Managing Listeners
@@ -419,16 +419,16 @@ maxctrl create listener db-listener db-service 4006
 maxctrl destroy listener db-listener
 ```
 
-Destroying a listener will close the network socket and stop it from accepting\
-new connections. Existing connections that were created through it will keep\
+Destroying a listener will close the network socket and stop it from accepting
+new connections. Existing connections that were created through it will keep
 displaying it as the originating listener.
 
-Listeners cannot be moved from one service to another. In order to do this, the\
+Listeners cannot be moved from one service to another. In order to do this, the
 listener must be destroyed and then recreated with the new service.
 
 ### Managing MaxCtrl and REST API Users
 
-MaxCtrl uses the same credentials as the MaxScale REST API. These users can be\
+MaxCtrl uses the same credentials as the MaxScale REST API. These users can be
 managed via MaxCtrl.
 
 #### Create a New MaxCtrl User
@@ -437,14 +437,14 @@ managed via MaxCtrl.
 maxctrl create user basic-user basic-password
 ```
 
-By default new users are only allowed to read data. To make the account an\
+By default new users are only allowed to read data. To make the account an
 administrative account, add the `--type=admin` option to the command:
 
 ```
 maxctrl create user admin-user admin-password --type=admin
 ```
 
-Administrative accounts are allowed to use all MaxCtrl commands and modify any\
+Administrative accounts are allowed to use all MaxCtrl commands and modify any
 parts of MaxScale.
 
 #### Change the Password of an Existing User

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-maxscale-and-xpand-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-maxscale-and-xpand-tutorial.md
@@ -4,25 +4,25 @@
 
 ## MaxScale and Xpand Tutorial
 
-Since version 2.4, MaxScale has built-in support for Xpand. This\
-tutorial explains how to setup MaxScale in front of a Xpand\
+Since version 2.4, MaxScale has built-in support for Xpand. This
+tutorial explains how to setup MaxScale in front of a Xpand
 cluster.
 
-There is no Xpand specific router, but both the [readconnroute](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readconnroute.md) and\
-the [readwritesplit](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md) routers can be\
+There is no Xpand specific router, but both the [readconnroute](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readconnroute.md) and
+the [readwritesplit](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md) routers can be
 used.
 
 ### Xpand and Readconnroute
 
-With _readconnroute_ you get simple connection based routing, where\
-each new connection is created (by default) to the Xpand node with\
-the least amount of existing connections. That is, with readconnroute\
-the behaviour will be very similar to the behaviour when [HAProxy](https://www.haproxy.org) is used as the Xpand load\
+With _readconnroute_ you get simple connection based routing, where
+each new connection is created (by default) to the Xpand node with
+the least amount of existing connections. That is, with readconnroute
+the behaviour will be very similar to the behaviour when [HAProxy](https://www.haproxy.org) is used as the Xpand load
 balancer.
 
 #### Bootstrap servers
 
-The Xpand monitor is capable of autonomously figuring out the cluster\
+The Xpand monitor is capable of autonomously figuring out the cluster
 configuration, but in order to get going there must be at least one_server_-section referring to a node in the Xpand cluster.
 
 ```
@@ -33,9 +33,9 @@ port=3306
 protocol=MySQLBackend
 ```
 
-That server definition will be used by the monitor in order to connect\
-to the Xpand cluster. There can be more than one such "bootstrap"\
-definition to cater for the case that the node used as a bootstrap\
+That server definition will be used by the monitor in order to connect
+to the Xpand cluster. There can be more than one such "bootstrap"
+definition to cater for the case that the node used as a bootstrap
 server is down when MaxScale starts.
 
 **NOTE** These bootstrap servers should _only_ be referred to from the\
@@ -43,7 +43,7 @@ Xpand monitor configuration, but _never_ from a service.
 
 #### Monitor
 
-In the Xpand monitor section, the bootstrap servers are referred to\
+In the Xpand monitor section, the bootstrap servers are referred to
 in the same way as "ordinary" servers are referred to in other monitors.
 
 ```
@@ -64,19 +64,19 @@ GRANT SELECT ON system.nodeinfo TO 'maxscale-monitor'@'maxscalehost';
 GRANT SELECT ON system.softfailed_nodes TO 'maxscale-monitor'@'maxscalehost';
 ```
 
-In case the same user is used both for the monitor and the service (see below),\
+In case the same user is used both for the monitor and the service (see below),
 then the user must be given the grants required by the service as well.
 
-The bootstrap servers are only used for connecting to the Xpand\
-cluster; thereafter the Xpand monitor will dynamically find out the\
+The bootstrap servers are only used for connecting to the Xpand
+cluster; thereafter the Xpand monitor will dynamically find out the
 cluster configuration.
 
-The discovered cluster configuration will be stored (the ips and ports\
-of the Xpand nodes) and upon subsequent restarts the Xpand\
-monitor will use that information if the bootstrap servers happen to\
+The discovered cluster configuration will be stored (the ips and ports
+of the Xpand nodes) and upon subsequent restarts the Xpand
+monitor will use that information if the bootstrap servers happen to
 be unavailable.
 
-With the configuration above `maxctrl list servers` might output\
+With the configuration above `maxctrl list servers` might output
 the following:
 
 ```
@@ -95,7 +95,7 @@ the following:
 
 All servers whose name start with `@@` have been detected dynamically.
 
-Note that the address `10.2.224.101` appears twice; once for`Bootstrap-1` and another time for `@@Xpand:node-6`. The Xpand\
+Note that the address `10.2.224.101` appears twice; once for`Bootstrap-1` and another time for `@@Xpand:node-6`. The Xpand
 monitor will create a dynamic server instance for _all_ nodes in the\
 Xpand cluster; also for the ones used in bootstrap server sections.
 
@@ -120,22 +120,22 @@ GRANT SELECT ON system.users TO 'maxscale-service'@'maxscalehost';
 GRANT SELECT ON system.user_acl TO 'maxscale-service'@'maxscalehost';
 ```
 
-In case the same user is used both for the monitor (see above) and the service,\
+In case the same user is used both for the monitor (see above) and the service,
 then the user must be given the grants required by the monitor as well.
 
-Note that the service does _not_ list any specific servers, but\
+Note that the service does _not_ list any specific servers, but
 instead refers, using the argument `cluster`, to the Xpand monitor.
 
-In practice this means that the service will use the servers of the\
-monitor named `Xpand` and in the case of a Xpand monitor those\
-servers will be the ones that the monitor has detected\
-dynamically. That is, when setup like this, the service will\
-automatically adjust to any changes taking place in the Xpand\
+In practice this means that the service will use the servers of the
+monitor named `Xpand` and in the case of a Xpand monitor those
+servers will be the ones that the monitor has detected
+dynamically. That is, when setup like this, the service will
+automatically adjust to any changes taking place in the Xpand
 cluster.
 
-**NOTE** There is no need to specify any `router_options`, but the\
+**NOTE** There is no need to specify any `router_options`, but the
 default `router_options=running` provides the desired behaviour.\
-In particular do **not** specify `router_options=master` as that will\
+In particular do **not** specify `router_options=master` as that will
 cause only a _single_ node to be used.
 
 #### Listener
@@ -152,22 +152,22 @@ port=4008
 
 ### Xpand and Readwritesplit
 
-The primary purpose of the router _readwritesplit_ is to split\
+The primary purpose of the router _readwritesplit_ is to split
 statements between one primary and multiple replicas. In the case of\
-Xpand, all servers will be primaries, but _readwritesplit_ may still\
+Xpand, all servers will be primaries, but _readwritesplit_ may still
 be the right choice.
 
-Namely, as _readwritesplit_ is transaction aware and capable of\
-replaying transactions, it can be used for hiding certain events\
+Namely, as _readwritesplit_ is transaction aware and capable of
+replaying transactions, it can be used for hiding certain events
 taking place in Xpand from the clients that use it.
 
-For instance, whenever a node is removed from or added to a Xpand\
-cluster there will be a _group change_, which is visible to a client\
-as a transaction rollback. However, if _readwritesplit_ is used and\
-transaction replay is enabled, then MaxScale may be able to hide the\
+For instance, whenever a node is removed from or added to a Xpand
+cluster there will be a _group change_, which is visible to a client
+as a transaction rollback. However, if _readwritesplit_ is used and
+transaction replay is enabled, then MaxScale may be able to hide the
 group change so that the client only detects a slight delay.
 
-Apart from the service section, the configuration when using_readwritesplit_ is identical to the _readconnroute_ configuration\
+Apart from the service section, the configuration when using_readwritesplit_ is identical to the _readconnroute_ configuration
 described above.
 
 #### Service
@@ -185,20 +185,20 @@ transaction_replay=true
 slave_selection_criteria=LEAST_GLOBAL_CONNECTIONS
 ```
 
-With this configuration, subject to the boundary conditions of\
-transaction replaying, a client will neither notice group change\
-events nor the disappearance of the very node the client is connected\
-to. In that latter case, MaxScale will simply connect to another node\
-and replay the current transaction (if one is active). For detailed\
-information about the transaction replay functionality, please refer\
+With this configuration, subject to the boundary conditions of
+transaction replaying, a client will neither notice group change
+events nor the disappearance of the very node the client is connected
+to. In that latter case, MaxScale will simply connect to another node
+and replay the current transaction (if one is active). For detailed
+information about the transaction replay functionality, please refer
 to the _readwritesplit_[documentation](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md#transaction_replay).
 
-**NOTE** It is vital to have`slave_selection_criteria=LEAST_GLOBAL_CONNECTIONS`, as otherwise\
-connections will **not** be distributed evenly across all Xpand\
+**NOTE** It is vital to have`slave_selection_criteria=LEAST_GLOBAL_CONNECTIONS`, as otherwise
+connections will **not** be distributed evenly across all Xpand
 nodes.
 
-As a rule of thumb, use _readwritesplit_ if it is important that\
-changes taking place in the cluster configuration are hidden from the\
+As a rule of thumb, use _readwritesplit_ if it is important that
+changes taking place in the cluster configuration are hidden from the
 applications, otherwise use _readconnroute_.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-read-write-splitting-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-read-write-splitting-with-mariadb-maxscale.md
@@ -4,8 +4,8 @@
 
 ## Read-Write Splitting with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that appears to the client as a single\
-database. MariaDB MaxScale will split the statements such that write statements are sent\
+The goal of this tutorial is to configure a system that appears to the client as a single
+database. MariaDB MaxScale will split the statements such that write statements are sent
 to the primary server and read statements are balanced across the replica servers.
 
 ### Setting up MariaDB MaxScale
@@ -15,9 +15,9 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring the service
 
-After configuring the servers and the monitor, we create a read-write-splitter service\
-configuration. Create the following section in your configuration file. The section name\
-is also the name of the service and should be meaningful. For this tutorial, we use the\
+After configuring the servers and the monitor, we create a read-write-splitter service
+configuration. Create the following section in your configuration file. The section name
+is also the name of the service and should be meaningful. For this tutorial, we use the
 name _Splitter-Service_.
 
 ```
@@ -29,14 +29,14 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readwritesplit_ for\
+_router_ defines the routing module used. Here we use _readwritesplit_ for
 query-level read-write-splitting.
 
-A service needs a list of servers where queries will be routed to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers where queries will be routed to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2308-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2308-encrypting-passwords.md).
@@ -44,7 +44,7 @@ For increased security, see [password encryption](mariadb-maxscale-2308-encrypti
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one is enough.
 
 ```
@@ -59,7 +59,7 @@ The _service_ parameter tells which service the listener connects to. For the_Sp
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-rest-api-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-rest-api-tutorial.md
@@ -4,23 +4,23 @@
 
 ## REST API Tutorial
 
-This tutorial is a quick overview of what the MaxScale REST API offers, how it\
-can be used to inspect the state of MaxScale and how to use it to modify the\
-runtime configuration of MaxScale. The tutorial uses the `curl` command line\
+This tutorial is a quick overview of what the MaxScale REST API offers, how it
+can be used to inspect the state of MaxScale and how to use it to modify the
+runtime configuration of MaxScale. The tutorial uses the `curl` command line
 client to demonstrate how the API is used.
 
 ### Configuration and Hardening
 
-The MaxScale REST API listens on port 8989 on the local host. The `admin_port`\
-and `admin_host` parameters control which port and address the REST API listens\
-on. Note that for security reasons the API only listens for local connections\
-with the default configuration. It is critical that the default credentials are\
-changed and TLS/SSL encryption is configured before exposing the REST API to a\
+The MaxScale REST API listens on port 8989 on the local host. The `admin_port`
+and `admin_host` parameters control which port and address the REST API listens
+on. Note that for security reasons the API only listens for local connections
+with the default configuration. It is critical that the default credentials are
+changed and TLS/SSL encryption is configured before exposing the REST API to a
 network.
 
-The default user for the REST API is `admin` and the password is `mariadb`. The\
-easiest way to secure the REST API is to use the `maxctrl` command line client\
-to create a new admin user and delete the default one. To do this, run the\
+The default user for the REST API is `admin` and the password is `mariadb`. The
+easiest way to secure the REST API is to use the `maxctrl` command line client
+to create a new admin user and delete the default one. To do this, run the
 following commands:
 
 ```
@@ -28,13 +28,13 @@ maxctrl create user my_user my_password --type=admin
 maxctrl destroy user admin
 ```
 
-This will create the user `my_user` with the password `my_password` that is an\
-administrative account. After this account is created, the default `admin`\
+This will create the user `my_user` with the password `my_password` that is an
+administrative account. After this account is created, the default `admin`
 account is removed with the next command.
 
-The next step is to enable TLS encryption. To do this, you need a CA\
-certificate, a private key and a public certificate file all in PEM format. Add\
-the following three parameters under the `[maxscale]` section of the MaxScale\
+The next step is to enable TLS encryption. To do this, you need a CA
+certificate, a private key and a public certificate file all in PEM format. Add
+the following three parameters under the `[maxscale]` section of the MaxScale
 configuration file and restart MaxScale.
 
 ```
@@ -43,15 +43,15 @@ admin_ssl_cert=/certs/server-cert.pem
 admin_ssl_ca_cert=/certs/ca-cert.pem
 ```
 
-Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our\
-server certificates are self-signed so the `--tls-verify-server-cert=false`\
+Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our
+server certificates are self-signed so the `--tls-verify-server-cert=false`
 option is required.
 
 ```
 maxctrl --user=my_user --password=my_password --secure --tls-ca-cert=/certs/ca-cert.pem --tls-verify-server-cert=false show maxscale
 ```
 
-If no errors are raised, this means that the communication via the REST API is\
+If no errors are raised, this means that the communication via the REST API is
 now secure and can be used across networks.
 
 ### Requesting Data
@@ -59,8 +59,8 @@ now secure and can be used across networks.
 **Note:** For the sake of brevity, the rest of this tutorial will omit the\
 TLS/SSL options from the `curl` command line. For more information, refer to the`curl` manpage.
 
-The most basic task to do with the REST API is to see whether MaxScale is up and\
-running. To do this, we do a HTTP request on the root resource (the `-i` option\
+The most basic task to do with the REST API is to see whether MaxScale is up and
+running. To do this, we do a HTTP request on the root resource (the `-i` option
 shows the HTTP headers).
 
 `curl -i 127.0.0.1:8989/v1/`
@@ -74,7 +74,7 @@ ETag: "0"
 Date: Mon, 04 Mar 19 08:29:41 GMT
 ```
 
-To query a resource collection endpoint, append it to the URL. The `/v1/filters/`\
+To query a resource collection endpoint, append it to the URL. The `/v1/filters/`
 endpoint shows the list of filters configured in MaxScale. This is a _resource collection_ endpoint: it contains the list of all resources of a particular type.
 
 `curl 127.0.0.1:8989/v1/filters`
@@ -149,17 +149,17 @@ endpoint shows the list of filters configured in MaxScale. This is a _resource c
 }
 ```
 
-The `data` holds the actual list of resources: the `Hint` and `Logger`\
-filters. Each object has the `id` field which is the unique name of that\
+The `data` holds the actual list of resources: the `Hint` and `Logger`
+filters. Each object has the `id` field which is the unique name of that
 object. It is the same as the section name in `maxscale.cnf`.
 
-Each resource in the list has a `relationships` object. This shows the\
-relationship links between resources. In our example, the `Hint` filter is used\
-by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in\
+Each resource in the list has a `relationships` object. This shows the
+relationship links between resources. In our example, the `Hint` filter is used
+by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in
 use.
 
-To request an individual resource, we add the object name to the resource\
-collection URL. For example, if we want to get only the `Logger` filter we\
+To request an individual resource, we add the object name to the resource
+collection URL. For example, if we want to get only the `Logger` filter we
 execute the following command.
 
 `curl 127.0.0.1:8989/v1/filters/Logger`
@@ -208,18 +208,18 @@ execute the following command.
 }
 ```
 
-Note that this time the `data` member holds an object instead of an array of\
-objects. All other parts of the response are similar to what was shown in the\
+Note that this time the `data` member holds an object instead of an array of
+objects. All other parts of the response are similar to what was shown in the
 previous example.
 
 ### Creating Objects
 
-One of the uses of the REST API is to create new objects in MaxScale at\
-runtime. This allows new servers, services, filters, monitor and listeners to be\
+One of the uses of the REST API is to create new objects in MaxScale at
+runtime. This allows new servers, services, filters, monitor and listeners to be
 created without restarting MaxScale.
 
-For example, to create a new server in MaxScale the JSON definition of a server\
-must be sent to the REST API at the `/v1/servers/` endpoint. The request body\
+For example, to create a new server in MaxScale the JSON definition of a server
+must be sent to the REST API at the `/v1/servers/` endpoint. The request body
 defines the server name as well as the parameters for it.
 
 To create objects with `curl`, first write the JSON definition into a file.
@@ -245,9 +245,9 @@ To send the data, use the following command.
 curl -X POST -d @new_server.txt 127.0.0.1:8989/v1/servers
 ```
 
-The `-d` option takes a file name prefixed with a `@` as an argument. Here we\
-have `@new_server.txt` which is the name of the file where the JSON definition\
-was stored. The `-X` option defines the HTTP verb to use and to create a new\
+The `-d` option takes a file name prefixed with a `@` as an argument. Here we
+have `@new_server.txt` which is the name of the file where the JSON definition
+was stored. The `-X` option defines the HTTP verb to use and to create a new
 object we must use the POST verb.
 
 To verify the data request the newly created object.
@@ -258,18 +258,18 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Modifying Data
 
-The easiest way to modify an object is to first request it, store the result in\
+The easiest way to modify an object is to first request it, store the result in
 a file, edit it and then send the updated object back to the REST API.
 
-Let's say we want to modify the port that the server we created earlier listens\
+Let's say we want to modify the port that the server we created earlier listens
 on. First we request the current object and store the result in a file.
 
 ```
 curl 127.0.0.1:8989/v1/servers/server1 > server1.txt
 ```
 
-After that we edit the file and change the port from 3003 to 3306. Next the\
-modified JSON object is sent to the REST API as a PATCH command. To do this,\
+After that we edit the file and change the port from 3003 to 3306. Next the
+modified JSON object is sent to the REST API as a PATCH command. To do this,
 execute the following command.
 
 ```
@@ -284,12 +284,12 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Object Relationships
 
-To continue with our previous example, we add the updated server to a\
-service. To do this, the `relationships` object of the server must be modified\
+To continue with our previous example, we add the updated server to a
+service. To do this, the `relationships` object of the server must be modified
 to include the service we want to add the server to.
 
-To define a relationship between a server and a service, the `data` member must\
-have the `relationships` field and it must contain an object with the `services`\
+To define a relationship between a server and a service, the `data` member must
+have the `relationships` field and it must contain an object with the `services`
 field (some fields omitted for brevity).
 
 ```
@@ -312,13 +312,13 @@ field (some fields omitted for brevity).
 }
 ```
 
-The `data.relationships.services.data` field contains a list of objects that\
-define the `id` and `type` fields. The id is the name of the object (a service\
-or a monitor for servers) and the type tells which type it is. Only `services`\
+The `data.relationships.services.data` field contains a list of objects that
+define the `id` and `type` fields. The id is the name of the object (a service
+or a monitor for servers) and the type tells which type it is. Only `services`
 type objects should be present in the `services` object.
 
-In our example we are linking the `server1` server to the `RW-Split-Router`\
-service. As was seen with the previous example, the easiest way to do this is to\
+In our example we are linking the `server1` server to the `RW-Split-Router`
+service. As was seen with the previous example, the easiest way to do this is to
 store the result, edit it and then send it back with a HTTP PATCH.
 
 If we want to remove a server from _all_ services and monitors, we can set the`data` member of the `services` and `monitors` relationships to an empty array:
@@ -338,39 +338,39 @@ If we want to remove a server from _all_ services and monitors, we can set the`d
 }
 ```
 
-This is useful if you want to delete the server which can only be done if it has\
+This is useful if you want to delete the server which can only be done if it has
 no relationships to other objects.
 
 ### Deleting Objects
 
-To delete an object, simply execute a HTTP DELETE request on the resource you\
-want to delete. For example, to delete the `server1` server, execute the\
+To delete an object, simply execute a HTTP DELETE request on the resource you
+want to delete. For example, to delete the `server1` server, execute the
 following command.
 
 ```
 curl -X DELETE 127.0.0.1:8989/v1/servers/server1
 ```
 
-In order to delete an object, it must not have any relationships to other\
+In order to delete an object, it must not have any relationships to other
 objects.
 
 ### Further Reading
 
 The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../../../../../en/mariadb-maxscale-2308-maxscale-rest-api/).
 
-The `maxctrl` command line client is self-documenting and the `maxctrl help`\
-command is a good tool for exploring the various commands that are available in\
-it. The `maxctrl api get` command can be useful way to explore the REST API as\
+The `maxctrl` command line client is self-documenting and the `maxctrl help`
+command is a good tool for exploring the various commands that are available in
+it. The `maxctrl api get` command can be useful way to explore the REST API as
 it provides a way to easily extract values out of the JSON data generated by the\
 REST API.
 
-There is a multitude of REST API clients readily available and most of them are\
-far more convenient to use than `curl`. We recommend investigating what you need\
-and how you intend to either integrate or use the MaxScale REST API. Most modern\
-languages either have a built-in HTTP library or there exists a de facto\
+There is a multitude of REST API clients readily available and most of them are
+far more convenient to use than `curl`. We recommend investigating what you need
+and how you intend to either integrate or use the MaxScale REST API. Most modern
+languages either have a built-in HTTP library or there exists a de facto
 standard library.
 
-The MaxScale REST API follows the JSON API specification and there exist\
+The MaxScale REST API follows the JSON API specification and there exist
 libraries that are built specifically for these sorts of APIs
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-setting-up-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-setting-up-mariadb-maxscale.md
@@ -7,26 +7,26 @@
 This document is designed as a quick introduction to setting up MariaDB MaxScale.
 
 The installation and configuration of the MariaDB Server is not covered in this document.\
-See the following MariaDB documentation articles for more information on setting up a\
-primary-replica-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)\
+See the following MariaDB documentation articles for more information on setting up a
+primary-replica-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)
 and [Getting Started With MariaDB Galera Cluster](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster)\
 .
 
-This tutorial assumes that one of the standard MaxScale binary distributions is used and\
+This tutorial assumes that one of the standard MaxScale binary distributions is used and
 that MaxScale is installed using default options.
 
 Building from source code in GitHub is covered in [Building from Source](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-building-mariadb-maxscale-from-source-code.md).
 
 ### Installing MaxScale
 
-The precise installation process varies from one distribution to another. Details on\
+The precise installation process varies from one distribution to another. Details on
 package installation can be found in the [Installation Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-installation-guide.md).
 
 ### Creating a user account for MaxScale
 
-MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve\
-user authentication information from the backend databases. Create a special user\
-account for this purpose by executing the following SQL commands on the primary server of\
+MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve
+user authentication information from the backend databases. Create a special user
+account for this purpose by executing the following SQL commands on the primary server of
 your database cluster. The following tutorials will use these credentials.
 
 ```
@@ -45,12 +45,12 @@ MariaDB versions 10.2.2 to 10.2.10 also require `GRANT SELECT ON mysql.* TO 'max
 
 ### Creating client user accounts
 
-Because MariaDB MaxScale sits between the clients and the backend databases, the backend\
-databases will see all clients as if they were connecting from MaxScale's address. This\
+Because MariaDB MaxScale sits between the clients and the backend databases, the backend
+databases will see all clients as if they were connecting from MaxScale's address. This
 usually means that two sets of grants for each user are required.
 
-For example, assume that the user _'jdoe'@'client-host'_ exists and MaxScale is located at\_maxscale-host\_. If _'jdoe'@'client-host'_ needs to be able to connect through MaxScale,\
-another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the\
+For example, assume that the user _'jdoe'@'client-host'_ exists and MaxScale is located at\_maxscale-host\_. If _'jdoe'@'client-host'_ needs to be able to connect through MaxScale,
+another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the
 same password and similar grants as _'jdoe'@'client-host'_.
 
 The quickest way to do this is to first create the new user:
@@ -77,18 +77,18 @@ Then copy the same grants to the `'jdoe'@'maxscale-host'` user.
 GRANT SELECT, INSERT, UPDATE, DELETE ON *.* TO 'jdoe'@'maxscale-host';
 ```
 
-An alternative to generating two separate accounts is to use one account with a wildcard\
-host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than\
+An alternative to generating two separate accounts is to use one account with a wildcard
+host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than
 having specific user accounts as it allows access from all hosts.
 
 ### Creating the configuration file
 
-MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is\
+MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is
 provided with the MaxScale installation.
 
-A global _maxscale_ section is included in every MaxScale configuration file. This section\
-sets the values of various global parameters, such as the number of threads MaxScale uses\
-to handle client requests. To set thread count to the number of available cpu cores, set\
+A global _maxscale_ section is included in every MaxScale configuration file. This section
+sets the values of various global parameters, such as the number of threads MaxScale uses
+to handle client requests. To set thread count to the number of available cpu cores, set
 the following.
 
 ```
@@ -98,7 +98,7 @@ threads=auto
 
 ### Configuring the servers
 
-Read the [Configuring Servers](mariadb-maxscale-2308-configuring-servers.md) mini-tutorial for server\
+Read the [Configuring Servers](mariadb-maxscale-2308-configuring-servers.md) mini-tutorial for server
 configuration instructions.
 
 ### Configuring the monitor
@@ -115,7 +115,7 @@ For a simple connection based setup, read the [Connection Routing Tutorial](mari
 
 ### Starting MaxScale
 
-After configuration is complete, MariaDB MaxScale is ready to start. For systems that\
+After configuration is complete, MariaDB MaxScale is ready to start. For systems that
 use systemd, use the _systemctl_ command.
 
 ```
@@ -128,13 +128,13 @@ For older SysV systems, use the _service_ command.
 sudo service maxscale start
 ```
 
-If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see\
+If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see
 if any errors are detected in the configuration file.
 
 ### Checking MaxScale status with MaxCtrl
 
-The _maxctrl_-command can be used to confirm that MaxScale is running and the services,\
-listeners and servers have been correctly configured. The following shows expected output\
+The _maxctrl_-command can be used to confirm that MaxScale is running and the services,
+listeners and servers have been correctly configured. The following shows expected output
 when using a read-write-splitting configuration.
 
 ```
@@ -167,7 +167,7 @@ when using a read-write-splitting configuration.
 └───────────────────┴──────┴──────┴─────────┘
 ```
 
-MariaDB MaxScale is now ready to start accepting client connections and route queries to\
+MariaDB MaxScale is now ready to start accepting client connections and route queries to
 the backend cluster.
 
 More options can be found in the [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/),[readwritesplit module documentation](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md) and [readconnroute module documentation](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readconnroute.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-simple-sharding-with-two-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-simple-sharding-with-two-servers.md
@@ -4,16 +4,16 @@
 
 ## Schemarouter: Simple Sharding With Two Servers
 
-Sharding is the method of splitting a single logical database server into\
-separate physical databases. This tutorial describes a very simple way of\
+Sharding is the method of splitting a single logical database server into
+separate physical databases. This tutorial describes a very simple way of
 sharding. Each schema is located on a different database server and MariaDB\
-MaxScale's schemarouter module is used to combine them into a single logical\
+MaxScale's schemarouter module is used to combine them into a single logical
 database server.
 
 ### Environment
 
-This tutorial was written for Ubuntu 22.04, MaxScale 23.08 and [MariaDB 10.11](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/what-is-mariadb-1011). In addition to\
-the MaxScale server, you'll need two MariaDB servers which will be used for the\
+This tutorial was written for Ubuntu 22.04, MaxScale 23.08 and [MariaDB 10.11](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/what-is-mariadb-1011). In addition to
+the MaxScale server, you'll need two MariaDB servers which will be used for the
 sharding. The installation of MariaDB is not covered by this tutorial.
 
 ### Installing MaxScale
@@ -30,13 +30,13 @@ apt -y install maxscale
 
 ### Creating Users
 
-This tutorial uses a broader set of grants than is required for the sake of\
+This tutorial uses a broader set of grants than is required for the sake of
 brevity and backwards compatibility. For the minimal set of grants, refer to the [MaxScale Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/).
 
-All MaxScale configurations require at least two accounts: one for reading\
-authentication data and another for monitoring the state of the\
-database. Services will use the first one and monitors will use the second\
-one. In addition to this, we want to have a separate account that our\
+All MaxScale configurations require at least two accounts: one for reading
+authentication data and another for monitoring the state of the
+database. Services will use the first one and monitors will use the second
+one. In addition to this, we want to have a separate account that our
 application will use.
 
 ```
@@ -61,8 +61,8 @@ All of the users must be created on both of the MariaDB servers.
 
 ### Creating the Schemas and Tables
 
-Each server will hold one unique schema which contains the data of one specific\
-customer. We'll also create a shared schema that is present on all shards that\
+Each server will hold one unique schema which contains the data of one specific
+customer. We'll also create a shared schema that is present on all shards that
 the shard-local tables can be joined into.
 
 Create the tables on the first server:
@@ -95,8 +95,8 @@ INSERT INTO shared_info.account_types VALUES (1, 'admin'), (2, 'user');
 
 The MaxScale configuration is stored in `/etc/maxscale.cnf`.
 
-First, we configure two servers we will use to shard our database. The `db-01`\
-server has the `customer_01` schema and the `db-02` server has the `customer_02`\
+First, we configure two servers we will use to shard our database. The `db-01`
+server has the `customer_01` schema and the `db-02` server has the `customer_02`
 schema.
 
 ```
@@ -127,7 +127,7 @@ password=secret
 ignore_tables_regex=.*
 ```
 
-After this we configure a listener for the service. The listener is the actual\
+After this we configure a listener for the service. The listener is the actual
 port that the user connects to. We will use the port 4000.
 
 ```
@@ -137,11 +137,11 @@ service=Sharded-Service
 port=4000
 ```
 
-The final step is to configure a monitor which will monitor the state of the\
-servers. The monitor will notify MariaDB MaxScale if the servers are down. We\
-add the two servers to the monitor and use the `monitor_user` credentials. For\
-the sharding use-case, the `galeramon` module is suitable even if we're not\
-using a Galera cluster. The `schemarouter` is only interested in whether the\
+The final step is to configure a monitor which will monitor the state of the
+servers. The monitor will notify MariaDB MaxScale if the servers are down. We
+add the two servers to the monitor and use the `monitor_user` credentials. For
+the sharding use-case, the `galeramon` module is suitable even if we're not
+using a Galera cluster. The `schemarouter` is only interested in whether the
 server is in the `Running` state or in the `Down` state.
 
 ```
@@ -196,12 +196,12 @@ systemctl start maxscale.service
 
 ### Testing the Sharding
 
-MariaDB MaxScale is now ready to start accepting client connections and routing\
-them. Queries are routed to the right servers based on the database they target\
-and switching between the shards is seamless since MariaDB MaxScale keeps the\
+MariaDB MaxScale is now ready to start accepting client connections and routing
+them. Queries are routed to the right servers based on the database they target
+and switching between the shards is seamless since MariaDB MaxScale keeps the
 session state intact between servers.
 
-To test, we query the schema that's located on the local shard and join it to\
+To test, we query the schema that's located on the local shard and join it to
 the shared table.
 
 ```
@@ -274,8 +274,8 @@ MariaDB [customer_02]> SELECT * FROM customer_01.accounts UNION SELECT * FROM cu
 ERROR 1146 (42S02): Table 'customer_01.accounts' doesn't exist
 ```
 
-In most multi-tenant situations, this is an acceptable limitation. If you do\
-need cross-shard joins, the [Spider](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/spider/spider-storage-engine-overview) storage\
+In most multi-tenant situations, this is an acceptable limitation. If you do
+need cross-shard joins, the [Spider](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/spider/spider-storage-engine-overview) storage
 engine will provide you this.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-This tutorial is an overview of what the MaxGUI offers as an alternative\
+This tutorial is an overview of what the MaxGUI offers as an alternative
 solution to [MaxCtrl](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md).
 
 ## Dashboard
@@ -14,11 +14,11 @@ solution to [MaxCtrl](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-
 ### Annotation
 
 1. [MaxScale object](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#objects). i.e.\
-   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate\
+   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate
    to its detail page)
 2. Create a new MaxScale object.
 3. Dashboard Tab Navigation.
-4. Search Input. This can be used as a quick way to search for a keyword in\
+4. Search Input. This can be used as a quick way to search for a keyword in
    tables.
 5. Dashboard graphs. Refresh interval is 10 seconds.
 
@@ -32,18 +32,18 @@ solution to [MaxCtrl](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-
 
 ### Create a new MaxScale object
 
-Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating\
+Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating
 a new object.
 
 ### View Replication Status
 
-The replication status of a server monitored by [MariaDB-Monitor](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md) can be viewed by mousing over\
+The replication status of a server monitored by [MariaDB-Monitor](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md) can be viewed by mousing over
 the server name. A tooltip will be displayed with the following information:\
 replication\_state, seconds\_behind\_master, slave\_io\_running, slave\_sql\_running.
 
 ### How to kill a session
 
-A session can be killed easily on the "Current Sessions" list which can be\
+A session can be killed easily on the "Current Sessions" list which can be
 found on the [Dashboard](mariadb-maxscale-2308-using-maxgui-tutorial.md#dashboard), Server detail, and Service detail page.
 
 #### Annotation
@@ -53,32 +53,32 @@ found on the [Dashboard](mariadb-maxscale-2308-using-maxgui-tutorial.md#dashboar
 
 ## Detail
 
-This page shows information on each MaxScale object and allow to edit its\
-parameter, relationships and perform other manipulation operations. Most of the\
+This page shows information on each MaxScale object and allow to edit its
+parameter, relationships and perform other manipulation operations. Most of the
 control buttons will be shown on the mouse hover. Below is a screenshot of a\
-Monitor Detail page, other Detail pages also have a similar layout structure so\
+Monitor Detail page, other Detail pages also have a similar layout structure so
 this is used for illustration purpose.
 
 ### Annotation
 
-1. Settings option. Clicking on the gear icon will show icons allowing to do\
+1. Settings option. Clicking on the gear icon will show icons allowing to do
    different operations depending on the type of the Detail page.
 
 * Monitor Detail page, there are icons to Stop, Start, and Destroy monitor.
 * Service Detail page, there are icons to Stop, Start, and Destroy service.
-* Server Detail page, there are icons to Set maintenance mode, Clear server\
+* Server Detail page, there are icons to Set maintenance mode, Clear server
   state, Drain and Delete server.
-* Filter and Listener Detail page, there is a delete icon to delete the\
+* Filter and Listener Detail page, there is a delete icon to delete the
   object.
 
-1. Switchover button. This button is shown on the mouse hover allowing to\
+1. Switchover button. This button is shown on the mouse hover allowing to
    swap the running primary server with a designated secondary server.
-2. Edit parameters button. This button is shown on the mouse hover allowing\
-   to edit the MaxScale object's parameter. Clicking on it will enable editable\
+2. Edit parameters button. This button is shown on the mouse hover allowing
+   to edit the MaxScale object's parameter. Clicking on it will enable editable
    mode on the table. After finishing editing the parameters, simply click the\
    Done Editing button.
-3. A Detail page has tables showing "Relationship" between other MaxScale\
-   object. This "unlink" icon is shown on the mouse hover allowing to\
+3. A Detail page has tables showing "Relationship" between other MaxScale
+   object. This "unlink" icon is shown on the mouse hover allowing to
    remove the relationship between two objects.
 4. This button is used to link other MaxScale objects to the relationship.
 
@@ -92,12 +92,12 @@ This page visualizes MaxScale configuration as shown in the figure below.
 
 #### Annotation
 
-1. A MaxScale object (a node graph). The position of the node in the graph can\
+1. A MaxScale object (a node graph). The position of the node in the graph can
    be changed by dragging and dropping it.
-2. Anchor link. The detail page of each MaxScale object can be accessed by\
+2. Anchor link. The detail page of each MaxScale object can be accessed by
    clicking on the name of the node.
-3. Filter visualization button. By default, if the number of filters used by a\
-   service is larger than 3, filter nodes aren't visualized as shown in the\
+3. Filter visualization button. By default, if the number of filters used by a
+   service is larger than 3, filter nodes aren't visualized as shown in the
    figure. Clicking this button will visualize them.
 4. Hide filter visualization button.
 5. Refresh rate dropdown. The frequency with which the data is refreshed.
@@ -106,40 +106,40 @@ This page visualizes MaxScale configuration as shown in the figure below.
 ### Clusters
 
 This page shows all monitor clusters using [mariadbmon](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md) module in a card-like view.\
-Clicking on the card will visualize the cluster into a tree graph as shown in\
+Clicking on the card will visualize the cluster into a tree graph as shown in
 the figure below.
 
 #### Annotation
 
-1. Drag a secondary server on top of a primary server to promote the secondary\
+1. Drag a secondary server on top of a primary server to promote the secondary
    server as the new primary server.
-2. Server manipulation operations button. Showing a dropdown with the following\
+2. Server manipulation operations button. Showing a dropdown with the following
    operations:
 
 * Set maintenance mode: Setting a server to a maintenance mode.
 * Clear server state: Clear current server state.
 * Drain server: Drain the server of connections.
 
-1. Quick access to query editor button. Opening the `Query Editor` page for\
-   this server. If the connection is already created for that server, it'll use\
-   it. Otherwise, it creates a blank worksheet and shows a connection dialog to\
+1. Quick access to query editor button. Opening the `Query Editor` page for
+   this server. If the connection is already created for that server, it'll use
+   it. Otherwise, it creates a blank worksheet and shows a connection dialog to
    connect to that server.
-2. Carousel navigation button. Viewing more information about the server in the\
+2. Carousel navigation button. Viewing more information about the server in the
    next slide.
 3. Collapse the carousel.
-4. Anchor link of the server. Opening the detail page of the server in a new\
+4. Anchor link of the server. Opening the detail page of the server in a new
    tab.
 5. Collapse its children nodes.
-6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be\
+6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be
    manually rejoined by dragging it on top of the primary server.
-7. Monitor manipulation operations button. Showing a dropdown with the\
+7. Monitor manipulation operations button. Showing a dropdown with the
    following operations:
 
 * Stop monitor.
 * Start monitor.
 * Reset Replication.
 * Release Locks.
-* Master failover. Manually performing a primary failover. This option is\
+* Master failover. Manually performing a primary failover. This option is
   visible only when the `auto_failover` parameter is disabled.
 
 1. Refresh rate dropdown. The frequency with which the data is refreshed.
@@ -151,11 +151,11 @@ This page shows and allows editing of MaxScale parameters.
 
 ### Annotation
 
-1. Edit parameters button. This button is shown on the mouse hover allowing\
-   to edit the MaxScale parameter. Clicking on it will enable editable mode on\
+1. Edit parameters button. This button is shown on the mouse hover allowing
+   to edit the MaxScale parameter. Clicking on it will enable editable mode on
    the table..
 2. Editable parameters are visible as it's illustrated in the screenshot.
-3. After finishing editing the parameters, simply click the Done Editing\
+3. After finishing editing the parameters, simply click the Done Editing
    button.
 
 ## Logs Archive
@@ -174,7 +174,7 @@ On this page, you may add numerous worksheets, each of which can be used for\
 
 ### Run Queries
 
-Clicking on the "Run Queries" card will open a dialog, providing options\
+Clicking on the "Run Queries" card will open a dialog, providing options
 to establish a connection to different MaxScale object types, including\
 "Listener, Server, Service".
 
@@ -186,10 +186,10 @@ There are various features in the Query Editor worksheet, the most notable ones 
 
 **Create a new connection**
 
-If the connection of the Query Editor expires, or if you wish to make\
-a new connection for the active worksheet, simply clicking on the button\
-located on the right side of the query tabs navigation bar which features a\
-server icon and an active connection name as a label. This will open the\
+If the connection of the Query Editor expires, or if you wish to make
+a new connection for the active worksheet, simply clicking on the button
+located on the right side of the query tabs navigation bar which features a
+server icon and an active connection name as a label. This will open the
 connection dialog and allow you to create a new connection.
 
 **Schemas objects sidebar**
@@ -199,7 +199,7 @@ connection dialog and allow you to create a new connection.
 There are two ways to set the current database:
 
 * Double-click on the name of the database.
-* Right-click on the name of the database to show the context menu, then select\
+* Right-click on the name of the database to show the context menu, then select
   the `Use database` option.
 
 **Preview table data of the top 1000 rows**
@@ -207,7 +207,7 @@ There are two ways to set the current database:
 There are two ways to preview data of a table:
 
 * Click on the name of the table.
-* Right-click on the name of the table to show the context menu, then select\
+* Right-click on the name of the table to show the context menu, then select
   the `Preview Data (top 1000)` option.
 
 **Describe table**
@@ -216,7 +216,7 @@ Right-click on the name of the table to show the context menu, then select the`V
 
 **Alter/Drop/Truncate table**
 
-Right-click on the name of the table to show the context menu, then select the\
+Right-click on the name of the table to show the context menu, then select the
 desired option.
 
 **Quickly insert an object into the editor**
@@ -224,13 +224,13 @@ desired option.
 There are two ways to quickly insert an object to the editor:
 
 * Drag the object and drop it in the desire position in the editor.
-* Right-click on the object to show the context menu, then mouse\
+* Right-click on the object to show the context menu, then mouse
   hover the `Place to Editor` option and select the desired insert option.
 
 **Show object creation statement and insights info**
 
-To view the statement that creates the given object in the [Schemas objects sidebar](mariadb-maxscale-2308-using-maxgui-tutorial.md#schemas-objects-sidebar), right-clicking on schema or table node and\
-select the `View Insights` option. For other objects such as view, stored\
+To view the statement that creates the given object in the [Schemas objects sidebar](mariadb-maxscale-2308-using-maxgui-tutorial.md#schemas-objects-sidebar), right-clicking on schema or table node and
+select the `View Insights` option. For other objects such as view, stored
 procedure, function and trigger, select the `Show Create` option.
 
 **Editor**
@@ -240,156 +240,156 @@ Visual Studio Code.
 
 To see the command palette, press F1 while the cursor is active on the editor.
 
-The editor also comes with various options to assist your querying tasks. To see\
+The editor also comes with various options to assist your querying tasks. To see
 available options, right-click on the editor to show the context menu.
 
 **Re-execute old queries**
 
 Every executed query will be saved in the browser's storage (IndexedDB).\
 Query history can be seen in the `History/Snippets` tab.\
-To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2308-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)\
+To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2308-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)
 and click the execute query button in the editor.
 
 **Create query snippet**
 
 Press CTRL/CMD + D to save the current SQL in the editor to the snippets storage.\
-A snippet is created with a prefix keyword, so when that keyword is typed in\
+A snippet is created with a prefix keyword, so when that keyword is typed in
 the editor, it will be suggested in the "code completion" menu.
 
 **Generate an ERD**
 
-To initiate the process, either right-click on the schema name and select the`Generate ERD` option, or click on the icon button that resembles a line graph,\
-located on the schemas sidebar. This will open a dialog for selecting the\
+To initiate the process, either right-click on the schema name and select the`Generate ERD` option, or click on the icon button that resembles a line graph,
+located on the schemas sidebar. This will open a dialog for selecting the
 tables for the diagram.
 
 ### Data Migration
 
-Clicking on the "Data Migration" card will open a dialog, providing an option\
-to name the task. The Data Migration worksheet will be rendered in the active\
+Clicking on the "Data Migration" card will open a dialog, providing an option
+to name the task. The Data Migration worksheet will be rendered in the active
 worksheet after clicking the `Create` button in the dialog.
 
 #### Data Migration worksheet
 
-MaxScale uses ODBC for extracting and loading from the data source to a server\
-in MaxScale. Before starting a migration, ensure that you have set up the\
-necessary configurations on the MaxScale server. Instruction can be found [here](../mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-sql-resource.md#prepare-etl-operation)\
+MaxScale uses ODBC for extracting and loading from the data source to a server
+in MaxScale. Before starting a migration, ensure that you have set up the
+necessary configurations on the MaxScale server. Instruction can be found [here](../mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-sql-resource.md#prepare-etl-operation)
 and limitations [here](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md#etl-limitations).
 
 **Connections**
 
-Source connection shows the most common parameter inputs for creating\
-an ODBC connection. For extra parameters, enable the `Advanced` mode\
+Source connection shows the most common parameter inputs for creating
+an ODBC connection. For extra parameters, enable the `Advanced` mode
 to manually edit the `Connection String` input.
 
-After successfully connected to both source and destination servers,\
+After successfully connected to both source and destination servers,
 click on the `Select objects to migrate` to navigate to the next stage.
 
 **Objects Selection**
 
 Select the objects you wish to migrate to the MariaDB server.
 
-After selecting the desired objects, click on the `Prepare Migration Script` to\
-navigate to the next stage. The migration scripts will be generated\
-differently based on the value selected for the `Create mode` input. Hover over\
+After selecting the desired objects, click on the `Prepare Migration Script` to
+navigate to the next stage. The migration scripts will be generated
+differently based on the value selected for the `Create mode` input. Hover over
 the question icon for additional information on the modes.
 
 **Migration**
 
-As shown in the screenshot, you can quickly modify the script for each object\
-by selecting the corresponding object in the table and using the editors on the\
+As shown in the screenshot, you can quickly modify the script for each object
+by selecting the corresponding object in the table and using the editors on the
 right-hand side to make any necessary changes.
 
-After clicking the `Start Migration` button, the script for each object will be\
+After clicking the `Start Migration` button, the script for each object will be
 executed in parallel.
 
 **Migration report**
 
-If errors are reported for certain objects, review the output messages and\
+If errors are reported for certain objects, review the output messages and
 adjust the script accordingly. Then, click the `Manage` button and select `Restart`.
 
-To migrate additional objects, click the `Manage` button and select`Migrate other objects`. Doing so will replace the current migration\
+To migrate additional objects, click the `Manage` button and select`Migrate other objects`. Doing so will replace the current migration
 report for the current object with a new one.
 
 To retain the report and terminate open connections after migration, click the`Manage` button, then select `Disconnect`, and finally delete the worksheet.
 
-Deleting the worksheet will not delete the migration task. To clean-up\
+Deleting the worksheet will not delete the migration task. To clean-up
 everything after migration, click the `Manage` button, then select`Delete`.
 
 ### Create an ERD
 
-There are various features in the ERD worksheet, the most notable ones are\
+There are various features in the ERD worksheet, the most notable ones are
 listed below.
 
 #### ERD worksheet
 
-From an empty new worksheet, clicking on the "Create an ERD" card will open a\
-connection dialog. After connecting successfully, the ERD worksheet will be\
-rendered in the active worksheet. The connection is required to retrieve\
+From an empty new worksheet, clicking on the "Create an ERD" card will open a
+connection dialog. After connecting successfully, the ERD worksheet will be
+rendered in the active worksheet. The connection is required to retrieve
 essential metadata, such as engines, character sets, and collation.
 
 **Generate an ERD from the existing databases**
 
-Click on the icon button featured as a line graph, located on the top\
-toolbar next to the connection button. This will open a dialog for selecting\
+Click on the icon button featured as a line graph, located on the top
+toolbar next to the connection button. This will open a dialog for selecting
 the tables for the diagram.
 
 **Create a new ERD**
 
 New tables can be created by using either of the following methods:
 
-* Click on the icon button that resembles a line graph, located on the\
+* Click on the icon button that resembles a line graph, located on the
   top toolbar.
-* Right-click on the diagram board and select the `Create Table`\
+* Right-click on the diagram board and select the `Create Table`
   option.
 
 **Entity options**
 
-Two options are available: `Edit Table` and `Remove from Diagram`. These\
+Two options are available: `Edit Table` and `Remove from Diagram`. These
 options can be accessed using either of the following methods:
 
 * Right-click on the entity and choose the desired option.
-* Hover over the entity, click the gear icon button, and select the desired\
+* Hover over the entity, click the gear icon button, and select the desired
   option.
 
-For quickly editing or viewing the table definitions, double-clicking on the\
+For quickly editing or viewing the table definitions, double-clicking on the
 entity. The entity editor will be shown at the bottom of the worksheet.
 
 **Foreign keys quick common options**
 
 * Edit Foreign Key, this opens an editor for viewing/editing foreign keys.
 * Remove Foreign Key.
-* `Change to One To One` or `Change to One To Many`. Toggling the uniqueness\
+* `Change to One To One` or `Change to One To Many`. Toggling the uniqueness
   of the foreign key column.
 * `Set FK Column Mandatory` or `Set FK Column Optional`. Toggling the`NOT NULL` option of the foreign key column.
 * `Set Referenced Column Mandatory` or `Set Referenced Column Optional`\
   Toggling the `NOT NULL` option of the referenced column.
 
-To show the above foreign key common options, perform a right-click on the link\
+To show the above foreign key common options, perform a right-click on the link
 within the diagram.
 
 **Viewing foreign key constraint SQL**
 
-Hover over the link in the diagram, the constraint SQL of that foreign key will\
+Hover over the link in the diagram, the constraint SQL of that foreign key will
 be shown in a tooltip.
 
 **Quickly draw a foreign key link**
 
-As shown in the screenshot, a foreign key can be quickly established by\
+As shown in the screenshot, a foreign key can be quickly established by
 performing the following actions:
 
 1. Click on the entity that will have the foreign key.
-2. Click on the connecting point of the desired foreign key column and drag\
+2. Click on the connecting point of the desired foreign key column and drag
    it over the desired referenced column.
 
 **Entity editor**
 
-Table columns, foreign keys and indexes can be modified via\
-the entity editor which can be accessed quickly by double-clicking\
+Table columns, foreign keys and indexes can be modified via
+the entity editor which can be accessed quickly by double-clicking
 on the entity.
 
 **Export options**
 
-Three options are available: `Copy script to clipboard`, `Export script` and`Export as jpeg`. These options can be accessed using either of the following\
+Three options are available: `Copy script to clipboard`, `Export script` and`Export as jpeg`. These options can be accessed using either of the following
 methods:
 
 * Right-click on the diagram board and choose the desired option.
@@ -404,7 +404,7 @@ editor within the dialog.
 
 **Visual Enhancement options**
 
-The first section of the top toolbar, there are options to improve the visual of\
+The first section of the top toolbar, there are options to improve the visual of
 the diagram as follows:
 
 * Change the shape of links

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-maxscale-2308-upgrading-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-maxscale-2308-upgrading-mariadb-maxscale.md
@@ -6,13 +6,13 @@
 
 For more information about what has changed, please refer to the [ChangeLog](../maxscale-23.08-changelog.md) and to the [release notes](https://mariadb.com/kb/Release-Notes/).
 
-Before starting the upgrade, any existing configuration files should\
+Before starting the upgrade, any existing configuration files should
 be backed up.
 
 ## Upgrading MariaDB MaxScale from 23.02 to 23.08
 
-MariaDB Monitor switchover requires an additional grant on MariaDB Server 10.5\
-and later. See [Cluster Manipulation Grants](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md#cluster-manipulation-grants)\
+MariaDB Monitor switchover requires an additional grant on MariaDB Server 10.5
+and later. See [Cluster Manipulation Grants](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md#cluster-manipulation-grants)
 for more information.
 
 ## Upgrading MariaDB MaxScale from 22.08 to 23.02
@@ -27,24 +27,24 @@ for more information.
 
 ### Removed Features
 
-* The support for legacy encryption keys generated with `maxkeys` from pre-2.5\
-  versions has been removed. This feature was deprecated in MaxScale 2.5 when\
-  the new key storage format was introduced. To migrate to the new key storage\
+* The support for legacy encryption keys generated with `maxkeys` from pre-2.5
+  versions has been removed. This feature was deprecated in MaxScale 2.5 when
+  the new key storage format was introduced. To migrate to the new key storage
   format, create a new key file with `maxkeys` and re-encrypt the passwords with`maxpasswd`.
 * The deprecated Database Firewall filter has been removed.
 
 ## Upgrading MariaDB MaxScale from 2.5 to 21.06
 
-**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have\
-been released as 6.4.16 in June, was released as 21.06.16. The purpose of this\
-change is to make the versioning scheme used by all MaxScale series\
+**NOTE** MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have
+been released as 6.4.16 in June, was released as 21.06.16. The purpose of this
+change is to make the versioning scheme used by all MaxScale series
 identical. 21.06 denotes the year and month when the first 6 release was made.
 
 ### Duration Type Parameters
 
 Using duration type parameters without an explicit suffix has been deprecated in\
 MaxScale 2.4. In MaxScale 6 they are no longer allowed when used with the REST\
-API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that\
+API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that
 use a duration type parameter must explicitly specify the suffix of the unit.
 
 For example, the following command:
@@ -59,8 +59,8 @@ should be replaced with:
 maxctrl alter service My-Service connection_keepalive 30000ms
 ```
 
-Duration type parameters can still be defined in the configuration file without\
-an explicit suffix but this behavior is deprecated. The recommended approach is\
+Duration type parameters can still be defined in the configuration file without
+an explicit suffix but this behavior is deprecated. The recommended approach is
 to add explicit suffixes to all duration type parameters when upgrading to\
 MaxScale 6.
 
@@ -82,22 +82,22 @@ The following deprecated core parameters have been removed:
 
 The deprecated aliases for the schemarouter parameters `ignore_databases` and`ignore_databases_regex` have been removed. They can be replaced with`ignore_tables` and `ignore_tables_regex`.
 
-In addition, the `preferred_server` parameter that was deprecated in 2.5 has\
+In addition, the `preferred_server` parameter that was deprecated in 2.5 has
 also been removed.
 
 #### `mariadbmon`
 
-* MariaDBMonitor settings `ignore_external_masters`, `detect_replication_lagdetect_standalone_master`, `detect_stale_master` and `detect_stale_slave`\
-  have been removed. The first two were ineffective, the latter three are\
+* MariaDBMonitor settings `ignore_external_masters`, `detect_replication_lagdetect_standalone_master`, `detect_stale_master` and `detect_stale_slave`
+  have been removed. The first two were ineffective, the latter three are
   replaced by `master_conditions` and `slave_conditions`.
 
 ### Session Command History
 
-The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`\
-have been made into generic service parameters that are shared between all\
+The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`
+have been made into generic service parameters that are shared between all
 routers that support it.
 
-The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it\
+The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it
 being enabled or are not affected by it.
 
 ## Upgrading MariaDB MaxScale from 2.4 to 2.5
@@ -105,33 +105,33 @@ being enabled or are not affected by it.
 ### MaxAdmin
 
 The deprecated MaxAdmin interface has been removed in 2.5.0 in favor of the REST\
-API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can\
+API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can
 no longer be used.
 
 ### Authentication
 
-The credentials used by services now require additional grants. For a full list\
+The credentials used by services now require additional grants. For a full list
 of required grants, refer to the [protocol documentation](../mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md#required-grants).
 
 ### MariaDB-Monitor
 
-The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in\
+The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in
 a later version.
 
 #### Password encryption
 
-The encrypted passwords feature has been updated to be more secure. Users are\
-recommended to generate a new encryption key and re-encrypt their passwords\
+The encrypted passwords feature has been updated to be more secure. Users are
+recommended to generate a new encryption key and re-encrypt their passwords
 using the `maxkeys` and `maxpasswd` utilities. Old passwords still work.
 
 ### Default Server State
 
-The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally\
+The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally
 used before they were monitored.
 
 ### Columnstore Monitor
 
-It is now mandatory to specify in the configuration what version the\
+It is now mandatory to specify in the configuration what version the
 monitored Columnstore cluster is.
 
 ```
@@ -142,20 +142,20 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)\
+Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)
 for details.
 
 ### New binlog router
 
-The binlog router delivered with MaxScale 2.5 is completely new and\
-not 100% backward compatible with the binlog router delivered with\
-earlier MaxScale versions. If you use the binlog router, carefully\
-assess whether the functionality provided by the new one fulfills\
+The binlog router delivered with MaxScale 2.5 is completely new and
+not 100% backward compatible with the binlog router delivered with
+earlier MaxScale versions. If you use the binlog router, carefully
+assess whether the functionality provided by the new one fulfills
 your requirements, before upgrading MaxScale.
 
 ### Tee Filter
 
-The tee filter parameter `service` has been deprecated in favor of the `target`\
+The tee filter parameter `service` has been deprecated in favor of the `target`
 parameter. All usages of `service` can be replaced with `target`.
 
 ## Upgrading MariaDB MaxScale from 2.3 to 2.4
@@ -164,10 +164,10 @@ parameter. All usages of `service` can be replaced with `target`.
 
 #### Reserved Names
 
-Section and object names starting with `@@` are now reserved for\
+Section and object names starting with `@@` are now reserved for
 internal use by MaxScale.
 
-In case such names have been used, they must manually be changed\
+In case such names have been used, they must manually be changed
 in all configuration files of MaxScale, before MaxScale 2.4 is started.
 
 Those files are:
@@ -178,7 +178,7 @@ Those files are:
 
 #### Whitespace in Names
 
-Whitespace in section names that was deprecated in MaxScale 2.2 will now be\
+Whitespace in section names that was deprecated in MaxScale 2.2 will now be
 rejected, which will cause the startup of MaxScale to fail.
 
 To prevent that, section names like
@@ -205,11 +205,11 @@ servers=MyServer
 
 ### Durations
 
-Durations can now be specified using one of the suffixes `h`, `m`, `s`\
-and `ms` for specifying durations in hours, minutes, seconds and\
+Durations can now be specified using one of the suffixes `h`, `m`, `s`
+and `ms` for specifying durations in hours, minutes, seconds and
 milliseconds, respectively.
 
-_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,\
+_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,
 so it is advisable to add suffixes to durations. For instance,
 
 ```
@@ -219,12 +219,12 @@ some_param=60000ms
 
 ### Improved Admin User Encryption
 
-MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a\
+MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a
 user to use the better hashing algorithm, either recreate the user or use the`maxctrl alter user` command.
 
 ### MariaDB-Monitor
 
-The following settings have been removed and cause a startup error\
+The following settings have been removed and cause a startup error
 if defined:
 
 * `mysql51_replication`
@@ -233,45 +233,45 @@ if defined:
 
 ### ReadWriteSplit
 
-* If multiple masters are available for a readwritesplit service, the one with\
+* If multiple masters are available for a readwritesplit service, the one with
   the lowest connection count is selected.
-* If a master server is placed into maintenance mode, all open transactions are\
-  allowed to gracefully finish before the session is closed. To forcefully close\
+* If a master server is placed into maintenance mode, all open transactions are
+  allowed to gracefully finish before the session is closed. To forcefully close
   the connections, use the `--force` option for `maxctrl set server`.
-* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the\
+* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the
   overall load on the system when connections are rapidly opened and closed.
-* Transaction replays now have a limit on how many times a replay is\
+* Transaction replays now have a limit on how many times a replay is
   attempted. The default values is five attempts and is controlled by the`transaction_replay_attempts` parameter.
-* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the\
+* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the
   transaction is automatically retried.
 
 ## Upgrading MariaDB MaxScale from 2.2 to 2.3
 
 ### Increased Memory Use
 
-Starting with MaxScale 2.3.0 up to 40% of the memory can be used for\
-caching parsed queries. The most noticeable change is that it improves\
-performance in almost all cases where queries need to be parsed. Most of\
+Starting with MaxScale 2.3.0 up to 40% of the memory can be used for
+caching parsed queries. The most noticeable change is that it improves
+performance in almost all cases where queries need to be parsed. Most of
 the time this happens when the readwritesplit router or filters are used.
 
-The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total\
-memory to 1GB, add `query_classifier_cache_size=1G` to your\
+The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total
+memory to 1GB, add `query_classifier_cache_size=1G` to your
 configuration. To disable it, set the value to `0`.
 
-In addition to the aforementioned query classifier caching, the\
-readwritesplit session command history is enabled by default in 2.3 but is\
-limited to a maximum of 50 commands after which the history is\
-disabled. This is unlikely to show in any metrics but it contributes to\
+In addition to the aforementioned query classifier caching, the
+readwritesplit session command history is enabled by default in 2.3 but is
+limited to a maximum of 50 commands after which the history is
+disabled. This is unlikely to show in any metrics but it contributes to
 the increased memory foorprint of MaxScale.
 
 ### Unknown Global Parameters
 
-All unknown parameters are now treated as errors. Check your configuration for\
+All unknown parameters are now treated as errors. Check your configuration for
 errors if MaxScale fails to start after upgrading to 2.3.1.
 
 ### `passwd` is deprecated
 
-In the configuration file, passwords for monitors and services should be\
+In the configuration file, passwords for monitors and services should be
 specified using `password`; the support for the deprecated`passwd` will be removed in the future. That is, the following
 
 ```
@@ -308,61 +308,61 @@ Authenticator options are now only used with listeners.
 
 #### Administrative Users
 
-The file format for the administrative users used by MaxScale has been\
-changed. Old style files are automatically upgraded and a backup of the old file is\
+The file format for the administrative users used by MaxScale has been
+changed. Old style files are automatically upgraded and a backup of the old file is
 stored in `/var/lib/maxscale/passwd.backup`.
 
 #### Regular Expression Parameters
 
-Modules may now use a built-in regular expression string parameter type instead\
-of a normal string when accepting patterns. The modules that use the new regex\
-parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the\
+Modules may now use a built-in regular expression string parameter type instead
+of a normal string when accepting patterns. The modules that use the new regex
+parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the
 string in slashes, e.g. `match=/^select/` defines the pattern `^select`.
 
 #### Binlog Server
 
-Binlog server automatically accepts GTID connection from MariaDB 10 slave servers\
+Binlog server automatically accepts GTID connection from MariaDB 10 slave servers
 by saving all incoming GTIDs into a SQLite map database.
 
 #### MaxCtrl Included in Main Package
 
-In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2\
-it is in the main `maxscale` package. If you have a previous installation\
+In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2
+it is in the main `maxscale` package. If you have a previous installation
 of MaxCtrl, please remove it before upgrading to MaxScale 2.2.2.
 
 ## Upgrading MariaDB MaxScale from 2.0 to 2.1
 
 ### IPv6 Support
 
-MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to\
-was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,\
+MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to
+was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,
 add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)\
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files
 
-The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The\
+The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The
 default location for the log file is _/var/log/maxscale/maxscale.log_.
 
-Rotating the log files will cause MaxScale to reopen the file instead of\
+Rotating the log files will cause MaxScale to reopen the file instead of
 renaming them. This makes the MaxScale logging facility _logrotate_ compatible.
 
 ### ReadWriteSplit
 
-The `disable_sescmd_history` option is now enabled by default. This means that\
-slaves will not be recovered mid-session even if a replacement slave is\
-available. To enable the legacy behavior, add the `disable_sescmd_history=true`\
+The `disable_sescmd_history` option is now enabled by default. This means that
+slaves will not be recovered mid-session even if a replacement slave is
+available. To enable the legacy behavior, add the `disable_sescmd_history=true`
 parameter to the service definition.
 
 ### Persistent Connections
 
-The MariaDB session state is reset in MaxScale 2.1 for persistent\
-connections. This means that any modifications to the session state (default\
-database, user variable etc.) will not survive if the connection is put into the\
+The MariaDB session state is reset in MaxScale 2.1 for persistent
+connections. This means that any modifications to the session state (default
+database, user variable etc.) will not survive if the connection is put into the
 connection pool. For most users, this is the expected behavior.
 
 ### User Data Cache
@@ -371,27 +371,27 @@ The location of the MariaDB user data cache was moved from`/var/cache/maxscale/<
 
 ### Galeramon Monitoring Algorithm
 
-Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with\
+Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with
 multiple MaxScales but it also causes slower changes of the master node.
 
-To enable the legacy behavior, add `root_node_as_master=false` to the Galera\
+To enable the legacy behavior, add `root_node_as_master=false` to the Galera
 monitor configuration.
 
 ### MaxAdmin Editing Mode
 
-The default editing mode was changed from _vim_ to _emacs_ mode. To start\
+The default editing mode was changed from _vim_ to _emacs_ mode. To start
 maxadmin in the legacy mode, use the `-i` option.
 
 ## Upgrading MariaDB MaxScale from 1.4 to 2.0
 
 ### MaxAdmin
 
-The default way the communication between MaxAdmin and MariaDB MaxScale is\
+The default way the communication between MaxAdmin and MariaDB MaxScale is
 handled has been changed from an internet socket to a Unix domain socket.\
 The former alternative is still available but has been _deprecated_.
 
 If no arguments are given to MaxAdmin, it will attempt to connect to\
-MariaDB MaxScale using a Unix domain socket. After the upgrade you will\
+MariaDB MaxScale using a Unix domain socket. After the upgrade you will
 need to provide at least one internet socket related flag - `-h`, `-P`,`-u` or `-p` - to force MaxAdmin to use the internet socket approach.
 
 E.g.
@@ -403,16 +403,16 @@ user@host $ maxadmin -u admin
 ### MySQL Monitor
 
 The MySQL Monitor now assigns the stale state to the master server by default.\
-In addition to this, the slave servers receive the stale slave state when they\
-lose the connection to the master. This should not cause changes in behavior\
+In addition to this, the slave servers receive the stale slave state when they
+lose the connection to the master. This should not cause changes in behavior
 but the output of MaxAdmin will show new states when replication is broken.
 
 ## Upgrading MaxScale from 1.3 to 1.4
 
 ### Service user permissions
 
-The service users now also need SELECT privileges on mysql.tables\_priv. This is\
-required for the resolution of table level grants. To grant SELECT privileges\
+The service users now also need SELECT privileges on mysql.tables\_priv. This is
+required for the resolution of table level grants. To grant SELECT privileges
 for the service user, replace the user and hostname in the following example.
 
 ```
@@ -427,8 +427,8 @@ For more information about how to do this, please read the installation guide:[M
 
 ### SSL
 
-The SSL configuration parameters are now a part of the listeners. If a service\
-used the old style SSL configuration parameters, the values should be moved to\
+The SSL configuration parameters are now a part of the listeners. If a service
+used the old style SSL configuration parameters, the values should be moved to
 the listener which is associated with that service.
 
 Here is an example of an old style configuration.
@@ -473,23 +473,23 @@ ssl_ca_cert=/home/user/certs/ca.pem
 ssl_version=TLSv12
 ```
 
-Please also note that the `enabled` SSL mode is no longer supported due to\
-the inherent security issues with allowing SSL and non-SSL connections on\
-the same port. In addition to this, SSLv3 is no longer supported due to\
+Please also note that the `enabled` SSL mode is no longer supported due to
+the inherent security issues with allowing SSL and non-SSL connections on
+the same port. In addition to this, SSLv3 is no longer supported due to
 vulnerabilities found in it.
 
 ## Upgrading MaxScale from 1.2 to 1.3
 
 ### Binlog Router
 
-The master server details are now provided with a **master.ini** file located in\
-the binlog directory and it can be changed using a CHANGE MASTER TO command issued\
+The master server details are now provided with a **master.ini** file located in
+the binlog directory and it can be changed using a CHANGE MASTER TO command issued
 via a MySQL connection to MaxScale.
 
-This file, properly filled, is now mandatory and without it the binlog router\
+This file, properly filled, is now mandatory and without it the binlog router
 cannot connect to the master database.
 
-Before starting binlog router after MaxScale 1.3 upgrade, please add relevant\
+Before starting binlog router after MaxScale 1.3 upgrade, please add relevant
 information to _master.ini_, example:
 
 ```
@@ -501,26 +501,26 @@ master_password=somepass
 filestem=repl-bin
 ```
 
-Additionally, the option `servers=masterdb` in the service definition is no\
+Additionally, the option `servers=masterdb` in the service definition is no
 longer required.
 
 ## Upgrading MaxScale from 1.1 to 1.2
 
-This document describes upgrading MaxScale from version 1.1.1 to 1.2 and\
-the major differences in the new version compared to the old version. The\
-major changes can be found in the `Changelog.txt` file in the installation\
+This document describes upgrading MaxScale from version 1.1.1 to 1.2 and
+the major differences in the new version compared to the old version. The
+major changes can be found in the `Changelog.txt` file in the installation
 directory and the official release notes in the `ReleaseNotes.txt` file.
 
 ### Installation
 
 Upgrading MaxScale will copy the `MaxScale.cnf` file in`/usr/local/mariadb-maxscale/etc/` to `/etc/` and renamed to `maxscale.cnf`.\
-Binary log files are not automatically copied and should be manually moved\
+Binary log files are not automatically copied and should be manually moved
 from `/usr/local/mariadb-maxscale` to `/var/lib/maxscale/`.
 
 ### File location changes
 
-MaxScale 1.2 follows the [FHS-standard](https://www.pathname.com/fhs/) and\
-installs to `/usr/` and `/var/` subfolders. Here are the major changes and\
+MaxScale 1.2 follows the [FHS-standard](https://www.pathname.com/fhs/) and
+installs to `/usr/` and `/var/` subfolders. Here are the major changes and
 file locations.
 
 * Configuration files are located in `/etc/` and use lowercase letters: `/etc/maxscale.cnf`
@@ -532,26 +532,26 @@ file locations.
 
 ### Running MaxScale without root permissions
 
-MaxScale can run as a non-root user with the 1.2 version. RPM and DEB\
-packages install the `maxscale` user and `maxscale` group which are used\
-by the init scripts and systemd configuration files. If you are installing\
-from a binary tarball, you can run the `postinst` script included in it to\
+MaxScale can run as a non-root user with the 1.2 version. RPM and DEB
+packages install the `maxscale` user and `maxscale` group which are used
+by the init scripts and systemd configuration files. If you are installing
+from a binary tarball, you can run the `postinst` script included in it to
 manually create these groups.
 
 ## Upgrading MaxScale from 1.0 to 1.1
 
-This document describes upgrading MaxScale from version 1.0.5 to 1.1.0 and\
-the major differences in the new version compared to the old version. The\
-major changes can be found in the `Changelog.txt` file in the installation\
+This document describes upgrading MaxScale from version 1.0.5 to 1.1.0 and
+the major differences in the new version compared to the old version. The
+major changes can be found in the `Changelog.txt` file in the installation
 directory and the official release notes in the `ReleaseNotes.txt` file.
 
 ### Installation
 
-If you are installing MaxScale from a RPM package, we recommend you back\
-up your configuration and log files and that you remove the old installation\
-of MaxScale completely. If you choose to upgrade MaxScale instead of removing\
-it and re-installing it afterwards, the init scripts in `/etc/init.d` folder\
-will be missing. This is due to the RPM packaging system but the script can\
+If you are installing MaxScale from a RPM package, we recommend you back
+up your configuration and log files and that you remove the old installation
+of MaxScale completely. If you choose to upgrade MaxScale instead of removing
+it and re-installing it afterwards, the init scripts in `/etc/init.d` folder
+will be missing. This is due to the RPM packaging system but the script can
 be re-installed by running the `postinst` script found in the`/usr/local/mariadb-maxscale` folder.
 
 ```
@@ -560,14 +560,14 @@ cd /usr/local/mariadb-maxscale
 ./postinst
 ```
 
-The 1.1.0 version of MaxScale installs into `/usr/local/mariadb-maxscale`\
-instead of `/usr/local/skysql/maxscale`. This will cause external references\
-to MaxScale's home directory to stop working so remember to update all\
+The 1.1.0 version of MaxScale installs into `/usr/local/mariadb-maxscale`
+instead of `/usr/local/skysql/maxscale`. This will cause external references
+to MaxScale's home directory to stop working so remember to update all
 paths with the new version.
 
 ### MaxAdmin changes
 
-The MaxAdmin client's default password in MaxScale 1.1.0 is `mariadb`\
+The MaxAdmin client's default password in MaxScale 1.1.0 is `mariadb`
 instead of `skysql`.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-14-to-20.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-14-to-20.md
@@ -11,17 +11,17 @@ For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog](bro
 
 ### Installation
 
-Before starting the upgrade, we **strongly** recommend you back up your current\
+Before starting the upgrade, we **strongly** recommend you back up your current
 configuration file.
 
 ### MaxAdmin
 
-The default way the communication between MaxAdmin and MariaDB MaxScale is\
+The default way the communication between MaxAdmin and MariaDB MaxScale is
 handled has been changed from an internet socket to a Unix domain socket.\
 The former alternative is still available but has been _deprecated_.
 
 If no arguments are given to MaxAdmin, it will attempt to connect to\
-MariaDB MaxScale using a Unix domain socket. After the upgrade you will\
+MariaDB MaxScale using a Unix domain socket. After the upgrade you will
 need to provide at least one internet socket related flag - `-h`, `-P`,`-u` or `-p` - to force MaxAdmin to use the internet socket approach.
 
 E.g.
@@ -33,8 +33,8 @@ user@host $ maxadmin -u admin
 ### MySQL Monitor
 
 The MySQL Monitor now assigns the stale state to the master server by default.\
-In addition to this, the slave servers receive the stale slave state when they\
-lose the connection to the master. This should not cause changes in behavior\
+In addition to this, the slave servers receive the stale slave state when they
+lose the connection to the master. This should not cause changes in behavior
 but the output of MaxAdmin will show new states when replication is broken.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -11,40 +11,40 @@ For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog]
 
 ### Installation
 
-Before starting the upgrade, we **strongly** recommend you back up your current\
+Before starting the upgrade, we **strongly** recommend you back up your current
 configuration file.
 
 ### IPv6 Support
 
-MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to\
-was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,\
+MaxScale 2.1.2 added support for IPv6 addresses. The default interface that listeners bind to
+was changed from the IPv4 address `0.0.0.0` to the IPv6 address `::`. To bind to the old IPv4 address,
 add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)\
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files
 
-The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The\
+The name of the log file was changed from _maxscaleN.log_ to _maxscale.log_. The
 default location for the log file is _/var/log/maxscale/maxscale.log_.
 
-Rotating the log files will cause MaxScale to reopen the file instead of\
+Rotating the log files will cause MaxScale to reopen the file instead of
 renaming them. This makes the MaxScale logging facility _logrotate_ compatible.
 
 ### ReadWriteSplit
 
-The `disable_sescmd_history` option is now enabled by default. This means that\
-slaves will not be recovered mid-session even if a replacement slave is\
-available. To enable the legacy behavior, add the `disable_sescmd_history=true`\
+The `disable_sescmd_history` option is now enabled by default. This means that
+slaves will not be recovered mid-session even if a replacement slave is
+available. To enable the legacy behavior, add the `disable_sescmd_history=true`
 parameter to the service definition.
 
 ### Persistent Connections
 
-The MariaDB session state is reset in MaxScale 2.1 for persistent\
-connections. This means that any modifications to the session state (default\
-database, user variable etc.) will not survive if the connection is put into the\
+The MariaDB session state is reset in MaxScale 2.1 for persistent
+connections. This means that any modifications to the session state (default
+database, user variable etc.) will not survive if the connection is put into the
 connection pool. For most users, this is the expected behavior.
 
 ### User Data Cache
@@ -53,15 +53,15 @@ The location of the MariaDB user data cache was moved from`/var/cache/maxscale/<
 
 ### Galeramon Monitoring Algorithm
 
-Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with\
+Galeramon will assign the master status _only_ to the node which has a_wsrep\_local\_index_ value of 0. This will guarantee consistent writes with
 multiple MaxScales but it also causes slower changes of the master node.
 
-To enable the legacy behavior, add `root_node_as_master=false` to the Galera\
+To enable the legacy behavior, add `root_node_as_master=false` to the Galera
 monitor configuration.
 
 ### MaxAdmin Editing Mode
 
-The default editing mode was changed from _vim_ to _emacs_ mode. To start\
+The default editing mode was changed from _vim_ to _emacs_ mode. To start
 maxadmin in the legacy mode, use the `-i` option.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-21-to-22.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-21-to-22.md
@@ -9,31 +9,31 @@ This document describes possible issues upgrading MariaDB MaxScale from version\
 
 For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, we recommend you back up your current configuration\
+Before starting the upgrade, we recommend you back up your current configuration
 file.
 
 #### Administrative Users
 
-The file format for the administrative users used by MaxScale has been\
-changed. Old style files are automatically upgraded and a backup of the old file is\
+The file format for the administrative users used by MaxScale has been
+changed. Old style files are automatically upgraded and a backup of the old file is
 stored in `/var/lib/maxscale/passwd.backup`.
 
 #### Regular Expression Parameters
 
-Modules may now use a built-in regular expression string parameter type instead\
-of a normal string when accepting patterns. The modules that use the new regex\
-parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the\
+Modules may now use a built-in regular expression string parameter type instead
+of a normal string when accepting patterns. The modules that use the new regex
+parameter type are _qlafilter_ and _tee_. When inputting pattern, enclose the
 string in slashes, e.g. `match=/^select/` defines the pattern `^select`.
 
 #### Binlog Server
 
-Binlog server automatically accepts GTID connection from MariaDB 10 slave servers\
+Binlog server automatically accepts GTID connection from MariaDB 10 slave servers
 by saving all incoming GTIDs into a SQLite map database.
 
 #### MaxCtrl Included in Main Package
 
-In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2\
-it is in the main `maxscale` package. If you have a previous installation\
+In the 2.2.1 beta version MaxCtrl was in its own package whereas in 2.2.2
+it is in the main `maxscale` package. If you have a previous installation
 of MaxCtrl, please remove it before upgrading to MaxScale 2.2.2.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-22-to-23.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-22-to-23.md
@@ -7,37 +7,37 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.2 to 2.3.
 
-For more information about MariaDB MaxScale 2.3, please refer\
+For more information about MariaDB MaxScale 2.3, please refer
 to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, we recommend you back up your current\
+Before starting the upgrade, we recommend you back up your current
 configuration file.
 
 ### Increased Memory Use
 
-Starting with MaxScale 2.3.0 up to 40% of the memory can be used for\
-caching parsed queries. The most noticeable change is that it improves\
-performance in almost all cases where queries need to be parsed. Most of\
+Starting with MaxScale 2.3.0 up to 40% of the memory can be used for
+caching parsed queries. The most noticeable change is that it improves
+performance in almost all cases where queries need to be parsed. Most of
 the time this happens when the readwritesplit router or filters are used.
 
-The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total\
-memory to 1GB, add `query_classifier_cache_size=1G` to your\
+The amount of memory that MaxScale uses can be controlled with the`query_classifier_cache_size` parameter. For example, to limit the total
+memory to 1GB, add `query_classifier_cache_size=1G` to your
 configuration. To disable it, set the value to `0`.
 
-In addition to the aforementioned query classifier caching, the\
-readwritesplit session command history is enabled by default in 2.3 but is\
-limited to a maximum of 50 commands after which the history is\
-disabled. This is unlikely to show in any metrics but it contributes to\
+In addition to the aforementioned query classifier caching, the
+readwritesplit session command history is enabled by default in 2.3 but is
+limited to a maximum of 50 commands after which the history is
+disabled. This is unlikely to show in any metrics but it contributes to
 the increased memory foorprint of MaxScale.
 
 ### Unknown Global Parameters
 
-All unknown parameters are now treated as errors. Check your configuration for\
+All unknown parameters are now treated as errors. Check your configuration for
 errors if MaxScale fails to start after upgrading to 2.3.1.
 
 ### `passwd` is deprecated
 
-In the configuration file, passwords for monitors and services should be\
+In the configuration file, passwords for monitors and services should be
 specified using `password`; the support for the deprecated`passwd` will be removed in the future. That is, the following
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2208-to-2302.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2208-to-2302.md
@@ -4,12 +4,12 @@
 
 ## Upgrading MariaDB MaxScale from 22.08 to 23.02
 
-This document describes possible issues when upgrading MariaDB MaxScale from\
+This document describes possible issues when upgrading MariaDB MaxScale from
 version 22.08 to 23.02.
 
 For more information about MaxScale 23.02, refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, any existing configuration files should be backed\
+Before starting the upgrade, any existing configuration files should be backed
 up.
 
 ## Removed Features

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-23-to-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-23-to-24.md
@@ -7,20 +7,20 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.3 to 2.4.
 
-For more information about MariaDB MaxScale 2.4, please refer\
+For more information about MariaDB MaxScale 2.4, please refer
 to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, we recommend you back up your current\
+Before starting the upgrade, we recommend you back up your current
 configuration file.
 
 ### Section Names
 
 #### Reserved Names
 
-Section and object names starting with `@@` are now reserved for\
+Section and object names starting with `@@` are now reserved for
 internal use by MaxScale.
 
-In case such names have been used, they must manually be changed\
+In case such names have been used, they must manually be changed
 in all configuration files of MaxScale, before MaxScale 2.4 is started.
 
 Those files are:
@@ -31,7 +31,7 @@ Those files are:
 
 #### Whitespace in Names
 
-Whitespace in section names that was deprecated in MaxScale 2.2 will now be\
+Whitespace in section names that was deprecated in MaxScale 2.2 will now be
 rejected, which will cause the startup of MaxScale to fail.
 
 To prevent that, section names like
@@ -58,11 +58,11 @@ servers=MyServer
 
 ### Durations
 
-Durations can now be specified using one of the suffixes `h`, `m`, `s`\
-and `ms` for specifying durations in hours, minutes, seconds and\
+Durations can now be specified using one of the suffixes `h`, `m`, `s`
+and `ms` for specifying durations in hours, minutes, seconds and
 milliseconds, respectively.
 
-_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,\
+_Not_ providing an explicit unit has been deprecated in MaxScale 2.4,
 so it is advisable to add suffixes to durations. For instance,
 
 ```
@@ -72,12 +72,12 @@ some_param=60000ms
 
 ### Improved Admin User Encryption
 
-MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a\
+MaxScale 2.4 will use a SHA2-512 hash for new admin user passwords. To upgrade a
 user to use the better hashing algorithm, either recreate the user or use the`maxctrl alter user` command.
 
 ### MariaDB-Monitor
 
-The following settings have been removed and cause a startup error\
+The following settings have been removed and cause a startup error
 if defined:
 
 * `mysql51_replication`
@@ -86,16 +86,16 @@ if defined:
 
 ### ReadWriteSplit
 
-* If multiple masters are available for a readwritesplit service, the one with\
+* If multiple masters are available for a readwritesplit service, the one with
   the lowest connection count is selected.
-* If a master server is placed into maintenance mode, all open transactions are\
-  allowed to gracefully finish before the session is closed. To forcefully close\
+* If a master server is placed into maintenance mode, all open transactions are
+  allowed to gracefully finish before the session is closed. To forcefully close
   the connections, use the `--force` option for `maxctrl set server`.
-* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the\
+* The `lazy_connect` feature can be used as a workaround to [MXS-619](https://jira.mariadb.org/browse/MXS-619). It also reduces the
   overall load on the system when connections are rapidly opened and closed.
-* Transaction replays now have a limit on how many times a replay is\
+* Transaction replays now have a limit on how many times a replay is
   attempted. The default values is five attempts and is controlled by the`transaction_replay_attempts` parameter.
-* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the\
+* If transaction replay is enabled and a deadlock occurs (SQLSTATE 40XXX), the
   transaction is automatically retried.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2302-to-2308.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2302-to-2308.md
@@ -4,12 +4,12 @@
 
 ## Upgrading MariaDB MaxScale from 23.02 to 23.08
 
-This document describes possible issues when upgrading MariaDB MaxScale from\
+This document describes possible issues when upgrading MariaDB MaxScale from
 version 23.02 to 23.08.
 
 For more information about MaxScale 23.08, refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, any existing configuration files should be backed\
+Before starting the upgrade, any existing configuration files should be backed
 up.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -9,39 +9,39 @@ MaxScale from version 2.4 to 2.5.
 
 For more information about MaxScale 2.5, refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, any existing configuration files should be\
+Before starting the upgrade, any existing configuration files should be
 backed up.
 
 ### MaxAdmin
 
 The deprecated MaxAdmin interface has been removed in 2.5.0 in favor of the REST\
-API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can\
+API and the MaxCtrl command line client. The `cli` and `maxscaled` modules can
 no longer be used.
 
 ### Authentication
 
-The credentials used by services now require additional grants. For a full list\
+The credentials used by services now require additional grants. For a full list
 of required grants, refer to the [protocol documentation](../mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md#required-grants).
 
 ### MariaDB-Monitor
 
-The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in\
+The settings `detect_stale_master`, `detect_standalone_master` and`detect_stale_slave` are replaced by `master_conditions` and`slave_conditions`. The old settings may still be used, but will be removed in
 a later version.
 
 #### Password encryption
 
-The encrypted passwords feature has been updated to be more secure. Users are\
-recommended to generate a new encryption key and re-encrypt their passwords\
+The encrypted passwords feature has been updated to be more secure. Users are
+recommended to generate a new encryption key and re-encrypt their passwords
 using the `maxkeys` and `maxpasswd` utilities. Old passwords still work.
 
 ### Default Server State
 
-The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally\
+The default state of servers in 2.4 was `Running` and in 2.5 it is now`Down`. This was done to prevent newly added servers from being accidentally
 used before they were monitored.
 
 ### Columnstore Monitor
 
-It is now mandatory to specify in the configuration what version the\
+It is now mandatory to specify in the configuration what version the
 monitored Columnstore cluster is.
 
 ```
@@ -52,20 +52,20 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)\
+Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)
 for details.
 
 ### New binlog router
 
-The binlog router delivered with MaxScale 2.5 is completely new and\
-not 100% backward compatible with the binlog router delivered with\
-earlier MaxScale versions. If you use the binlog router, carefully\
-assess whether the functionality provided by the new one fulfills\
+The binlog router delivered with MaxScale 2.5 is completely new and
+not 100% backward compatible with the binlog router delivered with
+earlier MaxScale versions. If you use the binlog router, carefully
+assess whether the functionality provided by the new one fulfills
 your requirements, before upgrading MaxScale.
 
 ### Tee Filter
 
-The tee filter parameter `service` has been deprecated in favor of the `target`\
+The tee filter parameter `service` has been deprecated in favor of the `target`
 parameter. All usages of `service` can be replaced with `target`.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-25-to-6.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-25-to-6.md
@@ -4,27 +4,27 @@
 
 ## Upgrading MariaDB MaxScale from 2.5 to 6
 
-This document describes possible issues when upgrading MariaDB MaxScale from\
+This document describes possible issues when upgrading MariaDB MaxScale from
 version 2.5 to 6.
 
-Note that the versioning scheme has changed and that version 6 immediately\
-follows version 2.5. Effectively, the non-changing `2.`-prefix has been dropped\
-and henceforth at a major release, the _major_, instead of the _minor_ version\
-number, will be bumped. This change also affects how maintenance releases are\
-versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was\
+Note that the versioning scheme has changed and that version 6 immediately
+follows version 2.5. Effectively, the non-changing `2.`-prefix has been dropped
+and henceforth at a major release, the _major_, instead of the _minor_ version
+number, will be bumped. This change also affects how maintenance releases are
+versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was
 followed by the maintenance release 2.5.2. 6.1, the first GA version of MaxScale\
 6, will be followed by the maintenance release 6.2.
 
 For more information about MaxScale 6, refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, any existing configuration files should be backed\
+Before starting the upgrade, any existing configuration files should be backed
 up.
 
 ### Duration Type Parameters
 
 Using duration type parameters without an explicit suffix has been deprecated in\
 MaxScale 2.4. In MaxScale 6 they are no longer allowed when used with the REST\
-API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that\
+API or MaxCtrl. This means that any `create` or `alter` commands in MaxCtrl that
 use a duration type parameter must explicitly specify the suffix of the unit.
 
 For example, the following command:
@@ -39,8 +39,8 @@ should be replaced with:
 maxctrl alter service My-Service connection_keepalive 30000ms
 ```
 
-Duration type parameters can still be defined in the configuration file without\
-an explicit suffix but this behavior is deprecated. The recommended approach is\
+Duration type parameters can still be defined in the configuration file without
+an explicit suffix but this behavior is deprecated. The recommended approach is
 to add explicit suffixes to all duration type parameters when upgrading to\
 MaxScale 6.
 
@@ -62,16 +62,16 @@ The following deprecated core parameters have been removed:
 
 The deprecated aliases for the schemarouter parameters `ignore_databases` and`ignore_databases_regex` have been removed. They can be replaced with`ignore_tables` and `ignore_tables_regex`.
 
-In addition, the `preferred_server` parameter that was deprecated in 2.5 has\
+In addition, the `preferred_server` parameter that was deprecated in 2.5 has
 also been removed.
 
 ### Session Command History
 
-The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`\
-have been made into generic service parameters that are shared between all\
+The `prune_sescmd_history`, `max_sescmd_history` and `disable_sescmd_history`
+have been made into generic service parameters that are shared between all
 routers that support it.
 
-The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it\
+The default value of `prune_sescmd_history` was changed from `false` to`true`. This was done as most MaxScale installations either benefit from it
 being enabled or are not affected by it.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-6-to-2208.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-6-to-2208.md
@@ -4,19 +4,19 @@
 
 ## Upgrading MariaDB MaxScale from 6 to 22.08
 
-This document describes possible issues when upgrading MariaDB MaxScale from\
+This document describes possible issues when upgrading MariaDB MaxScale from
 version 6 to 22.08.
 
 For more information about MaxScale 22.08, refer to the [ChangeLog](broken-reference).
 
-Before starting the upgrade, any existing configuration files should be backed\
+Before starting the upgrade, any existing configuration files should be backed
 up.
 
 ## Removed Features
 
-* The support for legacy encryption keys generated with `maxkeys` from pre-2.5\
-  versions has been removed. This feature was deprecated in MaxScale 2.5 when\
-  the new key storage format was introduced. To migrate to the new key storage\
+* The support for legacy encryption keys generated with `maxkeys` from pre-2.5
+  versions has been removed. This feature was deprecated in MaxScale 2.5 when
+  the new key storage format was introduced. To migrate to the new key storage
   format, create a new key file with `maxkeys` and re-encrypt the passwords with`maxpasswd`.
 * The deprecated Database Firewall filter has been removed.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-2308-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-2308-contents.md
@@ -50,8 +50,8 @@ Here are tutorials on monitoring and managing MariaDB MaxScale in cluster enviro
 
 ### Routers
 
-The routing module is the core of a MariaDB MaxScale service. The router documentation\
-contains all module specific configuration options and detailed explanations\
+The routing module is the core of a MariaDB MaxScale service. The router documentation
+contains all module specific configuration options and detailed explanations
 of their use.
 
 * [Avrorouter](mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avrorouter.md)
@@ -111,7 +111,7 @@ The MaxScale CDC Connector provides a C++ API for consuming data from a CDC syst
 
 ### Authenticators
 
-A short description of the authentication module type can be found in the [Authentication Modules](mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md)\
+A short description of the authentication module type can be found in the [Authentication Modules](mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md)
 document.
 
 * [MariaDB/MySQL Authenticator](https://mariadb.com/kb/en/mariadbmysql-authenticator/)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/mariadb-maxscale-2402-maxscale-2402-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/mariadb-maxscale-2402-maxscale-2402-contents.md
@@ -46,8 +46,8 @@ Here are tutorials on monitoring and managing MariaDB MaxScale in cluster enviro
 
 ### Routers
 
-The routing module is the core of a MariaDB MaxScale service. The router documentation\
-contains all module specific configuration options and detailed explanations\
+The routing module is the core of a MariaDB MaxScale service. The router documentation
+contains all module specific configuration options and detailed explanations
 of their use.
 
 * [Avrorouter](maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-avrorouter.md)
@@ -117,7 +117,7 @@ The MaxScale CDC Connector provides a C++ API for consuming data from a CDC syst
 
 ### Authenticators
 
-A short description of the authentication module type can be found in the [Authentication Modules](maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules.md)\
+A short description of the authentication module type can be found in the [Authentication Modules](maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules.md)
 document.
 
 * [MariaDB/MySQL Authenticator](maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-mariadbmysql-authenticator.md)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-about-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-about-mariadb-maxscale.md
@@ -1,48 +1,48 @@
 # MaxScale 24.02 About MariaDB MaxScale
 
-**MariaDB MaxScale** is a database proxy that forwards database statements to\
+**MariaDB MaxScale** is a database proxy that forwards database statements to
 one or more database servers.
 
-The forwarding is performed using rules based on the semantic understanding of\
-the database statements and on the roles of the servers within the backend\
+The forwarding is performed using rules based on the semantic understanding of
+the database statements and on the roles of the servers within the backend
 cluster of databases.
 
-MariaDB MaxScale is designed to provide, transparently to applications, load\
-balancing and high availability functionality. MariaDB MaxScale has a scalable\
-and flexible architecture, with plugin components to support different protocols\
+MariaDB MaxScale is designed to provide, transparently to applications, load
+balancing and high availability functionality. MariaDB MaxScale has a scalable
+and flexible architecture, with plugin components to support different protocols
 and routing approaches.
 
 MariaDB MaxScale makes extensive use of the asynchronous I/O capabilities of the\
-Linux operating system, combined with a fixed number of worker threads. _epoll_\
-is used to provide the event driven framework for the input and output via\
+Linux operating system, combined with a fixed number of worker threads. _epoll_
+is used to provide the event driven framework for the input and output via
 sockets.
 
-Many of the services provided by MariaDB MaxScale are implemented as external\
-shared object modules loaded at runtime. These modules support a fixed\
-interface, communicating the entry points via a structure consisting of a set of\
-function pointers. This structure is called the "module object". Additional\
+Many of the services provided by MariaDB MaxScale are implemented as external
+shared object modules loaded at runtime. These modules support a fixed
+interface, communicating the entry points via a structure consisting of a set of
+function pointers. This structure is called the "module object". Additional
 modules can be created to work with MariaDB MaxScale.
 
-Commonly used module types are _protocol_, _router_ and _filter_. Protocol\
-modules implement the communication between clients and MariaDB MaxScale, and\
-between MariaDB MaxScale and backend servers. Routers inspect the queries from\
-clients and decide the target backend. The decisions are usually based on\
-routing rules and backend server status. Filters work on data as it passes\
-through MariaDB MaxScale. Filter are often used for logging queries or modifying\
+Commonly used module types are _protocol_, _router_ and _filter_. Protocol
+modules implement the communication between clients and MariaDB MaxScale, and
+between MariaDB MaxScale and backend servers. Routers inspect the queries from
+clients and decide the target backend. The decisions are usually based on
+routing rules and backend server status. Filters work on data as it passes
+through MariaDB MaxScale. Filter are often used for logging queries or modifying
 server responses.
 
-A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,\
+A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,
 issues and communicate with the MariaDB MaxScale community. Send email to [maxscale@googlegroups.com](mailto:maxscale@googlegroups.com) or use the [forum](https://groups.google.com/forum/#!forum/maxscale) interface.
 
 Bugs can be reported in the MariaDB Jira [jira.mariadb.org](https://jira.mariadb.org)
 
 ### Installing MariaDB MaxScale
 
-Information about installing MariaDB MaxScale, either from a repository or by\
+Information about installing MariaDB MaxScale, either from a repository or by
 building from source code, is included in the [MariaDB MaxScale Installation\
 Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-installation-guide.md).
 
-The same guide also provides basic information on running MariaDB MaxScale. More\
+The same guide also provides basic information on running MariaDB MaxScale. More
 detailed information about configuring MariaDB MaxScale can be found in the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale.md
@@ -1,42 +1,42 @@
 # MaxScale 24.02 Limitations and Known Issues within MariaDB MaxScale
 
-This document lists known issues and limitations in MariaDB MaxScale and its\
-plugins. Since limitations are related to specific plugins, this document is\
+This document lists known issues and limitations in MariaDB MaxScale and its
+plugins. Since limitations are related to specific plugins, this document is
 divided into several sections.
 
 ### Configuration limitations
 
-In versions 2.1.2 and earlier, the configuration files are limited to 1024\
+In versions 2.1.2 and earlier, the configuration files are limited to 1024
 characters per line. This limitation was increased to 16384 characters in\
 MaxScale 2.1.3. MaxScale 2.3.0 increased this limit to 16777216 characters.
 
-In versions 2.2.12 and earlier, the section names in the configuration files\
-were limited to 49 characters. This limitation was increased to 1023 characters\
+In versions 2.2.12 and earlier, the section names in the configuration files
+were limited to 49 characters. This limitation was increased to 1023 characters
 in MaxScale 2.2.13.
 
 #### Multiple MaxScales on same server
 
-Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to\
-the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale\
-instances to listen on the same network port if the directories used by both\
-instances are completely separate and there are no conflicts which can cause\
-unexpected splitting of connections. This will only happen if users explicitly\
-tell MaxScale to ignore the default directories and will not happen in normal\
+Starting with MaxScale 2.4.0, on systems with Linux kernels 3.9 or newer due to
+the addition of SO\_REUSEPORT support, it is possible for multiple MaxScale
+instances to listen on the same network port if the directories used by both
+instances are completely separate and there are no conflicts which can cause
+unexpected splitting of connections. This will only happen if users explicitly
+tell MaxScale to ignore the default directories and will not happen in normal
 use.
 
 ### Security limitations
 
 #### MariaDB 10.2
 
-The parser of MaxScale correctly parses `WITH` statements, but fails to\
+The parser of MaxScale correctly parses `WITH` statements, but fails to
 collect columns, functions and tables used in the `SELECT` defining the`WITH` clause.
 
-Consequently, the database firewall will **not** block `WITH` statements\
+Consequently, the database firewall will **not** block `WITH` statements
 where the `SELECT` of the `WITH` clause refers to forbidden columns.
 
 ### MariaDB Default Values
 
-MaxScale assumes that certain configuration parameters in MariaDB are set to\
+MaxScale assumes that certain configuration parameters in MariaDB are set to
 their default values. These include but are not limited to:
 
 * `autocommit`: Autocommit is enabled for all new connections.
@@ -51,38 +51,38 @@ require query classification, a custom parser is used to detect them. Currently\
 the only situation in which this parser is used is when a `readconnroute`\
 service uses the `cache` filter.
 
-The custom parser detects a subset of the full SQL syntax used to start\
-transactions. This means that more complex statements will not be fully parsed\
-and will cause the transaction state to not match the real state on the\
-database. For example, `SET @my_var = (SELECT 1), autocommit = 0` is not parsed\
+The custom parser detects a subset of the full SQL syntax used to start
+transactions. This means that more complex statements will not be fully parsed
+and will cause the transaction state to not match the real state on the
+database. For example, `SET @my_var = (SELECT 1), autocommit = 0` is not parsed
 by the custom parser and causes the autocommit modification to not be noticed.
 
 #### XA Transactions
 
-MaxScale will treat statements executed after `XA START` and before `XA END` as\
-if they were executed in a normal read-write transaction started with `START TRANSACTION`. This means that only XA transactions in the ACTIVE state will be\
+MaxScale will treat statements executed after `XA START` and before `XA END` as
+if they were executed in a normal read-write transaction started with `START TRANSACTION`. This means that only XA transactions in the ACTIVE state will be
 routed as transactions and all statements after `XA END` are routed normally.
 
-XA transactions and normal transactions are mutually exclusive in MariaDB. This\
-means that a `START TRANSACTION` command will fail if the connection already has\
-an open XA transaction. MaxScale currently only inspects the SQL and deduces the\
-transaction state from that. If a transaction fails to start due to an open XA\
-transaction, the state in MaxScale and in MariaDB can be different and MaxScale\
-will keep routing statements as if they were inside of a transaction. However,\
+XA transactions and normal transactions are mutually exclusive in MariaDB. This
+means that a `START TRANSACTION` command will fail if the connection already has
+an open XA transaction. MaxScale currently only inspects the SQL and deduces the
+transaction state from that. If a transaction fails to start due to an open XA
+transaction, the state in MaxScale and in MariaDB can be different and MaxScale
+will keep routing statements as if they were inside of a transaction. However,
 as this is an unlikely scenario, usually no action needs to be taken.
 
 ### Prepared Statements
 
-For its proper functioning, MaxScale needs in general to be aware of the\
-transaction state and _autocommit_ mode. In order to be that, MaxScale\
+For its proper functioning, MaxScale needs in general to be aware of the
+transaction state and _autocommit_ mode. In order to be that, MaxScale
 parses statements going through it.
 
-However, if a transaction is committed or rolled back, or the autocommit\
-mode is changed using a prepared statement, MaxScale will miss that and its\
-internal state will be incorrect, until the transaction state or autocommit\
+However, if a transaction is committed or rolled back, or the autocommit
+mode is changed using a prepared statement, MaxScale will miss that and its
+internal state will be incorrect, until the transaction state or autocommit
 mode is changed using an explicit statement.
 
-For instance, after the following sequence of commands, MaxScale will still\
+For instance, after the following sequence of commands, MaxScale will still
 think _autocommit_ is on:
 
 ```
@@ -91,7 +91,7 @@ PREPARE hide_autocommit FROM "set autocommit=0"
 EXECUTE hide_autocommit
 ```
 
-To ensure that MaxScale functions properly, do not commit or rollback a\
+To ensure that MaxScale functions properly, do not commit or rollback a
 transaction or change the autocommit mode using a prepared statement.
 
 ### Protocol limitations
@@ -99,65 +99,65 @@ transaction or change the autocommit mode using a prepared statement.
 #### Limitations with MySQL/MariaDB Protocol support (MariaDBClient)
 
 * Compression is not included in the server handshake.
-* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept\
-  it. If the ID matches a MaxScale session ID, it will be closed by sending\
-  modified `KILL` commands of the same type to all backend server to which the\
-  session in question is connected to. This results in behavior that is similar\
-  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,\
+* If a `KILL [CONNECTION] <ID>` statement is executed, MaxScale will intercept
+  it. If the ID matches a MaxScale session ID, it will be closed by sending
+  modified `KILL` commands of the same type to all backend server to which the
+  session in question is connected to. This results in behavior that is similar
+  to how MariaDB does it. If the `KILL CONNECTION USER <user>` form is given,
   all connections with a matching username will be closed instead.
-* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type\
-  statements. If a query by a query ID is to be killed, it needs to be done\
+* MariaDB MaxScale does not support `KILL QUERY ID <query_id>` type
+  statements. If a query by a query ID is to be killed, it needs to be done
   directly on the backend databases.
 * Any `KILL` commands executed using a prepared statement are ignored by\
-  MaxScale. If any are executed, it is highly likely that the wrong connection\
+  MaxScale. If any are executed, it is highly likely that the wrong connection
   ends up being killed.
-* If a `KILL` connection kills a session that is connected to a readwritesplit\
-  service that has `transaction_replay` or `delayed_retry` enabled, it is\
-  possible that the query is retried even if the connection is killed. To avoid\
+* If a `KILL` connection kills a session that is connected to a readwritesplit
+  service that has `transaction_replay` or `delayed_retry` enabled, it is
+  possible that the query is retried even if the connection is killed. To avoid
   this, use `KILL QUERY` instead.
-* A `KILL` on one service can cause a connection from another service to be\
+* A `KILL` on one service can cause a connection from another service to be
   closed even if it uses a different protocol.
-* The change user command (COM\_CHANGE\_USER) only works with standard\
+* The change user command (COM\_CHANGE\_USER) only works with standard
   authentication.
-* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session\
-  ends up in an inconsistent state. This can happen if the password of the\
-  target user is changed and MaxScale uses old user account data when processing\
-  the change user. In such a situation, MaxScale and server will disagree on the\
+* If a COM\_CHANGE\_USER succeeds on MaxScale yet fails on the server the session
+  ends up in an inconsistent state. This can happen if the password of the
+  target user is changed and MaxScale uses old user account data when processing
+  the change user. In such a situation, MaxScale and server will disagree on the
   current user. This can affect e.g. reconnections.
 
 ### Authenticator limitations
 
 #### Limitations in the MySQL authenticator (MariaDBAuth)
 
-* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use\
+* MySQL old style passwords are not supported. MySQL versions 4.1 and newer use
   a new authentication protocol which does not support pre-4.1 style passwords.
 * When users have different passwords based on the host from which they connect\
-  MariaDB MaxScale is unable to determine which password it should use to connect\
-  to the backend database. This results in failed connections and unusable\
+  MariaDB MaxScale is unable to determine which password it should use to connect
+  to the backend database. This results in failed connections and unusable
   usernames in MariaDB MaxScale.
 
 ### Filter limitations
 
 #### Tee filter limitations (tee)
 
-The Tee filter does not support binary protocol prepared statements. The\
-execution of a prepared statements through a service that uses the tee filter is\
-not guaranteed to succeed on the service where the filter branches to as it does\
+The Tee filter does not support binary protocol prepared statements. The
+execution of a prepared statements through a service that uses the tee filter is
+not guaranteed to succeed on the service where the filter branches to as it does
 on the original service.
 
-This possibility exists due to the fact that the binary protocol prepared\
-statements are identified by a server-generated ID. The ID sent to the client\
-from the main service is not guaranteed to be the same that is sent by the\
+This possibility exists due to the fact that the binary protocol prepared
+statements are identified by a server-generated ID. The ID sent to the client
+from the main service is not guaranteed to be the same that is sent by the
 branch service.
 
 ### Monitor limitations
 
-A server can only be monitored by one monitor. Two or more monitors monitoring\
+A server can only be monitored by one monitor. Two or more monitors monitoring
 the same server is considered an error.
 
 #### Limitations with Galera Cluster Monitoring (galeramon)
 
-The default master selection is based only on MIN(wsrep\_local\_index). This\
+The default master selection is based only on MIN(wsrep\_local\_index). This
 can be influenced with the server priority mechanic described in the [Galera Monitor](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-galera-monitor.md) manual.
 
 ### Router limitations
@@ -166,38 +166,38 @@ Refer to individual router documentation for a list of their limitations.
 
 ## ETL Limitations
 
-The ETL feature in MaxScale always uses the MariaDB Connector/ODBC driver to\
-perform the data loading into MariaDB. The recommended minimum version of the\
-connector is 3.1.18. Older versions of the driver suffer from problems that may\
-manifest as crashes or memory leaks. The driver must be installed on the system\
+The ETL feature in MaxScale always uses the MariaDB Connector/ODBC driver to
+perform the data loading into MariaDB. The recommended minimum version of the
+connector is 3.1.18. Older versions of the driver suffer from problems that may
+manifest as crashes or memory leaks. The driver must be installed on the system
 in order for the ETL feature to work.
 
-The data loading into MariaDB is done with `autocommit`, `unique_checks` and`foreign_key_checks` disabled inside of a single transaction. This is done to\
-leverage the optimizations done for InnoDB that allows faster insertions into\
-empty tables. When loading data into MariaDB versions 10.5 or older, this can\
+The data loading into MariaDB is done with `autocommit`, `unique_checks` and`foreign_key_checks` disabled inside of a single transaction. This is done to
+leverage the optimizations done for InnoDB that allows faster insertions into
+empty tables. When loading data into MariaDB versions 10.5 or older, this can
 translate into long rollback times in case the ETL operation fails.
 
 ### ETL Limitations with PostgreSQL as the Source
 
-For ETL operations that migrate data from PostgreSQL, we recommend using the\
-official PostgreSQL ODBC driver. Use of other PostgreSQL ODBC drivers is\
-possible but not recommended: correct configuration of the driver is necessary\
+For ETL operations that migrate data from PostgreSQL, we recommend using the
+official PostgreSQL ODBC driver. Use of other PostgreSQL ODBC drivers is
+possible but not recommended: correct configuration of the driver is necessary
 to prevent the driver from consuming too much memory.
 
 #### Limitations in Automatic SQL Generation
 
 * Triggers on tables are not migrated automatically.
-* Check constraints are defined using the native PostgreSQL\
+* Check constraints are defined using the native PostgreSQL
   syntax. Incompatibilities must be manually fixed.
 * All indexes specific to PostgreSQL will be converted into normal indexes in\
   MariaDB.
-* The `GEOMETRY` type is assumed to be the type provided by PostGIS. It is\
+* The `GEOMETRY` type is assumed to be the type provided by PostGIS. It is
   converted into a MariaDB `GEOMETRY` type and is extracted using `ST_AsText`.
 
 ### ETL Limitations with Generic ODBC Targets
 
-It is the responsibility of the end-user to correctly configure the ODBC\
-driver. Some drivers read the whole resultset into memory by default which will\
+It is the responsibility of the end-user to correctly configure the ODBC
+driver. Some drivers read the whole resultset into memory by default which will
 result in MaxScale running out of memory
 
 * ETL operations that operate on more than one catalog are not supported.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules.md
@@ -3,45 +3,45 @@
 This document describes general MySQL protocol authentication in MaxScale. For\
 REST-api authentication, see the [configuration guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) and the [REST-api guide](../maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md).
 
-Similar to the MariaDB Server, MaxScale uses authentication plugins to implement\
-different authentication schemes for incoming clients. The same plugins also\
-handle authenticating the clients to backend servers. The authentication plugins\
+Similar to the MariaDB Server, MaxScale uses authentication plugins to implement
+different authentication schemes for incoming clients. The same plugins also
+handle authenticating the clients to backend servers. The authentication plugins
 available in MaxScale are [standard MySQL password](mariadb-maxscale-2402-maxscale-2402-mariadbmysql-authenticator.md),[GSSAPI](mariadb-maxscale-2402-maxscale-2402-gssapi-client-authenticator.md) and [pluggable authentication modules (PAM)](mariadb-maxscale-2402-maxscale-2402-pam-authenticator.md).
 
-Most of the authentication processing is performed on the protocol level, before\
-handing it over to one of the plugins. This shared part is described in this\
+Most of the authentication processing is performed on the protocol level, before
+handing it over to one of the plugins. This shared part is described in this
 document. For information on an individual plugin, see its documentation.
 
 ### User account management
 
-Every MaxScale service with a MariaDB protocol listener requires knowledge of\
-the user accounts defined on the backend databases. The service maintains this\
+Every MaxScale service with a MariaDB protocol listener requires knowledge of
+the user accounts defined on the backend databases. The service maintains this
 information in an internal component called the _user account manager_ (UAM).\
-The UAM queries relevant data from the _mysql_-database of the backends and\
-stores it. Typically, only the current primary server is queried, as all servers\
-are assumed to have the same users. The service settings _user_ and _password_\
+The UAM queries relevant data from the _mysql_-database of the backends and
+stores it. Typically, only the current primary server is queried, as all servers
+are assumed to have the same users. The service settings _user_ and _password_
 define the credentials used when fetching user accounts.
 
-The service uses the stored data when authenticating clients, checking their\
-passwords and database access rights. This results in an authentication process\
-very similar to the MariaDB Server itself. Unauthorized users are generally\
-detected already at the MaxScale level instead of the backend servers. This may\
+The service uses the stored data when authenticating clients, checking their
+passwords and database access rights. This results in an authentication process
+very similar to the MariaDB Server itself. Unauthorized users are generally
+detected already at the MaxScale level instead of the backend servers. This may
 not apply in some cases, for example if MaxScale is using old user account data.
 
-If authentication fails, the UAM updates its data from a backend. MaxScale may\
-attempt authenticating the client again with the refreshed data without\
-communicating the first failure to the client. This transparent user data update\
+If authentication fails, the UAM updates its data from a backend. MaxScale may
+attempt authenticating the client again with the refreshed data without
+communicating the first failure to the client. This transparent user data update
 does not always work, in which case the client should try to log in again.
 
-As the UAM is shared between all listeners of a service, its settings are\
-defined in the service configuration. For more information, search the [configuration guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
-for _users\_refresh\_time_, _users\_refresh\_interval_ and_auth\_all\_servers_. Other settings which affect how the UAM connects to backends\
-are the global settings _auth\_connect\_timeout_ and _local\_address_, and\
+As the UAM is shared between all listeners of a service, its settings are
+defined in the service configuration. For more information, search the [configuration guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
+for _users\_refresh\_time_, _users\_refresh\_interval_ and_auth\_all\_servers_. Other settings which affect how the UAM connects to backends
+are the global settings _auth\_connect\_timeout_ and _local\_address_, and
 the various server-level ssl-settings.
 
 #### Required grants
 
-To properly fetch user account information, the MaxScale service user must be\
+To properly fetch user account information, the MaxScale service user must be
 able to read from various tables in the _mysql_-database: _user_, _db_,_tables\_priv_, _columns\_priv_, _procs\_priv_, _proxies\_priv_ and _roles\_mapping_.\
 The user should also have the _SHOW DATABASES_-grant.
 
@@ -66,23 +66,23 @@ GRANT ALL ON infinidb_vtable.* TO 'maxscale'@'maxscalehost';
 ### Limitations and troubleshooting
 
 When a client logs in to MaxScale, MaxScale sees the client's IP address. When\
-MaxScale then connects the client to backends (using the client's username and\
+MaxScale then connects the client to backends (using the client's username and
 password), the backends see the connection coming from the IP address of\
-MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this\
-is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),\
+MaxScale. If the client user account is to a wildcard host (`'alice'@'%'`), this
+is not an issue. If the host is restricted (`'alice'@'123.123.123.123'`),
 authentication to backends will fail.
 
 There are two primary ways to deal with this:
 
-1. Duplicate user accounts. For every user account with a restricted hostname an\
+1. Duplicate user accounts. For every user account with a restricted hostname an
    equivalent user account for MaxScale is added (`'alice'@'maxscale-ip'`).
 2. Use [proxy protocol](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
 
-Option 1 limits the passwords for user accounts with shared usernames. Such\
+Option 1 limits the passwords for user accounts with shared usernames. Such
 accounts must use the same password since they will effectively share the\
 MaxScale-to-backend user account. Option 2 requires server support.
 
-See [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)\
+See [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 for additional information on how to solve authentication issues.
 
 #### Wildcard database grants
@@ -90,14 +90,14 @@ for additional information on how to solve authentication issues.
 MaxScale supports wildcards `_` and `%` for database-level grants. As with\
 MariaDB Server, `grant select on test_.* to 'alice'@'%';` gives access to _test\__ as well as _test1_, _test2_ and so on. If the GRANT command escapes the
 wildcard (`grant select on` test\_`.* to 'alice'@'%';`) both MaxScale and the\
-MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`\
+MariaDB Server interpret it as only allowing access to _test\__. `_` and `%`
 are only interpreted as wildcards when the grant is to a database:`grant select on` test\_`.t1 to 'alice'@'%';` only grants access to the_test\_.t1_-table, not to _test1.t1_.
 
 ### Authenticator options
 
-The listener configuration defines authentication options which only affect the\
-listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an\
-individual authentication plugin or the authentication as a whole. The latter\
+The listener configuration defines authentication options which only affect the
+listener. _authenticator_ defines the authentication plugins to use._authenticator\_options_ sets various options. These options may affect an
+individual authentication plugin or the authentication as a whole. The latter
 are explained below. Multiple options can be given as a comma-separated list.
 
 ```
@@ -111,20 +111,20 @@ authenticator_options=skip_authentication=true,lower_case_table_names=1
 * Dynamic: No
 * Default: `false`
 
-If enabled, MaxScale will not check the\
+If enabled, MaxScale will not check the
 passwords of incoming clients and just assumes that they are correct.\
-Wrong passwords are instead detected when MaxScale tries to authenticate to the\
+Wrong passwords are instead detected when MaxScale tries to authenticate to the
 backend servers.
 
-This setting is mainly meant for failure tolerance in situations where the\
-password check is performed outside of MaxScale. If, for example, MaxScale\
-cannot use an LDAP-server but the backend databases can, enabling this setting\
-allows clients to log in. Even with this setting enabled, a user account\
+This setting is mainly meant for failure tolerance in situations where the
+password check is performed outside of MaxScale. If, for example, MaxScale
+cannot use an LDAP-server but the backend databases can, enabling this setting
+allows clients to log in. Even with this setting enabled, a user account
 matching the incoming client username and IP must exist on the backends for\
 MaxScale to accept the client.
 
 This setting is incompatible with standard MariaDB/MySQL authentication plugin\
-(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to\
+(_MariaDBAuth_ in MaxScale). If enabled, MaxScale cannot authenticate clients to
 backend servers using standard authentication.
 
 ```
@@ -138,12 +138,12 @@ authenticator_options=skip_authentication=true
 * Dynamic: No
 * Default: `true`
 
-If disabled, MaxScale does not require that a\
+If disabled, MaxScale does not require that a
 valid user account entry for incoming clients exists on the backends.\
-Specifically, only the client username needs to match a user account,\
+Specifically, only the client username needs to match a user account,
 hostname/IP is ignored.
 
-This setting may be used to force clients to connect through MaxScale. Normally,\
+This setting may be used to force clients to connect through MaxScale. Normally,
 creating the user _jdoe@%_ will allow the user _jdoe_ to connect from any\
 IP-address. By disabling _match\_host_ and replacing the user with _jdoe@maxscale-IP_, the user can still connect from any client IP but will be
 forced to go through MaxScale.
@@ -159,29 +159,29 @@ authenticator_options=match_host=false
 * Dynamic: No
 * Default: `0`
 
-Controls database name matching for authentication\
-when an incoming client logs in to a non-empty database. The setting functions\
-similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)\
+Controls database name matching for authentication
+when an incoming client logs in to a non-empty database. The setting functions
+similar to the MariaDB Server setting [lower\_case\_table\_names](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables)
 and should be set to the value used by the backends.
 
 The setting accepts the values 0, 1 or 2:
 
 * `0`: case-sensitive matching (default)
-* `1`: convert the requested database name to lower case before using case-insensitive\
+* `1`: convert the requested database name to lower case before using case-insensitive
   matching. Assumes that database names on the server are stored in lower case.
 * `2`: use case-insensitive matching.
 
-_true_ and _false_ are also accepted for backwards compatibility. These map to 1\
+_true_ and _false_ are also accepted for backwards compatibility. These map to 1
 and 0, respectively.
 
-The identifier names are converted using an ASCII-only function. This means that\
+The identifier names are converted using an ASCII-only function. This means that
 non-ASCII characters will retain their case-sensitivity.
 
-Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior\
-of `lower_case_table_names=1` is identical with how the MariaDB server\
-behaves. In older releases the comparisons were done in a case-sensitive manner\
-after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes\
-it a safe alternative to use when a mix of older and newer MaxScale versions is\
+Starting with MaxScale versions 2.5.25, 6.4.6, 22.08.5 and 23.02.2, the behavior
+of `lower_case_table_names=1` is identical with how the MariaDB server
+behaves. In older releases the comparisons were done in a case-sensitive manner
+after the requested database name was converted into lowercase. Using`lower_case_table_names=2` will behave identically in all versions which makes
+it a safe alternative to use when a mix of older and newer MaxScale versions is
 being used.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-ed25519-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-ed25519-authenticator.md
@@ -1,19 +1,19 @@
 # MaxScale 24.02 Ed25519 Authenticator
 
-Ed25519 is a highly secure authentication method based on public key\
+Ed25519 is a highly secure authentication method based on public key
 cryptography. It is used with the auth\_ed25519-plugin of MariaDB Server.
 
-When a client authenticates via ed25519, MaxScale first sends them a random\
-message. The client signs the message using their password as private key and\
-sends the signature back. MaxScale then checks the signature using the public\
-key fetched from the _mysql.user_-table. The client password or an equivalent\
+When a client authenticates via ed25519, MaxScale first sends them a random
+message. The client signs the message using their password as private key and
+sends the signature back. MaxScale then checks the signature using the public
+key fetched from the _mysql.user_-table. The client password or an equivalent
 token is never exposed. For more information, see [server documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-ed25519).
 
-The security of this authentication scheme presents a problem for a proxy such\
-as MaxScale since MaxScale needs to log in to backend servers on behalf of the\
-client. Since each server will generate their own random messages, MaxScale\
-cannot simply forward the original signature. Either the real password is\
-required, or a different authentication scheme must be used between MaxScale\
+The security of this authentication scheme presents a problem for a proxy such
+as MaxScale since MaxScale needs to log in to backend servers on behalf of the
+client. Since each server will generate their own random messages, MaxScale
+cannot simply forward the original signature. Either the real password is
+required, or a different authentication scheme must be used between MaxScale
 and backends. The MaxScale ed25519auth-plugin supports both alternatives.
 
 ### Configuration
@@ -28,17 +28,17 @@ service=Read-Write-Service
 authenticator=ed25519auth
 ```
 
-MaxScale will now authenticate incoming clients with ed25519 if their user\
-account has _plugin_ set to "ed25519" in the _mysql.user_-table. However,\
-routing queries will fail since MaxScale cannot authenticate to backends. To\
-continue, either use a mapping file or enable sha256-mode. Sha256-mode is\
+MaxScale will now authenticate incoming clients with ed25519 if their user
+account has _plugin_ set to "ed25519" in the _mysql.user_-table. However,
+routing queries will fail since MaxScale cannot authenticate to backends. To
+continue, either use a mapping file or enable sha256-mode. Sha256-mode is
 enabled with the following settings.
 
 #### `ed_mode`
 
 This setting defines the authentication mode used. Two values are supported:
 
-* `ed25519` (default) Digital signature based authentication. Requires mapping\
+* `ed25519` (default) Digital signature based authentication. Requires mapping
   for backend support.
 * `sha256` Authenticate client with caching\_sha2\_password-plugin instead.\
   Requires either SSL or configured RSA-keys.
@@ -49,7 +49,7 @@ authenticator_options=ed_mode=sha256
 
 #### `ed_rsa_privkey_path` and `ed_rsa_pubkey_path`
 
-Defines the RSA-keys used for encrypting the client password if SSL is not in\
+Defines the RSA-keys used for encrypting the client password if SSL is not in
 use. Should point to files with the private and public keys.
 
 ```
@@ -60,13 +60,13 @@ authenticator_options=ed_mode=sha256,
 
 ### Using a mapping file
 
-To enable MaxScale to authenticate to backends,[user mapping](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+To enable MaxScale to authenticate to backends,[user mapping](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 can be used. The mapping and backend passwords are given in a json-file.\
-The client can map to an identical username or to another user, and the backend\
+The client can map to an identical username or to another user, and the backend
 authentication scheme can be something else than ed25519.
 
-The following example maps user "alpha" to "beta" and MaxScale then uses\
-standard authentication to log into backends as "beta". User "alpha"\
+The following example maps user "alpha" to "beta" and MaxScale then uses
+standard authentication to log into backends as "beta". User "alpha"
 authenticates to MaxScale using whatever method configured in the server.\
 User "gamma" does not map to another user, just the password is given.
 
@@ -112,16 +112,16 @@ user_mapping_file=/home/joe/mapping.json
 
 ### Using sha256-authentication
 
-The mapping-based solution requires the DBA to maintain a file with user\
+The mapping-based solution requires the DBA to maintain a file with user
 passwords, which has security and upkeep implications. To avoid this,\
-MaxScale can instead use the caching\_sha2\_password-plugin to authenticate\
-the client. This authentication scheme transmits the client password to MaxScale\
-in full, allowing MaxScale to log into backends using ed25519. MaxScale\
-effectively lies to the client about its authentication plugin and then uses\
-the correct plugin with the backends. Enable sha256-authentication by setting\
+MaxScale can instead use the caching\_sha2\_password-plugin to authenticate
+the client. This authentication scheme transmits the client password to MaxScale
+in full, allowing MaxScale to log into backends using ed25519. MaxScale
+effectively lies to the client about its authentication plugin and then uses
+the correct plugin with the backends. Enable sha256-authentication by setting
 authentication option _ed\_mode_ to "sha256".
 
-sha256-authentication is best used with encrypted connections. The example\
+sha256-authentication is best used with encrypted connections. The example
 below shows a listener configured for sha256-mode and SSL.
 
 ```
@@ -139,9 +139,9 @@ ssl_ca=/tmp/myCA.pem
 
 If SSL is not in use, caching\_sha2\_password transmits the password using\
 RSA-encryption. In this case, MaxScale needs the public and private RSA-keys.\
-MaxScale sends the public key to the client if they don't already have it and\
-the client uses it to encrypt the password. MaxScale then uses the private key\
-to decrypt the password. The example below shows a listener configured for\
+MaxScale sends the public key to the client if they don't already have it and
+the client uses it to encrypt the password. MaxScale then uses the private key
+to decrypt the password. The example below shows a listener configured for
 sha256-mode without SSL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-gssapi-client-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-gssapi-client-authenticator.md
@@ -1,24 +1,24 @@
 # MaxScale 24.02 GSSAPI Client Authenticator
 
-GSSAPI is an authentication protocol that is commonly implemented with Kerberos\
-on Unix or Active Directory on Windows. This document describes GSSAPI\
+GSSAPI is an authentication protocol that is commonly implemented with Kerberos
+on Unix or Active Directory on Windows. This document describes GSSAPI
 authentication in MaxScale. The authentication module name in MaxScale is_GSSAPIAuth_.
 
 ### Preparing the GSSAPI system
 
-For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short\
+For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short
 guide on how to set up Kerberos for MaxScale.
 
-The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB\
-documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)\
+The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB
+documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)
 is a good example on how to set it up.
 
-The next step is to copy the keytab file from the server where MariaDB is\
-installed to the server where MaxScale is located. The keytab file must be\
-placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an\
+The next step is to copy the keytab file from the server where MariaDB is
+installed to the server where MaxScale is located. The keytab file must be
+placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an
 authenticator option.
 
-The location of the keytab file can be changed with the KRB5\_KTNAME environment\
+The location of the keytab file can be changed with the KRB5\_KTNAME environment
 variable: [keytab\_def.html](https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html)
 
 To take GSSAPI authentication into use, add the following to the listener.
@@ -39,10 +39,10 @@ The principal name should be the same as on the MariaDB servers.
 * Dynamic: No
 * Default: `mariadb/localhost.localdomain`
 
-The service principal name to send to the client. This parameter is a string\
+The service principal name to send to the client. This parameter is a string
 parameter which is used by the client to request the token.
 
-This parameter _must_ be the same as the principal name that the backend MariaDB\
+This parameter _must_ be the same as the principal name that the backend MariaDB
 server uses.
 
 #### `gssapi_keytab_path`
@@ -52,10 +52,10 @@ server uses.
 * Dynamic: No
 * Default: Kerberos Default
 
-Keytab file location. This should be an absolute path to the file containing the\
-keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that\
+Keytab file location. This should be an absolute path to the file containing the
+keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that
 multiple listeners with GSSAPIAuth will override each other. If using multiple\
-GSSAPI authenticators, either do not set this option or use the same value for\
+GSSAPI authenticators, either do not set this option or use the same value for
 all listeners.
 
 ```
@@ -64,23 +64,23 @@ authenticator_options=principal_name=mymariadb@EXAMPLE.COM,gssapi_keytab_path=/h
 
 ### Implementation details
 
-Read the [Authentication Modules](mariadb-maxscale-2402-maxscale-2402-authentication-modules.md) document for more\
+Read the [Authentication Modules](mariadb-maxscale-2402-maxscale-2402-authentication-modules.md) document for more
 details on how authentication modules work in MaxScale.
 
 #### GSSAPI authentication
 
-The GSSAPI plugin authentication starts when the database server sends the\
-service principal name in the AuthSwitchRequest packet. The principal name will\
+The GSSAPI plugin authentication starts when the database server sends the
+service principal name in the AuthSwitchRequest packet. The principal name will
 usually be in the form `service@REALM.COM`.
 
-The client searches its local cache for a token for the service or may request\
-it from the GSSAPI server. If found, the client sends the token to the database\
-server. The database server verifies the authenticity of the token using its\
+The client searches its local cache for a token for the service or may request
+it from the GSSAPI server. If found, the client sends the token to the database
+server. The database server verifies the authenticity of the token using its
 keytab file and sends the final OK packet to the client.
 
 ### Building the module
 
-The GSSAPI authenticator modules require the GSSAPI development libraries\
+The GSSAPI authenticator modules require the GSSAPI development libraries
 (krb5-devel on CentOS 7).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-mariadbmysql-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-mariadbmysql-authenticator.md
@@ -1,37 +1,37 @@
 # MaxScale 24.02 MariaDB/MySQL Authenticator
 
-The _MariaDBAuth_-module implements the client and backend authentication for the\
-server plugin _mysql\_native\_password_. This is the default authentication\
+The _MariaDBAuth_-module implements the client and backend authentication for the
+server plugin _mysql\_native\_password_. This is the default authentication
 plugin used by both MariaDB and MySQL.
 
 ### Authenticator options
 
-The following settings may be given in the _authenticator\_options_ of the\
+The following settings may be given in the _authenticator\_options_ of the
 listener.
 
 #### `clear_pw_passthrough`
 
 Boolean, default value is "false". Activates passthrough-mode. In this mode,\
-MaxScale does not check client credentials at all and defers authentication to\
-the backend server. This feature is primarily meant to be used with Xpand LDAP-\
-authentication, although it may be useful in any situation where MaxScale\
+MaxScale does not check client credentials at all and defers authentication to
+the backend server. This feature is primarily meant to be used with Xpand LDAP-
+authentication, although it may be useful in any situation where MaxScale
 cannot check the existence of client user account nor authenticate the client.
 
-When a client connects to a listener with this setting enabled, MaxScale will\
-change authentication method to "mysql\_clear\_password", causing the client to\
-send their cleartext password to MaxScale. MaxScale will then attempt to use\
-the password to authenticate to backends. The authentication result of the\
+When a client connects to a listener with this setting enabled, MaxScale will
+change authentication method to "mysql\_clear\_password", causing the client to
+send their cleartext password to MaxScale. MaxScale will then attempt to use
+the password to authenticate to backends. The authentication result of the
 first backend to respond will be sent to the client. The backend may ask\
-MaxScale for either cleartext password or standard ("mysql\_native\_password")\
-authentication token. MaxScale can work with both backend plugins since it has\
+MaxScale for either cleartext password or standard ("mysql\_native\_password")
+authentication token. MaxScale can work with both backend plugins since it has
 the original password.
 
-This feature is incompatible with service setting _lazy\_connect_. Either leave\
-it unspecified or set `lazy_connect=false` in the linked service. Also,\
-multiple client authenticators are not allowed on the listener when\
+This feature is incompatible with service setting _lazy\_connect_. Either leave
+it unspecified or set `lazy_connect=false` in the linked service. Also,
+multiple client authenticators are not allowed on the listener when
 passthrough-mode is on.
 
-Because passwords are sent in cleartext, the listener should be configured for\
+Because passwords are sent in cleartext, the listener should be configured for
 ssl.
 
 ```
@@ -50,10 +50,10 @@ ssl=true
 * Dynamic: No
 * Default: `false`
 
-The service setting _log\_auth\_warnings_ must\
-also be enabled for this setting to have effect. When both settings are enabled,\
-password hashes are logged if a client gives a wrong password. This feature may\
-be useful when diagnosing authentication issues. It should only be enabled on a\
+The service setting _log\_auth\_warnings_ must
+also be enabled for this setting to have effect. When both settings are enabled,
+password hashes are logged if a client gives a wrong password. This feature may
+be useful when diagnosing authentication issues. It should only be enabled on a
 secure system as the logging of password hashes may be a security risk.
 
 #### `cache_dir`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-pam-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-pam-authenticator.md
@@ -1,15 +1,15 @@
 # MaxScale 24.02 PAM Authenticator
 
 Pluggable authentication module (PAM) is a general purpose authentication API.\
-An application using PAM can authenticate a user without knowledge about the\
-underlying authentication implementation. The actual authentication scheme is\
-defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be\
-quite elaborate. MaxScale supports a very limited form of the PAM protocol,\
+An application using PAM can authenticate a user without knowledge about the
+underlying authentication implementation. The actual authentication scheme is
+defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be
+quite elaborate. MaxScale supports a very limited form of the PAM protocol,
 which this document details.
 
 ### Configuration
 
-The MaxScale PAM module requires little configuration. All that is required\
+The MaxScale PAM module requires little configuration. All that is required
 is to change the listener authenticator module to "PAMAuth".
 
 ```
@@ -25,14 +25,14 @@ address=123.456.789.10
 port=12345
 ```
 
-MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_\
-set to "pam" in the _mysql.user_-table. The PAM service name of a user is read\
-from the _authentication\_string_-column. The matching PAM service in the\
-operating system PAM config is used for authenticating the user. If the\_authentication\_string\_ for a user is empty, the fallback service "mysql" is\
+MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_
+set to "pam" in the _mysql.user_-table. The PAM service name of a user is read
+from the _authentication\_string_-column. The matching PAM service in the
+operating system PAM config is used for authenticating the user. If the\_authentication\_string\_ for a user is empty, the fallback service "mysql" is
 used.
 
-PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)\
-for more information. A simple service definition used for testing this module\
+PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)
+for more information. A simple service definition used for testing this module
 is below.
 
 ```
@@ -48,8 +48,8 @@ account         required        pam_unix.so
 * Default: `false`
 
 If enabled, MaxScale communicates with the client as if using [mysql\_clear\_password](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/1-connecting/connection#mysql_clear_password-plugin).\
-This setting has no effect on MaxScale-to-backend communication, which adapts to\
-either "dialog" or "mysql\_clear\_password", depending on which one the backend\
+This setting has no effect on MaxScale-to-backend communication, which adapts to
+either "dialog" or "mysql\_clear\_password", depending on which one the backend
 suggests. This setting is meant to be used with the similarly named MariaDB\
 Server setting.
 
@@ -75,23 +75,23 @@ This setting defines the authentication mode used. Two values are supported:
 authenticator_options=pam_mode=password_2FA
 ```
 
-If set to _password\_2FA_, any users authenticating via PAM will be asked two\
-passwords ("Password" and "Verification code") during login. MaxScale uses the\
+If set to _password\_2FA_, any users authenticating via PAM will be asked two
+passwords ("Password" and "Verification code") during login. MaxScale uses the
 normal password when either the local PAM api or a backend asks for "Password".\
-MaxScale answers any other password prompt (e.g. "Verification code") with the\
-second password. See [the limitations section](mariadb-maxscale-2402-maxscale-2402-pam-authenticator.md#implementation-details-and-limitations)\
+MaxScale answers any other password prompt (e.g. "Verification code") with the
+second password. See [the limitations section](mariadb-maxscale-2402-maxscale-2402-pam-authenticator.md#implementation-details-and-limitations)
 for more details. Two-factor mode is incompatible with\_pam\_use\_cleartext\_plugin\_.
 
-If set to _suid_, MaxScale will launch a separate subprocess for every client to\
-handle pam authentication. This subprocess runs the binary`maxscale_pam_auth_tool` (installed in the binary directory), which calls the\
-system pam libraries. The binary is installed with the SUID bit set, which means\
-that it runs with root-privileges regardless of the user launching it. This\
-should bypass any file grant issues (e.g. reading `etc/shadow`) that may arise\
-with the _password_ or _password\_2FA_ options. The _suid_-option may also\
-perform faster if many clients authenticate with pam simultaneously due\
-to better separation of clients. It may also resist buggy pam plugins crashing,\
-as the crash would be limited to the subprocess only. The MariaDB Server uses\
-a similar pam authentication scheme. _suid_-mode supports two-factor\
+If set to _suid_, MaxScale will launch a separate subprocess for every client to
+handle pam authentication. This subprocess runs the binary`maxscale_pam_auth_tool` (installed in the binary directory), which calls the
+system pam libraries. The binary is installed with the SUID bit set, which means
+that it runs with root-privileges regardless of the user launching it. This
+should bypass any file grant issues (e.g. reading `etc/shadow`) that may arise
+with the _password_ or _password\_2FA_ options. The _suid_-option may also
+perform faster if many clients authenticate with pam simultaneously due
+to better separation of clients. It may also resist buggy pam plugins crashing,
+as the crash would be limited to the subprocess only. The MariaDB Server uses
+a similar pam authentication scheme. _suid_-mode supports two-factor
 authentication.
 
 #### `pam_backend_mapping`
@@ -102,7 +102,7 @@ authentication.
 * Values: `none`, `mariadb`
 * Default: `none`
 
-Defines backend authentication mapping, i.e. switch of authentication method\
+Defines backend authentication mapping, i.e. switch of authentication method
 between client-to-MaxScale and MaxScale-to-backend. Supported values:
 
 * `none` No mapping
@@ -112,28 +112,28 @@ between client-to-MaxScale and MaxScale-to-backend. Supported values:
 authenticator_options=pam_backend_mapping=mariadb
 ```
 
-If set to "mariadb", MaxScale will authenticate clients to backends using\
+If set to "mariadb", MaxScale will authenticate clients to backends using
 standard MariaDB authentication. Authentication to MaxScale itself still uses\
-PAM. MaxScale asks the local PAM system if the client username was mapped\
-to another username during authentication, and use the mapped username when\
-logging in to backends. Passwords for the mapped users can be given in a file,\
-see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to\
-authenticate without a password. Because of this, normal PAM users and mapped\
+PAM. MaxScale asks the local PAM system if the client username was mapped
+to another username during authentication, and use the mapped username when
+logging in to backends. Passwords for the mapped users can be given in a file,
+see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to
+authenticate without a password. Because of this, normal PAM users and mapped
 users cannot be used on the same listener.
 
-Because the client still needs to authenticate to MaxScale normally, an\
-anonymous user may be required. If the backends do not allow such a user, one\
+Because the client still needs to authenticate to MaxScale normally, an
+anonymous user may be required. If the backends do not allow such a user, one
 can be manually added using the service setting [user\_accounts\_file](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
 
-To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be\
-installed separately. It is included in recent MariaDB Server packages and can\
-also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)\
-for more information on how to configure the module. If the goal is to only map\
-users from PAM to MariaDB in MaxScale, then configuring user mapping\
+To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be
+installed separately. It is included in recent MariaDB Server packages and can
+also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)
+for more information on how to configure the module. If the goal is to only map
+users from PAM to MariaDB in MaxScale, then configuring user mapping
 on just the machine running MaxScale is enough.
 
-Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md),\
-as it is easier to configure. `pam_backend_mapping` should only be used when\
+Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md),
+as it is easier to configure. `pam_backend_mapping` should only be used when
 the user mapping needs to be defined by pam.
 
 #### `pam_mapped_pw_file`
@@ -143,19 +143,19 @@ the user mapping needs to be defined by pam.
 * Dynamic: No
 * Default: None
 
-Path to a json-text file with user passwords. Default value is empty, which\
+Path to a json-text file with user passwords. Default value is empty, which
 disables the feature.
 
 ```
 authenticator_options=pam_mapped_pw_file=/home/root/passwords.json,pam_backend_mapping=mariadb
 ```
 
-This feature only works together with `pam_backend_mapping=mariadb`. The file is\
-only read during listener creation (typically MaxScale start) or when a listener\
-is modified during runtime. The file should contain passwords for the mapped\
-users. When a client is authenticating, MaxScale searches the password data for a\
-matching username. If one is found, MaxScale uses the supplied password when\
-logging in to backends. Otherwise, MaxScale tries to authenticate without a\
+This feature only works together with `pam_backend_mapping=mariadb`. The file is
+only read during listener creation (typically MaxScale start) or when a listener
+is modified during runtime. The file should contain passwords for the mapped
+users. When a client is authenticating, MaxScale searches the password data for a
+matching username. If one is found, MaxScale uses the supplied password when
+logging in to backends. Otherwise, MaxScale tries to authenticate without a
 password.
 
 One array, "users\_and\_passwords", is read from the file. Each array element in the array must define the following fields:
@@ -182,105 +182,105 @@ An example file is below.
 
 ### Anonymous user mapping
 
-When backend authenticator mapping is not in use\
-(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator\
+When backend authenticator mapping is not in use
+(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator
 supports a limited version of [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
 It requires less configuration but is also less accurate than proper mapping.\
 Anonymous mapping is enabled in MaxScale if the following user exists:
 
 * Empty username (e.g. `''@'%'` or `''@'myhost.com'`)
 * `plugin = 'pam'`
-* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one\
+* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one
   row with `GRANT PROXY ON ...`)
 
-When the authenticator detects such users, anonymous account mapping is enabled\
-for the hosts of the anonymous users. To verify this, enable the info log\
-(`log_info=1` in MaxScale config file). When a client is logging in using the\
-anonymous user account, MaxScale will log a message starting with "Found\
+When the authenticator detects such users, anonymous account mapping is enabled
+for the hosts of the anonymous users. To verify this, enable the info log
+(`log_info=1` in MaxScale config file). When a client is logging in using the
+anonymous user account, MaxScale will log a message starting with "Found
 matching anonymous user ...".
 
-When mapping is on, the MaxScale PAM authenticator does not require client\
-accounts to exist in the `mysql.user`-table received from the backend. MaxScale\
-only requires that the hostname of the incoming client matches the host field of\
-one of the anonymous users (comparison performed using `LIKE`). If a match is\
-found, MaxScale attempts to authenticate the client to the local machine with\
-the username and password supplied. The PAM service used for authentication is\
-read from the `authentication_string`-field of the anonymous user. If\
-authentication was successful, MaxScale then uses the username and password to\
+When mapping is on, the MaxScale PAM authenticator does not require client
+accounts to exist in the `mysql.user`-table received from the backend. MaxScale
+only requires that the hostname of the incoming client matches the host field of
+one of the anonymous users (comparison performed using `LIKE`). If a match is
+found, MaxScale attempts to authenticate the client to the local machine with
+the username and password supplied. The PAM service used for authentication is
+read from the `authentication_string`-field of the anonymous user. If
+authentication was successful, MaxScale then uses the username and password to
 log to the backends.
 
-Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2402-maxscale-2402-pam-authenticator.md#configuration). This means,\
-that if a user is found and the authentication fails, anonymous authentication\
-is not attempted even when it could use a different PAM service with a different\
+Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2402-maxscale-2402-pam-authenticator.md#configuration). This means,
+that if a user is found and the authentication fails, anonymous authentication
+is not attempted even when it could use a different PAM service with a different
 outcome.
 
-Setting up PAM group mapping for the MariaDB server is a more involved process\
+Setting up PAM group mapping for the MariaDB server is a more involved process
 as the server requires details on which Unix user or group is mapped to which\
-MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)\
-for more details. Performing all the steps in the guide also on the MaxScale\
-machine is not required, as the MaxScale PAM plugin only checks that the client\
-host matches an anonymous user and that the client (with the username and\
-password it provided) can log into the local PAM configuration. If using normal\
-password authentication, simply generating the Unix user and password should be\
+MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)
+for more details. Performing all the steps in the guide also on the MaxScale
+machine is not required, as the MaxScale PAM plugin only checks that the client
+host matches an anonymous user and that the client (with the username and
+password it provided) can log into the local PAM configuration. If using normal
+password authentication, simply generating the Unix user and password should be
 enough.
 
 ### Implementation details and limitations
 
 The general PAM authentication scheme is difficult for a proxy such as MaxScale.\
-An application using the PAM interface needs to define a _conversation function_\
-to allow the OS PAM modules to communicate with the client, possibly exchanging\
-multiple messages. This works when a client logs in to a normal server, but not\
+An application using the PAM interface needs to define a _conversation function_
+to allow the OS PAM modules to communicate with the client, possibly exchanging
+multiple messages. This works when a client logs in to a normal server, but not
 with MaxScale since it needs to autonomously log into multiple backends. For\
-MaxScale to successfully log into the servers, the messages and answers need to\
-be predefined. The passwords given to MaxScale need to work as is when MaxScale\
+MaxScale to successfully log into the servers, the messages and answers need to
+be predefined. The passwords given to MaxScale need to work as is when MaxScale
 logs into the backends. This requirement prevents the use of one-time passwords.
 
-The MaxScale PAM authentication module supports two password modes. In normal\
+The MaxScale PAM authentication module supports two password modes. In normal
 mode, client authentication begins with MaxScale sending an\
-AuthSwitchRequest packet. In addition to the command, the packet contains the\
-client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)\
-and the message "Password: ". In the next packet, the client should send the\
-password, which MaxScale will forward to the PAM api running on the local\
-machine. If the password is correct, an OK packet is sent to the client. If the\
-local PAM api asks for additional credentials as is typical in two-factor\
-authentication schemes, authentication fails. Informational messages such as\
-password expiration notifications are allowed. These are simply printed to the\
+AuthSwitchRequest packet. In addition to the command, the packet contains the
+client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)
+and the message "Password: ". In the next packet, the client should send the
+password, which MaxScale will forward to the PAM api running on the local
+machine. If the password is correct, an OK packet is sent to the client. If the
+local PAM api asks for additional credentials as is typical in two-factor
+authentication schemes, authentication fails. Informational messages such as
+password expiration notifications are allowed. These are simply printed to the
 log.
 
-On the backend side, MaxScale expects the servers to act as MaxScale did towards\
-the client. The servers should send an AuthSwitchRequest packet as defined\
-above, MaxScale responds with the password received by the client authenticator\
-and finally backend replies with OK. Informational messages from backends are\
+On the backend side, MaxScale expects the servers to act as MaxScale did towards
+the client. The servers should send an AuthSwitchRequest packet as defined
+above, MaxScale responds with the password received by the client authenticator
+and finally backend replies with OK. Informational messages from backends are
 only printed to the info-log.
 
 #### Two-factor authentication support
 
-MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the\
-client to log in to the local PAM api as well as all the backends, the code must\
-be reusable. This prevents the use of any kind of centrally checked one-use\
-codes. Time-based codes work, assuming the backends are checking the codes\
+MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the
+client to log in to the local PAM api as well as all the backends, the code must
+be reusable. This prevents the use of any kind of centrally checked one-use
+codes. Time-based codes work, assuming the backends are checking the codes
 independently of each other. Automatic reconnection features (e.g.\
-readwritesplit-router) will not work, as the code has likely changed since\
+readwritesplit-router) will not work, as the code has likely changed since
 original authentication.
 
-Optionally, the PAM configuration on the backend servers can be weakened such\
-that the servers only asks for the normal password. This way, MaxScale will\
-check the 2FA-code of the incoming client, while MaxScale logs into the backends\
+Optionally, the PAM configuration on the backend servers can be weakened such
+that the servers only asks for the normal password. This way, MaxScale will
+check the 2FA-code of the incoming client, while MaxScale logs into the backends
 using only the password.
 
-Due to technical reasons, MaxScale does not forward the password prompts from\
+Due to technical reasons, MaxScale does not forward the password prompts from
 the PAM api to the client. MaxScale will always ask for "Password" and\
-"Verification code", even if the PAM api asks for other items. This prevents the\
+"Verification code", even if the PAM api asks for other items. This prevents the
 use of authentication schemes where a specific question must be answered (e.g.\
-"Input code Nr. 5"). This is not a significant limitation, as such schemes would\
+"Input code Nr. 5"). This is not a significant limitation, as such schemes would
 not work with backend servers anyway.
 
 ### Test tool
 
-MaxScale binary directory contains the _test\_pam\_login_-executable. This simple\
-program asks for a username, password and PAM service and then uses the given\
-credentials to login to the given service. _test\_pam\_login_ uses the same code\
-as MaxScale itself to communicate with the OS PAM interface and may be useful\
+MaxScale binary directory contains the _test\_pam\_login_-executable. This simple
+program asks for a username, password and PAM service and then uses the given
+credentials to login to the given service. _test\_pam\_login_ uses the same code
+as MaxScale itself to communicate with the OS PAM interface and may be useful
 for diagnosing PAM login issues.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02connectors/mariadb-maxscale-2402-maxscale-2402-maxscale-cdc-connector.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02connectors/mariadb-maxscale-2402-maxscale-2402-maxscale-cdc-connector.md
@@ -4,29 +4,29 @@ The C++ connector for the [MariaDB MaxScale](https://mariadb.com/products/techno
 
 ### Usage
 
-The CDC connector is a single-file connector which allows it to be relatively\
+The CDC connector is a single-file connector which allows it to be relatively
 easily embedded into existing applications.
 
-To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
+To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
 and install the `maxscale-cdc-connector` package.
 
 ### API Overview
 
-A CDC connection object is prepared by instantiating the `CDC::Connection`\
-class. To create the actual connection, call the `CDC::Connection::connect`\
+A CDC connection object is prepared by instantiating the `CDC::Connection`
+class. To create the actual connection, call the `CDC::Connection::connect`
 method of the class.
 
-After the connection has been created, call the `CDC::Connection::read` method\
-to get a row of data. The `CDC::Row::length` method tells how many values a row\
-has and `CDC::Row::value` is used to access that value. The field name of a\
-value can be extracted with the `CDC::Row::key` method and the current GTID of a\
+After the connection has been created, call the `CDC::Connection::read` method
+to get a row of data. The `CDC::Row::length` method tells how many values a row
+has and `CDC::Row::value` is used to access that value. The field name of a
+value can be extracted with the `CDC::Row::key` method and the current GTID of a
 row of data is retrieved with the `CDC::Row::gtid` method.
 
 To close the connection, destroy the instantiated object.
 
 ### Examples
 
-The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)\
+The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)
 that demonstrates basic usage of the MaxScale CDC Connector.
 
 ### Dependencies
@@ -65,7 +65,7 @@ sudo zypper install -y libjansson-devel openssl-devel cmake make gcc-c++ git
 
 ### Building and Packaging
 
-To build and package the connector as a library, follow MaxScale build\
+To build and package the connector as a library, follow MaxScale build
 instructions with the exception of adding `-DTARGET_COMPONENT=devel` to the\
 CMake call.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-cache.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-cache.md
@@ -4,34 +4,34 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-From MaxScale version 2.2.11 onwards, the cache filter is no longer\
-considered experimental. The following changes to the default behaviour\
+From MaxScale version 2.2.11 onwards, the cache filter is no longer
+considered experimental. The following changes to the default behaviour
 have also been made:
 
 * The default value of `cached_data` is now `thread_specific` (used to be`shared`).
 * The default value of `selects` is now `assume_cacheable` (used to be`verify_cacheable`).
 
 The cache filter is a simple cache that is capable of caching the result of\
-SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,\
+SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,
 without the queries being routed to any server.
 
 By _default_ the cache will be used and populated in the following circumstances:
 
 * There is no explicit transaction active, that is, autocommit is used,
 * there is an explicitly read-only transaction (that is,`START TRANSACTION READ ONLY`) active, or
-* there is a transaction active and no statement that modifies the database\
+* there is a transaction active and no statement that modifies the database
   has been performed.
 
-In practice, the last bullet point basically means that if a transaction has\
+In practice, the last bullet point basically means that if a transaction has
 been started with `BEGIN`, `START TRANSACTION` or `START TRANSACTION READ WRITE`, then the cache will be used and populated until the first `UPDATE`,`INSERT` or `DELETE` statement is encountered.
 
-That is, in default mode the cache effectively causes the system to behave\
-as if the _isolation level_ would be `READ COMMITTED`, irrespective of what\
+That is, in default mode the cache effectively causes the system to behave
+as if the _isolation level_ would be `READ COMMITTED`, irrespective of what
 the isolation level of the backends actually is.
 
 The default behaviour can be altered using the configuration parameter [cache\_in\_transactions](mariadb-maxscale-2402-cache.md#cache_in_transactions).
 
-By default it is assumed that all `SELECT` statements are cacheable, which\
+By default it is assumed that all `SELECT` statements are cacheable, which
 means that also statements like `SELECT LOCALTIME` are cached. Please check [selects](mariadb-maxscale-2402-cache.md#selects) for how to change the default behaviour.
 
 ### Limitations
@@ -50,34 +50,34 @@ Multi-statements are always sent to the backend and their result is**not** cache
 
 The cache is **not** aware of grants.
 
-The implication is that unless the cache has been explicitly configured\
-who the caching should apply to, the presence of the cache may provide\
+The implication is that unless the cache has been explicitly configured
+who the caching should apply to, the presence of the cache may provide
 a user with access to data he should not have access to.
 
 Please read the section [Security](mariadb-maxscale-2402-cache.md#security-1) for more detailed information.
 
-However, from 2.5 onwards it is possible to configure the cache to cache\
-the data of each user separately, which effectively means that there can\
-be no unintended sharing. Please see [users](mariadb-maxscale-2402-cache.md#users) for how to change\
+However, from 2.5 onwards it is possible to configure the cache to cache
+the data of each user separately, which effectively means that there can
+be no unintended sharing. Please see [users](mariadb-maxscale-2402-cache.md#users) for how to change
 the default behaviour.
 
 #### `information_schema`
 
-When [invalidation](mariadb-maxscale-2402-cache.md#invalidation) is enabled, SELECTs targeting tables\
-in `information_schema` are not cached. The reason is that as the content\
-of the tables changes as the side-effect of something else, the cache would\
+When [invalidation](mariadb-maxscale-2402-cache.md#invalidation) is enabled, SELECTs targeting tables
+in `information_schema` are not cached. The reason is that as the content
+of the tables changes as the side-effect of something else, the cache would
 not know when to invalidate the cache-entries.
 
 ### Invalidation
 
-Since MaxScale 2.5, the cache is capable of invalidating entries in the\
-cache when a modification (UPDATE, INSERT or DELETE) that may affect those\
+Since MaxScale 2.5, the cache is capable of invalidating entries in the
+cache when a modification (UPDATE, INSERT or DELETE) that may affect those
 entries is made.
 
-The cache invalidation works on the table-level, that is, a modification\
-made to a particular table will cause all cache entries that refer to that\
-table to be invalidated, irrespective of whether the modification actually\
-has an impact on the cache entries or not. For instance, suppose the result\
+The cache invalidation works on the table-level, that is, a modification
+made to a particular table will cause all cache entries that refer to that
+table to be invalidated, irrespective of whether the modification actually
+has an impact on the cache entries or not. For instance, suppose the result
 of the following SELECT has been cached
 
 ```
@@ -90,55 +90,55 @@ An insert like
 INSERT INTO t SET a=42;
 ```
 
-will cause the cache entry containing the result of that SELECT to be\
+will cause the cache entry containing the result of that SELECT to be
 invalidated even if the INSERT actually does not affect it. Please see [invalidate](mariadb-maxscale-2402-cache.md#invalidate) for how to enable the invalidation.
 
-When invalidation has been enabled MaxScale must be able to completely\
-parse a SELECT statement for its results to be stored in the cache. The\
-reason is that in order to be able to invalidate cache entries, MaxScale\
-must know what tables a SELECT statement depends upon. Consequently, if\
-(and only if) invalidation has been enabled and MaxScale fails to parse a\
+When invalidation has been enabled MaxScale must be able to completely
+parse a SELECT statement for its results to be stored in the cache. The
+reason is that in order to be able to invalidate cache entries, MaxScale
+must know what tables a SELECT statement depends upon. Consequently, if
+(and only if) invalidation has been enabled and MaxScale fails to parse a
 statement, the result of that particular statement will not be cached.
 
 When invalidation has been enabled, MaxScale will also parse all UPDATE,\
-INSERT and DELETE statements, in order to find out what tables are\
-modified. If that parsing fails, MaxScale will _by default_ clear the\
-entire cache. The reason is that unless MaxScale can completely parse\
-the statement it cannot know what tables are modified and hence not what\
-cache entries should be invalidated. Consequently, to prevent stale data\
-from being returned, the entire cache is cleared. The default behaviour\
+INSERT and DELETE statements, in order to find out what tables are
+modified. If that parsing fails, MaxScale will _by default_ clear the
+entire cache. The reason is that unless MaxScale can completely parse
+the statement it cannot know what tables are modified and hence not what
+cache entries should be invalidated. Consequently, to prevent stale data
+from being returned, the entire cache is cleared. The default behaviour
 can be changed using the configuration parameter [clear\_cache\_on\_parse\_errors](mariadb-maxscale-2402-cache.md#clear_cache_on_parse_errors).
 
-Note that what threading approach is used has a big impact on the\
-invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2402-cache.md#threads-users-and-invalidation)\
+Note that what threading approach is used has a big impact on the
+invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2402-cache.md#threads-users-and-invalidation)
 for how the threading approach affects the invalidation.
 
-Note also that since the invalidation may not, depending on how the\
-cache has been configured, be visible to all sessions of all users, it\
+Note also that since the invalidation may not, depending on how the
+cache has been configured, be visible to all sessions of all users, it
 is still important to configure a reasonable [soft](mariadb-maxscale-2402-cache.md#soft_ttl) and [hard](mariadb-maxscale-2402-cache.md#hard_ttl) TTL.
 
 #### Best Efforts
 
-The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the\
-cache in all circumstances reflects the state in the actual database,\
-would require that the operations involving the cache and the MariaDB\
+The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the
+cache in all circumstances reflects the state in the actual database,
+would require that the operations involving the cache and the MariaDB
 server are synchronized, which would cause an unacceptable overhead.
 
 What _best efforts_ means in this context is best illustrated using an example.
 
-Suppose a client executes the statement `SELECT * FROM tbl` and that the result\
-is cached. Next time that or any other client executes the same statement, the\
-result is returned from the cache and the MariaDB server will not be accessed\
+Suppose a client executes the statement `SELECT * FROM tbl` and that the result
+is cached. Next time that or any other client executes the same statement, the
+result is returned from the cache and the MariaDB server will not be accessed
 at all.
 
-If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the\
-cached value for the `SELECT` statement above and all other statements that are\
-dependent upon `tbl` will be invalidated. That is, the next time someone executes\
+If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the
+cached value for the `SELECT` statement above and all other statements that are
+dependent upon `tbl` will be invalidated. That is, the next time someone executes
 the statement `SELECT * FROM tbl` the result will again be fetched from the\
 MariaDB server and stored to the cache.
 
-However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`\
-at the same time someone else executes the `INSERT ...` statement. A possible\
+However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`
+at the same time someone else executes the `INSERT ...` statement. A possible
 chain of events is as follows:
 
 ```
@@ -149,7 +149,7 @@ MaxScale -> DB                                   SELECT COUNT(*) FROM tbl
 MaxScale -> DB        INSERT ...
 ```
 
-That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of\
+That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of
 each other, the events may be re-ordered as far as the cache is concerned.
 
 ```
@@ -157,16 +157,16 @@ MaxScale -> Cache     Delete invalidated values
 MaxScale -> Cache                                Store result and invalidation key
 ```
 
-That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the\
+That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the
 situation _before_ the insert and will thus not be correct.
 
-The stale result will be returned until the value has reached its _time-to-live_\
+The stale result will be returned until the value has reached its _time-to-live_
 or its invalidation is caused by some update operation.
 
 ### Configuration
 
-The cache is simple to add to any existing service. However, some experimentation\
-may be required in order to find the configuration settings that provide\
+The cache is simple to add to any existing service. However, some experimentation
+may be required in order to find the configuration settings that provide
 the maximum benefit.
 
 ```
@@ -184,21 +184,21 @@ type=service
 filters=Cache
 ```
 
-Each configured cache filter uses a storage of its own. That is, if there\
-are two services, each configured with a specific cache filter, then,\
-even if queries target the very same servers the cached data will not\
+Each configured cache filter uses a storage of its own. That is, if there
+are two services, each configured with a specific cache filter, then,
+even if queries target the very same servers the cached data will not
 be shared.
 
-Two services can use the same cache filter, but then either the services\
-should use the very same servers _or_ a completely different set of servers,\
-where the used table names are different. Otherwise there can be unintended\
+Two services can use the same cache filter, but then either the services
+should use the very same servers _or_ a completely different set of servers,
+where the used table names are different. Otherwise there can be unintended
 sharing.
 
 #### Filter Parameters
 
 The cache filter has no mandatory parameters but a range of optional ones.\
-Note that it is advisable to specify `max_size` to prevent the cache from\
-using up all memory there is, in case there is very little overlap among the\
+Note that it is advisable to specify `max_size` to prevent the cache from
+using up all memory there is, in case there is very little overlap among the
 queries.
 
 **`storage`**
@@ -208,8 +208,8 @@ queries.
 * Dynamic: No
 * Default: `storage_inmemory`
 
-The name of the module that provides the storage for the cache. That\
-module will be loaded and provided with the value of `storage_options` as\
+The name of the module that provides the storage for the cache. That
+module will be loaded and provided with the value of `storage_options` as
 argument. For instance:
 
 ```
@@ -227,11 +227,11 @@ See [Storage](mariadb-maxscale-2402-cache.md#storage-1) for what storage modules
 
 **NOTE** Deprecated in 23.02.
 
-A string that is provided verbatim to the storage module specified in `storage`,\
-when the module is loaded. Note that the needed arguments and their format depend\
+A string that is provided verbatim to the storage module specified in `storage`,
+when the module is loaded. Note that the needed arguments and their format depend
 upon the specific module.
 
-From 23.02 onwards, the storage module configuration should be provided using\
+From 23.02 onwards, the storage module configuration should be provided using
 nested parameters.
 
 **`hard_ttl`**
@@ -241,8 +241,8 @@ nested parameters.
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Hard time to live_; the maximum amount of time the cached\
-result is used before it is discarded and the result is fetched from the\
+_Hard time to live_; the maximum amount of time the cached
+result is used before it is discarded and the result is fetched from the
 backend (and cached). See also [soft\_ttl](mariadb-maxscale-2402-cache.md#soft_ttl).
 
 ```
@@ -256,21 +256,21 @@ hard_ttl=60s
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Soft time to live_; the amount of time - in seconds - the cached result is\
-used before it is refreshed from the server. When `soft_ttl` has passed, the\
+_Soft time to live_; the amount of time - in seconds - the cached result is
+used before it is refreshed from the server. When `soft_ttl` has passed, the
 result will be refreshed when the _first_ client requests the value.
 
-However, as long as [hard\_ttl](mariadb-maxscale-2402-cache.md#hard_ttl) has not passed, _all_ other clients\
-requesting the same value will use the result from the cache while it is being\
-fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`\
-has passed, even if several clients request the same value at the same time,\
+However, as long as [hard\_ttl](mariadb-maxscale-2402-cache.md#hard_ttl) has not passed, _all_ other clients
+requesting the same value will use the result from the cache while it is being
+fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`
+has passed, even if several clients request the same value at the same time,
 there will be just one request to the backend.
 
 ```
 soft_ttl=60s
 ```
 
-If the value of `soft_ttl` is larger than `hard_ttl` it will be adjusted\
+If the value of `soft_ttl` is larger than `hard_ttl` it will be adjusted
 down to the same value.
 
 **`max_resultset_rows`**
@@ -280,7 +280,7 @@ down to the same value.
 * Dynamic: No
 * Default: `0` (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 stored in the cache. A resultset larger than this, will not be stored.
 
 ```
@@ -295,14 +295,14 @@ max_resultset_rows=1000
 * Default: `0` (no limit)
 
 Specifies the maximum size of a resultset, for it to be stored in the cache.\
-A resultset larger than this, will not be stored. The size can be specified\
+A resultset larger than this, will not be stored. The size can be specified
 as described [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
 
 ```
 max_resultset_size=128Ki
 ```
 
-Note that the value of `max_resultset_size` should not be larger than the\
+Note that the value of `max_resultset_size` should not be larger than the
 value of `max_size`.
 
 **`max_count`**
@@ -312,12 +312,12 @@ value of `max_size`.
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum number of items the cache may contain. If the limit has been\
+The maximum number of items the cache may contain. If the limit has been
 reached and a new item should be stored, then an older item will be evicted.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
-is used, then the total number of cached items is #threads \* the value\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
+is used, then the total number of cached items is #threads \* the value
 of `max_count`.
 
 ```
@@ -331,11 +331,11 @@ max_count=1000
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum size the cache may occupy. If the limit has been reached and a new\
+The maximum size the cache may occupy. If the limit has been reached and a new
 item should be stored, then some older item(s) will be evicted to make space.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
 is used, then the total size is #threads \* the value of `max_size`.
 
 ```
@@ -349,15 +349,15 @@ max_size=100Mi
 * Dynamic: Yes
 * Default: `""` (no rules)
 
-Specifies the path of the file where the caching rules are stored. A relative\
+Specifies the path of the file where the caching rules are stored. A relative
 path is interpreted relative to the _data directory_ of MariaDB MaxScale.
 
 ```
 rules=/path/to/rules-file
 ```
 
-Note that the rules will be reloaded, and applied if different, every time\
-a dynamic configuration change is made. Thus, to cause a reloading of the\
+Note that the rules will be reloaded, and applied if different, every time
+a dynamic configuration change is made. Thus, to cause a reloading of the
 rules, alter the rules parameter to the same value it has.
 
 ```
@@ -372,22 +372,22 @@ maxctrl alter filter MyCache rules='/path/to/rules-file'
 * Values: `shared`, `thread_specific`
 * Default: `thread_specific`
 
-An enumeration option specifying how data is shared between threads. The\
+An enumeration option specifying how data is shared between threads. The
 allowed values are:
 
-* `shared`: The cached data is shared between threads. On the one hand\
-  it implies that there will be synchronization between threads, on\
+* `shared`: The cached data is shared between threads. On the one hand
+  it implies that there will be synchronization between threads, on
   the other hand that all threads will use data fetched by any thread.
-* `thread_specific`: The cached data is specific to a thread. On the\
-  one hand it implies that no synchronization is needed between threads,\
-  on the other hand that the very same data may be fetched and stored\
+* `thread_specific`: The cached data is specific to a thread. On the
+  one hand it implies that no synchronization is needed between threads,
+  on the other hand that the very same data may be fetched and stored
   multiple times.
 
 ```
 cached_data=shared
 ```
 
-Default is `thread_specific`. See `max_count` and `max_size` what implication\
+Default is `thread_specific`. See `max_count` and `max_size` what implication
 changing this setting to `shared` has.
 
 **`selects`**
@@ -398,35 +398,35 @@ changing this setting to `shared` has.
 * Values: `assume_cacheable`, `verify_cacheable`
 * Default: `assume_cacheable`
 
-An enumeration option specifying what approach the cache should take with\
+An enumeration option specifying what approach the cache should take with
 respect to `SELECT` statements. The allowed values are:
 
-* `assume_cacheable`: The cache can assume that all `SELECT` statements,\
+* `assume_cacheable`: The cache can assume that all `SELECT` statements,
   without exceptions, are cacheable.
-* `verify_cacheable`: The cache can not assume that all `SELECT`\
+* `verify_cacheable`: The cache can not assume that all `SELECT`
   statements are cacheable, but must verify that.
 
 ```
 selects=verify_cacheable
 ```
 
-Default is `assume_cacheable`. In this case, all `SELECT` statements are\
-assumed to be cacheable and will be parsed _only_ if some specific rule\
+Default is `assume_cacheable`. In this case, all `SELECT` statements are
+assumed to be cacheable and will be parsed _only_ if some specific rule
 requires that.
 
-If `verify_cacheable` is specified, then all `SELECT` statements will be\
-parsed and only those that are safe for caching - e.g. do _not_ call any\
-non-cacheable functions or access any non-cacheable variables - will be\
+If `verify_cacheable` is specified, then all `SELECT` statements will be
+parsed and only those that are safe for caching - e.g. do _not_ call any
+non-cacheable functions or access any non-cacheable variables - will be
 subject to caching.
 
-If `verify_cacheable` has been specified, the cache will not be used in\
+If `verify_cacheable` has been specified, the cache will not be used in
 the following circumstances:
 
 * The `SELECT` uses any of the following functions: `BENCHMARK`,`CONNECTION_ID`, `CONVERT_TZ`, `CURDATE`, `CURRENT_DATE`, `CURRENT_TIMESTAMP`,`CURTIME`, `DATABASE`, `ENCRYPT`, `FOUND_ROWS`, `GET_LOCK`, `IS_FREE_LOCK`,`IS_USED_LOCK`, `LAST_INSERT_ID`, `LOAD_FILE`, `LOCALTIME`, `LOCALTIMESTAMP`,`MASTER_POS_WAIT`, `NOW`, `RAND`, `RELEASE_LOCK`, `SESSION_USER`, `SLEEP`,`SYSDATE`, `SYSTEM_USER`, `UNIX_TIMESTAMP`, `USER`, `UUID`, `UUID_SHORT`.
 * The `SELECT` accesses any of the following fields: `CURRENT_DATE`,`CURRENT_TIMESTAMP`, `LOCALTIME`, `LOCALTIMESTAMP`
 * The `SELECT` uses system or user variables.
 
-Note that parsing all `SELECT` statements carries a performance\
+Note that parsing all `SELECT` statements carries a performance
 cost. Please read [performance](mariadb-maxscale-2402-cache.md#performance) for more details.
 
 **`cache_in_transactions`**
@@ -437,21 +437,21 @@ cost. Please read [performance](mariadb-maxscale-2402-cache.md#performance) for 
 * Values: `never`, `read_only_transactions`, `all_transactions`
 * Default: `all_transactions`
 
-An enumeration option specifying how the cache should behave when there\
+An enumeration option specifying how the cache should behave when there
 are active transactions:
 
-* `never`: When there is an active transaction, no data will be returned\
+* `never`: When there is an active transaction, no data will be returned
   from the cache, but all requests will always be sent to the backend.\
   The cache will be populated inside explicitly read-only transactions.\
-  Inside transactions that are not explicitly read-only, the cache will\
+  Inside transactions that are not explicitly read-only, the cache will
   be populated until the first non-SELECT statement.
-* `read_only_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be populated, but not used\
+* `read_only_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be populated, but not used
   until the first non-SELECT statement.
-* `all_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be used and populated until the\
+* `all_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be used and populated until the
   first non-SELECT statement.
 
 ```
@@ -460,7 +460,7 @@ cache_in_transactions=never
 
 Default is `all_transactions`.
 
-The values `read_only_transactions` and `all_transactions` have roughly the\
+The values `read_only_transactions` and `all_transactions` have roughly the
 same effect as changing the isolation level of the backend to `read_committed`.
 
 **`debug`**
@@ -470,8 +470,8 @@ same effect as changing the isolation level of the backend to `read_committed`.
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the cache\
-can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the cache
+can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -500,9 +500,9 @@ Specifies whether the cache is initially enabled or disabled.
 enabled=false
 ```
 
-The value affects the initial state of the MaxScale user\
-variables using which the behaviour of the cache can be modified\
-at runtime. Please see [Runtime Configuration](mariadb-maxscale-2402-cache.md#runtime-configuration)\
+The value affects the initial state of the MaxScale user
+variables using which the behaviour of the cache can be modified
+at runtime. Please see [Runtime Configuration](mariadb-maxscale-2402-cache.md#runtime-configuration)
 for details.
 
 **`invalidate`**
@@ -513,7 +513,7 @@ for details.
 * Values: `never`, `current`
 * Default: `never`
 
-An enumeration option specifying how the cache should invalidate\
+An enumeration option specifying how the cache should invalidate
 cache entries.
 
 ```
@@ -524,18 +524,18 @@ cache entries.
   not.
 ```
 
-The effect of `current` depends upon the value of `cached_data`. If the value\
-is `shared`, that is, all threads share the same cache, then the effect of an\
+The effect of `current` depends upon the value of `cached_data`. If the value
+is `shared`, that is, all threads share the same cache, then the effect of an
 invalidation is immediately visible to all sessions, as there is just one cache.\
-However, if the value is `thread_specific`, then an invalidation will affect only\
+However, if the value is `thread_specific`, then an invalidation will affect only
 the cache that the session happens to be using.
 
-If it is important and _sufficient_ that an application immediately sees a change\
-that it itself has caused, then a combination of `invalidate=current`\
+If it is important and _sufficient_ that an application immediately sees a change
+that it itself has caused, then a combination of `invalidate=current`
 and `cached_data=thread_specific` can be used.
 
-If it is important that an application _immediately_ sees all changes, irrespective\
-of who has caused them, then a combination of `invalidate=current`\
+If it is important that an application _immediately_ sees all changes, irrespective
+of who has caused them, then a combination of `invalidate=current`
 and `cached_data=shared` _must_ be used.
 
 **`clear_cache_on_parse_errors`**
@@ -545,18 +545,18 @@ and `cached_data=shared` _must_ be used.
 * Dynamic: No
 * Default: `true`
 
-This boolean option specifies how the cache should behave in case of\
+This boolean option specifies how the cache should behave in case of
 parsing errors when invalidation has been enabled.
 
-* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE\
+* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE
   statement then all cached data will be cleared.
-* `false`: A failure to parse an UPDATE/INSERT/DELETE statement\
+* `false`: A failure to parse an UPDATE/INSERT/DELETE statement
   is ignored and no invalidation will take place due that statement.
 
 The default value is `true`.
 
-Changing the value to `false` may mean that stale data is returned from\
-the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement\
+Changing the value to `false` may mean that stale data is returned from
+the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement
 affects entries in the cache.
 
 **`users`**
@@ -567,7 +567,7 @@ affects entries in the cache.
 * Values: `mixed`, `isolated`
 * Default: `mixed`
 
-An enumeration option specifying how the cache should cache data for\
+An enumeration option specifying how the cache should cache data for
 different users.
 
 ```
@@ -578,11 +578,11 @@ different users.
   no unintended sharing.
 ```
 
-Note that if `isolated` has been specified, then each user will\
-conceptually have a cache of his own, which is populated\
-independently from each other. That is, if two users make the\
-same query, then the data will be fetched twice and also stored\
-twice. So, a `isolated` cache will in general use more memory and\
+Note that if `isolated` has been specified, then each user will
+conceptually have a cache of his own, which is populated
+independently from each other. That is, if two users make the
+same query, then the data will be fetched twice and also stored
+twice. So, a `isolated` cache will in general use more memory and
 cause more traffic to the backend compared to a `mixed` cache.
 
 **`timeout`**
@@ -592,7 +592,7 @@ cause more traffic to the backend compared to a `mixed` cache.
 * Dynamic: No
 * Default: `5s`
 
-The _timeout_ used when performing operations to distributed storages\
+The _timeout_ used when performing operations to distributed storages
 such as _redis_ or _memcached_.
 
 ```
@@ -601,19 +601,19 @@ timeout=7000ms
 
 #### Runtime Configuration
 
-The cache filter can be configured at runtime by executing SQL commands. If\
-there is more than one cache filter in a service, only the first cache filter\
-will be able to process the variables. The remaining filters will not see them\
+The cache filter can be configured at runtime by executing SQL commands. If
+there is more than one cache filter in a service, only the first cache filter
+will be able to process the variables. The remaining filters will not see them
 and thus configuring them at runtime is not possible.
 
 **`@maxscale.cache.populate`**
 
-Using the variable `@maxscale.cache.populate` it is possible to specify at\
-runtime whether the cache should be populated or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.populate` it is possible to specify at
+runtime whether the cache should be populated or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be populated.
 
 ```
@@ -623,10 +623,10 @@ SET @maxscale.cache.populate=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-In the example above, the first `SELECT` will always be sent to the\
-server and the result will be cached, provided the actual cache rules\
-specifies that it should be. The second `SELECT` may be served from the\
-cache, depending on the value of `@maxscale.cache.use` (and the cache\
+In the example above, the first `SELECT` will always be sent to the
+server and the result will be cached, provided the actual cache rules
+specifies that it should be. The second `SELECT` may be served from the
+cache, depending on the value of `@maxscale.cache.use` (and the cache
 rules).
 
 The value of `@maxscale.cache.populate` can be queried
@@ -639,12 +639,12 @@ but only _after_ it has been explicitly set once.
 
 **`@maxscale.cache.use`**
 
-Using the variable `@maxscale.cache.use` it is possible to specify at\
-runtime whether the cache should be used or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.use` it is possible to specify at
+runtime whether the cache should be used or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be used.
 
 ```
@@ -654,15 +654,15 @@ SET @maxscale.cache.use=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-The first `SELECT` will be served from the cache, providing the rules\
-specify that the statement should be cached, the cache indeed contains\
+The first `SELECT` will be served from the cache, providing the rules
+specify that the statement should be cached, the cache indeed contains
 the result and the date is not stale (as specified by the _TTL_).
 
-If the data is stale, the `SELECT` will be sent to the server **and**\
+If the data is stale, the `SELECT` will be sent to the server **and**
 the cache entry will be updated, irrespective of the value of`@maxscale.cache.populate`.
 
-If `@maxscale.cache.use` is `true` but the result is not found in the\
-cache, and the result is subsequently fetched from the server, the\
+If `@maxscale.cache.use` is `true` but the result is not found in the
+cache, and the result is subsequently fetched from the server, the
 result will **not** be added to the cache, unless`@maxscale.cache.populate` is also `true`.
 
 The value of `@maxscale.cache.use` can be queried
@@ -675,12 +675,12 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.soft_ttl`**
 
-Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime\
-to specify _in seconds_ what _soft ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `soft_ttl`. That is,\
+Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime
+to specify _in seconds_ what _soft ttl_ should be applied. Its initial
+value is the value of the configuration parameter `soft_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _soft ttl_ should be applied.
 
 ```
@@ -690,13 +690,13 @@ SET @maxscale.cache.soft_ttl=60;
 SELECT c, d FROM important;
 ```
 
-When data is `SELECT`ed from the unimportant table `unimportant`, the data\
-will be returned from the cache provided it is no older than 10 minutes,\
-but when data is `SELECT`ed from the important table `important`, the\
+When data is `SELECT`ed from the unimportant table `unimportant`, the data
+will be returned from the cache provided it is no older than 10 minutes,
+but when data is `SELECT`ed from the important table `important`, the
 data will be returned from the cache provided it is no older than 1 minute.
 
-Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`\
-in the sense that if the former is less that the latter, then _soft ttl_\
+Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`
+in the sense that if the former is less that the latter, then _soft ttl_
 will, when used, be adjusted down to the value of _hard ttl_.
 
 The value of `@maxscale.cache.soft_ttl` can be queried
@@ -709,16 +709,16 @@ but only after it has explicitly been set once.
 
 **`@maxscale.cache.hard_ttl`**
 
-Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime\
-to specify _in seconds_ what _hard ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `hard_ttl`. That is,\
+Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime
+to specify _in seconds_ what _hard ttl_ should be applied. Its initial
+value is the value of the configuration parameter `hard_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _hard ttl_ should be applied.
 
-Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,\
-is important to ensure that the former is at least as large as the latter\
+Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,
+is important to ensure that the former is at least as large as the latter
 and for best overall performance that it is larger.
 
 ```
@@ -738,11 +738,11 @@ but only after it has explicitly been set once.
 
 **Client Driven Caching**
 
-With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible\
+With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible
 to make the caching completely client driven.
 
-Provide no `rules` file, which means that _all_ `SELECT` statements are\
-subject to caching and that all users receive data from the cache. Set\
+Provide no `rules` file, which means that _all_ `SELECT` statements are
+subject to caching and that all users receive data from the cache. Set
 the startup mode of the cache to _disabled_.
 
 ```
@@ -762,10 +762,10 @@ SELECT e, f FROM tbl3;
 SET @maxscale.cache.populate=FALSE;
 ```
 
-Note that those `SELECT`s must return something in order for the\
+Note that those `SELECT`s must return something in order for the
 statement to be _marked_ for caching.
 
-After this, the value of `@maxscale.cache.use` will decide whether\
+After this, the value of `@maxscale.cache.use` will decide whether
 or not the cache is considered.
 
 ```
@@ -774,12 +774,12 @@ SELECT a, b FROM tbl1;
 SET @maxscale.cache.use=FALSE;
 ```
 
-With `@maxscale.cache.use` being `true`, the cache is considered\
-and the result returned from there, if not stale. If it is stale,\
+With `@maxscale.cache.use` being `true`, the cache is considered
+and the result returned from there, if not stale. If it is stale,
 the result is fetched from the server and the cached entry is updated.
 
-By setting a very long _TTL_ it is possible to prevent the cache\
-from ever considering an entry to be stale and instead manually\
+By setting a very long _TTL_ it is possible to prevent the cache
+from ever considering an entry to be stale and instead manually
 cause the cache to be updated when needed.
 
 ```
@@ -791,8 +791,8 @@ SET @maxscale.cache.populate=FALSE;
 
 ### Threads, Users and Invalidation
 
-What caching approach is used and how different users are treated\
-has a significant impact on the behaviour of the cache. In the\
+What caching approach is used and how different users are treated
+has a significant impact on the behaviour of the cache. In the
 following the implication of different combinations is explained.
 
 | cached\_data/users | mixed                                                                                                                          | isolated                                                                                                                        |
@@ -802,14 +802,14 @@ following the implication of different combinations is explained.
 
 #### Invalidation
 
-Invalidation takes place only in the current cache, so how _visible_\
+Invalidation takes place only in the current cache, so how _visible_
 the invalidation is, depends upon the configuration value of`cached_data`.
 
 **`cached_data=thread_specific`**
 
-The invalidation is visible only to the sessions that are handled by\
-the same worker thread where the invalidation occurred. Sessions of the\
-same or other users that are handled by different worker threads will\
+The invalidation is visible only to the sessions that are handled by
+the same worker thread where the invalidation occurred. Sessions of the
+same or other users that are handled by different worker threads will
 not see the new value before the TTL causes the value to be refreshed.
 
 **`cache_data=shared`**
@@ -820,8 +820,8 @@ The invalidation is immediately visible to all sessions of all users.
 
 The caching rules are expressed as a JSON object or as an array of JSON objects.
 
-There are two decisions to be made regarding the caching; in what circumstances\
-should data be stored to the cache and in what circumstances should the data in\
+There are two decisions to be made regarding the caching; in what circumstances
+should data be stored to the cache and in what circumstances should the data in
 the cache be used.
 
 Expressed in JSON this looks as follows
@@ -845,9 +845,9 @@ or, in case an array is used, as
 ]
 ```
 
-The `store` field specifies in what circumstances data should be stored to\
-the cache and the `use` field specifies in what circumstances the data in\
-the cache should be used. In both cases, the value is a JSON array containing\
+The `store` field specifies in what circumstances data should be stored to
+the cache and the `use` field specifies in what circumstances the data in
+the cache should be used. In both cases, the value is a JSON array containing
 objects.
 
 If an array of rule objects is specified, then, when looking for a rule that\
@@ -857,14 +857,14 @@ deciding whether data in the cache should be used.
 
 #### When to Store
 
-By default, if no rules file have been provided or if the `store` field is\
-missing from the object, the results of all queries will be stored to the\
-cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter\
+By default, if no rules file have been provided or if the `store` field is
+missing from the object, the results of all queries will be stored to the
+cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter
 parameters.
 
-By providing a `store` field in the JSON object, the decision whether to\
-store the result of a particular query to the cache can be controlled in\
-a more detailed manner. The decision to cache the results of a query can\
+By providing a `store` field in the JSON object, the decision whether to
+store the result of a particular query to the cache can be controlled in
+a more detailed manner. The decision to cache the results of a query can
 depend upon
 
 * the database,
@@ -888,21 +888,21 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`\
+If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`
 or `unlike`, then _value_ is interpreted as a _pcre2_ regular expression.\
-Note though that if _attribute_ is `database`, `table` or `column`, then\
-the string is interpreted as a name, where a dot `.` denotes qualification\
+Note though that if _attribute_ is `database`, `table` or `column`, then
+the string is interpreted as a name, where a dot `.` denotes qualification
 or scoping.
 
-The objects in the `store` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `store` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 result of the query in question will be stored to the cache.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then the result of the query is not stored to the cache.
 
-Note that as the query itself is used as the key, although the following\
+Note that as the query itself is used as the key, although the following
 queries
 
 ```
@@ -916,7 +916,7 @@ USE db1;
 SELECT * FROM tbl
 ```
 
-target the same table and produce the same results, they will be cached\
+target the same table and produce the same results, they will be cached
 separately. The same holds for queries like
 
 ```
@@ -929,13 +929,13 @@ and
 SELECT * FROM tbl WHERE b = 3 AND a = 2;
 ```
 
-as well. Although they conceptually are identical, there will be two\
+as well. Although they conceptually are identical, there will be two
 cache entries.
 
-Note that if a column has been specified in a rule, then a statement\
+Note that if a column has been specified in a rule, then a statement
 will match _irrespective_ of where that particular column appears.\
-For instance, if a rule specifies that the result of statements referring\
-to the column _a_ should be cached, then the following statement will\
+For instance, if a rule specifies that the result of statements referring
+to the column _a_ should be cached, then the following statement will
 match
 
 ```
@@ -950,7 +950,7 @@ SELECT b FROM tbl WHERE a > 5;
 
 **Qualified Names**
 
-When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,\
+When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,
 dot (`.`) denotes qualification or scope.
 
 In practice that means that if _attribute_ is `database` then _value_ may\
@@ -959,20 +959,20 @@ dot, used for separating the database and table names respectively, and\
 if _attribute_ is `column` then _value_ may contain one or two dots, used\
 for separating table and column names, or database, table and column names.
 
-Note that if a qualified name is used as a _value_, then all parts of the\
-name must be available for a match. Currently Maria DB MaxScale may not\
-always be capable of deducing in what table a particular column is. If\
-that is the case, then a value like `tbl.field` may not necessarily\
+Note that if a qualified name is used as a _value_, then all parts of the
+name must be available for a match. Currently Maria DB MaxScale may not
+always be capable of deducing in what table a particular column is. If
+that is the case, then a value like `tbl.field` may not necessarily
 be a match even if the field is `field` and the table actually is `tbl`.
 
 **Implication of the default database**
 
-If the rules concerns the `database`, then only if the statement refers\
+If the rules concerns the `database`, then only if the statement refers
 to _no_ specific database, will the default database be considered.
 
 **Regexp Matching**
 
-The string used for matching the regular expression contains as much\
+The string used for matching the regular expression contains as much
 information as there is available. For instance, in a situation like
 
 ```
@@ -1012,8 +1012,8 @@ Cache all queries _not_ targeting a particular table
 }
 ```
 
-That will exclude queries targeting table _tbl1_ irrespective of which\
-database it is in. To exclude a table in a particular database, specify\
+That will exclude queries targeting table _tbl1_ irrespective of which
+database it is in. To exclude a table in a particular database, specify
 the table name using a qualified name.
 
 ```
@@ -1042,16 +1042,16 @@ Cache all queries containing a WHERE clause
 }
 ```
 
-Note that this will actually cause all queries that contain WHERE anywhere,\
+Note that this will actually cause all queries that contain WHERE anywhere,
 to be cached.
 
 #### When to Use
 
-By default, if no rules file have been provided or if the `use` field is\
+By default, if no rules file have been provided or if the `use` field is
 missing from the object, all users may be returned data from the cache.
 
-By providing a `use` field in the JSON object, the decision whether to use\
-data from the cache can be controlled in a more detailed manner. The decision\
+By providing a `use` field in the JSON object, the decision whether to use
+data from the cache can be controlled in a more detailed manner. The decision
 to use data from the cache can depend upon
 
 * the user.
@@ -1072,7 +1072,7 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account\
+If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account
 string, that is, `%` means indicates wildcard, but if _op_ is `like` or`unlike` it is simply assumed _value_ is a pcre2 regular expression.
 
 For instance, the following are equivalent:
@@ -1091,26 +1091,26 @@ For instance, the following are equivalent:
 }
 ```
 
-Note that if _op_ is `=` or `!=` then the usual assumptions apply,\
-that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_\
-or _unlike_ is used, then no assumptions apply, but the string is\
+Note that if _op_ is `=` or `!=` then the usual assumptions apply,
+that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_
+or _unlike_ is used, then no assumptions apply, but the string is
 used verbatim as a regular expression.
 
-The objects in the `use` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `use` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 data in the cache will be used, subject to the value of `ttl`.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then data in the cache will not be used.
 
-Note that `use` is relevant only if the query is subject to caching,\
-that is, if all queries are cached or if a query matches a particular\
+Note that `use` is relevant only if the query is subject to caching,
+that is, if all queries are cached or if a query matches a particular
 rule in the `store` array.
 
 **Examples**
 
-Use data from the cache for all users except `admin` (actually `'admin'@'%'`),\
+Use data from the cache for all users except `admin` (actually `'admin'@'%'`),
 regardless of what host the `admin` user comes from.
 
 ```
@@ -1127,15 +1127,15 @@ regardless of what host the `admin` user comes from.
 
 ### Security
 
-As the cache is not aware of grants, unless the cache has been explicitly\
-configured who the caching should apply to, the presence of the cache\
+As the cache is not aware of grants, unless the cache has been explicitly
+configured who the caching should apply to, the presence of the cache
 may provide a user with access to data he should not have access to.\
 Note that the following applies _only_ if `users=mixed` has been configured.\
-If `users=isolated` has been configured, then there can never be any\
+If `users=isolated` has been configured, then there can never be any
 unintended sharing between users.
 
-Suppose there is a table `access` that the user _alice_ has access to,\
-but the user _bob_ does not. If _bob_ tries to access the table, he will\
+Suppose there is a table `access` that the user _alice_ has access to,
+but the user _bob_ does not. If _bob_ tries to access the table, he will
 get an error as reply:
 
 ```
@@ -1143,8 +1143,8 @@ MySQL [testdb]> select * from access;
 ERROR 1142 (42000): SELECT command denied to user 'bob'@'localhost' for table 'access'
 ```
 
-If we now setup caching for the table, using the simplest possible rules\
-file, _bob_ will get access to data from the table, provided he executes\
+If we now setup caching for the table, using the simplest possible rules
+file, _bob_ will get access to data from the table, provided he executes
 a select identical with one _alice_ has executed.
 
 For instance, suppose the rules look as follows:
@@ -1161,7 +1161,7 @@ For instance, suppose the rules look as follows:
 }
 ```
 
-If _alice_ now queries the table, she will get the result, which also will\
+If _alice_ now queries the table, she will get the result, which also will
 be cached:
 
 ```
@@ -1173,7 +1173,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-If _bob_ now executes the very same query, and the result is still in the\
+If _bob_ now executes the very same query, and the result is still in the
 cache, it will be returned to him.
 
 ```
@@ -1193,7 +1193,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-That can be prevented, by explicitly declaring in the rules that the caching\
+That can be prevented, by explicitly declaring in the rules that the caching
 should be applied to _alice_ only.
 
 ```
@@ -1215,24 +1215,24 @@ should be applied to _alice_ only.
 }
 ```
 
-With these rules in place, _bob_ is again denied access, since queries\
+With these rules in place, _bob_ is again denied access, since queries
 targeting the table `access` will in his case not be served from the cache.
 
 ### Storage
 
 There are two types of storages that can be used; _local_ and _shared_.
 
-The only _local_ storage implementation is `storage_inmemory` that simply\
-stores the cache values in memory. The storage is not persistent and is\
-destroyed when MaxScale terminates. Since the storage exists in the MaxScale\
+The only _local_ storage implementation is `storage_inmemory` that simply
+stores the cache values in memory. The storage is not persistent and is
+destroyed when MaxScale terminates. Since the storage exists in the MaxScale
 process, it is very fast and provides almost always a performance benefit.
 
-Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)\
+Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)
 and [redis](https://redis.io/) respectively.
 
 The shared storages are accessed across the network and consequently it is _not_ self-evident that their use will provide any performance benefit.
-Namely, irrespective of whether the data is fetched from the cache or from\
-the server there will be a network hop and often that network hop is, as far\
+Namely, irrespective of whether the data is fetched from the cache or from
+the server there will be a network hop and often that network hop is, as far
 as the performance goes, what costs the most.
 
 The presence of a shared cache _may_ provide a performance benefit
@@ -1241,12 +1241,12 @@ The presence of a shared cache _may_ provide a performance benefit
 * if the used SELECT statements are heavy (that is, take a significant amount of time) to process for the database server, or
 * if the presence of the cache reduces the overall load of an otherwise overloaded database server.
 
-As a general rule a _shared_ storage should not be used without first\
+As a general rule a _shared_ storage should not be used without first
 assessing its value using a realistic workload.
 
 #### `storage_inmemory`
 
-This simple storage module uses the standard memory allocator for storing\
+This simple storage module uses the standard memory allocator for storing
 the cached data.
 
 ```
@@ -1257,12 +1257,12 @@ This storage module takes no arguments.
 
 #### `storage_memcached`
 
-This storage module uses [memcached](https://memcached.org/) for storing the\
+This storage module uses [memcached](https://memcached.org/) for storing the
 cached data.
 
-Multiple MaxScale instances can share the same memcached server and items\
+Multiple MaxScale instances can share the same memcached server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
@@ -1286,18 +1286,18 @@ If no port is provided, then the default port `11211` will be used.
 * Dynamic: No
 * Default: 1Mi
 
-By default, the maximum size of a value stored to memcached is 1MiB, but that\
-can be configured to something else, in which case this parameter should be\
+By default, the maximum size of a value stored to memcached is 1MiB, but that
+can be configured to something else, in which case this parameter should be
 set accordingly.
 
-The value of `max_value_size` will be used for capping `max_resultset_size`,\
-that is, if memcached has been configured to allow larger values than 1MiB\
-but `max_value_size` has not been set accordingly, only resultsets up to 1MiB\
+The value of `max_value_size` will be used for capping `max_resultset_size`,
+that is, if memcached has been configured to allow larger values than 1MiB
+but `max_value_size` has not been set accordingly, only resultsets up to 1MiB
 in size will be cached.
 
 **Example**
 
-From MaxScale 23.02 onwards, the storage configuration should be provided\
+From MaxScale 23.02 onwards, the storage configuration should be provided
 as nested parameters.
 
 ```
@@ -1309,7 +1309,7 @@ storage_memcached.server=192.168.1.31
 storage_memcached.max_value_size=10M
 ```
 
-Although _deprecated_ in 23.02, the configuration can also be provided\
+Although _deprecated_ in 23.02, the configuration can also be provided
 using `storage_options`:
 
 ```
@@ -1323,39 +1323,39 @@ storage_options="server=192.168.1.31,max_value_size=10M"
 
 **Security**
 
-_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and\
-the memcached server is encrypted. Consequently, _anybody_ with access to the\
+_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and
+the memcached server is encrypted. Consequently, _anybody_ with access to the
 memcached server or to the network have access to the cached data.
 
 #### `storage_redis`
 
-This storage module uses [redis](https://redis.io/) for storing the\
+This storage module uses [redis](https://redis.io/) for storing the
 cached data.
 
-Note that Redis should be configured with no idle timeout or with a timeout that\
-is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which\
+Note that Redis should be configured with no idle timeout or with a timeout that
+is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which
 will hurt both the functionality and the performance.
 
-Multiple MaxScale instances can share the same redis server and items\
+Multiple MaxScale instances can share the same redis server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
 storage=storage_redis
 ```
 
-If `storage_redis` cannot connect to the Redis server, caching will silently\
-be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2402-cache.md#timeout)\
+If `storage_redis` cannot connect to the Redis server, caching will silently
+be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2402-cache.md#timeout)
 interval.
 
-If a timeout error occurs during an operation, reconnecting will be attempted\
-after a delay, which will be an increasing multiple of `timeout`. For example,\
-if `timeout` is the default 5 seconds, then reconnection attempts will first\
-be made after 10 seconds, then after 15 seconds, then 20 and so on. However,\
-once 60 seconds have been reached, the delay will no longer be increased but\
-the delay will stay at one minute. Note that each time a reconnection attempt\
-is made, unless the reason for the timeout has disappeared, the client will be\
+If a timeout error occurs during an operation, reconnecting will be attempted
+after a delay, which will be an increasing multiple of `timeout`. For example,
+if `timeout` is the default 5 seconds, then reconnection attempts will first
+be made after 10 seconds, then after 15 seconds, then 20 and so on. However,
+once 60 seconds have been reached, the delay will no longer be increased but
+the delay will stay at one minute. Note that each time a reconnection attempt
+is made, unless the reason for the timeout has disappeared, the client will be
 stalled for `timeout` seconds.
 
 `storage_redis` has the following parameters:
@@ -1402,7 +1402,7 @@ Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
 * Dynamic: No
 * Default: `""`
 
-The SSL client certificate that MaxScale should use with the Redis\
+The SSL client certificate that MaxScale should use with the Redis
 server. The certificate must match the key defined in `ssl_key`.
 
 Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
@@ -1425,7 +1425,7 @@ Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
 * Dynamic: No
 * Default: `""`
 
-The Certificate Authority (CA) certificate for the CA that signed the\
+The Certificate Authority (CA) certificate for the CA that signed the
 certificate specified with `ssl_cert`.
 
 Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
@@ -1444,16 +1444,16 @@ then both _username_ and _password_ must be provided.
 
 **SSL**
 
-If `ssl_key`, `ssl_cert` and `ssl_ca` are provided, then SSL/TLS will be used\
+If `ssl_key`, `ssl_cert` and `ssl_ca` are provided, then SSL/TLS will be used
 in the communication with the Redis server, if `ssl` is set to `true`.
 
-Note that the SSL/TLS support is only available in Redis from version 6\
-onwards and that the support is not by default built into Redis, but has\
+Note that the SSL/TLS support is only available in Redis from version 6
+onwards and that the support is not by default built into Redis, but has
 to be specifically enabled at compile time as explained [here](https://redis.io/docs/management/security/encryption/).
 
 **Example**
 
-From MaxScale 23.02 onwards, the storage configuration should be provided\
+From MaxScale 23.02 onwards, the storage configuration should be provided
 as nested parameters.
 
 ```
@@ -1466,7 +1466,7 @@ storage_redis.username=hello
 storage_redis.password=world
 ```
 
-Although _deprecated_ in 23.02, the configuration can also be provided\
+Although _deprecated_ in 23.02, the configuration can also be provided
 using `storage_options`:
 
 ```
@@ -1480,12 +1480,12 @@ storage_options="server=192.168.1.31,username=hello,password=world"
 
 **Invalidation**
 
-`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2402-cache.md#best-efforts)\
-are of greater significance since also the communication between the cache and the\
+`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2402-cache.md#best-efforts)
+are of greater significance since also the communication between the cache and the
 cache storage is asynchronous and takes place over the network.
 
-_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation\
-mode), redis must be flushed as otherwise there will be entries in the cache that\
+_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation
+mode), redis must be flushed as otherwise there will be entries in the cache that
 will not be affected by the invalidation.
 
 ```
@@ -1494,15 +1494,15 @@ $ redis-cli flushall
 
 **Security**
 
-The data in the redis server is _not_ encrypted. Consequently, _anybody_ with\
+The data in the redis server is _not_ encrypted. Consequently, _anybody_ with
 access to the redis server has access to the cached data.
 
-Unless [SSL](mariadb-maxscale-2402-cache.md#ssl) has been enabled, _anybody_ with access to the network has\
+Unless [SSL](mariadb-maxscale-2402-cache.md#ssl) has been enabled, _anybody_ with access to the network has
 access to the cached data.
 
 ### Example
 
-In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size\
+In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size
 of the cached data is `50` mebibytes. The rules for the cache are in the file`cache_rules.json`.
 
 #### Configuration
@@ -1542,16 +1542,16 @@ The rules specify that the data of the table `sbtest` should be cached.
 
 ### Performance
 
-When the cache filter was introduced, the most significant factor affecting\
+When the cache filter was introduced, the most significant factor affecting
 the performance of the cache was whether the statements needed to be parsed.\
-Initially, all statements were parsed in order to exclude `SELECT` statements\
-that use non-cacheable functions, access non-cacheable variables or refer\
-to system or user variables. Later, the default value of the `selects` parameter\
+Initially, all statements were parsed in order to exclude `SELECT` statements
+that use non-cacheable functions, access non-cacheable variables or refer
+to system or user variables. Later, the default value of the `selects` parameter
 was changed to `assume_cacheable`, to maximize the default performance.
 
-With the default configuration, the cache itself will not cause the statements\
-to be parsed. However, even with `assume_cacheable` configured, a rule referring\
-specifically to a _database_, _table_ or _column_ will still cause the\
+With the default configuration, the cache itself will not cause the statements
+to be parsed. However, even with `assume_cacheable` configured, a rule referring
+specifically to a _database_, _table_ or _column_ will still cause the
 statement to be parsed.
 
 For instance, a simple rule like
@@ -1586,15 +1586,15 @@ If the rule is instead expressed using a regular expression
 
 then the statement will not be parsed.
 
-However, when the [query classifier cache](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
-was introduced, the parsing cost was significantly reduced and\
-currently the cost for parsing and regular expression matching\
+However, when the [query classifier cache](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
+was introduced, the parsing cost was significantly reduced and
+currently the cost for parsing and regular expression matching
 is roughly the same.
 
-In the following is a table with numbers giving a rough picture\
+In the following is a table with numbers giving a rough picture
 of the relative cost of different approaches.
 
-In the table, _regexp match_ means that the cacheable statements\
+In the table, _regexp match_ means that the cacheable statements
 were picked out using a rule like
 
 ```
@@ -1605,7 +1605,7 @@ were picked out using a rule like
 }
 ```
 
-while _exact match_ means that the cacheable statements were picked out using a\
+while _exact match_ means that the cacheable statements were picked out using a
 rule like
 
 ```
@@ -1618,12 +1618,12 @@ rule like
 
 The exact match rule requires all statements to be parsed.
 
-As the purpose of the test is to illustrate the overhead of\
-different approaches, the rules were formulated so that\
+As the purpose of the test is to illustrate the overhead of
+different approaches, the rules were formulated so that
 all SELECT statements would match.
 
 Note that these figures were obtained by running sysbench,\
-MaxScale and the server in the same computer, so they are\
+MaxScale and the server in the same computer, so they are
 only indicative.
 
 | selects           | Rule         | qps |
@@ -1637,18 +1637,18 @@ only indicative.
 
 For comparison, without caching, the qps is `33`.
 
-As can be seen, due to the query classifier cache there is\
+As can be seen, due to the query classifier cache there is
 no difference between exact and regex based matching.
 
 #### Summary
 
 For maximum performance:
 
-* Arrange the situation so that the default `selects=assume_cacheable`\
+* Arrange the situation so that the default `selects=assume_cacheable`
   can be used, and use no rules.
 
-Otherwise it is mostly a personal preference whether exact or regex\
-based rules are used. However, one should always test with real data\
+Otherwise it is mostly a personal preference whether exact or regex
+based rules are used. However, one should always test with real data
 and real queries before choosing one over the other.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-binlog-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-binlog-filter.md
@@ -4,22 +4,22 @@ This filter was introduced in MariaDB MaxScale 2.3.0.
 
 ### Overview
 
-The `binlogfilter` can be combined with a `binlogrouter` service to selectively\
+The `binlogfilter` can be combined with a `binlogrouter` service to selectively
 replicate the binary log events to replica servers.
 
-The filter uses two settings, _match_ and _exclude_, to determine which events\
-are replicated. If a binlog event does not match or is excluded, the event is\
-replaced with an empty data event. The empty event is always 35 bytes which\
+The filter uses two settings, _match_ and _exclude_, to determine which events
+are replicated. If a binlog event does not match or is excluded, the event is
+replaced with an empty data event. The empty event is always 35 bytes which
 translates to a space reduction in most cases.
 
-When statement-based replication is used, any query events that are filtered out\
-are replaced with a SQL comment. This causes the query event to do nothing and\
-thus the event will not modify the contents of the database. The GTID position\
-of the replicating database will still advance which means that downstream\
+When statement-based replication is used, any query events that are filtered out
+are replaced with a SQL comment. This causes the query event to do nothing and
+thus the event will not modify the contents of the database. The GTID position
+of the replicating database will still advance which means that downstream
 servers replicating from it keep functioning correctly.
 
-The filter works with both row based and statement based replication but we\
-recommend using row based replication with the binlogfilter. This guarantees\
+The filter works with both row based and statement based replication but we
+recommend using row based replication with the binlogfilter. This guarantees
 that there are no ambiguities in the event filtering.
 
 ### Configuration
@@ -42,18 +42,18 @@ Include queries that match the regex. See next entry, `exclude`, for more inform
 
 Exclude queries that match the regex.
 
-If neither `match` nor `exclude` are defined, the filter does nothing and all events\
-are replicated. This filter does not accept regular expression options as a separate\
-setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for\
+If neither `match` nor `exclude` are defined, the filter does nothing and all events
+are replicated. This filter does not accept regular expression options as a separate
+setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for
 more information.
 
-The two settings are matched against the database and table name concatenated\
-with a period. For example, the string the patterns are matched against for the\
+The two settings are matched against the database and table name concatenated
+with a period. For example, the string the patterns are matched against for the
 database `test` and table `t1` is `test.t1`.
 
-For statement based replication, the pattern is matched against all the tables\
-in the statements. If any of the tables matches the _match_ pattern, the event\
-is replicated. If any of the tables matches the _exclude_ pattern, the event is\
+For statement based replication, the pattern is matched against all the tables
+in the statements. If any of the tables matches the _match_ pattern, the event
+is replicated. If any of the tables matches the _exclude_ pattern, the event is
 not replicated.
 
 #### `rewrite_src`
@@ -73,28 +73,28 @@ See the next entry, `rewrite_dest`, for more information.
 * Default: None
 
 `rewrite_src` and `rewrite_dest` control the statement rewriting of the binlogfilter.\
-The `rewrite_src` setting is a PCRE2 regular expression that is matched against\
-the default database and the SQL of statement based replication events (query\
+The `rewrite_src` setting is a PCRE2 regular expression that is matched against
+the default database and the SQL of statement based replication events (query
 events). `rewrite_dest` is the replacement string which supports the normal\
-PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,\
+PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,
 etc.).
 
 Both `rewrite_src` and `rewrite_dest` must be defined to enable statement rewriting.
 
-When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)\
-must be used. The filter will disallow replication for all replicas that attempt\
+When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)
+must be used. The filter will disallow replication for all replicas that attempt
 to replicate with traditional file-and-position based replication.
 
-The replacement is done both on the default database as well as the SQL\
-statement in the query event. This means that great care must be taken when\
-defining the rewriting rules. To prevent accidental modification of the SQL into\
-a form that is no longer valid, use database and table names that never occur in\
+The replacement is done both on the default database as well as the SQL
+statement in the query event. This means that great care must be taken when
+defining the rewriting rules. To prevent accidental modification of the SQL into
+a form that is no longer valid, use database and table names that never occur in
 the inserted data and is never used as a constant value.
 
 ### Example Configuration
 
-With the following configuration, only events belonging to database `customers`\
-are replicated. In addition to this, events for the table `orders` are excluded\
+With the following configuration, only events belonging to database `customers`
+are replicated. In addition to this, events for the table `orders` are excluded
 and thus are not replicated.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-comment-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-comment-filter.md
@@ -2,8 +2,8 @@
 
 ### Overview
 
-With the _comment_ filter it is possible to define comments that are\
-injected before the actual statements. These comments appear as sql\
+With the _comment_ filter it is possible to define comments that are
+injected before the actual statements. These comments appear as sql
 comments when they are received by the server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-consistent-critical-read-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-consistent-critical-read-filter.md
@@ -4,41 +4,41 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Consistent Critical Read (CCR) filter allows consistent critical reads to be\
+The Consistent Critical Read (CCR) filter allows consistent critical reads to be
 done through MaxScale while still allowing scaleout of non-critical reads.
 
-When the filter detects a statement that would modify the database, it attaches\
-a routing hint to all following statements done by that connection. This routing\
-hint guides the routing module to route the statement to the primary server where\
-data is guaranteed to be in an up-to-date state. Writes from one session do not,\
+When the filter detects a statement that would modify the database, it attaches
+a routing hint to all following statements done by that connection. This routing
+hint guides the routing module to route the statement to the primary server where
+data is guaranteed to be in an up-to-date state. Writes from one session do not,
 by default, propagate to other sessions.
 
-_Note:_ This filter does not work with prepared statements. Only text protocol\
+_Note:_ This filter does not work with prepared statements. Only text protocol
 queries are handled by this filter.
 
 #### Controlling the Filter with SQL Comments
 
-The triggering of the filter can be limited further by adding MaxScale supported\
-comments to queries and/or by using regular expressions. The query comments take\
-precedence: if a comment is found it is obeyed even if a regular expression\
+The triggering of the filter can be limited further by adding MaxScale supported
+comments to queries and/or by using regular expressions. The query comments take
+precedence: if a comment is found it is obeyed even if a regular expression
 parameter might give a different result. Even a comment cannot cause a\
-SELECT-query to trigger the filter. Such a comment is considered an error and\
+SELECT-query to trigger the filter. Such a comment is considered an error and
 ignored.
 
-The comments must follow the [MaxScale hint syntax](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-hint-syntax.md)\
-and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a\
-query has a MaxScale supported comment line which defines the parameter `ccr`,\
-that comment is caught by the CCR-filter. Parameter values `match` and `ignore`\
-are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)\
+The comments must follow the [MaxScale hint syntax](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-hint-syntax.md)
+and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a
+query has a MaxScale supported comment line which defines the parameter `ccr`,
+that comment is caught by the CCR-filter. Parameter values `match` and `ignore`
+are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)
 on receiving the write query. For example, the query
 
 ```
 INSERT INTO departments VALUES ('d1234', 'NewDepartment'); -- maxscale ccr=ignore
 ```
 
-would normally cause the filter to trigger, but does not because of the\
-comment. The `match`-comment typically has no effect, since write queries by\
-default trigger the filter anyway. It can be used to override an ignore-type\
+would normally cause the filter to trigger, but does not because of the
+comment. The `match`-comment typically has no effect, since write queries by
+default trigger the filter anyway. It can be used to override an ignore-type
 regular expression that would otherwise prevent triggering.
 
 ### Filter Parameters
@@ -52,19 +52,19 @@ The CCR filter has no mandatory parameters.
 * Dynamic: Yes
 * Default: `60s`
 
-The time window during which queries are routed to the primary. The duration\
-can be specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+The time window during which queries are routed to the primary. The duration
+can be specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 but the value will always be rounded to the nearest second.\
-If no explicit unit has been specified, the value is interpreted as seconds\
+If no explicit unit has been specified, the value is interpreted as seconds
 in MaxScale 2.4. In subsequent versions a value without a unit may be rejected.\
 The default value for this parameter is 60 seconds.
 
-When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new\
-data modifying SQL statement is processed within the time window, the timer is\
+When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new
+data modifying SQL statement is processed within the time window, the timer is
 reset to the value of _time_.
 
-Enabling this parameter in combination with the _count_ parameter causes both\
-the time window and number of queries to be inspected. If either of the two\
+Enabling this parameter in combination with the _count_ parameter causes both
+the time window and number of queries to be inspected. If either of the two
 conditions are met, the query is re-routed to the primary.
 
 #### `count`
@@ -77,10 +77,10 @@ conditions are met, the query is re-routed to the primary.
 The number of SQL statements to route to primary after detecting a data modifying\
 SQL statement. This feature is disabled by default.
 
-After processing a data modifying SQL statement, a counter is set to the value\
-of _count_ and all statements are routed to the primary. Each executed statement\
-after a data modifying SQL statement cause the counter to be decremented. Once\
-the counter reaches zero, the statements are routed normally. If a new data\
+After processing a data modifying SQL statement, a counter is set to the value
+of _count_ and all statements are routed to the primary. Each executed statement
+after a data modifying SQL statement cause the counter to be decremented. Once
+the counter reaches zero, the statements are routed normally. If a new data
 modifying SQL statement is processed, the counter is reset to the value of_count_.
 
 #### `match`, `ignore`
@@ -90,9 +90,9 @@ modifying SQL statement is processed, the counter is reset to the value of_count
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
-control which statements trigger statement re-routing. Only non-SELECT statements are\
-inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works\
+These [regular expression settings](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
+control which statements trigger statement re-routing. Only non-SELECT statements are
+inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works
 similarly.
 
 ```
@@ -118,16 +118,16 @@ Regular expression options for `match` and `ignore`.
 * Dynamic: Yes
 * Default: `false`
 
-`global` is a boolean parameter that when enabled causes writes from one\
-connection to propagate to all other connections. This can be used to work\
-around cases where one connection writes data and another reads it, expecting\
+`global` is a boolean parameter that when enabled causes writes from one
+connection to propagate to all other connections. This can be used to work
+around cases where one connection writes data and another reads it, expecting
 the write done by the other connection to be visible.
 
 This parameter only works with the `time` parameter. The use of `global` and`count` at the same time is not allowed and will be treated as an error.
 
 ### Example Configuration
 
-Here is a minimal filter configuration for the CCRFilter which should solve most\
+Here is a minimal filter configuration for the CCRFilter which should solve most
 problems with critical reads after writes.
 
 ```
@@ -137,13 +137,13 @@ module=ccrfilter
 time=5
 ```
 
-With this configuration, whenever a connection does a write, all subsequent\
+With this configuration, whenever a connection does a write, all subsequent
 reads done by that connection will be forced to the primary for 5 seconds.
 
-This prevents read scaling until the modifications have been replicated to the\
-replicas. For best performance, the value of _time_ should be slightly greater\
-than the actual replication lag between the primary and its replicas. If the number\
-of critical read statements is known, the _count_ parameter could be used to\
+This prevents read scaling until the modifications have been replicated to the
+replicas. For best performance, the value of _time_ should be slightly greater
+than the actual replication lag between the primary and its replicas. If the number
+of critical read statements is known, the _count_ parameter could be used to
 control the number reads that are sent to the primary.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-hintfilter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-hintfilter.md
@@ -4,14 +4,14 @@ This filter adds routing hints to a service. The filter has no parameters.
 
 ## Hint Syntax
 
-**Note:** If a query has more than one comment only the first comment is\
-processed. Always place any MaxScale related comments first before any other\
+**Note:** If a query has more than one comment only the first comment is
+processed. Always place any MaxScale related comments first before any other
 comments that might appear in the query.
 
 ### Comments and comment types
 
-The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and\
-they need to be enabled by passing the `--comments` or `-c` option to it. Most,\
+The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and
+they need to be enabled by passing the `--comments` or `-c` option to it. Most,
 if not all, connectors keep all comments intact in executed queries.
 
 ```
@@ -19,10 +19,10 @@ if not all, connectors keep all comments intact in executed queries.
 mariadb --comments -u my-user -psecret -e "SELECT @@hostname -- maxscale route to server db1"
 ```
 
-For comment types, use either `--` (notice the whitespace after the double\
+For comment types, use either `--` (notice the whitespace after the double
 hyphen) or `#` after the semicolon or `/* ... */` before the semicolon.
 
-Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character\
+Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character
 after the start tag or before the end tag but adding the whitespace is advised.
 
 ### Hint body
@@ -33,12 +33,12 @@ All hints must start with the `maxscale` tag.
 -- maxscale <hint body>
 ```
 
-The hints have two types, ones that define a server type and others that contain\
+The hints have two types, ones that define a server type and others that contain
 name-value pairs.
 
 #### Routing destination hints
 
-These hints will instruct the router to route a query to a certain type of a\
+These hints will instruct the router to route a query to a certain type of a
 server.
 
 ```
@@ -51,8 +51,8 @@ server.
 -- maxscale route to master
 ```
 
-A `master` value in a routing hint will route the query to a primary server. This\
-can be used to direct read queries to a primary server for a up-to-date result\
+A `master` value in a routing hint will route the query to a primary server. This
+can be used to direct read queries to a primary server for a up-to-date result
 with no replication lag.
 
 **Route to replica**
@@ -61,8 +61,8 @@ with no replication lag.
 -- maxscale route to slave
 ```
 
-A `slave` value will route the query to a replica server. Please note that the\
-hints will override any decisions taken by the routers which means that it is\
+A `slave` value will route the query to a replica server. Please note that the
+hints will override any decisions taken by the routers which means that it is
 possible to force writes to a replica server.
 
 **Route to named server**
@@ -71,7 +71,7 @@ possible to force writes to a replica server.
 -- maxscale route to server <server name>
 ```
 
-A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in\
+A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in
 maxscale.cnf. If the server is not used by the service, the hint is ignored.
 
 **Route to last used server**
@@ -80,8 +80,8 @@ maxscale.cnf. If the server is not used by the service, the hint is ignored.
 -- maxscale route to last
 ```
 
-A `last` value will route the query to the server that processed the last\
-query. This hint can be used to force certain queries to be grouped to the same\
+A `last` value will route the query to the server that processed the last
+query. This hint can be used to force certain queries to be grouped to the same
 server.
 
 **Name-value hints**
@@ -90,13 +90,13 @@ server.
 -- maxscale <param>=<value>
 ```
 
-These control the behavior and affect the routing decisions made by the\
-router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower\
+These control the behavior and affect the routing decisions made by the
+router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower
 replication lag than this parameter's value.
 
 ### Hint stack
 
-Hints can be either single-use hints, which makes them affect only one query, or\
+Hints can be either single-use hints, which makes them affect only one query, or
 named hints, which can be pushed on and off a stack of active hints.
 
 Defining named hints:
@@ -123,7 +123,7 @@ You can define and activate a hint in a single command using the following:
 -- maxscale <hint name> begin <hint content>
 ```
 
-You can also push anonymous hints onto the stack which are only used as long as\
+You can also push anonymous hints onto the stack which are only used as long as
 they are on the stack:
 
 ```
@@ -132,14 +132,14 @@ they are on the stack:
 
 ## Prepared Statements
 
-The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared\
+The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared
 statements.
 
 ### Binary Protocol
 
-With binary protocol prepared statements, a routing hint in the prepared\
-statement is applied to the execution of the statement but not the preparation\
-of it. The preparation of the statement is routed normally and is sent to all\
+With binary protocol prepared statements, a routing hint in the prepared
+statement is applied to the execution of the statement but not the preparation
+of it. The preparation of the statement is routed normally and is sent to all
 servers.
 
 For example, when the following prepared statement is prepared with the MariaDB\
@@ -165,13 +165,13 @@ Support for direct execution of prepared statements was added in MaxScale\
 
 ### Text Protocol
 
-Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL\
-commands) behave differently. If a `PREPARE` command has a routing hint, it will\
-be routed according to the routing hint. Any subsequent `EXECUTE` command will\
-not be affected by the routing hint in the `PREPARE` statement. This means they\
+Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL
+commands) behave differently. If a `PREPARE` command has a routing hint, it will
+be routed according to the routing hint. Any subsequent `EXECUTE` command will
+not be affected by the routing hint in the `PREPARE` statement. This means they
 must have their own routing hints.
 
-The following example is the recommended method of executing text protocol\
+The following example is the recommended method of executing text protocol
 prepared statements with hints:
 
 ```
@@ -185,7 +185,7 @@ The `PREPARE` is routed normally and will be routed to all servers. The`EXECUTE`
 
 ### Routing `SELECT` queries to primary
 
-In this example, MariaDB MaxScale is configured with the readwritesplit router\
+In this example, MariaDB MaxScale is configured with the readwritesplit router
 and the hint filter.
 
 ```
@@ -202,9 +202,9 @@ type=filter
 module=hintfilter
 ```
 
-Behind MariaDB MaxScale is a primary server and a replica server. If there is\
-replication lag between the primary and the replica, read queries sent to the replica\
-might return old data. To guarantee up-to-date data, we can add a routing hint\
+Behind MariaDB MaxScale is a primary server and a replica server. If there is
+replication lag between the primary and the replica, read queries sent to the replica
+might return old data. To guarantee up-to-date data, we can add a routing hint
 to the query.
 
 ```
@@ -212,9 +212,9 @@ INSERT INTO table1 VALUES ("John","Doe",1);
 SELECT * FROM table1; -- maxscale route to master
 ```
 
-The first INSERT query will be routed to the primary. The following SELECT query\
-would normally be routed to the replica but with the added routing hint it will be\
-routed to the primary. This way we can do an INSERT and a SELECT right after it\
+The first INSERT query will be routed to the primary. The following SELECT query
+would normally be routed to the replica but with the added routing hint it will be
+routed to the primary. This way we can do an INSERT and a SELECT right after it
 and still get up-to-date data.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-ldi-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-ldi-filter.md
@@ -1,13 +1,13 @@
 # MaxScale 24.02 LDI Filter
 
-The `ldi` (LOAD DATA INFILE) filter was introduced in MaxScale 23.08.0 and it\
-extends the MariaDB `LOAD DATA INFILE` syntax to support loading data from any\
+The `ldi` (LOAD DATA INFILE) filter was introduced in MaxScale 23.08.0 and it
+extends the MariaDB `LOAD DATA INFILE` syntax to support loading data from any
 object storage that supports the S3 API. This includes cloud offerings like AWS\
 S3 and Google Cloud Storage as well as locally run services like Minio.
 
-If the filename starts with either `S3://` or `gs://`, the path is interpreted\
-as a S3 object file. The prefix is case-insensitive. For example, the following\
-command would load the file `my-data.csv` from the bucket `my-bucket` into the\
+If the filename starts with either `S3://` or `gs://`, the path is interpreted
+as a S3 object file. The prefix is case-insensitive. For example, the following
+command would load the file `my-data.csv` from the bucket `my-bucket` into the
 table `t1`.
 
 ```
@@ -17,7 +17,7 @@ LOAD DATA INFILE 'S3://my-bucket/my-data.csv' INTO TABLE t1
 
 ### How to Upload Data
 
-Here is a minimal configuration for the filter that can be used to load data\
+Here is a minimal configuration for the filter that can be used to load data
 from AWS S3:
 
 ```
@@ -29,11 +29,11 @@ region=us-east-1
 ```
 
 The first step is to move the file to be loaded into the same region that\
-MaxScale and the MariaDB servers are in. One factor in the speed of the upload\
-is the network latency and minimizing it by moving the source and the\
+MaxScale and the MariaDB servers are in. One factor in the speed of the upload
+is the network latency and minimizing it by moving the source and the
 destination closer improves the data loading speed.
 
-The next step is to connect to MaxScale and prepare the session for an upload by\
+The next step is to connect to MaxScale and prepare the session for an upload by
 providing the service account access and secret keys.
 
 ```
@@ -54,17 +54,17 @@ This feature has been removed in MaxScale 24.02.
 
 #### Missing Files
 
-If you are using self-hosted object storage programs like Minio, a common\
-problem is that they do not necessarily support the newer virtual-hosted-style\
-requests that is used by AWS. This usually manifests as an error either about a\
+If you are using self-hosted object storage programs like Minio, a common
+problem is that they do not necessarily support the newer virtual-hosted-style
+requests that is used by AWS. This usually manifests as an error either about a
 missing file or a missing bucket.
 
-If the `host` parameter is set to a hostname, it's assumed that the object\
-storage supports the newer virtual-hosted-style requests. If this not the case,\
+If the `host` parameter is set to a hostname, it's assumed that the object
+storage supports the newer virtual-hosted-style requests. If this not the case,
 the filter must be configured with `protocol_version=1`.
 
-Conversely, if the `host` parameter is set to a plain IP address, it is assumed\
-that it does not support the newer virtual-hosted-style request. If the host\
+Conversely, if the `host` parameter is set to a plain IP address, it is assumed
+that it does not support the newer virtual-hosted-style request. If the host
 does support it, the filter must be configured with `protocol_version=2`.
 
 ### Configuration Parameters
@@ -98,7 +98,7 @@ This must be either configured in the MaxScale configuration file or set with`SE
 
 The S3 region where the data is located.
 
-The value can be overridden with `SET @maxscale.ldi.s3_region='<region>'` before\
+The value can be overridden with `SET @maxscale.ldi.s3_region='<region>'` before
 starting the data load.
 
 #### `host`
@@ -108,10 +108,10 @@ starting the data load.
 * Dynamic: Yes
 * Default: `s3.amazonaws.com`
 
-The location of the S3 object storage. By default the original AWS S3 host is\
+The location of the S3 object storage. By default the original AWS S3 host is
 used. The corresponding value for Google Cloud Storage is`storage.googleapis.com`.
 
-The value can be overridden with `SET @maxscale.ldi.s3_host='<host>'` before\
+The value can be overridden with `SET @maxscale.ldi.s3_host='<host>'` before
 starting the data load.
 
 #### `port`
@@ -121,11 +121,11 @@ starting the data load.
 * Dynamic: Yes
 * Default: 0
 
-The port on which the S3 object storage is listening. If unset or set to the\
+The port on which the S3 object storage is listening. If unset or set to the
 value of 0, the default S3 port is used.
 
-The value can be overridden with `SET @maxscale.ldi.s3_port=<port>` before\
-starting the data load. Note that unlike the other values, the value for this\
+The value can be overridden with `SET @maxscale.ldi.s3_port=<port>` before
+starting the data load. Note that unlike the other values, the value for this
 variable must be an SQL integer and not an SQL string.
 
 #### `no_verify`
@@ -155,14 +155,14 @@ HTTP instead of HTTPS.
 * Default: 0
 * Values: 0, 1, 2
 
-Which protocol version to use. By default the protocol version is derived from\
-the value of `host` but this automatic protocol version deduction will not\
-always produce the correct result. For the legacy path-style requests used by\
-older S3 storage buckets, the value must be set to 1. All new buckets use the\
+Which protocol version to use. By default the protocol version is derived from
+the value of `host` but this automatic protocol version deduction will not
+always produce the correct result. For the legacy path-style requests used by
+older S3 storage buckets, the value must be set to 1. All new buckets use the
 protocol version 2.
 
-For object storage programs like Minio, the value must be set to 1 as the bucket\
-name cannot be resolved via the subdomain like it is done for object stores in\
+For object storage programs like Minio, the value must be set to 1 as the bucket
+name cannot be resolved via the subdomain like it is done for object stores in
 the cloud.
 
 #### `import_user`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-lua-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-lua-filter.md
@@ -2,34 +2,34 @@
 
 The luafilter is a filter that calls a set of functions in a Lua script.
 
-Read the [Lua language documentation](https://www.lua.org/docs.html) for\
+Read the [Lua language documentation](https://www.lua.org/docs.html) for
 information on how to write Lua scripts.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Filter Parameters
 
-The luafilter has two parameters. They control which scripts will be called by\
-the filter. Both parameters are optional but at least one should be defined. If\
-both `global_script` and `session_script` are defined, the entry points in both\
+The luafilter has two parameters. They control which scripts will be called by
+the filter. Both parameters are optional but at least one should be defined. If
+both `global_script` and `session_script` are defined, the entry points in both
 scripts will be called.
 
 #### `global_script`
 
-The global Lua script. The parameter value is a path to a readable Lua script\
+The global Lua script. The parameter value is a path to a readable Lua script
 which will be executed.
 
-This script will always be called with the same global Lua state and it can be\
+This script will always be called with the same global Lua state and it can be
 used to build a global view of the whole service.
 
 #### `session_script`
 
-The session level Lua script. The parameter value is a path to a readable Lua\
+The session level Lua script. The parameter value is a path to a readable Lua
 script which will be executed once for each session.
 
-Each session will have its own Lua state meaning that each session can have a\
+Each session will have its own Lua state meaning that each session can have a
 unique Lua environment. Use this script to do session specific tasks.
 
 ### Lua Script Calling Convention
@@ -37,38 +37,38 @@ unique Lua environment. Use this script to do session specific tasks.
 The entry points for the Lua script expect the following signatures:
 
 * `nil createInstance(name)` - global script only, called when the script is first loaded
-  * When the global script is loaded, it first executes on a global level\
-    before the luafilter calls the createInstance function in the Lua script\
+  * When the global script is loaded, it first executes on a global level
+    before the luafilter calls the createInstance function in the Lua script
     with the filter's name as its argument.
 * `nil newSession(string, string)` - new session is created
-  * After the session script is loaded, the newSession function in the Lua\
-    scripts is called. The first parameter is the username of the client and\
+  * After the session script is loaded, the newSession function in the Lua
+    scripts is called. The first parameter is the username of the client and
     the second parameter is the client's network address.
 * `nil closeSession()` - session is closed
   * The `closeSession` function in the Lua scripts will be called.
 * `(nil | bool | string) routeQuery()` - query is being routed
-  * The Luafilter calls the `routeQuery` functions of both the session and the\
-    global script. The query is passed as a string parameter to the\
-    routeQuery Lua function and the return values of the session specific\
-    function, if any were returned, are interpreted. If the first value is\
-    bool, it is interpreted as a decision whether to route the query or to\
-    send an error packet to the client. If it is a string, the current query\
-    is replaced with the return value and the query will be routed. If nil is\
+  * The Luafilter calls the `routeQuery` functions of both the session and the
+    global script. The query is passed as a string parameter to the
+    routeQuery Lua function and the return values of the session specific
+    function, if any were returned, are interpreted. If the first value is
+    bool, it is interpreted as a decision whether to route the query or to
+    send an error packet to the client. If it is a string, the current query
+    is replaced with the return value and the query will be routed. If nil is
     returned, the query is routed normally.
 * `nil clientReply()` - reply to a query is being routed
   * This function is called with the name of the server that returned the response.
 * `string diagnostic()` - global script only, print diagnostic information
-  * If the Lua function returns a string that is valid JSON, it will be\
-    decoded as JSON and displayed as such in the REST API. If the object does\
+  * If the Lua function returns a string that is valid JSON, it will be
+    decoded as JSON and displayed as such in the REST API. If the object does
     not decode into JSON, it will be stored as a JSON string.
 
-These functions, if found in the script, will be called whenever a call to the\
+These functions, if found in the script, will be called whenever a call to the
 matching entry point is made.
 
 **Script Template**
 
-Here is a script template that can be used to try out the luafilter. Copy it\
-into a file and add `global_script=<path to script>` into the filter\
+Here is a script template that can be used to try out the luafilter. Copy it
+into a file and add `global_script=<path to script>` into the filter
 configuration. Make sure the file is readable by the `maxscale` user.
 
 ```
@@ -99,29 +99,29 @@ end
 
 #### Functions Exposed by the Luafilter
 
-The luafilter exposes the following functions that can be called inside the Lua\
-script API endpoints. The callback function in which they can be called is\
-documented after the function signature. If the functions are called outside of\
+The luafilter exposes the following functions that can be called inside the Lua
+script API endpoints. The callback function in which they can be called is
+documented after the function signature. If the functions are called outside of
 the correct callback function, they raise a Lua error.
 
 * `string mxs_get_sql()` (use: `routeQuery`)
-* Returns the SQL of the query being executed. This returns an empty string\
-  for any query that is not a text protocol query (COM\_QUERY). Support for\
+* Returns the SQL of the query being executed. This returns an empty string
+  for any query that is not a text protocol query (COM\_QUERY). Support for
   prepared statements is not yet implemented.
 * `string mxs_get_type_mask()` (use: `routeQuery`)
-* Returns the type of the current query being executed as a string. The values\
-  are the string versions of the query types defined in query\_classifier.h\
+* Returns the type of the current query being executed as a string. The values
+  are the string versions of the query types defined in query\_classifier.h
   are separated by vertical bars (`|`).\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_operation()` (use: `routeQuery`)
-* Returns the current operation type as a string. The values are defined in\
+* Returns the current operation type as a string. The values are defined in
   query\_classifier.h.\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_canonical()` (use: `routeQuery`)
 * Returns the canonical version of a query by replacing all user-defined constant values with question marks.\
   This function can only be called from the `routeQuery` entry point.
 * `number mxs_get_session_id()` (use: `newSession`, `routeQuery`, `clientReply`, `closeSession`)
-* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return\
+* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return
   the value 0.
 * `string mxs_get_db()` (use: `newSession`, `routeQuery`, `clientReply`, `closeSession`)
 * Returns the current default database used by the connection.
@@ -176,10 +176,10 @@ end
 
 ### Limitations
 
-* `mxs_get_sql()` and `mxs_get_canonical()` do not work with queries done with\
+* `mxs_get_sql()` and `mxs_get_canonical()` do not work with queries done with
   the binary protocol.
-* The Lua code is not restricted in any way which means excessively slow\
-  execution of it can cause the MaxScale process to become slower or to be\
+* The Lua code is not restricted in any way which means excessively slow
+  execution of it can cause the MaxScale process to become slower or to be
   aborted due to a SystemD watchdog timeout.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-masking.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-masking.md
@@ -4,15 +4,15 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-With the _masking_ filter it is possible to obfuscate the returned\
+With the _masking_ filter it is possible to obfuscate the returned
 value of a particular column.
 
-For instance, suppose there is a table _person_ that, among other\
-columns, contains the column _ssn_ where the social security number\
+For instance, suppose there is a table _person_ that, among other
+columns, contains the column _ssn_ where the social security number
 of a person is stored.
 
-With the masking filter it is possible to specify that when the _ssn_\
-field is queried, a masked value is returned unless the user making\
+With the masking filter it is possible to specify that when the _ssn_
+field is queried, a masked value is returned unless the user making
 the query is a specific one. That is, when making the query
 
 ```
@@ -41,44 +41,44 @@ the _ssn_ would be masked, as in
 ...
 ```
 
-Note that the masking filter should be viewed as a best-effort solution\
-intended for protecting against accidental misuse rather than malicious\
+Note that the masking filter should be viewed as a best-effort solution
+intended for protecting against accidental misuse rather than malicious
 attacks.
 
 ### Security
 
-From MaxScale 2.3 onwards, the masking filter will reject statements\
+From MaxScale 2.3 onwards, the masking filter will reject statements
 that use functions in conjunction with columns that should be masked.\
-Allowing function usage provides a way for circumventing the masking,\
+Allowing function usage provides a way for circumventing the masking,
 unless a firewall filter is separately configured and installed.
 
-Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2402-maxscale-2402-masking.md#prevent_function_usage)\
+Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2402-maxscale-2402-masking.md#prevent_function_usage)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will check the\
-definition of user variables and reject statements that define a user\
+From MaxScale 2.3.5 onwards, the masking filter will check the
+definition of user variables and reject statements that define a user
 variable using a statement that refers to columns that should be masked.
 
-Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2402-maxscale-2402-masking.md#check_user_variables)\
+Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2402-maxscale-2402-masking.md#check_user_variables)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine unions\
-and if the second or subsequent SELECT refer to columns that should\
+From MaxScale 2.3.5 onwards, the masking filter will examine unions
+and if the second or subsequent SELECT refer to columns that should
 be masked, the statement will be rejected.
 
-Please see the configuration parameter [check\_unions](mariadb-maxscale-2402-maxscale-2402-masking.md#check_unions)\
+Please see the configuration parameter [check\_unions](mariadb-maxscale-2402-maxscale-2402-masking.md#check_unions)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine subqueries\
-and if a subquery refers to columns that should be masked, the statement\
+From MaxScale 2.3.5 onwards, the masking filter will examine subqueries
+and if a subquery refers to columns that should be masked, the statement
 will be rejected.
 
-Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2402-maxscale-2402-masking.md#check_subqueries)\
+Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2402-maxscale-2402-masking.md#check_subqueries)
 for how to change the default behaviour.
 
-Note that in order to ensure that it is not possible to get access to\
-masked data, the privileges of the users should be minimized. For instance,\
-if a user can create tables and perform inserts, he or she can execute\
+Note that in order to ensure that it is not possible to get access to
+masked data, the privileges of the users should be minimized. For instance,
+if a user can create tables and perform inserts, he or she can execute
 something like
 
 ```
@@ -89,16 +89,16 @@ SELECT revealed_ssn FROM cheat;
 
 to get access to the cleartext version of a masked field `ssn`.
 
-From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that\
+From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that
 cannot be fully parsed.
 
-Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2402-maxscale-2402-masking.md#require_fully_parsed)\
+Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2402-maxscale-2402-masking.md#require_fully_parsed)
 for how to change the default behaviour.
 
-From MaxScale 2.3.7 onwards, the masking filter will treat any strings\
+From MaxScale 2.3.7 onwards, the masking filter will treat any strings
 passed to functions as if they were fields. The reason is that as the\
-MaxScale query classifier is not aware of whether `ANSI_QUOTES` is\
-enabled or not, it is possible to bypass the masking by turning that\
+MaxScale query classifier is not aware of whether `ANSI_QUOTES` is
+enabled or not, it is possible to bypass the masking by turning that
 option on.
 
 ```
@@ -106,32 +106,32 @@ mysql> set @@sql_mode = 'ANSI_QUOTES';
 mysql> select concat("ssn") from managers;
 ```
 
-Before this change, the content of the field `ssn` would have been\
+Before this change, the content of the field `ssn` would have been
 returned in clear text even if the column should have been masked.
 
-Note that this change will mean that there may be false positives\
-if `ANSI_QUOTES` is not enabled and a string argument happens to\
+Note that this change will mean that there may be false positives
+if `ANSI_QUOTES` is not enabled and a string argument happens to
 be the same as the name of a field to be masked.
 
 Please see the configuration parameter\
-\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)\
+\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)
 for how to change the default behaviour.
 
 ### Limitations
 
-The masking filter can _only_ be used for masking columns of the following\
-types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no\
+The masking filter can _only_ be used for masking columns of the following
+types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no
 masking will be performed.
 
-Currently, the masking filter can only work on packets whose payload is less\
-than 16MB. If the masking filter encounters a packet whose payload is exactly\
-that, thus indicating a situation where the payload is delivered in multiple\
-packets, the value of the parameter `large_payloads` specifies how the masking\
+Currently, the masking filter can only work on packets whose payload is less
+than 16MB. If the masking filter encounters a packet whose payload is exactly
+that, thus indicating a situation where the payload is delivered in multiple
+packets, the value of the parameter `large_payloads` specifies how the masking
 filter should handle the situation.
 
 ### Configuration
 
-The masking filter is taken into use with the following kind of\
+The masking filter is taken into use with the following kind of
 configuration setup.
 
 ```
@@ -157,7 +157,7 @@ The masking filter has one mandatory parameter - `rules`.
 * Dynamic: Yes
 
 Specifies the path of the file where the masking rules are stored.\
-A relative path is interpreted relative to the _module configuration directory_\
+A relative path is interpreted relative to the _module configuration directory_
 of MariaDB MaxScale. The default module configuration directory is_/etc/maxscale.modules.d_.
 
 ```
@@ -172,8 +172,8 @@ rules=/path/to/rules-file
 * Values: `never`, `always`
 * Default: `never`
 
-With this optional parameter the masking filter can be instructed to log\
-a warning if a masking rule matches a column that is not of one of the\
+With this optional parameter the masking filter can be instructed to log
+a warning if a masking rule matches a column that is not of one of the
 allowed types.
 
 ```
@@ -188,17 +188,17 @@ warn_type_mismatch=always
 * Values: `ignore`, `abort`
 * Default: `abort`
 
-This optional parameter specifies how the masking filter should treat\
-payloads larger than `16MB`, that is, payloads that are delivered in\
+This optional parameter specifies how the masking filter should treat
+payloads larger than `16MB`, that is, payloads that are delivered in
 multiple MySQL protocol packets.
 
-The values that can be used are `ignore`, which means that columns in\
-such payloads are not masked, and `abort`, which means that if such\
-payloads are encountered, the client connection is closed. The default\
+The values that can be used are `ignore`, which means that columns in
+such payloads are not masked, and `abort`, which means that if such
+payloads are encountered, the client connection is closed. The default
 is `abort`.
 
-Note that the aborting behaviour is applied only to resultsets that\
-contain columns that should be masked. There are _no_ limitations on\
+Note that the aborting behaviour is applied only to resultsets that
+contain columns that should be masked. There are _no_ limitations on
 resultsets that do not contain such columns.
 
 ```
@@ -212,23 +212,23 @@ large_payload=ignore
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should behave\
-if a column that should be masked, is used in conjunction with some\
-function. As the masking filter works _only_ on the basis of the\
-information in the returned result-set, if the name of a column is\
-not present in the result-set, then the masking filter cannot mask a\
-value. This means that the masking filter basically can be bypassed\
+This optional parameter specifies how the masking filter should behave
+if a column that should be masked, is used in conjunction with some
+function. As the masking filter works _only_ on the basis of the
+information in the returned result-set, if the name of a column is
+not present in the result-set, then the masking filter cannot mask a
+value. This means that the masking filter basically can be bypassed
 with a query like:
 
 ```
 SELECT CONCAT(masked_column) FROM tbl;
 ```
 
-If the value of `prevent_function_usage` is `true`, then all\
-statements that contain functions referring to masked columns will\
-be rejected. As that means that also queries using potentially\
-harmless functions, such as `LENGTH(masked_column)`, are rejected\
-as well, this feature can be turned off. In that case, the firewall\
+If the value of `prevent_function_usage` is `true`, then all
+statements that contain functions referring to masked columns will
+be rejected. As that means that also queries using potentially
+harmless functions, such as `LENGTH(masked_column)`, are rejected
+as well, this feature can be turned off. In that case, the firewall
 filter should be setup to allow or reject the use of certain functions.
 
 ```
@@ -242,19 +242,19 @@ prevent_function_usage=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
-behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a\
+This optional parameter specifies how the masking filter should
+behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a
 statement that cannot be fully parsed,
 
-If true, then statements that cannot be fully parsed (due to a\
+If true, then statements that cannot be fully parsed (due to a
 parser limitation) will be blocked.
 
 ```
 require_fully_parsed=false
 ```
 
-Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered\
-less effective, as it with a statement that cannot be fully parsed may be\
+Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered
+less effective, as it with a statement that cannot be fully parsed may be
 possible to bypass the protection that they are intended to provide.
 
 **`treat_string_arg_as_field`**
@@ -264,9 +264,9 @@ possible to bypass the protection that they are intended to provide.
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should treat\
-strings used as arguments to functions. If true, they will be handled\
-as fields, which will cause fields to be masked even if `ANSI_QUOTES` has\
+This optional parameter specifies how the masking filter should treat
+strings used as arguments to functions. If true, they will be handled
+as fields, which will cause fields to be masked even if `ANSI_QUOTES` has
 been enabled and `"` is used instead of backtick.
 
 ```
@@ -280,7 +280,7 @@ treat_string_arg_as_field=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to user variables. If true, then a statement like
 
 ```
@@ -300,7 +300,7 @@ check_user_variables=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to UNIONs. If true, then a statement like
 
 ```
@@ -320,7 +320,7 @@ check_unions=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to subqueries. If true, then a statement like
 
 ```
@@ -337,7 +337,7 @@ check_subqueries=false
 
 The masking rules are expressed as a JSON object.
 
-The top-level object is expected to contain a key `rules` whose\
+The top-level object is expected to contain a key `rules` whose
 value is an array of rule objects.
 
 ```
@@ -346,8 +346,8 @@ value is an array of rule objects.
 }
 ```
 
-Each rule in the rules array is a JSON object, expected to\
-contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two\
+Each rule in the rules array is a JSON object, expected to
+contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two
 latter ones optional.
 
 ```
@@ -365,15 +365,15 @@ latter ones optional.
 
 #### `replace`
 
-The value of this key is an object that specifies the column\
-whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The\
+The value of this key is an object that specifies the column
+whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The
 value of these keys must be a string.
 
-If only `column` is specified, then a column with that name\
-matches irrespective of the table and database. If `table`\
-is specified, then the column matches only if it is in a table\
-with the specified name, and if `database` is specified when\
-the column matches only if it is in a database with the\
+If only `column` is specified, then a column with that name
+matches irrespective of the table and database. If `table`
+is specified, then the column matches only if it is in a table
+with the specified name, and if `database` is specified when
+the column matches only if it is in a database with the
 specified name.
 
 ```
@@ -393,10 +393,10 @@ specified name.
 }
 ```
 
-**NOTE** If a rule contains a table/database then if the resultset\
-does _not_ contain table/database information, it will always be\
-considered a match if the column matches. For instance, given the\
-rule above, if there is a table `person2`, also containing an `ssn`\
+**NOTE** If a rule contains a table/database then if the resultset
+does _not_ contain table/database information, it will always be
+considered a match if the column matches. For instance, given the
+rule above, if there is a table `person2`, also containing an `ssn`
 field, then a query like
 
 ```
@@ -409,24 +409,24 @@ will not return masked values, but a query like
 SELECT ssn FROM person UNION SELECT ssn FROM person2;
 ```
 
-will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is\
+will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is
 observed even with a nonsensical query like
 
 ```
 SELECT ssn FROM person2 UNION SELECT ssn FROM person2;
 ```
 
-even if nothing from `person2` should be masked. The reason is that\
-as the resultset contains no table information, the values must be\
-masked if the column name matches, as otherwise the masking could\
+even if nothing from `person2` should be masked. The reason is that
+as the resultset contains no table information, the values must be
+masked if the column name matches, as otherwise the masking could
 easily be circumvented with a query like
 
 ```
 SELECT ssn FROM person UNION SELECT ssn FROM person;
 ```
 
-The optional key `match` makes partial replacement of the original\
-value possible: only the matched part would be replaced\
+The optional key `match` makes partial replacement of the original
+value possible: only the matched part would be replaced
 with the fill character.\
 The `match` value must be a valid pcre2 regular expression.
 
@@ -442,14 +442,14 @@ The `match` value must be a valid pcre2 regular expression.
 
 #### `obfuscate`
 
-The obfuscate rule allows the obfuscation of the value\
+The obfuscate rule allows the obfuscation of the value
 by passing it through an obfuscation algorithm.\
 Current solution uses a non-reversible obfuscation approach.
 
-However, note that although it is in principle impossible to obtain the\
-original value from the obfuscated one, if the range of possible original\
-values is limited, it is straightforward to figure out the possible\
-original values by running all possible values through the obfuscation\
+However, note that although it is in principle impossible to obtain the
+original value from the obfuscated one, if the range of possible original
+values is limited, it is straightforward to figure out the possible
+original values by running all possible values through the obfuscation
 algorithm and then comparing the results.
 
 The minimal configuration is:
@@ -474,20 +474,20 @@ SELECT name from db1.tbl1;`
 
 #### `with`
 
-The value of this key is an object that specifies what the value of the matched\
-column should be replaced with for the `replace` rule. Currently, the object\
+The value of this key is an object that specifies what the value of the matched
+column should be replaced with for the `replace` rule. Currently, the object
 is expected to contain either the key `value` or the key `fill`.\
 The value of both must be a string with length greater than zero.\
 If both keys are specified, `value` takes precedence.\
 If `fill` is not specified, the default `X` is used as its value.
 
-If `value` is specified, then its value is used to replace the actual value\
-verbatim and the length of the specified value must match the actual returned\
+If `value` is specified, then its value is used to replace the actual value
+verbatim and the length of the specified value must match the actual returned
 value (from the server) exactly. If the lengths do not match, the value of`fill` is used to mask the actual value.
 
-When the value of `fill` (fill-value) is used for masking the returned value,\
-the fill-value is used as many times as necessary to match the length of the\
-return value. If required, only a part of the fill-value may be used in the end\
+When the value of `fill` (fill-value) is used for masking the returned value,
+the fill-value is used as many times as necessary to match the length of the
+return value. If required, only a part of the fill-value may be used in the end
 of the mask value to get the lengths to match.
 
 ```
@@ -530,8 +530,8 @@ of the mask value to get the lengths to match.
 
 #### `applies_to`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is applied to. Each string\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is applied to. Each string
 should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -547,13 +547,13 @@ should be a MariaDB account string, that is, `%` is a wildcard.
 }
 ```
 
-If this key is not specified, then the masking is performed for all\
+If this key is not specified, then the masking is performed for all
 users, except the ones exempted using the key `exempted`.
 
 #### `exempted`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is _not_ applied to. Each\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is _not_ applied to. Each
 string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -571,14 +571,14 @@ string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ### Module commands
 
-Read [Module Commands](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md) documentation for details\
+Read [Module Commands](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md) documentation for details
 about module commands.
 
 The masking filter supports the following module commands.
 
 #### `reload`
 
-Reload the rules from the rules file. The new rules are taken into use\
+Reload the rules from the rules file. The new rules are taken into use
 only if the loading succeeds without any errors.
 
 ```
@@ -590,8 +590,8 @@ MariaDB MaxScale configuration file.
 
 ### Example
 
-In the following we configure a masking filter _MyMasking_ that should always log a\
-warning if a masking rule matches a column that is of a type that cannot be masked,\
+In the following we configure a masking filter _MyMasking_ that should always log a
+warning if a masking rule matches a column that is of a type that cannot be masked,
 and that should abort the client connection if a resultset package is larger than\
 16MB. The rules for the masking filter are in the file `masking_rules.json`.
 
@@ -613,9 +613,9 @@ filters=MyMasking
 
 #### `masking_rules.json`
 
-The rules specify that the data of a column whose name is `ssn`, should\
-be replaced with the string _012345-ABCD_. If the length of the data is\
-not exactly the same as the length of the replacement value, then the\
+The rules specify that the data of a column whose name is `ssn`, should
+be replaced with the string _012345-ABCD_. If the length of the data is
+not exactly the same as the length of the replacement value, then the
 data should be replaced with as many _X_ characters as needed.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-maxrows.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-maxrows.md
@@ -8,11 +8,11 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Maxrows filter is capable of restricting the amount of rows that a SELECT,\
+The Maxrows filter is capable of restricting the amount of rows that a SELECT,
 a prepared statement or stored procedure could return to the client application.
 
-If a resultset from a backend server has more rows than the configured limit\
-or the resultset size exceeds the configured size,\
+If a resultset from a backend server has more rows than the configured limit
+or the resultset size exceeds the configured size,
 an empty result will be sent to the client.
 
 ### Configuration
@@ -42,7 +42,7 @@ Optional parameters are:
 * Dynamic: Yes
 * Default: (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 returned to the user.
 
 If a resultset is larger than this an empty result will be sent instead.
@@ -58,8 +58,8 @@ max_resultset_rows=1000
 * Dynamic: Yes
 * Default: `64Ki`
 
-Specifies the maximum size a resultset can have in order\
-to be sent to the client. A resultset larger than this, will\
+Specifies the maximum size a resultset can have in order
+to be sent to the client. A resultset larger than this, will
 not be sent: an empty resultset will be sent instead.
 
 ```
@@ -74,7 +74,7 @@ max_resultset_size=128Ki
 * Values: `empty`, `error`, `ok`
 * Default: `empty`
 
-Specifies what the filter sends to the client when the\
+Specifies what the filter sends to the client when the
 rows or size limit is hit, possible values:
 
 * an empty result set
@@ -95,8 +95,8 @@ ERROR 1415 (0A000): Row limit/size exceeded for query: select * from test.t4
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the Maxrows\
-filter can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the Maxrows
+filter can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -111,7 +111,7 @@ debug=2
 
 ### Example Configuration
 
-Here is an example of filter configuration where the maximum number of returned\
+Here is an example of filter configuration where the maximum number of returned
 rows is 10000 and maximum allowed resultset size is 256KB
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-named-server-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-named-server-filter.md
@@ -2,25 +2,25 @@
 
 ### Overview
 
-The **namedserverfilter** is a MariaDB MaxScale filter module able to route\
-queries to servers based on regular expression (regex) matches. Since it is a\
+The **namedserverfilter** is a MariaDB MaxScale filter module able to route
+queries to servers based on regular expression (regex) matches. Since it is a
 filter instead of a router, the NamedServerFilter only sets routing suggestions.\
-It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the\
-data packets. This filter uses the _PCRE2_ library for regular expression\
+It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the
+data packets. This filter uses the _PCRE2_ library for regular expression
 matching.
 
 ### Configuration
 
-The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of\
-the modes may be used for a given filter instance. The legacy mode is meant for\
-backwards compatibility and allows only one regular expression and one server\
-name in the configuration. In indexed mode, up to 25 regex-server pairs are\
+The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of
+the modes may be used for a given filter instance. The legacy mode is meant for
+backwards compatibility and allows only one regular expression and one server
+name in the configuration. In indexed mode, up to 25 regex-server pairs are
 allowed in the form _match01_ - _target01_, _match02_ - _target02_ and so on.\
-Also, in indexed mode, the server names (targets) may contain a list of names or\
+Also, in indexed mode, the server names (targets) may contain a list of names or
 special tags `->master` or `->slave`.
 
-All parameters except the deprecated `match` and `target` parameters can\
-be modified at runtime. Any modifications to the filter configuration will\
+All parameters except the deprecated `match` and `target` parameters can
+be modified at runtime. Any modifications to the filter configuration will
 only affect sessions created after the change has completed.
 
 Below is a configuration example for the filter in indexed-mode. The legacy mode\
@@ -61,10 +61,10 @@ NamedServerFilter requires at least one _matchXY_ - _targetXY_ pair.
 * Dynamic: Yes
 * Default: None
 
-_matchXY_ defines a [PCRE2 regular expression](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+_matchXY_ defines a [PCRE2 regular expression](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 against which the incoming SQL query is matched. _XY_ must be a number in the range\
-01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is\
-defined, the other must be defined as well. If a query matches the pattern, the filter\
+01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is
+defined, the other must be defined as well. If a query matches the pattern, the filter
 attaches a routing hint defined by the _target_-setting to the query. The _options_-parameter affects how the patterns are compiled.
 
 ```
@@ -80,7 +80,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-[Regular expression options](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+[Regular expression options](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 for `matchXY`.
 
 #### `targetXY`
@@ -99,8 +99,8 @@ accordingly. The target can be one of the following:
 * `->slave` (adds a `HINT_ROUTE_TO_SLAVE` hint)
 * `->all` (adds a `HINT_ROUTE_TO_ALL` hint)
 
-The support for service names was added in MaxScale 6.3.2. Older\
-versions of MaxScale did not accept service names in the `target`\
+The support for service names was added in MaxScale 6.3.2. Older
+versions of MaxScale did not accept service names in the `target`
 parameters.
 
 ```
@@ -114,9 +114,9 @@ target01=MyServer2
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines an IP address or mask which a connecting\
-client's IP address is matched against. Only sessions whose address matches this\
-setting will have this filter active and performing the regex matching. Traffic\
+This optional parameter defines an IP address or mask which a connecting
+client's IP address is matched against. Only sessions whose address matches this
+setting will have this filter active and performing the regex matching. Traffic
 from other client IPs is simply left as is and routed straight through.
 
 ```
@@ -133,7 +133,7 @@ source=192.168.10.%
 
 Note that using `source=%` to match any IP is not allowed.
 
-Since MaxScale 2.3 it's also possible to specify multiple addresses separated\
+Since MaxScale 2.3 it's also possible to specify multiple addresses separated
 by comma. Incoming client connections are subsequently checked against each.
 
 ```
@@ -147,9 +147,9 @@ source=192.168.21.3,192.168.10.%
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines a username the connecting client username is\
-matched against. Only sessions that are connected using this username will have\
-the match and routing hints applied to them. Traffic from other users is simply\
+This optional parameter defines a username the connecting client username is
+matched against. Only sessions that are connected using this username will have
+the match and routing hints applied to them. Traffic from other users is simply
 left as is and routed straight through.
 
 ```
@@ -160,30 +160,30 @@ user=john
 
 The maximum number of accepted _match_ - _target_ pairs is 25.
 
-In the configuration file, the indexed match and target settings may be in any order\
-and may skip numbers. During SQL-query matching, however, the regexes are tested\
-in ascending order: match01, match02, match03 and so on. As soon as a match is\
-found for a given query, the routing hints are written and the packet is\
-forwarded to the next filter or router. Any remaining match regexes are\
-ignored. This means the _match_ - _target_ pairs should be indexed in priority\
-order, or, if priority is not a factor, in order of decreasing match\
+In the configuration file, the indexed match and target settings may be in any order
+and may skip numbers. During SQL-query matching, however, the regexes are tested
+in ascending order: match01, match02, match03 and so on. As soon as a match is
+found for a given query, the routing hints are written and the packet is
+forwarded to the next filter or router. Any remaining match regexes are
+ignored. This means the _match_ - _target_ pairs should be indexed in priority
+order, or, if priority is not a factor, in order of decreasing match
 probability.
 
-Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching\
-the prepared sql against the _match_-parameters. If a match is found, the\
-routing hints are attached to any execution of that prepared statement. Text-\
-mode prepared statements are not supported in this way. To divert them, use\
+Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching
+the prepared sql against the _match_-parameters. If a match is found, the
+routing hints are attached to any execution of that prepared statement. Text-
+mode prepared statements are not supported in this way. To divert them, use
 regular expressions which match the specific "EXECUTE"-query.
 
 ### Examples
 
 #### Example 1 - Route queries targeting a specific table to a server
 
-This will route all queries matching the regular expression `*from *users` to\
+This will route all queries matching the regular expression `*from *users` to
 the server named _server2_. The filter will ignore character case in queries.
 
-A query like `SELECT * FROM users` would be routed to server2 where as a query\
-like `SELECT * FROM accounts` would be routed according to the normal rules of\
+A query like `SELECT * FROM users` would be routed to server2 where as a query
+like `SELECT * FROM accounts` would be routed according to the normal rules of
 the router.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-query-log-all-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-query-log-all-filter.md
@@ -27,13 +27,13 @@ filters=MyLogFilter
 
 ### Log Rotation
 
-The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`\
-command. This will cause the log files to be reopened when the next message is\
+The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`
+command. This will cause the log files to be reopened when the next message is
 written to the file. This applies to both unified and session type logging.
 
 ### Filter Parameters
 
-The QLA filter has one mandatory parameter, `filebase`, and a number of optional\
+The QLA filter has one mandatory parameter, `filebase`, and a number of optional
 parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 
 #### `filebase`
@@ -42,7 +42,7 @@ parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 * Mandatory: Yes
 * Dynamic: No
 
-The basename of the output file created for each session. A session index is\
+The basename of the output file created for each session. A session index is
 added to the filename for each written session file. For unified log files,_.unified_ is appended.
 
 ```
@@ -101,7 +101,7 @@ Limit logging to sessions with this client source address.
 * Mandatory: No
 * Dynamic: Yes
 
-Only log queries from users that match this pattern. If the `user` parameter is\
+Only log queries from users that match this pattern. If the `user` parameter is
 used, the value of `user_match` is ignored.
 
 Here is an example pattern that matches the users `alice` and `bob`:
@@ -116,7 +116,7 @@ user_match=/(^alice$)|(^bob$)/
 * Mandatory: No
 * Dynamic: Yes
 
-Exclude all queries from users that match this pattern. If the `user` parameter\
+Exclude all queries from users that match this pattern. If the `user` parameter
 is used, the value of `user_exclude` is ignored.
 
 Here is an example pattern that excludes the users `alice` and `bob`:
@@ -131,10 +131,10 @@ user_exclude=/(^alice$)|(^bob$)/
 * Mandatory: No
 * Dynamic: Yes
 
-Only log queries from hosts that match this pattern. If the `source` parameter\
+Only log queries from hosts that match this pattern. If the `source` parameter
 is used, the value of `source_match` is ignored.
 
-Here is an example pattern that matches the loopback interface as well as the\
+Here is an example pattern that matches the loopback interface as well as the
 address `192.168.0.109`:
 
 ```
@@ -147,10 +147,10 @@ source_match=/(^127[.]0[.]0[.]1)|(^192[.]168[.]0[.]109)/
 * Mandatory: No
 * Dynamic: Yes
 
-Exclude all queries from hosts that match this pattern. If the `source`\
+Exclude all queries from hosts that match this pattern. If the `source`
 parameter is used, the value of `source_exclude` is ignored.
 
-Here is an example pattern that excludes the loopback interface as well as the\
+Here is an example pattern that excludes the loopback interface as well as the
 address `192.168.0.109`:
 
 ```
@@ -202,14 +202,14 @@ Type of data to log in the log files.
 | server             | The server where the query was routed (if any) (v22.08) |
 | command            | The protocol command that was executed (v24.02)         |
 
-The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,\
+The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,
 but can be specified to another unit using _duration\_unit_.
 
 The log entry is written when the last reply from the server is received.\
-Prior to version 6.2 the entry was written when the query was received from\
+Prior to version 6.2 the entry was written when the query was received from
 the client, or if _reply\_time_ was specified, on first reply from the server.
 
-**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_\
+**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_
 is set the error message may contain user defined constants. For example:
 
 ```
@@ -219,10 +219,10 @@ that corresponds to your MariaDB server version for the right syntax to
 use near 'password="clear text pwd"' at line 1
 ```
 
-Starting with MaxScale 24.02, the `query` parameter now correctly logs\
+Starting with MaxScale 24.02, the `query` parameter now correctly logs
 the execution of binary protocol commands as SQL\
-([MXS-4959](https://jira.mariadb.org/browse/MXS-4959)). The execution of\
-batched statements (COM\_STMT\_BULK\_LOAD) used by some connectors is not\
+([MXS-4959](https://jira.mariadb.org/browse/MXS-4959)). The execution of
+batched statements (COM\_STMT\_BULK\_LOAD) used by some connectors is not
 logged.
 
 #### `duration_unit`
@@ -243,7 +243,7 @@ This option is available as of MaxScale version 6.2.
 * Dynamic: Yes
 * Default: `false`
 
-When this option is true the canonical form of the query is logged. In the\
+When this option is true the canonical form of the query is logged. In the
 canonical form all user defined constants are replaced with question marks.\
 This option is available as of MaxScale version 6.2.
 
@@ -270,7 +270,7 @@ Flush log files after every write.
 * Dynamic: Yes
 * Default: `","`
 
-Defines the separator string between elements of\
+Defines the separator string between elements of
 log entries. The value should be enclosed in quotes.
 
 #### `newline_replacement`
@@ -280,10 +280,10 @@ log entries. The value should be enclosed in quotes.
 * Dynamic: Yes
 * Default: `" "`
 
-Default value is `" "` (one space). SQL-queries may include line breaks, which, if\
-printed directly to the log, may break automatic parsing. This parameter defines\
-what should be written in the place of a newline sequence (\r, \n or \r\n). If\
-this is set as the empty string, then newlines are not replaced and printed as\
+Default value is `" "` (one space). SQL-queries may include line breaks, which, if
+printed directly to the log, may break automatic parsing. This parameter defines
+what should be written in the place of a newline sequence (\r, \n or \r\n). If
+this is set as the empty string, then newlines are not replaced and printed as
 is to the output. The value should be enclosed in quotes.
 
 ```
@@ -292,19 +292,19 @@ newline_replacement=" NL "
 
 ### Limitations
 
-* Trailing parts of SQL queries that are larger than 16MiB are not\
+* Trailing parts of SQL queries that are larger than 16MiB are not
   logged. This means that the log output might contain truncated SQL.
-* Batched execution using COM\_STMT\_BULK\_EXECUTE is not converted into\
-  their textual form. This is done due to the large volumes of data that\
+* Batched execution using COM\_STMT\_BULK\_EXECUTE is not converted into
+  their textual form. This is done due to the large volumes of data that
   are usually involved with batched execution.
 
 ### Examples
 
 #### Example 1 - Query without primary key
 
-Imagine you have observed an issue with a particular table and you want to\
-determine if there are queries that are accessing that table but not using the\
-primary key of the table. Let's assume the table name is PRODUCTS and the\
+Imagine you have observed an issue with a particular table and you want to
+determine if there are queries that are accessing that table but not using the
+primary key of the table. Let's assume the table name is PRODUCTS and the
 primary key is called PRODUCT\_ID. Add a filter with the following definition:
 
 ```
@@ -324,7 +324,7 @@ password=mypasswd
 filters=ProductsSelectLogger
 ```
 
-The result of using this filter with the service used by the application would\
+The result of using this filter with the service used by the application would
 be a log file of all select queries querying PRODUCTS without using the\
 PRODUCT\_ID primary key in the predicates of the query. Executing `SELECT * FROM PRODUCTS` would log the following into `/var/logs/qla/SelectProducts`:
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-regex-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-regex-filter.md
@@ -2,13 +2,13 @@
 
 ### Overview
 
-The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite\
-query content using regular expression matches and text substitution. The\
+The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite
+query content using regular expression matches and text substitution. The
 regular expressions use the [PCRE2 syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html).
 
-PCRE2 library uses a different syntax than POSIX to refer to capture\
-groups in the replacement string. The main difference is the usage of the dollar\
-character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)\
+PCRE2 library uses a different syntax than POSIX to refer to capture
+groups in the replacement string. The main difference is the usage of the dollar
+character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)
 chapter in the PCRE2 manual.
 
 ### Configuration
@@ -64,7 +64,7 @@ The _options_-parameter affects how the patterns are compiled as [usual](../maxs
 * Mandatory: Yes
 * Dynamic: Yes
 
-This is the text that should replace the part of the SQL-query matching the\
+This is the text that should replace the part of the SQL-query matching the
 pattern defined in _match_.
 
 ```
@@ -78,9 +78,9 @@ replace=ENGINE =
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
-the address from which the client connection to MariaDB MaxScale\
-originates. Only sessions that originate from this address will have the match\
+The optional source parameter defines an address that is used to match against
+the address from which the client connection to MariaDB MaxScale
+originates. Only sessions that originate from this address will have the match
 and replacement applied to them.
 
 ```
@@ -94,9 +94,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will have the match and\
+The optional user parameter defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will have the match and
 replacement applied to them.
 
 ```
@@ -110,9 +110,9 @@ user=john
 * Dynamic: Yes
 * Default: None
 
-The optional log\_file parameter defines a log file in which the filter writes\
-all queries that are not matched and matching queries with their replacement\
-queries. All sessions will log to this file so this should only be used for\
+The optional log\_file parameter defines a log file in which the filter writes
+all queries that are not matched and matching queries with their replacement
+queries. All sessions will log to this file so this should only be used for
 diagnostic purposes.
 
 ```
@@ -126,10 +126,10 @@ log_file=/tmp/regexfilter.log
 * Dynamic: Yes
 * Default: None
 
-The optional log\_trace parameter toggles the logging of non-matching and\
+The optional log\_trace parameter toggles the logging of non-matching and
 matching queries with their replacements into the log file on the _info_ level.\
-This is the preferred method of diagnosing the matching of queries since the log\
-level can be changed at runtime. For more details about logging levels and\
+This is the preferred method of diagnosing the matching of queries since the log
+level can be changed at runtime. For more details about logging levels and
 session specific logging, please read the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
 
 ```
@@ -140,10 +140,10 @@ log_trace=true
 
 #### Example 1 - Replace MySQL 5.1 create table syntax with that for later versions
 
-MySQL 5.1 used the parameter TYPE = to set the storage engine that should be\
-used for a table. In later versions this changed to be ENGINE =. Imagine you\
-have an application that you cannot change for some reason, but you wish to\
-migrate to a newer version of MySQL. The regexfilter can be used to transform\
+MySQL 5.1 used the parameter TYPE = to set the storage engine that should be
+used for a table. In later versions this changed to be ENGINE =. Imagine you
+have an application that you cannot change for some reason, but you wish to
+migrate to a newer version of MySQL. The regexfilter can be used to transform
 the create table statements into the form that could be used by MySQL 5.5
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-rewrite-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-rewrite-filter.md
@@ -3,8 +3,8 @@
 ### Overview
 
 The rewrite filter allows modification of sql queries on the fly.\
-Reasons for modifying queries can be to rewrite a query for performance,\
-or to change a specific query when the client query is incorrect and\
+Reasons for modifying queries can be to rewrite a query for performance,
+or to change a specific query when the client query is incorrect and
 cannot be changed in a timely manner.
 
 The examples will use Rewrite Filter file format. See below.
@@ -19,7 +19,7 @@ Rewriter native syntax uses placeholders to grab and replace parts of text.
 
 The syntax for a plain placeholder is `@{N}` where N is a positive integer.
 
-The syntax for a placeholder regex is `@{N:regex}`. It allows more control\
+The syntax for a placeholder regex is `@{N:regex}`. It allows more control
 when needed.
 
 The below is a valid entry in rf format. For demonstration, all options are set.\
@@ -53,23 +53,23 @@ For a match, the two `@{2}` text grabs must be equal.
 
 The match template is used to match against the sql to be rewritten.
 
-The match template can be partial `from mytable`. But the actual underlying\
-regex match is always for the whole sql. If the match template does not\
-start or end with a placeholder, placeholders are automatically added so\
-that the above becomes `@{1}from mytable@{2}`. The automatically added\
+The match template can be partial `from mytable`. But the actual underlying
+regex match is always for the whole sql. If the match template does not
+start or end with a placeholder, placeholders are automatically added so
+that the above becomes `@{1}from mytable@{2}`. The automatically added
 placeholders cannot be used in the replace template.
 
-Matching the whole input also means that Native syntax does not support\
-(and is not intended to support) scan and replace. Only the first occurrence\
+Matching the whole input also means that Native syntax does not support
+(and is not intended to support) scan and replace. Only the first occurrence
 of the above `from mytable` can be modified in the replace template.\
-However, one can selectively choose to modify e.g. the first through\
+However, one can selectively choose to modify e.g. the first through
 third occurrence of `from mytable` by writing`from mytable @{1} from mytable @{2} from mytable @{3}`.
 
 For scan and replace use a different regex\_grammar (see below).
 
 **Replace template**
 
-The replace template uses the placeholders from the match template to\
+The replace template uses the placeholders from the match template to
 rewrite sql.
 
 ```
@@ -85,11 +85,11 @@ Input: select count(distinct author) from books where entity != "AI"
 Rewritten: select count(*) from (select distinct author from books where entity != "AI") as t123
 ```
 
-An important option for smooth matching is `ignore_whitespace`, which\
-is on (true) by default. It creates the match regex in such a way that\
-the amount and kind of whitespace does not affect matching. However,\
-to make `ignore_whitespace` always work, it is important to add\
-whitespace where allowed. If "id=42" is in the match template then\
+An important option for smooth matching is `ignore_whitespace`, which
+is on (true) by default. It creates the match regex in such a way that
+the amount and kind of whitespace does not affect matching. However,
+to make `ignore_whitespace` always work, it is important to add
+whitespace where allowed. If "id=42" is in the match template then
 only the exact "id=42" can match. But if "id = 42" is used, and`ignore_whitespace` is on, both "id=42" and "id = 42" will match.
 
 Another example, and what not to do:
@@ -106,7 +106,7 @@ Input: select name from mytable where id=42
 Rewritten: select name from mytable force index (myindex) where id=42
 ```
 
-That works, but because the match lacks specific detail about the\
+That works, but because the match lacks specific detail about the
 expected sql, things are likely to break. In this case`show indexes from my_table` would no longer work.
 
 The minimum detail in this case could be:
@@ -119,22 +119,22 @@ The minimum detail in this case could be:
 select @{2} from mytable force index (myindex)
 ```
 
-but if more detail is known, like something specific in the where clause,\
+but if more detail is known, like something specific in the where clause,
 that too should be added.
 
 **Placeholder Regex**
 
 Syntax: @{N:regex}
 
-In a placeholder regex the character `}` must be escaped to `\}`\
-(for literal matching). Plain parenthesis "()" indicate capturing\
+In a placeholder regex the character `}` must be escaped to `\}`
+(for literal matching). Plain parenthesis "()" indicate capturing
 groups, which are internally used by the Native grammar.\
 Thus plain parentheses in a placeholder regex will break matching.\
 However, non-capturing groups can be used: e.g. `@{1:(:?Jane|Joe)}`.\
 To match a literal parenthesis use an escape, e.g. `\(`.
 
 Suppose an application is misbehaving after an upgrade and a quick fix is needed.\
-This query `select zip from address_book where str_id = "AZ-124"` is correct,\
+This query `select zip from address_book where str_id = "AZ-124"` is correct,
 but if the id is an integer the where clause should be `id = 1234`.
 
 ```
@@ -155,7 +155,7 @@ For scan and replace the regex\_grammar must be set to something else than\
 Native. An example will illustrate the usage.
 
 Replace all occurrences of "wrong\_table\_name" with "correct\_table\_name".\
-Further, if the replacement was made then replace all occurrences\
+Further, if the replacement was made then replace all occurrences
 of wrong\_column\_name with correct\_column\_name.
 
 ```
@@ -260,7 +260,7 @@ Ignore whitespace differences in the match template and input sql.
 * Type: boolean
 * Default: false
 
-If a template matches and the replacement is done, continue to the\
+If a template matches and the replacement is done, continue to the
 next template and apply it to the result of the previous rewrite.
 
 **`what_if`**
@@ -268,7 +268,7 @@ next template and apply it to the result of the previous rewrite.
 * Type: boolean
 * Default: false
 
-Do not make the replacement, only log what would have\
+Do not make the replacement, only log what would have
 been replaced (NOTICE level).
 
 ### Rewrite file format
@@ -284,12 +284,12 @@ match template
 replace template
 ```
 
-The character `#` starts a single line comment when it is the\
+The character `#` starts a single line comment when it is the
 first character on a line.
 
 Empty lines are ignored.
 
-The rf format does not need any additional escaping to what the basic\
+The rf format does not need any additional escaping to what the basic
 format requires (see Placeholder Regex).
 
 Options are specified as follows:
@@ -300,11 +300,11 @@ case_sensitive: true
 
 The colon must stick to the option name.
 
-The separators `%` and `%%` must be the exact content of\
+The separators `%` and `%%` must be the exact content of
 their respective separator lines.
 
-The templates can span multiple lines. Whitespace does not\
-matter as long as `ignore_whitespace = true`. Always use space\
+The templates can span multiple lines. Whitespace does not
+matter as long as `ignore_whitespace = true`. Always use space
 where space is allowed to maximize the utility of`ignore_whitespace`.
 
 Example
@@ -324,10 +324,10 @@ and @{3} in (select user from approved_users)
 ### Json file format
 
 The json file format is harder to read and edit manually.\
-It will be needed if support for editing of rewrite templates\
+It will be needed if support for editing of rewrite templates
 is added to the GUI.
 
-All double quotes and escape characters have to be escaped in json,\
+All double quotes and escape characters have to be escaped in json,
 i.e '"' and '\\'.
 
 The same example as above is:
@@ -347,7 +347,7 @@ and @{3} in (select user from approved_users)"
 
 ### Reload template file
 
-The configuration is re-read if any dynamic value is updated\
+The configuration is re-read if any dynamic value is updated
 even if the value does not change.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-tee-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-tee-filter.md
@@ -3,17 +3,17 @@
 ### Overview
 
 The tee filter is a "plumbing" fitting in the MariaDB MaxScale filter toolkit.\
-It can be used in a filter pipeline of a service to make copies of requests from\
+It can be used in a filter pipeline of a service to make copies of requests from
 the client and send the copies to another service within MariaDB MaxScale.
 
-**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a\
-service which uses a tee filter will require a grant for the loopback address,\
+**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a
+service which uses a tee filter will require a grant for the loopback address,
 i.e. `127.0.0.1`.
 
 ### Configuration
 
-The configuration block for the TEE filter requires the minimal filter\
-parameters in its section within the MaxScale configuration file. The service to\
+The configuration block for the TEE filter requires the minimal filter
+parameters in its section within the MaxScale configuration file. The service to
 send the duplicates to must be defined.
 
 ```
@@ -33,7 +33,7 @@ filters=DataMartFilter
 
 ### Filter Parameters
 
-The tee filter requires a mandatory parameter to define the service to replicate\
+The tee filter requires a mandatory parameter to define the service to replicate
 statements to and accepts a number of optional parameters.
 
 #### `target`
@@ -43,8 +43,8 @@ statements to and accepts a number of optional parameters.
 * Dynamic: Yes
 * Default: none
 
-The target where the filter will duplicate all queries. The target can be either\
-a service or a server. The duplicate connection that is created to this target\
+The target where the filter will duplicate all queries. The target can be either
+a service or a server. The duplicate connection that is created to this target
 will be referred to as the "branch target" in this document.
 
 #### `service`
@@ -54,8 +54,8 @@ will be referred to as the "branch target" in this document.
 * Dynamic: Yes
 * Default: none
 
-The service where the filter will duplicate all queries. This parameter is\
-deprecated in favor of the `target` parameter and will be removed in a future\
+The service where the filter will duplicate all queries. This parameter is
+deprecated in favor of the `target` parameter and will be removed in a future
 release. Both `target` and `service` cannot be defined.
 
 #### `match`
@@ -105,7 +105,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
+The optional source parameter defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be replicated.
 
@@ -120,8 +120,8 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a user name that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
+The optional user parameter defines a user name that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
 sessions that are connected using this username are replicated.
 
 ```
@@ -135,63 +135,63 @@ user=john
 * Dynamic: Yes
 * Default: `false`
 
-Enable synchronous routing mode. When configured with `sync=true`, the filter\
-will queue new queries until the response from both the main and the branch\
-target has been received. This means that for `n` executed queries, `n - 1`\
-queries are guaranteed to be synchronized. Adding one extra statement\
-(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL\
+Enable synchronous routing mode. When configured with `sync=true`, the filter
+will queue new queries until the response from both the main and the branch
+target has been received. This means that for `n` executed queries, `n - 1`
+queries are guaranteed to be synchronized. Adding one extra statement
+(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL
 statements have been successfully executed on both targets.
 
-In the synchronous routing mode, a failure of the branch target will cause the\
+In the synchronous routing mode, a failure of the branch target will cause the
 client session to be closed.
 
 ### Limitations
 
-* All statements that are executed on the branch target are done in an\
-  asynchronous manner. This means that when the client receives the response\
-  there is no guarantee that the statement has completed on the branch\
-  target. The `sync` feature provides some synchronization guarantees that can\
+* All statements that are executed on the branch target are done in an
+  asynchronous manner. This means that when the client receives the response
+  there is no guarantee that the statement has completed on the branch
+  target. The `sync` feature provides some synchronization guarantees that can
   be used to verify successful execution on both targets.
-* Any errors on the branch target will cause the connection to it to be\
-  closed. If `target` is a service, it is up to the router to decide whether the\
-  connection is closed. For direct connections to servers, any network errors\
-  cause the connection to be closed. When the connection is closed, no new\
+* Any errors on the branch target will cause the connection to it to be
+  closed. If `target` is a service, it is up to the router to decide whether the
+  connection is closed. For direct connections to servers, any network errors
+  cause the connection to be closed. When the connection is closed, no new
   queries will be routed to the branch target.
 
-With `sync=true`, a failure of the branch target will cause the whole session\
+With `sync=true`, a failure of the branch target will cause the whole session
 to be closed.
 
 ### Module commands
 
-Read [Module Commands](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md) documentation for\
+Read [Module Commands](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md) documentation for
 details about module commands.
 
 The tee filter supports the following module commands.
 
 #### `tee disable [FILTER]`
 
-This command disables a tee filter instance. A disabled tee filter will not send\
+This command disables a tee filter instance. A disabled tee filter will not send
 any queries to the target service.
 
 #### `tee enable [FILTER]`
 
-Enable a disabled tee filter. This resumes the sending of queries to the target\
+Enable a disabled tee filter. This resumes the sending of queries to the target
 service.
 
 ### Examples
 
 #### Example 1 - Replicate all inserts into the orders table
 
-Assume an order processing system that has a table called orders. You also have\
-another database server, the datamart server, that requires all inserts into\
+Assume an order processing system that has a table called orders. You also have
+another database server, the datamart server, that requires all inserts into
 orders to be replicated to it. Deletes and updates are not, however, required.
 
-Set up a service in MariaDB MaxScale, called Orders, to communicate with the\
-order processing system with the tee filter applied to it. Also set up a service\
-to talk to the datamart server, using the DataMart service. The tee filter would\
+Set up a service in MariaDB MaxScale, called Orders, to communicate with the
+order processing system with the tee filter applied to it. Also set up a service
+to talk to the datamart server, using the DataMart service. The tee filter would
 have as its service entry the DataMart service, by adding a match parameter of\
-"insert into orders" would then result in all requests being sent to the order\
-processing system, and insert statements that include the orders table being\
+"insert into orders" would then result in all requests being sent to the order
+processing system, and insert statements that include the orders table being
 additionally sent to the datamart server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-throttle.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-throttle.md
@@ -4,13 +4,13 @@ This filter was added in MariaDB MaxScale 2.3
 
 ### Overview
 
-The throttle filter is used to limit the maximum query frequency (QPS - queries\
-per second) of a database session to a configurable value. The main use cases\
-are to prevent a rogue session (client side error) and a DoS attack from\
+The throttle filter is used to limit the maximum query frequency (QPS - queries
+per second) of a database session to a configurable value. The main use cases
+are to prevent a rogue session (client side error) and a DoS attack from
 overloading the system.
 
-The throttling is dynamic. The query frequency is not limited to an absolute\
-value. Depending on the configuration the throttle will allow some amount of\
+The throttling is dynamic. The query frequency is not limited to an absolute
+value. Depending on the configuration the throttle will allow some amount of
 high frequency queries, or especially short bursts with no frequency limitation.
 
 ### Configuration
@@ -31,27 +31,27 @@ filters = Throttle
 ```
 
 This configuration states that the query frequency will be throttled to around\
-500 qps, and that the time limit a query is allowed to stay at the maximum\
-frequency is 60 seconds. All values involving time are configured in\
-milliseconds. With the basic configuration the throttling will be nearly\
-immediate, i.e. a session will only be allowed very short bursts of high\
+500 qps, and that the time limit a query is allowed to stay at the maximum
+frequency is 60 seconds. All values involving time are configured in
+milliseconds. With the basic configuration the throttling will be nearly
+immediate, i.e. a session will only be allowed very short bursts of high
 frequency querying.
 
-When a session has been continuously throttled for `throttling_duration`\
-milliseconds, or 60 seconds in this example, MaxScale will disconnect the\
+When a session has been continuously throttled for `throttling_duration`
+milliseconds, or 60 seconds in this example, MaxScale will disconnect the
 session.
 
 #### Allowing high frequency bursts
 
-The two parameters `max_qps` and `sampling_duration` together define how a\
+The two parameters `max_qps` and `sampling_duration` together define how a
 session is throttled.
 
-Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not\
-an instantaneous measure, but one could say it has a granularity of 10 seconds,\
-we see that over the 10 seconds 10\*400 = 4000 queries are allowed before\
+Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not
+an instantaneous measure, but one could say it has a granularity of 10 seconds,
+we see that over the 10 seconds 10\*400 = 4000 queries are allowed before
 throttling kicks in.
 
-With these values, a fresh session can start off with a speed of 2000 qps, and\
+With these values, a fresh session can start off with a speed of 2000 qps, and
 maintain that speed for 2 seconds before throttling starts.
 
 If the client continues to query at high speed and throttling duration is set to\
@@ -67,8 +67,8 @@ If the client continues to query at high speed and throttling duration is set to
 
 Maximum queries per second.
 
-This is the frequency to which a session will be limited over a given time\
-period. QPS is not measured as an instantaneous value but over a configurable\
+This is the frequency to which a session will be limited over a given time
+period. QPS is not measured as an instantaneous value but over a configurable
 sampling duration (see `sampling_duration`).
 
 **`throttling_duration`**
@@ -77,7 +77,7 @@ sampling duration (see `sampling_duration`).
 * Mandatory: Yes
 * Dynamic: Yes
 
-This defines how long a session is allowed to be throttled before MaxScale\
+This defines how long a session is allowed to be throttled before MaxScale
 disconnects the session.
 
 #### `sampling_duration`
@@ -87,11 +87,11 @@ disconnects the session.
 * Dynamic: Yes
 * Default: 250ms
 
-Sampling duration defines the window of time over which QPS is measured. This\
-parameter directly affects the amount of time that high frequency queries are\
+Sampling duration defines the window of time over which QPS is measured. This
+parameter directly affects the amount of time that high frequency queries are
 allowed before throttling kicks in.
 
-The lower this value is, the more strict throttling becomes. Conversely, the\
+The lower this value is, the more strict throttling becomes. Conversely, the
 longer this time is, the longer bursts of high frequency querying is allowed.
 
 #### `continuous_duration`
@@ -101,8 +101,8 @@ longer this time is, the longer bursts of high frequency querying is allowed.
 * Dynamic: Yes
 * Default: 2s
 
-This value defines what continuous throttling means. Continuous throttling\
-starts as soon as the filter throttles the frequency. Continuous throttling ends\
+This value defines what continuous throttling means. Continuous throttling
+starts as soon as the filter throttles the frequency. Continuous throttling ends
 when no throttling has been performed in the past `continuous_duration` time.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-top-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-top-filter.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-The top filter is a filter module for MariaDB MaxScale that monitors every SQL\
-statement that passes through the filter. It measures the duration of that\
-statement, the time between the statement being sent and the first result being\
-returned. The top N times are kept, along with the SQL text itself and a list\
-sorted on the execution times of the query is written to a file upon closure of\
+The top filter is a filter module for MariaDB MaxScale that monitors every SQL
+statement that passes through the filter. It measures the duration of that
+statement, the time between the statement being sent and the first result being
+returned. The top N times are kept, along with the SQL text itself and a list
+sorted on the execution times of the query is written to a file upon closure of
 the client session.
 
 ### Configuration
@@ -29,7 +29,7 @@ filters=MyLogFilter
 
 #### Filter Parameters
 
-The top filter has one mandatory parameter, `filebase`, and a number of optional\
+The top filter has one mandatory parameter, `filebase`, and a number of optional
 parameters.
 
 **`filebase`**
@@ -38,15 +38,15 @@ parameters.
 * Mandatory: Yes
 * Dynamic: Yes
 
-The basename of the output file created for each session. The session ID is\
+The basename of the output file created for each session. The session ID is
 added to the filename for each file written. This is a mandatory parameter.
 
 ```
 filebase=/tmp/SqlQueryLog
 ```
 
-The filebase may also be set as the filter, the mechanism to set the filebase\
-via the filter option is superseded by the parameter. If both are set the\
+The filebase may also be set as the filter, the mechanism to set the filebase
+via the filter option is superseded by the parameter. If both are set the
 parameter setting will be used and the filter option ignored.
 
 **`count`**
@@ -69,7 +69,7 @@ count=30
 * Dynamic: Yes
 * Default: None
 
-[Limits](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+[Limits](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 ```
@@ -85,7 +85,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-[Limits](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+[Limits](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 **`options`**
@@ -96,7 +96,7 @@ the queries logged by the filter.
 * Values: `ignorecase`, `case`, `extended`
 * Default: `case`
 
-[Regular expression options](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+[Regular expression options](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 for `match` and `exclude`.
 
 **`source`**
@@ -106,7 +106,7 @@ for `match` and `exclude`.
 * Dynamic: Yes
 * Default: None
 
-Defines an address that is used to match against\
+Defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be logged.
 
@@ -121,9 +121,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-Defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will result in results being\
+Defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will result in results being
 generated.
 
 ```
@@ -134,8 +134,8 @@ user=john
 
 #### Example 1 - Heavily Contended Table
 
-You have an order system and believe the updates of the PRODUCTS table is\
-causing some performance issues for the rest of your application. You would like\
+You have an order system and believe the updates of the PRODUCTS table is
+causing some performance issues for the rest of your application. You would like
 to know which of the many updates in your application is causing the issue.
 
 Add a filter with the following definition:
@@ -150,12 +150,12 @@ exclude=UPDATE.*PRODUCTS_STOCK.*WHERE
 filebase=/var/logs/top/ProductsUpdate
 ```
 
-Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table\
+Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table
 from being included in the report.
 
 #### Example 2 - One Application Server is Slow
 
-One of your applications servers is slower than the rest, you believe it is\
+One of your applications servers is slower than the rest, you believe it is
 related to database access but you are not sure what is taking the time.
 
 Add a filter with the following definition:
@@ -169,7 +169,7 @@ source=192.168.0.32
 filebase=/var/logs/top/SlowAppServer
 ```
 
-In order to produce a comparison with an unaffected application server you can\
+In order to produce a comparison with an unaffected application server you can
 also add a second filter as a control.
 
 ```
@@ -194,14 +194,14 @@ password=mypasswd
 filters=SlowAppServer | ControlAppServer
 ```
 
-You will then have two sets of logs files written, one which profiles the top 20\
-queries of the slow application server and another that gives you the top 20\
-queries of your control application server. These two sets of files can then be\
+You will then have two sets of logs files written, one which profiles the top 20
+queries of the slow application server and another that gives you the top 20
+queries of your control application server. These two sets of files can then be
 compared to determine what if anything is different between the two.
 
 ### Output Report
 
-The following is an example report for a number of fictitious queries executed\
+The following is an example report for a number of fictitious queries executed
 against the employees example database available for MySQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-transaction-performance-monitoring-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-transaction-performance-monitoring-filter.md
@@ -1,21 +1,21 @@
 # MaxScale 24.02 Transaction Performance Monitoring Filter
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Overview
 
-The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale\
+The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale
 that monitors every SQL statement that passes through the filter.\
 The filter groups a series of SQL statements into a transaction by detecting\
-'commit' or 'rollback' statements. It logs all committed transactions with necessary\
-information, such as timestamp, client, SQL statements, latency, etc., which\
+'commit' or 'rollback' statements. It logs all committed transactions with necessary
+information, such as timestamp, client, SQL statements, latency, etc., which
 can be used later for transaction performance analysis.
 
 ### Configuration
 
-The configuration block for the TPM filter requires the minimal filter\
+The configuration block for the TPM filter requires the minimal filter
 options in it's section within the maxscale.cnf file, stored in /etc/maxscale.cnf.
 
 ```
@@ -51,9 +51,9 @@ filename=/tmp/SqlQueryLog
 
 #### Source
 
-The optional `source` parameter defines an address that is used\
-to match against the address from which the client connection\
-to MaxScale originates. Only sessions that originate from this\
+The optional `source` parameter defines an address that is used
+to match against the address from which the client connection
+to MaxScale originates. Only sessions that originate from this
 address will be logged.
 
 ```
@@ -62,9 +62,9 @@ source=127.0.0.1
 
 #### User
 
-The optional `user` parameter defines a user name that is used\
+The optional `user` parameter defines a user name that is used
 to match against the user from which the client connection to\
-MaxScale originates. Only sessions that are connected using\
+MaxScale originates. Only sessions that are connected using
 this username are logged.
 
 ```
@@ -73,7 +73,7 @@ user=john
 
 #### Delimiter
 
-The optional `delimiter` parameter defines a delimiter that is used to\
+The optional `delimiter` parameter defines a delimiter that is used to
 distinguish columns in the log. The default delimiter is **`:::`**.
 
 ```
@@ -82,7 +82,7 @@ delimiter=:::
 
 #### Query\_delimiter
 
-The optional `query_delimiter` defines a delimiter that is used to\
+The optional `query_delimiter` defines a delimiter that is used to
 distinguish different SQL statements in a transaction.\
 The default query delimiter is **`@@@`**.
 
@@ -92,9 +92,9 @@ query_delimiter=@@@
 
 #### Named\_pipe
 
-**`named_pipe`** is the path to a named pipe, which TPM filter uses to\
+**`named_pipe`** is the path to a named pipe, which TPM filter uses to
 communicate with 3rd-party applications (e.g., [DBSeer](https://dbseer.org)).\
-Logging is enabled when the router receives the character '1' and logging is\
+Logging is enabled when the router receives the character '1' and logging is
 disabled when the router receives the character '0' from this named pipe.\
 The default named pipe is **`/tmp/tpmfilter`** and logging is **disabled** by default.
 
@@ -124,7 +124,7 @@ For each transaction, the TPM filter prints its log in the following format:
 
 #### Example 1 - Log Transactions for Performance Analysis
 
-You want to log every transaction with its SQL statements and latency\
+You want to log every transaction with its SQL statements and latency
 for future transaction performance analysis.
 
 Add a filter with the following definition:
@@ -147,7 +147,7 @@ password=mypasswd
 filters=PerformanceLogger
 ```
 
-After the filter reads the character '1' from its named pipe, the following\
+After the filter reads the character '1' from its named pipe, the following
 is an example log that is generated from the above TPM filter with the above configuration:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-building-mariadb-maxscale-from-source-code.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-building-mariadb-maxscale-from-source-code.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Building MariaDB MaxScale from Source Code
 
-MariaDB MaxScale can be built on any system that meets the requirements. The main\
+MariaDB MaxScale can be built on any system that meets the requirements. The main
 requirements are as follows:
 
 * CMake version 3.16 or later (Packaging requires CMake 3.25.1 or later)
@@ -23,7 +23,7 @@ requirements are as follows:
 * pcre2
 * zstd
 
-This is the minimum set of requirements that must be met to build the MaxScale\
+This is the minimum set of requirements that must be met to build the MaxScale
 core package. Some modules in MaxScale require optional extra dependencies.
 
 * libuuid (binlogrouter)
@@ -34,9 +34,9 @@ core package. Some modules in MaxScale require optional extra dependencies.
 * memcached (storage\_memcached for the cache filter)
 * hiredis (storage\_redis for the cache filter)
 
-Some of these dependencies are not available on all operating systems and are\
-downloaded automatically during the build step. To skip the building of modules\
-that need automatic downloading of the dependencies, use `-DBUNDLE=N` when\
+Some of these dependencies are not available on all operating systems and are
+downloaded automatically during the build step. To skip the building of modules
+that need automatic downloading of the dependencies, use `-DBUNDLE=N` when
 configuring CMake.
 
 ### Quickstart
@@ -62,7 +62,7 @@ For a definitive list of packages, consult the [install\_build\_deps.sh](https:/
 
 The tests and other parts of the build can be controlled via CMake arguments.
 
-Here is a small table with the names of the most common parameters and what\
+Here is a small table with the names of the most common parameters and what
 they control. These should all be given as parameters to the -D switch in _NAME_=_VALUE_ format (e.g. `-DBUILD_TESTS=Y`).
 
 | Argument Name          | Explanation                                                                                                                                                                |
@@ -74,25 +74,25 @@ they control. These should all be given as parameters to the -D switch in _NAME_
 | TARGET\_COMPONENT      | Which component to install, default is the 'core' package. Other targets are 'experimental', which installs experimental packages and 'all' which installs all components. |
 | TARBALL                | Build tar.gz packages, requires PACKAGE=Y                                                                                                                                  |
 
-**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a\
+**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a
 list of the CMake variables.
 
 ### Running unit tests
 
-To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,\
+To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,
 compile and then run the `make test` command.
 
 ## Building MariaDB MaxScale packages
 
-If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation\
-and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your\
+If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation
+and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your
 system.
 
-To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create\
+To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create
 a _maxscale-x.y.z.tar.gz_ file where _x.y.z_ is the version number.
 
-Some Debian and Ubuntu systems suffer from a bug where `make package` fails\
-with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to\
+Some Debian and Ubuntu systems suffer from a bug where `make package` fails
+with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to
 the LD\_LIBRARY\_PATH environment variable.
 
 ```
@@ -102,14 +102,14 @@ LD_LIBRARY_PATH=$PWD/server/core/ make package
 
 ### Installing optional components
 
-The MaxScale build system is split into multiple components. The main component\
-is the `core` MaxScale package which contains MaxScale and all the modules. This\
-is the default component that is build, installed and packaged. There is also\
-the `experimental` component that contains all experimental modules which are\
-not considered as part of the core MaxScale package and are either alpha or beta\
+The MaxScale build system is split into multiple components. The main component
+is the `core` MaxScale package which contains MaxScale and all the modules. This
+is the default component that is build, installed and packaged. There is also
+the `experimental` component that contains all experimental modules which are
+not considered as part of the core MaxScale package and are either alpha or beta
 quality modules.
 
-To build the experimental modules along with the MaxScale core components,\
+To build the experimental modules along with the MaxScale core components,
 invoke CMake with `-DTARGET_COMPONENT=core,experimental`.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-installing-mariadb-maxscale-using-a-tarball.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-installing-mariadb-maxscale-using-a-tarball.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Installing MariaDB MaxScale using a tarball
 
-MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`\
+MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`
 identifies the operating system, e.g. `maxscale-2.5.6.centos.7.tar.gz`.
 
 In order to use the tarball, the following libraries are required:
@@ -13,12 +13,12 @@ In order to use the tarball, the following libraries are required:
 * unixODBC
 
 The tarball has been built with the assumption that it will be installed in `/usr/local`.\
-However, it is possible to install it in any directory, but in that case MariaDB MaxScale\
+However, it is possible to install it in any directory, but in that case MariaDB MaxScale
 must be invoked with a flag.
 
 ### Installing as root in `/usr/local`
 
-If you have root access to the system you probably want to install MariaDB MaxScale under\
+If you have root access to the system you probably want to install MariaDB MaxScale under
 the user and group `maxscale`.
 
 The required steps are as follows:
@@ -33,14 +33,14 @@ $ cd maxscale
 $ sudo chown -R maxscale var
 ```
 
-Creating the symbolic link is necessary, since MariaDB MaxScale has been built\
+Creating the symbolic link is necessary, since MariaDB MaxScale has been built
 with the assumption that the plugin directory is `/usr/local/maxscale/lib/maxscale`.
 
 The symbolic link also makes it easy to switch between different versions of\
 MariaDB MaxScale that have been installed side by side in `/usr/local`;\
 just make the symbolic link point to another installation.
 
-In addition, the first time you install MariaDB MaxScale from a tarball\
+In addition, the first time you install MariaDB MaxScale from a tarball
 you need to create the following directories:
 
 ```
@@ -69,14 +69,14 @@ When the configuration file has been created, MariaDB MaxScale can be started.
 $ sudo bin/maxscale --user=maxscale -d
 ```
 
-The `-d` flag causes maxscale _not_ to turn itself into a daemon,\
+The `-d` flag causes maxscale _not_ to turn itself into a daemon,
 which is advisable the first time MariaDB MaxScale is started, as it makes it easier to spot problems.
 
 If you want to place the configuration file somewhere else but in `/etc`\
 you can invoke MariaDB MaxScale with the `--config` flag,\
 for instance, `--config=/usr/local/maxscale/etc/maxscale.cnf`.
 
-Note also that if you want to keep _everything_ under `/usr/local/maxscale`\
+Note also that if you want to keep _everything_ under `/usr/local/maxscale`
 you can invoke MariaDB MaxScale using the flag `--basedir`.
 
 ```
@@ -104,12 +104,12 @@ $ cd maxscale-x.y.z.OS
 $ bin/maxscale -d --basedir=.
 ```
 
-With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`\
-directories are found. Unless it is specified, MariaDB MaxScale assumes\
-the `lib` directory is found in `/usr/local/maxscale`,\
+With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`
+directories are found. Unless it is specified, MariaDB MaxScale assumes
+the `lib` directory is found in `/usr/local/maxscale`,
 and the `var` and `etc` directories in `/`.
 
-It is also possible to specify the directories and the location of\
+It is also possible to specify the directories and the location of
 the configuration file individually. Invoke MaxScale like
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-This document describes how to configure MariaDB MaxScale and presents some\
-possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,\
-and consists of an event processing core with various support functions and\
+This document describes how to configure MariaDB MaxScale and presents some
+possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,
+and consists of an event processing core with various support functions and
 plugin modules that tailor the behavior of the program.
 
 ## Concepts
@@ -24,9 +24,9 @@ plugin modules that tailor the behavior of the program.
 
 #### Server
 
-A server represents an individual database server to which a client can be\
-connected via MariaDB MaxScale. The status of a server varies during the lifetime\
-of the server and typically the status is updated by some monitor. However, it\
+A server represents an individual database server to which a client can be
+connected via MariaDB MaxScale. The status of a server varies during the lifetime
+of the server and typically the status is updated by some monitor. However, it
 is also possible to update the status of a server manually.
 
 | Status                   | Description                                                                                                                                                                                                                                                                                                                |
@@ -45,62 +45,62 @@ For more information on how to manually set these states via MaxCtrl, read the [
 
 #### Monitor
 
-A monitor module is capable of monitoring the state of a particular kind\
+A monitor module is capable of monitoring the state of a particular kind
 of cluster and making that state available to the routers of MaxScale.
 
-Examples of monitor modules are `mariadbmon` that is capable of monitoring\
-a regular primary-replica cluster and in addition of performing both _switchover_\
-and _failover_, `galeramon` that is capable of monitoring a Galera cluster,\
+Examples of monitor modules are `mariadbmon` that is capable of monitoring
+a regular primary-replica cluster and in addition of performing both _switchover_
+and _failover_, `galeramon` that is capable of monitoring a Galera cluster,
 and `csmon` that is capable of monitoring a Columnstore cluster.
 
-Monitor modules have sections of their own in the MaxScale configuration\
+Monitor modules have sections of their own in the MaxScale configuration
 file.
 
 #### Filter
 
-A filter module resides in front of routers in the request processing chain\
-of MaxScale. That is, a filter will see a request before it reaches the router\
-and before a response is sent back to the client. This allows filters to\
+A filter module resides in front of routers in the request processing chain
+of MaxScale. That is, a filter will see a request before it reaches the router
+and before a response is sent back to the client. This allows filters to
 reject, handle, alter or log information about a request.
 
 Examples of filters `cache` that provides query caching according to rules,`regexfilter` that can rewrite requests according to regular expressions, and`qlafilter` that logs information about requests.
 
-Filters have sections of their own in the MaxScale configuration file that are\
+Filters have sections of their own in the MaxScale configuration file that are
 referred to from _services_.
 
 #### Router
 
-A router module is capable of routing requests to backend servers according to\
-the characteristics of a request and/or the algorithm the router\
+A router module is capable of routing requests to backend servers according to
+the characteristics of a request and/or the algorithm the router
 implements. Examples of routers are `readconnroute` that provides _connection routing_, that is, the server is chosen according to specified rules when the
-session is created and all requests are subsequently routed to that server,\
-and `readwritesplit` that provides _statement routing_, that is, each\
+session is created and all requests are subsequently routed to that server,
+and `readwritesplit` that provides _statement routing_, that is, each
 individual request is routed to the most appropriate server.
 
-Routers do not have sections of their own in the MaxScale configuration file,\
+Routers do not have sections of their own in the MaxScale configuration file,
 but are referred to from _services_.
 
 #### Service
 
-A service abstracts a set of databases and makes them appear as a single one\
-to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular\
-way. If the service uses filters, then all requests will be pre-processed in\
+A service abstracts a set of databases and makes them appear as a single one
+to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular
+way. If the service uses filters, then all requests will be pre-processed in
 some way before they reach the router.
 
 Services have sections of their own in the MaxScale configuration file.
 
 #### Listener
 
-A listener defines a port MaxScale listens on. Connection requests arriving on\
-that port will be forwarded to the service the listener is associated with. A\
-listener may be associated with a single service, but several listeners may be\
+A listener defines a port MaxScale listens on. Connection requests arriving on
+that port will be forwarded to the service the listener is associated with. A
+listener may be associated with a single service, but several listeners may be
 associated with the same service.
 
 Listeners have sections of their own in the MaxScale configuration file.
 
 #### Include
 
-An [include section](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#include-1) defines common parameters used in other\
+An [include section](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#include-1) defines common parameters used in other
 configuration sections.
 
 ## Administration
@@ -110,33 +110,33 @@ The administration of MaxScale can be divided in two parts:
 * Writing the MaxScale configuration file, which is described in the following [section](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#configuration).
 * Performing runtime modifications using [MaxCtrl](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-maxctrl.md)
 
-For detailed information about _MaxCtrl_ please refer to the specific\
+For detailed information about _MaxCtrl_ please refer to the specific
 documentation referred to above. In the following it will only be explained how\
 MaxCtrl relate to each other, as far as user credentials go.
 
-**Note**: By default all runtime configuration changes are saved on disk and\
-loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details\
+**Note**: By default all runtime configuration changes are saved on disk and
+loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details
 on how it works and how to disable it.
 
 MaxCtrl can connect using TCP/IP sockets. When connecting with MaxCtrl using\
-TCP/IP sockets, the user and password must be provided and are checked against a\
+TCP/IP sockets, the user and password must be provided and are checked against a
 separate user credentials database. By default, that database contains the user`admin` whose password is `mariadb`.
 
-Note that if MaxCtrl is invoked without explicitly providing a user and password\
-then it will by default use `admin` and `mariadb`. That means that when the\
+Note that if MaxCtrl is invoked without explicitly providing a user and password
+then it will by default use `admin` and `mariadb`. That means that when the
 default user is removed, the credentials must always be provided.
 
 ### Administration audit file
 
-The REST API calls to MaxScale can be logged\
+The REST API calls to MaxScale can be logged
 by enabling [admin\_audit](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#admin_audit).
 
-For more detail see the admin audit configuration values `admin_audit`,`admin_audit_file` and `admin_audit_exclude_methods` below\
+For more detail see the admin audit configuration values `admin_audit`,`admin_audit_file` and `admin_audit_exclude_methods` below
 and [Administration Tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-administration-tutorial.md).
 
 ### Static Configuration Parameters
 
-The following list of global configuration parameters can **NOT** be changed at\
+The following list of global configuration parameters can **NOT** be changed at
 runtime and can only be defined in a configuration file:
 
 * `admin_auth`
@@ -179,35 +179,35 @@ runtime and can only be defined in a configuration file:
 * `substitute_variables`
 * `threads_max`
 
-All other parameters that relate to objects can be altered at runtime or can be\
+All other parameters that relate to objects can be altered at runtime or can be
 changed by destroying and recreating the object in question.
 
 ## Configuration
 
-MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If\
-the command line argument `--configdir=<path>` is given, `maxscale.cnf` is\
-searched for in _\<path>_ instead. If the argument `--config=<file>` is given,\
+MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If
+the command line argument `--configdir=<path>` is given, `maxscale.cnf` is
+searched for in _\<path>_ instead. If the argument `--config=<file>` is given,
 configuration is read from the file _\<file>_.
 
-MaxScale also looks for a directory with the same name as the configuration\
-file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale\
+MaxScale also looks for a directory with the same name as the configuration
+file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale
 recursively reads all files with the ".cnf" suffix in the directory hierarchy.\
 Other files are ignored.
 
-After loading normal configuration files, MaxScale reads runtime-generated\
+After loading normal configuration files, MaxScale reads runtime-generated
 configuration files, if any, from the [persisted configuration files directory](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#persistdir).
 
 Different configuration sections can be arranged with little restrictions.\
-Global path settings such as `logdir`, `piddir` and `datadir` are only read from\
-the main configuration file. Other global settings are also best left in the\
-main file to ensure they are read before other configuration sections are\
+Global path settings such as `logdir`, `piddir` and `datadir` are only read from
+the main configuration file. Other global settings are also best left in the
+main file to ensure they are read before other configuration sections are
 parsed.
 
 The configuration file format used is [INI](https://en.wikipedia.org/wiki/INI_file), similar to the\
-MariaDB Server. The files contain sections and each section can contain multiple\
+MariaDB Server. The files contain sections and each section can contain multiple
 key-value pairs.
 
-Comments are defined by prefixing a row with a hash (#). Trailing comments are\
+Comments are defined by prefixing a row with a hash (#). Trailing comments are
 not supported.
 
 ```
@@ -215,8 +215,8 @@ not supported.
 some_parameter=123
 ```
 
-A parameter can be defined on multiple lines as shown below. A value spread over\
-multiple lines is simply concatenated. The additional lines of the value\
+A parameter can be defined on multiple lines as shown below. A value spread over
+multiple lines is simply concatenated. The additional lines of the value
 definition need to have at least one whitespace character in the beginning.
 
 ```
@@ -232,24 +232,24 @@ servers=server1,
 
 Section names may not contain whitespace and must not start with the characters`@@`.
 
-As the object names are used to form URLs in the MaxScale REST API, they must be\
+As the object names are used to form URLs in the MaxScale REST API, they must be
 safe for use in URLs. This means that only alphanumeric characters (i.e. `a-zA-Z` and `0-9`) and the special characters `_.~-` can be used.
 
 ### Dynamic Configuration
 
 By default all changes done at runtime via the MaxScale GUI, MaxCtrl or the REST\
-API will be saved on disk, inside the [persistdir](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#persistdir) directory. The\
-changes done at runtime will override the configuration found in the static\
+API will be saved on disk, inside the [persistdir](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#persistdir) directory. The
+changes done at runtime will override the configuration found in the static
 configuration files for that particular object.
 
-This means that if an object that is found in `/etc/maxscale.cnf` is modified at\
-runtime, all future changes to it must also be done at runtime. Any\
-modifications done to `/etc/maxscale.cnf` after a runtime change has been made\
+This means that if an object that is found in `/etc/maxscale.cnf` is modified at
+runtime, all future changes to it must also be done at runtime. Any
+modifications done to `/etc/maxscale.cnf` after a runtime change has been made
 are ignored for that object.
 
-To prevent the saving of runtime changes and to make all runtime changes\
-volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`\
-section. This will make MaxScale behave like the MariaDB server does: any\
+To prevent the saving of runtime changes and to make all runtime changes
+volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`
+section. This will make MaxScale behave like the MariaDB server does: any
 changes done with `SET GLOBAL` statements are lost if the process is restarted.
 
 ### Special Parameter Types
@@ -257,16 +257,16 @@ changes done with `SET GLOBAL` statements are lost if the process is restarted.
 #### Booleans
 
 Boolean type parameters interpret the values `true`, `yes`, `on` and `1` as\_true\_ values and `false`, `no`, `off` and `0` as _false_ values. Starting with\
-MaxScale 23.02, the REST API also accepts the same boolean values for boolean\
+MaxScale 23.02, the REST API also accepts the same boolean values for boolean
 type parameters.
 
 #### Sizes
 
-Where _specifically noted_, a number denoting a size can be suffixed by a subset\
-of the IEC binary prefixes or the SI prefixes. In the former case the number\
-will be interpreted as a certain multiple of 1024 and in the latter case as a\
-certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`\
-and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,\
+Where _specifically noted_, a number denoting a size can be suffixed by a subset
+of the IEC binary prefixes or the SI prefixes. In the former case the number
+will be interpreted as a certain multiple of 1024 and in the latter case as a
+certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`
+and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,
 the matching is case-insensitive.
 
 For instance, the following entries
@@ -291,8 +291,8 @@ max_size=1T
 
 #### Durations
 
-A number denoting a duration can be suffixed by one of the case-insensitive\
-suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,\
+A number denoting a duration can be suffixed by one of the case-insensitive
+suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,
 minutes, seconds and milliseconds, respectively.
 
 For instance, the following entries
@@ -307,8 +307,8 @@ soft_ttl=3600000ms
 
 are equivalent.
 
-Note that if an explicit unit is not specified, then it is specific to the\
-configuration parameter whether the duration is interpreted as seconds or\
+Note that if an explicit unit is not specified, then it is specific to the
+configuration parameter whether the duration is interpreted as seconds or
 milliseconds.
 
 _Not_ providing an explicit unit has been deprecated in MaxScale 2.4.
@@ -325,71 +325,71 @@ some_param=42%
 
 #### Regular Expressions
 
-Many modules have settings which accept a regular expression. In most cases, these\
+Many modules have settings which accept a regular expression. In most cases, these
 settings are named either _match_ or _exclude_, and are used to filter users or queries.\
-MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching\
+MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching
 regular expressions.
 
-When writing a regular expression (regex) type parameter to a MaxScale configuration file,\
-the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This\
-clarifies where the pattern begins and ends, even if it includes whitespace. Without\
-slashes the configuration loader trims the pattern from the ends. The slashes are removed\
-before compiling the pattern. For backwards compatibility, the slashes are not yet\
-mandatory. Omitting them is, however, deprecated and will be rejected in a future release\
-of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_\
-accept parameters in this type of regular expression form. Some other modules may not\
+When writing a regular expression (regex) type parameter to a MaxScale configuration file,
+the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This
+clarifies where the pattern begins and ends, even if it includes whitespace. Without
+slashes the configuration loader trims the pattern from the ends. The slashes are removed
+before compiling the pattern. For backwards compatibility, the slashes are not yet
+mandatory. Omitting them is, however, deprecated and will be rejected in a future release
+of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_
+accept parameters in this type of regular expression form. Some other modules may not
 handle the slashes yet correctly.
 
-PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses\
-regular expressions simply, only checking whether the pattern and subject match at some\
-point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to\
-accept any query with the text "SELECT" somewhere within. To force the pattern to only\
+PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses
+regular expressions simply, only checking whether the pattern and subject match at some
+point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to
+accept any query with the text "SELECT" somewhere within. To force the pattern to only
 match at the beginning of the query, set `match=/^SELECT/`. To only match the end, set`match=/SELECT$/`.
 
-Modules which accept regular expression parameters also often accept options which affect\
-how the patterns are compiled. Typically, this setting is called _options_ and accepts\
+Modules which accept regular expression parameters also often accept options which affect
+how the patterns are compiled. Typically, this setting is called _options_ and accepts
 values such as `ignorecase`, `case` and `extended`.
 
-* `ignorecase`: Causes the regular expression matcher to ignore letter case, and\
+* `ignorecase`: Causes the regular expression matcher to ignore letter case, and
   is often on by default. When enabled, `/SELECT/` would match both `SELECT` and`select`.
-* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this\
+* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this
   is not the same as the extended regular expression syntax that for example`grep -E` uses.
-* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not\
+* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not
   match `select`.
 
-These settings can also be defined in the pattern itself, so they can be\
-used even in modules without pattern compilation settings. The pattern\
-settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)\
+These settings can also be defined in the pattern itself, so they can be
+used even in modules without pattern compilation settings. The pattern
+settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)
 for more information.
 
 **Standard regular expression settings for filters**
 
-Many filters use the settings _match_, _exclude_ and _options_. Since these settings are\
-used in a similar way across these filters, the settings are explained here. The\
-documentation of the filters link here and describe any exceptions to this\
+Many filters use the settings _match_, _exclude_ and _options_. Since these settings are
+used in a similar way across these filters, the settings are explained here. The
+documentation of the filters link here and describe any exceptions to this
 generalized explanation.
 
-These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the\
+These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the
 patterns are compiled. _options_ works as explained above, accepting the values`ignorecase`, `case` and `extended`, with `ignorecase` being the default.
 
-The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is\
+The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is
 not defined, all queries are considered to match.
 
 If _exclude_ is defined, the filter only acts on queries not matching that pattern. If\_exclude\_ is not defined, nothing is excluded.
 
 If both are defined, the query needs to match _match_ but not match _exclude_.
 
-Even if a filter does not act on a query, the query is not lost. The query is simply\
+Even if a filter does not act on a query, the query is not lost. The query is simply
 passed on to the next module in the processing chain as if the filter was not there.
 
 #### Enumerations
 
-Enumeration type parameters have a pre-defined set of accepted values. For types\
-declared as `enum`, only one value is accepted. For `enum_mask` types, multiple\
+Enumeration type parameters have a pre-defined set of accepted values. For types
+declared as `enum`, only one value is accepted. For `enum_mask` types, multiple
 values can be defined by separating them with commas. All enumeration values in\
 MaxScale are case-sensitive.
 
-For example the `router_options` parameter in the `readconnroute` router is a\
+For example the `router_options` parameter in the `readconnroute` router is a
 mask type enumeration:
 
 ```
@@ -398,7 +398,7 @@ router_options=master,slave
 
 #### Path Lists
 
-A `pathlist` type parameter expects one or more filesystem paths separated by\
+A `pathlist` type parameter expects one or more filesystem paths separated by
 colons. The value must not include space between the separators.
 
 Here is an example path list parameter that points to `/tmp/something.log` and`/var/log/maxscale/maxscale.log`:
@@ -409,8 +409,8 @@ path_list_parameter=/tmp/something.log:/var/log/maxscale/maxscale.log
 
 ### Global Settings
 
-The global settings, in a section named `[MaxScale]`, allow various parameters\
-that affect MariaDB MaxScale as a whole to be tuned. This section must be\
+The global settings, in a section named `[MaxScale]`, allow various parameters
+that affect MariaDB MaxScale as a whole to be tuned. This section must be
 defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 
 #### `core_file`
@@ -419,9 +419,9 @@ defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 * Default: true
 * Dynamic: No
 
-This parameter specifies whether a core file should be generated if MaxScale\
-crashes. The default is `true` although usually a core file is not needed,\
-as MaxScale is capable of logging the full stack trace of all threads\
+This parameter specifies whether a core file should be generated if MaxScale
+crashes. The default is `true` although usually a core file is not needed,
+as MaxScale is capable of logging the full stack trace of all threads
 when it crashes.
 
 #### `auto_tune`
@@ -432,7 +432,7 @@ when it crashes.
 * Mandatory: No
 * Dynamic: No
 
-An _auto tunable_ parameter is a parameter whose value can be derived from a\
+An _auto tunable_ parameter is a parameter whose value can be derived from a
 particular server variable. With this parameter it can be specified whether`all` or a specific set of parameters should automatically be set.
 
 The current auto tunable parameters are:
@@ -442,13 +442,13 @@ The current auto tunable parameters are:
 | [connection\_keepalive](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#connection_keepalive)                  | 80% of the smallest \[wait\_timeout]server-system-variables/#wait\_timeout) value of the servers used by the service                                                                             |
 | [wait\_timeout](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#wait_timeout) | The smallest [wait\_timeout](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#wait_timeout) value of the servers used by the service |
 
-The values of the server variables are collected by monitors, which means that\
-if the servers of a service are not monitored by a monitor, then the parameters\
+The values of the server variables are collected by monitors, which means that
+if the servers of a service are not monitored by a monitor, then the parameters
 of that service will not be auto tuned.
 
-Note that even if `auto_tune` is set to `all`, the auto tunable parameters\
+Note that even if `auto_tune` is set to `all`, the auto tunable parameters
 can still be set in the configuration file and modified with _maxctrl_.\
-However, the specified value will be overwritten at the next auto tuning\
+However, the specified value will be overwritten at the next auto tuning
 round, but only if the servers of the service are monitored by a monitor.
 
 #### `threads`
@@ -458,20 +458,20 @@ round, but only if the servers of the service are monitored by a monitor.
 * Dynamic: No
 * Default: `auto`
 
-This parameter controls the number of worker threads that are handling the\
-events coming from the kernel. The default is `auto` which uses as many threads\
-as there are CPU cores. MaxScale versions older than 6 used one thread by\
+This parameter controls the number of worker threads that are handling the
+events coming from the kernel. The default is `auto` which uses as many threads
+as there are CPU cores. MaxScale versions older than 6 used one thread by
 default.
 
-You can explicitly enable automatic configuration of this value by setting the\
-value to `auto`. This way MariaDB MaxScale will detect the number of available\
+You can explicitly enable automatic configuration of this value by setting the
+value to `auto`. This way MariaDB MaxScale will detect the number of available
 processors and set the amount of threads to be equal to that number.
 
-Note that if MaxScale is running in a container where the CPU resources\
-have been limited, the use of `auto` may cause MaxScale to use more resources\
-than what is available. In such a situation `auto` should not be used, but instead\
-an explicit number that corresponds to the amount of CPU resources available in\
-the container. As a rule of thumb, an appropriate value for `threads` is the\_vCPU\_ of the container rounded up to the nearest integer. For instance, if\
+Note that if MaxScale is running in a container where the CPU resources
+have been limited, the use of `auto` may cause MaxScale to use more resources
+than what is available. In such a situation `auto` should not be used, but instead
+an explicit number that corresponds to the amount of CPU resources available in
+the container. As a rule of thumb, an appropriate value for `threads` is the\_vCPU\_ of the container rounded up to the nearest integer. For instance, if
 the _vCPU_ of the container is `0.5` then `1` is an appropriate value for`threads`, if the _vCPU_ is `2.3` then `3` is.
 
 The maximum value for `threads` is specified by [threads\_max](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#threads_max).
@@ -488,7 +488,7 @@ From 23.02 onwards it is possible to change the number threads at runtime.\
 Please see [Threads](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#threads-1) for more details.
 
 Additional threads will be created to execute other internal services within\
-MariaDB MaxScale. This setting is used to configure the number of threads that\
+MariaDB MaxScale. This setting is used to configure the number of threads that
 will be used to manage the user connections.
 
 #### `threads_max`
@@ -497,11 +497,11 @@ will be used to manage the user connections.
 * Default: 256
 * Dynamic: No
 
-This parameter specifies the hard limit for the number of worker threads,\
+This parameter specifies the hard limit for the number of worker threads,
 which is specified using [threads](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#threads).
 
-At startup, if the value of `threads` is larger than that of `threads_max`,\
-the value of `threads` will be reduced to that. At runtime, an attempt to\
+At startup, if the value of `threads` is larger than that of `threads_max`,
+the value of `threads` will be reduced to that. At runtime, an attempt to
 increase the value of `threads` beyond that of `threads_max` is an error.
 
 #### `rebalance_period`
@@ -511,19 +511,19 @@ increase the value of `threads` beyond that of `threads_max` is an error.
 * Dynamic: Yes
 * Default: `0s`
 
-This duration parameter controls how often the load of the worker threads\
-should be checked. The default value is 0, which means that no checks and\
+This duration parameter controls how often the load of the worker threads
+should be checked. The default value is 0, which means that no checks and
 no rebalancing will be performed.
 
 ```
 rebalance_period=10s
 ```
 
-Note that the value of `rebalance_period` should not be smaller than the\
+Note that the value of `rebalance_period` should not be smaller than the
 value of `rebalance_window` whose default value is 10.
 
-If the value of `rebalance_period` is significantly shorter than that\
-of `rebalance_window`, it may lead to oscillation where work is constantly\
+If the value of `rebalance_period` is significantly shorter than that
+of `rebalance_window`, it may lead to oscillation where work is constantly
 moved from one thread to another.
 
 #### `rebalance_threshold`
@@ -533,21 +533,21 @@ moved from one thread to another.
 * Dynamic: Yes
 * Default: `20`
 
-This integer parameter controls at which point MaxScale should start\
+This integer parameter controls at which point MaxScale should start
 moving work from one worker thread to another.
 
 If the difference in load between the thread with the maximum load and\
 the thread with the minimum load is larger than the value of this parameter,\
 then work will be moved from the former to the latter.
 
-Although the load of a thread can vary between 0 and 100, the value of this\
+Although the load of a thread can vary between 0 and 100, the value of this
 parameter must be between 5 and 100.
 
 ```
 rebalance_threshold=15
 ```
 
-Note that rebalancing will not be performed unless `rebalance_period`\
+Note that rebalancing will not be performed unless `rebalance_period`
 has been specified.
 
 #### `rebalance_window`
@@ -557,11 +557,11 @@ has been specified.
 * Dynamic: Yes
 * Default: `10`
 
-This integer parameter controls how many seconds of load should be\
-taken into account when deciding whether work should be moved from\
+This integer parameter controls how many seconds of load should be
+taken into account when deciding whether work should be moved from
 one thread to another.
 
-The default value is 10, which means that the load during the last 10\
+The default value is 10, which means that the load during the last 10
 seconds is considered when deciding whether work should be moved.
 
 The minimum value is 1 and the maximum 60.
@@ -573,8 +573,8 @@ The minimum value is 1 and the maximum 60.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether reverse domain name lookups are made to convert\
-client IP addresses to hostnames. If enabled, client IP addresses will not be\
+This parameter controls whether reverse domain name lookups are made to convert
+client IP addresses to hostnames. If enabled, client IP addresses will not be
 resolved to hostnames during authentication or for the REST API even if requested.
 
 If you have database users that use a hostname in the host part of the user\
@@ -590,8 +590,8 @@ an IP address.
 * Dynamic: Yes
 * Default: `10s`
 
-Duration, default 10s. This setting defines the connection timeout when\
-attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same\
+Duration, default 10s. This setting defines the connection timeout when
+attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same
 value is also used for read and write timeouts. Increasing this value causes\
 MaxScale to wait longer for a response from a server before user fetching fails.\
 Other servers may then be attempted.
@@ -600,10 +600,10 @@ Other servers may then be attempted.
 auth_connect_timeout=10s
 ```
 
-The value is given as [a duration](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,\
-the value is interpreted as seconds. In subsequent versions a value without a\
-unit may be rejected. Since the granularity of the timeout is seconds, a timeout\
-specified in milliseconds will be rejected even if the given value is longer\
+The value is given as [a duration](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,
+the value is interpreted as seconds. In subsequent versions a value without a
+unit may be rejected. Since the granularity of the timeout is seconds, a timeout
+specified in milliseconds will be rejected even if the given value is longer
 than a second.
 
 #### `auth_read_timeout`
@@ -621,14 +621,14 @@ Deprecated and ignored as of MaxScale 2.5.0. See _auth\_connect\_timeout_ above.
 * Dynamic: No
 * Default: `1`
 
-The number of times an interrupted internal query will be retried. The default\
-is to retry the query once. This feature was added in MaxScale 2.1.10 and was\
+The number of times an interrupted internal query will be retried. The default
+is to retry the query once. This feature was added in MaxScale 2.1.10 and was
 disabled by default until MaxScale 2.3.0.
 
-An interrupted query is any query that is interrupted by a network\
-error. Connection timeouts are included in network errors and thus is it\
-advisable to make sure that the value of `query_retry_timeout` is set to an\
-adequate value. Internal queries are only used to retrieve authentication data\
+An interrupted query is any query that is interrupted by a network
+error. Connection timeouts are included in network errors and thus is it
+advisable to make sure that the value of `query_retry_timeout` is set to an
+adequate value. Internal queries are only used to retrieve authentication data
 and monitor the servers.
 
 #### `query_retry_timeout`
@@ -638,16 +638,16 @@ and monitor the servers.
 * Dynamic: Yes
 * Default: `10s`
 
-The total timeout in seconds for any retried queries. The default value is 5\
+The total timeout in seconds for any retried queries. The default value is 5
 seconds.
 
-An interrupted query is retried for either the configured amount of attempts or\
+An interrupted query is retried for either the configured amount of attempts or
 until the configured timeout is reached.
 
-The value is specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `passive`
@@ -657,11 +657,11 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `false`
 
-Controls whether MaxScale is a passive node in a cluster of multiple MaxScale\
+Controls whether MaxScale is a passive node in a cluster of multiple MaxScale
 instances.
 
-This parameter is intended to be used with multiple MaxScale instances that use\
-failover functionality to manipulate the cluster in some form. Passive nodes\
+This parameter is intended to be used with multiple MaxScale instances that use
+failover functionality to manipulate the cluster in some form. Passive nodes
 only observe the clusters being monitored and take no direct actions.
 
 The following functionality is disabled when passive mode is enabled:
@@ -670,8 +670,8 @@ The following functionality is disabled when passive mode is enabled:
 * Automatic rejoin in the `mariadbmon` module
 * Launching of monitor scripts
 
-**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and\
-route any traffic sent to it. The **only** operations affected by the passive\
+**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and
+route any traffic sent to it. The **only** operations affected by the passive
 mode are the ones listed above.
 
 #### `ms_timestamp`
@@ -681,7 +681,7 @@ mode are the ones listed above.
 * Dynamic: Yes
 * Default: `false`
 
-Enable or disable the high precision timestamps in logfiles. Enabling this adds\
+Enable or disable the high precision timestamps in logfiles. Enabling this adds
 millisecond precision to all logfile timestamps.
 
 #### `syslog`
@@ -691,10 +691,10 @@ millisecond precision to all logfile timestamps.
 * Dynamic: Yes
 * Default: `false`
 
-Log messages to the system journal. This logs messages using the native SystemD\
+Log messages to the system journal. This logs messages using the native SystemD
 journal interface. The logs can be viewed with `journalctl`.
 
-MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be\
+MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be
 logged twice: once into the system journal and once into MaxScale's own logfile.
 
 #### `maxlog`
@@ -715,8 +715,8 @@ Log messages to MariaDB MaxScale's log file. The name of the log file is`maxscal
 
 Log messages whose syslog priority is _warning_.
 
-MaxScale logs warning level messages whenever a condition is encountered that\
-the user should be notified of but does not require immediate action or it\
+MaxScale logs warning level messages whenever a condition is encountered that
+the user should be notified of but does not require immediate action or it
 indicates a minor problem.
 
 #### `log_notice`
@@ -728,8 +728,8 @@ indicates a minor problem.
 
 Log messages whose syslog priority is _notice_.
 
-These messages contain information that is helpful for the user and they usually\
-do not indicate a problem. These are logged whenever something worth nothing\
+These messages contain information that is helpful for the user and they usually
+do not indicate a problem. These are logged whenever something worth nothing
 happens in either MaxScale or in the servers it monitors.
 
 #### `log_info`
@@ -742,10 +742,10 @@ happens in either MaxScale or in the servers it monitors.
 Log messages whose syslog priority is _info_.
 
 These messages provide detailed information about the internal workings of\
-MariaDB MaxScale. These messages should only be enabled when there is a need to\
-inspect the internal logic of MaxScale. A common use-case is to see why a\
-particular query was handled in a certain way. Almost all modules log some\
-messages on the info level and this can be very helpful when trying to solve\
+MariaDB MaxScale. These messages should only be enabled when there is a need to
+inspect the internal logic of MaxScale. A common use-case is to see why a
+particular query was handled in a certain way. Almost all modules log some
+messages on the info level and this can be very helpful when trying to solve
 routing related problems.
 
 #### `log_debug`
@@ -757,11 +757,11 @@ routing related problems.
 
 Log messages whose syslog priority is _debug_.
 
-These messages are intended for development purposes and are disabled by\
+These messages are intended for development purposes and are disabled by
 default. These are rarely useful outside of debugging core MaxScale issues.
 
-**Note:** If MariaDB MaxScale has been built in release mode, then debug\
-messages are excluded from the build and this setting will not have any\
+**Note:** If MariaDB MaxScale has been built in release mode, then debug
+messages are excluded from the build and this setting will not have any
 effect. If an attempt to enable these is made, a warning is logged.
 
 #### `log_warn_super_user`
@@ -771,10 +771,10 @@ effect. If an attempt to enable these is made, a warning is logged.
 * Dynamic: No
 * Default: `false`
 
-When enabled, a warning is logged whenever a client with SUPER-privilege\
-successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The\
-setting is intended for diagnosing situations where a client interferes with a\
-primary server switchover. Super-users bypass the _read\_only_-flag which\
+When enabled, a warning is logged whenever a client with SUPER-privilege
+successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The
+setting is intended for diagnosing situations where a client interferes with a
+primary server switchover. Super-users bypass the _read\_only_-flag which
 switchover uses to block writes to the primary.
 
 #### `log_augmentation`
@@ -784,9 +784,9 @@ switchover uses to block writes to the primary.
 * Dynamic: Yes
 * Default: `0`
 
-Enable or disable the augmentation of messages. If this is enabled, then each\
-logged message is appended with the name of the function where the message was\
-logged. This is primarily for development purposes and hence is disabled by\
+Enable or disable the augmentation of messages. If this is enabled, then each
+logged message is appended with the name of the function where the message was
+logged. This is primarily for development purposes and hence is disabled by
 default.
 
 ```
@@ -804,10 +804,10 @@ To disable the augmentation use the value 0 and to enable it use the value 1.
 * Dynamic: Yes
 * Default: `10, 1000ms, 10000ms`
 
-It is possible that a particular error (or warning) is logged over and over\
-again, if the cause for the error persistently remains. To prevent the log from\
-flooding, it is possible to specify how many times a particular error may be\
-logged within a time period, before the logging of that error is suppressed for\
+It is possible that a particular error (or warning) is logged over and over
+again, if the cause for the error persistently remains. To prevent the log from
+flooding, it is possible to specify how many times a particular error may be
+logged within a time period, before the logging of that error is suppressed for
 a while.
 
 ```
@@ -823,18 +823,18 @@ log_throttling=8, 2s, 15000ms
 In the example above, the logging of a particular error will be suppressed for\
 15 seconds if the error has been logged 8 times in 2 seconds.
 
-The default is `10, 1000ms, 10000ms`, which means that if the same error is\
-logged 10 times in one second, the logging of that error is suppressed for the\
+The default is `10, 1000ms, 10000ms`, which means that if the same error is
+logged 10 times in one second, the logging of that error is suppressed for the
 following 10 seconds.
 
-Whenever an error message that is being throttled is logged within the\
-triggering window (the second argument), the suppression window is\
-extended. This continues until there is a pause in the messages that is longer\
+Whenever an error message that is being throttled is logged within the
+triggering window (the second argument), the suppression window is
+extended. This continues until there is a pause in the messages that is longer
 than the triggering window.
 
-For example, with the default configuration the messages must pause for at least\
-one second in order for the throttling to eventually stop. This mechanism\
-prevents long-lasting error conditions from slowly filling up the log with short\
+For example, with the default configuration the messages must pause for at least
+one second in order for the throttling to eventually stop. This mechanism
+prevents long-lasting error conditions from slowly filling up the log with short
 bursts of messages.
 
 To disable log throttling, add an entry with an empty value
@@ -849,8 +849,8 @@ or one where any of the integers is 0.
 log_throttling=0, 0, 0
 ```
 
-The durations can be specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In\
+The durations can be specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In
 subsequent versions a value without a unit may be rejected.
 
 Note that _notice_, _info_ and _debug_ messages are never throttled.
@@ -862,7 +862,7 @@ Note that _notice_, _info_ and _debug_ messages are never throttled.
 * Dynamic: No
 * Default: `/var/log/maxscale`
 
-Set the directory where the logfiles are stored. The folder needs to be both\
+Set the directory where the logfiles are stored. The folder needs to be both
 readable and writable by the user running MariaDB MaxScale.
 
 ```
@@ -877,10 +877,10 @@ logdir=/var/log/maxscale/
 * Default: `/var/lib/maxscale`
 
 Set the directory where the data files used by MariaDB MaxScale are stored.\
-Modules can write to this directory and for example the binlogrouter uses this\
+Modules can write to this directory and for example the binlogrouter uses this
 folder as the default location for storing binary logs.
 
-This is also the directory where the password encryption key is read from that\
+This is also the directory where the password encryption key is read from that
 is generated by `maxkeys`.
 
 ```
@@ -894,10 +894,10 @@ datadir=/var/lib/maxscale/
 * Dynamic: No
 * Default: `""`
 
-The location where the `.secrets` file is read from. If `secretsdir` is not\
+The location where the `.secrets` file is read from. If `secretsdir` is not
 defined, the file is read from [datadir](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#datadir).
 
-This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6\
+This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6
 and 24.02.2.
 
 #### `libdir`
@@ -907,12 +907,12 @@ and 24.02.2.
 * Dynamic: No
 * Default: OS Dependent
 
-Set the directory where MariaDB MaxScale looks for modules. The library\
-directory is the only directory that MariaDB MaxScale uses when it searches for\
-modules. If you have custom modules for MariaDB MaxScale, make sure you have\
+Set the directory where MariaDB MaxScale looks for modules. The library
+directory is the only directory that MariaDB MaxScale uses when it searches for
+modules. If you have custom modules for MariaDB MaxScale, make sure you have
 them in this folder.
 
-The default value depends on the operating system. For RHEL versions the value\
+The default value depends on the operating system. For RHEL versions the value
 is `/usr/lib64/maxscale/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/`
 
 ```
@@ -928,14 +928,14 @@ libdir=/usr/lib64/maxscale/
 
 Sets the directory where static data assets are loaded.
 
-The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI\
-files have been manually moved somewhere else, this path must be configured to\
+The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI
+files have been manually moved somewhere else, this path must be configured to
 point to the parent directory of the `gui/` subdirectory.
 
-The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path\
-resolves to outside of this directory are not served by the MaxScale GUI: this\
+The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path
+resolves to outside of this directory are not served by the MaxScale GUI: this
 is done to prevent other files from being accessible via the MaxScale REST\
-API. This means that path to the GUI source directory can contain symbolic links\
+API. This means that path to the GUI source directory can contain symbolic links
 but all parts after the `/gui/` directory must reside inside it.
 
 #### `cachedir`
@@ -958,7 +958,7 @@ cachedir=/var/cache/maxscale/
 * Dynamic: No
 * Default: `/var/run/maxscale`
 
-Configure the directory for the PID file for MariaDB MaxScale. This file\
+Configure the directory for the PID file for MariaDB MaxScale. This file
 contains the Process ID for the running MariaDB MaxScale process.
 
 ```
@@ -972,8 +972,8 @@ piddir=/var/run/maxscale/
 * Dynamic: No
 * Default: `/usr/bin`
 
-Configure the directory where the executable files reside. All internal\
-processes which are launched will use this directory to look for executable\
+Configure the directory where the executable files reside. All internal
+processes which are launched will use this directory to look for executable
 files.
 
 ```
@@ -987,13 +987,13 @@ execdir=/usr/bin/
 * Dynamic: No
 * Default: OS Dependent
 
-Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C\
-used in MaxScale can use this directory to load authentication plugins. The\
-versions of the plugins must be binary compatible with the connector version\
+Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C
+used in MaxScale can use this directory to load authentication plugins. The
+versions of the plugins must be binary compatible with the connector version
 that MaxScale was built with.
 
-Starting with version 6.2.0, the plugins are bundled with MaxScale and the\
-default value now points to the bundled plugins. The location where the plugins\
+Starting with version 6.2.0, the plugins are bundled with MaxScale and the
+default value now points to the bundled plugins. The location where the plugins
 are stored depends on the operating system. For RHEL versions the value is`/usr/lib64/maxscale/plugin/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/plugin/`.
 
 Older versions of MaxScale used `/usr/lib/mysql/plugin/` as the default value.
@@ -1009,10 +1009,10 @@ connector_plugindir=/usr/lib64/maxscale/plugin/
 * Dynamic: No
 * Default: `/var/lib/maxscale/maxscale.cnf.d/`
 
-Configure the directory where persisted configurations are stored. When a new\
-object is created via MaxCtrl, it will be stored in this directory. Do not use\
-this directory for normal configuration files, use _/etc/maxscale.cnf.d/_\
-instead. The user MaxScale is running as must be able to write into this\
+Configure the directory where persisted configurations are stored. When a new
+object is created via MaxCtrl, it will be stored in this directory. Do not use
+this directory for normal configuration files, use _/etc/maxscale.cnf.d/_
+instead. The user MaxScale is running as must be able to write into this
 directory.
 
 ```
@@ -1026,16 +1026,16 @@ persistdir=/var/lib/maxscale/maxscale.cnf.d/
 * Dynamic: No
 * Default: `/etc/maxscale.modules.d/`
 
-Configure the directory where module configurations are stored. Path arguments\
-are resolved relative to this directory. This directory should be used to store\
+Configure the directory where module configurations are stored. Path arguments
+are resolved relative to this directory. This directory should be used to store
 module specific configurations.
 
-Any configuration parameter that is not an absolute path will be interpreted as\
-a relative path. The relative paths use the module configuration directory as\
+Any configuration parameter that is not an absolute path will be interpreted as
+a relative path. The relative paths use the module configuration directory as
 the working directory.
 
-For example, the configuration parameter `file=my_file.txt` would be interpreted\
-as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would\
+For example, the configuration parameter `file=my_file.txt` would be interpreted
+as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would
 be interpreted as `/home/user/my_file.txt`.
 
 ```
@@ -1049,7 +1049,7 @@ module_configdir=/etc/maxscale.modules.d/
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will\
+Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will
 look for the errmsg.sys file installed with MariaDB MaxScale from this folder.
 
 ```
@@ -1068,20 +1068,20 @@ Deprecated since MariaDB MaxScale 23.08.
 * Default: System Dependent
 
 Specifies the maximum size of the query classifier cache. The default limit is\
-15% of total system memory starting with MaxScale 2.3.7. In older versions the\
+15% of total system memory starting with MaxScale 2.3.7. In older versions the
 default limit was 40% of total system memory. This feature was added in MaxScale\
 2.3.0.
 
-When the query classifier cache has been enabled, MaxScale will, after a\
-statement has been parsed, store the classification result using the\
+When the query classifier cache has been enabled, MaxScale will, after a
+statement has been parsed, store the classification result using the
 canonicalized version of the statement as the key.
 
-If the classification result for a statement is needed, MaxScale will first\
-canonicalize the statement and check whether the result can be found in the\
-cache. If it can, the statement will not be parsed at all but the cached result\
+If the classification result for a statement is needed, MaxScale will first
+canonicalize the statement and check whether the result can be found in the
+cache. If it can, the statement will not be parsed at all but the cached result
 is used.
 
-The configuration parameter takes one integer that specifies the maximum size of\
+The configuration parameter takes one integer that specifies the maximum size of
 the cache. The size of the cache can be specified as explained [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#sizes).
 
 ```
@@ -1089,17 +1089,17 @@ the cache. The size of the cache can be specified as explained [here](mariadb-ma
 query_classifier_cache_size=1MB
 ```
 
-Note that MaxScale uses a separate cache for each worker thread. To obtain the\
-amount of memory available for each thread, divide the cache size with the value\
-of `threads`. If statements are evicted from the cache (visible in the\
+Note that MaxScale uses a separate cache for each worker thread. To obtain the
+amount of memory available for each thread, divide the cache size with the value
+of `threads`. If statements are evicted from the cache (visible in the
 diagnostic output), consider increasing the cache size.
 
-Note also that limit is not a hard limit, but an approximate one. Namely, although\
-the memory needed for storing the canonicalized statement and the classification\
-result is correctly accounted for, there is additional overhead whose size is not\
+Note also that limit is not a hard limit, but an approximate one. Namely, although
+the memory needed for storing the canonicalized statement and the classification
+result is correctly accounted for, there is additional overhead whose size is not
 exactly known and over which we do not have direct control.
 
-Using `maxctrl show threads` it is possible to check what the actual size of\
+Using `maxctrl show threads` it is possible to check what the actual size of
 the cache is and to see performance statistics.
 
 | Key                | Meaning                                                                                                                 |
@@ -1121,15 +1121,15 @@ Deprecated since MariaDB MaxScale 23.08.
 * Dynamic: No
 * Default: `false`
 
-Enable or disable the substitution of environment variables in the MaxScale\
-configuration file. If the substitution of variables is enabled and a\
+Enable or disable the substitution of environment variables in the MaxScale
+configuration file. If the substitution of variables is enabled and a
 configuration line like
 
 ```
 some_parameter=$SOME_VALUE
 ```
 
-is encountered, then `$SOME_VALUE` will be replaced with the actual value\
+is encountered, then `$SOME_VALUE` will be replaced with the actual value
 of the environment variable `SOME_VALUE`. Note: _Variable substitution will be made only if '$' is the first character of the value._ _Everything_ following '$' is interpreted as the name of the environment
 variable.
 
@@ -1139,9 +1139,9 @@ variable.
 substitute_variables=true
 ```
 
-The setting of `substitute_variables` will have an effect on all parameters\
-in the all other sections, irrespective of where the `[maxscale]` section\
-is placed in the configuration file. However, in the `[maxscale]` section,\
+The setting of `substitute_variables` will have an effect on all parameters
+in the all other sections, irrespective of where the `[maxscale]` section
+is placed in the configuration file. However, in the `[maxscale]` section,
 to ensure that substitution will take place, place the`substitute_variables=true` line first.
 
 #### `sql_mode`
@@ -1152,7 +1152,7 @@ to ensure that substitution will take place, place the`substitute_variables=true
 * Values: `default`, `oracle`
 * Default: `default`
 
-Specifies whether the query classifier parser should initially expect _MariaDB_\
+Specifies whether the query classifier parser should initially expect _MariaDB_
 or _PL/SQL_ kind of SQL.
 
 The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`oracle` : The parser expects PL/SQL.
@@ -1161,7 +1161,7 @@ The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`orac
 sql_mode=oracle
 ```
 
-**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume\
+**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume
 that `autocommit` initially is off.
 
 At runtime, MariaDB MaxScale will recognize statements like
@@ -1178,12 +1178,12 @@ set sql_mode=default;
 
 and change mode accordingly.
 
-**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also\
-behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave\
+**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also
+behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave
 as if `autocommit` had been turned on.
 
-Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of\
-the server, so the value of `sql_mode` should reflect the sql mode used\
+Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of
+the server, so the value of `sql_mode` should reflect the sql mode used
 when the server is started.
 
 #### `local_address`
@@ -1195,15 +1195,15 @@ when the server is started.
 
 What specific local address/interface to use when connecting to servers.
 
-This can be used for ensuring that MaxScale uses a particular interface\
-when connecting to servers, in case the computer MaxScale is running on\
+This can be used for ensuring that MaxScale uses a particular interface
+when connecting to servers, in case the computer MaxScale is running on
 has multiple interfaces.
 
 ```
 local_address=192.168.1.254
 ```
 
-If given as a hostname, MaxScale will perform name lookup on the address\
+If given as a hostname, MaxScale will perform name lookup on the address
 when starting and reuse the result.
 
 #### `users_refresh_time`
@@ -1213,27 +1213,27 @@ when starting and reuse the result.
 * Dynamic: Yes
 * Default: `30s`
 
-How often, in seconds, MaxScale at most may refresh the users from the\
+How often, in seconds, MaxScale at most may refresh the users from the
 backend server.
 
-MaxScale will at startup load the users from the backend server, but if\
-the authentication of a user fails, MaxScale assumes it is because a new\
-user has been created and will thus refresh the users. By default, MaxScale\
-will do that at most once per 30 seconds and with this configuration option\
-that can be changed. A value of 0 allows infinite refreshes and a negative\
+MaxScale will at startup load the users from the backend server, but if
+the authentication of a user fails, MaxScale assumes it is because a new
+user has been created and will thus refresh the users. By default, MaxScale
+will do that at most once per 30 seconds and with this configuration option
+that can be changed. A value of 0 allows infinite refreshes and a negative
 value disables the refreshing entirely.
 
 ```
 users_refresh_time=120s
 ```
 
-The value is specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds\
+In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds
 but, due to a bug, the default value was 0 which allowed infinite refreshes.
 
 #### `users_refresh_interval`
@@ -1243,12 +1243,12 @@ but, due to a bug, the default value was 0 which allowed infinite refreshes.
 * Dynamic: Yes
 * Default: `0s`
 
-How often, in seconds, MaxScale will automatically refresh the users from the\
+How often, in seconds, MaxScale will automatically refresh the users from the
 backend server.
 
-This configuration is used to periodically refresh the backend users, making sure\
-they are up to date. The default value for this setting is 0, meaning the users\
-are not periodically refreshed. However, they can still be refreshed in case of\
+This configuration is used to periodically refresh the backend users, making sure
+they are up to date. The default value for this setting is 0, meaning the users
+are not periodically refreshed. However, they can still be refreshed in case of
 failed authentication depending on `users_refresh_time`.
 
 ```
@@ -1262,13 +1262,13 @@ users_refresh_interval=2h
 * Dynamic: Yes
 * Default: `0`
 
-How many statements MaxScale should store for each session. This is for\
-debugging purposes, as in case of problems it is often of value to be able\
-to find out exactly what statements were sent before a particular\
+How many statements MaxScale should store for each session. This is for
+debugging purposes, as in case of problems it is often of value to be able
+to find out exactly what statements were sent before a particular
 problem turned up.
 
-**Note:** See also `dump_last_statements` using which the actual dumping\
-of the statements is enabled. Unless both of the parameters are defined,\
+**Note:** See also `dump_last_statements` using which the actual dumping
+of the statements is enabled. Unless both of the parameters are defined,
 the statement dumping mechanism doesn't work.
 
 ```
@@ -1283,10 +1283,10 @@ retain_last_statements=20
 * Values: `on_close`, `on_error`, `never`
 * Default: `never`
 
-With this configuration item it is specified in what circumstances MaxScale\
-should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never\
-logged, with `on_error` they are logged if the client closes the connection\
-improperly, and with `on_close` they are always logged when a client session\
+With this configuration item it is specified in what circumstances MaxScale
+should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never
+logged, with `on_error` they are logged if the client closes the connection
+improperly, and with `on_close` they are always logged when a client session
 is closed.
 
 ```
@@ -1294,7 +1294,7 @@ dump_last_statements=on_error
 ```
 
 Note that you need to specify with `retain_last_statements` how many statements\
-MaxScale should retain for each session. Unless it has been set to another value\
+MaxScale should retain for each session. Unless it has been set to another value
 than `0`, this configuration setting will not have an effect.
 
 #### `session_trace`
@@ -1304,8 +1304,8 @@ than `0`, this configuration setting will not have an effect.
 * Dynamic: Yes
 * Default: `0`
 
-How many log entries are stored in the session specific trace log. This log is\
-written to disk when a session ends abnormally and can be used for debugging\
+How many log entries are stored in the session specific trace log. This log is
+written to disk when a session ends abnormally and can be used for debugging
 purposes. Currently the session trace log is written to the log in the following situations:
 
 * When MaxScale receives a fatal signal and is about to crash.
@@ -1313,8 +1313,8 @@ purposes. Currently the session trace log is written to the log in the following
 * If the session is not closed gracefully (i.e. client doesn't send a COM\_QUIT packet)
 * Whenever readwritesplit receives a response that is was not expecting.
 
-It would be good to enable this if a session is disconnected and the log is not\
-detailed enough. In this case the info log might reveal the true cause of why\
+It would be good to enable this if a session is disconnected and the log is not
+detailed enough. In this case the info log might reveal the true cause of why
 the connection was closed.
 
 ```
@@ -1326,9 +1326,9 @@ Default is `0`.
 The session trace log is also exposed by REST API and is shown with`maxctrl show sessions`.
 
 The order in which the session trace messages are logged into the log changed in\
-MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal\
-log order" of older events coming first and newer events appearing later in the\
-file. Older versions of MaxScale logged the trace dump in the reverse order with\
+MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal
+log order" of older events coming first and newer events appearing later in the
+file. Older versions of MaxScale logged the trace dump in the reverse order with
 the newest messages first and oldest ones last.
 
 #### `session_trace_match`
@@ -1338,17 +1338,17 @@ the newest messages first and oldest ones last.
 * Dynamic: Yes
 * Default: None
 
-If both `session_trace` and `session_trace_match` are defined, and a trace log\
-entry of a session matches the regular expression, the trace log is written to\
+If both `session_trace` and `session_trace_match` are defined, and a trace log
+entry of a session matches the regular expression, the trace log is written to
 disk. The check for the match is done when the session is stopping.
 
-The most effective way to debug MaxScale related issues is to turn on `log_info`\
-and observe the events written into the MaxScale log. The only problem with this\
-approach is that it can cause a severe performance bottleneck and can easily\
-fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged\
+The most effective way to debug MaxScale related issues is to turn on `log_info`
+and observe the events written into the MaxScale log. The only problem with this
+approach is that it can cause a severe performance bottleneck and can easily
+fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged
 can be filtered to only what is needed.
 
-For example, the following configuration would only log the trace log messages\
+For example, the following configuration would only log the trace log messages
 from sessions that execute SQL queries with syntax errors:
 
 ```
@@ -1356,10 +1356,10 @@ session_trace=1000
 session_trace_match=/You have an error in your SQL syntax/
 ```
 
-This could be used to easily identify which applications execute the queries\
-without having to gather the info level log output from all the sessions that\
-connect to MaxScale. For every session that ends up logging a syntax error\
-message, the last 1000 lines of log output done by that session is written into\
+This could be used to easily identify which applications execute the queries
+without having to gather the info level log output from all the sessions that
+connect to MaxScale. For every session that ends up logging a syntax error
+message, the last 1000 lines of log output done by that session is written into
 the MaxScale log.
 
 #### `writeq_high_water`
@@ -1369,17 +1369,17 @@ the MaxScale log.
 * Dynamic: Yes
 * Default: `65536`
 
-High water mark for network write buffer. When the size of the outbound network\
-buffer in MaxScale for a single connection exceeds this value, network traffic\
-throttling for that connection is started. The parameter accepts [size type\
+High water mark for network write buffer. When the size of the outbound network
+buffer in MaxScale for a single connection exceeds this value, network traffic
+throttling for that connection is started. The parameter accepts [size type
 values](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#sizes). The default value was 16777216 bytes before 22.08.4.
 
-More specifically, if the client side write queue is above this value, it will\
-block traffic coming from backend servers. If the backend side write queue is\
+More specifically, if the client side write queue is above this value, it will
+block traffic coming from backend servers. If the backend side write queue is
 above this value, it will block traffic from client.
 
-The buffer that this parameter controls is the buffer internal to MaxScale and\
-is not the kernel TCP send buffer. This means that the total amount of buffered\
+The buffer that this parameter controls is the buffer internal to MaxScale and
+is not the kernel TCP send buffer. This means that the total amount of buffered
 data is determined by both the kernel TCP buffers and the value of`writeq_high_water`.
 
 Network throttling is only enabled when `writeq_high_water` is non-zero. In\
@@ -1392,8 +1392,8 @@ MaxScale 23.02 and earlier, also `writeq_low_water` had to be non-zero.
 * Dynamic: Yes
 * Default: `1024`
 
-Low water mark for network write buffer. Once the traffic throttling is enabled,\
-it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#sizes). The\
+Low water mark for network write buffer. Once the traffic throttling is enabled,
+it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#sizes). The
 default value was 8192 bytes before 22.08.4.
 
 The value of `writeq_high_water` must always be greater than the value of`writeq_low_water`.
@@ -1406,10 +1406,10 @@ The value of `writeq_high_water` must always be greater than the value of`writeq
 
 Persist changes done at runtime. This parameter was added in MaxScale 22.08.0.
 
-When `persist_runtime_changes` is enabled, runtime configuration changes done\
-with the GUI, MaxCtrl or via the REST API cause a new configuration file to be\
-saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is\
-enabled, these files will be applied on top of any existing values found in\
+When `persist_runtime_changes` is enabled, runtime configuration changes done
+with the GUI, MaxCtrl or via the REST API cause a new configuration file to be
+saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is
+enabled, these files will be applied on top of any existing values found in
 static configuration files whenever MaxScale is starting up.
 
 #### `load_persisted_configs`
@@ -1422,11 +1422,11 @@ static configuration files whenever MaxScale is starting up.
 Load persisted runtime changes on startup. This parameter was added in MaxScale\
 2.3.6.
 
-All runtime configuration changes are persisted in generated configuration files\
-located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on\
-startup after main configuration files have been read. To make runtime\
-configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores\
-the current runtime state of MaxScale. This makes problem analysis easier if an\
+All runtime configuration changes are persisted in generated configuration files
+located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on
+startup after main configuration files have been read. To make runtime
+configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores
+the current runtime state of MaxScale. This makes problem analysis easier if an
 unexpected outage happens.
 
 #### `max_auth_errors_until_block`
@@ -1436,14 +1436,14 @@ unexpected outage happens.
 * Dynamic: Yes
 * Default: `10`
 
-The maximum number of authentication failures that are tolerated before a host\
-is temporarily blocked. The default value is 10 failures. After a host is\
-blocked, connections from it are rejected for 60 seconds. To disable this\
+The maximum number of authentication failures that are tolerated before a host
+is temporarily blocked. The default value is 10 failures. After a host is
+blocked, connections from it are rejected for 60 seconds. To disable this
 feature, set the value to 0.
 
-Note that the configured value is not a hard limit. The number of tolerated\
-failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the\
-configured value of this parameter and `threads` is the number of configured\
+Note that the configured value is not a hard limit. The number of tolerated
+failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the
+configured value of this parameter and `threads` is the number of configured
 threads.
 
 #### `debug`
@@ -1453,16 +1453,16 @@ threads.
 * Dynamic: No
 * Default: `""`
 
-Define debug options from the --debug command line option. Either the command\
-line option or the parameter should be used, not both. The debug options are\
+Define debug options from the --debug command line option. Either the command
+line option or the parameter should be used, not both. The debug options are
 only for testing purposes and are not to be used in production.
 
 #### REST API Configuration
 
-The MaxScale REST API is an HTTP interface that provides JSON format data\
+The MaxScale REST API is an HTTP interface that provides JSON format data
 intended to be consumed by monitoring applications and visualization tools.
 
-The following options must be defined under the `[maxscale]` section in the\
+The following options must be defined under the `[maxscale]` section in the
 configuration file.
 
 #### `admin_host`
@@ -1491,8 +1491,8 @@ The port where the REST API listens on. The default value is port 8989.
 * Dynamic: No
 * Default: `true`
 
-Enable REST API authentication using HTTP Basic Access\
-authentication. This is not a secure method of authentication without HTTPS but\
+Enable REST API authentication using HTTP Basic Access
+authentication. This is not a secure method of authentication without HTTPS but
 it does add a small layer of security.
 
 For more information, read the [REST API documentation](../maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md).
@@ -1506,7 +1506,7 @@ For more information, read the [REST API documentation](../maxscale-24-02rest-ap
 
 The path to the TLS private key in PEM format for the admin interface.
 
-If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin\
+If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin
 interface will use encrypted HTTPS instead of plain HTTP.
 
 #### `admin_ssl_cert`
@@ -1516,7 +1516,7 @@ interface will use encrypted HTTPS instead of plain HTTP.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS public certificate in PEM format. See `admin_ssl_key`\
+The path to the TLS public certificate in PEM format. See `admin_ssl_key`
 documentation for more details.
 
 #### `admin_ssl_ca_cert`
@@ -1530,11 +1530,11 @@ Deprecated since MariaDB MaxScale 22.08. See `admin_ssl_ca`.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS CA certificate in PEM format. If defined, the client\
-certificate, if provided, will be validated against it. This parameter is\
+The path to the TLS CA certificate in PEM format. If defined, the client
+certificate, if provided, will be validated against it. This parameter is
 optional starting with MaxScale 2.3.19.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,
 which is still accepted as an alias for `admin_ssl_ca`.
 
 #### `admin_ssl_version`
@@ -1545,7 +1545,7 @@ which is still accepted as an alias for `admin_ssl_ca`.
 * Values: `MAX`, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`, `TLSv10`, `TLSv11`, `TLSv12`, `TLSv13`
 * Default: `MAX`
 
-This parameter controls the enabled TLS versions in the REST API. Accepted\
+This parameter controls the enabled TLS versions in the REST API. Accepted
 values are:
 
 * `TLSv10`
@@ -1554,7 +1554,7 @@ values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -1562,19 +1562,19 @@ releases accept also the following alias values:
 * `TLSv1.2`
 * `TLSv1.3` (not supported on OpenSSL 1.0)
 
-The default value is `MAX` which negotiates the highest level of encryption that\
-both the client and server support. The list of supported TLS versions depends\
+The default value is `MAX` which negotiates the highest level of encryption that
+both the client and server support. The list of supported TLS versions depends
 on the operating system and what TLS versions the GnuTLS library supports.
 
 For example, to enable only TLSv1.1 and TLSv1.3, use`admin_ssl_version=TLSv1.1,TLSv1.3`.
 
 This parameter was added in MaxScale 2.5.7.
 
-Older versions of MaxScale interpreted `admin_ssl_version` as the minimum\
+Older versions of MaxScale interpreted `admin_ssl_version` as the minimum
 allowed TLS version. In those versions, `admin_ssl_version=TLSv1.2` allowed both\
-TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2\
-and all newer versions, the value is a enumeration of accepted TLS protocol\
-versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To\
+TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2
+and all newer versions, the value is a enumeration of accepted TLS protocol
+versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To
 retain the old behavior, specify all the accepted values with`admin_ssl_version=TLSv1.2,TLSv1.3`
 
 #### `admin_enabled`
@@ -1584,7 +1584,7 @@ retain the old behavior, specify all the accepted values with`admin_ssl_version=
 * Dynamic: No
 * Default: `true`
 
-Enable or disable the admin interface. This allows the admin interface to\
+Enable or disable the admin interface. This allows the admin interface to
 be completely disabled to prevent access to it.
 
 #### `admin_gui`
@@ -1597,9 +1597,9 @@ be completely disabled to prevent access to it.
 Enable or disable the admin graphical user interface.
 
 MaxScale provides a GUI for administrative operations via the REST API. When the\
-GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will\
-serve the GUI. When disabled, the REST API will respond with a 200 OK to the\
-request. By disabling the GUI, the root resource can be used as a low overhead\
+GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will
+serve the GUI. When disabled, the REST API will respond with a 200 OK to the
+request. By disabling the GUI, the root resource can be used as a low overhead
 health check.
 
 #### `admin_secure_gui`
@@ -1611,10 +1611,10 @@ health check.
 
 Whether to serve the GUI only over secure HTTPS connections.
 
-To be secure by default, the GUI is only served over HTTPS connections as\
+To be secure by default, the GUI is only served over HTTPS connections as
 it uses a token authentication scheme. This also controls whether the`/auth` endpoint requires an encrypted connection.
 
-To allow use of the GUI without having to configure TLS certificates for\
+To allow use of the GUI without having to configure TLS certificates for
 the MaxScale REST API, set this parameter to false.
 
 #### `admin_log_auth_failures`
@@ -1633,17 +1633,17 @@ Log authentication failures for the admin interface.
 * Dynamic: No
 * Default: `""`
 
-Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings\
-accept a PAM service name which is used during authentication if normal authentication\
+Use Pluggable Authentication Modules (PAM) for REST API authentication. The settings
+accept a PAM service name which is used during authentication if normal authentication
 fails. `admin_pam_readwrite_service` should accept users who can do any\
-MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only\
-do read operations. Because REST-API does not support back and forth communication between\
-the client and MaxScale, the PAM services must be simple. They should only ask for the\
+MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only
+do read operations. Because REST-API does not support back and forth communication between
+the client and MaxScale, the PAM services must be simple. They should only ask for the
 password and nothing else.
 
-If only `admin_pam_readwrite_service` is configured, both read and write operations can be\
-authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read\
-operations can be authenticated by PAM. If both are set, the service used is determined by\
+If only `admin_pam_readwrite_service` is configured, both read and write operations can be
+authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read
+operations can be authenticated by PAM. If both are set, the service used is determined by
 the requested operation. Leave or set both empty to disable PAM for REST-API.
 
 #### `admin_readwrite_hosts`
@@ -1653,32 +1653,32 @@ the requested operation. Leave or set both empty to disable PAM for REST-API.
 * Dynamic: No
 * Default: `%`
 
-Limit REST-API logins to specific source addresses/hosts. Supports\
+Limit REST-API logins to specific source addresses/hosts. Supports
 a comma-separated list of addresses and hostnames. Addresses can be given in\
 CIDR-notation. Admin clients still need to supply credentials as usual.\
-By default, all source addresses are allowed. `admin_readwrite_hosts` lists\
+By default, all source addresses are allowed. `admin_readwrite_hosts` lists
 the hosts from which any operation is allowed.
 
 ```
 admin_readwrite_hosts=192.168.1.1,127.0.0.1/21
 ```
 
-When listing hostnames, `%` and `_` act as wildcards, similar to the hostname\
-component in MariaDB Server user accounts. `localhost` is a reserved hostname\
+When listing hostnames, `%` and `_` act as wildcards, similar to the hostname
+component in MariaDB Server user accounts. `localhost` is a reserved hostname
 and will not match any connection (use `127.0.0.1` for loopback connections).
 
-When checking the source host of the incoming REST-API client, MaxScale first\
-compares against addresses and address masks. If a match was not found and the\
-setting values contain hostnames, reverse name lookup is performed on the\
-client address. The lookup can take a while in rare cases. To prevent such\
+When checking the source host of the incoming REST-API client, MaxScale first
+compares against addresses and address masks. If a match was not found and the
+setting values contain hostnames, reverse name lookup is performed on the
+client address. The lookup can take a while in rare cases. To prevent such
 slowdown, use only IP-addresses in the host lists.
 
 `skip_name_resolve` cannot be enabled if `admin_readwrite_hosts` or`admin_readonly_hosts` includes hostname patterns, as these would not work.
 
 #### `admin_readonly_hosts`
 
-Works similar to `admin_readwrite_hosts`. Lists the hosts from which only read\
-operations are allowed. An admin client can do a read operation if their source\
+Works similar to `admin_readwrite_hosts`. Lists the hosts from which only read
+operations are allowed. An admin client can do a read operation if their source
 address matches either `admin_readwrite_hosts` or `admin_readonly_hosts`.
 
 ```
@@ -1696,46 +1696,46 @@ admin_readonly_hosts=mydomain%.com
 The signature algorithm used by the MaxScale REST API when generating JSON Web\
 Tokens.
 
-For more information about the tokens and how they work, refer to [the REST API\
+For more information about the tokens and how they work, refer to [the REST API
 documentation](../maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md).
 
-If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale\
-will generate a random encryption key on startup and use that to sign the\
+If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale
+will generate a random encryption key on startup and use that to sign the
 messages. The symmetric key can also be retrieved from an if the `admin_jwt_key` parameter is defined.
 
-If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must\
-contain a private key and a public certificate of the correct type. If the wrong\
+If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must
+contain a private key and a public certificate of the correct type. If the wrong
 key type, key length or elliptic curve is used, MaxScale will refuse to start.
 
-Asymmetric key algorithms make it possible for the clients of the REST API to\
+Asymmetric key algorithms make it possible for the clients of the REST API to
 validate that the token was indeed generated by the correct entity.
 
-Symmetric algorithms make it easy to share the same tokens between\
-multiple MaxScale instances as the shared secret can be stored in a key\
+Symmetric algorithms make it easy to share the same tokens between
+multiple MaxScale instances as the shared secret can be stored in a key
 management system.
 
 The possible values for this parameter are:
 
 * `auto`
-* MaxScale will attempt to detect the best algorithm to use for\
+* MaxScale will attempt to detect the best algorithm to use for
   signatures. The algorithm used depends on the private key type: RSA keys use`PS256`, EC keys use the `ES256`, `ES384` or `ES512` depending on the curve,\
-  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot\
+  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot
   auto-detect the key type, it falls back to `HS256` as the default algorithm.
 * `HS256`, `HS384` or `HS512`
 * [HMAC with SHA-2\
-  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct\
+  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct
   size.
 * `RS256`, `RS384` or `RS512`
 * [Digital Signature with\
-  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires\
+  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires
   at least a 2048-bit RSA key.
 * `PS256`, `PS384` or `PS512`
 * [Digital Signature with\
-  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires\
+  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires
   at least a 2048-bit RSA key.
 * `ES256`, `ES384` or `ES512`
 * [Digital Signature with\
-  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires\
+  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires
   an EC key with the correct curve: P-256 for `ES256`, P-384 for `ES384` and\
   P-512 for `ES512`.
 * `ED25519` or `ED448`
@@ -1750,15 +1750,15 @@ The possible values for this parameter are:
 * Dynamic: No
 * Default: `""`
 
-The ID for the encryption key used to sign the JSON Web Tokens. If configured,\
-an [Encryption Key Manager](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured\
-and it must contain the key with the given ID. If no key is defined, MaxScale\
-will use a random encryption key whenever a symmetric signature algorithm is\
+The ID for the encryption key used to sign the JSON Web Tokens. If configured,
+an [Encryption Key Manager](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured
+and it must contain the key with the given ID. If no key is defined, MaxScale
+will use a random encryption key whenever a symmetric signature algorithm is
 used.
 
-Currently, the encryption key is only read on startup. This means that the\
+Currently, the encryption key is only read on startup. This means that the
 tokens will be signed by the latest key version that is available on startup:\
-rotating the encryption key in the key management system will not cause the JWTs\
+rotating the encryption key in the key management system will not cause the JWTs
 to be signed with newer versions of the key.
 
 #### `admin_jwt_max_age`
@@ -1770,11 +1770,11 @@ to be signed with newer versions of the key.
 
 The maximum lifetime of a token generated by the `/auth` endpoint.
 
-If a client requests for a token with a lifetime that exceeds the configured\
-value, the token lifetime is silently truncated to this value. This can be used\
+If a client requests for a token with a lifetime that exceeds the configured
+value, the token lifetime is silently truncated to this value. This can be used
 to control the maximum length of a MaxGUI session.
 
-This also acts as the effective maximum age of any database connection created\
+This also acts as the effective maximum age of any database connection created
 from the `/sql` endpoint.
 
 #### `admin_oidc_url`
@@ -1786,14 +1786,14 @@ from the `/sql` endpoint.
 
 The URL to a OpenID Connect server that is used for JWT validation.
 
-If defined, any tokens signed by this server are accepted as valid bearer tokens\
-for the MaxScale REST API. The `"sub"` field of the token is assumed to be the\
-username of an administrative user in MaxScale and the `"account"` claim is\
-assumed to be the type of the user: `"admin"` for administrative users with full\
+If defined, any tokens signed by this server are accepted as valid bearer tokens
+for the MaxScale REST API. The `"sub"` field of the token is assumed to be the
+username of an administrative user in MaxScale and the `"account"` claim is
+assumed to be the type of the user: `"admin"` for administrative users with full
 access to the REST-API and `"basic"` for users with read-only access to the\
 REST-API. This means that all users must be first created with `maxctrl create user` before the tokens are accepted if the OIDC provider is not able to add the`"account"` claim.
 
-If this URL is changed at runtime, the new certificates will not be\
+If this URL is changed at runtime, the new certificates will not be
 fetched until a `maxctrl reload tls` command is executed.
 
 #### `admin_verify_url`
@@ -1805,19 +1805,19 @@ fetched until a `maxctrl reload tls` command is executed.
 
 URL to a server to which the REST API token verification is delegated.
 
-If the URL is defined, any tokens passed to the REST API will be validated by\
-doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client\
+If the URL is defined, any tokens passed to the REST API will be validated by
+doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client
 and the custom `X-Referrer-Method` header is set to the HTTP method being used\
 (PUT, GET etc.).
 
-**Note**: When `admin_verify_url` is used and the remote server cannot\
-be accessed, all REST API access that uses tokens will be disabled. The\
-only way to use the REST API with tokens is to remove `admin_verify_url`\
-from the configuration which requires restarting MaxScale. The REST API\
-still accepts HTTP Basic Access authentication even if the remote server\
+**Note**: When `admin_verify_url` is used and the remote server cannot
+be accessed, all REST API access that uses tokens will be disabled. The
+only way to use the REST API with tokens is to remove `admin_verify_url`
+from the configuration which requires restarting MaxScale. The REST API
+still accepts HTTP Basic Access authentication even if the remote server
 cannot be reached.
 
-By delegating the authentication and authorization of the REST API to an\
+By delegating the authentication and authorization of the REST API to an
 external server, users can implement custom access control systems for the\
 MaxScale REST API.
 
@@ -1828,9 +1828,9 @@ MaxScale REST API.
 * Dynamic: No
 * Default: `maxscale`
 
-The issuer (`"iss"`) claim of all JWTs generated by MaxScale. This can be set\
-to a custom value to uniquely identify which MaxScale issued a JWT. This is\
-especially useful for cases where the MaxScale GUI is used from behind\
+The issuer (`"iss"`) claim of all JWTs generated by MaxScale. This can be set
+to a custom value to uniquely identify which MaxScale issued a JWT. This is
+especially useful for cases where the MaxScale GUI is used from behind
 a reverse proxy.
 
 #### `admin_audit`
@@ -1851,8 +1851,8 @@ Enable logging of incoming REST API calls.
 
 The file where the REST API auditing information is logged.
 
-If a non-default value is used, the directory where the file resides must\
-exist. For example, with `/var/log/maxscale/audit_files/audit.csv`, the\
+If a non-default value is used, the directory where the file resides must
+exist. For example, with `/var/log/maxscale/audit_files/audit.csv`, the
 directory `/var/log/maxscale/audit_files` must exist.
 
 #### `admin_audit_exclude_methods`
@@ -1866,9 +1866,9 @@ directory `/var/log/maxscale/audit_files` must exist.
 List of comma separated HTTP methods to exclude from logging\
 Currently MaxScale does not use `CONNECT` or `TRACE`.
 
-Resetting to log all methods can be done in the configuration file by\
+Resetting to log all methods can be done in the configuration file by
 writing `admin_audit_exclude_methods=` or at runtime with`maxctrl alter maxscale admin_audit_exclude_methods=`.\
-Remember that once a runtime change has been made, the entry for that\
+Remember that once a runtime change has been made, the entry for that
 setting is ignored in the main configuration file (usually maxscale.cnf).
 
 #### `config_sync_cluster`
@@ -1878,10 +1878,10 @@ setting is ignored in the main configuration file (usually maxscale.cnf).
 * Dynamic: Yes
 * Default: None
 
-This parameter controls which cluster (i.e. monitor) is used to synchronize\
+This parameter controls which cluster (i.e. monitor) is used to synchronize
 configuration changes between MaxScale instances. The first server labeled`Master` will be used for the synchronization.
 
-By default configuration synchronization is not enabled and it must be\
+By default configuration synchronization is not enabled and it must be
 explicitly enabled by defining a monitor name for `config_sync_cluster`.
 
 When `config_sync_cluster` is defined, `config_sync_user` and`config_sync_password` must also be defined.
@@ -1896,8 +1896,8 @@ Synchronization](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configurat
 * Dynamic: Yes
 * Default: None
 
-The username for the account that is used to synchronize configuration changes\
-across MaxScale instances. Both this parameter and `config_sync_password` are\
+The username for the account that is used to synchronize configuration changes
+across MaxScale instances. Both this parameter and `config_sync_password` are
 required if `config_sync_cluster` is configured.
 
 This account must have the following grants:
@@ -1906,7 +1906,7 @@ This account must have the following grants:
 GRANT SELECT, INSERT, UPDATE, CREATE ON `mysql`.`maxscale_config`
 ```
 
-The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`\
+The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`
 grant is not needed by the user configured in `config_sync_user`. The following\
 SQL is used to create the table.
 
@@ -1920,7 +1920,7 @@ CREATE TABLE IF NOT EXISTS mysql.maxscale_config(
 ) ENGINE=InnoDB;
 ```
 
-If the database where the table is created is changed with `config_sync_db`, the\
+If the database where the table is created is changed with `config_sync_db`, the
 grants must be adjusted to target that database instead.
 
 #### `config_sync_password`
@@ -1930,8 +1930,8 @@ grants must be adjusted to target that database instead.
 * Dynamic: Yes
 * Default: None
 
-The password for `config_sync_user`. Both this parameter and `config_sync_user`\
-are required if `config_sync_cluster` is configured. This password can\
+The password for `config_sync_user`. Both this parameter and `config_sync_user`
+are required if `config_sync_cluster` is configured. This password can
 optionally be encrypted using `maxpasswd`.
 
 #### `config_sync_db`
@@ -1941,13 +1941,13 @@ optionally be encrypted using `maxpasswd`.
 * Dynamic: No
 * Default: `mysql`
 
-The database where the `maxscale_config` table is created. By default the table\
-is created in the `mysql` database. This parameter was added in MaxScale\
+The database where the `maxscale_config` table is created. By default the table
+is created in the `mysql` database. This parameter was added in MaxScale
 versions 6.4.6 and 22.08.5.
 
-As tables in the `mysql` database cannot have triggers on them, the database\
+As tables in the `mysql` database cannot have triggers on them, the database
 must be changed to a user-created one in order to create triggers on the table.\
-An example use-case for triggers on this table is to track all configuration\
+An example use-case for triggers on this table is to track all configuration
 changes done to MaxScale by inserting them into a separate table.
 
 #### `config_sync_interval`
@@ -1959,9 +1959,9 @@ changes done to MaxScale by inserting them into a separate table.
 
 How often to synchronize the configuration with the cluster.
 
-As the synchronization involves selecting the configuration version from the\
-database, this value should not be set to an unreasonably low value. The default\
-value of 5 second should provide a good compromise between responsiveness and\
+As the synchronization involves selecting the configuration version from the
+database, this value should not be set to an unreasonably low value. The default
+value of 5 second should provide a good compromise between responsiveness and
 how much load it places on the database.
 
 #### `config_sync_timeout`
@@ -1971,8 +1971,8 @@ how much load it places on the database.
 * Dynamic: Yes
 * Default: `10s`
 
-Timeout for all SQL operations done during the configuration synchronization. If\
-an operation exceeds this timeout, the configuration change is treated as failed\
+Timeout for all SQL operations done during the configuration synchronization. If
+an operation exceeds this timeout, the configuration change is treated as failed
 and an error is reported to the client that did the change.
 
 #### `key_manager`
@@ -1987,13 +1987,13 @@ The encryption key manager to use. The available encryption key managers are:
 * `none` - No key manager, encryption keys are not available.
 * `file` - [File-based key manager](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#file-based-key-manager)
 * `kmip` - [KMIP key manager](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#kmip-key-manager)
-* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This\
-  key manager is only included on systems with GCC 9 or newer which\
+* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This
+  key manager is only included on systems with GCC 9 or newer which
   means it cannot be used on Ubuntu 18.04.
 
-Refer to the [Encryption Key Managers](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for\
-more information on how to configure the key managers. The key managers each\
-have their configuration in their own namespace and must have their name as a\
+Refer to the [Encryption Key Managers](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for
+more information on how to configure the key managers. The key managers each
+have their configuration in their own namespace and must have their name as a
 prefix.
 
 For example to configure the `file` key manager, the following must be used:
@@ -2005,16 +2005,16 @@ file.keyfile=/path/to/keyfile
 
 ### Events
 
-MaxScale logs warnings and errors for various reasons and often it is self-\
-evident and generally applicable whether some occurrence should warrant a\
+MaxScale logs warnings and errors for various reasons and often it is self-
+evident and generally applicable whether some occurrence should warrant a
 warning or an error, or perhaps just an info-level message.
 
-However, there are events whose seriousness is not self-evident. For\
-instance, in some environments an authentication failure may simply indicate\
-that someone has made a typo, while in some other environment that can only\
+However, there are events whose seriousness is not self-evident. For
+instance, in some environments an authentication failure may simply indicate
+that someone has made a typo, while in some other environment that can only
 happen in case there has been a security breech.
 
-To handle events like these, MaxScale defines _events_ whose logging\
+To handle events like these, MaxScale defines _events_ whose logging
 facility and level can be controlled by the administrator. Given an event`X`, its facility and level are controlled in the following manner:
 
 ```
@@ -2022,21 +2022,21 @@ event.X.facility=LOG_LOCAL0
 event.X.level=LOG_ERR
 ```
 
-The above means that if event _X_ occurs, then that is logged using the\
+The above means that if event _X_ occurs, then that is logged using the
 facility `LOG_LOCAL0` and the level `LOG_ERR`.
 
-The valid values of facility`are the facility values reported by`man\
+The valid values of facility`are the facility values reported by`man
 syslog`, e.g.`LOG\_AUTH`,`LOG\_LOCAL0`and`LOG\_USER`. Likewise, the valid values for`level`are the ones also reported by`man syslog`, e.g.`LOG\_WARNING`,`LOG\_ERR`and`LOG\_CRIT\`.
 
-Note that MaxScale does not act upon the level, that is, even if the level\
-of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut\
+Note that MaxScale does not act upon the level, that is, even if the level
+of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut
 down if that event occurs.
 
 The default facility is `LOG_USER` and the default level is `LOG_WARNING`.
 
-Note that you may also have to configure `rsyslog` to ensure that the\
-event can be logged to the intended log file. For instance, if the facility\
-is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line\
+Note that you may also have to configure `rsyslog` to ensure that the
+event can be logged to the intended log file. For instance, if the facility
+is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line
 like
 
 ```
@@ -2058,22 +2058,22 @@ event.authentication_failure.level=LOG_CRIT
 
 ### Service
 
-A service represents the database service that MariaDB MaxScale offers to the\
-clients. In general a service consists of a set of backend database servers and\
-a routing algorithm that determines how MariaDB MaxScale decides to send\
+A service represents the database service that MariaDB MaxScale offers to the
+clients. In general a service consists of a set of backend database servers and
+a routing algorithm that determines how MariaDB MaxScale decides to send
 statements or route connections to those backend servers.
 
-A service may be considered as a virtual database server that MariaDB MaxScale\
+A service may be considered as a virtual database server that MariaDB MaxScale
 makes available to its clients.
 
 Several different services may be defined using the same set of backend servers.\
-For example a connection based routing service might be used by clients that\
-already performed internal read/write splitting, whilst a different statement\
-based router may be used by clients that are not written with this functionality\
-in place. Both sets of applications could access the same data in the same\
+For example a connection based routing service might be used by clients that
+already performed internal read/write splitting, whilst a different statement
+based router may be used by clients that are not written with this functionality
+in place. Both sets of applications could access the same data in the same
 databases.
 
-A service is identified by a service name, which is the name of the\
+A service is identified by a service name, which is the name of the
 configuration file section and a type parameter of service.
 
 ```
@@ -2081,9 +2081,9 @@ configuration file section and a type parameter of service.
 type=service
 ```
 
-In order for MariaDB MaxScale to forward any requests it must have at least one\
-service defined within the configuration file. The definition of a service alone\
-is not enough to allow MariaDB MaxScale to forward requests however, the service\
+In order for MariaDB MaxScale to forward any requests it must have at least one
+service defined within the configuration file. The definition of a service alone
+is not enough to allow MariaDB MaxScale to forward requests however, the service
 is merely present to link together the other configuration elements.
 
 #### `router`
@@ -2092,15 +2092,15 @@ is merely present to link together the other configuration elements.
 * Mandatory: Yes
 * Dynamic: No
 
-The router parameter of a service defines the name of the router module that\
+The router parameter of a service defines the name of the router module that
 will be used to implement the routing algorithm between the client of MariaDB\
-MaxScale and the backend databases. Additionally routers may also be passed a\
-comma separated list of options that are used to control the behavior of the\
-routing algorithm. The two parameters that control the routing choice are router\
-and router\_options. The router options are specific to a particular router and\
-are used to modify the behavior of the router. The read connection router can be\
-passed options of `master`, `slave` or `synced`, an example of configuring a service\
-to use this router and limiting the choice of servers to those in `slave` state\
+MaxScale and the backend databases. Additionally routers may also be passed a
+comma separated list of options that are used to control the behavior of the
+routing algorithm. The two parameters that control the routing choice are router
+and router\_options. The router options are specific to a particular router and
+are used to modify the behavior of the router. The read connection router can be
+passed options of `master`, `slave` or `synced`, an example of configuring a service
+to use this router and limiting the choice of servers to those in `slave` state
 would be as follows.
 
 ```
@@ -2108,7 +2108,7 @@ router=readconnroute
 router_options=slave
 ```
 
-To change the router to connect on to servers in the `master` state as well as\
+To change the router to connect on to servers in the `master` state as well as
 slave servers, the router options can be modified to include the `master` state.
 
 ```
@@ -2116,7 +2116,7 @@ router=readconnroute
 router_options=master,slave
 ```
 
-A more complete description of router options and what is available for a given\
+A more complete description of router options and what is available for a given
 router is included with the documentation of the router itself.
 
 #### `filters`
@@ -2126,17 +2126,17 @@ router is included with the documentation of the router itself.
 * Dynamic: Yes
 * Default: None
 
-The filters option allow a set of filters to be defined for a service; requests\
-from the client are passed through these filters before being sent to the router\
-for dispatch to the backend server. The filters parameter takes one or more\
-filter names, as defined within the filter definition section of the\
+The filters option allow a set of filters to be defined for a service; requests
+from the client are passed through these filters before being sent to the router
+for dispatch to the backend server. The filters parameter takes one or more
+filter names, as defined within the filter definition section of the
 configuration file. Multiple filters are separated using the | character.
 
 ```
 filters=counter | QLA
 ```
 
-The requests pass through the filters from left to right in the order defined in\
+The requests pass through the filters from left to right in the order defined in
 the configuration parameter.
 
 #### `targets`
@@ -2146,7 +2146,7 @@ the configuration parameter.
 * Dynamic: Yes
 * Default: None
 
-The `targets` parameter is a comma separated list of server and/or service names\
+The `targets` parameter is a comma separated list of server and/or service names
 that comprise the routing targets of the service. This parameter was added in\
 MaxScale 2.5.0.
 
@@ -2154,9 +2154,9 @@ MaxScale 2.5.0.
 targets=My-Service,server2
 ```
 
-This parameter allows nested service configurations to be defined without having\
-to configure listeners for all services. For example, one use-case is to use\
-multiple readwritesplit services behind a schemarouter service to have both the\
+This parameter allows nested service configurations to be defined without having
+to configure listeners for all services. For example, one use-case is to use
+multiple readwritesplit services behind a schemarouter service to have both the
 sharding of schemarouter with the high-availability of readwritesplit.
 
 **NOTE:** The `targets` parameter is mutually exclusive with the `cluster` and`servers` parameters.
@@ -2168,8 +2168,8 @@ sharding of schemarouter with the high-availability of readwritesplit.
 * Dynamic: Yes
 * Default: None
 
-The servers parameter in a service definition provides a comma separated list of\
-the backend servers that comprise the service. The server names are those used\
+The servers parameter in a service definition provides a comma separated list of
+the backend servers that comprise the service. The server names are those used
 in the name section of a block with a type parameter of server (see below).
 
 ```
@@ -2185,7 +2185,7 @@ servers=server1,server2,server3
 * Dynamic: Yes
 * Default: None
 
-The servers the service uses are defined by the monitor specified as value\
+The servers the service uses are defined by the monitor specified as value
 of this configuration parameter.
 
 ```
@@ -2200,7 +2200,7 @@ cluster=TheMonitor
 * Mandatory: Yes
 * Dynamic: Yes
 
-This setting defines the _user_ the service uses to fetch user account\
+This setting defines the _user_ the service uses to fetch user account
 information from backends. A _password_ is specified using [password](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#password).
 
 ```
@@ -2208,8 +2208,8 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
 #### `password`
@@ -2218,9 +2218,9 @@ regarding user account management and client authentication.
 * Mandatory: Yes
 * Dynamic: Yes
 
-This settings defines the _password_ the service uses to fetch user account\
-information from backends. The _password_ may be either a plain text password or\
-an [encrypted password](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified\
+This settings defines the _password_ the service uses to fetch user account
+information from backends. The _password_ may be either a plain text password or
+an [encrypted password](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified
 using [user](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#user).
 
 ```
@@ -2228,20 +2228,20 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
-From 23.08.0 onwards, MaxScale will remember the previous password when the\
-password is changed. If the fetching of the user account information fails\
-using the new password, it will be attempted using the previous one. The purpose\
-of this change is to make it a smoother operation to change the password of\
+From 23.08.0 onwards, MaxScale will remember the previous password when the
+password is changed. If the fetching of the user account information fails
+using the new password, it will be attempted using the previous one. The purpose
+of this change is to make it a smoother operation to change the password of
 the service user. The steps are as follows:
 
 1. `$ maxctrl alter service MyService password=TheNewPassword`
 2. `MariaDB [(none)]> set password for TheServiceUser = password('TheNewPassword');`
 
-Since the old password is remembered and used if the new password does not\
+Since the old password is remembered and used if the new password does not
 work, it is no longer necessary to perform those steps simultaneously.
 
 #### `enable_root_user`
@@ -2265,7 +2265,7 @@ Deprecated and ignored.
 * Dynamic: No
 * Default: None
 
-This parameter sets a custom version string that is sent in the MySQL Handshake\
+This parameter sets a custom version string that is sent in the MySQL Handshake
 from MariaDB MaxScale to clients.
 
 Example:
@@ -2274,13 +2274,13 @@ Example:
 version_string=10.11.2-MariaDB-RWsplit
 ```
 
-If not set, MaxScale will attempt to use a version string from the\
-backend databases by selecting the version string of the database with\
+If not set, MaxScale will attempt to use a version string from the
+backend databases by selecting the version string of the database with
 the lowest version number. If the selected version is from the MariaDB\
 10 series, a `5.5.5-` prefix will be added to it similarly to how the\
 MariaDB 10 series versions added it.
 
-If MaxScale has not been able to connect to a single database and the\
+If MaxScale has not been able to connect to a single database and the
 versions are unknown, the default value of `5.5.5-10.4.32 <MaxScale version>-maxscale` is used where `<MaxScale version>` is the version of\
 MaxScale.
 
@@ -2291,15 +2291,15 @@ MaxScale.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether only a single server or all of the servers are\
+This parameter controls whether only a single server or all of the servers are
 used when loading the users from the backend servers.
 
-By default MaxScale uses the first server labeled as `Master` as the source of\
-the authentication data. When this option is enabled, the authentication data is\
+By default MaxScale uses the first server labeled as `Master` as the source of
+the authentication data. When this option is enabled, the authentication data is
 loaded from all the servers and combined into one big data set.
 
-**Note:** This parameter was deprecated in MaxScale 24.02.0 but it was then\
-un-deprecated as there were still uses for it. Modules that required this to\
+**Note:** This parameter was deprecated in MaxScale 24.02.0 but it was then
+un-deprecated as there were still uses for it. Modules that required this to
 function correctly (e.g. schemarouter) now automatically enable it.
 
 #### `strip_db_esc`
@@ -2309,7 +2309,7 @@ function correctly (e.g. schemarouter) now automatically enable it.
 * Dynamic: Yes
 * Default: `true`
 
-**Note:** This parameter has been deprecated in MaxScale 23.08. The stripping of\
+**Note:** This parameter has been deprecated in MaxScale 23.08. The stripping of
 escape characters is in all known cases the correct thing to do.
 
 This setting controls whether escape characters (`\`) are removed from database\
@@ -2317,12 +2317,12 @@ names when loading user grants from a backend server. When enabled, a grant\
 such as `grant select on` test\_`.* to 'user'@'%';` is read as `grant select on` test\_`.* to 'user'@'%';`
 
 This setting has no effect on database-level grants fetched from a MariaDB\
-Server. The database names of a MariaDB Server are compared using the LIKE\
-operator to properly handle wildcards and escaped wildcards. This setting may\
-affect database names in table and column level grants, although these typically\
+Server. The database names of a MariaDB Server are compared using the LIKE
+operator to properly handle wildcards and escaped wildcards. This setting may
+affect database names in table and column level grants, although these typically
 do not contain backlashes.
 
-Some visual database management tools automatically escape some characters and\
+Some visual database management tools automatically escape some characters and
 this might cause conflicts when MaxScale tries to authenticate users.
 
 #### `log_auth_warnings`
@@ -2332,8 +2332,8 @@ this might cause conflicts when MaxScale tries to authenticate users.
 * Dynamic: Yes
 * Default: `true`
 
-Enable or disable the logging of authentication failures and warnings. If\
-enabled, messages about failed authentication attempts will be logged with\
+Enable or disable the logging of authentication failures and warnings. If
+enabled, messages about failed authentication attempts will be logged with
 details about who tried to connect to MariaDB MaxScale and from where.
 
 #### `log_warning`
@@ -2343,10 +2343,10 @@ details about who tried to connect to MariaDB MaxScale and from where.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log warning messages even if the global\
+When enabled, this allows a service to log warning messages even if the global
 log level configuration disables them.
 
-Note that disabling the service level logging does not override the global\
+Note that disabling the service level logging does not override the global
 logging configuration: with `log_warning=false` in the service and`log_warning=true` globally, warnings will still be logged for all services.
 
 #### `log_notice`
@@ -2356,7 +2356,7 @@ logging configuration: with `log_warning=false` in the service and`log_warning=t
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log notice messages even if the global\
+When enabled, this allows a service to log notice messages even if the global
 log level configuration disables them.
 
 #### `log_info`
@@ -2366,7 +2366,7 @@ log level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log info messages even if the global log\
+When enabled, this allows a service to log info messages even if the global log
 level configuration disables them.
 
 #### `log_debug`
@@ -2376,10 +2376,10 @@ level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log debug messages even if the global log\
+When enabled, this allows a service to log debug messages even if the global log
 level configuration disables them.
 
-Debug messages are only enabled for debug builds. Enabling `log_debug` in a\
+Debug messages are only enabled for debug builds. Enabling `log_debug` in a
 release build does nothing.
 
 #### `wait_timeout`
@@ -2390,33 +2390,33 @@ release build does nothing.
 * Default: `28800s` (>= MaxScale 24.02.5, 25.01.2), `0s` (<= MaxScale 24.02.4, 25.01.1)
 * Auto tune: [Yes](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#auto_tune)
 
-The wait\_timeout parameter is used to disconnect sessions to MariaDB MaxScale\
-that have been idle for too long. The session timeout is set to 28800 seconds by\
+The wait\_timeout parameter is used to disconnect sessions to MariaDB MaxScale
+that have been idle for too long. The session timeout is set to 28800 seconds by
 default. A value of zero is interpreted as no timeout.
 
-This parameter used to be called `connection_timeout` and this name is still\
+This parameter used to be called `connection_timeout` and this name is still
 accepted as an alias for `wait_timeout`. The old name has been deprecated in\
 MaxScale 23.08.
 
-The default value of `wait_timeout` changed from `0s` to `28800s` in MaxScale\
+The default value of `wait_timeout` changed from `0s` to `28800s` in MaxScale
 versions 24.02.5 and 25.01.2 to match the default value of MariaDB\
 ([MXS-5530](https://jira.mariadb.org/browse/MXS-5530)).
 
-Note that since the granularity of the timeout is seconds, a timeout specified\
+Note that since the granularity of the timeout is seconds, a timeout specified
 in milliseconds will be rejected, even if the duration is longer than a second.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `wait_timeout` for those is not used.
 
-The value of `wait_timeout` in MaxScale should be lower than the lowest`wait_timeout` value on the backend servers. This way idle clients are\
-disconnected by MaxScale before the backend servers have to close them. Any\
-client-side idle timeouts (e.g. maximum lifetime for connection pools) should be\
-lower than `wait_timeout` in both MaxScale and MariaDB. This way the client\
-application will end up closing the connection itself which most of the time\
+The value of `wait_timeout` in MaxScale should be lower than the lowest`wait_timeout` value on the backend servers. This way idle clients are
+disconnected by MaxScale before the backend servers have to close them. Any
+client-side idle timeouts (e.g. maximum lifetime for connection pools) should be
+lower than `wait_timeout` in both MaxScale and MariaDB. This way the client
+application will end up closing the connection itself which most of the time
 results in better and more helpful error messages.
 
-**Warning:** If a connection is idle for longer than the configured connection\
+**Warning:** If a connection is idle for longer than the configured connection
 timeout, it will be forcefully disconnected and a warning will be logged in the\
 MaxScale log file.
 
@@ -2434,13 +2434,13 @@ wait_timeout=300s
 * Dynamic: Yes
 * Default: `0`
 
-The maximum number of simultaneous connections MaxScale should permit to this\
-service. If the parameter is zero or is omitted, there is no limit. Any attempt\
-to make more connections after the limit is reached will result in a "Too many\
+The maximum number of simultaneous connections MaxScale should permit to this
+service. If the parameter is zero or is omitted, there is no limit. Any attempt
+to make more connections after the limit is reached will result in a "Too many
 connections" error being returned.
 
-**Warning**: In MaxScale 2.5, it is possible that the number of concurrent\
-connections temporarily exceeds the value of `max_connections`. This has been\
+**Warning**: In MaxScale 2.5, it is possible that the number of concurrent
+connections temporarily exceeds the value of `max_connections`. This has been
 fixed in MaxScale 6.
 
 Example:
@@ -2457,25 +2457,25 @@ max_connections=100
 * Dynamic: Yes
 * Default: `false`
 
-\*_Note:_ This parameter has been deprecated in MaxScale 23.08 as the feature is\
-now used automatically if needed. In addition, the session tracking no longer\
-needs to be enabled in MariaDB for the transaction state tracking to work\
+\*_Note:_ This parameter has been deprecated in MaxScale 23.08 as the feature is
+now used automatically if needed. In addition, the session tracking no longer
+needs to be enabled in MariaDB for the transaction state tracking to work
 correctly.
 
 Enable transaction state tracking by offloading it to the backend servers.\
-Getting the transaction state from the server will be more accurate for stored\
-procedures or multi-statement SQL that modifies the transaction state\
+Getting the transaction state from the server will be more accurate for stored
+procedures or multi-statement SQL that modifies the transaction state
 non-atomically.
 
-In general, it is better to avoid using this type of SQL as tracking the\
-transaction state via the server responses is not compatible with features such\
-as `transaction_replay` in readwritesplit. `session_track_trx_state` should only\
-be enabled if the default transaction tracking done by MaxScale does not produce\
+In general, it is better to avoid using this type of SQL as tracking the
+transaction state via the server responses is not compatible with features such
+as `transaction_replay` in readwritesplit. `session_track_trx_state` should only
+be enabled if the default transaction tracking done by MaxScale does not produce
 the desired outcome.
 
-This is only supported by MariaDB versions 10.3 or newer. The following must be\
-configured in the MariaDB server in order for this feature to work. Not\
-configuring the MariaDB server with it can result in the transaction state being\
+This is only supported by MariaDB versions 10.3 or newer. The following must be
+configured in the MariaDB server in order for this feature to work. Not
+configuring the MariaDB server with it can result in the transaction state being
 wrong in MaxScale which can result in data inconsistency.
 
 ```
@@ -2492,12 +2492,12 @@ session_track_transaction_info = CHARACTERISTICS
 
 How many statements MaxScale should store for each session of this service.\
 This overrides the value of the global setting with the same name. If`retain_last_statements` has been specified in the global section of the\
-MaxScale configuration file, then if it has _not_ been explicitly specified\
-for the service, the global value holds, otherwise the service specific\
-value rules. That is, it is possible to enable the setting globally and\
+MaxScale configuration file, then if it has _not_ been explicitly specified
+for the service, the global value holds, otherwise the service specific
+value rules. That is, it is possible to enable the setting globally and
 turn it off for a specific service, or just enable it for specific services.
 
-The value of this parameter can be changed at runtime using `maxctrl` and the\
+The value of this parameter can be changed at runtime using `maxctrl` and the
 new value will take effect for sessions created thereafter.
 
 ```
@@ -2512,38 +2512,38 @@ maxctrl alter service MyService retain_last_statements 5
 * Default: `300s`
 * Auto tune: [Yes](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#auto_tune)
 
-Keep idle connections alive by sending pings to backend servers. This feature\
-was introduced in MaxScale 2.5.0 where it was changed from a\
-readwritesplit-specific feature to a generic service feature. The default value\
+Keep idle connections alive by sending pings to backend servers. This feature
+was introduced in MaxScale 2.5.0 where it was changed from a
+readwritesplit-specific feature to a generic service feature. The default value
 for this parameter is 300 seconds. To disable this feature, set the value to 0.
 
-The keepalive interval is specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no\
+The keepalive interval is specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no
 explicit unit is provided, the value is interpreted as seconds in MaxScale\
-2.5. In subsequent versions a value without a unit may be rejected. Note that\
-since the granularity of the keepalive is seconds, a keepalive specified in\
+2.5. In subsequent versions a value without a unit may be rejected. Note that
+since the granularity of the keepalive is seconds, a keepalive specified in
 milliseconds will be rejected, even if the duration is longer than a second.
 
-The parameter value is the interval in seconds between each keepalive ping. A\
-keepalive ping will be sent to a backend server if the connection has been idle\
+The parameter value is the interval in seconds between each keepalive ping. A
+keepalive ping will be sent to a backend server if the connection has been idle
 for longer than the configured keepalive interval.
 
-Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client\
-has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings\
+Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client
+has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings
 regardless of the client state.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `connection_keepalive` for those is not used.
 
-If the value of `connection_keepalive` is changed at runtime, the change in the\
+If the value of `connection_keepalive` is changed at runtime, the change in the
 value takes effect immediately.
 
-As the connection keepalive pings must be done only when there's no ongoing\
-query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that\
-rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the\
+As the connection keepalive pings must be done only when there's no ongoing
+query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that
+rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the
 performance will be the same with or without `connection_keepalive`.
 
-If you want to avoid the performance cost and you don't need the connection\
+If you want to avoid the performance cost and you don't need the connection
 keepalive feature, you can disable it with `connection_keepalive=0s`.
 
 #### `force_connection_keepalive`
@@ -2553,16 +2553,16 @@ keepalive feature, you can disable it with `connection_keepalive=0s`.
 * Dynamic: Yes
 * Default: `false`
 
-By default, connection keepalive pings are only sent if the client is either\
-executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are\
-unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can\
-be used to emulate the pre-2.5.21 behavior if long-lived application connections\
+By default, connection keepalive pings are only sent if the client is either
+executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are
+unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can
+be used to emulate the pre-2.5.21 behavior if long-lived application connections
 rely on the old unconditional keepalive pings.
 
 _Note:_ if `force_connection_keepalive` is enabled and `connection_keepalive` in\
-MaxScale is set to a lower value than the `wait_timeout` on the database, the\
-client idle timeouts that `wait_timeout` control are no longer effective. This\
-happens because MaxScale unconditionally sends the pings which make the client\
+MaxScale is set to a lower value than the `wait_timeout` on the database, the
+client idle timeouts that `wait_timeout` control are no longer effective. This
+happens because MaxScale unconditionally sends the pings which make the client
 behave like it is not idle and thus the connections will never be killed due to`wait_timeout`.
 
 #### `net_write_timeout`
@@ -2572,17 +2572,17 @@ behave like it is not idle and thus the connections will never be killed due to`
 * Dynamic: Yes
 * Default: `0s`
 
-This parameter controls how long a network write to the client can stay\
+This parameter controls how long a network write to the client can stay
 buffered. This feature is disabled by default.
 
-When `net_write_timeout` is configured and data is buffered on the client\
-network connection, if the time since the last successful network write exceeds\
+When `net_write_timeout` is configured and data is buffered on the client
+network connection, if the time since the last successful network write exceeds
 the configured limit, the client connection will be disconnected.
 
-The value is specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `max_sescmd_history`
@@ -2592,45 +2592,45 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `50`
 
-`max_sescmd_history` sets a limit on how many distinct session commands are\
-stored in the session command history. When the history limit is exceeded, the\
-history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server\
+`max_sescmd_history` sets a limit on how many distinct session commands are
+stored in the session command history. When the history limit is exceeded, the
+history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server
 reconnections are no longer possible.
 
-The required history size can be estimated by counting the total number of\
-session state modifying commands (e.g `SET NAMES`) that are used by a\
-client. Note that connectors usually add some commands that aren't visible to\
-the application developer which means a safety margin should be added. A good\
-rule of thumb is to count the expected number of statements and double that\
-number. The default value of 50 is a value that'll work for most applications\
+The required history size can be estimated by counting the total number of
+session state modifying commands (e.g `SET NAMES`) that are used by a
+client. Note that connectors usually add some commands that aren't visible to
+the application developer which means a safety margin should be added. A good
+rule of thumb is to count the expected number of statements and double that
+number. The default value of 50 is a value that'll work for most applications
 that do not rely heavily on user variables.
 
-Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4\
-and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol\
-prepared statements opened by the client are also kept open by MaxScale and are\
+Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4
+and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol
+prepared statements opened by the client are also kept open by MaxScale and are
 restored whenever a reconnection to a server happens. The limits imposed by`max_sescmd_history` apply to other text protocol commands e.g. `SET NAMES`.\
-Note that text protocol prepared statements count as text protocol commands and\
-are thus potentially pruned when history pruning happens. If an application uses\
+Note that text protocol prepared statements count as text protocol commands and
+are thus potentially pruned when history pruning happens. If an application uses
 a lot of `PREPARE stmt FROM <sql>` commands, it is recommended that the value of`max_sescmd_history` is increased accordingly.
 
-In older versions of MaxScale, binary protocol prepared statements were limited\
-by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this\
-caused problems when the binary protocol prepared statement were pruned while\
-they were still open from the client's point of view. In older versions, the\
-recommended value of `max_sescmd_history` is the number of state modifying\
-commands plus the maximum number of open prepared statements that any application\
+In older versions of MaxScale, binary protocol prepared statements were limited
+by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this
+caused problems when the binary protocol prepared statement were pruned while
+they were still open from the client's point of view. In older versions, the
+recommended value of `max_sescmd_history` is the number of state modifying
+commands plus the maximum number of open prepared statements that any application
 may use.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
-In addition to limiting the number of commands to store, it also acts as a hard\
-limit on the number of packets that may be queued up on a backend before it is\
-closed. Packets are queued while the TCP socket is being opened and when\
-prepared statements are being prepared. In certain rare cases, a slow server may\
-fall behind and not catch up to the rest of the cluster and a backlog of packets\
-forms. In these cases, if more than `max_sescmd_history` packets are queued, the\
+In addition to limiting the number of commands to store, it also acts as a hard
+limit on the number of packets that may be queued up on a backend before it is
+closed. Packets are queued while the TCP socket is being opened and when
+prepared statements are being prepared. In certain rare cases, a slow server may
+fall behind and not catch up to the rest of the cluster and a backlog of packets
+forms. In these cases, if more than `max_sescmd_history` packets are queued, the
 connection to the server is closed.
 
 #### `prune_sescmd_history`
@@ -2640,24 +2640,24 @@ connection to the server is closed.
 * Dynamic: Yes
 * Default: `true`
 
-This option enables pruning of the session command history when it exceeds the\
-value configured in `max_sescmd_history`. When this option is enabled, only a\
-set number of statements are stored in the history. This limits the per-session\
+This option enables pruning of the session command history when it exceeds the
+value configured in `max_sescmd_history`. When this option is enabled, only a
+set number of statements are stored in the history. This limits the per-session
 memory use while still allowing safe reconnections.
 
-This parameter is intended to be used with pooled connections that remain in use\
-for a very long time. Most connection pool implementations do not reset the\
-session state and instead re-initialize it with new values. This causes the\
-session command history to grow at roughly a constant rate for the lifetime of\
+This parameter is intended to be used with pooled connections that remain in use
+for a very long time. Most connection pool implementations do not reset the
+session state and instead re-initialize it with new values. This causes the
+session command history to grow at roughly a constant rate for the lifetime of
 the pooled connection.
 
-Starting with MaxScale 23.08, the session command history is also simplified\
-before being stored. The simplification is done by removing repeated occurrences\
-of the same command and only executing the latest one of them. The order in\
-which the commands are executed still remains the same but inter-dependencies\
+Starting with MaxScale 23.08, the session command history is also simplified
+before being stored. The simplification is done by removing repeated occurrences
+of the same command and only executing the latest one of them. The order in
+which the commands are executed still remains the same but inter-dependencies
 between commands are not preserved.
 
-For example, the following set of commands demonstrates how the history\
+For example, the following set of commands demonstrates how the history
 simplification works and how inter-dependencies can be lost.
 
 ```
@@ -2666,45 +2666,45 @@ SET @my_home='My home is: ' || @my_planet;         -- Command #1 in the history
 SET @my_planet='Earth';                            -- Command #2 in the history
 ```
 
-In the example, the value of `@my_home` has a dependency on the value of`@my_planet` which is lost when the same statement is executed again and\
+In the example, the value of `@my_home` has a dependency on the value of`@my_planet` which is lost when the same statement is executed again and
 the history simplification removes the earlier one.
 
-This same problem can occur even in older versions of MaxScale that used\
-a sliding window of the history when the window moves past the statement\
-that later statement depended on. If inter-dependent session commands\
+This same problem can occur even in older versions of MaxScale that used
+a sliding window of the history when the window moves past the statement
+that later statement depended on. If inter-dependent session commands
 are being used, the history pruning should be disabled.
 
-Each client-side session that uses a pooled connection only executes a finite\
-amount of session commands. By retaining a shorter history that encompasses all\
-session commands the individual clients execute, the session state of a pooled\
+Each client-side session that uses a pooled connection only executes a finite
+amount of session commands. By retaining a shorter history that encompasses all
+session commands the individual clients execute, the session state of a pooled
 connection can be accurately recreated on another server.
 
-When the session command history pruning is enabled, there is a theoretical\
-possibility that upon server reconnection the session states of the connections\
-are inconsistent. This can only happen if the length of the stored history is\
-shorter than the list of relevant statements that affect the session state. In\
-practice the default value of 50 session commands is a fairly reasonable value\
+When the session command history pruning is enabled, there is a theoretical
+possibility that upon server reconnection the session states of the connections
+are inconsistent. This can only happen if the length of the stored history is
+shorter than the list of relevant statements that affect the session state. In
+practice the default value of 50 session commands is a fairly reasonable value
 and the risk of inconsistent session state is relatively low.
 
-In case the default history length is too short for safe pruning, set the value\
-of `max_sescmd_history` to the total number of commands that affect the session\
-state plus a safety margin of 10. The safety margin reserves some extra space\
-for new commands that might be executed due to changes in the client side\
+In case the default history length is too short for safe pruning, set the value
+of `max_sescmd_history` to the total number of commands that affect the session
+state plus a safety margin of 10. The safety margin reserves some extra space
+for new commands that might be executed due to changes in the client side
 application.
 
-Starting with MaxScale 24.02.1, the execution of simple session commands done\
-with binary protocol prepared statements are also stored in the history. A\
+Starting with MaxScale 24.02.1, the execution of simple session commands done
+with binary protocol prepared statements are also stored in the history. A
 simple session command in the binary protocol is one that:
 
 * Takes no parameters
 * Modifies the session state
 * Is executed while the original prepared statement is still in the history
 
-The same limitations that apply to the text protocol session commands apply to\
+The same limitations that apply to the text protocol session commands apply to
 the binary protocol session commands.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `disable_sescmd_history`
@@ -2714,17 +2714,17 @@ history. Currently only `readwritesplit` and `schemarouter` support it.
 * Dynamic: Yes
 * Default: `false`
 
-This option disables the session command history. This way no history is stored\
-and if a replica server fails, the router will not try to replace the failed\
-replica. Disabling session command history will allow long-lived connections\
+This option disables the session command history. This way no history is stored
+and if a replica server fails, the router will not try to replace the failed
+replica. Disabling session command history will allow long-lived connections
 without causing a constant growth in the memory consumption.
 
-This parameter should only be used when either the memory footprint must be as\
-small as possible or when the pruning of the session command history is not\
+This parameter should only be used when either the memory footprint must be as
+small as possible or when the pruning of the session command history is not
 acceptable.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `user_accounts_file`
@@ -2741,25 +2741,25 @@ Default value is empty, which disables the feature.
 user_accounts_file=/home/root/users.json
 ```
 
-In addition to querying the backends, MaxScale can read users from a file. This\
-feature is useful when backends have limitations on the type of users that can\
-be created, or if MaxScale needs to allow users to log in even\
-when backends are down (e.g. binlog router). The users read from the file are\
-only present on MaxScale, so logging into backends can still fail. The format of\
-the file is protocol-specific. The following only applies to MariaDB-protocol,\
+In addition to querying the backends, MaxScale can read users from a file. This
+feature is useful when backends have limitations on the type of users that can
+be created, or if MaxScale needs to allow users to log in even
+when backends are down (e.g. binlog router). The users read from the file are
+only present on MaxScale, so logging into backends can still fail. The format of
+the file is protocol-specific. The following only applies to MariaDB-protocol,
 which is also the only protocol supporting this feature.
 
-The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which\
-contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at\
-least the string fields _user_ and _host_, which define the user account to add\
+The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which
+contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at
+least the string fields _user_ and _host_, which define the user account to add
 or modify.
 
-The elements in the _user_-array may contain the following additional fields. If\
+The elements in the _user_-array may contain the following additional fields. If
 a field is not defined, it is assumed either empty (string) or false (boolean).
 
 * password: String. Password hash, similar to the equivalent column on server.
 * plugin: String. Authentication plugin used by client, similar to server.
-* authentication\_string: String. Additional authentication info, similar to\
+* authentication\_string: String. Additional authentication info, similar to
   server.
 * default\_role: String. Default role of user, similar to server.
 * super\_priv: Boolean. True if user has SUPER grant.
@@ -2769,17 +2769,17 @@ a field is not defined, it is assumed either empty (string) or false (boolean).
 
 The elements in the _db_-array must contain the following additional field:
 
-* db: String. Database which the user can access. Can contain % and \_\
+* db: String. Database which the user can access. Can contain % and \_
   wildcards.
 
-The elements in the _roles\_mapping_-array must contain the following additional\
+The elements in the _roles\_mapping_-array must contain the following additional
 field:
 
 * role: String. Role the user can access.
 
 When users are read from both servers and the file, the server takes priority.\
 That is, if user `'joe'@'%'` is defined on both, the file-version is discarded.\
-The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant\
+The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant
 and role lists.
 
 An example users file is below.
@@ -2838,9 +2838,9 @@ Defines when _user\_accounts\_file_ is read. The value is an enum, either\
 read from a server. The file contents are then added to the server-based data.\
 If reading from server fails (e.g. servers are down), the file is ignored.
 
-"file\_only\_always" means that users are not read from the servers at all and the\
-file contents is all that matters. The state of the servers is ignored. This\
-mode can be useful with the binlog router, as it allows clients to log in and\
+"file\_only\_always" means that users are not read from the servers at all and the
+file contents is all that matters. The state of the servers is ignored. This
+mode can be useful with the binlog router, as it allows clients to log in and
 fetch binary logs from MaxScale even when backend servers are down.
 
 ```
@@ -2854,36 +2854,36 @@ user_accounts_file_usage=file_only_always
 * Dynamic: Yes
 * Default: `-1s`
 
-Normally, MaxScale only pools backend connections when\
-a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections\
+Normally, MaxScale only pools backend connections when
+a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections
 instead of creating new connections to backends. If connection sharing is enabled,\
-MaxScale can pool backend connections also from running sessions, and\
-re-attach a pooled connection when a session is doing a query. This effectively\
+MaxScale can pool backend connections also from running sessions, and
+re-attach a pooled connection when a session is doing a query. This effectively
 allows multiple sessions to share backend connections.
 
-_idle\_session\_pool\_time_ defines the amount of time a session must be idle\
-before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in\
+_idle\_session\_pool\_time_ defines the amount of time a session must be idle
+before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in
 seconds or milliseconds.
 
-This feature has a significant drawback: when a backend connection is reused, it\
-needs to be restored to the correct state. This means reauthenticating and\
-replaying session commands. This can add a significant delay before the\
-connection is actually ready for a query. If the session command history size\
-exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for\
+This feature has a significant drawback: when a backend connection is reused, it
+needs to be restored to the correct state. This means reauthenticating and
+replaying session commands. This can add a significant delay before the
+connection is actually ready for a query. If the session command history size
+exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for
 the session.
 
-This feature should only be used when limiting the backend connection count is\
-a priority, even at the cost of query delay and throughput. This feature only\
+This feature should only be used when limiting the backend connection count is
+a priority, even at the cost of query delay and throughput. This feature only
 works when the following server settings are also set in MaxScale configuration:
 
 1. [max\_routing\_connections](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#max_routing_connections)
 2. [persistpoolmax](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#persistpoolmax)
 3. [persistmaxtime](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#persistmaxtime)
 
-Since reusing a backend connection is an expensive operation, MaxScale only\
-pools connections when another session requires them. _idle\_session\_pool\_time_\
-thus effectively limits the frequency at which a connection can be moved from\
-one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to\
+Since reusing a backend connection is an expensive operation, MaxScale only
+pools connections when another session requires them. _idle\_session\_pool\_time_
+thus effectively limits the frequency at which a connection can be moved from
+one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to
 move connections as soon as possible.
 
 ```
@@ -2895,57 +2895,57 @@ See below for more information on configuring connection sharing.
 **Details, limitations and suggestions for connection sharing**
 
 As noted above, when a connection is pooled and reused its state is lost.\
-Although session variables and prepared statements are restored by replaying\
+Although session variables and prepared statements are restored by replaying
 session commands, some state information cannot be transferred.
 
-The most common such state is a transaction. When a transaction is on,\
+The most common such state is a transaction. When a transaction is on,
 connection sharing is disabled for that session until the transaction completes.\
-Other similar situations may not be properly detected, and it's the\
-responsibility of the user to avoid introducing such state to the session when\
+Other similar situations may not be properly detected, and it's the
+responsibility of the user to avoid introducing such state to the session when
 using connection sharing. This means that the following should not be used:
 
-* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that\
+* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that
   introduces state into the connection.
-* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector\
+* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector
   must be used instead of the variable.
 * Stored procedures that cause session level side-effects.
 
-Several settings affect connection sharing and its effectiveness. Reusing a\
-connection is an expensive operation so its frequency should be minimized. The\
+Several settings affect connection sharing and its effectiveness. Reusing a
+connection is an expensive operation so its frequency should be minimized. The
 important configuration settings in addition to _idle\_session\_pool\_time_ are\
 MaxScale server settings [persistpoolmax](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#persistpoolmax),[persistmaxtime](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#persistmaxtime) and [max\_routing\_connections](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#max_routing_connections).\
-The service settings [max\_sescmd\_history](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These\
+The service settings [max\_sescmd\_history](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These
 settings should be tuned according to the use case.
 
-_persistpoolmax_ limits how many connections can be kept in a pool for a given\
-server. If the pool is full, no more connections are detached from sessions even\
-if they are idle and required. The pool size should be large enough to contain\
+_persistpoolmax_ limits how many connections can be kept in a pool for a given
+server. If the pool is full, no more connections are detached from sessions even
+if they are idle and required. The pool size should be large enough to contain
 any connections being transferred between sessions, but not be greater than _max\_routing\_connections_. Using the value of _max\_routing\_connections_ is a
 reasonable starting point.
 
-_persistmaxtime_ limits the time a connection may stay in the pool. This should\
-be high enough so that pooled connections are not unnecessarily closed. Cleaning\
+_persistmaxtime_ limits the time a connection may stay in the pool. This should
+be high enough so that pooled connections are not unnecessarily closed. Cleaning
 up clearly unneeded connections from the pool may be useful when _max\_routing\_connections_ is restrictively tuned. Because each MaxScale routing
-thread has its own connection pool, one thread can monopolize access to a\
-server. For example, if the pool of thread 1 has 100 connections to _ServerA_\
-with `max_routing_connections=100`, other threads can no longer connect to the\
-server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as\
-it would cause unneeded connections in the pool to be closed faster. Such\
-connection slots then become available to other routing threads. Reducing the\
-number of [routing threads](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool\
-fragmentation. This may reduce overall throughput, though. When using connection\
+thread has its own connection pool, one thread can monopolize access to a
+server. For example, if the pool of thread 1 has 100 connections to _ServerA_
+with `max_routing_connections=100`, other threads can no longer connect to the
+server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as
+it would cause unneeded connections in the pool to be closed faster. Such
+connection slots then become available to other routing threads. Reducing the
+number of [routing threads](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool
+fragmentation. This may reduce overall throughput, though. When using connection
 sharing, backend connections are only in the pool momentarily. Consequently,_persistmaxtime_ can be set quite low, e.g. 10s.
 
-If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is\
-disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find\
-a backend connection. This can be avoided with _prune\_sescmd\_history_. However,\
-pruning means that old session commands will not be replayed when a pooled\
-connection is reused. If the pruned commands are important\
+If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is
+disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find
+a backend connection. This can be avoided with _prune\_sescmd\_history_. However,
+pruning means that old session commands will not be replayed when a pooled
+connection is reused. If the pruned commands are important
 (e.g. statement preparations), the session may fail later on.
 
 If the number of clients actively running queries is greater than _max\_routing\_connections_, query throughput will suffer as clients will need to
-take turns. In this situation, it's imperative to minimize the number of\
-backend connections a single session uses. The settings to achieve this depend\
+take turns. In this situation, it's imperative to minimize the number of
+backend connections a single session uses. The settings to achieve this depend
 on the router. For ReadWriteSplit the following should be used:
 
 ```
@@ -2954,12 +2954,12 @@ lazy_connect=1
 transaction_replay=true
 ```
 
-The above settings mean that MaxScale can process roughly\
-(_number of replica servers_ X _max\_routing\_connections_) read queries\
-simultaneously. Write queries will still need to take turns as there is only one\
+The above settings mean that MaxScale can process roughly
+(_number of replica servers_ X _max\_routing\_connections_) read queries
+simultaneously. Write queries will still need to take turns as there is only one
 primary server.
 
-The following configuration snippet shows example server and service\
+The following configuration snippet shows example server and service
 configurations for connection sharing with ReadWriteSplit.
 
 ```
@@ -2986,11 +2986,11 @@ lazy_connect=1
 * Dynamic: Yes
 * Default: `60s`
 
-When connection sharing (as described above) is on, clients\
-may have to wait for their turn to use a backend connection. If too much time\
-passes without a connection becoming available, MaxScale returns an error to\
-the client, usually also ending the session. _multiplex\_timeout_ sets this\
-timeout. Increase it if queries are failing with "Timed out when waiting for a\
+When connection sharing (as described above) is on, clients
+may have to wait for their turn to use a backend connection. If too much time
+passes without a connection becoming available, MaxScale returns an error to
+the client, usually also ending the session. _multiplex\_timeout_ sets this
+timeout. Increase it if queries are failing with "Timed out when waiting for a
 connection". Decrease it if failing early is preferable to stalling.
 
 ```
@@ -2999,10 +2999,10 @@ multiplex_timeout=33s
 
 ### Server
 
-Server sections define the backend database servers MaxScale uses. A server is\
-identified by its section name in the configuration file. The only mandatory\
-parameter of a server is _type_, but _address_ and _port_ are also usually\
-defined. A server may be a member of one or more services. A server may only be\
+Server sections define the backend database servers MaxScale uses. A server is
+identified by its section name in the configuration file. The only mandatory
+parameter of a server is _type_, but _address_ and _port_ are also usually
+defined. A server may be a member of one or more services. A server may only be
 monitored by at most one monitor.
 
 ```
@@ -3019,12 +3019,12 @@ port=3000
 * Dynamic: Yes
 * Default: `""`
 
-The IP-address or hostname of the machine running the database server. MaxScale\
+The IP-address or hostname of the machine running the database server. MaxScale
 uses this address to connect to the server.
 
 Either _address_ or _socket_ must be defined, but not both.\
-If the address is given as a hostname, MaxScale will\
-perform name lookup on the hostname when starting and update the result every\
+If the address is given as a hostname, MaxScale will
+perform name lookup on the hostname when starting and update the result every
 minute and when the address changes.
 
 #### `port`
@@ -3034,7 +3034,7 @@ minute and when the address changes.
 * Dynamic: Yes
 * Default: `3306`
 
-The port the backend server listens on for incoming connections. MaxScale uses\
+The port the backend server listens on for incoming connections. MaxScale uses
 this port to connect to the server.
 
 #### `socket`
@@ -3044,7 +3044,7 @@ this port to connect to the server.
 * Dynamic: Yes
 * Default: `""`
 
-The absolute path to a UNIX domain socket the MariaDB server is listening\
+The absolute path to a UNIX domain socket the MariaDB server is listening
 on.
 
 #### `private_address`
@@ -3054,8 +3054,8 @@ on.
 * Dynamic: Yes
 * Default: `""`
 
-Alternative IP-address or hostname for the server. This is currently only used\
-by MariaDB Monitor to detect and set up replication. See [MariaDB Monitor documentation](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md)\
+Alternative IP-address or hostname for the server. This is currently only used
+by MariaDB Monitor to detect and set up replication. See [MariaDB Monitor documentation](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md)
 for more information.
 
 #### `monitoruser`
@@ -3065,9 +3065,9 @@ for more information.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitorpasswd](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -3082,9 +3082,9 @@ monitorpw=mymonitorpasswd
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitoruser](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitoruser](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -3092,7 +3092,7 @@ monitoruser=mymonitoruser
 monitorpw=mymonitorpasswd
 ```
 
-`monitorpw` may be either a plain text password or an encrypted password. See\
+`monitorpw` may be either a plain text password or an encrypted password. See
 the section [encrypting passwords](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#encrypting-passwords) for more information.
 
 #### `extra_port`
@@ -3102,19 +3102,19 @@ the section [encrypting passwords](mariadb-maxscale-2402-maxscale-2402-mariadb-m
 * Dynamic: Yes
 * Default: `0`
 
-An alternative port used for administrative connections to the server. If this\
-setting is defined, MaxScale uses it for monitoring the server and to fetch user\
+An alternative port used for administrative connections to the server. If this
+setting is defined, MaxScale uses it for monitoring the server and to fetch user
 accounts. Client sessions will still use the normal port.
 
-Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on\
-the backend server has been reached. Extra-port connections have their own\
-connection limit, which is one by default. This needs to be increased to allow\
+Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on
+the backend server has been reached. Extra-port connections have their own
+connection limit, which is one by default. This needs to be increased to allow
 both monitor and user account manager to connect.
 
-If the connection to the extra-port fails due to connection number limit or if\
+If the connection to the extra-port fails due to connection number limit or if
 the port is not open on the server, normal port is used.
 
-For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)\
+For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)
 and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables#extra_max_connections).
 
 #### `persistpoolmax`
@@ -3125,15 +3125,15 @@ and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-
 * Default: `0`
 
 Sets the size of the server connection pool. Disabled by default. When enabled,\
-MaxScale places unused connections to the server to a pool and reuses them\
-later. Connections typically become unused when a session closes. If the size of\
+MaxScale places unused connections to the server to a pool and reuses them
+later. Connections typically become unused when a session closes. If the size of
 the pool reaches _persistpoolmax_, unused connections are closed instead.
 
-Every routing thread has its own pool. As of version 6.3.0, MaxScale will round\
+Every routing thread has its own pool. As of version 6.3.0, MaxScale will round
 up _persistpoolmax_ so that every thread has an equal size pool.
 
-When a MariaDB-protocol connection is taken from the pool to be used in a new\
-session, the state of the connection is dependent on the router. ReadWriteSplit\
+When a MariaDB-protocol connection is taken from the pool to be used in a new
+session, the state of the connection is dependent on the router. ReadWriteSplit
 restores the connection to match the session state. Other routers do not.
 
 #### `persistmaxtime`
@@ -3143,15 +3143,15 @@ restores the connection to match the session state. Other routers do not.
 * Dynamic: Yes
 * Default: `0s`
 
-The `persistmaxtime` parameter defaults to zero but can be set to a duration as\
-documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is\
-interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a\
-unit may be rejected. Note that since the granularity of the parameter is\
-seconds, a value specified in milliseconds will be rejected, even if the\
+The `persistmaxtime` parameter defaults to zero but can be set to a duration as
+documented [here](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is
+interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a
+unit may be rejected. Note that since the granularity of the parameter is
+seconds, a value specified in milliseconds will be rejected, even if the
 duration is longer than a second.
 
-A DCB placed in the persistent pool for a server will only be reused if the\
-elapsed time since it joined the pool is less than the given value. Otherwise,\
+A DCB placed in the persistent pool for a server will only be reused if the
+elapsed time since it joined the pool is less than the given value. Otherwise,
 the DCB will be discarded and the connection closed.
 
 #### `max_routing_connections`
@@ -3161,18 +3161,18 @@ the DCB will be discarded and the connection closed.
 * Dynamic: Yes
 * Default: `0`
 
-Maximum number of routing connections to this server. Connections held in a pool\
-also count towards this maximum. Does not limit monitor connections or user\
+Maximum number of routing connections to this server. Connections held in a pool
+also count towards this maximum. Does not limit monitor connections or user
 account fetching. A value of 0 (default) means no limit.
 
-Since every client session can generate a connection to a server, the server may\
-run out of memory when the number of clients is high enough. This setting limits\
-server memory use caused by MaxScale. The effect depends on if the service\
-setting [idle\_session\_pool\_time](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection\
+Since every client session can generate a connection to a server, the server may
+run out of memory when the number of clients is high enough. This setting limits
+server memory use caused by MaxScale. The effect depends on if the service
+setting [idle\_session\_pool\_time](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection
 sharing, is enabled or not.
 
 If connection sharing is not on, _max\_routing\_connections_ simply sets a limit.\
-Any sessions attempting to exceed this limit will fail to connect to the\
+Any sessions attempting to exceed this limit will fail to connect to the
 backend. The client can still connect to MaxScale, but queries will fail.
 
 If connection sharing is on, sessions exceeding the limit will be put on hold\
@@ -3190,37 +3190,37 @@ max_routing_connections=1234
 * Dynamic: Yes
 * Default: `false`
 
-If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-header when connecting client sessions to the server. The header contains the\
-original client IP address and port, as seen by MaxScale. The server will then\
-read the header and perform authentication as if the connection originated from\
-this address instead of MaxScale's IP address. With this feature, the user\
-accounts on the backend server can be simplified to only contain the actual\
+If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+header when connecting client sessions to the server. The header contains the
+original client IP address and port, as seen by MaxScale. The server will then
+read the header and perform authentication as if the connection originated from
+this address instead of MaxScale's IP address. With this feature, the user
+accounts on the backend server can be simplified to only contain the actual
 client hosts and not the MaxScale host.
 
-**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy\
-protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#proxy_protocol_networks) in MaxScale. This also needs\
-to be done whenever one MaxScale may connect to another Maxscale and the\
+**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy
+protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#proxy_protocol_networks) in MaxScale. This also needs
+to be done whenever one MaxScale may connect to another Maxscale and the
 connecting MaxScale has `proxy_protocol` enabled.
 
-PROXY protocol will be supported by MariaDB 10.3, which this feature has been\
-tested with. To use it, enable the PROXY protocol in MaxScale for every\
-compatible server and configure the MariaDB servers themselves to accept the\
-protocol headers from MaxScale's IP address. On the server side, the protocol\
-should be enabled only for trusted IPs, as it allows the sender to spoof the\
-connection origin. If a proxy header is sent to a server not expecting it, the\
-connection will fail. Usually PROXY protocol should be enabled for every\
+PROXY protocol will be supported by MariaDB 10.3, which this feature has been
+tested with. To use it, enable the PROXY protocol in MaxScale for every
+compatible server and configure the MariaDB servers themselves to accept the
+protocol headers from MaxScale's IP address. On the server side, the protocol
+should be enabled only for trusted IPs, as it allows the sender to spoof the
+connection origin. If a proxy header is sent to a server not expecting it, the
+connection will fail. Usually PROXY protocol should be enabled for every
 server in a cluster, as they typically have similar grants.
 
-Other SQL-servers may support PROXY protocol as well, but the implementation may\
-be highly restricting. Strict adherence to the protocol requires that the\
-backend server does not allow mixing of un-proxied and proxied connections from\
-a given IP. MaxScale requires normal connections to backends for monitoring and\
-authentication data queries, which would be blocked. To bypass this restriction,\
-the server monitor needs to be disabled and the service listener needs to be\
+Other SQL-servers may support PROXY protocol as well, but the implementation may
+be highly restricting. Strict adherence to the protocol requires that the
+backend server does not allow mixing of un-proxied and proxied connections from
+a given IP. MaxScale requires normal connections to backends for monitoring and
+authentication data queries, which would be blocked. To bypass this restriction,
+the server monitor needs to be disabled and the service listener needs to be
 configured to disregard authentication errors (`skip_authentication=true`).\
-Server states also need to be set manually in MaxCtrl. These steps are _not_\
-required for MariaDB 10.3, since its implementation is more flexible and allows\
+Server states also need to be set manually in MaxCtrl. These steps are _not_
+required for MariaDB 10.3, since its implementation is more flexible and allows
 both PROXY-headered and headerless connections from a proxy-enabled IP.
 
 #### `disk_space_threshold`
@@ -3230,30 +3230,30 @@ both PROXY-headered and headerless connections from a proxy-enabled IP.
 * Dynamic: No
 * Default: None
 
-This parameter specifies how full a disk may be, before MaxScale should start\
-logging warnings or take other actions (e.g. perform a switchover). This\
+This parameter specifies how full a disk may be, before MaxScale should start
+logging warnings or take other actions (e.g. perform a switchover). This
 functionality will only work with MariaDB server versions 10.1.32, 10.2.14 and\
 10.3.6 onwards, if the `DISKS` _information schema plugin_ has been installed.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-A limit is specified as a path followed by a colon and a percentage specifying\
+A limit is specified as a path followed by a colon and a percentage specifying
 how full the corresponding disk may be, before action is taken. E.g. an entry like
 
 ```
 /data:80
 ```
 
-specifies that the disk that has been mounted on `/data` may be used until 80%\
-of the total space has been consumed. Multiple entries can be specified by\
-separating them by a comma. If the path is specified using `*`, then the limit\
-applies to all disks. However, the value of `*` is only applied if there is not\
+specifies that the disk that has been mounted on `/data` may be used until 80%
+of the total space has been consumed. Multiple entries can be specified by
+separating them by a comma. If the path is specified using `*`, then the limit
+applies to all disks. However, the value of `*` is only applied if there is not
 an exact match.
 
-Note that if a particular disk has been mounted on several paths, only one path\
-need to be specified. If several are specified, then the one with the smallest\
+Note that if a particular disk has been mounted on several paths, only one path
+need to be specified. If several are specified, then the one with the smallest
 percentage will be applied.
 
 Examples:
@@ -3265,7 +3265,7 @@ disk_space_threshold=/data1:80,/data2:60,*:90
 ```
 
 The last line means that the disk mounted at `/data1` may be used up to\
-80%, the disk mounted at `/data2` may be used up to 60% and all other disks\
+80%, the disk mounted at `/data2` may be used up to 60% and all other disks
 mounted at any paths may be used up until 90% of maximum capacity, before\
 MaxScale starts to warn to take action.
 
@@ -3282,7 +3282,7 @@ Note that the path to be used, is one of the paths returned by:
 ...
 ```
 
-There is no default value, but this parameter must be explicitly specified\
+There is no default value, but this parameter must be explicitly specified
 if the disk space situation should be monitored.
 
 #### `rank`
@@ -3293,20 +3293,20 @@ if the disk space situation should be monitored.
 * Values: `primary`, `secondary`
 * Default: `primary`
 
-This parameter controls the order in which servers are used. Valid values for\
+This parameter controls the order in which servers are used. Valid values for
 this parameter are `primary` and `secondary`. The default value is`primary`.
 
-This behavior depends on the router implementation but the general rule of thumb\
+This behavior depends on the router implementation but the general rule of thumb
 is that primary servers will be used before secondary servers.
 
-Readconnroute will always use primary servers before secondary servers as long\
+Readconnroute will always use primary servers before secondary servers as long
 as they match the configured server type.
 
-Readwritesplit will pick servers that have the same rank as the current\
-primary. Read the [readwritesplit documentation on server ranks](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md)\
+Readwritesplit will pick servers that have the same rank as the current
+primary. Read the [readwritesplit documentation on server ranks](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md)
 for a detailed description of the behavior.
 
-The following example server configuration demonstrates how `rank` can be used\
+The following example server configuration demonstrates how `rank` can be used
 to exclude `DR-site` servers from routing.
 
 ```
@@ -3331,7 +3331,7 @@ address=192.168.0.22
 rank=secondary
 ```
 
-The `main-site-primary` and `main-site-replica` servers will be used as long as\
+The `main-site-primary` and `main-site-replica` servers will be used as long as
 they are available. When they are no longer available, the `DR-site-primary` and`DR-site-replica` will be used.
 
 #### `priority`
@@ -3341,11 +3341,11 @@ they are available. When they are no longer available, the `DR-site-primary` and
 * Dynamic: Yes
 * Default: 0
 
-Server priority. Currently only used by galeramon to choose the order in which\
-nodes are selected as the current primary server. Refer to the [Server Priorities](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-galera-monitor.md)\
+Server priority. Currently only used by galeramon to choose the order in which
+nodes are selected as the current primary server. Refer to the [Server Priorities](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-galera-monitor.md)
 section of the galeramon documentation for more information on how to use it.
 
-Starting with MaxScale 2.5.21, this parameter also accepts negative values. In\
+Starting with MaxScale 2.5.21, this parameter also accepts negative values. In
 older versions, the parameter only accepted non-negative values.
 
 #### `replication_custom_options`
@@ -3355,33 +3355,33 @@ older versions, the parameter only accepted non-negative values.
 * Dynamic: Yes
 
 Server-specific custom string added to "CHANGE MASTER TO"-commands sent by\
-MariaDB Monitor. Overrides `replication_custom_options` setting set in\
-the monitor. This setting affects the server where the command is ran at, not\
-the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-\
-command to server A telling it to replicate from server B, the setting value\
+MariaDB Monitor. Overrides `replication_custom_options` setting set in
+the monitor. This setting affects the server where the command is ran at, not
+the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-
+command to server A telling it to replicate from server B, the setting value
 from MaxScale configuration for server A would be used.
 
-See [MariaDB Monitor documentation](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md)\
+See [MariaDB Monitor documentation](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md)
 for more information.
 
 ### Monitor
 
-Monitor sections are used to define the monitoring module that watches a set of\
+Monitor sections are used to define the monitoring module that watches a set of
 servers. Each server can only be monitored by one monitor.
 
 Common monitor parameters [can be found here](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md).
 
 ### Listener
 
-A listener defines a port MaxScale listens on for incoming connections. Accepted\
-connections are linked with a MaxScale service. Multiple listeners can feed the\
-same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface\
+A listener defines a port MaxScale listens on for incoming connections. Accepted
+connections are linked with a MaxScale service. Multiple listeners can feed the
+same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface
 only. _socket_ is also optional and is used for Unix socket connections.
 
-The network socket where the listener listens may have a backlog of\
+The network socket where the listener listens may have a backlog of
 connections. The size of this backlog is controlled by the\_net.ipv4.tcp\_max\_syn\_backlog\_ and _net.core.somaxconn_ kernel parameters.
 
-Increasing the size of the backlog by modifying the kernel parameters helps with\
+Increasing the size of the backlog by modifying the kernel parameters helps with
 sudden connection spikes and rejected connections. For more information see [listen(2)](https://man7.org/linux/man-pages/man2/listen.2.html).
 
 ```
@@ -3397,7 +3397,7 @@ port=3006
 * Mandatory: Yes
 * Dynamic: No
 
-The service to which the listener is associated. This is the name of a service\
+The service to which the listener is associated. This is the name of a service
 that is defined elsewhere in the configuration file.
 
 #### `protocol`
@@ -3410,11 +3410,11 @@ that is defined elsewhere in the configuration file.
 The name of the protocol module used for communication between the client and\
 MaxScale. The same protocol is also used for backend communication.
 
-Usually this does not need to be defined as the default protocol is the MariaDB\
+Usually this does not need to be defined as the default protocol is the MariaDB
 network protocol that is used by SQL connections.
 
-For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL\
-protocol, refer to the [NoSQL Protocol](../maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md) module\
+For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL
+protocol, refer to the [NoSQL Protocol](../maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md) module
 documentation.
 
 #### `address`
@@ -3424,8 +3424,8 @@ documentation.
 * Dynamic: No
 * Default: `"::"`
 
-This sets the address the listening socket is bound to. The address may be\
-specified as an IP address in 'dot notation' or as a hostname. If left undefined\
+This sets the address the listening socket is bound to. The address may be
+specified as an IP address in 'dot notation' or as a hostname. If left undefined
 the listener will bind to all network interfaces.
 
 #### `port`
@@ -3435,7 +3435,7 @@ the listener will bind to all network interfaces.
 * Dynamic: No
 * Default: `0`
 
-The port the listener listens on. If left undefined a default port for the\
+The port the listener listens on. If left undefined a default port for the
 protocol is used.
 
 #### `socket`
@@ -3445,10 +3445,10 @@ protocol is used.
 * Dynamic: No
 * Default: `""`
 
-If defined, the listener uses Unix domain sockets to listen for incoming\
+If defined, the listener uses Unix domain sockets to listen for incoming
 connections. The parameter value is the name of the socket to use.
 
-If you want to use both network ports and UNIX domain sockets with a service,\
+If you want to use both network ports and UNIX domain sockets with a service,
 define two separate listeners that connect to the same service.
 
 #### `authenticator`
@@ -3458,9 +3458,9 @@ define two separate listeners that connect to the same service.
 * Dynamic: No
 * Default: `""`
 
-The authenticator module to use. Each protocol module defines a default\
+The authenticator module to use. Each protocol module defines a default
 authentication module, which is used if the setting is left undefined.\
-MariaDB and PostgreSQL protocols support multiple authenticators and they can\
+MariaDB and PostgreSQL protocols support multiple authenticators and they can
 be used simultaneously by giving a comma-separated list e.g.`authenticator=PAMAuth,mariadbauth,gssapiauth`
 
 #### `authenticator_options`
@@ -3470,8 +3470,8 @@ be used simultaneously by giving a comma-separated list e.g.`authenticator=PAMAu
 * Dynamic: No
 * Default: `""`
 
-This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of\
-this parameter should be a comma-separated list of key-value pairs. See\
+This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of
+this parameter should be a comma-separated list of key-value pairs. See
 authenticator specific documentation for more details.
 
 #### `sql_mode`
@@ -3487,33 +3487,33 @@ If both are used this setting will override the global setting for this listener
 
 #### `proxy_protocol_networks`
 
-Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-when connecting. The proxy header contains the original client IP-address and\
+Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+when connecting. The proxy header contains the original client IP-address and
 port, and MaxScale will use that information in its internal bookkeeping.\
-This means the client is authenticated as if it was connecting from the host\
-in the proxy header. If proxy protocol is also enabled in MaxScale server\
-settings, MaxScale will relay the original client address and port to\
+This means the client is authenticated as if it was connecting from the host
+in the proxy header. If proxy protocol is also enabled in MaxScale server
+settings, MaxScale will relay the original client address and port to
 the server. See [server settings](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#proxy_protocol) for more information.
 
-This setting may be useful if a compatible load balancer is relaying client\
-connections to MaxScale. If proxy headers are used, both MaxScale and the\
+This setting may be useful if a compatible load balancer is relaying client
+connections to MaxScale. If proxy headers are used, both MaxScale and the
 backends will know where the client originally came from.
 
-The `proxy_protocol_networks`-setting works similarly to the equivalent setting\
+The `proxy_protocol_networks`-setting works similarly to the equivalent setting
 in [MariaDB Server](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/server-client-software/client-libraries/proxy-protocol-support).\
 The value can be a single IP or subnetwork, or a comma-separated list of them.\
-Subnetworks are given in CIDR-format, e.g. "192.168.0.0/16". "\*" is a valid\
-value, allowing anyone to send the header. "localhost" allows proxy headers\
+Subnetworks are given in CIDR-format, e.g. "192.168.0.0/16". "\*" is a valid
+value, allowing anyone to send the header. "localhost" allows proxy headers
 from domain socket connections.
 
-Only trusted IPs should be added to the list, as the proxy header may affect\
+Only trusted IPs should be added to the list, as the proxy header may affect
 authentication results.
 
 ```
 proxy_protocol_networks=192.168.0.1,198.168.0.0/16
 ```
 
-Similar to MariaDB Server, MaxScale will also accept normal connections even\
+Similar to MariaDB Server, MaxScale will also accept normal connections even
 if `proxy_protocol_networks` is configured for the listener.
 
 #### `connection_init_sql_file`
@@ -3523,10 +3523,10 @@ if `proxy_protocol_networks` is configured for the listener.
 * Dynamic: Yes
 * Default: `""`
 
-Path to a text file with sql queries. Any sessions created from the listener\
-will send the contents of the file to backends after authentication. Each\
-non-empty line in the file is interpreted as a query. Each query must succeed\
-for the backend connection to be usable for client queries. The queries should\
+Path to a text file with sql queries. Any sessions created from the listener
+will send the contents of the file to backends after authentication. Each
+non-empty line in the file is interpreted as a query. Each query must succeed
+for the backend connection to be usable for client queries. The queries should
 not return any data.
 
 ```
@@ -3547,28 +3547,28 @@ set @myvar2 = 4;
 * Dynamic: Yes
 * Default: `""`
 
-Path to a json-text file with user and group mapping, as well as server\
-credentials. Only affects MariaDB-protocol based listeners. Default value is\
+Path to a json-text file with user and group mapping, as well as server
+credentials. Only affects MariaDB-protocol based listeners. Default value is
 empty, which disables the feature.
 
 ```
 user_mapping_file=/home/root/mapping.json
 ```
 
-Should not be used together with [PAM Authenticator](../maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-pam-authenticator.md)\
-settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite\
-the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on\
+Should not be used together with [PAM Authenticator](../maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-pam-authenticator.md)
+settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite
+the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on
 backends and map them to backend users.
 
 This file functions very similar to [PAM-based mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
-Both user-to-user and group-to-user mappings can be defined. Also, the password\
-and authentication plugin for the mapped users can be added. The file is only\
-read during listener creation (typically MaxScale start) or when a listener is\
-modified during runtime. When a client logs into MaxScale, their username is\
+Both user-to-user and group-to-user mappings can be defined. Also, the password
+and authentication plugin for the mapped users can be added. The file is only
+read during listener creation (typically MaxScale start) or when a listener is
+modified during runtime. When a client logs into MaxScale, their username is
 searched from the mapping data. If the name matches either a name mapping or a\
-Linux group mapping, the username is replaced by the mapped name. The mapped\
-name is then used when logging into backends. If the file also contains\
-credentials for the mapped user, then those are used. Otherwise, MaxScale tries\
+Linux group mapping, the username is replaced by the mapped name. The mapped
+name is then used when logging into backends. If the file also contains
+credentials for the mapped user, then those are used. Otherwise, MaxScale tries
 to log in with an empty password and default MariaDB authentication.
 
 Three arrays are read from the file: _user\_map_, _group\_map_ and\_server\_credentials\_, none of which are mandatory.
@@ -3583,25 +3583,25 @@ Each array element in the _group\_map_-array must define the following fields:
 * original\_group: String. Incoming client Linux group.
 * mapped\_user: String. Username the client is mapped to.
 
-Each array element in the _server\_credentials_-array can define the following\
+Each array element in the _server\_credentials_-array can define the following
 fields:
 
 * mapped\_user: String. The mapped username this password is for.
-* password: String. Backend server password. Can be encrypted with\
+* password: String. Backend server password. Can be encrypted with
   maxpasswd.
-* plugin: String, optional. Authentication plugin to use. Must be enabled on\
-  the listener. Defaults to empty, which results in standard MariaDB\
+* plugin: String, optional. Authentication plugin to use. Must be enabled on
+  the listener. Defaults to empty, which results in standard MariaDB
   authentication.
 
-When a client successfully logs into MaxScale, MaxScale first searches for\
-name-based mapping. The incoming client does not need to be a Linux user for\
-name-based mapping to take place. If the name is not found, MaxScale checks if\
-the client is a Linux user with a group membership matching an element in the\
-group mapping array. If the client is a member of more than 100 groups, this\
+When a client successfully logs into MaxScale, MaxScale first searches for
+name-based mapping. The incoming client does not need to be a Linux user for
+name-based mapping to take place. If the name is not found, MaxScale checks if
+the client is a Linux user with a group membership matching an element in the
+group mapping array. If the client is a member of more than 100 groups, this
 check may fail.
 
-If a mapping is found, MaxScale searches the credentials array for a matching\
-username, and uses the password and plugin listed. The plugin need not be the\
+If a mapping is found, MaxScale searches the credentials array for a matching
+username, and uses the password and plugin listed. The plugin need not be the
 same as the one the original user used. Currently, "mysql\_native\_password" and\
 "pam" are supported as mapped plugins.
 
@@ -3647,35 +3647,35 @@ An example mapping file is below.
 * Dynamic: Yes
 * Mandatory: No
 
-Metadata that's sent to all connecting clients. The value must be a\
-comma-separated list of key-value arguments. The keys or values cannot contain\
+Metadata that's sent to all connecting clients. The value must be a
+comma-separated list of key-value arguments. The keys or values cannot contain
 commas in them.
 
-Any values that are set to `auto` will be substituted with the value of the\
-corresponding MariaDB system variable. Any system variables that do not\
-exist or have empty or null values will not be sent to the client. The system\
-variable values are read from the first `Master` server that's reachable from\
-the listener's service. If no `Master` server is reachable, the value is read\
-from the first `Slave` server and if no `Slave` servers are available, from the\
-first `Running` server. If no running servers are available, the system\
+Any values that are set to `auto` will be substituted with the value of the
+corresponding MariaDB system variable. Any system variables that do not
+exist or have empty or null values will not be sent to the client. The system
+variable values are read from the first `Master` server that's reachable from
+the listener's service. If no `Master` server is reachable, the value is read
+from the first `Slave` server and if no `Slave` servers are available, from the
+first `Running` server. If no running servers are available, the system
 variables are not sent.
 
-The exception to this is the `maxscale=auto` value where the `auto` will be\
-replaced with the MaxScale version string. This is useful for detecting whether\
-a client is connected to MaxScale. To make MaxScale completely transparent to\
+The exception to this is the `maxscale=auto` value where the `auto` will be
+replaced with the MaxScale version string. This is useful for detecting whether
+a client is connected to MaxScale. To make MaxScale completely transparent to
 the client application, the `maxscale=auto` value can be removed from`connection_metadata`.
 
-MaxScale will always send a metadata value for `threads_connected` that contains\
-the current number of connections to the service that the listener points to and\
-for `connection_id` that contains the 64-bit connection ID value. The values can\
+MaxScale will always send a metadata value for `threads_connected` that contains
+the current number of connections to the service that the listener points to and
+for `connection_id` that contains the 64-bit connection ID value. The values can
 be overridden by defining them with some value, for example,`connection_metadata=threads_connected=0,connection_id=0`.
 
-The metadata is implemented using [the session state information](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/4-server-response-packets/ok_packet#session-state-info)\
-that is embedded in the OK packets that are generated by MaxScale. The values\
-are encoded as system variables changes. This information can be accessed by all\
-connectors that support reading the session state information. One example of\
-this is the MariaDB Connector/C that implements it with the [mysql\_session\_track\_get\_first](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_first)\
-and [mysql\_session\_track\_get\_next](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_next)\
+The metadata is implemented using [the session state information](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/4-server-response-packets/ok_packet#session-state-info)
+that is embedded in the OK packets that are generated by MaxScale. The values
+are encoded as system variables changes. This information can be accessed by all
+connectors that support reading the session state information. One example of
+this is the MariaDB Connector/C that implements it with the [mysql\_session\_track\_get\_first](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_first)
+and [mysql\_session\_track\_get\_next](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_next)
 functions.
 
 The following example demonstrates the use of `connection_metadata`:
@@ -3684,20 +3684,20 @@ The following example demonstrates the use of `connection_metadata`:
 connection_metadata=redirect_url=localhost:3306,service_name=my-service,max_allowed_packet=auto
 ```
 
-The configuration has three variables, `redirect_url`, `service_name` and`max_allowed_packet` that have the values `localhost:3306`, `my-service` and`auto`. The `auto` value is special and gets replaced with the`max_allowed_packet` value from the MariaDB server. This means that the final\
+The configuration has three variables, `redirect_url`, `service_name` and`max_allowed_packet` that have the values `localhost:3306`, `my-service` and`auto`. The `auto` value is special and gets replaced with the`max_allowed_packet` value from the MariaDB server. This means that the final
 metadata that is sent to the client would be `redirect_url=localhost:3306`,`service_name=my-service` and `max_allowed_packet=16777216`.
 
 #### Version-specific Behavior
 
-If the `connection_metadata` variable list contains the `tx_isolation` variable\
+If the `connection_metadata` variable list contains the `tx_isolation` variable
 and the backend MariaDB server from which the variable is retrieved is MariaDB\
-11 or newer, the value is renamed to `transaction_isolation`. The `tx_isolation`\
+11 or newer, the value is renamed to `transaction_isolation`. The `tx_isolation`
 parameter was deprecated in favor of `transaction_isolation` in MariaDB 11\
 (MDEV-21921).
 
 ### Include
 
-An _include_ section defined common parameters used in other configuration\
+An _include_ section defined common parameters used in other configuration
 sections. Consider the following configuration.
 
 ```
@@ -3725,7 +3725,7 @@ servers=Server3, Server4
 ```
 
 The two monitor sections are identical except for the `servers` setting.\
-If they otherwise should remain identical, a change must be made in two\
+If they otherwise should remain identical, a change must be made in two
 places. With an `include` section the situation can be simplified.
 
 ```
@@ -3750,20 +3750,20 @@ type=monitor
 servers=Server3, Server3
 ```
 
-With an `include` section, all common settings can be defined in one\
+With an `include` section, all common settings can be defined in one
 place, and then included to any number of other sections using the`@include` parameter.
 
-The `@include` parameter takes a list of section names, so the settings\
+The `@include` parameter takes a list of section names, so the settings
 can be distributed across several `include` sections.
 
 ```
 @include=Some-Common-Attributes, Other-Common-Attributes
 ```
 
-It is permissible to specify in the _including_ section, parameters\
-that have already been specified in the _included_ section and they\
-will take precedence. For instance, if `Monitor2` in the example\
-above should have a longer backend connect timeout it can be\
+It is permissible to specify in the _including_ section, parameters
+that have already been specified in the _included_ section and they
+will take precedence. For instance, if `Monitor2` in the example
+above should have a longer backend connect timeout it can be
 specified as follows.
 
 ```
@@ -3774,9 +3774,9 @@ servers=Server3, Server3
 backend_connect_timeout = 5s
 ```
 
-Note that an included section **must** be an `include` section and\
-that an `include` section **cannot** include another `include`\
-section. For instance, both of the following sections would cause\
+Note that an included section **must** be an `include` section and
+that an `include` section **cannot** include another `include`
+section. For instance, both of the following sections would cause
 an error at startup.
 
 ```
@@ -3791,22 +3791,22 @@ type=monitor
 ...
 ```
 
-Note also that if an included parameter is changed using `maxctrl`,\
-it will be changed _only_ on the actual object the change is applied\
-on, not on the `include` section where the parameter is originally\
+Note also that if an included parameter is changed using `maxctrl`,
+it will be changed _only_ on the actual object the change is applied
+on, not on the `include` section where the parameter is originally
 specified.
 
 ## Available Protocols
 
-Protocol modules in MaxScale define what kind of clients can connect to a\
-listener and what type of backend servers are supported. Protocol is defined in\
-listener settings, and affects both the listener and any services the listener\
+Protocol modules in MaxScale define what kind of clients can connect to a
+listener and what type of backend servers are supported. Protocol is defined in
+listener settings, and affects both the listener and any services the listener
 is linked to.
 
 ### `MariaDB` or `MariaDBClient`
 
-Implements MariaDB protocol. The listener will accept MariaDB/MySQL connections\
-from clients and route the client queries through a linked MaxScale service\
+Implements MariaDB protocol. The listener will accept MariaDB/MySQL connections
+from clients and route the client queries through a linked MaxScale service
 to backend servers. The backends used by the service should be\
 MariaDB servers or compatible.
 
@@ -3817,55 +3817,55 @@ See [Change Data Capture Protocol](../maxscale-24-02protocols/mariadb-maxscale-2
 ### `Postgresql` or `Postgresprotocol`
 
 Implements [Postgresql protocol](https://www.postgresql.org/docs/current/protocol.html).\
-The listener will accept Postgresql connections from clients and route the\
-client queries through a linked MaxScale service to backend servers. The\
+The listener will accept Postgresql connections from clients and route the
+client queries through a linked MaxScale service to backend servers. The
 backends used by the service should be PostgreSQL servers or compatible.
 
 ### `nosqlprotocol`
 
 Accepts MongoDB® connections, yet stores and fetches results to/from\
-MariaDB servers. See [NoSQL documentation](../maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md)\
+MariaDB servers. See [NoSQL documentation](../maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md)
 for more information.
 
 ## TLS/SSL encryption
 
-This section describes configuration parameters for both servers and listeners\
-that control the TLS/SSL encryption method and the various certificate files\
+This section describes configuration parameters for both servers and listeners
+that control the TLS/SSL encryption method and the various certificate files
 involved in it.
 
 To enable TLS/SSL for a listener, you must set the `ssl` parameter to`true` and provide at least the `ssl_cert` and `ssl_key` parameters.
 
-To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification\
+To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification
 enabled, the `ssl_cert` and `ssl_key` parameters must also be defined.
 
-Custom CA certificates can be defined with the `ssl_ca` parameter. If`ssl_verify_peer_certificate` is enabled yet `ssl_ca` is not set, MaxScale\
+Custom CA certificates can be defined with the `ssl_ca` parameter. If`ssl_verify_peer_certificate` is enabled yet `ssl_ca` is not set, MaxScale
 will load CA certificates from the system default location.
 
-After this, MaxScale connections between the server and/or the client will be\
-encrypted. Note that the database must also be configured to use TLS/SSL\
+After this, MaxScale connections between the server and/or the client will be
+encrypted. Note that the database must also be configured to use TLS/SSL
 connections if backend connection encryption is used.
 
-**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on\
+**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on
 the same port.
 
-If TLS encryption is enabled for a listener, any unencrypted connections to it\
-will be rejected. MaxScale does this to improve security by preventing\
+If TLS encryption is enabled for a listener, any unencrypted connections to it
+will be rejected. MaxScale does this to improve security by preventing
 accidental creation of unencrypted connections.
 
 The separation of secure and insecure connections differs from the MariaDB\
 Server which allows both secure and insecure connections on the same port. As\
-MaxScale is the gateway through which all connections go, MaxScale enforces\
-a stricter security policy than MariaDB Server. Multiple listeners with\
+MaxScale is the gateway through which all connections go, MaxScale enforces
+a stricter security policy than MariaDB Server. Multiple listeners with
 different configurations can be created to enable different encryption schemes.
 
-TLS encryption must be enabled for listeners when they are created. For servers,\
+TLS encryption must be enabled for listeners when they are created. For servers,
 the TLS can be enabled after creation but it cannot be disabled or altered.
 
 Starting with MaxScale 2.5.20, if the TLS certificate given to MaxScale has the\
-X509v3 extended key usage information, MaxScale will check it and refuse to use\
-a certificate with the wrong usage. This means that a certificate with only\
-clientAuth can only be used with servers and a certificate with only serverAuth\
-can only be used with listeners. In order to use the same certificate for both\
+X509v3 extended key usage information, MaxScale will check it and refuse to use
+a certificate with the wrong usage. This means that a certificate with only
+clientAuth can only be used with servers and a certificate with only serverAuth
+can only be used with listeners. In order to use the same certificate for both
 listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 #### `ssl`
@@ -3877,12 +3877,12 @@ listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 This enables SSL connections when set to true. The legacy values `required` and`disabled` were removed in MaxScale 6.0.
 
-If enabled, the certificate files mentioned above must also be\
+If enabled, the certificate files mentioned above must also be
 supplied. MaxScale connections to will then be encrypted with TLS/SSL.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require\
-ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created\
+24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require
+ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created
 with `REQUIRE SSL` or `REQUIRE X509`.
 
 #### `ssl_key`
@@ -3892,8 +3892,8 @@ with `REQUIRE SSL` or `REQUIRE X509`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client private key MaxScale should use. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client private key MaxScale should use. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_cert`
@@ -3903,9 +3903,9 @@ parameter for listeners but an optional parameter for servers.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client certificate MaxScale should use with the server. The\
-certificate must match the key defined in `ssl_key`. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client certificate MaxScale should use with the server. The
+certificate must match the key defined in `ssl_key`. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_ca_cert`
@@ -3919,12 +3919,12 @@ Deprecated since MariaDB MaxScale 22.08. See `ssl_ca`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be a Certificate Authority (CA) certificate. It will be used to verify\
+A string giving a file path that identifies an existing readable file. The file
+must be a Certificate Authority (CA) certificate. It will be used to verify
 that the peer certificate (sent by either client or a MariaDB Server) is valid.\
 The CA certificate can consist of a certificate chain.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,
 which is still accepted as an alias for `ssl_ca`.
 
 #### `ssl_version`
@@ -3943,7 +3943,7 @@ This parameter controls the allowed TLS version. Accepted values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -3955,18 +3955,18 @@ The default setting (MAX) allows all supported versions. MaxScale supports\
 TLSv1.0, TLSv1.1, TLSv1.2 and TLSv1.3 depending on the OpenSSL library version.\
 TLSv1.0 and TLSv1.1 are considered deprecated and should not be used, so setting`ssl_version=TLSv1.2,TLSv1.3` or `ssl_version=TLSv1.3` is recommended.
 
-In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this\
-setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would\
+In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this
+setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would
 only enable TLSv12. The interpretation changed in MaxScale versions 6.4.14,\
-22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while\
-allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`\
+22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while
+allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`
 enabled both TLSv1.2 and TLSv1.3.
 
 The interpretation changed again in MaxScale versions 6.4.16, 22.08.13,\
-23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an\
-enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior\
-from the previous releases where the newer versions were automatically enabled,\
-the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)\
+23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an
+enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior
+from the previous releases where the newer versions were automatically enabled,
+the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)
 parameter works.
 
 #### `ssl_cipher`
@@ -3976,8 +3976,8 @@ parameter works.
 * Dynamic: Yes
 * Default: `""`
 
-Set the list of TLS ciphers. By default, no explicit ciphers are defined and the\
-system defaults are used. Note that this parameter does not modify TLSv1.3\
+Set the list of TLS ciphers. By default, no explicit ciphers are defined and the
+system defaults are used. Note that this parameter does not modify TLSv1.3
 ciphers.
 
 #### `ssl_cert_verify_depth`
@@ -3987,8 +3987,8 @@ ciphers.
 * Dynamic: Yes
 * Default: `9`
 
-The maximum length of the certificate authority chain that will be accepted. The\
-default value is 9, same as the OpenSSL default. The configured value must be\
+The maximum length of the certificate authority chain that will be accepted. The
+default value is 9, same as the OpenSSL default. The configured value must be
 larger than 0.
 
 #### `ssl_verify_peer_certificate`
@@ -3998,11 +3998,11 @@ larger than 0.
 * Dynamic: Yes
 * Default: `false`
 
-Peer certificate verification. This functionality is disabled by default. In\
+Peer certificate verification. This functionality is disabled by default. In
 versions prior to 2.3.17 the feature was enabled by default.
 
-When this feature is enabled, the peer (client or MariaDB Server) must send a\
-certificate. The certificate sent by the peer is verified against the\
+When this feature is enabled, the peer (client or MariaDB Server) must send a
+certificate. The certificate sent by the peer is verified against the
 configured Certificate Authority to ensure the peer is who they claim to be.\
 For listeners, this behaves as if `REQUIRE X509` was defined for all users.
 
@@ -4016,8 +4016,8 @@ For listeners, this behaves as if `REQUIRE X509` was defined for all users.
 Peer host verification.
 
 When this feature is enabled, the peer (client or MariaDB Server) hostname or\
-IP is verified against the certificate sent by the peer. If the IP address or\
-the hostname does not match the one in the certificate, the connection is\
+IP is verified against the certificate sent by the peer. If the IP address or
+the hostname does not match the one in the certificate, the connection is
 closed.
 
 If the peer does not provide a certificate, host verification is skipped.\
@@ -4038,8 +4038,8 @@ behaves like the `--ssl-verify-server-cert` command line option for the`mysql` c
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be a Certificate Revocation List in the PEM format that defines the revoked\
+A string giving a file path that identifies an existing readable file. The file
+must be a Certificate Revocation List in the PEM format that defines the revoked
 certificates. This parameter is only accepted by listeners.
 
 **Example SSL enabled server configuration**
@@ -4055,7 +4055,7 @@ ssl_key=/usr/local/mariadb/maxscale/ssl/key.max-client.pem
 ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
-This example configuration requires all connections to this server to be\
+This example configuration requires all connections to this server to be
 encrypted with SSL. The paths to the certificate files and the Certificate\
 Authority file are also provided.
 
@@ -4073,18 +4073,18 @@ ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
 This example configuration requires all connections to be encrypted with\
-SSL. The paths to the certificate files and the Certificate Authority file are\
+SSL. The paths to the certificate files and the Certificate Authority file are
 also provided.
 
 ## Module Types
 
 ### Routing Modules
 
-The main task of MariaDB MaxScale is to accept database connections from client\
-applications and route the connections or the statements sent over those\
+The main task of MariaDB MaxScale is to accept database connections from client
+applications and route the connections or the statements sent over those
 connections to the various services supported by MariaDB MaxScale.
 
-Currently a number of routing modules are available, these are designed for a\
+Currently a number of routing modules are available, these are designed for a
 range of different needs.
 
 Connection based load balancing:
@@ -4105,18 +4105,18 @@ Binary log server:
 
 ### Monitor Modules
 
-Monitor modules are used by MariaDB MaxScale to internally monitor the state of\
-the backend databases in order to set the server flags for each of those\
-servers. The router modules then use these flags to determine if the particular\
-server is a suitable destination for routing connections for particular query\
+Monitor modules are used by MariaDB MaxScale to internally monitor the state of
+the backend databases in order to set the server flags for each of those
+servers. The router modules then use these flags to determine if the particular
+server is a suitable destination for routing connections for particular query
 classifications. The monitors are run within separate threads of MariaDB\
 MaxScale and do not affect MariaDB MaxScale's routing performance.
 
 * [MariaDB Monitor](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md)
 * [Galera Monitor](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-galera-monitor.md)
 
-The use of monitors in MaxScale is not absolutely mandatory: it is possible to\
-run MariaDB MaxScale without a monitor module. In this case an external\
+The use of monitors in MaxScale is not absolutely mandatory: it is possible to
+run MariaDB MaxScale without a monitor module. In this case an external
 monitoring system must the status of each server via MaxCtrl or the REST\
 API. **Only do this if you know what you are doing.**
 
@@ -4150,10 +4150,10 @@ flowchart LR
 _A client's query passes through the router session's QLA and Regex filters on its way to the backend server, with QLA also logging the query._
 
 Filters provide a means to manipulate or process requests as they pass through\
-MariaDB MaxScale between the client side protocol and the query router. A full\
+MariaDB MaxScale between the client side protocol and the query router. A full
 explanation of each filter's functionality can be found in its documentation.
 
-The [Filter Tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-filters.md) document shows how you\
+The [Filter Tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-filters.md) document shows how you
 can add a filter to a service and combine multiple filters in one service.
 
 * [Query Log All (QLA) Filter](../maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-query-log-all-filter.md)
@@ -4166,8 +4166,8 @@ can add a filter to a service and combine multiple filters in one service.
 
 Passwords stored in the maxscale.cnf file may optionally be encrypted for added security.\
 This is done by creation of an encryption key on installation of MariaDB MaxScale.\
-Encryption keys may be created manually by executing the maxkeys utility with the argument\
-of the filename to store the key. The default location MariaDB MaxScale stores\
+Encryption keys may be created manually by executing the maxkeys utility with the argument
+of the filename to store the key. The default location MariaDB MaxScale stores
 the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES CBC encryption.
 
 ```
@@ -4175,16 +4175,16 @@ the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES C
 maxkeys /var/lib/maxscale/
 ```
 
-Changing the encryption key for MariaDB MaxScale will invalidate any currently\
+Changing the encryption key for MariaDB MaxScale will invalidate any currently
 encrypted keys stored in the maxscale.cnf file.
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
 ### Creating Encrypted Passwords
 
-Encrypted passwords are created by executing the maxpasswd command with the location\
+Encrypted passwords are created by executing the maxpasswd command with the location
 of the .secrets file and the password you require to encrypt as an argument.
 
 ```
@@ -4193,9 +4193,9 @@ maxpasswd /var/lib/maxscale/ MaxScalePw001
 61DD955512C39A4A8BC4BB1E5F116705
 ```
 
-The output of the maxpasswd command is a hexadecimal string, this should be inserted\
+The output of the maxpasswd command is a hexadecimal string, this should be inserted
 into the maxscale.cnf file in place of the ordinary, plain text, password.\
-MariaDB MaxScale will determine this as an encrypted password and automatically decrypt\
+MariaDB MaxScale will determine this as an encrypted password and automatically decrypt
 it before sending it the database server.
 
 ```
@@ -4209,7 +4209,7 @@ password=61DD955512C39A4A8BC4BB1E5F116705
 
 ## Runtime Configuration Changes
 
-Read the following documents for different methods of altering the MaxScale\
+Read the following documents for different methods of altering the MaxScale
 configuration at runtime.
 
 * MaxCtrl
@@ -4220,88 +4220,88 @@ configuration at runtime.
 * [alter](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-maxctrl.md)
 * [REST API](../maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md) documentation
 
-All changes to the configuration done via MaxCtrl are persisted as individual\
-configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these\
-files will override any configurations found in the main configuration file or\
+All changes to the configuration done via MaxCtrl are persisted as individual
+configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these
+files will override any configurations found in the main configuration file or
 any auxiliary configuration files.
 
-Refer to the [Dynamic Configuration](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more\
+Refer to the [Dynamic Configuration](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more
 details on how this mechanism works and how to disable it.
 
 ### Configuration Synchronization
 
-The configuration synchronization mechanism is intended for synchronizing\
-configuration changes done on one MaxScale to all other MaxScales. This is done\
+The configuration synchronization mechanism is intended for synchronizing
+configuration changes done on one MaxScale to all other MaxScales. This is done
 by propagating the changes via the database cluster used by Maxscale.
 
-When configuring configuration synchronization for the first time, the same\
-static configuration files should be used on all MaxScale instances that use the\
+When configuring configuration synchronization for the first time, the same
+static configuration files should be used on all MaxScale instances that use the
 same cluster: the value of `config_sync_cluster` must be the same on all\
-MaxScale instances and the cluster (i.e. the monitor) pointed by it and its\
+MaxScale instances and the cluster (i.e. the monitor) pointed by it and its
 servers must be the same in every configuration.
 
-Whenever the MaxScale configuration is modified at runtime, the latest\
-configuration is stored in the database cluster in the `mysql.maxscale_config`\
-table. The table is created when the first modification to the configuration is\
+Whenever the MaxScale configuration is modified at runtime, the latest
+configuration is stored in the database cluster in the `mysql.maxscale_config`
+table. The table is created when the first modification to the configuration is
 done. A local copy of the configuration is stored in the data directory to allow\
-MaxScale to function even if a connection to the cluster cannot be made. By\
+MaxScale to function even if a connection to the cluster cannot be made. By
 default this file is stored at `/var/lib/maxscale/maxscale-config.json`.
 
-Whenever MaxScale starts up, it checks if a local version of this configuration\
-exists. If it does and it is a valid cached configuration, the static\
-configuration file as well as any other generated configuration files are\
-ignored. The exception is the `[maxscale]` section of the main static\
+Whenever MaxScale starts up, it checks if a local version of this configuration
+exists. If it does and it is a valid cached configuration, the static
+configuration file as well as any other generated configuration files are
+ignored. The exception is the `[maxscale]` section of the main static
 configuration file which is always read.
 
-Each configuration has a version number with the initial configuration being\
-version 0. Each time the configuration is modified, the version number is\
-incremented. This version number is used to detect when MaxScale needs to update\
+Each configuration has a version number with the initial configuration being
+version 0. Each time the configuration is modified, the version number is
+incremented. This version number is used to detect when MaxScale needs to update
 its configuration.
 
 #### Error Handling in Configuration Synchronization
 
-When doing a configuration change on the local MaxScale, if the configuration\
-change completes on MaxScale but fails to be committed to the database, MaxScale\
+When doing a configuration change on the local MaxScale, if the configuration
+change completes on MaxScale but fails to be committed to the database, MaxScale
 will attempt to revert the local configuration change. If this attempt fails,\
 MaxScale will discard the cached configuration and abort the process.
 
-When synchronizing with the cluster, if MaxScale fails to apply a configuration\
-retrieved from the cluster, it attempts to revert the configuration to the\
-previous version. If successful, the failed configuration update is ignored. If\
-the configuration update that fails cannot be reverted, the MaxScale\
-configuration will be in an indeterminate state. When this happens, MaxScale\
+When synchronizing with the cluster, if MaxScale fails to apply a configuration
+retrieved from the cluster, it attempts to revert the configuration to the
+previous version. If successful, the failed configuration update is ignored. If
+the configuration update that fails cannot be reverted, the MaxScale
+configuration will be in an indeterminate state. When this happens, MaxScale
 will discard the cached configuration and abort the process.
 
-When loading a locally cached configuration during startup, if any errors are\
-found in the cached configuration, it is discarded and the MaxScale process will\
-attempt to restart by exiting with code 75 from the main process. If MaxScale is\
+When loading a locally cached configuration during startup, if any errors are
+found in the cached configuration, it is discarded and the MaxScale process will
+attempt to restart by exiting with code 75 from the main process. If MaxScale is
 being used as a SystemD service, this will automatically trigger a restart of\
 MaxScale and no further actions are needed.
 
-The most common reason for a failed configuration update is missing files. For\
-example, if a configuration update adds encrypted connections to a server and\
-the TLS certificates it uses were not copied over to all MaxScale nodes before\
-the change was done, the operation will fail on all nodes that do not have these\
+The most common reason for a failed configuration update is missing files. For
+example, if a configuration update adds encrypted connections to a server and
+the TLS certificates it uses were not copied over to all MaxScale nodes before
+the change was done, the operation will fail on all nodes that do not have these
 files.
 
-If the synchronization of the configuration change fails at the step when the\
-database transaction is being committed, the new configuration can be\
-momentarily visible to the local MaxScale. This means the changes are not\
-guaranteed to be atomic on the local MaxScale but are atomic from the cluster's\
+If the synchronization of the configuration change fails at the step when the
+database transaction is being committed, the new configuration can be
+momentarily visible to the local MaxScale. This means the changes are not
+guaranteed to be atomic on the local MaxScale but are atomic from the cluster's
 point of view.
 
 #### Synchronization of Encrypted Passwords
 
-Starting with MaxScale 6.4.9, any passwords that are transmitted by the\
-configuration synchronization are encrypted if password encryption has been\
-enabled in MaxScale. This means that all MaxScale nodes in the same\
-configuration cluster must be configured to use password encryption and they\
+Starting with MaxScale 6.4.9, any passwords that are transmitted by the
+configuration synchronization are encrypted if password encryption has been
+enabled in MaxScale. This means that all MaxScale nodes in the same
+configuration cluster must be configured to use password encryption and they
 need to all use the same encryption keys that were created with `maxkeys`.
 
 #### Managing Configuration Synchronization
 
-The output of `maxctrl show maxscale` contains the `Config Sync` field with\
-information about the current configuration state of the local Maxscale as well\
+The output of `maxctrl show maxscale` contains the `Config Sync` field with
+information about the current configuration state of the local Maxscale as well
 as the state of any other nodes using this cluster.
 
 ```
@@ -4319,17 +4319,17 @@ as the state of any other nodes using this cluster.
 ├──────────────┼─────────────────────────────────────────────────────────────┤
 ```
 
-The `version` field is the logical configuration version and the `origin` is the\
-node that originates the latest configuration change. The `checksum` field is\
+The `version` field is the logical configuration version and the `origin` is the
+node that originates the latest configuration change. The `checksum` field is
 the checksum of the logical configuration and can be used to compare whether two\
-Maxscale instances are in the same configuration state. The `nodes` field\
-contains the status of each MaxScale instance mapped to the hostname of the\
-server. This field is updated whenever MaxScale reads the configuration from the\
-cluster and can thus be used to detect which MaxScales have updated their\
+Maxscale instances are in the same configuration state. The `nodes` field
+contains the status of each MaxScale instance mapped to the hostname of the
+server. This field is updated whenever MaxScale reads the configuration from the
+cluster and can thus be used to detect which MaxScales have updated their
 configuration.
 
-The `mysql.maxscale_config` table where the configuration changes are stored\
-must not be modified manually. The only case when the table should be modified\
+The `mysql.maxscale_config` table where the configuration changes are stored
+must not be modified manually. The only case when the table should be modified
 is when resetting the configuration synchronization.
 
 To reset the configuration synchronization:
@@ -4339,71 +4339,71 @@ To reset the configuration synchronization:
 3. Drop the `mysql.maxscale_config` table
 4. Start all MaxScale instances
 
-To disable configuration synchronization, remove `config_sync_cluster` from the\
-configuration file or set it to an empty string: `config_sync_cluster=""`. This\
+To disable configuration synchronization, remove `config_sync_cluster` from the
+configuration file or set it to an empty string: `config_sync_cluster=""`. This
 can be done at runtime with MaxCtrl by passing an empty string to`config_sync_cluster`:
 
 ```
 maxctrl alter maxscale config_sync_cluster ""
 ```
 
-If MaxScale cannot create a connection to the database cluster, configuration\
-changes are not possible until communication with the database is possible. To\
-override this behavior and force the changes to be done, use the `--skip-sync`\
-option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any\
-updates done with `--skip-sync` will overwritten by changes coming from the\
+If MaxScale cannot create a connection to the database cluster, configuration
+changes are not possible until communication with the database is possible. To
+override this behavior and force the changes to be done, use the `--skip-sync`
+option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any
+updates done with `--skip-sync` will overwritten by changes coming from the
 cluster.
 
 #### Limitations in Configuration Synchronization
 
-Only the MaxScale configuration is synchronized. Any external files (TLS\
-certificates, configuration files for modules or data generated by MaxScale) are\
-not synchronized. For example, the rule files for the cache filter must be\
+Only the MaxScale configuration is synchronized. Any external files (TLS
+certificates, configuration files for modules or data generated by MaxScale) are
+not synchronized. For example, the rule files for the cache filter must be
 synchronized separately if the filter itself is modified.
 
-Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers\
-and modifications to the administrative users will be synchronized. In older\
-versions servers had to be put into maintenance mode and users had to be\
+Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers
+and modifications to the administrative users will be synchronized. In older
+versions servers had to be put into maintenance mode and users had to be
 modified separately on each MaxScale.
 
-* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not\
+* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not
   synchronized.
-* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`\
-  option will not export the cluster configuration and instead exports only the\
-  static configuration files. To start a new MaxScale based off of a clustered\
-  configuration, copy the static configuration files as well as the JSON\
-  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale\
+* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`
+  option will not export the cluster configuration and instead exports only the
+  static configuration files. To start a new MaxScale based off of a clustered
+  configuration, copy the static configuration files as well as the JSON
+  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale
   instance.
 
 ### Backing Up Configuration Changes
 
-The combination of configuration files can be done either manually\
-(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line\
+The combination of configuration files can be done either manually
+(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line
 option. See `maxscale --help` for more information about how to use the`--export-config` flag.
 
-For example, to export the current runtime configuration, run the following\
+For example, to export the current runtime configuration, run the following
 command.
 
 ```
 maxscale --export-config=/tmp/maxscale.cnf.combined
 ```
 
-This will create the `/tmp/maxscale.cnf.combined` file and write the current\
-configuration into the it. This allows new MaxScale instances to be easily set\
-up without requiring copying of all runtime configuration files. The user\
-executing the command must be able to read all MaxScale configuration files as\
+This will create the `/tmp/maxscale.cnf.combined` file and write the current
+configuration into the it. This allows new MaxScale instances to be easily set
+up without requiring copying of all runtime configuration files. The user
+executing the command must be able to read all MaxScale configuration files as
 well as create and write the provided filename.
 
 ## Encryption Key Managers
 
-The encryption key managers are how MaxScale retrieves symmetric encryption keys\
-from a key management system. Some parts of MaxScale require the `key_manager`\
-to be configured in order to work. The key manager that is used is selected with\
-the [key\_manager](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is\
+The encryption key managers are how MaxScale retrieves symmetric encryption keys
+from a key management system. Some parts of MaxScale require the `key_manager`
+to be configured in order to work. The key manager that is used is selected with
+the [key\_manager](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is
 configured by placing the parameters in the `[maxscale]` section.
 
-The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key\
-management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration\
+The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key
+management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration
 files.
 
 ### File-based Key Manager
@@ -4411,13 +4411,13 @@ files.
 The encryption keys are stored in a text file stored on a local filesystem.
 
 The file uses the same format as the MariaDB server [File Key Management\
-Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file\
-consisting of an encryption key ID number and the hex-encoded encryption key\
+Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file
+consisting of an encryption key ID number and the hex-encoded encryption key
 separated by a semicolon. Read [Creating the Key\
-File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)\
+File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)
 for more details on how to create the file.
 
-For example, to configure encryption for the `nosqlprotocol` shared credentials\
+For example, to configure encryption for the `nosqlprotocol` shared credentials
 using the file-based encryption key:
 
 1. Create the key file with `(echo -n '1;' ; openssl rand -hex 32) | cat > /var/lib/maxscale/encryption.key`
@@ -4454,9 +4454,9 @@ nosqlprotocol.authentication_password=my_password
 * Mandatory: Yes
 * Dynamic: Yes
 
-Path to the file that contains the encryption keys. The user MaxScale runs as\
-(almost always `maxscale`) must be able to read this file. Encryption keys are\
-read from disk only during startup or when any global MaxScale parameter is\
+Path to the file that contains the encryption keys. The user MaxScale runs as
+(almost always `maxscale`) must be able to read this file. Encryption keys are
+read from disk only during startup or when any global MaxScale parameter is
 modified at runtime.
 
 ### KMIP Key Manager
@@ -4468,7 +4468,7 @@ The KMIP key manager has been verified to work with the PyKMIP server.
 #### Limitations
 
 * Key versioning is not supported
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the KMIP server.
 
 #### Parameters
@@ -4515,17 +4515,17 @@ The CA certificate to use. By default the system default certificates are used.
 
 ### HashiCorp Vault Key Manager
 
-Encryption keys are read from a local or remote Vault server using the secret\
-engine included in the Vault. This key manager supports versioned keys. Only\
+Encryption keys are read from a local or remote Vault server using the secret
+engine included in the Vault. This key manager supports versioned keys. Only
 version 2 key-value stores are supported.
 
 The encryption keys use the same format as the MariaDB [HashiCorp Vault Key\
 Management Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/hashicorp-key-management-plugin):\
-The key-value secret for each encryption key ID must contain the field `data`\
-which must contain a hex-encoded string that is either 32, 48 or 64 characters\
+The key-value secret for each encryption key ID must contain the field `data`
+which must contain a hex-encoded string that is either 32, 48 or 64 characters
 long.
 
-An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit\
+An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit
 encryption key using `openssl` and stores it using the key ID `1`:
 
 ```
@@ -4545,7 +4545,7 @@ version            1
 
 #### Limitations
 
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the Vault server.
 
 #### Parameters
@@ -4556,7 +4556,7 @@ version            1
 * Mandatory: Yes
 * Dynamic: Yes
 
-The authentication token used to connect to the Vault server. This can be\
+The authentication token used to connect to the Vault server. This can be
 encrypted using `maxpasswd`, similar to how other passwords are encrypted.
 
 **`vault.host`**
@@ -4589,7 +4589,7 @@ The CA certificate to use. By default the system default certificates are used.
 * Default: true
 * Dynamic: Yes
 
-Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating\
+Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating
 with the Vault server.
 
 **`vault.mount`**
@@ -4598,7 +4598,7 @@ with the Vault server.
 * Default: `secret`
 * Dynamic: Yes
 
-The Key-Value mount where the secret is stored. By default the `secret` mount is\
+The Key-Value mount where the secret is stored. By default the `secret` mount is
 used which is present by default in most Vault installations.
 
 **`vault.timeout`**
@@ -4611,30 +4611,30 @@ The connection and request timeout used with the Vault server.
 
 ## Threads
 
-For routing, MaxScale uses asynchronous I/O and a fixed number of threads\
+For routing, MaxScale uses asynchronous I/O and a fixed number of threads
 (aka _routing workers_), whose number up until 23.02 was fixed at startup.\
-From 23.02 onwards the number of threads can be altered at runtime, which\
-is convenient, for instance, if MaxScale is running in a container whose\
+From 23.02 onwards the number of threads can be altered at runtime, which
+is convenient, for instance, if MaxScale is running in a container whose
 properties are changed during the lifetime of the container.
 
 A thread can be in three different states:
 
-* **Active**: The thread is routing client traffic and is listening\
+* **Active**: The thread is routing client traffic and is listening
   for new connections.
-* **Draining**: The thread is routing client traffic but is **not**\
+* **Draining**: The thread is routing client traffic but is **not**
   listening for new connections.
-* **Dormant**: The thread is not routing client traffic (all sessions\
-  have ended), and is not listening for new connections, and is waiting\
+* **Dormant**: The thread is not routing client traffic (all sessions
+  have ended), and is not listening for new connections, and is waiting
   to be terminated.
 
-All threads start as _Active_ and may become _Draining_ if the number of\
-threads is reduced. A draining thread will eventually become _Dormant_,\
+All threads start as _Active_ and may become _Draining_ if the number of
+threads is reduced. A draining thread will eventually become _Dormant_,
 unless the number of threads is increased while the thread is still _Draining_.
 
-Note that it is not possible to terminate a specific thread, but it is only\
-possible to specify the _number_ of threads that MaxScale should use, and\
-that the threads will be terminated from the end. This has implications\
-if the number of threads is reduced by more than 1, as a _Dormant_ thread\
+Note that it is not possible to terminate a specific thread, but it is only
+possible to specify the _number_ of threads that MaxScale should use, and
+that the threads will be terminated from the end. This has implications
+if the number of threads is reduced by more than 1, as a _Dormant_ thread
 will not be terminated before it is the last thread.
 
 In the following, MaxScale has been started with `threads=4`.
@@ -4663,8 +4663,8 @@ $ bin/maxctrl show threads
 ...
 ```
 
-we will see that the threads 2 and 3 are now _Draining_. The reason is\
-that threads 2 and 3 still handle client sessions. If some client sessions\
+we will see that the threads 2 and 3 are now _Draining_. The reason is
+that threads 2 and 3 still handle client sessions. If some client sessions
 now end, the situation may become like
 
 ```
@@ -4676,13 +4676,13 @@ now end, the situation may become like
 ...
 ```
 
-That is, thread 2 is _Dormant_ and thread 3 is _Draining_. All client sessions\
-that were handled by thread 2 have ended and the thread is ready to be\
-terminated. However, as thread 3 is still _Draining_, thread 2 will not be\
+That is, thread 2 is _Dormant_ and thread 3 is _Draining_. All client sessions
+that were handled by thread 2 have ended and the thread is ready to be
+terminated. However, as thread 3 is still _Draining_, thread 2 will not be
 terminated but stay _Dormant_.
 
-If the sessions handled by thread 3 end, then it will become _Dormant_ at\
-which point first thread 3 will be terminated and immediately after that\
+If the sessions handled by thread 3 end, then it will become _Dormant_ at
+which point first thread 3 will be terminated and immediately after that
 thread 2.
 
 ```
@@ -4707,7 +4707,7 @@ $ bin/maxctrl show threads
 ...
 ```
 
-that is, the number of threads was 4 but has been reduced to 2, and while\
+that is, the number of threads was 4 but has been reduced to 2, and while
 thread 2 has become drained it stays as _Dormant_ since thread 3 is still _Draining_, it is possible to make thread 2 _Active_ again by increasing the
 number of threads to 3.
 
@@ -4737,8 +4737,8 @@ $ bin/maxctrl show threads
 
 ## Error Reporting
 
-MariaDB MaxScale is designed to be executed as a service, therefore all error\
-reports, including configuration errors, are written to the MariaDB MaxScale\
+MariaDB MaxScale is designed to be executed as a service, therefore all error
+reports, including configuration errors, are written to the MariaDB MaxScale
 error log file. By default, MariaDB MaxScale will log to a file in`/var/log/maxscale` and the system log.
 
 ## Limitations
@@ -4747,31 +4747,31 @@ The current limitations of MaxScale are listed in the [Limitations](../maxscale-
 
 ## Performance Optimization
 
-* Tune `query_classifier_cache_size` to allow maximal use of the query\
-  classifier cache. Increase the value and/or system memory until the set of\
-  unique SQL patterns fits into memory. By default at most 15% of the system\
-  memory is used for this cache. To detect if the SQL statements fit into\
-  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to\
-  see how many evictions take place. If it keeps increasing, increase the size\
-  of the query classifier cache. Using the query classifier cache with a CPU\
-  bound workload gives a roughly 20% improvement in performance compared to when\
+* Tune `query_classifier_cache_size` to allow maximal use of the query
+  classifier cache. Increase the value and/or system memory until the set of
+  unique SQL patterns fits into memory. By default at most 15% of the system
+  memory is used for this cache. To detect if the SQL statements fit into
+  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to
+  see how many evictions take place. If it keeps increasing, increase the size
+  of the query classifier cache. Using the query classifier cache with a CPU
+  bound workload gives a roughly 20% improvement in performance compared to when
   it is turned off.
-* A faster CPU with more CPU cores is better. This is true for most applications\
+* A faster CPU with more CPU cores is better. This is true for most applications
   but especially for MaxScale as it is mostly limited by the speed of the\
   CPU. Using `threads=auto` is recommended (the default starting with MaxScale\
   6\).
-* Network throughput between the client, MaxScale and the database nodes governs\
-  how much traffic can be handled. The client-to-MaxScale network is likely to\
-  be saturated first: having multiple MaxScales in front of the cluster is an\
+* Network throughput between the client, MaxScale and the database nodes governs
+  how much traffic can be handled. The client-to-MaxScale network is likely to
+  be saturated first: having multiple MaxScales in front of the cluster is an
   easy way of solving this problem.
-* Certain MaxScale modules store data on disk. A faster disk improves their\
-  performance but depending on the module, this might not be a big enough of a\
-  problem to worry about. Filters like the `qlafilter` that write information to\
+* Certain MaxScale modules store data on disk. A faster disk improves their
+  performance but depending on the module, this might not be a big enough of a
+  problem to worry about. Filters like the `qlafilter` that write information to
   disk for every SQL query can cause performance bottlenecks.
 
 ### MaxScale Diagnostics using MaxCtrl
 
-From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with\
+From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with
 information about the system MaxScale is running on. The fields are:
 
 | Field                                   | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -4790,34 +4790,34 @@ In addition there is an `os` object that contains what the Linux command `uname`
 
 **`threads`**
 
-If `threads` has not been specified at all in the MaxScale configuration file,\
-or if its value is `auto`, then MaxScale will use as many routing threads as\
-there are physical cores on the machine. This is the right choice, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
+If `threads` has not been specified at all in the MaxScale configuration file,
+or if its value is `auto`, then MaxScale will use as many routing threads as
+there are physical cores on the machine. This is the right choice, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
 in any way.
 
-However, if the number of cores available to MaxScale have been restricted or\
-if MaxScale is running in a container whose CPU quota and period have been\
-limited, then it will lead to MaxScale using more routing threads than what\
+However, if the number of cores available to MaxScale have been restricted or
+if MaxScale is running in a container whose CPU quota and period have been
+limited, then it will lead to MaxScale using more routing threads than what
 is appropriate in the environment where it is running.
 
-If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`\
-should be specified explicitly in the MaxScale configuration file and its value\
-should be that of `machine.cores_virtual` rounded up to the nearest integer. If\
+If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`
+should be specified explicitly in the MaxScale configuration file and its value
+should be that of `machine.cores_virtual` rounded up to the nearest integer. If
 that value is `1` it may be beneficial to check whether `2` gives better performance.
 
 **`query_classifier_cache_size`**
 
-If `query_classifier_cache_size` has not been specified in the MaxScale\
-configuration file, then MaxScale will use at most 15% of the amount of physical\
-memory in the machine for the cache. This is a good starting point, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
-in any way. Note that the amount specifies how much memory the cache at maximum\
+If `query_classifier_cache_size` has not been specified in the MaxScale
+configuration file, then MaxScale will use at most 15% of the amount of physical
+memory in the machine for the cache. This is a good starting point, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
+in any way. Note that the amount specifies how much memory the cache at maximum
 is allowed to use, not what would immediately be allocated for the cache.
 
-However, if the amount of memory available to MaxScale has been restricted,\
-which may be the case if MaxScale is running in a container, this may cause the\
-cache to grow beyond what is available, which will lead to a crash or MaxScale\
+However, if the amount of memory available to MaxScale has been restricted,
+which may be the case if MaxScale is running in a container, this may cause the
+cache to grow beyond what is available, which will lead to a crash or MaxScale
 being killed.
 
 If the value of `machine.memory_available` is less than that of`machine.memory_physical`, then `query_classifier_cache_size` should be explicitly\
@@ -4856,7 +4856,7 @@ $ maxctrl show maxscale
 As can be seen, `maxscale.threads` is larger than `machine.cores_virtual` and thus,`threads=4` should explicitly be specified in the MaxScale configuration file.
 
 `maxscale.query_classifier_cache_size` is the default 15% of `machine.memory_physical`\
-but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be\
+but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be
 added to the configuration file.
 
 ```
@@ -4868,12 +4868,12 @@ query_classifier_cache_size=3100000000
 
 ## Troubleshooting
 
-For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)\
+For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 article on the MariaDB documentation.
 
 ### Systemd Watchdog
 
-If MaxScale is running as a systemd service, the systemd Watchdog will be\
+If MaxScale is running as a systemd service, the systemd Watchdog will be
 enabled by default. To configure it, change the `WatchdogSec` option in the\
 Service section of the maxscale systemd configuration file located in`/lib/systemd/system/maxscale.service`:
 
@@ -4881,8 +4881,8 @@ Service section of the maxscale systemd configuration file located in`/lib/syste
 WatchdogSec=30s
 ```
 
-It is not recommended to use a watchdog timeout less than 30 seconds. When\
-enabled MaxScale will check that all threads are running and notify systemd\
+It is not recommended to use a watchdog timeout less than 30 seconds. When
+enabled MaxScale will check that all threads are running and notify systemd
 with a "keep-alive ping".
 
 Systemd reference: [systemd.service.html](https://www.freedesktop.org/software/systemd/man/systemd.service.html)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-installation-guide.md
@@ -1,14 +1,14 @@
 # MaxScale 24.02 MariaDB MaxScale Installation Guide
 
-We recommend to install MaxScale on a separate server, to ensure that there\
-can be no competition of resources between MaxScale and a MariaDB Server that\
+We recommend to install MaxScale on a separate server, to ensure that there
+can be no competition of resources between MaxScale and a MariaDB Server that
 it manages.
 
 ### Install MariaDB MaxScale From MariaDB Repositories
 
-The recommended approach is to use [the MariaDB package\
-repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
-to install MaxScale. After enabling the repository by following the\
+The recommended approach is to use [the MariaDB package
+repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
+to install MaxScale. After enabling the repository by following the
 instructions, MaxScale can be installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install maxscale`.
@@ -17,9 +17,9 @@ instructions, MaxScale can be installed with the following commands.
 
 ### Install MariaDB MaxScale From a RPM/DEB Package
 
-Download the correct MaxScale package for your CPU architecture and operating\
-system from [the MariaDB Downloads\
-page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be\
+Download the correct MaxScale package for your CPU architecture and operating
+system from [the MariaDB Downloads
+page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be
 installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install /path/to/maxscale-*.rpm`
@@ -29,7 +29,7 @@ installed with the following commands.
 ### Install MariaDB MaxScale Using a Tarball
 
 MaxScale can also be installed using a tarball.\
-That may be required if you are using a Linux distribution for which there\
+That may be required if you are using a Linux distribution for which there
 exist no installation package or if you want to install many different\
 MaxScale versions side by side. For instructions on how to do that, please refer to [Install MariaDB MaxScale using a Tarball](mariadb-maxscale-2402-maxscale-2402-installing-mariadb-maxscale-using-a-tarball.md).
 
@@ -42,20 +42,20 @@ To do this, refer to the separate document [Building MariaDB MaxScale from Sourc
 
 #### Memory allocation behavior
 
-MaxScale assumes that memory allocations always succeed and in general does\
-not check for memory allocation failures. This assumption is compatible with\
-the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)\
+MaxScale assumes that memory allocations always succeed and in general does
+not check for memory allocation failures. This assumption is compatible with
+the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)
 having the value `0`, which is also the default on most systems.
 
-With `vm.overcommit_memory` being `0`, memory _allocations_ made by an\
-application never fail, but instead the application may be killed by the\
-so-called OOM (out-of-memory) killer if, by the time the application\
-actually attempts to _use_ the allocated memory, there is not available\
+With `vm.overcommit_memory` being `0`, memory _allocations_ made by an
+application never fail, but instead the application may be killed by the
+so-called OOM (out-of-memory) killer if, by the time the application
+actually attempts to _use_ the allocated memory, there is not available
 free memory on the system.
 
-If the value is `2`, then a memory allocation made by an application may\
-fail and unless the application is prepared for that possibility, it will\
-likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory\
+If the value is `2`, then a memory allocation made by an application may
+fail and unless the application is prepared for that possibility, it will
+likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory
 allocation failures, it will crash in this situation.
 
 The current value of `vm.overcommit_memory` can be checked with
@@ -72,36 +72,36 @@ cat /proc/sys/vm/overcommit_memory
 
 ### Configuring MariaDB MaxScale
 
-[The MaxScale Tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-setting-up-mariadb-maxscale.md) covers the first\
-steps in configuring your MariaDB MaxScale installation. Follow this tutorial\
+[The MaxScale Tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-setting-up-mariadb-maxscale.md) covers the first
+steps in configuring your MariaDB MaxScale installation. Follow this tutorial
 to learn how to configure and start using MaxScale.
 
-For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) and the module specific documents\
+For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) and the module specific documents
 listed in the [Documentation Contents](../mariadb-maxscale-2402-maxscale-2402-contents.md).
 
 ### Encrypting Passwords
 
-Read the [Encrypting Passwords](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
-section of the configuration guide to set up password encryption for the\
+Read the [Encrypting Passwords](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
+section of the configuration guide to set up password encryption for the
 configuration file.
 
 ### Administration Of MariaDB MaxScale
 
 There are various administration tasks that may be done with MariaDB MaxScale.\
-A command line tools is available, [maxctrl](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-maxctrl.md), that will\
+A command line tools is available, [maxctrl](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-maxctrl.md), that will
 interact with a running MariaDB MaxScale and allow the status of MariaDB\
-MaxScale to be monitored and give some control of the MariaDB MaxScale\
+MaxScale to be monitored and give some control of the MariaDB MaxScale
 functionality.
 
-[The administration tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-administration-tutorial.md)\
+[The administration tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-administration-tutorial.md)
 covers the common administration tasks that need to be done with MariaDB MaxScale.
 
 ### Copying or Backing Up MaxScale
 
-The main configuration file for MaxScale is in `/etc/maxscale.cnf` and\
+The main configuration file for MaxScale is in `/etc/maxscale.cnf` and
 additional user-created configuration files are in`/etc/maxscale.cnf.d/`. Objects created or modified at runtime are stored in`/var/lib/maxscale/maxscale.cnf.d/`. Some modules also store internal data in`/var/lib/maxscale/` named after the module or the configuration object.
 
-The simplest way to back up the configuration and runtime data of a MaxScale\
+The simplest way to back up the configuration and runtime data of a MaxScale
 installation is to create an archive from the following files and directories:
 
 * `/etc/maxscale.cnf`
@@ -114,7 +114,7 @@ This can be done with the following command:
 tar -caf maxscale-backup.tar.gz /etc/maxscale.cnf /etc/maxscale.cnf.d/ /var/lib/maxscale/
 ```
 
-If MaxScale is configured to store data in custom locations, these should be\
+If MaxScale is configured to store data in custom locations, these should be
 included in the backup as well.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-maxgui-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-maxgui-guide.md
@@ -6,27 +6,27 @@ _MaxGUI_ is a browser-based interface for MaxScale REST-API and query execution.
 
 ## Enabling MaxGUI
 
-To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale\
+To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale
 configuration file. Once enabled, MaxGUI will be available on port 8989:`http://127.0.0.1:8989/`
 
 ### Securing the GUI
 
 To make MaxGUI secure, set `admin_secure_gui=true` and configure both the`admin_ssl_key` and `admin_ssl_cert` parameters.
 
-See [Configuration Guide](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-rest-api-tutorial.md)\
+See [Configuration Guide](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-rest-api-tutorial.md)
 for instructions on how to harden your MaxScale installation for production use.
 
 ## Authentication
 
-MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`\
+MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`
 with `mariadb` as the password.
 
-Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the\
-authentication method for persisting the user's session. If the _Remember me_\
-checkbox is ticked, the session will persist for 24 hours. Otherwise, the\
+Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the
+authentication method for persisting the user's session. If the _Remember me_
+checkbox is ticked, the session will persist for 24 hours. Otherwise, the
 session will expire as soon as MaxGUI is closed.
 
-To log out, simply click the username section in the top right corner of the\
+To log out, simply click the username section in the top right corner of the
 page header to access the logout menu.
 
 ## Pages
@@ -40,7 +40,7 @@ By default, the refresh interval is 10 seconds.
 
 ### Detail
 
-This page shows information on each [MaxScale object](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) and allow to edit its\
+This page shows information on each [MaxScale object](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) and allow to edit its
 parameter, relationships and perform other manipulation operations.
 
 Access this page by clicking on the MaxScale object name on the [dashboard page](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-maxgui-guide.md#dashboard)
@@ -50,8 +50,8 @@ Access this page by clicking on the MaxScale object name on the [dashboard page]
 This page visualizes MaxScale configuration and clusters.
 
 * Configuration: Visualizing MaxScale configuration.
-* Cluster: Visualizing a replication cluster into a tree graph and provides\
-  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the\
+* Cluster: Visualizing a replication cluster into a tree graph and provides
+  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the
   moment, it supports only servers monitored by Monitor using [mariadbmon](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md) module.
 
 Access this page by clicking the graph icon on the sidebar navigation.
@@ -64,30 +64,30 @@ Access this page by clicking the gear icon on the sidebar navigation.
 
 ### Logs Archive
 
-Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar\
+Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar
 navigation.
 
 ### Workspace
 
-The "Workspace" page offers a versatile set of tools for effectively managing\
+The "Workspace" page offers a versatile set of tools for effectively managing
 data and database interactions. It includes the following key tasks:
 
 #### 1. Run Queries
 
-Execute queries on various servers, services, or listeners to retrieve data and\
-perform database operations. Visualize query results using different graph\
-types such as line, bar, or scatter graphs. Export query results in formats\
+Execute queries on various servers, services, or listeners to retrieve data and
+perform database operations. Visualize query results using different graph
+types such as line, bar, or scatter graphs. Export query results in formats
 like CSV or JSON for further analysis and sharing.
 
 #### 2. Data Migration
 
-The "Data Migration" feature facilitates seamless transitions from PostgreSQL\
-to MariaDB. Transfer data and database structures between the two systems while\
+The "Data Migration" feature facilitates seamless transitions from PostgreSQL
+to MariaDB. Transfer data and database structures between the two systems while
 ensuring data integrity and consistency throughout the process.
 
 #### 3. Create an ERD
 
-Generating Entity-Relationship Diagrams (ERDs) to gain insights regarding data\
+Generating Entity-Relationship Diagrams (ERDs) to gain insights regarding data
 structure, optimizing database design for both efficiency and clarity.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Common Monitor Parameters
 
-This document settings supported by all monitors. These should be defined\
+This document settings supported by all monitors. These should be defined
 in the monitor section of the configuration file.
 
 ### Parameters
@@ -19,7 +19,7 @@ The monitor module this monitor should use. Typically `mariadbmon` or`galeramon`
 * Mandatory: Yes
 * Dynamic: Yes
 
-Username used by the monitor to connect to the backend servers. If a server defines\
+Username used by the monitor to connect to the backend servers. If a server defines
 the `monitoruser` parameter, that value will be used instead.
 
 #### `password`
@@ -28,10 +28,10 @@ the `monitoruser` parameter, that value will be used instead.
 * Mandatory: Yes
 * Dynamic: Yes
 
-Password for the user defined with the `user` parameter. If a server defines\
+Password for the user defined with the `user` parameter. If a server defines
 the `monitorpw` parameter, that value will be used instead.
 
-**Note:** In older versions of MaxScale this parameter was called `passwd`. The\
+**Note:** In older versions of MaxScale this parameter was called `passwd`. The
 use of `passwd` was deprecated in MaxScale 2.3.0.
 
 #### `servers`
@@ -53,17 +53,17 @@ servers=MyServer1,MyServer2
 * Dynamic: Yes
 * Default: `2s`
 
-Defines how often the monitor updates the status of the servers. Choose a lower\
+Defines how often the monitor updates the status of the servers. Choose a lower
 value if servers should be queried more often. The smallest possible value is\
-100 milliseconds. If querying the servers takes longer than `monitor_interval`,\
+100 milliseconds. If querying the servers takes longer than `monitor_interval`,
 the effective update rate is reduced.
 
 ```
 monitor_interval=2s
 ```
 
-The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.
 
 #### `backend_connect_timeout`
@@ -74,10 +74,10 @@ versions a value without a unit may be rejected.
 * Default: `3s`
 
 This parameter controls the timeout for connecting to a monitored server.\
-The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -92,10 +92,10 @@ backend_connect_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for writing to a monitored server.\
-The timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 seconds.
 
 ```
@@ -110,10 +110,10 @@ backend_write_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for reading from a monitored server.\
-The timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -127,9 +127,9 @@ backend_read_timeout=3s
 * Dynamic: Yes
 * Default: `1`
 
-This parameter defines the maximum times a backend connection is attempted every\
-monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds\
-to perform. If none of the attempts are successful, the backend is considered to\
+This parameter defines the maximum times a backend connection is attempted every
+monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds
+to perform. If none of the attempts are successful, the backend is considered to
 be unreachable and down.
 
 ```
@@ -147,18 +147,18 @@ This parameter duplicates the `disk_space_threshold`[server parameter](../maxsca
 If the parameter has _not_ been specified for a server, then the one specified\
 for the monitor is applied.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-That is, if the disk configuration is the same on all servers monitored by\
-the monitor, it is sufficient (and more convenient) to specify the disk\
-space threshold in the monitor section, but if the disk configuration is\
-different on all or some servers, then the disk space threshold can be\
+That is, if the disk configuration is the same on all servers monitored by
+the monitor, it is sufficient (and more convenient) to specify the disk
+space threshold in the monitor section, but if the disk configuration is
+different on all or some servers, then the disk space threshold can be
 specified individually for each server.
 
-For example, suppose `server1`, `server2` and `server3` are identical\
-in all respects. In that case we can specify `disk_space_threshold`\
+For example, suppose `server1`, `server2` and `server3` are identical
+in all respects. In that case we can specify `disk_space_threshold`
 in the monitor.
 
 ```
@@ -181,8 +181,8 @@ disk_space_threshold=/data:80
 ...
 ```
 
-However, if the servers are heterogeneous with the disk used for the\
-data directory mounted on different paths, then the disk space threshold\
+However, if the servers are heterogeneous with the disk used for the
+data directory mounted on different paths, then the disk space threshold
 must be specified separately for each server.
 
 ```
@@ -207,8 +207,8 @@ servers=server1,server2,server3
 ...
 ```
 
-If _most_ of the servers have the data directory disk mounted on\
-the same path, then the disk space threshold can be specified on\
+If _most_ of the servers have the data directory disk mounted on
+the same path, then the disk space threshold can be specified on
 the monitor and separately on the server with a different setup.
 
 ```
@@ -232,7 +232,7 @@ disk_space_threshold=/data:80
 ...
 ```
 
-Above, `server1` has the disk used for the data directory mounted\
+Above, `server1` has the disk used for the data directory mounted
 at `/DbData` while both `server2` and `server3` have it mounted on`/data` and thus the setting in the monitor covers them both.
 
 #### `disk_space_check_interval`
@@ -242,15 +242,15 @@ at `/DbData` while both `server2` and `server3` have it mounted on`/data` and th
 * Dynamic: Yes
 * Default: `0s`
 
-With this parameter it can be specified the minimum amount of time\
-between disk space checks. The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+With this parameter it can be specified the minimum amount of time
+between disk space checks. The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.\
-The default value is 0, which means that by default the disk space\
+The default value is 0, which means that by default the disk space
 will not be checked.
 
-Note that as the checking is made as part of the regular monitor interval\
-cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,\
+Note that as the checking is made as part of the regular monitor interval
+cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,
 the checking will still take place at `monitor_interval` intervals.
 
 #### `script`
@@ -260,9 +260,9 @@ the checking will still take place at `monitor_interval` intervals.
 * Dynamic: Yes
 * Default: None
 
-This command will be executed on a server state change. The parameter should\
-be an absolute path to a command or the command should be in the executable\
-path. The user running MaxScale should have execution rights to the file itself\
+This command will be executed on a server state change. The parameter should
+be an absolute path to a command or the command should be in the executable
+path. The user running MaxScale should have execution rights to the file itself
 and the directory it resides in. The script may have placeholders which\
 MaxScale will substitute with useful information when launching the script.
 
@@ -276,15 +276,15 @@ The placeholders and their substitution results are:
 * `$MASTERLIST` -> list of IPs and ports of all primary servers
 * `$SYNCEDLIST` -> list of IPs and ports of all synced Galera nodes
 * `$PARENT` -> IP and port of the parent of the server which initiated the event.\
-  For primary-replica setups, this will be the primary if the initiating server is a\
+  For primary-replica setups, this will be the primary if the initiating server is a
   replica.
-* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who\
-  initiated the event. For primary-replica setups, this will be a list of replica\
+* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who
+  initiated the event. For primary-replica setups, this will be a list of replica
   servers if the initiating server is a primary.
 
-The expanded variable value can be an empty string if no servers match the\
-variable's requirements. For example, if no primaries are available `$MASTERLIST`\
-will expand into an empty string. The list-type substitutions will only contain\
+The expanded variable value can be an empty string if no servers match the
+variable's requirements. For example, if no primaries are available `$MASTERLIST`
+will expand into an empty string. The list-type substitutions will only contain
 servers monitored by the current monitor.
 
 ```
@@ -299,17 +299,17 @@ The above script could be executed as:
 
 See section [Script example](mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md#script-example) below for an example script.
 
-Any output by the executed script will be logged into the MaxScale log. Each\
+Any output by the executed script will be logged into the MaxScale log. Each
 outputted line will be logged as a separate log message.
 
-The log level on which the messages are logged depends on the format of the\
-messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the\
-corresponding level. If the message is not prefixed with one of the keywords,\
-the message will be logged on the notice level. Whitespace before, after or\
-between the keyword and the colon is ignored and the matching is\
+The log level on which the messages are logged depends on the format of the
+messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the
+corresponding level. If the message is not prefixed with one of the keywords,
+the message will be logged on the notice level. Whitespace before, after or
+between the keyword and the colon is ignored and the matching is
 case-insensitive.
 
-Currently, the script must not execute any of the following MaxCtrl\
+Currently, the script must not execute any of the following MaxCtrl
 calls as they cause a deadlock:
 
 * `alter monitor` to the monitor executing the script
@@ -323,14 +323,14 @@ calls as they cause a deadlock:
 * Dynamic: Yes
 * Default: `90s`
 
-The timeout for the executed script. The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout for the executed script. The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If the script execution exceeds the configured timeout, it is stopped by sending\
-a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be\
+If the script execution exceeds the configured timeout, it is stopped by sending
+a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be
 sent to it once the execution time is greater than twice the configured timeout.
 
 #### `events`
@@ -341,15 +341,15 @@ sent to it once the execution time is greater than twice the configured timeout.
 * Values: `master_down`, `master_up`, `slave_down`, `slave_up`, `server_down`, `server_up`, `lost_master`, `lost_slave`, `new_master`, `new_slave`
 * Default: All events
 
-A list of event names which cause the script to be executed. If this option is\
-not defined, all events cause the script to be executed. The list must contain a\
+A list of event names which cause the script to be executed. If this option is
+not defined, all events cause the script to be executed. The list must contain a
 comma separated list of event names.
 
 ```
 events=master_down,slave_down
 ```
 
-The following table contains all the possible event types and their\
+The following table contains all the possible event types and their
 descriptions.
 
 | Event Name   | Description                                  |
@@ -372,38 +372,38 @@ descriptions.
 * Dynamic: Yes
 * Default: `28800s`
 
-The maximum journal file age. The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the max age is seconds, a max age specified in milliseconds will be rejected,\
+The maximum journal file age. The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the max age is seconds, a max age specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-When the monitor starts, it reads any stored journal files. If the journal file\
-is older than the value of _journal\_max\_age_, it will be removed and the monitor\
+When the monitor starts, it reads any stored journal files. If the journal file
+is older than the value of _journal\_max\_age_, it will be removed and the monitor
 starts with no prior knowledge of the servers.
 
 ### Monitor Crash Safety
 
-Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the\
-latest server states. This change makes the monitors crash-safe when options\
-that introduce states are used. It also allows the monitors to retain stateful\
+Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the
+latest server states. This change makes the monitors crash-safe when options
+that introduce states are used. It also allows the monitors to retain stateful
 information when MaxScale is restarted.
 
-For MySQL monitor, options that introduce states into the monitoring process are\
-the `detect_stale_master` and `detect_stale_slave` options, both of which are\
-enabled by default. Galeramon has the `disable_master_failback` parameter which\
+For MySQL monitor, options that introduce states into the monitoring process are
+the `detect_stale_master` and `detect_stale_slave` options, both of which are
+enabled by default. Galeramon has the `disable_master_failback` parameter which
 introduces a state.
 
-The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the\
-name of the monitor section in the configuration file. If MaxScale crashes or is\
-shut down in an uncontrolled fashion, the journal will be read when MaxScale is\
-started. To skip the recovery process, manually delete the journal file before\
+The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the
+name of the monitor section in the configuration file. If MaxScale crashes or is
+shut down in an uncontrolled fashion, the journal will be read when MaxScale is
+started. To skip the recovery process, manually delete the journal file before
 starting MaxScale.
 
 ### Script example
 
-Below is an example monitor configuration which launches a script with all\
-supported substitutions. The example script reads the results and prints it to\
+Below is an example monitor configuration which launches a script with all
+supported substitutions. The example script reads the results and prints it to
 file and sends it as email.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-galera-monitor.md
@@ -2,39 +2,39 @@
 
 ### Overview
 
-The Galera Monitor is a monitoring module for MaxScale that monitors a Galera\
-cluster. It detects whether nodes are a part of the cluster and if they are in\
-sync with the rest of the cluster. It can also assign primary and replica roles\
-inside MaxScale, allowing Galera clusters to be used with modules designed for\
+The Galera Monitor is a monitoring module for MaxScale that monitors a Galera
+cluster. It detects whether nodes are a part of the cluster and if they are in
+sync with the rest of the cluster. It can also assign primary and replica roles
+inside MaxScale, allowing Galera clusters to be used with modules designed for
 traditional primary-replica clusters.
 
-By default, the Galera Monitor will choose the node with the lowest`wsrep_local_index` value as the primary. This will mean that two MaxScales\
+By default, the Galera Monitor will choose the node with the lowest`wsrep_local_index` value as the primary. This will mean that two MaxScales
 running on different servers will choose the same server as the primary.
 
 #### WSREP Variables and Their Effects
 
-The following WSREP variables are inspected by galeramon to see whether a node is\
-usable. If the node is not usable, it loses the `Master` and `Slave` labels and\
+The following WSREP variables are inspected by galeramon to see whether a node is
+usable. If the node is not usable, it loses the `Master` and `Slave` labels and
 will be in the `Running` state.
 
-* If `wsrep_ready=0`, the WSREP system is not yet ready and the Galera node\
+* If `wsrep_ready=0`, the WSREP system is not yet ready and the Galera node
   cannot accept queries.
-* If `wsrep_desync=1` is set, the node is desynced and is not participating in\
+* If `wsrep_desync=1` is set, the node is desynced and is not participating in
   the Galera replication.
-* If `wsrep_reject_queries=[ALL|ALL_KILL]` is set, queries are refused and the\
+* If `wsrep_reject_queries=[ALL|ALL_KILL]` is set, queries are refused and the
   node is unusable.
-* With `wsrep_sst_donor_rejects_queries=1`, donor nodes reject\
-  queries. Galeramon treats this the same as if `wsrep_reject_queries=ALL` was\
+* With `wsrep_sst_donor_rejects_queries=1`, donor nodes reject
+  queries. Galeramon treats this the same as if `wsrep_reject_queries=ALL` was
   set.
-* If `wsrep_local_state` is not 4 (or 2 with `available_when_donor=true`), the\
+* If `wsrep_local_state` is not 4 (or 2 with `available_when_donor=true`), the
   node is not in the correct state and is not used.
 
 #### Galera clusters and replicas replicating from it
 
-MaxScale 2.4.0 added support for replicas replicating off of Galera nodes. If a\
-non-Galera server monitored by galeramon is replicating from a Galera node also\
-monitored by galeramon, it will be assigned the `Slave, Running` status as long\
-as the replication works. This allows read-scaleout with Galera servers without\
+MaxScale 2.4.0 added support for replicas replicating off of Galera nodes. If a
+non-Galera server monitored by galeramon is replicating from a Galera node also
+monitored by galeramon, it will be assigned the `Slave, Running` status as long
+as the replication works. This allows read-scaleout with Galera servers without
 increasing the size of the Galera cluster.
 
 ### Required Grants
@@ -60,7 +60,7 @@ GRANT SUPER ON *.* TO 'maxscale'@'maxscalehost';
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers. The user requires the\
 REPLICATION CLIENT privilege to successfully monitor the state of the servers.
 
@@ -87,10 +87,10 @@ These are optional parameters specific to the Galera Monitor.
 * Default: false
 * Dynamic: Yes
 
-If a node marked as primary inside MaxScale happens to fail and the primary\
-status is assigned to another node MaxScale will normally return the primary\
-status to the original node after it comes back up. With this option enabled, if\
-the primary status is assigned to a new node it will not be reassigned to the\
+If a node marked as primary inside MaxScale happens to fail and the primary
+status is assigned to another node MaxScale will normally return the primary
+status to the original node after it comes back up. With this option enabled, if
+the primary status is assigned to a new node it will not be reassigned to the
 original node for as long as the new primary node is running. In this case the`Master Stickiness` status bit is set which will be visible in the`maxctrl list servers` output.
 
 #### `available_when_donor`
@@ -100,16 +100,16 @@ original node for as long as the new primary node is running. In this case the`M
 * Dynamic: Yes
 
 This option allows Galera nodes to be used normally when they are donors in an\
-SST operation when the SST method is non-blocking\
+SST operation when the SST method is non-blocking
 (e.g. `wsrep_sst_method=mariadb-backup`).
 
-Normally when an SST is performed, both participating nodes lose their `Synced`,`Master` or `Slave` statuses. When this option is enabled, the donor is treated as\
-if it was a normal member of the cluster (i.e. `wsrep_local_state = 4`). This is\
-especially useful if the cluster drops down to one node and an SST is required\
+Normally when an SST is performed, both participating nodes lose their `Synced`,`Master` or `Slave` statuses. When this option is enabled, the donor is treated as
+if it was a normal member of the cluster (i.e. `wsrep_local_state = 4`). This is
+especially useful if the cluster drops down to one node and an SST is required
 to increase the cluster size.
 
-The current list of non-blocking SST\
-methods are `xtrabackup`, `xtrabackup-v2` and `mariadb-backup`. Read the [wsrep\_sst\_method](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables)\
+The current list of non-blocking SST
+methods are `xtrabackup`, `xtrabackup-v2` and `mariadb-backup`. Read the [wsrep\_sst\_method](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables)
 documentation for more details.
 
 #### `disable_master_role_setting`
@@ -118,8 +118,8 @@ documentation for more details.
 * Default: false
 * Dynamic: Yes
 
-This disables the assignment of primary and replica roles to the Galera cluster\
-nodes. If this option is enabled, Synced is the only status assigned by this\
+This disables the assignment of primary and replica roles to the Galera cluster
+nodes. If this option is enabled, Synced is the only status assigned by this
 monitor.
 
 #### `use_priority`
@@ -128,8 +128,8 @@ monitor.
 * Default: false
 * Dynamic: Yes
 
-Enable interaction with server priorities. This will allow the monitor to\
-deterministically pick the write node for the monitored Galera cluster and will\
+Enable interaction with server priorities. This will allow the monitor to
+deterministically pick the write node for the monitored Galera cluster and will
 allow for controlled node replacement.
 
 #### `root_node_as_master`
@@ -138,27 +138,27 @@ allow for controlled node replacement.
 * Default: false
 * Dynamic: Yes
 
-This option controls whether the write primary Galera node requires a_wsrep\_local\_index_ value of 0. This option was introduced in MaxScale 2.1.0 and\
-it is disabled by default in versions 2.1.5 and newer. In versions 2.1.4 and\
+This option controls whether the write primary Galera node requires a_wsrep\_local\_index_ value of 0. This option was introduced in MaxScale 2.1.0 and
+it is disabled by default in versions 2.1.5 and newer. In versions 2.1.4 and
 older, the option was enabled by default.
 
-A Galera cluster will always have a node which has a _wsrep\_local\_index_ value\
-of 0. Based on this information, multiple MaxScale instances can always pick the\
+A Galera cluster will always have a node which has a _wsrep\_local\_index_ value
+of 0. Based on this information, multiple MaxScale instances can always pick the
 same node for writes.
 
 If the `root_node_as_master` option is disabled for galeramon, the node with the\
 lowest index will always be chosen as the primary. If it is enabled, only the\
 node with a _wsrep\_local\_index_ value of 0 can be chosen as the primary.
 
-This parameter can work with `disable_master_failback` but using them together\
-is not advisable: the intention of `root_node_as_master` is to make sure that\
-all MaxScale instances that are configured to use the same Galera cluster will\
-send writes to the same node. If `disable_master_failback` is enabled, this is\
-no longer true if the Galera cluster reorganizes itself in a way that a\
-different node gets the node index 0, writes would still be going to the old\
-node that previously had the node index 0. A restart of one of the MaxScales or\
-a new MaxScale joining the cluster will cause writes to be sent to the wrong\
-node, thus resulting in an increasing the rate of deadlock errors and\
+This parameter can work with `disable_master_failback` but using them together
+is not advisable: the intention of `root_node_as_master` is to make sure that
+all MaxScale instances that are configured to use the same Galera cluster will
+send writes to the same node. If `disable_master_failback` is enabled, this is
+no longer true if the Galera cluster reorganizes itself in a way that a
+different node gets the node index 0, writes would still be going to the old
+node that previously had the node index 0. A restart of one of the MaxScales or
+a new MaxScale joining the cluster will cause writes to be sent to the wrong
+node, thus resulting in an increasing the rate of deadlock errors and
 sub-optimal performance.
 
 #### `set_donor_nodes`
@@ -167,12 +167,12 @@ sub-optimal performance.
 * Default: false
 * Dynamic: Yes
 
-This option controls whether the global variable _wsrep\_sst\_donor_ should be set\
+This option controls whether the global variable _wsrep\_sst\_donor_ should be set
 in each cluster node with _slave' status_.\
-The variable contains a list of replica servers, automatically sorted, with\
+The variable contains a list of replica servers, automatically sorted, with
 possible primary candidates at its end.
 
-The sorting is based either on _wsrep\_local\_index_ or node server _priority_\
+The sorting is based either on _wsrep\_local\_index_ or node server _priority_
 depending on the value of _use\_priority_ option.\
 If no server has _priority_ defined the sorting switches to _wsrep\_local\_index_.\
 Node names are collected by fetching the result of the variable _wsrep\_node\_name_.
@@ -184,24 +184,24 @@ SET GLOBAL wsrep_sst_donor = "galera001,galera000"
 ```
 
 **Note**:\
-in order to set the global variable _wsrep\_sst\_donor_, proper privileges are\
+in order to set the global variable _wsrep\_sst\_donor_, proper privileges are
 required for the monitor user that connects to cluster nodes.\
 This option is disabled by default and was introduced in MaxScale 2.1.0.
 
 ### Interaction with Server Priorities
 
-If the `use_priority` option is set and a server is configured with the`priority=<int>` parameter, galeramon will use that as the basis on which the\
-primary node is chosen. This requires the `disable_master_role_setting` to be\
-undefined or disabled. The server with the lowest positive value of _priority_\
-will be chosen as the primary node when a replacement Galera node is promoted to\
-a primary server inside MaxScale. If all candidate servers have the same\
-priority, the order of the servers in the `servers` parameter dictates which is\
+If the `use_priority` option is set and a server is configured with the`priority=<int>` parameter, galeramon will use that as the basis on which the
+primary node is chosen. This requires the `disable_master_role_setting` to be
+undefined or disabled. The server with the lowest positive value of _priority_
+will be chosen as the primary node when a replacement Galera node is promoted to
+a primary server inside MaxScale. If all candidate servers have the same
+priority, the order of the servers in the `servers` parameter dictates which is
 chosen as the primary.
 
-Nodes with a negative value (_priority_ < 0) will never be chosen as the\
-primary. This allows you to mark some servers as permanent replicas by assigning a\
-non-positive value into _priority_. Nodes with the default priority of 0 are\
-only selected if no nodes with higher priority are present and the normal node\
+Nodes with a negative value (_priority_ < 0) will never be chosen as the
+primary. This allows you to mark some servers as permanent replicas by assigning a
+non-positive value into _priority_. Nodes with the default priority of 0 are
+only selected if no nodes with higher priority are present and the normal node
 selection rules apply to them (i.e. selection is based on `wsrep_local_index`).
 
 Here is an example.
@@ -232,13 +232,13 @@ port=3306
 priority=-1
 ```
 
-In this example `node-1` is always used as the primary if available. If `node-1`\
-is not available, then the next node with the highest priority rank is used. In\
-this case it would be `node-3`. If both `node-1` and `node-3` were down, then`node-2` would be used. Because `node-4` has a value of -1 in _priority_, it\
-will never be the primary. Nodes without _priority_ parameter are considered as\
+In this example `node-1` is always used as the primary if available. If `node-1`
+is not available, then the next node with the highest priority rank is used. In
+this case it would be `node-3`. If both `node-1` and `node-3` were down, then`node-2` would be used. Because `node-4` has a value of -1 in _priority_, it
+will never be the primary. Nodes without _priority_ parameter are considered as
 having a priority of 0 and will be used only if all nodes with a positive_priority_ value are not available.
 
-With priority ranks you can control the order in which MaxScale chooses the\
+With priority ranks you can control the order in which MaxScale chooses the
 primary node. This will allow for a controlled failure and replacement of nodes.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-MariaDB Monitor monitors a Primary-Replica replication cluster. It probes the\
-state of the backends and assigns server roles such as primary and replica, which\
-are used by the routers when deciding where to route a query. It can also modify\
-the replication cluster by performing failover, switchover and rejoin. Backend\
-server versions older than MariaDB/MySQL 5.5 are not supported. Failover and\
+MariaDB Monitor monitors a Primary-Replica replication cluster. It probes the
+state of the backends and assigns server roles such as primary and replica, which
+are used by the routers when deciding where to route a query. It can also modify
+the replication cluster by performing failover, switchover and rejoin. Backend
+server versions older than MariaDB/MySQL 5.5 are not supported. Failover and
 other similar operations require MariaDB 10.4 or later.
 
 Up until MariaDB MaxScale 2.2.0, this monitor was called _MySQL Monitor_.
@@ -41,7 +41,7 @@ set), then the FILE-grant is required with MariaDB Server versions 10.4.7,\
 GRANT FILE ON *.* TO 'maxscale'@'maxscalehost';
 ```
 
-MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it\
+MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it
 allows the monitor to log in even if server connection limit has been reached.
 
 ```
@@ -50,7 +50,7 @@ GRANT CONNECTION ADMIN ON *.* TO 'maxscale'@'maxscalehost';
 
 #### Cluster Manipulation Grants
 
-If [cluster manipulation operations](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cluster-manipulation-operations) are used,\
+If [cluster manipulation operations](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cluster-manipulation-operations) are used,
 the following additional grants are required:
 
 ```
@@ -64,7 +64,7 @@ MariaDB 10.5.2 and later require read access to _mysql.global\_priv_:
 GRANT SELECT ON mysql.global_priv TO 'maxscale'@'maxscalehost';
 ```
 
-As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of\
+As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of
 its former sub-privileges. These must be given separately.
 
 ```
@@ -83,59 +83,59 @@ GRANT REPLICATION SLAVE ON *.* TO 'replication'@'replicationhost';
 
 ### Primary selection
 
-Only one backend can be primary at any given time. A primary must be running\
-(successfully connected to by the monitor) and its _read\_only_-setting must be\
-off. A primary may not be replicating from another server in the monitored\
-cluster unless the primary is part of a multiprimary group. Primary selection\
-prefers to select the server with the most replicas, possibly in multiple\
-replication layers. Only replicas reachable by a chain of running relays or\
-directly connected to the primary count. When multiple servers are tied for\
-primary status, the server which appears earlier in the `servers`-setting of the\
+Only one backend can be primary at any given time. A primary must be running
+(successfully connected to by the monitor) and its _read\_only_-setting must be
+off. A primary may not be replicating from another server in the monitored
+cluster unless the primary is part of a multiprimary group. Primary selection
+prefers to select the server with the most replicas, possibly in multiple
+replication layers. Only replicas reachable by a chain of running relays or
+directly connected to the primary count. When multiple servers are tied for
+primary status, the server which appears earlier in the `servers`-setting of the
 monitor is selected.
 
-Servers in a cyclical replication topology (multiprimary group) are interpreted\
-as having all the servers in the group as replicas. Even from a multiprimary group\
+Servers in a cyclical replication topology (multiprimary group) are interpreted
+as having all the servers in the group as replicas. Even from a multiprimary group
 only one server is selected as the overall primary.
 
-After a primary has been selected, the monitor prefers to stick with the choice\
-even if other potential primaries with more replica servers are available. Only if\
-the current primary is clearly unsuitable does the monitor try to select another\
+After a primary has been selected, the monitor prefers to stick with the choice
+even if other potential primaries with more replica servers are available. Only if
+the current primary is clearly unsuitable does the monitor try to select another
 primary. An existing primary turns invalid if:
 
 1. It is unwritable (read\_only is on).
-2. It has been down for more than failcount monitor passes and has no running\
-   replicas. Running replicas behind a downed relay count. A replica in this\
-   context is any server with at least a partially running replication connection\
-   (either io or sql thread is running). The replicas must also be down for more\
+2. It has been down for more than failcount monitor passes and has no running
+   replicas. Running replicas behind a downed relay count. A replica in this
+   context is any server with at least a partially running replication connection
+   (either io or sql thread is running). The replicas must also be down for more
    than failcount monitor passes to allow new master selection.
-3. It did not previously replicate from another server in the cluster but it\
+3. It did not previously replicate from another server in the cluster but it
    is now replicating.
-4. It was previously part of a multiprimary group but is no longer, or the\
+4. It was previously part of a multiprimary group but is no longer, or the
    multiprimary group is replicating from a server not in the group.
 
-Cases 1 and 2 cover the situations in which the DBA, an external script or even\
-another MaxScale has modified the cluster such that the old primary can no longer\
-act as primary. Cases 3 and 4 are less severe. In these cases the topology has\
-changed significantly and the primary should be re-selected, although the old\
+Cases 1 and 2 cover the situations in which the DBA, an external script or even
+another MaxScale has modified the cluster such that the old primary can no longer
+act as primary. Cases 3 and 4 are less severe. In these cases the topology has
+changed significantly and the primary should be re-selected, although the old
 primary may still be the best choice.
 
-The primary change described above is different from failover and switchover\
+The primary change described above is different from failover and switchover
 described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
-A primary change only modifies the server roles inside MaxScale but does not\
+A primary change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a primary change on their own.
 
-As a general rule, it's best to avoid situations where the cluster has multiple\
+As a general rule, it's best to avoid situations where the cluster has multiple
 standalone servers, separate primary-replica pairs or separate multiprimary groups.\
-Due to primary invalidation rule 2, a standalone primary can easily lose the\
-primary status to another valid primary if it goes down. The new primary probably\
-does not have the same data as the previous one. Non-standalone primaries are less\
-vulnerable, as a single running replica or multiprimary group member will keep the\
+Due to primary invalidation rule 2, a standalone primary can easily lose the
+primary status to another valid primary if it goes down. The new primary probably
+does not have the same data as the previous one. Non-standalone primaries are less
+vulnerable, as a single running replica or multiprimary group member will keep the
 primary valid even when down.
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers.
 
 ```
@@ -149,8 +149,8 @@ password=mypwd
 
 From MaxScale 2.2.1 onwards, the module name is `mariadbmon` instead of`mysqlmon`. The old name can still be used.
 
-The grants required by `user` depend on which monitor features are used. A full\
-list of the grants can be found in the [Required Grants](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#required-grants)\
+The grants required by `user` depend on which monitor features are used. A full
+list of the grants can be found in the [Required Grants](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#required-grants)
 section.
 
 ### Common Monitor Parameters
@@ -159,9 +159,9 @@ For a list of optional parameters that all monitors support, read the [Monitor C
 
 ### MariaDB Monitor optional parameters
 
-These are optional parameters specific to the MariaDB Monitor. Failover,\
-switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are\
-described in the [Rebuild server-section](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#rebuild-server). ColumnStore\
+These are optional parameters specific to the MariaDB Monitor. Failover,
+switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are
+described in the [Rebuild server-section](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#rebuild-server). ColumnStore
 parameters are described in the [ColumnStore commands-section](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#settings).
 
 #### `assume_unique_hostnames`
@@ -171,49 +171,49 @@ parameters are described in the [ColumnStore commands-section](mariadb-maxscale-
 * Dynamic: Yes
 * Default: `true`
 
-When active, the monitor assumes that server hostnames and\
-ports are consistent between the server definitions in the MaxScale\
-configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers\
-themselves. Specifically, the monitor assumes that if server A is replicating\
-from server B, then A must have a replica connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this\
-is not the case, e.g. an IP is used in the server while a hostname is given in\
-the file, the monitor may misinterpret the topology. The monitor attempts name\
-resolution on the addresses if a simple string comparison\
-does not find a match. Using exact matching addresses is, however, more\
-reliable. In MaxScale 24.02.0, an alternative IP or hostname for a server can be\
+When active, the monitor assumes that server hostnames and
+ports are consistent between the server definitions in the MaxScale
+configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers
+themselves. Specifically, the monitor assumes that if server A is replicating
+from server B, then A must have a replica connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this
+is not the case, e.g. an IP is used in the server while a hostname is given in
+the file, the monitor may misinterpret the topology. The monitor attempts name
+resolution on the addresses if a simple string comparison
+does not find a match. Using exact matching addresses is, however, more
+reliable. In MaxScale 24.02.0, an alternative IP or hostname for a server can be
 given in [private\_address](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#private_address).
 
-This setting must be ON to use any cluster operation features such as failover\
-or switchover, because MaxScale uses the addresses and ports in the\
+This setting must be ON to use any cluster operation features such as failover
+or switchover, because MaxScale uses the addresses and ports in the
 configuration file when issuing "CHANGE MASTER TO"-commands.
 
-If the network configuration is such that the addresses MaxScale uses to connect\
-to backends are different from the ones the servers use to connect to each\
-other and `private_address` is not used, `assume_unique_hostnames` should be\
-set to OFF. In this mode, MaxScale uses server id:s it queries from\
-the servers and the `Master_Server_Id` fields of the replica connections\
-to deduce which server is replicating from which. This is not perfect though,\
-since MaxScale doesn't know the id:s of servers it has\
-never connected to (e.g. server has been down since MaxScale was started). Also,\
-the `Master_Server_Id`-field may have an incorrect value if the replica connection\
-has not been established. MaxScale will only trust the value if the monitor has\
-seen the replica connection IO thread connected at least once. If this is not the\
+If the network configuration is such that the addresses MaxScale uses to connect
+to backends are different from the ones the servers use to connect to each
+other and `private_address` is not used, `assume_unique_hostnames` should be
+set to OFF. In this mode, MaxScale uses server id:s it queries from
+the servers and the `Master_Server_Id` fields of the replica connections
+to deduce which server is replicating from which. This is not perfect though,
+since MaxScale doesn't know the id:s of servers it has
+never connected to (e.g. server has been down since MaxScale was started). Also,
+the `Master_Server_Id`-field may have an incorrect value if the replica connection
+has not been established. MaxScale will only trust the value if the monitor has
+seen the replica connection IO thread connected at least once. If this is not the
 case, the replica connection is ignored.
 
 #### `private_address`
 
-String. This is an optional server setting, yet documented here since it's only\
-used by MariaDB Monitor. If not set, the normal server address setting\
+String. This is an optional server setting, yet documented here since it's only
+used by MariaDB Monitor. If not set, the normal server address setting
 is used.
 
-Defines an alternative IP-address or hostname for the server for use with\
-replication. Whenever MaxScale modifies replication (e.g. during switchover),\
+Defines an alternative IP-address or hostname for the server for use with
+replication. Whenever MaxScale modifies replication (e.g. during switchover),
 the private address is given as _Master\_Host_ to "CHANGE MASTER TO"-commands.\
 Also, when detecting replication, any _Master\_Host_-values from\
-"SHOW SLAVE STATUS"-queries are compared to the private addresses of configured\
+"SHOW SLAVE STATUS"-queries are compared to the private addresses of configured
 servers if the normal address doesn't match.
 
-This setting is useful if replication and application traffic are\
+This setting is useful if replication and application traffic are
 separated to different network interfaces.
 
 #### `master_conditions`
@@ -226,9 +226,9 @@ separated to different network interfaces.
 
 Designate additional conditions for\_Master\_-status, i.e. qualified for read and write queries.
 
-Normally, if a suitable primary candidate server is found as described in [Primary selection](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#primary-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a primary server. This\
+Normally, if a suitable primary candidate server is found as described in [Primary selection](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#primary-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a primary server. This
 setting is an enum\_mask, allowing multiple conditions to be set simultaneously.\
-Conditions 2, 3 and 4 refer to replica servers. A single replica must\
+Conditions 2, 3 and 4 refer to replica servers. A single replica must
 fulfill all of the given conditions for the primary to be viable.
 
 If the primary candidate fails _master\_conditions_ but fulfills\_slave\_conditions\_, it may be designated _Slave_ instead.
@@ -236,28 +236,28 @@ If the primary candidate fails _master\_conditions_ but fulfills\_slave\_conditi
 The available conditions are:
 
 1. none : No additional conditions
-2. connecting\_slave : At least one immediate replica (not behind relay) is\
+2. connecting\_slave : At least one immediate replica (not behind relay) is
    attempting to replicate or is replicating from the primary (Slave\_IO\_Running is\
-   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A replica with incorrect\
-   replication credentials does not count. If the replica is currently down, results\
+   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A replica with incorrect
+   replication credentials does not count. If the replica is currently down, results
    from the last successful monitor tick are used.
-3. connected\_slave : Same as above, with the difference that the replication\
-   connection must be up (Slave\_IO\_Running is 'Yes'). If the replica is currently\
+3. connected\_slave : Same as above, with the difference that the replication
+   connection must be up (Slave\_IO\_Running is 'Yes'). If the replica is currently
    down, results from the last successful monitor tick are used.
-4. running\_slave : Same as connecting\_slave, with the addition that the\
+4. running\_slave : Same as connecting\_slave, with the addition that the
    replica must also be Running.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate primary is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate primary is selected also by the
    primary MaxScale.
-6. disk\_space\_ok : The candidate primary must not be low on disk space. This\
+6. disk\_space\_ok : The candidate primary must not be low on disk space. This
    option only takes effect if [disk space check](mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md) is enabled. Added in\
    MaxScale 23.08.5.
 
-The default value of this setting is`master_requirements=primary_monitor_master,disk_space_ok` to ensure that both\
-monitors use the same primary server when cooperating and that the primary is\
+The default value of this setting is`master_requirements=primary_monitor_master,disk_space_ok` to ensure that both
+monitors use the same primary server when cooperating and that the primary is
 not out of disk space.
 
-For example, to require that the primary must have a replica which is both\
+For example, to require that the primary must have a replica which is both
 connected and running, set
 
 ```
@@ -272,32 +272,32 @@ master_conditions=connected_slave,running_slave
 * Values: `none`, `linked_master`, `running_master`, `writable_master`, `primary_monitor_master`
 * Default: `none`
 
-Designate additional conditions for _Slave_-status,\
+Designate additional conditions for _Slave_-status,
 i.e qualified for read queries.
 
-Normally, a server is _Slave_ if it is at least attempting to replicate from the\
+Normally, a server is _Slave_ if it is at least attempting to replicate from the
 primary candidate or a relay (Slave\_IO\_Running is 'Yes' or 'Connecting',\
-Slave\_SQL\_Running is 'Yes', valid replication credentials). The primary candidate\
-does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a replica\
-server. This setting is an enum\_mask, allowing multiple conditions to be set\
+Slave\_SQL\_Running is 'Yes', valid replication credentials). The primary candidate
+does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a replica
+server. This setting is an enum\_mask, allowing multiple conditions to be set
 simultaneously.
 
 The available conditions are:
 
 1. none : No additional conditions. This is the default value.
-2. linked\_master : The replica must be connected to the primary (Slave\_IO\_Running\
-   and Slave\_SQL\_Running are 'Yes') and the primary must be Running. The same\
+2. linked\_master : The replica must be connected to the primary (Slave\_IO\_Running
+   and Slave\_SQL\_Running are 'Yes') and the primary must be Running. The same
    applies to any relays between the replica and the primary.
 3. running\_master : The primary must be running. Relays may be down.
 4. writable\_master : The primary must be writable, i.e. labeled Master.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate primary is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate primary is selected also by the
    primary MaxScale.
-6. disk\_space\_ok : The replica must not be low on disk space. This\
+6. disk\_space\_ok : The replica must not be low on disk space. This
    option only takes effect if [disk space check](mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md) is enabled. Added in\
    MaxScale 23.08.5.
 
-For example, to require that the primary server of the cluster must be running\
+For example, to require that the primary server of the cluster must be running
 and writable for any servers to have _Slave_-status, set
 
 ```
@@ -311,8 +311,8 @@ slave_conditions=running_master,writable_master
 * Dynamic: Yes
 * Default: `5`
 
-Number of consecutive monitor passes a primary server must be down before it is\
-considered failed. If automatic failover is enabled (`auto_failover=true`), it\
+Number of consecutive monitor passes a primary server must be down before it is
+considered failed. If automatic failover is enabled (`auto_failover=true`), it
 may be performed at this time. A value of 0 or 1 enables immediate failover.
 
 If automatic failover is not possible, the monitor will try to\
@@ -321,8 +321,8 @@ for more details. Changing the primary may break replication as queries could be
 routed to a server without previous events. To prevent this, avoid having\
 multiple valid primary servers in the cluster.
 
-The worst-case delay between the primary failure and the start of the failover\
-can be estimated by summing up the timeout values and `monitor_interval` and\
+The worst-case delay between the primary failure and the start of the failover
+can be estimated by summing up the timeout values and `monitor_interval` and
 multiplying that by `failcount`:
 
 ```
@@ -336,19 +336,19 @@ multiplying that by `failcount`:
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-disable the _read\_only_-flag on the primary when seen. The flag is\
-checked every monitor tick. The monitor user requires the SUPER-privilege for\
+If set to ON, the monitor attempts to
+disable the _read\_only_-flag on the primary when seen. The flag is
+checked every monitor tick. The monitor user requires the SUPER-privilege for
 this feature to work.
 
-Typically, the primary server should never be in read-only-mode. Such a situation\
-may arise due to misconfiguration or accident, or perhaps if MaxScale crashed\
+Typically, the primary server should never be in read-only-mode. Such a situation
+may arise due to misconfiguration or accident, or perhaps if MaxScale crashed
 during switchover.
 
-When this feature is enabled, setting the primary manually to _read\_only_ will no\
-longer cause the monitor to search for another primary. The primary will instead\
-for a moment lose its \[Master]-status (no writes), until the monitor again\
-enables writes on the primary. When starting from scratch, the monitor still\
+When this feature is enabled, setting the primary manually to _read\_only_ will no
+longer cause the monitor to search for another primary. The primary will instead
+for a moment lose its \[Master]-status (no writes), until the monitor again
+enables writes on the primary. When starting from scratch, the monitor still
 prefers to select a writable server as primary if possible.
 
 #### `enforce_read_only_slaves`
@@ -358,18 +358,18 @@ prefers to select a writable server as primary if possible.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-enable the _read\_only_-flag on any writable replica server. The flag is checked\
-every monitor tick. The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this\
+If set to ON, the monitor attempts to
+enable the _read\_only_-flag on any writable replica server. The flag is checked
+every monitor tick. The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this
 feature to work. While the _read\_only_-flag is ON, only users with the\
-SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If\
-temporary write access is required, this feature should be disabled before\
-attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly\
+SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If
+temporary write access is required, this feature should be disabled before
+attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly
 re-enable it.
 
-_read\_only_ won't be enabled on the master server, even if it has\
-lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#master_conditions) and is\
+_read\_only_ won't be enabled on the master server, even if it has
+lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#master_conditions) and is
 marked \[Slave].
 
 #### `enforce_read_only_servers`
@@ -379,12 +379,12 @@ marked \[Slave].
 * Dynamic: Yes
 * Default: `false`
 
-Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in\
+Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in
 maintenance (a superset of the servers altered by _enforce\_read\_only\_slaves_).
 
-The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid\
-primary or primary candidate, _read\_only_ is not set on any server as it is\
+The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid
+primary or primary candidate, _read\_only_ is not set on any server as it is
 unclear which servers should be altered.
 
 #### `maintenance_on_low_disk_space`
@@ -394,16 +394,16 @@ unclear which servers should be altered.
 * Dynamic: Yes
 * Default: `true`
 
-If a running server that is not the primary\
+If a running server that is not the primary
 or a relay primary is out of disk space the server is set to maintenance mode.\
-Such servers are not used for router sessions and are ignored when performing a\
-failover or other cluster modification operation. See the general monitor\
-parameters [disk\_space\_threshold](mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md) and [disk\_space\_check\_interval](mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md)\
+Such servers are not used for router sessions and are ignored when performing a
+failover or other cluster modification operation. See the general monitor
+parameters [disk\_space\_threshold](mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md) and [disk\_space\_check\_interval](mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md)
 on how to enable disk space monitoring.
 
-Once a server has been put to maintenance mode, the disk space situation\
-of that server is no longer updated. The server will not be taken out of\
-maintenance mode even if more disk space becomes available. The maintenance\
+Once a server has been put to maintenance mode, the disk space situation
+of that server is no longer updated. The server will not be taken out of
+maintenance mode even if more disk space becomes available. The maintenance
 flag must be removed manually:
 
 ```
@@ -418,22 +418,22 @@ maxctrl clear server server2 Maint
 * Values: `none`, `majority_of_all`, `majority_of_running`
 * Default: `none`
 
-Using this setting is recommended when multiple MaxScales are monitoring the\
-same backend cluster. When enabled, the monitor attempts to acquire exclusive\
-locks on the backend servers. The monitor considers itself the primary monitor\
-if it has a majority of locks. The majority can be either over all configured\
-servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cooperative-monitoring)\
+Using this setting is recommended when multiple MaxScales are monitoring the
+same backend cluster. When enabled, the monitor attempts to acquire exclusive
+locks on the backend servers. The monitor considers itself the primary monitor
+if it has a majority of locks. The majority can be either over all configured
+servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cooperative-monitoring)
 for more details on how this feature works and which value to use.
 
 Allowed values:
 
 1. `none` Default value, no locking.
-2. `majority_of_all` Primary monitor requires a majority of locks, even counting\
+2. `majority_of_all` Primary monitor requires a majority of locks, even counting
    servers which are \[Down].
 3. `majority_of_running` Primary monitor requires a majority of locks over\
    \[Running] servers.
 
-This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has\
+This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has
 acquired the locks. Generally, it's best not to mix cooperative monitoring with\_passive\_. Either set `passive=false` or do not set it at all.
 
 #### `script_max_replication_lag`
@@ -443,38 +443,38 @@ acquired the locks. Generally, it's best not to mix cooperative monitoring with\
 * Dynamic: Yes
 * Default: `-1`
 
-Defines a replication lag limit in seconds for\
-launching the monitor script configured in the _script_-parameter. If the\
+Defines a replication lag limit in seconds for
+launching the monitor script configured in the _script_-parameter. If the
 replication lag of a server goes above this limit, the script is ran with the\
-$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the\
+$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
-Negative values disable this feature. For more information on monitor scripts,\
+Negative values disable this feature. For more information on monitor scripts,
 see [general monitor documentation](https://mariadb.com/kb/en/node:maxscale-24-02-common-monitor-parameters#script).
 
 ### Cluster manipulation operations
 
-Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster\
+Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster
 modification. The operations implemented are:
 
 * [failover](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#failover), which replaces a failed primary with a replica
 * [switchover](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#switchover), which swaps a running primary with a replica
-* [switchover-force](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#switchover-force), which swaps a running primary with a replica, ignoring\
+* [switchover-force](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#switchover-force), which swaps a running primary with a replica, ignoring
   most errors. Can break replication.
 * [async-switchover](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#queued-switchover), which schedules a switchover and returns
 * [rejoin](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#rejoin), which directs servers to replicate from the primary
-* [reset-replication](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and\
+* [reset-replication](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
-See [operation details](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#operation-details) for more information on the\
+See [operation details](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#operation-details) for more information on the
 implementation of the commands.
 
-The cluster operations require that the monitor user (`user`) has the following\
+The cluster operations require that the monitor user (`user`) has the following
 privileges:
 
-* SUPER, to modify replica connections, set globals such as read\_only and kill\
+* SUPER, to modify replica connections, set globals such as read\_only and kill
   connections from other super-users
-* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list\
+* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list
   replica connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
@@ -482,19 +482,19 @@ privileges:
 * SELECT on mysql.user, to see which users have SUPER
 * SELECT on mysql.global\_priv so see to see which users have READ\_ONLY ADMIN
 
-A list of the grants can be found in the [Required Grants](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#required-grants)\
+A list of the grants can be found in the [Required Grants](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#required-grants)
 section.
 
-The privilege system was changed in MariaDB Server 10.5. The effects of this on\
-the MaxScale monitor user are minor, as the SUPER-privilege contains many of the\
-required privileges and is still required to kill connections from other\
+The privilege system was changed in MariaDB Server 10.5. The effects of this on
+the MaxScale monitor user are minor, as the SUPER-privilege contains many of the
+required privileges and is still required to kill connections from other
 super-users.
 
-In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required\
+In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required
 grants. The monitor requires:
 
 * READ\_ONLY ADMIN, to set read\_only
-* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication\
+* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication
   connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
@@ -504,19 +504,19 @@ grants. The monitor requires:
 * SELECT on mysql.user, to see which users have SUPER
 * SELECT on mysql.global\_priv so see to see which users have READ\_ONLY ADMIN
 
-In addition, the monitor needs to know which username and password a\
+In addition, the monitor needs to know which username and password a
 replica should use when starting replication. These are given in`replication_user` and `replication_password`.
 
-The user can define files with SQL statements which are executed on any server\
+The user can define files with SQL statements which are executed on any server
 being demoted or promoted by cluster manipulation commands. See the sections on`promotion_sql_file` and `demotion_sql_file` for more information.
 
-The monitor can manipulate scheduled server events when promoting or demoting a\
+The monitor can manipulate scheduled server events when promoting or demoting a
 server. See the section on `handle_events` for more information.
 
-All cluster operations can be activated manually through MaxCtrl. See\
+All cluster operations can be activated manually through MaxCtrl. See
 section [Manual activation](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#manual-activation) for more details.
 
-See [Limitations and requirements](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#limitations-and-requirements) for\
+See [Limitations and requirements](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#limitations-and-requirements) for
 information on possible issues with failover and switchover.
 
 #### Operation details
@@ -527,22 +527,22 @@ information on possible issues with failover and switchover.
 call command mariadbmon failover MONITOR
 ```
 
-**Failover** replaces a failed primary with a running replica. It does the\
+**Failover** replaces a failed primary with a running replica. It does the
 following:
 
-1. Select the most up-to-date replica of the old primary to be the new primary. The\
+1. Select the most up-to-date replica of the old primary to be the new primary. The
    selection criteria is as follows in descending priority:
 2. gtid\_IO\_pos (latest event in relay log)
 3. gtid\_current\_pos (most processed events)
 4. log\_slave\_updates is on
 5. disk space is not low
-6. If the new primary has unprocessed relay log items, cancel and try again\
+6. If the new primary has unprocessed relay log items, cancel and try again
    later.
 7. Prepare the new primary:
-8. Remove the replica connection the new primary used to replicate from the\
+8. Remove the replica connection the new primary used to replicate from the
    old primary.
 9. Disable the read\_only-flag.
-10. Enable scheduled server events (if event handling is on). Only events\
+10. Enable scheduled server events (if event handling is on). Only events
     that were enabled on the old primary are enabled.
 11. Run the commands in `promotion_sql_file`.
 12. Start replication from external primary if one existed.
@@ -552,7 +552,7 @@ following:
 16. START SLAVE
 17. Check that all replicas are replicating.
 
-Failover is considered successful if steps 1 to 3 succeed, as the cluster then\
+Failover is considered successful if steps 1 to 3 succeed, as the cluster then
 has at least a valid primary server.
 
 **Switchover**
@@ -561,26 +561,26 @@ has at least a valid primary server.
 call command mariadbmon switchover MONITOR [NEW_PRIMARY] [OLD_PRIMARY]
 ```
 
-**Switchover** swaps a running primary with a running replica. It does the\
+**Switchover** swaps a running primary with a running replica. It does the
 following:
 
 1. Prepare the old primary for demotion:
 2. If `backend_read_timeout` is short, extend it and reconnect.
 3. Stop any external replication.
 4. Enable the read\_only-flag to stop writes from normal users.
-5. Kill connections from super and read-only admin users since\
-   read\_only does not affect them. During this step, all writes are\
+5. Kill connections from super and read-only admin users since
+   read\_only does not affect them. During this step, all writes are
    blocked with "FLUSH TABLES WITH READ LOCK".
 6. Disable scheduled server events (if event handling is on).
 7. Run the commands in `demotion_sql_file`.
 8. Flush the binary log ("flush logs") so that all events are on disk.
 9. Wait a moment to check that gtid is stable.
 10. Wait for the new primary to catch up with the old primary.
-11. Promote new primary and redirect replicas as in failover steps 3 and 4. Also\
+11. Promote new primary and redirect replicas as in failover steps 3 and 4. Also
     redirect the demoted old primary.
 12. Check that all replicas are replicating.
 
-Similar to failover, switchover is considered successful if the new primary was\
+Similar to failover, switchover is considered successful if the new primary was
 successfully promoted.
 
 **Switchover-force**
@@ -589,11 +589,11 @@ successfully promoted.
 call command mariadbmon switchover-force MONITOR [NEW_PRIMARY] [OLD_PRIMARY]
 ```
 
-**Switchover-force** performs the same steps as a normal switchover but ignores\
-any errors on the old primary. Switchover-force also does not expect the new\
-primary to reach the gtid-position of the old, as the old primary\
-could be receiving more events constantly. Thus, switchover-force may lose\
-events and replication can break on multiple (or even all) replicas. This is\
+**Switchover-force** performs the same steps as a normal switchover but ignores
+any errors on the old primary. Switchover-force also does not expect the new
+primary to reach the gtid-position of the old, as the old primary
+could be receiving more events constantly. Thus, switchover-force may lose
+events and replication can break on multiple (or even all) replicas. This is
 an unsafe command and should only be used as a last resort.
 
 **Rejoin**
@@ -602,8 +602,8 @@ an unsafe command and should only be used as a last resort.
 call command mariadbmon rejoin MONITOR OLD_PRIMARY
 ```
 
-**Rejoin** joins a standalone server to the cluster or redirects a replica\
-replicating from a server other than the primary. A standalone server is joined\
+**Rejoin** joins a standalone server to the cluster or redirects a replica
+replicating from a server other than the primary. A standalone server is joined
 by:
 
 1. Run the commands in `demotion_sql_file`.
@@ -620,9 +620,9 @@ STOP SLAVE, RESET SLAVE, CHANGE MASTER TO and START SLAVE commands.
 maxctrl call command mariadbmon reset-replication MONITOR [NEW_PRIMARY]
 ```
 
-**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets\
-gtid:s. This destructive command is meant for situations where the gtid:s in the\
-cluster are out of sync while the actual data is known to be in sync. The\
+**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets
+gtid:s. This destructive command is meant for situations where the gtid:s in the
+cluster are out of sync while the actual data is known to be in sync. The
 operation proceeds as follows:
 
 1. Reset gtid:s and delete binary logs on all servers:
@@ -630,38 +630,38 @@ operation proceeds as follows:
 3. Enable the read\_only-flag.
 4. Disable scheduled server events (if event handling is on).
 5. Delete binary logs (RESET MASTER).
-6. Set the sequence number of gtid\_slave\_pos to zero. This also affects\
+6. Set the sequence number of gtid\_slave\_pos to zero. This also affects
    gtid\_current\_pos.
 7. Prepare new primary:
 8. Disable the read\_only-flag.
-9. Enable scheduled server events (if event handling is on). Events are\
-   only enabled if the cluster had a primary server when starting the\
-   reset-replication operation. Only events that were enabled on the previous\
+9. Enable scheduled server events (if event handling is on). Events are
+   only enabled if the cluster had a primary server when starting the
+   reset-replication operation. Only events that were enabled on the previous
    primary are enabled on the new.
-10. Direct other servers to replicate from the new primary as in the other\
+10. Direct other servers to replicate from the new primary as in the other
     operations.
 
 #### Manual activation
 
 Cluster operations can be activated manually through the REST API or MaxCtrl.\
-The commands are only performed when MaxScale is in active mode. The commands\
-generally match their automatic versions. The exception is _rejoin_, in which\
-the manual command allows rejoining even when the joining server has empty\
-gtid:s. This rule allows the user to force a rejoin on a server without binary\
+The commands are only performed when MaxScale is in active mode. The commands
+generally match their automatic versions. The exception is _rejoin_, in which
+the manual command allows rejoining even when the joining server has empty
+gtid:s. This rule allows the user to force a rejoin on a server without binary
 logs.
 
-All commands require the monitor instance name as the first parameter. Failover\
-selects the new primary server automatically and does not require additional\
+All commands require the monitor instance name as the first parameter. Failover
+selects the new primary server automatically and does not require additional
 parameters. Rejoin requires the name of the joining server as second parameter.\
 Replication reset accepts the name of the new primary server as second parameter.\
 If not given, the current primary is selected.
 
-Switchover takes one to three parameters. If only the monitor name is given,\
-switchover will autoselect both the replica to promote and the current primary as\
-the server to be demoted. If two parameters are given, the second parameter is\
-interpreted as the replica to promote. If three parameters are given, the third\
-parameter is interpreted as the current primary. The user-given current primary is\
-compared to the primary server currently deduced by the monitor and if the two\
+Switchover takes one to three parameters. If only the monitor name is given,
+switchover will autoselect both the replica to promote and the current primary as
+the server to be demoted. If two parameters are given, the second parameter is
+interpreted as the replica to promote. If three parameters are given, the third
+parameter is interpreted as the current primary. The user-given current primary is
+compared to the primary server currently deduced by the monitor and if the two
 are unequal, an error is given.
 
 Example commands are below:
@@ -677,28 +677,28 @@ maxctrl call command mariadbmon switchover MyMonitor NewPrimaryServ OldPrimarySe
 maxctrl call command mariadbmon switchover-force MyMonitor NewPrimaryServ
 ```
 
-The commands follow the standard module command syntax. All require the monitor\
-configuration name (MyMonitor) as the first parameter. For switchover, the\
-last two parameters define the server to promote (NewPrimaryServ) and the server\
-to demote (OldPrimaryServ). For rejoin, the server to join (OldPrimaryServ) is\
+The commands follow the standard module command syntax. All require the monitor
+configuration name (MyMonitor) as the first parameter. For switchover, the
+last two parameters define the server to promote (NewPrimaryServ) and the server
+to demote (OldPrimaryServ). For rejoin, the server to join (OldPrimaryServ) is
 required. Replication reset requires the server to promote (NewPrimaryServ).
 
-It is safe to perform manual operations even with automatic failover, switchover\
-or rejoin enabled since automatic operations cannot happen simultaneously\
+It is safe to perform manual operations even with automatic failover, switchover
+or rejoin enabled since automatic operations cannot happen simultaneously
 with manual ones.
 
-When a cluster modification is initiated via the REST-API, the URL path is of the\
+When a cluster modification is initiated via the REST-API, the URL path is of the
 form:
 
 ```
 /v1/maxscale/modules/mariadbmon/<operation>?<monitor-name>&<server-name1>&<server-name2>
 ```
 
-* `<operation>` is the name of the command e.g. failover, switchover,\
+* `<operation>` is the name of the command e.g. failover, switchover,
   rejoin or reset-replication.
 * `<monitor-name>` is the monitor name from the MaxScale configuration file.
-* `<server-name1>` and `<server-name2>` are server names as described\
-  above for MaxCtrl. Only switchover accepts both, failover doesn't need any\
+* `<server-name1>` and `<server-name2>` are server names as described
+  above for MaxCtrl. Only switchover accepts both, failover doesn't need any
   and both rejoin and reset-replication accept one.
 
 Given a MaxScale configuration file like
@@ -711,7 +711,7 @@ servers=server1, server2, server3, server 4
 ...
 ```
 
-with the assumption that `server2` is the current primary, then the URL\
+with the assumption that `server2` is the current primary, then the URL
 path for making `server4` the new primary would be:
 
 ```
@@ -728,9 +728,9 @@ Example REST-API paths for other commands are listed below.
 
 **Queued switchover**
 
-Most cluster modification commands wait until the operation either succeeds or\
-fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the\
-module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,\
+Most cluster modification commands wait until the operation either succeeds or
+fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the
+module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,
 whether queued or not.
 
 ```
@@ -747,123 +747,123 @@ maxctrl call command mariadbmon fetch-cmd-result Cluster1
 
 #### Automatic activation
 
-Failover can activate automatically if `auto_failover` is on. The activation\
+Failover can activate automatically if `auto_failover` is on. The activation
 begins when the primary has been down at least `failcount` monitor iterations.\
-Before modifying the cluster, the monitor checks that all prerequisites for the\
-failover are fulfilled. If the cluster does not seem ready, an error is printed\
+Before modifying the cluster, the monitor checks that all prerequisites for the
+failover are fulfilled. If the cluster does not seem ready, an error is printed
 and the cluster is rechecked during the next monitor iteration.
 
-Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the primary\
-server is low on disk space but otherwise the operating logic is quite similar\
+Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the primary
+server is low on disk space but otherwise the operating logic is quite similar
 to automatic failover.
 
-Rejoin stands for starting replication on a standalone server or redirecting a\
-replica replicating from the wrong primary (any server that is not the cluster\
-primary). The rejoined servers are directed to replicate from the current cluster\
-primary server, forcing the replication topology to a 1-primary-N-replicas\
+Rejoin stands for starting replication on a standalone server or redirecting a
+replica replicating from the wrong primary (any server that is not the cluster
+primary). The rejoined servers are directed to replicate from the current cluster
+primary server, forcing the replication topology to a 1-primary-N-replicas
 configuration.
 
-A server is categorized as standalone if the server has no replica connections,\
-not even stopped ones. A server is replicating from the wrong primary if the\
-replica IO thread is connected but the primary server id seen by the replica does not\
-match the cluster primary id. Alternatively, the IO thread may be stopped or\
-connecting but the primary server host or port information differs from the\
-cluster primary info. These criteria mean that a STOP SLAVE does not yet set a\
+A server is categorized as standalone if the server has no replica connections,
+not even stopped ones. A server is replicating from the wrong primary if the
+replica IO thread is connected but the primary server id seen by the replica does not
+match the cluster primary id. Alternatively, the IO thread may be stopped or
+connecting but the primary server host or port information differs from the
+cluster primary info. These criteria mean that a STOP SLAVE does not yet set a
 replica as standalone.
 
-With `auto_rejoin` active, the monitor will try to rejoin any servers matching\
-the above requirements. Rejoin does not obey `failcount` and will attempt to\
-rejoin any valid servers immediately. When activating rejoin manually, the\
+With `auto_rejoin` active, the monitor will try to rejoin any servers matching
+the above requirements. Rejoin does not obey `failcount` and will attempt to
+rejoin any valid servers immediately. When activating rejoin manually, the
 user-designated server must fulfill the same requirements.
 
 #### Limitations and requirements
 
-Switchover and failover are meant for simple topologies (one primary and\
-several replicas). Using these commands with complicated topologies\
-(multiple primaries, relays, circular replication) may give unpredictable results\
+Switchover and failover are meant for simple topologies (one primary and
+several replicas). Using these commands with complicated topologies
+(multiple primaries, relays, circular replication) may give unpredictable results
 and should be tested before use on a production system.
 
-The server cluster is assumed to be well-behaving with no significant\
-replication lag (within `failover_timeout`/`switchover_timeout`) and all\
+The server cluster is assumed to be well-behaving with no significant
+replication lag (within `failover_timeout`/`switchover_timeout`) and all
 commands that modify the cluster (such as "STOP SLAVE", "CHANGE MASTER",\
-"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`\
+"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`
 and `backend_write_timeout`).
 
-The backends must all use GTID-based replication, and the domain id should not\
-change during a switchover or failover. Replicas should not have extra\
+The backends must all use GTID-based replication, and the domain id should not
+change during a switchover or failover. Replicas should not have extra
 local events so that GTIDs are compatible across the cluster.
 
-Failover cannot be performed if MaxScale was started only after the primary\
-server went down. This is because MaxScale needs reliable information on the\
-gtid domain of the cluster and the replication topology in general to properly\
+Failover cannot be performed if MaxScale was started only after the primary
+server went down. This is because MaxScale needs reliable information on the
+gtid domain of the cluster and the replication topology in general to properly
 select the new primary. `enforce_simple_topology=1` relaxes this requirement.
 
-Failover may lose events. If a primary goes down before sending new events to at\
-least one replica, those events are lost when a new primary is chosen. If the old\
-primary comes back online, the other servers have likely moved on with a\
+Failover may lose events. If a primary goes down before sending new events to at
+least one replica, those events are lost when a new primary is chosen. If the old
+primary comes back online, the other servers have likely moved on with a
 diverging history and the old primary can no longer join the replication cluster.
 
 To reduce the chance of losing data, use [semisynchronous replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication).\
-In semisynchronous mode, the primary waits for a replica to receive an event before\
-returning an acknowledgement to the client. This does not yet guarantee a clean\
-failover. If the primary fails after preparing a transaction but before receiving\
-replica acknowledgement, it will still commit the prepared transaction as part of\
-its crash recovery. If the replicas never saw this transaction, the\
-old primary has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
+In semisynchronous mode, the primary waits for a replica to receive an event before
+returning an acknowledgement to the client. This does not yet guarantee a clean
+failover. If the primary fails after preparing a transaction but before receiving
+replica acknowledgement, it will still commit the prepared transaction as part of
+its crash recovery. If the replicas never saw this transaction, the
+old primary has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
 for more information. This situation is much less likely in MariaDB Server\
-10.6.2 and later, as the improved crash recovery logic will delete such\
+10.6.2 and later, as the improved crash recovery logic will delete such
 transactions.
 
-Even a controlled shutdown of the primary may lose events. The server does not by\
-default wait for all data to be replicated to the replicas when shutting down and\
-instead simply closes all connections. Before shutting down the primary with the\
-intention of having a replica promoted, run _switchover_ first to ensure that all\
+Even a controlled shutdown of the primary may lose events. The server does not by
+default wait for all data to be replicated to the replicas when shutting down and
+instead simply closes all connections. Before shutting down the primary with the
+intention of having a replica promoted, run _switchover_ first to ensure that all
 data is replicated. For more information on server shutdown, see [Binary Log Dump Threads and the Shutdown Process](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-threads).
 
-Switchover requires that the cluster is "frozen" for the duration of the\
-operation. This means that no data modifying statements such as INSERT or UPDATE\
-are executed and the GTID position of the primary server is stable. When\
-switchover begins, the monitor sets the global _read\_only_ flag on the old\
+Switchover requires that the cluster is "frozen" for the duration of the
+operation. This means that no data modifying statements such as INSERT or UPDATE
+are executed and the GTID position of the primary server is stable. When
+switchover begins, the monitor sets the global _read\_only_ flag on the old
 primary backend to stop any updates. _read\_only_ does not affect users with the\
-SUPER-privilege so any such user can issue writes during a switchover. These\
-writes have a high chance of breaking replication, because the write may not be\
-replicated to all replicas before they switch to the new primary. To prevent this,\
-any users who commonly do updates should NOT have the SUPER-privilege. For even\
+SUPER-privilege so any such user can issue writes during a switchover. These
+writes have a high chance of breaking replication, because the write may not be
+replicated to all replicas before they switch to the new primary. To prevent this,
+any users who commonly do updates should NOT have the SUPER-privilege. For even
 more security, the only SUPER-user session during a switchover should be the\
-MaxScale monitor user. This also applies to users running scheduled server\
-events. Although the monitor by default disables events on the master, an\
-event may already be executing. If the event definer has SUPER-privilege, the\
+MaxScale monitor user. This also applies to users running scheduled server
+events. Although the monitor by default disables events on the master, an
+event may already be executing. If the event definer has SUPER-privilege, the
 event can write to the database even through _read\_only_.
 
-When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest\
-of the cluster. If the current cluster primary does not have binary logs from the\
-moment the rejoining server lost connection, the rejoining server cannot\
-continue replication. This is an issue if the primary has changed and\
+When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest
+of the cluster. If the current cluster primary does not have binary logs from the
+moment the rejoining server lost connection, the rejoining server cannot
+continue replication. This is an issue if the primary has changed and
 the new primary does not have _log\_slave\_updates_ on.
 
-If an automatic cluster operation such as auto-failover or auto-rejoin fails,\
-all cluster modifying operations are disabled for `failcount` monitor iterations,\
-after which the operation may be retried. Similar logic applies if the cluster is\
+If an automatic cluster operation such as auto-failover or auto-rejoin fails,
+all cluster modifying operations are disabled for `failcount` monitor iterations,
+after which the operation may be retried. Similar logic applies if the cluster is
 unsuitable for such operations, e.g. replication is not using GTID.
 
 #### External primary support
 
-The monitor detects if a server in the cluster is replicating from an external\
-primary (a server that is not monitored by the monitor). If the replicating\
-server is the cluster primary server, then the cluster itself is considered to\
+The monitor detects if a server in the cluster is replicating from an external
+primary (a server that is not monitored by the monitor). If the replicating
+server is the cluster primary server, then the cluster itself is considered to
 have an external primary.
 
-If a failover/switchover happens, the new primary server is set to replicate from\
-the cluster external primary server. The username and password for the replication\
-are defined in `replication_user` and `replication_password`. The address and\
-port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster\
-primary server. In the case of switchover, the old primary also stops replicating\
+If a failover/switchover happens, the new primary server is set to replicate from
+the cluster external primary server. The username and password for the replication
+are defined in `replication_user` and `replication_password`. The address and
+port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster
+primary server. In the case of switchover, the old primary also stops replicating
 from the external server to preserve the topology.
 
-After failover the new primary is replicating from the external primary. If the\
-failed old primary comes back online, it is also replicating from the external\
-server. To normalize the situation, either have _auto\_rejoin_ on or manually\
-execute a rejoin. This will redirect the old primary to the current cluster\
+After failover the new primary is replicating from the external primary. If the
+failed old primary comes back online, it is also replicating from the external
+server. To normalize the situation, either have _auto\_rejoin_ on or manually
+execute a rejoin. This will redirect the old primary to the current cluster
 primary.
 
 #### Configuration parameters
@@ -875,18 +875,18 @@ primary.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic primary failover. When automatic failover is enabled, MaxScale\
-will elect a new primary server for the cluster if the old primary goes down. A\
-server is assumed _Down_ if it cannot be connected to, even if this is caused by\
+Enable automatic primary failover. When automatic failover is enabled, MaxScale
+will elect a new primary server for the cluster if the old primary goes down. A
+server is assumed _Down_ if it cannot be connected to, even if this is caused by
 incorrect credentials. Failover triggers if the primary stays down for [failcount](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#failcount) monitor intervals. Failover will not take place if\
 MaxScale is set [passive](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
 
-As failover alters replication, it requires more privileges than normal\
+As failover alters replication, it requires more privileges than normal
 monitoring. See [here](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cluster-manipulation-grants) for a list of grants.
 
-Failover is designed to be used with simple primary-replica topologies. More\
-complicated topologies, such as multilayered or circular replication, are not\
-guaranteed to always work correctly. Test before using failover with such\
+Failover is designed to be used with simple primary-replica topologies. More
+complicated topologies, such as multilayered or circular replication, are not
+guaranteed to always work correctly. Test before using failover with such
 setups.
 
 **`auto_rejoin`**
@@ -896,20 +896,20 @@ setups.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic joining of servers to the cluster. When enabled, MaxScale will\
-attempt to direct servers to replicate from the current cluster primary if they\
-are not currently doing so. Replication will be started on any standalone\
+Enable automatic joining of servers to the cluster. When enabled, MaxScale will
+attempt to direct servers to replicate from the current cluster primary if they
+are not currently doing so. Replication will be started on any standalone
 servers. Servers that are replicating from another server will be redirected.\
-This effectively enforces a 1-primary-N-replicas topology. The current primary\
-itself is not redirected, so it can continue to replicate from an external\
-primary. Rejoin is also not performed on any server that is replicating from\
-multiple sources, as this indicates a complicated topology (this rule is\
+This effectively enforces a 1-primary-N-replicas topology. The current primary
+itself is not redirected, so it can continue to replicate from an external
+primary. Rejoin is also not performed on any server that is replicating from
+multiple sources, as this indicates a complicated topology (this rule is
 overridden by [enforce\_simple\_topology](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#enforce_simple_topology)).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#auto_failover) to redirect\
-the former primary when it comes back online. Sometimes this kind of rejoin will\
-fail as the old primary may have transactions that were never replicated to the\
-current one. See [limitations](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#limitations-and-requirements) for more\
+This feature is often paired with [auto\_failover](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#auto_failover) to redirect
+the former primary when it comes back online. Sometimes this kind of rejoin will
+fail as the old primary may have transactions that were never replicated to the
+current one. See [limitations](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#limitations-and-requirements) for more
 information.
 
 As an example, consider the following series of events:
@@ -919,9 +919,9 @@ As an example, consider the following series of events:
 3. Replica A comes back
 4. Old primary comes back
 
-Replica A is still trying to replicate from the downed primary, since it wasn't\
-online during failover. If _auto\_rejoin_ is on, Replica A will quickly be\
-redirected to Replica B, the current primary. The old primary will also rejoin the\
+Replica A is still trying to replicate from the downed primary, since it wasn't
+online during failover. If _auto\_rejoin_ is on, Replica A will quickly be
+redirected to Replica B, the current primary. The old primary will also rejoin the
 cluster if possible.
 
 **`switchover_on_low_disk_space`**
@@ -954,18 +954,18 @@ switchover_on_low_disk_space=true
 * Default: `false`
 
 This setting tells the monitor to assume that the servers should be arranged in a\
-1-primary-N-replicas topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual\
+1-primary-N-replicas topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual
 settings.
 
-By default, mariadbmon will not rejoin servers with more than one replication\
-stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the\
-cluster and any extra replication sources will be removed. This is done to make\
+By default, mariadbmon will not rejoin servers with more than one replication
+stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the
+cluster and any extra replication sources will be removed. This is done to make
 automated failover with multi-source external replication possible.
 
-This setting also allows the monitor to perform a failover to a cluster where the primary\
-server has not been seen \[Running]. This is usually the case when the primary goes down\
-before MaxScale is started. When using this feature, the monitor will guess the GTID\
-domain id of the primary from the replicas. For reliable results, the GTID:s of the cluster\
+This setting also allows the monitor to perform a failover to a cluster where the primary
+server has not been seen \[Running]. This is usually the case when the primary goes down
+before MaxScale is started. When using this feature, the monitor will guess the GTID
+domain id of the primary from the replicas. For reliable results, the GTID:s of the cluster
 should be simple.
 
 ```
@@ -979,19 +979,19 @@ enforce_simple_topology=true
 * Dynamic: Yes
 * Default: None
 
-The username and password of the replication user. These are given as the values\
-for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is\
+The username and password of the replication user. These are given as the values
+for `MASTER_USER` and `MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is
 executed.
 
-Both `replication_user` and `replication_password` parameters must be defined if\
-a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication\
+Both `replication_user` and `replication_password` parameters must be defined if
+a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication
 user.
 
-The credentials used for replication must have the `REPLICATION SLAVE`\
+The credentials used for replication must have the `REPLICATION SLAVE`
 privilege.
 
-`replication_password` uses the same encryption scheme as other password\
-parameters. If password encryption is in use, `replication_password` must be\
+`replication_password` uses the same encryption scheme as other password
+parameters. If password encryption is in use, `replication_password` must be
 encrypted with the same key to avoid erroneous decryption.
 
 **`replication_master_ssl`**
@@ -1001,25 +1001,25 @@ encrypted with the same key to avoid erroneous decryption.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable\
-encryption for the replication stream. This setting should only be enabled if the backend\
-servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication\
+If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable
+encryption for the replication stream. This setting should only be enabled if the backend
+servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication
 user should require an encrypted connection (`e.g. ALTER USER repl@'%' REQUIRE SSL;`).
 
-If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing\
+If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing
 settings when redirecting a replica connection.
 
 **`replication_custom_options`**
 
 Type: string
 
-A custom string added to "CHANGE MASTER TO"-commands sent by the monitor\
-whenever setting up replication (e.g. during switchover). Useful for defining\
-ssl certificates or other specialized replication options. MaxScale does not\
-check the contents of the string, so care should be taken to ensure that\
-only valid options are set and that the contents do not interfere with\
-the options MaxScale sets on its own (e.g. MASTER\_HOST). This setting can\
-also be configured for an individual server. If configured for both\
+A custom string added to "CHANGE MASTER TO"-commands sent by the monitor
+whenever setting up replication (e.g. during switchover). Useful for defining
+ssl certificates or other specialized replication options. MaxScale does not
+check the contents of the string, so care should be taken to ensure that
+only valid options are set and that the contents do not interfere with
+the options MaxScale sets on its own (e.g. MASTER\_HOST). This setting can
+also be configured for an individual server. If configured for both
 the monitor and a server, the server setting takes priority.
 
 ```
@@ -1036,19 +1036,19 @@ replication_custom_options=MASTER_SSL_CERT = '/tmp/certs/client-cert.pem',
 * Dynamic: Yes
 * Default: `90s`
 
-Time limit for failover and switchover operations. The default\
-values are 90 seconds for both. `switchover_timeout` is also used as the time\
-limit for a rejoin operation. Rejoin should rarely time out, since it is a\
+Time limit for failover and switchover operations. The default
+values are 90 seconds for both. `switchover_timeout` is also used as the time
+limit for a rejoin operation. Rejoin should rarely time out, since it is a
 faster operation than switchover.
 
-The timeouts are specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeouts is seconds, a timeout specified in milliseconds will be rejected,\
+The timeouts are specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeouts is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If no successful failover/switchover takes place within the configured time\
-period, a message is logged and automatic failover is disabled. This prevents\
+If no successful failover/switchover takes place within the configured time
+period, a message is logged and automatic failover is disabled. This prevents
 further automatic modifications to the misbehaving cluster.
 
 #### **`verify_master_failure`**
@@ -1060,24 +1060,24 @@ further automatic modifications to the misbehaving cluster.
 
 Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and [master\_failure\_timeout](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#master_failure_timeout) defines the timeout.
 
-The primary failure timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The primary failure timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-Failure verification is performed by checking whether the replica servers are\
-still connected to the primary and receiving events. An event is either a change\
-in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat\
-event. Effectively, if a replica has received an event within`master_failure_timeout` duration, the primary is not considered down when\
-deciding whether to failover, even if MaxScale cannot connect to the primary.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of\
+Failure verification is performed by checking whether the replica servers are
+still connected to the primary and receiving events. An event is either a change
+in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat
+event. Effectively, if a replica has received an event within`master_failure_timeout` duration, the primary is not considered down when
+deciding whether to failover, even if MaxScale cannot connect to the primary.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of
 the replica connection to be effective.
 
 If every replica loses its connection to the primary (_Slave\_IO\_Running_ is not\
-"Yes"), primary failure is considered verified regardless of timeout. This allows\
+"Yes"), primary failure is considered verified regardless of timeout. This allows
 faster failover when the primary properly disconnects.
 
-For automatic failover to activate, the `failcount` requirement must also be\
+For automatic failover to activate, the `failcount` requirement must also be
 met.
 
 #### **`master_failure_timeout`**
@@ -1087,10 +1087,10 @@ met.
 * Dynamic: Yes
 * Default: `10s`
 
-`master_failure_timeout` is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+`master_failure_timeout` is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### **`servers_no_promotion`**
@@ -1100,20 +1100,20 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: None
 
-This is a comma-separated list of server names that will not be chosen for\
-primary promotion during a failover or autoselected for switchover. This does not\
-affect switchover if the user selects the server to promote. Using this setting\
-can disrupt new primary selection for failover such that a non-optimal server is\
-chosen. At worst, this will cause replication to break. Alternatively, failover\
+This is a comma-separated list of server names that will not be chosen for
+primary promotion during a failover or autoselected for switchover. This does not
+affect switchover if the user selects the server to promote. Using this setting
+can disrupt new primary selection for failover such that a non-optimal server is
+chosen. At worst, this will cause replication to break. Alternatively, failover
 may fail if all valid promotion candidates are in the exclusion list.
 
 ```
 servers_no_promotion=backup_dc_server1,backup_dc_server2
 ```
 
-As of MaxScale 24.02.4 and 24.08.1, this setting also affects primary\
-server selection during MaxScale startup or due to replication topology\
-changes. A server listed in `servers_no_promotion` will thus not be\
+As of MaxScale 24.02.4 and 24.08.1, this setting also affects primary
+server selection during MaxScale startup or due to replication topology
+changes. A server listed in `servers_no_promotion` will thus not be
 selected as primary unless manually designated in a _switchover_-command.
 
 #### **`promotion_sql_file` and `demotion_sql_file`**
@@ -1124,30 +1124,30 @@ selected as primary unless manually designated in a _switchover_-command.
 * Default: None
 
 These optional settings are paths to text files with SQL statements in them.\
-During promotion or demotion, the contents are read line-by-line and executed on\
-the backend. Use these settings to execute custom statements on the servers to\
+During promotion or demotion, the contents are read line-by-line and executed on
+the backend. Use these settings to execute custom statements on the servers to
 complement the built-in operations.
 
-Empty lines or lines starting with '#' are ignored. Any results returned by the\
-statements are ignored. All statements must succeed for the failover, switchover\
-or rejoin to continue. The monitor user may require additional privileges and\
+Empty lines or lines starting with '#' are ignored. Any results returned by the
+statements are ignored. All statements must succeed for the failover, switchover
+or rejoin to continue. The monitor user may require additional privileges and
 grants for the custom commands to succeed.
 
-When promoting a replica to primary during switchover or failover, the`promotion_sql_file` is read and executed on the new primary server after its\
-read-only flag is disabled. The commands are ran _before_ starting replication\
+When promoting a replica to primary during switchover or failover, the`promotion_sql_file` is read and executed on the new primary server after its
+read-only flag is disabled. The commands are ran _before_ starting replication
 from an external primary if any.
 
-`demotion_sql_file` is ran on an old primary during demotion to replica, before the\
-old primary starts replicating from the new primary. The file is also ran before\
-rejoining a standalone server to the cluster, as the standalone server is\
-typically a former primary server. When redirecting a replica replicating from a\
+`demotion_sql_file` is ran on an old primary during demotion to replica, before the
+old primary starts replicating from the new primary. The file is also ran before
+rejoining a standalone server to the cluster, as the standalone server is
+typically a former primary server. When redirecting a replica replicating from a
 wrong primary, the sql-file is not executed.
 
-Since the queries in the files are ran during operations which modify\
-replication topology, care is required. If `promotion_sql_file` contains data\
-modification (DML) queries, the new primary server may not be able to\
-successfully replicate from an external primary. `demotion_sql_file` should never\
-contain DML queries, as these may not replicate to the replica servers before\
+Since the queries in the files are ran during operations which modify
+replication topology, care is required. If `promotion_sql_file` contains data
+modification (DML) queries, the new primary server may not be able to
+successfully replicate from an external primary. `demotion_sql_file` should never
+contain DML queries, as these may not replicate to the replica servers before
 replica threads are stopped, breaking replication.
 
 ```
@@ -1162,71 +1162,71 @@ demotion_sql_file=/home/root/scripts/demotion.sql
 * Dynamic: Yes
 * Default: `true`
 
-If enabled, the monitor continuously queries the\
-servers for enabled scheduled events and uses this information when performing\
+If enabled, the monitor continuously queries the
+servers for enabled scheduled events and uses this information when performing
 cluster operations, enabling and disabling events as appropriate.
 
 When a server is being demoted, any events with "ENABLED" status are set to\
 "SLAVESIDE\_DISABLED". When a server is being promoted to primary, events that are either\
-"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled\
-on the old primary server last time it was successfully queried. Events are considered\
-identical if they have the same schema and name. When a standalone server is rejoined to\
+"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled
+on the old primary server last time it was successfully queried. Events are considered
+identical if they have the same schema and name. When a standalone server is rejoined to
 the cluster, its events are also disabled since it is now a replica.
 
-The monitor does not check whether the same events were disabled and enabled during a\
+The monitor does not check whether the same events were disabled and enabled during a
 switchover or failover/rejoin. All events that meet the criteria above are altered.
 
-The monitor does not enable or disable the event scheduler itself. For the\
-events to run on the new primary server, the scheduler should be enabled by the\
+The monitor does not enable or disable the event scheduler itself. For the
+events to run on the new primary server, the scheduler should be enabled by the
 admin. Enabling it in the server configuration file is recommended.
 
-Events running at high frequency may cause replication to break in a failover\
-scenario. If an old primary which was failed over restarts, its event scheduler\
-will be on if set in the server configuration file. Its events will also\
-remember their "ENABLED"-status and run when scheduled. This may happen before\
-the monitor rejoins the server and disables the events. This should only be an\
-issue for events running more often than the monitor interval or events that run\
+Events running at high frequency may cause replication to break in a failover
+scenario. If an old primary which was failed over restarts, its event scheduler
+will be on if set in the server configuration file. Its events will also
+remember their "ENABLED"-status and run when scheduled. This may happen before
+the monitor rejoins the server and disables the events. This should only be an
+issue for events running more often than the monitor interval or events that run
 immediately after the server has restarted.
 
 ### Cooperative monitoring
 
-As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means\
-that multiple monitors (typically in different MaxScale instances) can monitor\
-the same backend server cluster and only one will be the primary monitor. Only\
+As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means
+that multiple monitors (typically in different MaxScale instances) can monitor
+the same backend server cluster and only one will be the primary monitor. Only
 the primary monitor may perform _switchover_, _failover_ or _rejoin_ operations.\
-The primary also decides which server is the primary. Cooperative monitoring is\
+The primary also decides which server is the primary. Cooperative monitoring is
 enabled with the [cooperative\_monitoring\_locks](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#cooperative_monitoring_locks)-setting.\
 Even with this setting, only one monitor per server per MaxScale is allowed.\
-This limitation can be circumvented by defining multiple copies of a server in\
+This limitation can be circumvented by defining multiple copies of a server in
 the configuration file.
 
-Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)\
-for coordinating between monitors. When cooperating, the monitor regularly\
-checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and\
-acquires it if free. If the monitor acquires a majority of locks, it is the\
+Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)
+for coordinating between monitors. When cooperating, the monitor regularly
+checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and
+acquires it if free. If the monitor acquires a majority of locks, it is the
 primary. If a monitor cannot claim majority locks, it is a secondary monitor.
 
 The primary monitor of a cluster also acquires the lock _maxscale\_mariadbmonitor\_master_ on the primary server. Secondary monitors check
 which server this lock is taken on and only accept that server as the primary.\
-This arrangement is required so that multiple monitors can agree on which server\
-is the primary regardless of replication topology. If a secondary monitor does\
-not see the primary-lock taken, then it won't mark any server as \[Master],\
+This arrangement is required so that multiple monitors can agree on which server
+is the primary regardless of replication topology. If a secondary monitor does
+not see the primary-lock taken, then it won't mark any server as \[Master],
 causing writes to fail.
 
-The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor\
-needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three\
-servers needs two locks for majority, a cluster of four needs three, and a\
+The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor
+needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three
+servers needs two locks for majority, a cluster of four needs three, and a
 cluster of five needs three.\
-This scheme is resistant against split-brain situations in the sense\
-that multiple monitors cannot be primary simultaneously. However, a split may\
-cause both monitors to consider themselves secondary, in which case a primary\
+This scheme is resistant against split-brain situations in the sense
+that multiple monitors cannot be primary simultaneously. However, a split may
+cause both monitors to consider themselves secondary, in which case a primary
 server won't be detected.
 
-Even without a network split, `cooperative_monitoring_locks=majority_of_all`\
-will lead to neither monitor claiming lock majority once too many servers go\
-down. This scenario is depicted in the image below. Only two out of four servers\
-are running when three are needed for majority. Although both MaxScales see both\
-running servers, neither is certain they have majority and the cluster stays in\
+Even without a network split, `cooperative_monitoring_locks=majority_of_all`
+will lead to neither monitor claiming lock majority once too many servers go
+down. This scenario is depicted in the image below. Only two out of four servers
+are running when three are needed for majority. Although both MaxScales see both
+running servers, neither is certain they have majority and the cluster stays in
 read-only mode. If the primary server is down, no failover is performed either.
 
 ```mermaid
@@ -1257,17 +1257,17 @@ flowchart TD
 ```
 _No majority: both MaxScale instances see the same two reachable servers, so neither can lock a majority and both remain secondary._
 
-Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only\
-servers currently \[Running] are considered. This scheme adapts to multiple\
+Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only
+servers currently \[Running] are considered. This scheme adapts to multiple
 servers going down, ensuring that claiming lock majority is always possible.\
-However, it can lead to multiple monitors claiming primary status in a\
-split-brain situation. As an example, consider a cluster with servers 1 to 4\
-with MaxScales A and B, as in the image below. MaxScale A can connect to\
-servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to\
-a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B\
+However, it can lead to multiple monitors claiming primary status in a
+split-brain situation. As an example, consider a cluster with servers 1 to 4
+with MaxScales A and B, as in the image below. MaxScale A can connect to
+servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to
+a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B
 does the opposite, claiming servers 3 and 4 and assuming 1 and 2 are down.\
-Both MaxScales claim two locks out of two available and assume that they have\
-lock majority. Both MaxScales may then promote their own primaries and route\
+Both MaxScales claim two locks out of two available and assume that they have
+lock majority. Both MaxScales may then promote their own primaries and route
 writes to different servers.
 
 ```mermaid
@@ -1300,23 +1300,23 @@ flowchart TD
 ```
 _Split brain: a broken heartbeat between datacenters lets both MaxScale A and MaxScale B act as primary at once, each locking its own read-write server._
 
-The recommended strategy depends on which failure scenario is more likely and/or\
-more destructive. If it's unlikely that multiple servers are ever down\
-simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other\
-hand, if split-brain is unlikely but multiple servers may be down\
+The recommended strategy depends on which failure scenario is more likely and/or
+more destructive. If it's unlikely that multiple servers are ever down
+simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other
+hand, if split-brain is unlikely but multiple servers may be down
 simultaneously, then _majority\_of\_running_ would keep the cluster operational.
 
-To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the\
-monitor has lock majority on the cluster. If cooperative monitoring is disabled,\
-the field value is _null_. Lock information for individual servers is listed in\
-the server-specific field **lock\_held**. Again, _null_ indicates that locks are\
+To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the
+monitor has lock majority on the cluster. If cooperative monitoring is disabled,
+the field value is _null_. Lock information for individual servers is listed in
+the server-specific field **lock\_held**. Again, _null_ indicates that locks are
 not in use or the lock status is unknown.
 
-If a MaxScale instance tries to acquire the locks but fails to get majority\
-(perhaps another MaxScale was acquiring locks simultaneously) it will release\
-any acquired locks and try again after a random number of monitor ticks. This\
+If a MaxScale instance tries to acquire the locks but fails to get majority
+(perhaps another MaxScale was acquiring locks simultaneously) it will release
+any acquired locks and try again after a random number of monitor ticks. This
 prevents multiple MaxScales from fighting over the locks continuously as one\
-MaxScale will eventually wait less time than the others. Conflict probability\
+MaxScale will eventually wait less time than the others. Conflict probability
 can be further decreased by configuring each monitor with a different\_monitor\_interval\_.
 
 The flowchart below illustrates the lock handling logic.
@@ -1362,19 +1362,19 @@ _MariaDB Monitor cooperative locking: on each tick, a MaxScale that holds (or ca
 
 #### Releasing locks
 
-Monitor cooperation depends on the server locks. The locks are\
-connection-specific. The owning connection can manually release a lock, allowing\
+Monitor cooperation depends on the server locks. The locks are
+connection-specific. The owning connection can manually release a lock, allowing
 another connection to claim it. Also, if the owning connection closes, the\
-MariaDB Server process releases the lock. How quickly a lost connection is\
-detected affects how quickly the primary monitor status moves from one monitor\
+MariaDB Server process releases the lock. How quickly a lost connection is
+detected affects how quickly the primary monitor status moves from one monitor
 and MaxScale to another.
 
-If the primary MaxScale or its monitor is stopped normally, the monitor\
+If the primary MaxScale or its monitor is stopped normally, the monitor
 connections are properly closed, releasing the locks. This allows the secondary\
-MaxScale to quickly claim the locks. However, if the primary simply vanishes\
+MaxScale to quickly claim the locks. However, if the primary simply vanishes
 (broken network), the connection may just look idle. In this case, the\
-MariaDB Server may take a long time before it considers the monitor connection\
-lost. This time ultimately depends on TCP keepalive settings on the machines\
+MariaDB Server may take a long time before it considers the monitor connection
+lost. This time ultimately depends on TCP keepalive settings on the machines
 running MariaDB Server.
 
 On MariaDB Server 10.3.3 and later, the TCP keepalive settings can be configured\
@@ -1383,15 +1383,15 @@ for information on settings _tcp\_keepalive\_interval_, _tcp\_keepalive\_probes_
 level, as described [here](https://www.tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html).
 
 As of MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6 and 24.02.2, configuring\
-TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_\
-variable when acquiring a lock. This causes the MariaDB Server to close the\
-monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout\
+TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_
+variable when acquiring a lock. This causes the MariaDB Server to close the
+monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout
 settings, and is logged at MaxScale startup.
 
-A monitor can also be ordered to manually release its locks via the module\
-command _release-locks_. This is useful for manually changing the primary\
-monitor. After running the release-command, the monitor will not attempt to\
-reacquire the locks for one minute, even if it wasn't the primary monitor to\
+A monitor can also be ordered to manually release its locks via the module
+command _release-locks_. This is useful for manually changing the primary
+monitor. After running the release-command, the monitor will not attempt to
+reacquire the locks for one minute, even if it wasn't the primary monitor to
 begin with. This command can cause the cluster to become temporarily unusable by\
 MaxScale. Only use it when there is another monitor ready to claim the locks.
 
@@ -1401,38 +1401,38 @@ maxctrl call command mariadbmon release-locks MyMonitor1
 
 ### Backup operations
 
-Backup operations manipulate the contents of a MariaDB Server, saving it or\
+Backup operations manipulate the contents of a MariaDB Server, saving it or
 overwriting it. MariaDB-Monitor supports three backup operations:
 
-1. rebuild-server: Replace the contents of a database server with the\
+1. rebuild-server: Replace the contents of a database server with the
    contents of another.
-2. create-backup: Copy the contents of a database server to a storage\
+2. create-backup: Copy the contents of a database server to a storage
    location.
-3. restore-from-backup: Overwrite the contents of a database server with a\
+3. restore-from-backup: Overwrite the contents of a database server with a
    backup.
 
-These operations do not modify server config files, only files in the data\
+These operations do not modify server config files, only files in the data
 directory (typically _/var/lib/mysql_) are affected.
 
 All of these operations are monitor commands and best launched with MaxCtrl.\
-The operations are asynchronous, which means MaxCtrl won't wait for the\
-operation to complete and instead immediately returns "OK". To see the current\
-status of an operation, either check MaxScale log or use the\
-fetch-cmd-result-command\
+The operations are asynchronous, which means MaxCtrl won't wait for the
+operation to complete and instead immediately returns "OK". To see the current
+status of an operation, either check MaxScale log or use the
+fetch-cmd-result-command
 (e.g. `maxctrl call command mariadbmon fetch-cmd-result MyMonitor`).
 
-To perform backup operations, MaxScale requires ssh-access on all affected\
+To perform backup operations, MaxScale requires ssh-access on all affected
 machines. The _ssh\_user_ and _ssh\_keyfile_-settings define the SSH credentials\
-MaxScale uses to access the servers. MaxScale must be able to run commands with\_sudo\_ on both the source and target servers. See [settings](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#settings) and [sudoers.d configuration](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#sudoersd-configuration) below\
+MaxScale uses to access the servers. MaxScale must be able to run commands with\_sudo\_ on both the source and target servers. See [settings](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#settings) and [sudoers.d configuration](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#sudoersd-configuration) below
 for more information.
 
 The following tools need to be installed on the backends:
 
 1. mariadb-backup. Backs up and restores MariaDB Server contents. Installed e.g.\
-   with `yum install MariaDB-backup`. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup) for more\
+   with `yum install MariaDB-backup`. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup) for more
    information.
 2. pigz. Compresses and decompresses the backup stream. Installed e.g. with`yum install pigz`.
-3. socat. Streams data from one machine to another. Is likely already\
+3. socat. Streams data from one machine to another. Is likely already
    installed. If not, can be installed e.g. with `yum install socat`.
 
 mariadb-backup needs server credentials to log in and authenticate to the\
@@ -1442,39 +1442,39 @@ for more details.
 
 #### Rebuild server
 
-The rebuild server-operation replaces the contents of a database server with the\
-contents of another server. The source server is effectively cloned and all data\
-on the target server is lost. This is useful when a replica server has diverged\
+The rebuild server-operation replaces the contents of a database server with the
+contents of another server. The source server is effectively cloned and all data
+on the target server is lost. This is useful when a replica server has diverged
 from the primary server, or when adding a new server to the cluster.\
-MaxScale performs this operation by running mariadb-backup on both the\
+MaxScale performs this operation by running mariadb-backup on both the
 source and target servers.
 
-When launched, the rebuild operation proceeds as below. If any step fails, the\
+When launched, the rebuild operation proceeds as below. If any step fails, the
 operation is stopped and the target server will be left in an unspecified state.
 
-1. Log in to both servers with ssh and check that the tools listed above are\
+1. Log in to both servers with ssh and check that the tools listed above are
    present (e.g. `mariadb-backup -v` should succeed).
-2. Check that the port used for transferring the backup is free on the source\
-   server. If not, kill the process holding it. This requires running lsof and\
+2. Check that the port used for transferring the backup is free on the source
+   server. If not, kill the process holding it. This requires running lsof and
    kill.
-3. Test the connection by streaming a short message from the source host to the\
+3. Test the connection by streaming a short message from the source host to the
    target.
-4. Launch mariadb-backup on the source machine, compress the stream and listen\
+4. Launch mariadb-backup on the source machine, compress the stream and listen
    for an incoming connection. This is performed with a command like`mariadb-backup --backup --safe-slave-backup --stream=xbstream --parallel=1 | pigz -c | socat - TCP-LISTEN:<port>`.
 5. Ask the target server what its data directory is (`select @@datadir;`). Stop\
-   MariaDB Server on the target machine and delete all contents of the data\
+   MariaDB Server on the target machine and delete all contents of the data
    directory.
-6. On the target machine, connect to the source machine, read the backup stream,\
-   decompress it and write to the data directory. This is performed with a command\
-   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can\
+6. On the target machine, connect to the source machine, read the backup stream,
+   decompress it and write to the data directory. This is performed with a command
+   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can
    take a long time if there is much data to transfer.
-7. Check that the data directory on the target machine is not empty,\
+7. Check that the data directory on the target machine is not empty,
    i.e. that the transfer at least appears to have succeeded.
-8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if\
+8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if
    the source server performed writes during data transfer.
-9. On the target server, change ownership of datadir contents to the\
+9. On the target server, change ownership of datadir contents to the
    mysql-user and start MariaDB-server.
-10. Read gtid from the data directory. Have the target server start replicating\
+10. Read gtid from the data directory. Have the target server start replicating
     from the primary if it is not one already.
 
 The rebuild-operation is a monitor module command and takes four arguments:
@@ -1482,12 +1482,12 @@ The rebuild-operation is a monitor module command and takes four arguments:
 1. Monitor name, e.g. MyMonitor.
 2. Target server name, e.g. MyTargetServer.
 3. Source server name, e.g. MySourceServer. This parameter is optional.\
-   If not specified, the monitor prefers to autoselect an up-to-date replica\
-   server to avoid increasing load on the primary server. Due to the`--safe-slave-backup`-option, the replica will stop\
+   If not specified, the monitor prefers to autoselect an up-to-date replica
+   server to avoid increasing load on the primary server. Due to the`--safe-slave-backup`-option, the replica will stop
    replicating until the backup data has been transferred.
-4. Data directory on target server. This parameter is optional. If not\
-   specified, the monitor will ask the target server. If target server is\
-   not running, monitor will assume /var/lib/mysql. Thus, this only needs to be\
+4. Data directory on target server. This parameter is optional. If not
+   specified, the monitor will ask the target server. If target server is
+   not running, monitor will assume /var/lib/mysql. Thus, this only needs to be
    defined with non-standard directory setups.
 
 The following example rebuilds MyTargetServer with contents of MySourceServer.
@@ -1502,45 +1502,45 @@ The following example uses a custom data directory on the target.
 maxctrl call command mariadbmon async-rebuild-server MyMonitor MyTargetServer MySourceServer /my_datadir
 ```
 
-The operation does not launch if the target server is already replicating or if\
+The operation does not launch if the target server is already replicating or if
 the source server is not a primary or replica.
 
-Steps 6 and 8 can take a long time depending on the size of the database and if\
-writes are ongoing. During these steps, the monitor will continue monitoring the\
-cluster normally. After each monitor tick the monitor checks if the\
-rebuild-operation can proceed. No other monitor operations, either manual or\
+Steps 6 and 8 can take a long time depending on the size of the database and if
+writes are ongoing. During these steps, the monitor will continue monitoring the
+cluster normally. After each monitor tick the monitor checks if the
+rebuild-operation can proceed. No other monitor operations, either manual or
 automatic, can run until the rebuild completes.
 
 #### Create backup
 
-The create backup-operation copies the contents of a database server to the\
-backup storage. The source server is not modified but may slow down during\
-backup creation. MaxScale performs this operation by running\
-mariadb-backup on both the source and storage servers. The storage location is\
+The create backup-operation copies the contents of a database server to the
+backup storage. The source server is not modified but may slow down during
+backup creation. MaxScale performs this operation by running
+mariadb-backup on both the source and storage servers. The storage location is
 defined by the _backup\_storage\_address_ and _backup\_storage\_path_ settings.\
-Normal ssh-settings are used to access the storage server. The backup storage\
+Normal ssh-settings are used to access the storage server. The backup storage
 machine does not need to have a MariaDB Server installed.
 
-Backup creation runs somewhat similar to rebuild-server. The main difference\
-is that the backup data is simply saved to a directory and not prepared or\
-used to start a MariaDB Server. If any step fails, the operation is stopped\
+Backup creation runs somewhat similar to rebuild-server. The main difference
+is that the backup data is simply saved to a directory and not prepared or
+used to start a MariaDB Server. If any step fails, the operation is stopped
 and the backup storage directory will be left in an unspecified state.
 
 1. Init. See rebuild-server.
 2. Check listen port on backup storage machine. See rebuild-server.
-3. Check that the backup storage main directory exists. Check that it does not\
-   contain a backup with the same name as the one being created. Create the final\
+3. Check that the backup storage main directory exists. Check that it does not
+   contain a backup with the same name as the one being created. Create the final
    backup directory.
-4. Test the connection by streaming a short message from the source host to the\
+4. Test the connection by streaming a short message from the source host to the
    backup storage.
 5. Serve backup on source. Similar to rebuild-server step 4.
-6. Transfer backup directly to the final storage directory. Similar to\
+6. Transfer backup directly to the final storage directory. Similar to
    rebuild-server step 5.
 7. Check that the copied backup data looks ok.
 
-Backup creation is a monitor module command and takes three\
-arguments: the monitor name, source server name and backup name. Backup name\
-defines the subdirectory where the backup is saved and should be a valid\
+Backup creation is a monitor module command and takes three
+arguments: the monitor name, source server name and backup name. Backup name
+defines the subdirectory where the backup is saved and should be a valid
 directory name. The command
 
 ```
@@ -1550,37 +1550,37 @@ maxctrl call command mariadbmon async-create-backup MyMonitor MySourceServer wed
 would save the backup of MySourceServer to `<backup_storage_path>/wednesday_161122` on the host defined in _backup\_storage\_address_. _ssh\_user_ needs to have read and write access
 to the main storage directory. The source server must be a primary or replica.
 
-Similar to rebuild-server, the monitor will continue monitoring the servers\
+Similar to rebuild-server, the monitor will continue monitoring the servers
 while the backup is transferred.
 
 #### Restore from backup
 
-The restore-operation is the reverse of create-backup. It overwrites the\
+The restore-operation is the reverse of create-backup. It overwrites the
 contents of an existing MariaDB Server with a backup from the backup storage.\
-The backup is not removed and can be used again. MaxScale performs this\
-operation by transferring the backup contents as a tar archive and overwriting\
-the target server data directory. The backup storage is defined in monitor\
+The backup is not removed and can be used again. MaxScale performs this
+operation by transferring the backup contents as a tar archive and overwriting
+the target server data directory. The backup storage is defined in monitor
 settings similar to create-backup.
 
-The restore-operation runs somewhat similar to rebuild-server. The main\
+The restore-operation runs somewhat similar to rebuild-server. The main
 difference is that the backup data is copied with _tar_ instead of mariadb-backup.\
-If any step fails, the operation is stopped and the target server will be\
+If any step fails, the operation is stopped and the target server will be
 left in an unspecified state.
 
 1. Init. See rebuild-server.
 2. Check listen port on target machine. See rebuild-server.
-3. Check that the backup storage main directory exists and that it contains\
+3. Check that the backup storage main directory exists and that it contains
    a backup with the name requested.
-4. Test the connection by streaming a short message from the backup storage to\
+4. Test the connection by streaming a short message from the backup storage to
    the target machine.
-5. On the backup storage machine, compress the backup with tar and serve it\
-   with socat, listening for an incoming connection. This is performed with\
+5. On the backup storage machine, compress the backup with tar and serve it
+   with socat, listening for an incoming connection. This is performed with
    a command like `tar -zc -C <backup_dir> . | socat - TCP-LISTEN:<port>`.
 6. Ask the target server what its data directory is (`select @@datadir;`). Stop\
-   MariaDB Server on the target machine and delete all contents of the data\
+   MariaDB Server on the target machine and delete all contents of the data
    directory.
-7. On the target machine, connect to the source machine, read the backup stream,\
-   decompress it and write to the data directory. This is performed with a command\
+7. On the target machine, connect to the source machine, read the backup stream,
+   decompress it and write to the data directory. This is performed with a command
    like `socat -u TCP:<host>:<port> STDOUT | sudo tar -xz -C /var/lib/mysql/`.\
    This step can take a long time if there is much data to transfer.
 8. From here on, the operation proceeds as from rebuild-server step 7.
@@ -1589,11 +1589,11 @@ Server restoration is a monitor module command and takes four arguments.
 
 1. Monitor name, e.g. MyMonitor.
 2. Target server name, e.g. MyNewServer.
-3. Backup name. This parameter defines the subdirectory where the backup is\
+3. Backup name. This parameter defines the subdirectory where the backup is
    read from and should be an existing directory on the backup storage host.
-4. Data directory on target server. This parameter is optional. If not\
-   specified, the monitor will ask the target server. If target server is\
-   not running, monitor will assume /var/lib/mysql. Thus, this only needs to be\
+4. Data directory on target server. This parameter is optional. If not
+   specified, the monitor will ask the target server. If target server is
+   not running, monitor will assume /var/lib/mysql. Thus, this only needs to be
    defined with non-standard directory setups.
 
 The command
@@ -1602,9 +1602,9 @@ The command
 maxctrl call command mariadbmon async-restore-from-backup MyMonitor MyTargetServer wednesday_161122
 ```
 
-would erase the contents of MyTargetServer and replace them with the backup\
+would erase the contents of MyTargetServer and replace them with the backup
 contained in `<backup_storage_path>/wednesday_161122` on the host defined in _backup\_storage\_address_. _ssh\_user_ needs to have read access
-to the main storage directory and the backup. The target server must not be\
+to the main storage directory and the backup. The target server must not be
 a primary or replica.
 
 The following example uses a custom data directory on the target.
@@ -1613,7 +1613,7 @@ The following example uses a custom data directory on the target.
 maxctrl call command mariadbmon async-restore-from-backup MyMonitor MyTargetServer wednesday_161122 /my_datadir
 ```
 
-Similar to rebuild-server, the monitor will continue monitoring the servers\
+Similar to rebuild-server, the monitor will continue monitoring the servers
 while the backup is transferred and prepared.
 
 #### Settings
@@ -1634,7 +1634,7 @@ Ssh username. Used when logging in to backend servers to run commands.
 * Dynamic: Yes
 * Default: None
 
-Path to file with an ssh private key. Used when logging in to backend servers to\
+Path to file with an ssh private key. Used when logging in to backend servers to
 run commands.
 
 **`ssh_check_host_key`**
@@ -1644,7 +1644,7 @@ run commands.
 * Dynamic: Yes
 * Default: `true`
 
-Boolean, default: true. When logging in to backends, require that the server is\
+Boolean, default: true. When logging in to backends, require that the server is
 already listed in the known\_hosts-file of the user running MaxScale.
 
 **`ssh_timeout`**
@@ -1654,10 +1654,10 @@ already listed in the known\_hosts-file of the user running MaxScale.
 * Dynamic: Yes
 * Default: `10s`
 
-The rebuild operation consists of multiple ssh\
-commands. Most of the commands are assumed to complete quickly. If these\
-commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust\
-this setting if rebuild fails due to ssh commands timing out. This setting does\
+The rebuild operation consists of multiple ssh
+commands. Most of the commands are assumed to complete quickly. If these
+commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust
+this setting if rebuild fails due to ssh commands timing out. This setting does
 not affect steps 5 and 6, as these are assumed to take significant time.
 
 **`ssh_port`**
@@ -1676,15 +1676,15 @@ SSH port. Used for running remote commands on servers.
 * Dynamic: Yes
 * Default: `4444`
 
-The port which the source server listens on for a\
-connection. The port must not be blocked by a firewall or listened on by any\
-other program. If another process is listening on the port when rebuild is\
+The port which the source server listens on for a
+connection. The port must not be blocked by a firewall or listened on by any
+other program. If another process is listening on the port when rebuild is
 starting, MaxScale will attempt to kill the process.
 
 **`mariadb-backup_use_memory`**
 
-String, default: "1G". Given as is to`mariadb-backup --prepare --use-memory=<mariadb-backup_use_memory>`. If set to empty,\
-no `--use-memory` is set and mariadb-backup will use its internal default. See [here](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-options#-use-memory) for more\
+String, default: "1G". Given as is to`mariadb-backup --prepare --use-memory=<mariadb-backup_use_memory>`. If set to empty,
+no `--use-memory` is set and mariadb-backup will use its internal default. See [here](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-options#-use-memory) for more
 information.
 
 ```
@@ -1694,7 +1694,7 @@ mariadb-backup_use_memory=2G
 **`mariadb-backup_parallel`**
 
 Numeric, default: 1. Given as is to`mariadb-backup --backup --parallel=<val>`.\
-Defines the number of threads used for parallel data file transfer. See [here](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-options#-parallel) for more\
+Defines the number of threads used for parallel data file transfer. See [here](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-options#-parallel) for more
 information.
 
 ```
@@ -1708,8 +1708,8 @@ mariadb-backup_parallel=2
 * Dynamic: Yes
 * Default: None
 
-Address of the backup storage. Does not need to have MariaDB Server\
-running or be monitored by the monitor. Connected to with ssh. Must have enough\
+Address of the backup storage. Does not need to have MariaDB Server
+running or be monitored by the monitor. Connected to with ssh. Must have enough
 disk space to store all backups.
 
 ```
@@ -1723,7 +1723,7 @@ backup_storage_address=192.168.1.11
 * Dynamic: Yes
 * Default: None
 
-Path to main backup storage directory on backup storage host. _ssh\_user_\
+Path to main backup storage directory on backup storage host. _ssh\_user_
 needs to have full access to this directory to save and read backups.
 
 ```
@@ -1732,10 +1732,10 @@ backup_storage_path=/home/maxscale_ssh_user/backup_storage
 
 #### sudoers.d configuration
 
-If giving MaxScale general sudo-access is out of the question, MaxScale must be\
-allowed to run the specific commands required by the backup operations. This can\
-be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the\
-power to run commands as root. The contents of the file may need to be tweaked\
+If giving MaxScale general sudo-access is out of the question, MaxScale must be
+allowed to run the specific commands required by the backup operations. This can
+be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the
+power to run commands as root. The contents of the file may need to be tweaked
 due to changes in install locations.
 
 ```
@@ -1753,31 +1753,31 @@ johnny ALL= NOPASSWD: /bin/tar -xz -C /var/lib/mysql/
 
 ### ColumnStore commands
 
-Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative\
+Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative
 commands against a ColumnStore cluster. The commands interact with the\
-ColumnStore REST-API present in recent ColumnStore versions and have been tested\
-with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the\
-commands affect monitor configuration or replication topology. MariaDB Monitor\
+ColumnStore REST-API present in recent ColumnStore versions and have been tested
+with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the
+commands affect monitor configuration or replication topology. MariaDB Monitor
 simply relays the commands to the backend cluster.
 
-MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop\
-the cluster, and set cluster read-only or readwrite. MaxScale only communicates\
+MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop
+the cluster, and set cluster read-only or readwrite. MaxScale only communicates
 with the first server in the `servers`-list.
 
-Most of the commands are asynchronous, i.e. they do not wait for the operation\
+Most of the commands are asynchronous, i.e. they do not wait for the operation
 to complete on the ColumnStore backend before returning to the command prompt.\
-MariaDB Monitor itself, however, runs the command in the background and does not\
-perform normal monitoring until the operation completes or fails. After an\
-operation has started the user should use _fetch-cmd-result_ to check its\
-status. The examples below show how to run the commands using MaxCtrl. If a\
-command takes a timeout-parameter, the timeout can be given in seconds (s),\
+MariaDB Monitor itself, however, runs the command in the background and does not
+perform normal monitoring until the operation completes or fails. After an
+operation has started the user should use _fetch-cmd-result_ to check its
+status. The examples below show how to run the commands using MaxCtrl. If a
+command takes a timeout-parameter, the timeout can be given in seconds (s),
 minutes (m) or hours (h).
 
 ColumnStore command settings are listed [here](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#settings). At least`cs_admin_api_key` must be set.
 
 #### Get status
 
-Fetch cluster status. Returns the result as is. Status fetching has an automatic\
+Fetch cluster status. Returns the result as is. Status fetching has an automatic
 timeout of ten seconds.
 
 ```
@@ -1891,7 +1891,7 @@ maxctrl call command mariadbmon fetch-cmd-result MyMonitor
 
 **`cs_admin_port`**
 
-Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes\
+Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes
 are assumed to listen on the same port.
 
 ```
@@ -1915,9 +1915,9 @@ String, default: _/cmapi/0.4.0_. Base path sent with the REST-API request.
 
 #### `fetch-cmd-result`
 
-Fetches the result of the last manual command. Requires monitor name as\
-parameter. Most commands only return a generic success message or an error\
-description. ColumnStore commands may return more data. Scheduling another\
+Fetches the result of the last manual command. Requires monitor name as
+parameter. Most commands only return a generic success message or an error
+description. ColumnStore commands may return more data. Scheduling another
 command clears a stored result.
 
 ```
@@ -1927,11 +1927,11 @@ maxctrl call command mariadbmon fetch-cmd-result MariaDB-Monitor
 
 #### `cancel-cmd`
 
-Cancels the latest operation, whether manual or automatic, if possible. Requires\
-monitor name as parameter. A scheduled manual command is simply canceled\
-before it can run. If a command is already running, it stops as soon as\
+Cancels the latest operation, whether manual or automatic, if possible. Requires
+monitor name as parameter. A scheduled manual command is simply canceled
+before it can run. If a command is already running, it stops as soon as
 possible. The _cancel-cmd_ itself does not wait for a running operation to stop.\
-Use _fetch-cmd-result_ or check the log to see if the operation has truly\
+Use _fetch-cmd-result_ or check the log to see if the operation has truly
 completed. Canceling is most useful for stopping a stalled rebuild operation.
 
 ```
@@ -1945,48 +1945,48 @@ OK
 
 See the [Limitations and requirements-section](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#limitations_and_requirements).
 
-Before performing failover or switchover, the monitor checks that\
-prerequisites are fulfilled, printing any errors and warnings found. This should\
+Before performing failover or switchover, the monitor checks that
+prerequisites are fulfilled, printing any errors and warnings found. This should
 catch and explain most issues with failover or switchover not working.\
-If the operations are attempted and still fail, then most likely one of\
-the commands the monitor issued to a server failed or timed out. The log should\
+If the operations are attempted and still fail, then most likely one of
+the commands the monitor issued to a server failed or timed out. The log should
 explain which query failed.
 
-A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the\
-monitor will retry most such queries if the failure was caused by a timeout. The retrying\
-continues until the total time for a failover or switchover has been spent. If the log\
-shows warnings or errors about commands timing out, increasing the backend timeout\
+A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the
+monitor will retry most such queries if the failure was caused by a timeout. The retrying
+continues until the total time for a failover or switchover has been spent. If the log
+shows warnings or errors about commands timing out, increasing the backend timeout
 settings of the monitor should help. Other settings to look at are `query_retries` and`query_retry_timeout`. These are general MaxScale settings described in the [Configuration guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). Setting`query_retries` to 2 is a reasonable first try.
 
-If switchover causes the old primary (now replica) to fail replication, then most\
-likely a user or perhaps a scheduled event performed a write while monitor\
+If switchover causes the old primary (now replica) to fail replication, then most
+likely a user or perhaps a scheduled event performed a write while monitor
 had set `read_only=1`. This is possible if the user performing the write has\
-"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick\
-out SUPER-users but this is not certain to succeed. Remove these privileges\
-from any users that regularly do writes to prevent them from interfering with\
+"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick
+out SUPER-users but this is not certain to succeed. Remove these privileges
+from any users that regularly do writes to prevent them from interfering with
 switchover.
 
-The server configuration files should have `log-slave-updates=1` to ensure that\
-a newly promoted primary has binary logs of previous events. This allows the new\
+The server configuration files should have `log-slave-updates=1` to ensure that
+a newly promoted primary has binary logs of previous events. This allows the new
 primary to replicate past events to any lagging replicas.
 
-To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the\
-backends by monitors and authenticators. The printed queries may include\
+To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the
+backends by monitors and authenticators. The printed queries may include
 usernames and passwords.
 
 #### Replica detection shows external primaries
 
 If a replica is shown in _maxctrl_ as "Slave of External Server" instead of\
-"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection\
-does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default\
-assumes that the replica connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact\
-same "Master\_Host" as used the MaxScale configuration file server definitions. This is\
+"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection
+does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default
+assumes that the replica connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact
+same "Master\_Host" as used the MaxScale configuration file server definitions. This is
 controlled by the setting [assume\_unique\_hostnames](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#assume_unique_hostnames).
 
 ### Using the MariaDB Monitor With Binlogrouter
 
-Since MaxScale 2.2 it's possible to detect a replication setup\
-which includes Binlog Server: the required action is to add the\
+Since MaxScale 2.2 it's possible to detect a replication setup
+which includes Binlog Server: the required action is to add the
 binlog server to the list of servers only if _master\_id_ identity is set.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-change-data-capture-cdc-protocol.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-change-data-capture-cdc-protocol.md
@@ -1,10 +1,10 @@
 # MaxScale 24.02 Change Data Capture (CDC) Protocol
 
-CDC is a new protocol that allows compatible clients to authenticate and\
-register for Change Data Capture events. The new protocol must be use in\
+CDC is a new protocol that allows compatible clients to authenticate and
+register for Change Data Capture events. The new protocol must be use in
 conjunction with AVRO router which currently converts MariaDB binlog events into\
-AVRO records. Change Data Capture protocol is used by clients in order to\
-interact with stored AVRO file and also allows registered clients to be notified\
+AVRO records. Change Data Capture protocol is used by clients in order to
+interact with stored AVRO file and also allows registered clients to be notified
 with the new events coming from MariaDB 10.0/10.1 database.
 
 ### Creating Users
@@ -47,12 +47,12 @@ In the future, optional flags could be implemented.
 
 #### Authentication
 
-The authentication starts when the client sends the hexadecimal representation\
+The authentication starts when the client sends the hexadecimal representation
 of the username concatenated with a colon (`:`) and the SHA1 of the password.
 
 `bin2hex(username + ':' + SHA1(password))`
 
-For example the user _foobar_ with a password of _foopasswd_ should send the\
+For example the user _foobar_ with a password of _foopasswd_ should send the
 following hexadecimal string
 
 ```
@@ -83,9 +83,9 @@ Server returns `OK` on success and `ERR` on failure.
 
 `REQUEST-DATA DATABASE.TABLE[.VERSION] [GTID]`
 
-This command fetches data from specified table in a database and returns the\
-output in the requested format (AVRO or JSON). Data records are sent to clients\
-and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new\
+This command fetches data from specified table in a database and returns the
+output in the requested format (AVRO or JSON). Data records are sent to clients
+and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new
 schema and data will be sent as well.
 
 The data will be streamed until the client closes the connection.
@@ -102,7 +102,7 @@ REQUEST-DATA db2.table4 0-11-345
 
 ### Example Client
 
-MaxScale includes an example CDC client application written in Python 3. You can\
+MaxScale includes an example CDC client application written in Python 3. You can
 find the source code for it [in the MaxScale repository](https://github.com/mariadb-corporation/MaxScale/tree/2.0/server/modules/protocol/examples/cdc.py).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-change-data-capture-cdc-users.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-change-data-capture-cdc-users.md
@@ -1,12 +1,12 @@
 # MaxScale 24.02 Change Data Capture (CDC) users
 
-Change Data Capture (CDC) is a new MaxScale protocol that allows compatible\
-clients to authenticate and register for Change Data Capture events. The new\
+Change Data Capture (CDC) is a new MaxScale protocol that allows compatible
+clients to authenticate and register for Change Data Capture events. The new
 protocol must be use in conjunction with AVRO router which currently converts\
-MariaDB binlog events into AVRO records. Clients connect to CDC listener and\
+MariaDB binlog events into AVRO records. Clients connect to CDC listener and
 authenticate using credentials provided in a format described in the [CDC Protocol documentation](mariadb-maxscale-2402-maxscale-2402-change-data-capture-cdc-protocol.md).
 
-**Note**: If no users are found in that file or if it doesn't exist, the only\
+**Note**: If no users are found in that file or if it doesn't exist, the only
 available user will be the _service user_:
 
 ```
@@ -26,7 +26,7 @@ Starting with MaxScale 2.1, users can also be created through maxctrl:
 maxctrl call command cdc add_user <service> <name> <password>
 ```
 
-The should be the service name where the user is created. Older\
+The should be the service name where the user is created. Older
 versions of MaxScale should use the _cdc\_users.py_ script.
 
 ```
@@ -39,7 +39,7 @@ The output of this command should be appended to the _cdcusers_ file at`/var/lib
 bash$ cdc_users.py user1 pass1 >> /var/lib/maxscale/avro-service/cdcusers
 ```
 
-Users can be deleted by removing the related rows in 'cdcusers' file. For\
+Users can be deleted by removing the related rows in 'cdcusers' file. For
 more details on the format of the _cdcusers_ file, read the [CDC Protocol documentation](mariadb-maxscale-2402-maxscale-2402-change-data-capture-cdc-protocol.md).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-mariadb-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-mariadb-protocol-module.md
@@ -2,7 +2,7 @@
 
 The `mariadbprotocol` module implements the MariaDB client-server protocol.
 
-The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all\
+The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all
 aliases to `mariadbprotocol`.
 
 * [MariaDB Protocol Module](mariadb-maxscale-2402-maxscale-2402-mariadb-protocol-module.md#mariadb-protocol-module)
@@ -11,7 +11,7 @@ aliases to `mariadbprotocol`.
 
 ### Configuration
 
-Protocol level parameters are defined in the listeners. They must be defined\
+Protocol level parameters are defined in the listeners. They must be defined
 using the scoped parameter syntax where the protocol name is used as the prefix.
 
 ```
@@ -32,8 +32,8 @@ For the MariaDB protocol module, the prefix is always `mariadbprotocol`.
 * Dynamic: Yes
 * Default: true
 
-Whether the use of the replication protocol is allowed through this listener. If\
-disabled with `mariadbprotocol.allow_replication=false`, all attempts to start\
+Whether the use of the replication protocol is allowed through this listener. If
+disabled with `mariadbprotocol.allow_replication=false`, all attempts to start
 replication will be rejected with a ER\_FEATURE\_DISABLED error (error number\
 1289\).
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md
@@ -4,21 +4,21 @@
 
 ## NoSQL Protocol Module
 
-The `nosqlprotocol` module allows a MariaDB server or cluster to be\
+The `nosqlprotocol` module allows a MariaDB server or cluster to be
 used as the backend of an application using a MongoDB® client library.\
 Internally, all documents are stored in a table containing two columns;\
 an `id` column for the object id and a `doc` column for the document itself.
 
-When the MongoDB® client application issues MongoDB protocol _commands_,\
-either directly or indirectly via the client library, they are transparently\
+When the MongoDB® client application issues MongoDB protocol _commands_,
+either directly or indirectly via the client library, they are transparently
 converted into the equivalent SQL and executed against the MariaDB backend.\
-The MariaDB responses are then in turn converted into the format expected by\
+The MariaDB responses are then in turn converted into the format expected by
 the MongoDB® client library and application.
 
 ## Configuring
 
-There are a number of [parameters](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#parameters) with which the behavior\
-of _nosqlprotocol_ can be adjusted. A minimal configuration looks\
+There are a number of [parameters](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#parameters) with which the behavior
+of _nosqlprotocol_ can be adjusted. A minimal configuration looks
 like:
 
 ```
@@ -35,13 +35,13 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-`nosqlprotocol.user` and `nosqlprotocol.password` specify the\
-credentials that will be used when accessing the backend database or\
+`nosqlprotocol.user` and `nosqlprotocol.password` specify the
+credentials that will be used when accessing the backend database or
 cluster. Note that the same credentials will be used for _all_ connecting\
 MongoDB® clients.
 
-Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which\
-the client requests will be sent. _Nosqlprotocol_ places no limitations\
+Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which
+the client requests will be sent. _Nosqlprotocol_ places no limitations
 on what filters, routers or backends can be used.
 
 To configure the same listener with MaxCtrl, the parameters must be passed in a\
@@ -51,7 +51,7 @@ JSON object in the following manner:
 maxctrl create listener TheService MongoDB-Listener --protocol=nosqlprotocol 'nosqlprotocol={"user":"the_user", "password": "the_password"}'
 ```
 
-All the parameters that the nosqlprotocol module takes must be passed in the\
+All the parameters that the nosqlprotocol module takes must be passed in the
 same JSON object.
 
 A complete example can be found at the [end](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#example) of this document.
@@ -61,18 +61,18 @@ A complete example can be found at the [end](mariadb-maxscale-2402-maxscale-2402
 Nosqlprotocol supports _SCRAM_ _authentication_ as implemented by MongoDB®.\
 The mechanisms `SCRAM-SHA-1` and `SCRAM-SHA-256` are both supported.
 
-If nosqlprotocol has been setup so that no authentication is required, then\
-when connecting only the host and port should be provided, but neither a\
+If nosqlprotocol has been setup so that no authentication is required, then
+when connecting only the host and port should be provided, but neither a
 username nor a password.
 
-For instance, if the _MongoDB Node.JS Driver_ is used, then the connection\
+For instance, if the _MongoDB Node.JS Driver_ is used, then the connection
 string should look like:
 
 ```
 const uri = "mongodb://127.0.0.1:17017"
 ```
 
-Similarly, if the _Mongo Shell_ is used, only the host and port should\
+Similarly, if the _Mongo Shell_ is used, only the host and port should
 be provided:
 
 ```
@@ -84,26 +84,26 @@ MongoDB shell version v4.4.1
 
 ### NoSQL and MariaDB Users
 
-A MariaDB user consists of a name and a host part. A user `'user'@'%'`\
-and a user `'user'@'127.0.0.1'` are completely different. The host part\
-specifies where a user may connect from, with `%` being a wildcard that\
-matches all hosts. What data a user is allowed to access and modify is\
+A MariaDB user consists of a name and a host part. A user `'user'@'%'`
+and a user `'user'@'127.0.0.1'` are completely different. The host part
+specifies where a user may connect from, with `%` being a wildcard that
+matches all hosts. What data a user is allowed to access and modify is
 specified by what _privileges_ are granted to the user.
 
-A NoSQL user is somewhat different. It is created in the context of a\
-particular database, so there may be a user `userx` in the database `dbA`\
-and different user with the same name `userx` in the database `dbB`. What\
-hosts a user may connect from can be restricted, but that is a property of\
-the user and not an implicit part of it. What data a user is allowed to\
-access and modify is specified by the _roles_ that have been assigned to\
+A NoSQL user is somewhat different. It is created in the context of a
+particular database, so there may be a user `userx` in the database `dbA`
+and different user with the same name `userx` in the database `dbB`. What
+hosts a user may connect from can be restricted, but that is a property of
+the user and not an implicit part of it. What data a user is allowed to
+access and modify is specified by the _roles_ that have been assigned to
 the user.
 
-From the above it should be clear that there is not a 1-to-1\
-correspondence between the concept of a user in NoSQL and the concept\
+From the above it should be clear that there is not a 1-to-1
+correspondence between the concept of a user in NoSQL and the concept
 of a user in MariaDB, but that some additional conventions are needed.
 
-To make it possible to have different NoSQL users with the same name,\
-the database in whose context the user is created is prepended to the\
+To make it possible to have different NoSQL users with the same name,
+the database in whose context the user is created is prepended to the
 user name, separated with a dot, when the MariaDB user is created.
 
 This is perhaps easiest to illustrate using an example:
@@ -119,7 +119,7 @@ MariaDB [(none)]> select user, host from mysql.user;
 2 rows in set (0.001 sec)
 ```
 
-Currently there are two user accounts defined. Even though there is\
+Currently there are two user accounts defined. Even though there is
 a user `bob`, creating a NoSQL user `bob` succeeds.
 
 ```
@@ -143,20 +143,20 @@ MariaDB [(none)]> select user, host from mysql.user;
 3 rows in set (0.001 sec)
 ```
 
-The MariaDB user corresponding to the NoSQL user `bob`, created in the\
+The MariaDB user corresponding to the NoSQL user `bob`, created in the
 context of the database `test`, has `test` as a prefix.
 
 #### The `mariadb` database
 
-The fact that NoSQL users have the database embedded in the MariaDB\
-name may be inconvenient if the same data is accessed both as NoSQL\
-via nosqlprotocol and as SQL directly from MariaDB. It also makes\
+The fact that NoSQL users have the database embedded in the MariaDB
+name may be inconvenient if the same data is accessed both as NoSQL
+via nosqlprotocol and as SQL directly from MariaDB. It also makes
 it impossible to use an existing MariaDB account from NoSQL.
 
-To provide a solution for this problem, the database `mariadb` is treated\
-in a specific fashion. A user created in the context of the `mariadb`\
+To provide a solution for this problem, the database `mariadb` is treated
+in a specific fashion. A user created in the context of the `mariadb`
 database is created in the MariaDB server without the database prefix.\
-If we now try to create a user `bob` in the `mariadb` database it will fail,\
+If we now try to create a user `bob` in the `mariadb` database it will fail,
 because the user `'bob'@'%'` exists already.
 
 ```
@@ -199,7 +199,7 @@ we will see that `alice` was created without a database prefix.
 
 When creating a user nosqlprotocol accepts all roles as predefined by\
 MongoDB®, but not all of them are translated into GRANT privileges.\
-The following table shows what privilege(s) a particular role is\
+The following table shows what privilege(s) a particular role is
 converted to.
 
 | Role      | Privileges                                    |
@@ -216,21 +216,21 @@ The following roles are shorthands for several other roles.
 | dbOwner | dbAdmin, readWrite, userAdmin |
 | root    | dbAdmin, readWrite, userAdmin |
 
-`dbOwner` differs from `root` in that the privileges of the former\
-apply only to a particular database, while the privileges of the\
-latter apply to _all_ databases. However, the role `root` can\
+`dbOwner` differs from `root` in that the privileges of the former
+apply only to a particular database, while the privileges of the
+latter apply to _all_ databases. However, the role `root` can
 only be assigned to a user in the `admin` database.
 
-In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in\
-the `admin` database. If so, then the privilege is granted on `*.*`,\
+In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in
+the `admin` database. If so, then the privilege is granted on `*.*`,
 otherwise on `<db>.*`.
 
-If the `root` role is assigned to a user in the `admin` database,\
+If the `root` role is assigned to a user in the `admin` database,
 then the privileges are granted on `*.*`, otherwise on `<db>.*`.
 
-Other pre-defined roles are recognized and stored in the local\
-nosqlprotocol account database, but they do not affect what privileges\
-are granted to the MariaDB user. Currently user-defined roles are\
+Other pre-defined roles are recognized and stored in the local
+nosqlprotocol account database, but they do not affect what privileges
+are granted to the MariaDB user. Currently user-defined roles are
 not supported.
 
 ### Client Authentication
@@ -243,11 +243,11 @@ Authenticationwise nosqlprotocol can be used in three different ways:
 
 #### Anonymously
 
-If there is an anonymous user on the MariaDB server and if nosqlprotocol\
-is configured without a user/password, then all nosqlprotocol clients will\
+If there is an anonymous user on the MariaDB server and if nosqlprotocol
+is configured without a user/password, then all nosqlprotocol clients will
 access the MariaDB server as anonymous users.
 
-Note that the anonymous MariaDB user is only intended for testing and\
+Note that the anonymous MariaDB user is only intended for testing and
 should in general not be used, but deleted.
 
 #### Shared Credentials
@@ -261,18 +261,18 @@ nosqlprotocol.password=thepassword
 ```
 
 then each MongoDB® client will use those credentials when accessing the\
-MariaDB server. Note that from the perspective of the MariaDB server, it\
+MariaDB server. Note that from the perspective of the MariaDB server, it
 is not possible to distinguish between different MongoDB® clients.
 
 #### Unique Credentials
 
-If nosqlprotocol authentication has been taken into use and a MongoDB®\
-client authenticates, either when connecting or later, then the credentials\
+If nosqlprotocol authentication has been taken into use and a MongoDB®
+client authenticates, either when connecting or later, then the credentials
 of MongoDB® client will be used when accessing the MariaDB server.
 
-Note that even if nosqlprotocol authentication has been enabled, authentication\
-is not required, and if the MongoDB® client has not authenticated itself, the\
-credentials specified with `nosqlprotocol.[user|password]` (or the anonymous\
+Note that even if nosqlprotocol authentication has been enabled, authentication
+is not required, and if the MongoDB® client has not authenticated itself, the
+credentials specified with `nosqlprotocol.[user|password]` (or the anonymous
 user) will be used when accessing the MariaDB server.
 
 #### Enforce Authentication
@@ -283,14 +283,14 @@ To enforce authentication, specify
 nosqlprotocol.authentication_required=true
 ```
 
-in the configuration. If authentication is required, then any command\
-that requires access to the MariaDB server will fail, unless the client\
+in the configuration. If authentication is required, then any command
+that requires access to the MariaDB server will fail, unless the client
 has authenticated.
 
 ### Authorization
 
-By default nosqlprotocol does no authorization. However, a nosqlprotocol\
-client is _always_ subject to the authorization performed by the MariaDB\
+By default nosqlprotocol does no authorization. However, a nosqlprotocol
+client is _always_ subject to the authorization performed by the MariaDB
 server.
 
 When nosqlprotocol authorization is enabled by adding
@@ -299,8 +299,8 @@ When nosqlprotocol authorization is enabled by adding
 nosqlprotocol.authorization_enabled=true
 ```
 
-to the configuration file, some commands will be subject to authorization,\
-by nosqlprotocol. The following table lists the commands and what role they\
+to the configuration file, some commands will be subject to authorization,
+by nosqlprotocol. The following table lists the commands and what role they
 require.
 
 | Command                                                                                                 | Role      |
@@ -315,27 +315,27 @@ require.
 | [updateUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#updateUser)                   | userAdmin |
 | [usersInfo](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#usersInfo)                     | userAdmin |
 
-It is important to note that even if nosqlprotocol authorization\
-is enabled, the MariaDB server has the final word. That is, even if the\
-roles of a user would be sufficient for a particular operation, if the\
-granted privileges are not, the operation will not succeed. There may\
-be a mismatch between roles and grants, for instance, if the wrong roles\
-were specified when the user was added, or if the grants have been\
+It is important to note that even if nosqlprotocol authorization
+is enabled, the MariaDB server has the final word. That is, even if the
+roles of a user would be sufficient for a particular operation, if the
+granted privileges are not, the operation will not succeed. There may
+be a mismatch between roles and grants, for instance, if the wrong roles
+were specified when the user was added, or if the grants have been
 altered directly and not via nosqlprotocol.
 
 ### Bootstrapping the Authentication/Authorization
 
-The authentication/authorization can be bootstrapped explicitly\
-or implicitly. Bootstrapping explicitly provides more control, while\
+The authentication/authorization can be bootstrapped explicitly
+or implicitly. Bootstrapping explicitly provides more control, while
 bootstrapping implicitly is much more convenient.
 
 #### Explicit bootstrapping
 
-In order to enable authorization you need to have NoSQL users and\
-those can be created with [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser) or added\
+In order to enable authorization you need to have NoSQL users and
+those can be created with [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser) or added
 with [mxsAddUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#addUser).
 
-If you want to _create_ a user, then you first need to configure\
+If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
 
 ```
@@ -343,7 +343,7 @@ nosqlprotocol.user = user_with_privileges_for_creating_a_user
 nosqlprotocol.password = the_users_password
 ```
 
-At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that\
+At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that
 as those are their default values, they do not have to be specified.
 
 Start MaxScale and connect to it with the MongoDB® command line client
@@ -363,8 +363,8 @@ switched to db admin
 { "ok" : 1 }
 ```
 
-Alternatively you can add an existing user. Note that it should be\
-added to the `mariadb` database, unless it was created with the\
+Alternatively you can add an existing user. Note that it should be
+added to the `mariadb` database, unless it was created with the
 convention of having the database as a prefix, e.g. `db.bob`.
 
 ```
@@ -383,12 +383,12 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but\
-as they will be ignored with `nosqlprotocol.authentication_required=true`\
+The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but
+as they will be ignored with `nosqlprotocol.authentication_required=true`
 being present, it is not mandatory.
 
-If you now try to create a user when not having been authenticated or\
-when authenticated as a user without the `userAdmin` role, the result\
+If you now try to create a user when not having been authenticated or
+when authenticated as a user without the `userAdmin` role, the result
 will be:
 
 ```
@@ -403,105 +403,105 @@ switched to db test
 }
 ```
 
-**NOTE** When a client authenticates, the password will not be\
-transferred in cleartext over the network, so, even without SSL,\
-it is not possible to gain access to a password by monitoring the\
+**NOTE** When a client authenticates, the password will not be
+transferred in cleartext over the network, so, even without SSL,
+it is not possible to gain access to a password by monitoring the
 network traffic.
 
-However, when a user is created or added (or the password is changed),\
-the password will be transferred in _cleartext_. To prevent eavesdropping,\
+However, when a user is created or added (or the password is changed),
+the password will be transferred in _cleartext_. To prevent eavesdropping,
 create/add users when connecting over a domain socket, or use [TLS/SSL](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#tlsssl)
 
 #### Implicit bootstrapping
 
-With implicit bootstrapping, you should first create the MariaDB\
-user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat\
-different in MariaDB and NoSQL, which means that certain factors\
-must be taken into account when creating the MariaDB user. Then\
+With implicit bootstrapping, you should first create the MariaDB
+user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat
+different in MariaDB and NoSQL, which means that certain factors
+must be taken into account when creating the MariaDB user. Then
 at first startup, nosqlprotocol will create the corresponding\
-NoSQL user, which will enable the authenticated and authorized\
+NoSQL user, which will enable the authenticated and authorized
 use of nosqlprotocol.
 
 When MaxScale is started, if the following hold
 
-* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration\
+* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration
   section of the nosqlprotocol listener,
 * `nosqlprotocol.user` and `nosqlprotocol.password` are provided, and
 * there are no NoSQL users in the NoSQL account database.
 
 then, MaxScale will
 
-* wait until the primary of the service pointed to by the listener\
+* wait until the primary of the service pointed to by the listener
   is available,
-* connect using the credentials specified in `nosqlprotocol.user`\
+* connect using the credentials specified in `nosqlprotocol.user`
   and `nosqlprotocol.password`,
 * execute `SHOW GRANTS`,
 * translate the privileges into the equivalent NoSQL roles, and
 * create a corresponding NoSQL user into the NoSQL account database.
 
-Immediately thereafter it is possible to connect to the nosqlprotocol\
+Immediately thereafter it is possible to connect to the nosqlprotocol
 port with a MongoDB® client using the specified credentials.
 
-Note that after the bootstrapping, nosqlprotocol will not use\
+Note that after the bootstrapping, nosqlprotocol will not use
 the `user` and `password` settings and they can be removed.
 
 **Grants**
 
-When a NoSQL user is created using [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser)\
-the MariaDB grants are obtained from the specified NoSQL roles\
+When a NoSQL user is created using [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser)
+the MariaDB grants are obtained from the specified NoSQL roles
 as explained [here](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#Roles_and_privileges).
 
 When implicitly creating a NoSQL user from an existing user in\
-MariaDB, the inverse operation must be performed. There are\
-many factors that affect what NoSQL roles the grants of a user\
+MariaDB, the inverse operation must be performed. There are
+many factors that affect what NoSQL roles the grants of a user
 are translated into:
 
 * whether the user is a regular or admin user,
 * whether the privileges are on `*.*` or some specific `db.*`, and
 * the privileges themselves, e.g. `SELECT`, `DELETE`, etc.
 
-In NoSQL, every user resides in a specific database. Note that\
-this does **not** mean that the database would have to exist\
+In NoSQL, every user resides in a specific database. Note that
+this does **not** mean that the database would have to exist
 in MariaDB.
 
-When it comes to users, the database effectively means a scope,\
-which in the case of nosqlprotocol is handled by prefixing the\
+When it comes to users, the database effectively means a scope,
+which in the case of nosqlprotocol is handled by prefixing the
 corresponding MariaDB user name with the database/scope name.
 
-When creating a user to be used from NoSQL, there are three\
+When creating a user to be used from NoSQL, there are three
 options for the user's name:
 
 * The name can be of the format `some_db.user_name` where`some_db` can be anything (subject to the naming rules of\
-  MariaDB), except `admin` or `mariadb`. In this case, the\
-  user will be a regular user, who can access data in\
+  MariaDB), except `admin` or `mariadb`. In this case, the
+  user will be a regular user, who can access data in
   databases that she has been granted access to.
-* The name can be of the format `admin.user_name` where `admin`\
-  is exactly just that. In this case, the user will be an\
+* The name can be of the format `admin.user_name` where `admin`
+  is exactly just that. In this case, the user will be an
   admin user, who can access any database.
-* The name can be of the format `user_name`. In this case, the\
-  user will be a regular user that from the NoSQL side appears\
-  to reside in the `mariadb` database. The primary purpose of\
-  this alternative is to enable the use of existing users from\
+* The name can be of the format `user_name`. In this case, the
+  user will be a regular user that from the NoSQL side appears
+  to reside in the `mariadb` database. The primary purpose of
+  this alternative is to enable the use of existing users from
   the NoSQL side.
 
-What database the privileges can be specified `ON` depends on\
+What database the privileges can be specified `ON` depends on
 what kind of user is being created.
 
-* If it is a regular user, the privileges must be granted on a\
+* If it is a regular user, the privileges must be granted on a
   specific database, such as `\`dbA\`\`.\*\`. Note that there is no\
   dependency between this database and the (conceptual) database\
   the user resides in.
 * If it is an admin user, the privileges must be granted on\
   the `*.*` database.
 
-In NoSQL, a role can be database specific or generic. However,\
-a generic role can _only_ be assigned to a user in the _admin_\
-database. In practice this means that if the privileges are\
-on `*.*`, then the user must reside in the _admin_ database\
+In NoSQL, a role can be database specific or generic. However,
+a generic role can _only_ be assigned to a user in the _admin_
+database. In practice this means that if the privileges are
+on `*.*`, then the user must reside in the _admin_ database
 (e.g. `admin.bob`) or it is treated as an error.
 
-The following table shows what privileges are required for a\
-role to be assigned. Note that `ALL PRIVILEGES` can be used as\
+The following table shows what privileges are required for a
+role to be assigned. Note that `ALL PRIVILEGES` can be used as
 well.
 
 | ALTER | CREATE | CREATE USER | DROP | DELETE | INDEX | INSERT | SHOW DATABASES(1) | SELECT | UPDATE | WITH GRANT OPTION | Role                    |
@@ -513,19 +513,19 @@ well.
 
 1. Only required if the user is an admin user.
 
-The `AnyDatabase` version will be assigned, if the user is\
+The `AnyDatabase` version will be assigned, if the user is
 an _admin_ user.
 
-If certain roles are assigned, then other roles will be\
+If certain roles are assigned, then other roles will be
 assigned as well.
 
-* If the roles `dbAdmin`, `readWrite` and `userAdmin` are\
+* If the roles `dbAdmin`, `readWrite` and `userAdmin` are
   assigned, then `dbOwner` will be assigned as well.
-* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`\
-  and `userAdminAnyDatabase` are assigned, then `root` will\
+* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`
+  and `userAdminAnyDatabase` are assigned, then `root` will
   be assigned as well.
 
-Once the user has been created and the desired privileges have\
+Once the user has been created and the desired privileges have
 been granted, the NoSQL listener should be configured as follows:
 
 ```
@@ -544,7 +544,7 @@ At MaxScale startup, the NoSQL user will then be created.
 
 **Admin User**
 
-We want the initial NoSQL user to be an administrator, with\
+We want the initial NoSQL user to be an administrator, with
 full rights.
 
 ```
@@ -552,8 +552,8 @@ CREATE USER 'admin.nosql_admin'@'%' IDENTIFIED BY 'nosql_password';
 GRANT ALL PRIVILEGES ON *.* TO 'admin.nosql_admin'@'%' WITH GRANT OPTION;
 ```
 
-As we want an admin user, the name is prefixed with `admin`,\
-which will have that effect. And since it is an admin user, the\
+As we want an admin user, the name is prefixed with `admin`,
+which will have that effect. And since it is an admin user, the
 privileges are granted ON `*.*`.
 
 Thereafter, we specify the following in the configuration file,
@@ -571,16 +571,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'admin.nosql_admin'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -590,9 +590,9 @@ $ mongo --quiet --port 17017 -u nosql_admin -p nosql_password admin
 >
 ```
 
-Note that when connecting the user is passed as `nosql_admin` and _not_\
-as `admin.nosql_admin`. The fact that we want to authenticate against\
-the `admin` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `nosql_admin` and _not_
+as `admin.nosql_admin`. The fact that we want to authenticate against
+the `admin` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -631,13 +631,13 @@ argument.
 }
 ```
 
-As can be seen, the user has the _any_ roles on the `admin`\
-database, which means that all databases can be accessed and\
+As can be seen, the user has the _any_ roles on the `admin`
+database, which means that all databases can be accessed and
 modified, and that new users can be created.
 
 **Test User**
 
-We want the initial NoSQL user to be a user with limited rights,\
+We want the initial NoSQL user to be a user with limited rights,
 intended to be used for testing.
 
 ```
@@ -645,11 +645,11 @@ CREATE USER 'test.test_user'@'%' IDENTIFIED BY 'test_password';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX ON `test`.* TO 'test.test_user'@'%';
 ```
 
-As we want a user with limited rights, the name is _not_ prefixed\
+As we want a user with limited rights, the name is _not_ prefixed
 with `admin`. The privileges are granted specifically on database`test.*`. Indeed, if `*.*` had been used, the creation of the initial\
-NoSQL user would have failed with an error. Here, the user is created\
-in the same database that the user is given access to, but it could\
-have been another one. Further, several `GRANT` statements could have\
+NoSQL user would have failed with an error. Here, the user is created
+in the same database that the user is given access to, but it could
+have been another one. Further, several `GRANT` statements could have
 been used, had we wanted to give access to several databases.
 
 Thereafter, we specify the following in the configuration file,
@@ -667,16 +667,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'test.test_user'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -686,9 +686,9 @@ $ mongo --quiet --port 17017 -u test_user -p test_password test
 >
 ```
 
-Note that when connecting the user is passed as `test_user` and _not_\
-as `test.test_user`. The fact that we want to authenticate against\
-the `test` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `test_user` and _not_
+as `test.test_user`. The fact that we want to authenticate against
+the `test` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -715,44 +715,44 @@ argument.
 }
 ```
 
-As can be seen, the user has the `readWrite` role on the `test` database,\
+As can be seen, the user has the `readWrite` role on the `test` database,
 which means that only the `test` database can be accessed and modified.
 
 #### TLS/SSL
 
-Since `nosqlprotocol` is a regular protocol module used in a listener,\
-the TLS/SSL support of listeners is available. Please see [TLS/SSL encryption](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#tlsssl-encryption)\
+Since `nosqlprotocol` is a regular protocol module used in a listener,
+the TLS/SSL support of listeners is available. Please see [TLS/SSL encryption](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#tlsssl-encryption)
 for details.
 
 ### NoSQL Account Database
 
-So as to be able to connect to the MariaDB server on behalf of\
-clients, nosqlprotocol must know their password. As the password\
-is not transferred to nosqlprotocol during the authentication in\
-a way that could be used when logging into MariaDB, the password\
-must be stored when the user is created with [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser)\
+So as to be able to connect to the MariaDB server on behalf of
+clients, nosqlprotocol must know their password. As the password
+is not transferred to nosqlprotocol during the authentication in
+a way that could be used when logging into MariaDB, the password
+must be stored when the user is created with [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser)
 or added with [mxsAddUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsAddUser).
 
-Note that the password is not stored in cleartext but as three\
-different hashes; hashed with sha1 for use with MariaDB, salted\
-and hashed with sha1 for use with the `SCRAM-SHA-1` authentication\
-mechanism (if that is enabled for the user) and salted and hashed\
-with sha256 for use with the `SCRAM-SHA-256` authentication mechanism\
+Note that the password is not stored in cleartext but as three
+different hashes; hashed with sha1 for use with MariaDB, salted
+and hashed with sha1 for use with the `SCRAM-SHA-1` authentication
+mechanism (if that is enabled for the user) and salted and hashed
+with sha256 for use with the `SCRAM-SHA-256` authentication mechanism
 (if that is enabled for the user).
 
-The account information can be stored _privately_, in which case it\
-can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can\
-share the information and a user created/added on one instance\
+The account information can be stored _privately_, in which case it
+can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can
+share the information and a user created/added on one instance
 can be used on another.
 
 #### Private
 
-In the private case, the account information of nosqlprotocol is\
-stored in an [sqlite3](https://sqlite.org/index.html) database\
-whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,\
-where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the\
-listener section in the MaxScale configuration file, and `-v1`\
-a suffix for making schema evolution easier, should there be\
+In the private case, the account information of nosqlprotocol is
+stored in an [sqlite3](https://sqlite.org/index.html) database
+whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,
+where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the
+listener section in the MaxScale configuration file, and `-v1`
+a suffix for making schema evolution easier, should there be
 a need for that.
 
 For instance, given a configuration like
@@ -767,41 +767,41 @@ protocol=nosqlprotocol
 
 the account information will be stored in the file`<libdir>/nosqlprotocol/NoSQL-Listener-v1.db`.
 
-Note that since the database name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the database name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
-To retain the accounts, the database file should also be\
+To retain the accounts, the database file should also be
 renamed.
 
-At first startup, the `nosqlprotocol` directory and\
-the file `NoSQL-Listener-v1.db` will be created. They will\
-be created with file permissions that only allow MaxScale\
-access. At subsequent startups the permissions will be checked\
-and MaxScale will refuse to start if the permissions allow\
+At first startup, the `nosqlprotocol` directory and
+the file `NoSQL-Listener-v1.db` will be created. They will
+be created with file permissions that only allow MaxScale
+access. At subsequent startups the permissions will be checked
+and MaxScale will refuse to start if the permissions allow
 access to others.
 
 **We strongly recommend that no manual modifications are made**\
 **to the database.**
 
-Note that we make **no** guarantees that the way in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the way in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ### Shared
 
-In the shared case, the account information of nosqlprotocol\
+In the shared case, the account information of nosqlprotocol
 is stored in the cluster of the service in front of which the\
-NoSQL listener resides. The primary of the cluster will be used\
+NoSQL listener resides. The primary of the cluster will be used
 both for reading and writing data.
 
 A table whose name is the same as the listener's name in the\
-MaxScale configuration will be created in the database\
-specified with the [authentication\_db](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_db)\
-parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of\
+MaxScale configuration will be created in the database
+specified with the [authentication\_db](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_db)
+parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of
 the listener section in the MaxScale configuration file.
 
 For instance, given a configuration like
@@ -816,61 +816,61 @@ protocol=nosqlprotocol
 
 the account information will be stored in the table`nosqlprotocol.NoSQL-Listener`.
 
-Note that since the table name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the table name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
 To retain the accounts, the table should also be renamed.
 
-`nosqlprotocol` will create the table when needed, so the\
-user specified with [authentication\_user](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_user)\
+`nosqlprotocol` will create the table when needed, so the
+user specified with [authentication\_user](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_user)
 must have sufficient grants to be able to do that.
 
-`nosqlprotocol` will store in the table, data that allow\
-any MaxScale to authenticate a MongoDB® client, irrespective\
+`nosqlprotocol` will store in the table, data that allow
+any MaxScale to authenticate a MongoDB® client, irrespective
 of which MaxScale instance was used when the user was created.
 
-`nosqlprotocol` also stores in the table the SHA1 of a user's\
+`nosqlprotocol` also stores in the table the SHA1 of a user's
 password, to be able to authenticate against the MariaDB server.\
-Therefore it is **strongly** suggested to enable encryption key\
-management in MaxScale and to provide an authentication\
-key ID with [authentication\_key\_id](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_key_id) so\
+Therefore it is **strongly** suggested to enable encryption key
+management in MaxScale and to provide an authentication
+key ID with [authentication\_key\_id](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_key_id) so
 that the data will be encrypted.
 
-If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_password) must also\
-be provided. With [authentication\_db](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_db) the\
-database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_key_id) an\
-encryption key ID, using which the sensitive data is encrypted,\
+If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_password) must also
+be provided. With [authentication\_db](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_db) the
+database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#authentication_key_id) an
+encryption key ID, using which the sensitive data is encrypted,
 can optionally be provided.
 
-Note that we make **no** guarantees that the table in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the table in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ## Wire Protocol
 
-_Nosqlprotocol_ fully supports wire protocol version 6 and only provides\
-rudimentary support for earlier wire protocol versions, but reports at\
-startup that it would support versions 0 to 6. The reason is that some\
-client libraries are buggy and use an old wire protocol version if the\
-server claims to support only version 6. Consequently, one should use a\
+_Nosqlprotocol_ fully supports wire protocol version 6 and only provides
+rudimentary support for earlier wire protocol versions, but reports at
+startup that it would support versions 0 to 6. The reason is that some
+client libraries are buggy and use an old wire protocol version if the
+server claims to support only version 6. Consequently, one should use a
 client library version that at least supports wire protocol version 6.
 
 ## Client Library
 
-As the goal of _nosqlprotocol_ is to implement, to the extent that it\
-is feasible, the wire protocol and the database commands the way MongoDB®\
+As the goal of _nosqlprotocol_ is to implement, to the extent that it
+is feasible, the wire protocol and the database commands the way MongoDB®
 implements them, it should be possible to use any language specific driver.
 
-However, during the development of _nosqlprotocol_, the _only_ client library\
+However, during the development of _nosqlprotocol_, the _only_ client library
 that has been verified to work is version 3.6 of _MongoDB Node.JS Driver_.
 
 ## Parameters
 
-Using the following parameters, the behavior of _nosqlprotocol_ can be\
+Using the following parameters, the behavior of _nosqlprotocol_ can be
 adjusted. As they are not generic listener parameters, but specific to _nosqlprotocol_ they must be qualified with the `nosqlprotocol`-prefix.
 
 For instance:
@@ -892,7 +892,7 @@ nosqlprotocol.on_unknown_command=return_error
 * Mandatory: No
 * Default: `""`
 
-Specifies the _user_ to be used when connecting to the backend, if the MongoDB®\
+Specifies the _user_ to be used when connecting to the backend, if the MongoDB®
 client is not authenticated.
 
 ### `password`
@@ -901,8 +901,8 @@ client is not authenticated.
 * Mandatory: No
 * Default: `""`
 
-Specifies the _password_ to be used when connecting to the backend, is the MongoDB®\
-client is not authenticated. Note that the same _user_/_password_ combination will be\
+Specifies the _password_ to be used when connecting to the backend, is the MongoDB®
+client is not authenticated. Note that the same _user_/_password_ combination will be
 used for all unauthenticated MongoDB® clients connecting to the same listener port.
 
 ### `authentication_required`
@@ -911,11 +911,11 @@ used for all unauthenticated MongoDB® clients connecting to the same listener p
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the client always must authenticate. If authentication is required,\
-it does not matter whether `user` and `password` have been specified, the client must\
+Specifies whether the client always must authenticate. If authentication is required,
+it does not matter whether `user` and `password` have been specified, the client must
 authenticate.
 
-Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsAddUser),\
+Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsAddUser),
 with authentication being optional and authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -927,7 +927,7 @@ MariaDB server.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the NoSQL account information should be stored in a shared\
+Specifies whether the NoSQL account information should be stored in a shared
 manner or privately.
 
 ### `authentication_db`
@@ -936,10 +936,10 @@ manner or privately.
 * Mandatory: No
 * Default: `"NoSQL"`
 
-Specifies the database of the table where the NoSQL account information\
-is stored, if `authentication_shared` is `true`. If the database does not\
-exist, nosqlprotocol will attempt to create it, so either is should be\
-manually created or the used specified with `authentication_user` should\
+Specifies the database of the table where the NoSQL account information
+is stored, if `authentication_shared` is `true`. If the database does not
+exist, nosqlprotocol will attempt to create it, so either is should be
+manually created or the used specified with `authentication_user` should
 have the grants required to do so.
 
 ### `authentication_key_id`
@@ -948,11 +948,11 @@ have the grants required to do so.
 * Mandatory: No
 * Default: `""`
 
-The encryption key ID, using which the NoSQL account information should be\
-encrypted with when stored in the MariaDB server. If an encryption key ID is\
+The encryption key ID, using which the NoSQL account information should be
+encrypted with when stored in the MariaDB server. If an encryption key ID is
 given, the encryption key manager in MaxScale must also be enabled.
 
-The encryption key must be a 256-bit key. Keys of shorter length are rejected\
+The encryption key must be a 256-bit key. Keys of shorter length are rejected
 as invalid encryption keys.
 
 ### `authentication_user`
@@ -960,7 +960,7 @@ as invalid encryption keys.
 * Type: string
 * Mandatory: Yes, if `authentication_shared` is true.
 
-Specifies the _user_ to be used when modifying and accessing the NoSQL\
+Specifies the _user_ to be used when modifying and accessing the NoSQL
 account information stored in the MariaDB server.
 
 ### `authentication_password`
@@ -977,9 +977,9 @@ Specifies the _password_ of `authentication_user`.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether nosqlprotocol itself should perform authorization in the context\
-of the commands [mxsAddUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users\
-have been created with [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsAddUser)\
+Specifies whether nosqlprotocol itself should perform authorization in the context
+of the commands [mxsAddUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users
+have been created with [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#mxsAddUser)
 with authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -992,8 +992,8 @@ MariaDB server.
 * Default: `"%"`
 
 Specifies the _host_ to be used when a MariaDB user is created via nosqlprotocol.\
-By default all users are created as `...@'%'`, which means that it is possible to\
-connect to the MariaDB server from any host using the credentials of the created\
+By default all users are created as `...@'%'`, which means that it is possible to
+connect to the MariaDB server from any host using the credentials of the created
 user. For tighter security, the IP-address of the MaxScale host can be specified.
 
 NOTE: This value does **not** specify from which host it is allowed to connect to\
@@ -1019,8 +1019,8 @@ Enumeration values:
 * Mandatory: No
 * Default: `false`
 
-Specifies whether an unknown command should be logged. This is primarily\
-for debugging purposes, to find out whether a client uses a command that\
+Specifies whether an unknown command should be logged. This is primarily
+for debugging purposes, to find out whether a client uses a command that
 currently is not supported.
 
 ### `auto_create_databases`
@@ -1042,7 +1042,7 @@ Note that setting this parameter to `true`, without also setting`auto_create_tab
 Specifies whether tables should automatically be created, as needed.
 
 Note that this applies only if the relevant database already exists.\
-If a database should also be created if needed, then `auto_create_databases`\
+If a database should also be created if needed, then `auto_create_databases`
 must also be set to `true`.
 
 ### `id_length`
@@ -1063,16 +1063,16 @@ Specifies the length of the id column in tables that are automatically created.
 
 Enumeration values:
 
-* `default`: Each document is inserted using a separate `INSERT`, either in a\
-  multi-statement or in a compound statement. Whether an error causes the remaining\
-  insertions to be aborted, depends on the value of `ordered` specified in the\
+* `default`: Each document is inserted using a separate `INSERT`, either in a
+  multi-statement or in a compound statement. Whether an error causes the remaining
+  insertions to be aborted, depends on the value of `ordered` specified in the
   insert command.
-* `atomic`: If the value of `ordered` in the insert command is `true`\
-  (the default) then all documents are inserted using a single `INSERT` statement,\
-  that is, either all insertions succeed or none will. If `ordered` is false, then\
+* `atomic`: If the value of `ordered` in the insert command is `true`
+  (the default) then all documents are inserted using a single `INSERT` statement,
+  that is, either all insertions succeed or none will. If `ordered` is false, then
   the behavior is as in the `default` case.
 
-What combination of `ordered_insert_behavior` and `ordered` (in the insert command\
+What combination of `ordered_insert_behavior` and `ordered` (in the insert command
 document) is used, has an impact on the performance. Please see the discussion at [insert](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#insert).
 
 ### `cursor_timeout`
@@ -1081,7 +1081,7 @@ document) is used, has an impact on the performance. Please see the discussion a
 * Mandatory: No
 * Default: `60s`
 
-Specifies how long a cursor can be idle, that is, not accessed, before it is\
+Specifies how long a cursor can be idle, that is, not accessed, before it is
 automatically closed.
 
 ### `debug`
@@ -1106,7 +1106,7 @@ So, specify
 nosqlprotocol.debug=in,out,back
 ```
 
-to have the incoming command, the corresponding SQL sent to the backend\
+to have the incoming command, the corresponding SQL sent to the backend
 and the resulting response sent to the client logged.
 
 ### `internal_cache`
@@ -1115,7 +1115,7 @@ and the resulting response sent to the client logged.
 * Mandatory: No
 * Default: ''
 
-Specifies what internal cache to use if any. Currently, the only\
+Specifies what internal cache to use if any. Currently, the only
 permissible value is `cache`, which refers to the [cache filter](../maxscale-24-02filters/mariadb-maxscale-2402-cache.md).
 
 Please see [caching](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#caching) for more information.
@@ -1123,15 +1123,15 @@ Please see [caching](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.m
 ## Databases and Tables
 
 By default, _nosqlprotocol_ automatically creates databases as needed.\
-The default behavior can be changed by setting `auto_create_databases` to\
+The default behavior can be changed by setting `auto_create_databases` to
 false. In that case, databases must manually be created.
 
 Each MongoDB® _collection_ corresponds to a MariaDB table with the same name.\
-However, it is always possible to access a collection irrespective of whether\
+However, it is always possible to access a collection irrespective of whether
 the corresponding table exists or not; it will simply appear to be empty.
 
-Inserting documents into a collection, whose corresponding table does not\
-exist, succeeds, provided `auto_create_tables` is `true`, as the table will\
+Inserting documents into a collection, whose corresponding table does not
+exist, succeeds, provided `auto_create_tables` is `true`, as the table will
 in that case be created.
 
 When _nosqlprotocol_ creates a table, it uses a statement like
@@ -1142,19 +1142,19 @@ CREATE TABLE name (id VARCHAR(35) AS (JSON_COMPACT(JSON_EXTRACT(doc, "$._id"))) 
                    CONSTRAINT id_not_null CHECK(id IS NOT NULL));
 ```
 
-where the length of the `VARCHAR` is specified by the value of `id_length`,\
+where the length of the `VARCHAR` is specified by the value of `id_length`,
 whose default and minimum is 35.
 
-_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain\
+_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain
 a similar constraint.
 
-Note that _nosqlprotocol_ does not in any way verify that the table\
-corresponding to a collection being accessed or modified does indeed\
-have the expected columns `id` and `doc` of the expected types, but it\
-simply uses the table, which will fail if the layout is not the expected\
+Note that _nosqlprotocol_ does not in any way verify that the table
+corresponding to a collection being accessed or modified does indeed
+have the expected columns `id` and `doc` of the expected types, but it
+simply uses the table, which will fail if the layout is not the expected
 one.
 
-To reduce the risk for confusion, the recommendation is to use a specific\
+To reduce the risk for confusion, the recommendation is to use a specific
 database for tables that contain documents.
 
 ## Operators
@@ -1190,7 +1190,7 @@ The following operators are currently supported.
 
 **`$type`**
 
-When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset\
+When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset
 of types can be used in `$type` queries:
 
 | Type           | Number | Alias    | MariaDB Type |
@@ -1237,10 +1237,10 @@ As arguments, only the operators `$eq` and `$ne` are supported.
 
 ## Database Commands
 
-The following commands are supported. At each command is specified\
+The following commands are supported. At each command is specified
 what fields are relevant for the command.
 
-**All** non-listed fields are ignored; their presence or absence have no\
+**All** non-listed fields are ignored; their presence or absence have no
 impact, unless otherwise explicitly specified.
 
 ### Aggregation Commands
@@ -1311,7 +1311,7 @@ The `projection` parameter takes a document of the following form:
 { <field1>: <value>, <field2>: <value> ... }
 ```
 
-If a `projection` document is not provided or if it is empty, the entire document\
+If a `projection` document is not provided or if it is empty, the entire document
 will be returned.
 
 | Projection     | Description                         |
@@ -1325,23 +1325,23 @@ For fields in an embedded documents, the field can be specified using:
 
 * dot notation; e.g. `"field.nestedfield": <value>`
 
-In particular, specifying fields in embedded documents using nested form\
+In particular, specifying fields in embedded documents using nested form
 is not supported.
 
 **`_id` Field Projection**
 
-The `_id` field is included in the returned documents by default unless you\
+The `_id` field is included in the returned documents by default unless you
 explicitly specify `_id: 0` in the projection to suppress the field.
 
 **Inclusion or Exclusion**
 
-A `projection` cannot contain both include and exclude specifications,\
+A `projection` cannot contain both include and exclude specifications,
 with the exception of the `_id` field:
 
 * In projections that explicitly include fields, the `_id` field is the only field that can be explicitly excluded.
 * In projections that explicitly excludes fields, the `_id` field is the only field that can be explicitly include; however, the `_id` field is included by default.
 
-_NOTE_ Currently `_id` is the only field that can be excluded, and _only_\
+_NOTE_ Currently `_id` is the only field that can be excluded, and _only_
 if other fields are explicitly included._NOTE_ Currently exclusion of other fields but `_id` is not supported.
 
 **Filtering by `_id`**
@@ -1370,7 +1370,7 @@ and in the latter
 ... WHERE (JSON_EXTRACT(doc, '$._id') = 4711)
 ```
 
-That is, in the former case the _indexed_ column `id` will be used, in the\
+That is, in the former case the _indexed_ column `id` will be used, in the
 latter it will not.
 
 #### findAndModify
@@ -1410,9 +1410,9 @@ The following fields are relevant.
 
 #### insert
 
-The `insert` command inserts one or more documents into the table whose\
-name is the same as that of the collection. If the option `auto_create_tables`\
-is `true`, then the table is created if it does not already exist. If the\
+The `insert` command inserts one or more documents into the table whose
+name is the same as that of the collection. If the option `auto_create_tables`
+is `true`, then the table is created if it does not already exist. If the
 value is `false`, then the insert will fail unless the table already exists.
 
 The following fields are relevant.
@@ -1429,9 +1429,9 @@ The impact of `ordered` is dependent upon the value of `ordered_insert_behavior`
 
 **`default`**
 
-In this case `ordered` has the same impact as in MongoDB®. That is, if the value\
-is `true`, then when an insert of a document fails, return without inserting any\
-remaining documents listed in the inserts array. If `false`, then when an insert\
+In this case `ordered` has the same impact as in MongoDB®. That is, if the value
+is `true`, then when an insert of a document fails, return without inserting any
+remaining documents listed in the inserts array. If `false`, then when an insert
 of a document fails, continue to insert the remaining documents.
 
 **`atomic`**
@@ -1443,7 +1443,7 @@ then the behavior is identical with that of `default`.
 
 **Performance**
 
-What combination of `ordered_insert_behavior` and `ordered` is used, has an\
+What combination of `ordered_insert_behavior` and `ordered` is used, has an
 impact on the performance.
 
 | ordered\_insert\_behavior | ordered = true                                                                                                                        | ordered = false                                                                                                                        |
@@ -1451,8 +1451,8 @@ impact on the performance.
 | default                   | All documents are inserted within a compound statement, in a transaction containing as many INSERT statements as there are documents. | All documents are inserted in a single multi-statement transaction containing as many INSERT IGNORE statements as there are documents. |
 | atomic                    | All documents are inserted using a single INSERT statement.                                                                           | Same as above                                                                                                                          |
 
-Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,\
-being roughly twice as slow. The performance of 'default + true' is halfway between\
+Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,
+being roughly twice as slow. The performance of 'default + true' is halfway between
 the two.
 
 #### resetError
@@ -1485,10 +1485,10 @@ Each document contains the following fields:
 | u     | document | The modifications to apply. See behavior below for details.                                                                                                        |
 | multi | boolean  | Optional. If true, updates all documents that meet the query criteria. If false limit the update to one document that meets the query criteria. Defaults to false. |
 
-Note that currently it is possible to set `multi` to `true` in conjunction\
+Note that currently it is possible to set `multi` to `true` in conjunction
 with a _replacement-style_ update, even though MongoDB® rejects that.
 
-All other fields are ignored, with the exception of `upsert` that if present\
+All other fields are ignored, with the exception of `upsert` that if present
 with the value of `true` will cause the command to fail.
 
 **Behavior**
@@ -1514,7 +1514,7 @@ In this case, the update command updates only the corresponding fields in the do
 
 **Update with a Replacement Document**
 
-The update statement field `u` field can accept a _replacement document_,\
+The update statement field `u` field can accept a _replacement document_,
 i.e. the document contains only `field:value` expressions. For example:
 
 ```
@@ -1529,12 +1529,12 @@ updates: [
 ```
 
 In this case, the update command replaces the matching document with the update document.\
-The update command can only replace a single matching document; i.e. the multi field\
+The update command can only replace a single matching document; i.e. the multi field
 cannot be true.
 
-**Note** If the replacement document contains an `_id` field, it will be ignored and the\
-document id will remain non-changed while the document otherwise is replaced. This is\
-different from MongoDB® where the presence of the `_id` field in the replacement document\
+**Note** If the replacement document contains an `_id` field, it will be ignored and the
+document id will remain non-changed while the document otherwise is replaced. This is
+different from MongoDB® where the presence of the `_id` field in the replacement document
 causes an error, if the value is not the same as it is in the document being replaced.
 
 ### Authentication Commands
@@ -1549,7 +1549,7 @@ The following fields are relevant.
 
 If you are not logged in and using authentication, `logout` has no effect.
 
-Note that in order to be logged out, the logging out must be done while\
+Note that in order to be logged out, the logging out must be done while
 using the same database that was used when you logged on.
 
 Always returns
@@ -1562,7 +1562,7 @@ Always returns
 
 #### createUser
 
-Creates a new MariaDB user and adds an entry to the local nosqlprotocol\
+Creates a new MariaDB user and adds an entry to the local nosqlprotocol
 account database.
 
 The following fields are relevant.
@@ -1576,8 +1576,8 @@ The following fields are relevant.
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is\
-the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the\
+The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is
+the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the
 following command
 
 ```
@@ -1587,19 +1587,19 @@ following command
 
 the MariaDB user `'myDatabase.user1'@'%'` will be created.
 
-The elements of the `roles` array are converted into privileges\
+The elements of the `roles` array are converted into privileges
 as explained in [here](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#roles_and_privileges).
 
 In practice the creation is performed as follows:_First the MariaDB user is created._ Then the privileges are granted.
 
 * Finally the local nosqlprotocol account database is updated.
 
-If the granting of privileges fails, an attempt will be made to\
+If the granting of privileges fails, an attempt will be made to
 drop the user.
 
 #### dropAllUsersFromDatabase
 
-Drops all users from the local nosqlprotocol account database and\
+Drops all users from the local nosqlprotocol account database and
 the corresponding MariaDB users.
 
 The following fields are relevant.
@@ -1621,13 +1621,13 @@ The following fields are relevant.
 | -------- | ------ | ----------------------------------- |
 | dropUser | string | The name of the user to be dropped. |
 
-The user will first be dropped from the MariaDB server and if\
+The user will first be dropped from the MariaDB server and if
 that succeeds also from the local nosqlprotocol account database.
 
 #### grantRolesToUser
 
-This command _adds_ more roles to a NoSQL user, which may imply\
-that additional privileges are granted to the corresponding MariaDB\
+This command _adds_ more roles to a NoSQL user, which may imply
+that additional privileges are granted to the corresponding MariaDB
 user.
 
 | Field            | Type   | Description                                    |
@@ -1636,12 +1636,12 @@ user.
 | roles            | array  | An array of additional roles.                  |
 
 Note that roles assigned to different databases will result in separate\
-GRANT statements, which means that it is possible that some succeed and\
+GRANT statements, which means that it is possible that some succeed and
 others do not.
 
 #### revokeRolesFromUser
 
-This command _removes_ roles from an NoSQL user, which may imply\
+This command _removes_ roles from an NoSQL user, which may imply
 that privileges are revoked from the corresponding MariaDB user.
 
 | Field               | Type   | Description                                |
@@ -1649,8 +1649,8 @@ that privileges are revoked from the corresponding MariaDB user.
 | revokeRolesFromUser | string | The name of the user to remove roles from. |
 | roles               | array  | An array of roles to remove.               |
 
-Note that roles to be removed from different databases will result in\
-separate REVOKE statements, which means that it is possible that some\
+Note that roles to be removed from different databases will result in
+separate REVOKE statements, which means that it is possible that some
 succeed and others do not.
 
 #### updateUser
@@ -1665,8 +1665,8 @@ This command updates the information about a particular user.
 | roles      | array    | Optional. The roles granted to the user. Note that the existing ones are replaced and not amended with these roles.                                                                                                                                                |
 | mechanisms | array    | Optional. The specific SCRAM mechanisms for user credentials. Note that if a new pwd is provided, then the array can contain all supported SCRAM mechanisms. If a new pwd is not provided, then the array must be a subset of the existing mechanisms of the user. |
 
-Changes to `customData` or `mechanisms` are made only to the local\
-nosqlprotocol database, but changes to `pwd` or `roles` require\
+Changes to `customData` or `mechanisms` are made only to the local
+nosqlprotocol database, but changes to `pwd` or `roles` require
 the MariaDB server to be updated.
 
 #### usersInfo
@@ -1690,11 +1690,11 @@ The returned information depends the value of `usersInfo`:
 | { usersInfo: \[{ user: , db: }, ...]} | Returns information about specified users.                                          |
 | { usersInfo: \[ , ... ]}              | Returns information about specified users in the database where the command is run. |
 
-Note that users may always view their own information. Otherwise the user must\
+Note that users may always view their own information. Otherwise the user must
 have the `userAdmin` or `userAdminAnyDatabase` role.
 
 If `showCredentials` is true, the returned object(s) will contain a`mariadb: { password: "*..."}` field, where `password` is the`SHA1(SHA1())` value of the password used when logging to MariaDB.\
-That is, the same string that is found in the `password` column in\
+That is, the same string that is found in the `password` column in
 the `mysql.user` table.
 
 ### Replication Commands
@@ -1756,8 +1756,8 @@ The following fields are relevant.
 | capped | boolean | Optional. If specified, the value must be false as capped collections are not supported. |
 | viewOn | string  | Optional. If specified, the command will fail as views are not supported.                |
 
-Currently, _capped collections_ and _views_ are not supported. Consequently,\
-specifying that the collection should be capped or that it should be a\
+Currently, _capped collections_ and _views_ are not supported. Consequently,
+specifying that the collection should be capped or that it should be a
 view on another collection, will cause the command to fail.
 
 #### createIndexes
@@ -1768,9 +1768,9 @@ The following fields are relevant.
 | ------------- | ------ | ------------------------------------------- |
 | createIndexes | string | The collection for which to create indexes. |
 
-**NOTE** Currently it is not possible to create indexes, but the command\
-will nonetheless return success, provide the index specification passes\
-some rudimentary sanity checks. Note also that the collection will be\
+**NOTE** Currently it is not possible to create indexes, but the command
+will nonetheless return success, provide the index specification passes
+some rudimentary sanity checks. Note also that the collection will be
 created if it does not exist.
 
 #### drop
@@ -1797,9 +1797,9 @@ The following fields are relevant.
 | ----------- | ---- | ----------- |
 | dropIndexes | any  | Ignored.    |
 
-**NOTE** Currently it is not possible to create indexes and thus there\
-will never be any indexes that could be dropped. However, provided the\
-specified collection exists, dropping indexes will always succeed except\
+**NOTE** Currently it is not possible to create indexes and thus there
+will never be any indexes that could be dropped. However, provided the
+specified collection exists, dropping indexes will always succeed except
 for an attempt to drop the built-in `_id_` index.
 
 #### fsync
@@ -1840,8 +1840,8 @@ The following fields are relevant.
 | filter          | document | The field name is honored, other fields are not but cause warnings to be logged.                                                                 |
 | nameOnly        | boolean  | Optional. A flag to indicate whether the command should return just the collection names and type or return both the name and other information. |
 
-Note that the command lists all collections (that is, tables) that are found\
-in the current database. The listed collections may or may not be suitable\
+Note that the command lists all collections (that is, tables) that are found
+in the current database. The listed collections may or may not be suitable
 for being accessed using _nosqlprotocol_.
 
 #### listDatabases
@@ -1861,9 +1861,9 @@ The following fields are relevant.
 | ----------- | ------ | --------------------------- |
 | listIndexes | string | The name of the collection. |
 
-**NOTE** As it currently is not possible to actually create indexes,\
-although an attempt to do so using `createIndexes` will succeed, the\
-result will always only contain information about the built-in\
+**NOTE** As it currently is not possible to actually create indexes,
+although an attempt to do so using `createIndexes` will succeed, the
+result will always only contain information about the built-in
 index `_id_`.
 
 #### renameCollection
@@ -1971,8 +1971,8 @@ The following fields are relevant.
 | -------- | ------ | --------------------------------------- |
 | validate | string | The name of the collection to validate. |
 
-The command does not actually perform any validation but for checking\
-that the collection exists. The response will contain in `nrecords`\
+The command does not actually perform any validation but for checking
+that the collection exists. The response will contain in `nrecords`
 the current number of documents/rows it contains.
 
 #### whatsmyuri
@@ -2009,11 +2009,11 @@ The following document will always be returned:
 
 **mxsAddUser**
 
-The `mxsAddUser` command adds an _existing_ MariaDB user to the local\
+The `mxsAddUser` command adds an _existing_ MariaDB user to the local
 nosqlprotocol account database. Use [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createUser) if the\
 MariaDB user should be created as well.
 
-Note that the `mxsAddUser` command does not check that the user exists\
+Note that the `mxsAddUser` command does not check that the user exists
 or that the specified roles are compatible with the grants of the user.
 
 **Syntax**
@@ -2049,17 +2049,17 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The value of `mxsAddUser` should be the name (without the host part) of\
-an existing user in the MariaDB server and the value of `pwd` should be\
+The value of `mxsAddUser` should be the name (without the host part) of
+an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the addition of the user succeeds, the command returns a document\
+If the addition of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2085,7 +2085,7 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsCreateDatabase**
 
-The 'mxsCreateDatabase' command creates a new database and must be run\
+The 'mxsCreateDatabase' command creates a new database and must be run
 against the `admin` database.
 
 **Syntax**
@@ -2110,7 +2110,7 @@ The command takes the following fields:
 
 **Returns**
 
-If database creation succeeds, the command returns a document with the\
+If database creation succeeds, the command returns a document with the
 single field `ok` whose value is `1`.
 
 ```
@@ -2161,7 +2161,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains diagnostics of the command\
+The command returns a document that contains diagnostics of the command
 provided as argument. For example:
 
 ```
@@ -2186,19 +2186,19 @@ provided as argument. For example:
 }
 ```
 
-`kind` specifies of what kind the command is; an _immediate_ command is one for\
-which MaxScale autonomously can generate the response, a _single_ command is one\
-where the command will cause a single SQL statement to be sent to the backend, and\
-a _multi_ command is one where potentially multiple SQL statements will be sent to\
+`kind` specifies of what kind the command is; an _immediate_ command is one for
+which MaxScale autonomously can generate the response, a _single_ command is one
+where the command will cause a single SQL statement to be sent to the backend, and
+a _multi_ command is one where potentially multiple SQL statements will be sent to
 the backend.
 
-If the command is _immediate_ then there will be a field `response` containing\
-the actual response of the command, if the command is _single_ then there will be\
-a field `sql` containing the actual statement that would have been sent to the backend,\
-and if the command is _multi_ then there will be a field `sql` containing an array\
+If the command is _immediate_ then there will be a field `response` containing
+the actual response of the command, if the command is _single_ then there will be
+a field `sql` containing the actual statement that would have been sent to the backend,
+and if the command is _multi_ then there will be a field `sql` containing an array
 of statements that would have been sent to the backend.
 
-If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that\
+If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that
 the value of `ok` will always be 1.
 
 #### mxsGetConfig
@@ -2207,7 +2207,7 @@ the value of `ok` will always be 1.
 
 **mxsGetConfig**
 
-The `mxsGetConfig` command returns the current configuration of the session\
+The `mxsGetConfig` command returns the current configuration of the session
 and must be run against the 'admin' database.
 
 **Syntax**
@@ -2231,7 +2231,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the current configuration of\
+The command returns a document that contains the current configuration of
 the session. For example:
 
 ```
@@ -2253,8 +2253,8 @@ the session. For example:
 
 **mxsRemoveUser**
 
-The `mxsRemoveUser` removes a user from the local nosqlprotocol account\
-database. Use [dropUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped\
+The `mxsRemoveUser` removes a user from the local nosqlprotocol account
+database. Use [dropUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped
 as well.
 
 **Syntax**
@@ -2279,7 +2279,7 @@ The command has the following fields:
 
 **Returns**
 
-If the removal of the user succeeds, the command returns a document\
+If the removal of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2305,10 +2305,10 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsSetConfig**
 
-The `mxsSetConfig` command changes the configuration of the session\
+The `mxsSetConfig` command changes the configuration of the session
 and must be run against the 'admin' database.
 
-Note that the changes only affect the current session and are **not**\
+Note that the changes only affect the current session and are **not**
 persisted.
 
 **Syntax**
@@ -2340,7 +2340,7 @@ The document takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the changed configuration of\
+The command returns a document that contains the changed configuration of
 the session. For example:
 
 ```
@@ -2372,12 +2372,12 @@ the session. For example:
 
 **mxsUpdateUser**
 
-The `mxsUpdateUser` command updates a user in the local nosqlprotocol\
-account database. Use [updateUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#updateUser) to update MariaDB user\
+The `mxsUpdateUser` command updates a user in the local nosqlprotocol
+account database. Use [updateUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#updateUser) to update MariaDB user
 as well.
 
-Note that the `mxsUpdateUser` command does not check that the changed\
-data is compatible e.g. with the grants of the corresponding MariaDB\
+Note that the `mxsUpdateUser` command does not check that the changed
+data is compatible e.g. with the grants of the corresponding MariaDB
 user.
 
 **Syntax**
@@ -2413,13 +2413,13 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. If a new password is not provided, the specified mechanisms must be a subset of the current mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the updating of the user succeeds, the command returns a document\
+If the updating of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2441,23 +2441,23 @@ If there is a failure of some kind, the command returns an error document
 
 ## Object Id
 
-When a document is created, an id of type `ObjectId` will be autogenerated by\
-the MongoDB® client library. If the id is provided explicitly, by assigning a\
-value to the `_id` field, the value must be an `ObjectId`, a string or an\
+When a document is created, an id of type `ObjectId` will be autogenerated by
+the MongoDB® client library. If the id is provided explicitly, by assigning a
+value to the `_id` field, the value must be an `ObjectId`, a string or an
 integer.
 
 ## Caching
 
 The conversion of the BSON used in the communication between the client and\
-MaxScale, to the SQL used in the communication between MaxScale and the server\
-carries a not insignificant cost, as does the conversion of result sets\
-returned by the server to the BSON returned by MaxScale to the client. The\
-regular [cache filter](../maxscale-24-02filters/mariadb-maxscale-2402-cache.md) provides no remedy for this, as\
-it is located after the protocol and uses SQL as the key and stores result\
+MaxScale, to the SQL used in the communication between MaxScale and the server
+carries a not insignificant cost, as does the conversion of result sets
+returned by the server to the BSON returned by MaxScale to the client. The
+regular [cache filter](../maxscale-24-02filters/mariadb-maxscale-2402-cache.md) provides no remedy for this, as
+it is located after the protocol and uses SQL as the key and stores result
 sets as values.
 
-From 23.08 onwards, the nosqlprotocol has a built-in cache that when used\
-under certain conditions diminishes the conversion cost. The cache is\
+From 23.08 onwards, the nosqlprotocol has a built-in cache that when used
+under certain conditions diminishes the conversion cost. The cache is
 enabled by adding the following line to the NoSQL listener.
 
 ```
@@ -2466,8 +2466,8 @@ enabled by adding the following line to the NoSQL listener.
 nosqlprotocol.internal_cache=cache
 ```
 
-This effectively causes the [cache filter](../maxscale-24-02filters/mariadb-maxscale-2402-cache.md) to be used\
-inside the NoSQL protocol module. The internal cache can be configured just\
+This effectively causes the [cache filter](../maxscale-24-02filters/mariadb-maxscale-2402-cache.md) to be used
+inside the NoSQL protocol module. The internal cache can be configured just
 like the cache filter is, by using the following nested configuration syntax.
 
 ```
@@ -2480,27 +2480,27 @@ nosqlprotocol.cache.hard_ttl=40s
 ...
 ```
 
-A limitation is that _only_ the default storage `storage_inmemory` is\
+A limitation is that _only_ the default storage `storage_inmemory` is
 supported; `storage_redis` and `storage_memcached` cannot be used.
 
-The cache works on both the SQL and the BSON layer. When a NoSQL request\
-that potentially is cacheable arrives, a lookup for the BSON response is\
-made. If it is found, the response is returned to the client. That is, in\
-this case neither BSON -> SQL, nor a Result Set -> BSON translation will\
+The cache works on both the SQL and the BSON layer. When a NoSQL request
+that potentially is cacheable arrives, a lookup for the BSON response is
+made. If it is found, the response is returned to the client. That is, in
+this case neither BSON -> SQL, nor a Result Set -> BSON translation will
 be made.
 
-If the request is not potentially cacheable or the response is not\
-available, the request is processed normally, which may mean that the\
-request is translated into SQL. If the SQL is a SELECT, a second lookup\
-will be made for the corresponding result set. If that is found, the\
+If the request is not potentially cacheable or the response is not
+available, the request is processed normally, which may mean that the
+request is translated into SQL. If the SQL is a SELECT, a second lookup
+will be made for the corresponding result set. If that is found, the
 result set is processed, but the roundtrip to the server will be saved.
 
-So, when a result set is received from the server, it will be cached and\
-if the generated NoSQL response is also cacheable, it will be cached as\
-well. The benefit of this approach is that two `Find` NoSQL requests\
-may effectively return the same documents, even though one but not the\
-other NoSQL response is cacheable. Both will benefit the result set being\
-in the cache. Since the used storage follows an LRU-approach when evicting\
+So, when a result set is received from the server, it will be cached and
+if the generated NoSQL response is also cacheable, it will be cached as
+well. The benefit of this approach is that two `Find` NoSQL requests
+may effectively return the same documents, even though one but not the
+other NoSQL response is cacheable. Both will benefit the result set being
+in the cache. Since the used storage follows an LRU-approach when evicting
 data from the cache, the less valuable result will be evicted first.
 
 ### Cached Commands
@@ -2509,25 +2509,25 @@ The responses of the following commands are cached.
 
 * [count](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#count)
 * [distinct](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#distinct)
-* [find](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#find), provided all found documents can be returned in one response,\
+* [find](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#find), provided all found documents can be returned in one response,
   i.e., if `singleBatch` is `true` or `batchSize` is large enough.
 
 ## Compatibility
 
-Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)\
+Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)
 test-suite pass.
 
 ## Example
 
-The following is a minimal setup for getting _nosqlprotocol_ up and\
-running. It is assumed the reader knows how to configure MaxScale for\
+The following is a minimal setup for getting _nosqlprotocol_ up and
+running. It is assumed the reader knows how to configure MaxScale for
 normal use. If not, please start with the [MaxScale tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-setting-up-mariadb-maxscale.md).\
-Note that as _nosqlprotocol_ is the first component in the MaxScale\
+Note that as _nosqlprotocol_ is the first component in the MaxScale
 routing chain, it can be used with all routers and filters.
 
 ### Configuring MaxScale
 
-In the following it is assumed that MaxScale already has been configured\
+In the following it is assumed that MaxScale already has been configured
 for normal use and that there exists a _service_ `[TheService]`.
 
 ```
@@ -2544,10 +2544,10 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-The values `the_user` and `the_password` must be replaced with the\
+The values `the_user` and `the_password` must be replaced with the
 actual credentials to be used for every MongoDB® client that connects.
 
-If MaxScale is now started, the following entry should appear in the\
+If MaxScale is now started, the following entry should appear in the
 log file.
 
 ```
@@ -2558,8 +2558,8 @@ log file.
 
 The mongo Shell is a powerful tool with which to access and manipulate a\
 MongoDB database. It is part of the MongoDB® package. Having the native\
-MongoDB database installed is convenient, as it makes it easy to ascertain\
-whether a problem is due to _nosqlprotocol_ not fully implementing something\
+MongoDB database installed is convenient, as it makes it easy to ascertain
+whether a problem is due to _nosqlprotocol_ not fully implementing something
 or due to the API not being used in the correct fashion.
 
 With the _mongo shell_, all that is needed is to invoke it with the port\_nosqlprotocol\_ is listening on:
@@ -2576,7 +2576,7 @@ MongoDB server version: 4.4.1
 >
 ```
 
-If the shell prompt appears, then a connection was successfully\
+If the shell prompt appears, then a connection was successfully
 established and the shell can be used.
 
 ```
@@ -2584,13 +2584,13 @@ established and the shell can be used.
 { "n" : 1, "ok" : 1 }
 ```
 
-The `db` variable is implicitly available, and refers by default to\
+The `db` variable is implicitly available, and refers by default to
 the `test` database.
 
 The command inserted a document into the collection called `collection`.\
-The table corresponding to that collection is created implicitly because\
-the default value of `auto_create_tables` is `true`. Here, the object id\
-is specified explicitly, but there is no need for that, as one will be\
+The table corresponding to that collection is created implicitly because
+the default value of `auto_create_tables` is `true`. Here, the object id
+is specified explicitly, but there is no need for that, as one will be
 created if needed.
 
 To check whether the documents was inserted into the collection, the`find` command can be issued:
@@ -2625,18 +2625,18 @@ MariaDB [(none)]> select * from test.collection;
 +------+------------------------------------+
 ```
 
-The collection `collection` is represented by a table `collection` with\
-the two columns `id` and `doc`. `id` is a virtual column whose content is\
+The collection `collection` is represented by a table `collection` with
+the two columns `id` and `doc`. `id` is a virtual column whose content is
 the value of the `_id` field of the document in the `doc` column.
 
-All MongoDB® commands that _mongdbprotocol_ support (but for the ones that\
-do not require database access), basically access or manipulate the\
+All MongoDB® commands that _mongdbprotocol_ support (but for the ones that
+do not require database access), basically access or manipulate the
 content in the `doc` column using the [JSON functions](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements-and-structure/sql-statements/built-in-functions/special-functions/json-functions) of MariaDB.
 
-From within the mongo shell itself it is easy to find out just what SQL\
+From within the mongo shell itself it is easy to find out just what SQL
 a particular MongoDB command is translated into.
 
-For instance, the SQL that the insert command with which the document was\
+For instance, the SQL that the insert command with which the document was
 added can be found out like:
 
 ```
@@ -2661,18 +2661,18 @@ Similarly, the SQL of the `find` command can be find out like:
 }
 ```
 
-The returned SQL can be directly pasted at the `mysql` prompt, which is\
+The returned SQL can be directly pasted at the `mysql` prompt, which is
 quite convenient in case the MongoDB® command does not behave as expected.
 
 ### MongoDB® Node.JS Driver
 
-As all client libraries implement and depend on the MongoDB® wire protocol,\
-all client libraries should work with _nosqlprotocol_. However, the\
-only client library that has been used and that has been verified to work\
+As all client libraries implement and depend on the MongoDB® wire protocol,
+all client libraries should work with _nosqlprotocol_. However, the
+only client library that has been used and that has been verified to work
 is version 3.6 of the _MongoDB Node.JS Driver_.
 
-In principle, the only thing that needs to be altered in an existing\
-program using the library is to change the uri string that typically\
+In principle, the only thing that needs to be altered in an existing
+program using the library is to change the uri string that typically
 is something like
 
 ```
@@ -2687,8 +2687,8 @@ const uri = "mongodb://<maxscale-ip>:17017";
 
 with the assumption that the default _nosqlprotocol_ port is used.
 
-In practice, additional modifications may be needed since _nosqlprotocol_\
-does not implement all commands and does not in all cases implement the\
+In practice, additional modifications may be needed since _nosqlprotocol_
+does not implement all commands and does not in all cases implement the
 full functionality of the commands that it supports.
 
 #### Inserting a Document

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-maxctrl.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-maxctrl.md
@@ -1,13 +1,13 @@
 # MaxScale 24.02 MaxCtrl
 
-MaxCtrl is a command line administrative client for MaxScale which uses\
-the MaxScale REST API for communication. It has replaced the legacy MaxAdmin\
+MaxCtrl is a command line administrative client for MaxScale which uses
+the MaxScale REST API for communication. It has replaced the legacy MaxAdmin
 command line client that is no longer supported or included.
 
-By default, the MaxScale REST API listens on port 8989 on the local host. The\
+By default, the MaxScale REST API listens on port 8989 on the local host. The
 default credentials for the REST API are `admin:mariadb`. The users used by the\
-REST API are the same that are used by the MaxAdmin network interface. This\
-means that any users created for the MaxAdmin network interface should work with\
+REST API are the same that are used by the MaxAdmin network interface. This
+means that any users created for the MaxAdmin network interface should work with
 the MaxScale REST API and MaxCtrl.
 
 For more information about the MaxScale REST API, refer to the [REST API documentation](../maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md) and the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
@@ -18,10 +18,10 @@ For more information about the MaxScale REST API, refer to the [REST API documen
 
 ## .maxctrl.cnf
 
-If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the\
-section `[maxctrl]` as defaults for command line arguments. For instance,\
-to avoid having to specify the user and password on the command line,\
-create the file `.maxctrl.cnf` in your home directory, with the following\
+If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the
+section `[maxctrl]` as defaults for command line arguments. For instance,
+to avoid having to specify the user and password on the command line,
+create the file `.maxctrl.cnf` in your home directory, with the following
 content:
 
 ```
@@ -30,11 +30,11 @@ u = my-name
 p = my-password
 ```
 
-Note that all access rights to the file must be removed from everybody else\
-but the owner. MaxCtrl refuses to use the file unless the rights have been\
+Note that all access rights to the file must be removed from everybody else
+but the owner. MaxCtrl refuses to use the file unless the rights have been
 removed.
 
-Another file from which to read the defaults can be specified with the `-c`\
+Another file from which to read the defaults can be specified with the `-c`
 flag.
 
 ## Commands

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md
@@ -1,16 +1,16 @@
 # MaxScale 24.02 Module commands
 
-Introduced in MaxScale 2.1, the module commands are special, module-specific\
+Introduced in MaxScale 2.1, the module commands are special, module-specific
 commands. They allow the modules to expand beyond the capabilities of the module\
 API. Currently, only MaxCtrl implements an interface to the module commands.
 
-All registered module commands can be shown with `maxctrl list commands` and\
+All registered module commands can be shown with `maxctrl list commands` and
 they can be executed with `maxctrl call command <module> <name> ARGS...` whereis the name of the module and is the name of the command._ARGS_ is a command specific list of arguments.
 
 ### Developer reference
 
-The module command API is defined in the _modulecmd.h_ header. It consists of\
-various functions to register and call module commands. Read the function\
+The module command API is defined in the _modulecmd.h_ header. It consists of
+various functions to register and call module commands. Read the function
 documentation in the header for more details.
 
 The following example registers the module command _my\_command_ for module _my\_module_.
@@ -50,11 +50,11 @@ int main(int argc, char **argv)
 }
 ```
 
-The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of\
-arguments the command expects. The first argument is a boolean and the second\
+The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of
+arguments the command expects. The first argument is a boolean and the second
 argument is an optional string.
 
-Arguments are passed to the parsing function as an array of void pointers. They\
+Arguments are passed to the parsing function as an array of void pointers. They
 are interpreted as the types the command expects.
 
 When the module command is executed, the _argv_ parameter for the _my\_simple\_cmd_ contains the parsed arguments received from the caller of the

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-securing-your-maxscale-deployment.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-securing-your-maxscale-deployment.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Securing Your MaxScale Deployment
 
-There are five main components that you need to make sure are completed\
+There are five main components that you need to make sure are completed
 before you go into production:
 
 * Encrypting Plaintext Passwords
@@ -11,8 +11,8 @@ before you go into production:
 
 ### Encrypting Plaintext Passwords
 
-Ensuring the security of your MaxScale setup involves stringent control over\
-the key file permissions. Utilizing [maxkeys](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+Ensuring the security of your MaxScale setup involves stringent control over
+the key file permissions. Utilizing [maxkeys](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 is an effective approach to generate a secure key file.
 
 This generates a keyfile in `/var/lib/maxscale`
@@ -21,22 +21,22 @@ This generates a keyfile in `/var/lib/maxscale`
 $ maxkeys
 ```
 
-See [Encrypting Passwords](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+See [Encrypting Passwords](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 for more information about `maxkeys`.
 
-Once generated, this key file can be relocated to a secure location. This\
-key file serves a dual purpose: it enables the encryption of passwords and\
+Once generated, this key file can be relocated to a secure location. This
+key file serves a dual purpose: it enables the encryption of passwords and
 facilitates MaxScale in decrypting those encrypted passwords.
 
-To maintain confidentiality, it is crucial to adjust the ownership and\
-permissions of the key file appropriately using `chown`. This step ensures\
+To maintain confidentiality, it is crucial to adjust the ownership and
+permissions of the key file appropriately using `chown`. This step ensures
 that the key file remains secure and inaccessible to unauthorized users.
 
 ```
 $ chown maxscale:maxscale /var/lib/maxscale/.secrets
 ```
 
-Following the secure setup of the key file, you can proceed to encrypt the\
+Following the secure setup of the key file, you can proceed to encrypt the
 plaintext passwords of users already created in your databases.
 
 ```
@@ -45,8 +45,8 @@ $ maxpasswd plaintextpassword
 ```
 
 These encrypted passwords can then replace the plaintext passwords in your\
-MaxScale configuration (CNF) files. This enhances the overall security\
-of your database system by reducing the risk that passwords are accidentally\
+MaxScale configuration (CNF) files. This enhances the overall security
+of your database system by reducing the risk that passwords are accidentally
 shared.
 
 ```
@@ -60,12 +60,12 @@ password=96F99AA1315BDC3604B006F427DD9484
 
 ### Securing the GUI Interface
 
-To enhance the security of your MaxScale environment, it’s crucial to\
-configure the GUI host address properly. The default setting, `0.0.0.0`,\
-allows unrestricted access from any network, which poses a significant\
-security risk. Instead, you should set the `admin_host` to a more secure\
-address. Additionally, you can change the default port (8989) to another\
-port for added security. For example, you can restrict access to the\
+To enhance the security of your MaxScale environment, it’s crucial to
+configure the GUI host address properly. The default setting, `0.0.0.0`,
+allows unrestricted access from any network, which poses a significant
+security risk. Instead, you should set the `admin_host` to a more secure
+address. Additionally, you can change the default port (8989) to another
+port for added security. For example, you can restrict access to the
 localhost by setting:
 
 ```
@@ -74,7 +74,7 @@ admin_host=127.0.0.1
 admin_port=2222
 ```
 
-Alternatively, you can specify an internal network IP address to limit\
+Alternatively, you can specify an internal network IP address to limit
 access within your internal network, such as:
 
 ```
@@ -83,14 +83,14 @@ admin_host=10.0.0.3
 admin_port=2222
 ```
 
-If you need to allow external access, ensure that the network is adequately\
-secured and that only authorized users can access the MaxScale\
-interface. Consult with your network administrator to determine the most\
+If you need to allow external access, ensure that the network is adequately
+secured and that only authorized users can access the MaxScale
+interface. Consult with your network administrator to determine the most
 appropriate and secure configuration.
 
 #### Enabling TLS Encryption
 
-To further secure your MaxScale setup, enable TLS encryption for data in\
+To further secure your MaxScale setup, enable TLS encryption for data in
 transit. Follow these steps to configure SSL:
 
 **1. Set Up SSL Keys and Certificates:**
@@ -125,17 +125,17 @@ $ maxctrl --user=my_user --password=my_password --secure --tls-ca-cert=/certs/ca
 
 ### Managing Users & Passwords
 
-MaxScale allows you to manage user access to its GUI, offering different\
-permission levels to suit various operational needs. Currently, MaxScale\
-supports two primary roles: `admin` and `basic`. This functionality is\
-particularly useful for organizations with hierarchical structures or\
-distinct departments, enabling you to grant status view access without\
+MaxScale allows you to manage user access to its GUI, offering different
+permission levels to suit various operational needs. Currently, MaxScale
+supports two primary roles: `admin` and `basic`. This functionality is
+particularly useful for organizations with hierarchical structures or
+distinct departments, enabling you to grant status view access without
 allowing execution or manipulation capabilities.
 
 #### Creating and Deleting Users
 
-To create or delete users in the MaxScale GUI, you can use the `maxctrl`\
-command. Here’s an example of creating a user with administrative\
+To create or delete users in the MaxScale GUI, you can use the `maxctrl`
+command. Here’s an example of creating a user with administrative
 privileges:
 
 ```
@@ -150,30 +150,30 @@ $ maxctrl destroy user admin
 
 #### Managing Users in the GUI
 
-The MaxScale GUI also provides functionality to manage user access and\
+The MaxScale GUI also provides functionality to manage user access and
 update the admin password. Through the GUI, you can:
 
 * Add Users: Create users with basic or admin access.
 * Modify User Permissions: Change roles as needed to adapt to evolving security requirements.
 * Update Admin Password: Enhance security by regularly updating the admin password.
 
-By leveraging these features, you can ensure that your MaxScale environment\
-remains secure and that user access is appropriately managed according to\
+By leveraging these features, you can ensure that your MaxScale environment
+remains secure and that user access is appropriately managed according to
 your organization’s needs.
 
 ### Enabling Audit Logging
 
-Turn on admin auditing to log all login, connection, and configuration\
+Turn on admin auditing to log all login, connection, and configuration
 changes. Choose an audit file location and set up log rotation.
 
 #### Enabling and Managing Admin Auditing in MaxScale
 
-Admin auditing in MaxScale provides comprehensive tracking of all\
-administrative activities, including logins, connections, and\
-modifications. These activities are recorded in an audit file for enhanced\
+Admin auditing in MaxScale provides comprehensive tracking of all
+administrative activities, including logins, connections, and
+modifications. These activities are recorded in an audit file for enhanced
 security and traceability.
 
-To enable admin auditing, add the following configuration to your MaxScale\
+To enable admin auditing, add the following configuration to your MaxScale
 configuration file:
 
 ```
@@ -182,7 +182,7 @@ admin_audit = true
 admin_audit_file = /var/log/maxscale/audit_files/audit.csv
 ```
 
-This configuration activates auditing and specifies the location of the\
+This configuration activates auditing and specifies the location of the
 audit file. Ensure that the specified directory exists before restarting\
 MaxScale.
 
@@ -195,7 +195,7 @@ MaxScale.
 
 **2. Audit File Management:**
 
-* Implement log rotation to manage the size and number of audit files. This\
+* Implement log rotation to manage the size and number of audit files. This
   can be achieved using standard Linux log rotation tools. See [Rotating Logs on Unix and Linux](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/rotating-logs-on-unix-and-linux)
 
 For manual log rotation, you can use the following MaxCtrl command:
@@ -208,9 +208,9 @@ $ maxctrl rotate logs
 
 Configuring SSL Encryption for MaxScale with an Encrypted MariaDB Server
 
-If you have already implemented encryption on your MariaDB server, it’s\
-crucial to extend this encryption configuration to MaxScale to ensure secure\
-communication. Once encryption is enabled on your MariaDB server, follow\
+If you have already implemented encryption on your MariaDB server, it’s
+crucial to extend this encryption configuration to MaxScale to ensure secure
+communication. Once encryption is enabled on your MariaDB server, follow
 these steps to configure MaxScale to utilize SSL.
 
 Steps to Configure SSL in MaxScale:
@@ -221,7 +221,7 @@ Steps to Configure SSL in MaxScale:
 
 #### 2. Verify Peer Certificates:
 
-* Add `ssl_verify_peer_certificate=true` to ensure that MaxScale verifies\
+* Add `ssl_verify_peer_certificate=true` to ensure that MaxScale verifies
   the server’s SSL certificates, providing an additional layer of security.
 
 Your MaxScale configuration file should look something like this:
@@ -233,8 +233,8 @@ ssl=true
 ssl_verify_peer_certificate=true
 ```
 
-These settings instruct MaxScale to use SSL for connections to the MariaDB\
-server and to verify peer certificates, enhancing the security of data in\
+These settings instruct MaxScale to use SSL for connections to the MariaDB
+server and to verify peer certificates, enhancing the security of data in
 transit.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-admin-user-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-admin-user-resource.md
@@ -11,7 +11,7 @@ MaxScale's configuration.
 GET /v1/users/inet/:name
 ```
 
-Get a single network user. The _:name_ in the URI must be a valid network\
+Get a single network user. The _:name_ in the URI must be a valid network
 user name.
 
 **Response**
@@ -134,7 +134,7 @@ Get all administrative users.
 POST /v1/users/inet
 ```
 
-Create a new network user. The request body must define at least the\
+Create a new network user. The request body must define at least the
 following fields.
 
 * `data.id`
@@ -146,11 +146,11 @@ following fields.
 * `data.attributes.account`
 * Set to `admin` for administrative users and `basic` to read-only users
 
-Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic\
-account performs one of the aforementioned request, the REST API will respond\
+Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic
+account performs one of the aforementioned request, the REST API will respond
 with a `401 Unauthorized` error.
 
-Here is an example request body defining the network user _my-user_ with the\
+Here is an example request body defining the network user _my-user_ with the
 password _my-password_ that is allowed to execute only read-only operations.
 
 ```
@@ -178,7 +178,7 @@ Status: 204 No Content
 POST /v1/users/unix
 ```
 
-This enables an existing UNIX account on the system for administrative\
+This enables an existing UNIX account on the system for administrative
 operations. The request body must define at least the following fields.
 
 * `data.id`
@@ -242,8 +242,8 @@ Status: 204 No Content
 PATCH /v1/users/inet/:name
 ```
 
-Update network user. Currently, only the password can be updated. This\
-means that the request body must define the `data.attributes.password`\
+Update network user. Currently, only the password can be updated. This
+means that the request body must define the `data.attributes.password`
 field.
 
 Here is an example request body that updates the password.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-filter-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-filter-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Filter Resource
 
-A filter resource represents an instance of a filter inside MaxScale. Multiple\
+A filter resource represents an instance of a filter inside MaxScale. Multiple
 services can use the same filter and a single service can use multiple filters.
 
 ### Resource Operations
@@ -186,7 +186,7 @@ GET /v1/filters
 POST /v1/filters
 ```
 
-Create a new filter. The posted object must define at\
+Create a new filter. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -198,8 +198,8 @@ least the following fields.
 
 All of the filter parameters should be defined at creation time in the`data.attributes.parameters` object.
 
-As the service to filter relationship is ordered (filters are applied in the\
-order they are listed), filter to service relationships cannot be defined at\
+As the service to filter relationship is ordered (filters are applied in the
+order they are listed), filter to service relationships cannot be defined at
 creation time.
 
 The following example defines a request body which creates a new filter.
@@ -231,8 +231,8 @@ Filter is created:
 PATCH /v1/filters/:name
 ```
 
-Filter parameters can be updated at runtime if the module supports it. Refer to\
-the individual module documentation for more details on whether it supports\
+Filter parameters can be updated at runtime if the module supports it. Refer to
+the individual module documentation for more details on whether it supports
 runtime configuration and which parameters can be updated.
 
 The following example modifies a filter by changing the `match` parameter to`.*users.*`.
@@ -264,10 +264,10 @@ DELETE /v1/filters/:filter
 The _:filter_ in the URI must map to the name of the filter to be destroyed.
 
 A filter can only be destroyed if no service uses it. This means that the`data.relationships` object for the filter must be empty. Note that the service\
-→ filter relationship cannot be modified from the filters resource and must be\
+→ filter relationship cannot be modified from the filters resource and must be
 done via the services resource.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the filter by first removing it from all services that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-listener-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-listener-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Listener Resource
 
-A listener resource represents a listener of a service in MaxScale. All\
+A listener resource represents a listener of a service in MaxScale. All
 listeners point to a service in MaxScale.
 
 ### Resource Operations
@@ -247,10 +247,10 @@ Creates a new listener. The request body must define the following fields.
 * `data.type`
 * Type of the object, must be `listeners`
 * `data.attributes.parameters.port` OR `data.attributes.parameters.socket`
-* The TCP port or UNIX Domain Socket the listener listens on. Only one of the\
+* The TCP port or UNIX Domain Socket the listener listens on. Only one of the
   fields can be defined.
 * `data.relationships.services.data`
-* The service relationships data, must define a JSON object with an `id` value\
+* The service relationships data, must define a JSON object with an `id` value
   that defines the service to use and a `type` value set to `services`.
 
 The following is the minimal required JSON object for defining a new listener.
@@ -276,7 +276,7 @@ The following is the minimal required JSON object for defining a new listener.
 }
 ```
 
-Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) for\
+Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) for
 a full list of listener parameters.
 
 **Response**
@@ -291,15 +291,15 @@ Listener is created:
 PATCH /v1/listeners/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the listener.
 
 All parameters marked as modifiable at runtime can be modified. Currently, all\
-TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters\
+TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters
 can be modified at runtime.
 
-Parameters that affect the network address or the port the listener listens on\
-cannot be modified at runtime. To modify these parameters, recreate the\
+Parameters that affect the network address or the port the listener listens on
+cannot be modified at runtime. To modify these parameters, recreate the
 listener.
 
 **Response**
@@ -314,7 +314,7 @@ Listener is modified:
 DELETE /v1/listeners/:name
 ```
 
-The _:name_ must be a valid listener name. When a listener is destroyed, the\
+The _:name_ must be a valid listener name. When a listener is destroyed, the
 network port it listens on is available for reuse.
 
 **Response**
@@ -333,7 +333,7 @@ Listener cannot be deleted:
 PUT /v1/listeners/:name/stop
 ```
 
-Stops a started listener. When a listener is stopped, new connections are no\
+Stops a started listener. When a listener is stopped, new connections are no
 longer accepted and are queued until the listener is started again.
 
 **Parameters**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-maxscale-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-maxscale-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 MaxScale Resource
 
-The MaxScale resource represents a MaxScale instance and it is the core on top\
+The MaxScale resource represents a MaxScale instance and it is the core on top
 of which the modules build upon.
 
 ### Resource Operations
@@ -11,7 +11,7 @@ of which the modules build upon.
 GET /v1/maxscale
 ```
 
-Retrieve global information about a MaxScale instance. This includes various\
+Retrieve global information about a MaxScale instance. This includes various
 file locations, configuration options and version information.
 
 **Response**
@@ -150,8 +150,8 @@ file locations, configuration options and version information.
 PATCH /v1/maxscale
 ```
 
-Update MaxScale parameters. The request body must define updated values for the`data.attributes.parameters` object. The parameters that can be modified are\
-listed in the `/v1/maxscale/modules/maxscale` endpoint and have the `modifiable`\
+Update MaxScale parameters. The request body must define updated values for the`data.attributes.parameters` object. The parameters that can be modified are
+listed in the `/v1/maxscale/modules/maxscale` endpoint and have the `modifiable`
 value set to `true`.
 
 **Response**
@@ -170,8 +170,8 @@ Invalid JSON body:
 GET /v1/maxscale/threads/:id
 ```
 
-Get the information and statistics of a particular thread. The _:id_ in\
-the URI must map to a valid thread number between 0 and the configured\
+Get the information and statistics of a particular thread. The _:id_ in
+the URI must map to a valid thread number between 0 and the configured
 value of `threads`.
 
 **Response**
@@ -390,15 +390,15 @@ Get the information for all threads. Returns a collection of threads resources.
 GET /v1/maxscale/logs
 ```
 
-Get information about the current state of logging, enabled log files and the\
+Get information about the current state of logging, enabled log files and the
 location where the log files are stored.
 
-**Note:** The parameters in this endpoint are a subset of the parameters in the`/v1/maxscale` endpoint. Because of this, the parameters in this endpoint are\
+**Note:** The parameters in this endpoint are a subset of the parameters in the`/v1/maxscale` endpoint. Because of this, the parameters in this endpoint are
 deprecated as of MaxScale 6.0.
 
-**Note:** In MaxScale 2.5 the `log_throttling` and `ms_timestamp` parameters\
-were incorrectly named as `throttling` and `highprecision`. In MaxScale 6,\
-the parameter names are now correct which means the parameters declared here\
+**Note:** In MaxScale 2.5 the `log_throttling` and `ms_timestamp` parameters
+were incorrectly named as `throttling` and `highprecision`. In MaxScale 6,
+the parameter names are now correct which means the parameters declared here
 aren't fully backwards compatible.
 
 **Response**
@@ -448,11 +448,11 @@ GET /v1/maxscale/logs/data
 
 Get the contents of the MaxScale logs. This endpoint was added in MaxScale 6.
 
-To navigate the log, use the `prev` link to move backwards to older log\
+To navigate the log, use the `prev` link to move backwards to older log
 entries. The latest log entries can be read with the `last` link.
 
-The entries are sorted in ascending order by the time they were logged. This\
-means that with the default parameters, the latest logged event is the last\
+The entries are sorted in ascending order by the time they were logged. This
+means that with the default parameters, the latest logged event is the last
 element in the returned array.
 
 **Parameters**
@@ -460,19 +460,19 @@ element in the returned array.
 This endpoint supports the following parameters:
 
 * `page[size]`
-* Set number of rows of data to read. By default, 50 rows of data are read\
+* Set number of rows of data to read. By default, 50 rows of data are read
   from the log.
 * `page[cursor]`
-* Set position from where the log data is retrieved. The default position to\
+* Set position from where the log data is retrieved. The default position to
   retrieve the log data is the end of the log.\
-  This value should not be modified by the user and the values returned in the`links` object should be used instead. This way the navigation will provide\
+  This value should not be modified by the user and the values returned in the`links` object should be used instead. This way the navigation will provide
   a consistent view of the log that does not overlap.\
-  Optionally, the `id` values in the returned data can be used as the values\
+  Optionally, the `id` values in the returned data can be used as the values
   for this parameter to read data from a known point in the file.
 * `priority`
-* Include messages only from these log levels. The default is to include all\
+* Include messages only from these log levels. The default is to include all
   messages.\
-  The value given should be a comma-separated list of log priorities. The\
+  The value given should be a comma-separated list of log priorities. The
   priorities are `alert`, `error`, `warning`, `notice`, `info` and`debug`. Note that the `debug` log level is only used in debug builds of\
   MaxScale.
 
@@ -526,8 +526,8 @@ This endpoint supports the following parameters:
 GET /v1/maxscale/logs/entries
 ```
 
-Get the contents of the MaxScale logs as separate entries. This endpoint was\
-added in MaxScale 24.02. This endpoint is nearly identical to the`/v1/maxscale/logs/data` endpoint except that this is a resource collection\
+Get the contents of the MaxScale logs as separate entries. This endpoint was
+added in MaxScale 24.02. This endpoint is nearly identical to the`/v1/maxscale/logs/data` endpoint except that this is a resource collection
 where each log line is a separate resource.
 
 **Parameters**
@@ -594,10 +594,10 @@ GET /v1/maxscale/logs/stream
 
 Stream the contents of the MaxScale logs. This endpoint was added in MaxScale 6.
 
-This endpoint opens a [WebSocket](https://tools.ietf.org/html/rfc6455)\
-connection and streams the contents of the log to it. Each WebSocket message\
-will contain the JSON representation of the log message. The JSON is formatted\
-in the same way as the values in the `log` array of the `/v1/maxscale/logs/data`\
+This endpoint opens a [WebSocket](https://tools.ietf.org/html/rfc6455)
+connection and streams the contents of the log to it. Each WebSocket message
+will contain the JSON representation of the log message. The JSON is formatted
+in the same way as the values in the `log` array of the `/v1/maxscale/logs/data`
 endpoint:
 
 ```
@@ -611,12 +611,12 @@ endpoint:
 
 #### Limitations
 
-* If the client writes any data to the open socket, it will be treated as\
+* If the client writes any data to the open socket, it will be treated as
   an error and the stream is closed.
-* The WebSocket ping and close commands are not yet supported and will be\
+* The WebSocket ping and close commands are not yet supported and will be
   treated as errors.
-* When `maxlog` is used as source of log data, any log messages logged after log\
-  rotation will not be sent if the file was moved or truncated. To fetch new\
+* When `maxlog` is used as source of log data, any log messages logged after log
+  rotation will not be sent if the file was moved or truncated. To fetch new
   events after log rotation, reopen the WebSocket connection.
 
 **Parameters**
@@ -624,14 +624,14 @@ endpoint:
 This endpoint supports the following parameters:
 
 * `page[cursor]`
-* Set position from where the log data is retrieved. The default position to\
+* Set position from where the log data is retrieved. The default position to
   retrieve the log data is the end of the log.\
-  To stream data from a known point, first read the data via the`/v1/maxscale/logs/data` endpoint and then use the `id` value of the newest\
+  To stream data from a known point, first read the data via the`/v1/maxscale/logs/data` endpoint and then use the `id` value of the newest
   log message (i.e. the first value in the `log` array) to start the stream.
 * `priority`
-* Include messages only from these log levels. The default is to include all\
+* Include messages only from these log levels. The default is to include all
   messages.\
-  The value given should be a comma-separated list of log priorities. The\
+  The value given should be a comma-separated list of log priorities. The
   priorities are `alert`, `error`, `warning`, `notice`, `info` and`debug`. Note that the `debug` log level is only used in debug builds of\
   MaxScale.
 
@@ -647,7 +647,7 @@ Client didn't request a WebSocket upgrade:
 
 ### Update logging parameters
 
-**Note:** The modification of logging parameters via this endpoint has\
+**Note:** The modification of logging parameters via this endpoint has
 deprecated in MaxScale 6.0. The parameters should be modified with the`/v1/maxscale` endpoint instead.
 
 Any PATCH requests done to this endpoint will be redirected to the`/v1/maxscale` endpoint. Due to the misspelling of the `ms_timestamp` and`log_throttling` parameters, this is not fully backwards compatible.
@@ -674,7 +674,7 @@ Invalid JSON body:
 POST /v1/maxscale/logs/flush
 ```
 
-Flushes any pending messages to disk and reopens the log files. The body of the\
+Flushes any pending messages to disk and reopens the log files. The body of the
 message is ignored.
 
 **Response**
@@ -687,15 +687,15 @@ message is ignored.
 POST /v1/maxscale/tls/reload
 ```
 
-Reloads all TLS certificates for listeners and servers as well as the REST API\
-itself. If the reloading fails, the old certificates will remain in use for the\
-objects that failed to reload. This also causes the JWT signature keys to be\
-reloaded if one of the asymmetric key algorithms is being used. If JWTs are\
+Reloads all TLS certificates for listeners and servers as well as the REST API
+itself. If the reloading fails, the old certificates will remain in use for the
+objects that failed to reload. This also causes the JWT signature keys to be
+reloaded if one of the asymmetric key algorithms is being used. If JWTs are
 being signed with a random symmetric keys, a new random key is created.
 
-The reloading is not transactional: if a single listener or server fails to\
-reload its certificates, the remaining ones are not reloaded. This means that a\
-failed reload can partially reload certificates. The REST API certificates are\
+The reloading is not transactional: if a single listener or server fails to
+reload its certificates, the remaining ones are not reloaded. This means that a
+failed reload can partially reload certificates. The REST API certificates are
 only reloaded if all other certificate reloads were successful.
 
 **Response**
@@ -708,16 +708,16 @@ only reloaded if all other certificate reloads were successful.
 GET /v1/maxscale/modules/:name
 ```
 
-Retrieve information about a loaded module. The _:name_ must be the name of a\
+Retrieve information about a loaded module. The _:name_ must be the name of a
 valid loaded module or either `maxscale` or `servers`.
 
-The `maxscale` module will display the global configuration options\
+The `maxscale` module will display the global configuration options
 (i.e. everything under the `[maxscale]` section) as a module.
 
-The `servers` module displays the server object type and the configuration\
+The `servers` module displays the server object type and the configuration
 parameters it accepts as a module.
 
-Any parameter with the `modifiable` value set to `true` can be modified\
+Any parameter with the `modifiable` value set to `true` can be modified
 at runtime using a PATCH command on the corresponding object endpoint.
 
 **Response**
@@ -1291,8 +1291,8 @@ GET /v1/maxscale/modules
 
 Retrieve information about all loaded modules.
 
-This endpoint supports the `load=all` parameter. When defined, all modules\
-located in the MaxScale module directory (`libdir`) will be loaded. This allows\
+This endpoint supports the `load=all` parameter. When defined, all modules
+located in the MaxScale module directory (`libdir`) will be loaded. This allows
 one to see the parameters of a module before the object is created.
 
 **Response**
@@ -4618,16 +4618,16 @@ For commands that can modify data:
 POST /v1/maxscale/modules/:module/:command
 ```
 
-Modules can expose commands that can be called via the REST API. The module\
-resource lists all commands in the `data.attributes.commands` list. Each value\
-is a command sub-resource identified by its `id` field and the HTTP method the\
+Modules can expose commands that can be called via the REST API. The module
+resource lists all commands in the `data.attributes.commands` list. Each value
+is a command sub-resource identified by its `id` field and the HTTP method the
 command uses is defined by the `attributes.method` field.
 
-The _:module_ in the URI must be a valid name of a loaded module and _:command_\
-must be a valid command identifier that is exposed by that module. All\
+The _:module_ in the URI must be a valid name of a loaded module and _:command_
+must be a valid command identifier that is exposed by that module. All
 parameters to the module commands are passed as HTTP request parameters.
 
-Here is an example POST requests to the mariadbmon module command _reset-replication_ with\
+Here is an example POST requests to the mariadbmon module command _reset-replication_ with
 two parameters, the name of the monitor instance and the server name:
 
 ```
@@ -4653,8 +4653,8 @@ Command with output:
 }
 ```
 
-The contents of the `meta` field will contain the output of the module\
-command. This output depends on the command that is being executed. It can\
+The contents of the `meta` field will contain the output of the module
+command. This output depends on the command that is being executed. It can
 contain any valid JSON value.
 
 Command with no output:

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-monitor-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-monitor-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Monitor Resource
 
-A monitor resource represents a monitor inside MaxScale that monitors one or\
+A monitor resource represents a monitor inside MaxScale that monitors one or
 more servers.
 
 ### Resource Operations
@@ -347,7 +347,7 @@ Get all monitors.
 POST /v1/monitors
 ```
 
-Create a new monitor. The request body must define at least the following\
+Create a new monitor. The request body must define at least the following
 fields.
 
 * `data.id`
@@ -363,8 +363,8 @@ fields.
 
 All monitor parameters can be defined at creation time.
 
-The following example defines a request body which creates a new monitor and\
-assigns two servers to be monitored by it. It also defines a custom value for\
+The following example defines a request body which creates a new monitor and
+assigns two servers to be monitored by it. It also defines a custom value for
 the _monitor\_interval_ parameter.
 
 ```
@@ -410,7 +410,7 @@ Monitor is created:
 PATCH /v1/monitors/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 monitor.
 
 #### Modifiable Fields
@@ -425,8 +425,8 @@ The following standard server parameter can be modified.
 * [backend\_read\_timeout](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md)
 * [backend\_connect\_attempts](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md)
 
-In addition to these standard parameters, the monitor specific parameters can\
-also be modified. Refer to the monitor module documentation for details on these\
+In addition to these standard parameters, the monitor specific parameters can
+also be modified. Refer to the monitor module documentation for details on these
 parameters.
 
 **Response**
@@ -445,12 +445,12 @@ Invalid request body:
 PATCH /v1/monitors/:name/relationships/servers
 ```
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the monitor.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 server relationship for a monitor.
 
 ```
@@ -489,10 +489,10 @@ Invalid JSON body:
 DELETE /v1/monitors/:name
 ```
 
-Destroy a created monitor. The monitor must not have relationships to any\
+Destroy a created monitor. The monitor must not have relationships to any
 servers in order to be destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the monitor by first unlinking it from all servers that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md
@@ -4,28 +4,28 @@ This document describes the version 1 of the MaxScale REST API.
 
 ### Note About Syntax
 
-Although JSON does not define a syntax for comments, some of the JSON examples\
-have C-style inline comments in them. These comments use `//` to mark the start\
+Although JSON does not define a syntax for comments, some of the JSON examples
+have C-style inline comments in them. These comments use `//` to mark the start
 of the comment and extend to the end of the current line.
 
 ### Configuration
 
-Read the [REST API](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+Read the [REST API](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 section of the configuration guide for more details on how to configure the REST API.
 
 ### Authentication
 
-The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)\
-authentication with the MaxScale administrative interface users. The default\
+The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)
+authentication with the MaxScale administrative interface users. The default
 user is `admin:mariadb`.
 
-It is highly recommended to enable HTTPS on the MaxScale REST API to make the\
-communication between the client and MaxScale secure. Without it, the passwords\
-can be intercepted from the network traffic. Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) for more\
+It is highly recommended to enable HTTPS on the MaxScale REST API to make the
+communication between the client and MaxScale secure. Without it, the passwords
+can be intercepted from the network traffic. Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) for more
 details on how to enable HTTPS for the MaxScale REST API.
 
-For more details on how administrative interface users are created and managed,\
-refer to the [MaxCtrl](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-maxctrl.md) documentation as well as the\
+For more details on how administrative interface users are created and managed,
+refer to the [MaxCtrl](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-maxctrl.md) documentation as well as the
 documentation of the [users](mariadb-maxscale-2402-maxscale-2402-admin-user-resource.md) resource.
 
 #### JSON Web Tokens
@@ -36,7 +36,7 @@ MaxScale supports authentication via [JSON Web Tokens](https://tools.ietf.org/ht
 GET /v1/auth
 ```
 
-The `/v1/auth` endpoint can be used to generate new tokens which are returned in\
+The `/v1/auth` endpoint can be used to generate new tokens which are returned in
 the following form.
 
 ```
@@ -47,41 +47,41 @@ the following form.
 }
 ```
 
-Note that by default the `/auth` endpoint requires the connection to be\
-encrypted (HTTPS) and attempts to use it without encryption will be treated as\
+Note that by default the `/auth` endpoint requires the connection to be
+encrypted (HTTPS) and attempts to use it without encryption will be treated as
 an error. To allow use of the `/auth` endpoint without encryption, use`admin_secure_gui=false`.
 
-If the token is used to authenticate users in a web browser, the token can be\
-optionally stored in cookies. This can be enabled with the `persist=yes`\
+If the token is used to authenticate users in a web browser, the token can be
+optionally stored in cookies. This can be enabled with the `persist=yes`
 parameter in the request:
 
 ```
 GET /v1/auth?persist=yes
 ```
 
-When the token is stored in the cookies, it will be stored in the `token_sig`\
+When the token is stored in the cookies, it will be stored in the `token_sig`
 cookie using the `SameSite=Strict` and `HttpOnly` cookie options. This means the\
-JavaScript context of the browser will not have access to it. This is done to\
+JavaScript context of the browser will not have access to it. This is done to
 prevent CSRF attacks.
 
-By default, the generated tokens are valid for 8 hours. The token validity\
+By default, the generated tokens are valid for 8 hours. The token validity
 period can be set with the `max-age` request parameter:
 
 ```
 GET /v1/auth?max-age=28800
 ```
 
-When `max-age` is combined with `persist`, the `Max-Age` cookie option is\
+When `max-age` is combined with `persist`, the `Max-Age` cookie option is
 also set to the same value.
 
-The maximum lifetime of the tokens is controlled by the `admin_jwt_max_age`\
-parameter. If the configured value is less than 8 hours, the default token\
-lifetime is also lowered to it. A request for a token with a lifetime longer\
-than `admin_jwt_max_age` will be accepted but the token will have its lifetime\
+The maximum lifetime of the tokens is controlled by the `admin_jwt_max_age`
+parameter. If the configured value is less than 8 hours, the default token
+lifetime is also lowered to it. A request for a token with a lifetime longer
+than `admin_jwt_max_age` will be accepted but the token will have its lifetime
 set to `admin_jwt_max_age`.
 
-To use the token for authentication, the generated token must be presented in\
-the Authorization header with the Bearer authentication scheme. For example, the\
+To use the token for authentication, the generated token must be presented in
+the Authorization header with the Bearer authentication scheme. For example, the
 token above would be used in the following manner:
 
 ```
@@ -92,24 +92,24 @@ If MaxScale is restarted, all generated tokens are invalidated.
 
 **`/auth` Request Parameters**
 
-The `/auth` endpoint supports the following request parameters that must be\
+The `/auth` endpoint supports the following request parameters that must be
 given in the HTTP query string.
 
 * `max-age`
-* Sets the token maximum age in seconds. The default is `max-age=28800`. Only\
-  positive values between 1 and 2147483646 are accepted and if a non-positive\
+* Sets the token maximum age in seconds. The default is `max-age=28800`. Only
+  positive values between 1 and 2147483646 are accepted and if a non-positive
   or a non-integer value is found, the parameter is ignored.
 * `persist`
 * Store the generated token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the
   response is 204 No Content instead of 200 OK.\
-  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie\
-  which prevents access to from JavaScript. This is done to mitigate any\
+  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie
+  which prevents access to from JavaScript. This is done to mitigate any
   attacks that might leak the token.
 
 ### Resources
 
-The MaxScale REST API provides the following resources. All resources conform to\
+The MaxScale REST API provides the following resources. All resources conform to
 the [JSON API](https://jsonapi.org/format/) specification.
 
 * [maxscale](mariadb-maxscale-2402-maxscale-2402-maxscale-resource.md)
@@ -122,45 +122,45 @@ the [JSON API](https://jsonapi.org/format/) specification.
 * [users](mariadb-maxscale-2402-maxscale-2402-admin-user-resource.md)
 * [sql](mariadb-maxscale-2402-maxscale-2402-sql-resource.md)
 
-In addition to the named resources, the REST API will respond with a HTTP 200 OK\
-response to GET requests on the root resource (`/`) as well as the namespace\
-root resource (`/v1/`). These can be used for HTTP health checks to determine\
+In addition to the named resources, the REST API will respond with a HTTP 200 OK
+response to GET requests on the root resource (`/`) as well as the namespace
+root resource (`/v1/`). These can be used for HTTP health checks to determine
 whether MaxScale is running.
 
 ### API Versioning
 
 All of the current resources are in the `/v1/` namespace of the MaxScale REST\
-API. Further additions to the namespace can be added that do not break backwards\
+API. Further additions to the namespace can be added that do not break backwards
 compatibility of any existing resources. What this means in practice is that:
 
 * No resources or URLs will be removed
 * The API will be JSON API compliant
 
-Note that this means that the contents of individual resources can change. New\
-fields can be added, old ones can be removed and the meaning of existing fields\
-can change. The aim is to be as backwards compatible as reasonably possible\
+Note that this means that the contents of individual resources can change. New
+fields can be added, old ones can be removed and the meaning of existing fields
+can change. The aim is to be as backwards compatible as reasonably possible
 without sacrificing the clarity and functionality of the API.
 
-Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the\
+Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the
 prefix is not used, the latest API version is used.
 
 #### Resource Relationships
 
-All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other\
+All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other
 objects. This closely resembles the JSON API definition of links.
 
-In the _relationships_ objects, all resources have a _self_ link that points to\
-the resource itself. This allows easy access to the objects pointed by the\
+In the _relationships_ objects, all resources have a _self_ link that points to
+the resource itself. This allows easy access to the objects pointed by the
 relationships as the reply URL is included in the response itself.
 
-To create a relationship between two objects, define it in the initial POST\
-request. To modify the relationships of existing objects, perform a PATCH\
-request with the new definition of the relevant relationship. To completely\
-remove all relationships from an object, the `data` field of the corresponding\
+To create a relationship between two objects, define it in the initial POST
+request. To modify the relationships of existing objects, perform a PATCH
+request with the new definition of the relevant relationship. To completely
+remove all relationships from an object, the `data` field of the corresponding
 relationship object must be set to an empty array.
 
-The following lists the resources and the types of links each resource can have\
-in addition to the _self_ link. Examples of these relationships can be seen in\
+The following lists the resources and the types of links each resource can have
+in addition to the _self_ link. Examples of these relationships can be seen in
 the resource documentation.
 
 * `services` - Service resource
@@ -170,7 +170,7 @@ the resource documentation.
   List of services used by the service
 * `filters`\
   List of filters used by the service\
-  NOTE: This is an ordered relationship where the order of the filters\
+  NOTE: This is an ordered relationship where the order of the filters
   defines the order in which they process queries.
 * `listeners`\
   List of listeners used by the service
@@ -193,57 +193,57 @@ the resource documentation.
 ### Common Request Parameters
 
 All parameters that use boolean values use the same rules that are used for the [boolean values](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) in the\
-MaxScale configuration. For example, both `pretty=off` and `pretty=false`\
+MaxScale configuration. For example, both `pretty=off` and `pretty=false`
 disable the `pretty` option.
 
-All the resources that return JSON content also support the following\
+All the resources that return JSON content also support the following
 parameters. Parameters are given in the HTTP query string:`https://localhost:8989/v1/servers?pretty=true&fields[servers]=state`.
 
 * `pretty`
 * Pretty-print output.\
-  If this parameter is set to `true` then the returned objects are formatted\
-  in a more human readable format. If the parameter is set to `false` then the\
-  returned objects are formatted in a compact format. All resources support\
+  If this parameter is set to `true` then the returned objects are formatted
+  in a more human readable format. If the parameter is set to `false` then the
+  returned objects are formatted in a compact format. All resources support
   this parameter. The default value for this parameter is `true`.
 * `fields[TYPE]=field1,field2...`
 * Return a [Sparse Fieldset](https://jsonapi.org/format/#fetching-sparse-fieldsets)\
-  This parameter controls which fields are returned in the REST API\
-  response. The `TYPE` value in the `fields` parameter must be the resource\
-  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated\
-  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which\
-  fields of the object to return. Only fields in objects in the `attributes`\
-  and `relationships` objects are inspected. This means that if the path\
-  marked by the JSON Pointer contains an array in it, it will not advance past\
+  This parameter controls which fields are returned in the REST API
+  response. The `TYPE` value in the `fields` parameter must be the resource
+  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated
+  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which
+  fields of the object to return. Only fields in objects in the `attributes`
+  and `relationships` objects are inspected. This means that if the path
+  marked by the JSON Pointer contains an array in it, it will not advance past
   this array.\
-  For example, to return only the server state output from the `/servers`\
-  endpoint, the `fields[servers]=state` parameter can be used. This would\
-  return only the `data.attributes.state` part of the resource. To return the\
-  nested value `data.attributes.statistics.connections`, the corresponding\
+  For example, to return only the server state output from the `/servers`
+  endpoint, the `fields[servers]=state` parameter can be used. This would
+  return only the `data.attributes.state` part of the resource. To return the
+  nested value `data.attributes.statistics.connections`, the corresponding
   parameter would be `fields[servers]=statistics/connections`.
 * `filter=json_ptr=expr`
 * Filter the output of the result\
-  This parameter controls which rows are returned in a REST API response that\
-  returns an array in the `data` member (i.e. a request to a resource\
+  This parameter controls which rows are returned in a REST API response that
+  returns an array in the `data` member (i.e. a request to a resource
   collection). Requests to individual resources are not filtered.\
-  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a\
-  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2402-maxscale-2402-rest-api.md#filter-expressions). The comparison is done for each\
-  individual object in the `data` array of the result. If given only a JSON\
-  value, the stored value is compared for equality. If an expression is used,\
+  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a
+  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2402-maxscale-2402-rest-api.md#filter-expressions). The comparison is done for each
+  individual object in the `data` array of the result. If given only a JSON
+  value, the stored value is compared for equality. If an expression is used,
   the expression is evaluated and only rows that match are returned.\
-  For example, if the object stored in `data[0]` has a value pointed by the\
-  given JSON pointer and that value compares equal to the given JSON value,\
-  the array row is kept in the result. Examples for filtering expression can\
+  For example, if the object stored in `data[0]` has a value pointed by the
+  given JSON pointer and that value compares equal to the given JSON value,
+  the array row is kept in the result. Examples for filtering expression can
   be found [here](mariadb-maxscale-2402-maxscale-2402-rest-api.md#filter-expression-examples).\
-  A practical use for this parameter is to return only sessions for a\
-  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can\
-  be used. Note the double quotes around the `"RW-Split-Router"`, they are\
+  A practical use for this parameter is to return only sessions for a
+  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
+  be used. Note the double quotes around the `"RW-Split-Router"`, they are
   required to correctly convert strings into JSON values.
 * `filter[json_path]=expr`
 * Filter based on a JSONPath and a filtering expression.\
-  Similar to the `filter` parameter that takes a JSON Pointer, this version of\
-  the `filter` controls which rows are returned in a REST API response for a\
+  Similar to the `filter` parameter that takes a JSON Pointer, this version of
+  the `filter` controls which rows are returned in a REST API response for a
   resource collection. Requests to individual resources are never filtered.\
-  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)\
+  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)
   expression that MaxScale supports. The currently supported syntax is:
   * dot notation: `$.store.book`
   * bracket notation: `$['store']['book']`
@@ -253,53 +253,53 @@ parameters. Parameters are given in the HTTP query string:`https://localhost:898
   * object wildcards: `$.store.bicycle.*`
   * optional root object: `store.book`
 
-The root object being optional is an extension to the JSONPath specification\
+The root object being optional is an extension to the JSONPath specification
 that MaxScale implements.\
-The `expr` value must be a [filter-expression](mariadb-maxscale-2402-maxscale-2402-rest-api.md#filter-expressions). Similarly to the other `filter`\
-parameter, the comparison is done for each individual object in the `data`\
+The `expr` value must be a [filter-expression](mariadb-maxscale-2402-maxscale-2402-rest-api.md#filter-expressions). Similarly to the other `filter`
+parameter, the comparison is done for each individual object in the `data`
 array of the result.\
-If the JSONPath expression returns multiple objects, the comparison is done\
-for each element and if any of them matches, the object is considered to\
+If the JSONPath expression returns multiple objects, the comparison is done
+for each element and if any of them matches, the object is considered to
 match. In other words, wildcard JSONPath expressions are ORed together.\
-If multiple `filter[json_path]=expr` parameters are found in the request,\
-all returned values must match all of them. In other words, the filter\
-parameters are all combined into an AND expression. For example, the\
-following filter will only return all values whose `id` field is `"srv1` and\
+If multiple `filter[json_path]=expr` parameters are found in the request,
+all returned values must match all of them. In other words, the filter
+parameters are all combined into an AND expression. For example, the
+following filter will only return all values whose `id` field is `"srv1` and
 the `attributes.parameters.port` field is 3306:`filter[id]=eq("srv1")&filter[attributes.parameters.port]=eq(3306)`
 
 * `page[size]`
-* The number of elements that are returned for resource collections. By\
-  default all elements in the resource collection are returned. The value must\
-  be a valid positive integer, otherwise the parameter is ignored. If\
-  pagination is used, the `links` object will have pagination links to the\
+* The number of elements that are returned for resource collections. By
+  default all elements in the resource collection are returned. The value must
+  be a valid positive integer, otherwise the parameter is ignored. If
+  pagination is used, the `links` object will have pagination links to the
   next page if more elements are available.
 * `page[number]`
-* How many pages of results to skip. The first page of results starts from 0\
-  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This\
-  should be considered pseudo-pagination as the results are not guaranteed to\
+* How many pages of results to skip. The first page of results starts from 0
+  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This
+  should be considered pseudo-pagination as the results are not guaranteed to
   be consistent between requests.
 * `sync`
 * Control configuration synchronization.\
-  If this parameter is set to `false` then the configuration synchronization\
-  is disabled for this request. This can be used to perform configuration\
-  changes when MaxScale is unable to reach the cluster used to synchronize the\
-  configuration. The modifications to the local configuration will be\
-  overwritten when the next modification to the cluster's configuration is\
+  If this parameter is set to `false` then the configuration synchronization
+  is disabled for this request. This can be used to perform configuration
+  changes when MaxScale is unable to reach the cluster used to synchronize the
+  configuration. The modifications to the local configuration will be
+  overwritten when the next modification to the cluster's configuration is
   done which means this should only be used to perform temporary fixes.
 
 #### Filter Expressions
 
-MaxScale 24.02 added support for expressions in the `filter` request\
-parameter. Each resource in a resource collection that evaluates to a true value\
-will be kept in the returned result. All rows that evaluate to false are\
+MaxScale 24.02 added support for expressions in the `filter` request
+parameter. Each resource in a resource collection that evaluates to a true value
+will be kept in the returned result. All rows that evaluate to false are
 removed.
 
-Equality and inequality is defined for all JSON types but ordering is defined\
-only for numbers and strings. The logical operators allow one or more\
+Equality and inequality is defined for all JSON types but ordering is defined
+only for numbers and strings. The logical operators allow one or more
 sub-expressions.
 
-The following table lists the supported operations in the filter expressions. In\
-it, the stored value is marked as `S` and the literal JSON value in the\
+The following table lists the supported operations in the filter expressions. In
+it, the stored value is marked as `S` and the literal JSON value in the
 expression as `V`. For the logical operators, the sub-expression is marked as`expr`.
 
 | Expression   | Logic          | Types               |
@@ -316,25 +316,25 @@ expression as `V`. For the logical operators, the sub-expression is marked as`ex
 
 **Filter Expression Examples**
 
-Ranges of values can be defined using an `and()` expression with the range\
-limits defined with the ordering operators `ge()` and `le()`. To filter the\
-sessions in MaxScale to ones that have an ID between 50 and 100, the following\
+Ranges of values can be defined using an `and()` expression with the range
+limits defined with the ordering operators `ge()` and `le()`. To filter the
+sessions in MaxScale to ones that have an ID between 50 and 100, the following
 filtering expression can be used.
 
 ```
 filter=id=and(ge(50),le(100))
 ```
 
-Limiting the result to only the given values can be done with an `or()`\
-expression that uses `eq()` expressions to select the rows to return. To only\
-return sessions with IDs 1, 5, 10 the following filtering expression can be\
+Limiting the result to only the given values can be done with an `or()`
+expression that uses `eq()` expressions to select the rows to return. To only
+return sessions with IDs 1, 5, 10 the following filtering expression can be
 used.
 
 ```
 filter=id=or(eq(1),eq(5),eq(10))
 ```
 
-Similarly, excluding certain rows from the result can be done by simply\
+Similarly, excluding certain rows from the result can be done by simply
 replacing `or()` with `not()`. This expression would exclude sessions with the\
 IDs 1, 5 and 10 from the result.
 
@@ -346,22 +346,22 @@ filter=id=not(eq(1),eq(5),eq(10))
 
 #### Request Headers
 
-REST makes use of the HTTP protocols in its aim to provide a natural way to\
-understand the workings of an API. The following request headers are understood\
+REST makes use of the HTTP protocols in its aim to provide a natural way to
+understand the workings of an API. The following request headers are understood
 by this API.
 
 **Authorization**
 
 Credentials for authentication. This header should consist of a HTTP Basic\
-Access authentication type payload which is the base64 encoded value of the\
+Access authentication type payload which is the base64 encoded value of the
 username and password joined by a colon e.g. `Base64("maxuser:maxpwd")`.
 
 **Content-Type**
 
-All PUT and POST requests must use the `Content-Type: application/json` media\
-type and the request body must be a complete and valid JSON representation of a\
-resource. All PATCH requests must use the `Content-Type: application/json` media\
-type and the request body must be a JSON document containing a partial\
+All PUT and POST requests must use the `Content-Type: application/json` media
+type and the request body must be a complete and valid JSON representation of a
+resource. All PATCH requests must use the `Content-Type: application/json` media
+type and the request body must be a JSON document containing a partial
 definition of the modified resource.
 
 **Host**
@@ -370,59 +370,59 @@ The address and port of the server.
 
 **If-Match**
 
-The request is performed only if the provided ETag value matches the one on the\
-server. This field should be used with PATCH requests to prevent concurrent\
+The request is performed only if the provided ETag value matches the one on the
+server. This field should be used with PATCH requests to prevent concurrent
 updates to the same resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Modified-Since**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **If-None-Match**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Unmodified-Since**
 
-The request is performed only if the requested resource has not been modified\
+The request is performed only if the requested resource has not been modified
 since the provided date.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **X-HTTP-Method-Override**
 
-Some clients only support GET and PUT requests. By providing the string value of\
-the intended method in the `X-HTTP-Method-Override` header, a client can, for\
-example, perform a POST, PATCH or DELETE request with the PUT method\
+Some clients only support GET and PUT requests. By providing the string value of
+the intended method in the `X-HTTP-Method-Override` header, a client can, for
+example, perform a POST, PATCH or DELETE request with the PUT method
 (e.g. `X-HTTP-Method-Override: PATCH`).
 
-If this header is defined in the request, the current method of the request is\
-replaced with the one in the header. The HTTP method must be in uppercase and it\
+If this header is defined in the request, the current method of the request is
+replaced with the one in the header. The HTTP method must be in uppercase and it
 must be one of the methods that the requested resource supports.
 
 #### Response Headers
 
 **Allow**
 
-All resources return the Allow header with the supported HTTP methods. For\
-example the resource `/services` will always return the `Accept: GET, PATCH, PUT`\
+All resources return the Allow header with the supported HTTP methods. For
+example the resource `/services` will always return the `Accept: GET, PATCH, PUT`
 header.
 
 **Accept-Patch**
 
-All PATCH capable resources return the `Accept-Patch: application/json-patch`\
+All PATCH capable resources return the `Accept-Patch: application/json-patch`
 header.
 
 **Date**
@@ -432,12 +432,12 @@ English and it uses the server's local timezone.
 
 **ETag**
 
-An identifier for a specific version of a resource. The value of this header\
-changes whenever a resource is modified via the REST API. It will not change if\
-an internal MaxScale event (e.g. server changing state or statistics being\
+An identifier for a specific version of a resource. The value of this header
+changes whenever a resource is modified via the REST API. It will not change if
+an internal MaxScale event (e.g. server changing state or statistics being
 updated) causes a change.
 
-When the client sends the `If-Match` or `If-None-Match` header, the provided\
+When the client sends the `If-Match` or `If-None-Match` header, the provided
 value should be the value of the `ETag` header of an earlier GET.
 
 **Last-Modified**
@@ -446,29 +446,29 @@ The date when the resource was last modified in "HTTP-date" format.
 
 **Location**
 
-If an out of date resource location is requested, a HTTP return code of 3XX with\
-the `Location` header is returned. The value of the header contains the new\
+If an out of date resource location is requested, a HTTP return code of 3XX with
+the `Location` header is returned. The value of the header contains the new
 location of the requested resource as a relative URI.
 
 **WWW-Authenticate**
 
-The requested authentication method. For example, `WWW-Authenticate: Basic`\
+The requested authentication method. For example, `WWW-Authenticate: Basic`
 would require basic HTTP authentication.
 
 **Mxs-Warning**
 
-This header is used for sending generic warnings to clients about actions that\
-were successful and valid but could cause problems in the future. Currently\
-these are used to indicate when a configuration change was made to a static\
-object and an overriding configuration is created or when a static object is\
+This header is used for sending generic warnings to clients about actions that
+were successful and valid but could cause problems in the future. Currently
+these are used to indicate when a configuration change was made to a static
+object and an overriding configuration is created or when a static object is
 being deleted at runtime.
 
-The content of the header is the human-readable warning that should be displayed\
+The content of the header is the human-readable warning that should be displayed
 to a user.
 
 ### Response Codes
 
-Every HTTP response starts with a line with a return code which indicates the\
+Every HTTP response starts with a line with a return code which indicates the
 outcome of the request. The API uses some of the standard HTTP values:
 
 #### 2xx Success
@@ -478,37 +478,37 @@ outcome of the request. The API uses some of the standard HTTP values:
 * 201 Created
 * A new resource was created.
 * 202 Accepted
-* The request has been accepted for processing, but the processing has not\
+* The request has been accepted for processing, but the processing has not
   been completed.
 * 204 No Content
 * Successful HTTP requests, response has no body.
 
 #### 3xx Redirection
 
-This class of status code indicates the client must take additional action to\
+This class of status code indicates the client must take additional action to
 complete the request.
 
 * 301 Moved Permanently
 * This and all future requests should be directed to the given URI.
 * 302 Found
-* The response to the request can be found under another URI using the same\
+* The response to the request can be found under another URI using the same
   method as in the original request.
 * 303 See Other
-* The response to the request can be found under another URI using a GET\
+* The response to the request can be found under another URI using a GET
   method.
 * 304 Not Modified
-* Indicates that the resource has not been modified since the version\
+* Indicates that the resource has not been modified since the version
   specified by the request headers If-Modified-Since or If-None-Match.
 * 307 Temporary Redirect
-* The request should be repeated with another URI but future requests should\
+* The request should be repeated with another URI but future requests should
   use the original URI.
 * 308 Permanent Redirect
 * The request and all future requests should be repeated using another URI.
 
 #### 4xx Client Error
 
-The 4xx class of status code is when the client seems to have erred. Except when\
-responding to a HEAD request, the body of the response _MAY_ contains a JSON\
+The 4xx class of status code is when the client seems to have erred. Except when
+responding to a HEAD request, the body of the response _MAY_ contains a JSON
 representation of the error.
 
 ```
@@ -519,7 +519,7 @@ representation of the error.
 }
 ```
 
-The _error_ field contains a short error description and the _description_ field\
+The _error_ field contains a short error description and the _description_ field
 contains a more detailed version of the error message.
 
 * 400 Bad Request
@@ -527,41 +527,41 @@ contains a more detailed version of the error message.
 * 401 Unauthorized
 * Authentication is required. The response includes a WWW-Authenticate header.
 * 403 Forbidden
-* The request was a valid request, but the client does not have the necessary\
+* The request was a valid request, but the client does not have the necessary
   permissions for the resource.
 * 404 Not Found
 * The requested resource could not be found.
 * 405 Method Not Allowed
 * A request method is not supported for the requested resource.
 * 406 Not Acceptable
-* The requested resource is capable of generating only content not acceptable\
+* The requested resource is capable of generating only content not acceptable
   according to the Accept headers sent in the request.
 * 409 Conflict
-* Indicates that the request could not be processed because of conflict in the\
+* Indicates that the request could not be processed because of conflict in the
   request, such as an edit conflict be tween multiple simultaneous updates.
 * 411 Length Required
-* The request did not specify the length of its content, which is required by\
+* The request did not specify the length of its content, which is required by
   the requested resource.
 * 412 Precondition Failed
-* The server does not meet one of the preconditions that the requester put on\
+* The server does not meet one of the preconditions that the requester put on
   the request.
 * 413 Payload Too Large
 * The request is larger than the server is willing or able to process.
 * 414 URI Too Long
 * The URI provided was too long for the server to process.
 * 415 Unsupported Media Type
-* The request entity has a media type which the server or resource does not\
+* The request entity has a media type which the server or resource does not
   support.
 * 422 Unprocessable Entity
-* The request was well-formed but was unable to be followed due to semantic\
+* The request was well-formed but was unable to be followed due to semantic
   errors.
 * 423 Locked
 * The resource that is being accessed is locked.
 * 428 Precondition Required
-* The origin server requires the request to be conditional. This error code is\
+* The origin server requires the request to be conditional. This error code is
   returned when none of the `Modified-Since` or `Match` type headers are used.
 * 431 Request Header Fields Too Large
-* The server is unwilling to process the request because either an individual\
+* The server is unwilling to process the request because either an individual
   header field, or all the header fields collectively, are too large.
 
 #### 5xx Server Error
@@ -569,30 +569,30 @@ contains a more detailed version of the error message.
 The server failed to fulfill an apparently valid request.
 
 * 500 Internal Server Error
-* A generic error message, given when an unexpected condition was encountered\
+* A generic error message, given when an unexpected condition was encountered
   and no more specific message is suitable.
 * 501 Not Implemented
-* The server either does not recognize the request method, or it lacks the\
+* The server either does not recognize the request method, or it lacks the
   ability to fulfill the request.
 * 502 Bad Gateway
-* The server was acting as a gateway or proxy and received an invalid response\
+* The server was acting as a gateway or proxy and received an invalid response
   from the upstream server.
 * 503 Service Unavailable
-* The server is currently unavailable (because it is overloaded or down for\
+* The server is currently unavailable (because it is overloaded or down for
   maintenance). Generally, this is a temporary state.
 * 504 Gateway Timeout
-* The server was acting as a gateway or proxy and did not receive a timely\
+* The server was acting as a gateway or proxy and did not receive a timely
   response from the upstream server.
 * 505 HTTP Version Not Supported
 * The server does not support the HTTP protocol version used in the request.
 * 506 Variant Also Negotiates
-* Transparent content negotiation for the request results in a circular\
+* Transparent content negotiation for the request results in a circular
   reference.
 * 507 Insufficient Storage
-* The server is unable to store the representation needed to complete the\
+* The server is unable to store the representation needed to complete the
   request.
 * 508 Loop Detected
-* The server detected an infinite loop while processing the request (sent in\
+* The server detected an infinite loop while processing the request (sent in
   lieu of 208 Already Reported).
 * 510 Not Extended
 * Further extensions to the request are required for the server to fulfil it.
@@ -603,23 +603,23 @@ The following response headers are not currently in use. Future versions of the\
 API could return them.
 
 * 206 Partial Content
-* The server is delivering only part of the resource (byte serving) due to a\
+* The server is delivering only part of the resource (byte serving) due to a
   range header sent by the client.
 * 300 Multiple Choices
-* Indicates multiple options for the resource from which the client may choose\
+* Indicates multiple options for the resource from which the client may choose
   (via agent-driven content negotiation).
 * 407 Proxy Authentication Required
 * The client must first authenticate itself with the proxy.
 * 408 Request Timeout
-* The server timed out waiting for the request. According to HTTP\
-  specifications: "The client did not produce a request within the time that\
-  the server was prepared to wait. The client MAY repeat the request without\
+* The server timed out waiting for the request. According to HTTP
+  specifications: "The client did not produce a request within the time that
+  the server was prepared to wait. The client MAY repeat the request without
   modifications at any later time."
 * 410 Gone
-* Indicates that the resource requested is no longer available and will not be\
+* Indicates that the resource requested is no longer available and will not be
   available again.
 * 416 Range Not Satisfiable
-* The client has asked for a portion of the file (byte serving), but the\
+* The client has asked for a portion of the file (byte serving), but the
   server cannot supply that portion.
 * 417 Expectation Failed
 * The server cannot meet the requirements of the Expect request-header field.
@@ -628,10 +628,10 @@ API could return them.
 * 424 Failed Dependency
 * The request failed due to failure of a previous request.
 * 426 Upgrade Required
-* The client should switch to a different protocol such as TLS/1.0, given in\
+* The client should switch to a different protocol such as TLS/1.0, given in
   the Upgrade header field.
 * 429 Too Many Requests
-* The user has sent too many requests in a given amount of time. Intended for\
+* The user has sent too many requests in a given amount of time. Intended for
   use with rate-limiting schemes.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-server-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-server-resource.md
@@ -767,7 +767,7 @@ Response contains a resource collection with all servers.
 POST /v1/servers
 ```
 
-Create a new server by defining the resource. The posted object must define at\
+Create a new server by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -775,10 +775,10 @@ least the following fields.
 * `data.type`
 * Type of the object, must be `servers`
 * `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-* The [address](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) or [socket](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) to use. Only\
+* The [address](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) or [socket](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) to use. Only
   one of the fields can be defined.
 * `data.attributes.parameters.port`
-* The [port](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) to use. Needs\
+* The [port](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) to use. Needs
   to be defined if the `address` field is defined.
 
 The following is the minimal required JSON object for defining a new server.
@@ -798,7 +798,7 @@ The following is the minimal required JSON object for defining a new server.
 }
 ```
 
-The relationships of a server can also be defined at creation time. This allows\
+The relationships of a server can also be defined at creation time. This allows
 new servers to be created and immediately taken into use.
 
 ```
@@ -838,7 +838,7 @@ new servers to be created and immediately taken into use.
 }
 ```
 
-Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 for a full list of server parameters.
 
 **Response**
@@ -857,19 +857,19 @@ Invalid JSON body:
 PATCH /v1/servers/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 server.
 
 #### Modifiable Fields
 
-In addition to the server [parameters](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md), the _services_\
-and _monitors_ fields of the _relationships_ object can be modified. Removal,\
-addition and modification of the links will change which service and monitors\
+In addition to the server [parameters](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md), the _services_
+and _monitors_ fields of the _relationships_ object can be modified. Removal,
+addition and modification of the links will change which service and monitors
 use this server.
 
 For example, removing the first value in the _services_ list in the_relationships_ object from the following JSON document will remove the_server1_ from the service _RW-Split-Router_.
 
-Removing a service from a server is analogous to removing the server from the\
+Removing a service from a server is analogous to removing the server from the
 service. Both unlink the two objects from each other.
 
 Request for `PATCH /v1/servers/server1` that modifies the address of the server:
@@ -907,9 +907,9 @@ Request for `PATCH /v1/servers/server1` that modifies the server relationships:
 }
 ```
 
-If parts of the resource are not defined (e.g. the `attributes` field in the\
-above example), those parts of the resource are not modified. All parts that are\
-defined are interpreted as the new definition of those part of the resource. In\
+If parts of the resource are not defined (e.g. the `attributes` field in the
+above example), those parts of the resource are not modified. All parts that are
+defined are interpreted as the new definition of those part of the resource. In
 the above example, the `relationships` of the resource are completely redefined.
 
 **Response**
@@ -928,15 +928,15 @@ Invalid JSON body:
 PATCH /v1/servers/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _services_, for service\
+The _:type_ in the URI must be either _services_, for service
 relationships, or _monitors_, for monitor relationships.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the particular type from the server.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 service relationship for a server.
 
 ```
@@ -975,11 +975,11 @@ Invalid JSON body:
 DELETE /v1/servers/:name
 ```
 
-A server can only be deleted if it is not used by any services or\
+A server can only be deleted if it is not used by any services or
 monitors.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the server by first unlinking it from all services and monitors that use\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the server by first unlinking it from all services and monitors that use
 it.
 
 **Response**
@@ -998,7 +998,7 @@ Server is in use:
 PUT /v1/servers/:name/set
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the following values.
 
 | Value       | State Description                |
@@ -1010,19 +1010,19 @@ request. The value of `state` must be one of the following values.
 | synced      | Server is a Galera node          |
 | drain       | Server is drained of connections |
 
-For example, to set the server _db-server-1_ into maintenance mode, a request to\
+For example, to set the server _db-server-1_ into maintenance mode, a request to
 the following URL must be made:
 
 ```
 PUT /v1/servers/db-server-1/set?state=maintenance
 ```
 
-This endpoint also supports the `force=yes` parameter that will cause all\
-connections to the server to be closed if `state=maintenance` is also set. By\
-default setting a server into maintenance mode will cause connections to be\
+This endpoint also supports the `force=yes` parameter that will cause all
+connections to the server to be closed if `state=maintenance` is also set. By
+default setting a server into maintenance mode will cause connections to be
 closed only after the next request is sent.
 
-The following example forcefully closes all connections to server _db-server-1_\
+The following example forcefully closes all connections to server _db-server-1_
 and sets it into maintenance mode:
 
 ```
@@ -1045,7 +1045,7 @@ Missing or invalid parameter:
 PUT /v1/servers/:name/clear
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the values defined in the_set_ endpoint documentation.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-service-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-service-resource.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Service Resource
 
-A service resource represents a service inside MaxScale. A service is a\
+A service resource represents a service inside MaxScale. A service is a
 collection of network listeners, filters, a router and a set of backend servers.
 
 ### Resource Operations
@@ -776,7 +776,7 @@ Get all services.
 POST /v1/services
 ```
 
-Create a new service by defining the resource. The posted object must define at\
+Create a new service by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -790,24 +790,24 @@ least the following fields.
 * `data.attributes.parameters.password`
 * The [password](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) to use
 
-The `data.attributes.parameters` object is used to define router and service\
-parameters. All configuration parameters that can be defined in the\
-configuration file can also be added to the parameters object. The exceptions to\
-this are the `type`, `router`, `servers` and `filters` parameters which must not\
+The `data.attributes.parameters` object is used to define router and service
+parameters. All configuration parameters that can be defined in the
+configuration file can also be added to the parameters object. The exceptions to
+this are the `type`, `router`, `servers` and `filters` parameters which must not
 be defined.
 
-As with other REST API resources, the `data.relationships` field defines the\
-relationships of the service to other resources. Services can have two types of\
+As with other REST API resources, the `data.relationships` field defines the
+relationships of the service to other resources. Services can have two types of
 relationships: `servers` and `filters` relationships.
 
-If the request body defines a valid `relationships` object, the service is\
-linked to those resources. For servers, this is equivalent to adding the list of\
-server names into the [servers](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) parameter. For\
-filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) parameter in the\
-order they appear. For other services, this is equivalent to adding the list of\
+If the request body defines a valid `relationships` object, the service is
+linked to those resources. For servers, this is equivalent to adding the list of
+server names into the [servers](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) parameter. For
+filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) parameter in the
+order they appear. For other services, this is equivalent to adding the list of
 server names into the [targets](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) parameter.
 
-The following example defines a new service with both a server and a filter\
+The following example defines a new service with both a server and a filter
 relationship.
 
 ```
@@ -856,21 +856,21 @@ Service is created:
 DELETE /v1/services/:name
 ```
 
-A service can only be destroyed if the service uses no servers or filters and\
-all the listeners pointing to the service have been destroyed. This means that\
-the `data.relationships` must be an empty object and `data.attributes.listeners`\
+A service can only be destroyed if the service uses no servers or filters and
+all the listeners pointing to the service have been destroyed. This means that
+the `data.relationships` must be an empty object and `data.attributes.listeners`
 must be an empty array in order for the service to qualify for destruction.
 
-If there are open client connections that use the service when it is destroyed,\
-they are allowed to gracefully close before the service is destroyed. This means\
-that the destruction of a service can be acknowledged via the REST API before\
+If there are open client connections that use the service when it is destroyed,
+they are allowed to gracefully close before the service is destroyed. This means
+that the destruction of a service can be acknowledged via the REST API before
 the destruction process has fully completed.
 
-To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2402-maxscale-2402-session-resource.md) resource should be used. If a session for\
+To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2402-maxscale-2402-session-resource.md) resource should be used. If a session for
 the service is still open, it has not yet been destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the service by first unlinking it from all servers and filters that it\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the service by first unlinking it from all servers and filters that it
 uses.
 
 **Response**
@@ -885,15 +885,15 @@ Service is destroyed:
 PATCH /v1/services/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the service.
 
-All standard service parameters can be modified. Refer to the [service](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) documentation on\
+All standard service parameters can be modified. Refer to the [service](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) documentation on
 the details of these parameters.
 
-In addition to the standard service parameters, router parameters can be updated\
-at runtime if the router module supports it. Refer to the individual router\
-documentation for more details on whether the router supports it and which\
+In addition to the standard service parameters, router parameters can be updated
+at runtime if the router module supports it. Refer to the individual router
+documentation for more details on whether the router supports it and which
 parameters can be updated at runtime.
 
 The following example modifies a service by changing the `user` parameter to `admin`.
@@ -922,22 +922,22 @@ Service is modified:
 PATCH /v1/services/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _servers_, _services_ or _filters_,\
+The _:type_ in the URI must be either _servers_, _services_ or _filters_,
 depending on which relationship is being modified.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of this type for the service.
 
-_Note:_ The order of the values in the `filters` relationship will define the\
-order the filters are set up in. The order in which the filters appear in the\
-array will be the order in which the filters are applied to each query. Refer\
-to the [filters](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) parameter\
+_Note:_ The order of the values in the `filters` relationship will define the
+order the filters are set up in. The order in which the filters appear in the
+array will be the order in which the filters are applied to each query. Refer
+to the [filters](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) parameter
 for more details.
 
-The following is an example request and request body that defines a single\
-server relationship for a service that is equivalent to a `servers=my-server`\
+The following is an example request and request body that defines a single
+server relationship for a service that is equivalent to a `servers=my-server`
 parameter.
 
 ```
@@ -1033,7 +1033,7 @@ This endpoint is deprecated, use the [this](mariadb-maxscale-2402-maxscale-2402-
 GET /v1/services/:name/listeners/:listener
 ```
 
-This endpoint is deprecated, use the [this](mariadb-maxscale-2402-maxscale-2402-listener-resource.md)\
+This endpoint is deprecated, use the [this](mariadb-maxscale-2402-maxscale-2402-listener-resource.md)
 listeners endpoint instead.
 
 #### Create a new listener

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-session-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-session-resource.md
@@ -1,7 +1,7 @@
 # MaxScale 24.02 Session Resource
 
-A session is an abstraction of a client connection, any number of related backend\
-connections, a router module session and possibly filter module sessions. Each\
+A session is an abstraction of a client connection, any number of related backend
+connections, a router module session and possibly filter module sessions. Each
 session is created on a service and each service can have multiple sessions.
 
 ### Resource Operations
@@ -12,11 +12,11 @@ session is created on a service and each service can have multiple sessions.
 GET /v1/sessions/:id
 ```
 
-Get a single session. _:id_ must be a valid session ID. The session ID is the\
+Get a single session. _:id_ must be a valid session ID. The session ID is the
 same that is exposed to the client as the connection ID.
 
-This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to\
-perform reverse DNS on the client IP address. As this requires communicating with\
+This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to
+perform reverse DNS on the client IP address. As this requires communicating with
 an external server, the operation may be expensive.
 
 **Response**
@@ -231,10 +231,10 @@ Get all sessions.
 PATCH /v1/sessions/:id
 ```
 
-The request body must be a JSON object which represents the new configuration of\
+The request body must be a JSON object which represents the new configuration of
 the session. The `:id` must be a valid session ID that is active.
 
-The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean\
+The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean
 parameters control whether the associated logging level is enabled:
 
 ```
@@ -249,11 +249,11 @@ parameters control whether the associated logging level is enabled:
 }
 ```
 
-The filters that a session uses can be updated by re-defining the filter\
-relationship of the session. This causes new filter sessions to be opened\
-immediately. The old filter session are closed and replaced with the new filter\
-session the next time the session is idle. The order in which the filters are\
-defined in the request body is the order in which the filters are installed,\
+The filters that a session uses can be updated by re-defining the filter
+relationship of the session. This causes new filter sessions to be opened
+immediately. The old filter session are closed and replaced with the new filter
+session the next time the session is idle. The order in which the filters are
+defined in the request body is the order in which the filters are installed,
 similar to how the filter relationship for services behaves.
 
 ```
@@ -285,14 +285,14 @@ Session is modified:
 POST /v1/sessions/:id/restart
 ```
 
-This endpoint causes the session to re-read the configuration from the\
-service. As a result of this, all backend connections will be closed and then\
-opened again. All router and filter sessions will be created again which means\
-that for modules that perform something whenever a new module session is opened,\
+This endpoint causes the session to re-read the configuration from the
+service. As a result of this, all backend connections will be closed and then
+opened again. All router and filter sessions will be created again which means
+that for modules that perform something whenever a new module session is opened,
 this behaves as if a new session was started.
 
-This endpoint can be used to apply configuration changes that were done after\
-the session was started. This can be useful for situations where the client\
+This endpoint can be used to apply configuration changes that were done after
+the session was started. This can be useful for situations where the client
 connections live for a long time and connections are not recycled often enough.
 
 **Response**
@@ -307,7 +307,7 @@ Session is was restarted:
 POST /v1/sessions/restart
 ```
 
-This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint\
+This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint
 except that it applies to all sessions.
 
 **Response**
@@ -329,8 +329,8 @@ This endpoint causes the session to be forcefully closed.
 This endpoint supports the following request parameters.
 
 * `ttl`
-* The time after which the session is killed. If this parameter is not given,\
-  the session is killed immediately. This can be used to give the session time\
+* The time after which the session is killed. If this parameter is not given,
+  the session is killed immediately. This can be used to give the session time
   to finish the work it is performing before the connection is closed.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-sql-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-sql-resource.md
@@ -7,35 +7,35 @@ The SQL resource represents a database connection.
 The following endpoints provide a simple REST API interface for executing\
 SQL queries on servers and services in MaxScale.
 
-This endpoint also supports executing SQL queries using an ODBC driver. The\
-results returned by connections that use ODBC drivers can differ from the ones\
+This endpoint also supports executing SQL queries using an ODBC driver. The
+results returned by connections that use ODBC drivers can differ from the ones
 returned by normal SQL connections to objects in MaxScale.
 
-This document uses the `:id` value in the URL to represent a connection ID and\
-the `:query_id` to represent a query ID. These values do not need to be manually\
+This document uses the `:id` value in the URL to represent a connection ID and
+the `:query_id` to represent a query ID. These values do not need to be manually
 added as the relevant links are returned in the request body of each endpoint.
 
-The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A\
-connection token can be acquired with a `POST /v1/sql` request and can be used\
-with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in\
+The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A
+connection token can be acquired with a `POST /v1/sql` request and can be used
+with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in
 the `token` parameter of the request:
 
 ```
 POST /v1/sql/query?token=eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhZG1pbiIsImV4cCI6MTU4MzI1NDE1MSwiaWF0IjoxNTgzMjI1MzUxLCJpc3MiOiJtYXhzY2FsZSJ9.B1BqhjjKaCWKe3gVXLszpOPfeu8cLiwSb4CMIJAoyqw
 ```
 
-In addition to request parameters, the token can be stored in cookies in which\
-case they are automatically used by the REST API. For more information about\
+In addition to request parameters, the token can be stored in cookies in which
+case they are automatically used by the REST API. For more information about
 token storage in cookies, see the documentation for `POST /v1/sql`.
 
 ### Request Parameters
 
-All of the endpoints that operate on a single connection support the following\
-request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an\
+All of the endpoints that operate on a single connection support the following
+request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an
 exception as they ignore the current connection token.
 
 * `token`
-* The connection token to use for the request. If provided, the value is\
+* The connection token to use for the request. If provided, the value is
   unconditionally used even if a cookie with a valid token exists.
 
 #### Get one SQL connection
@@ -131,24 +131,24 @@ POST /v1/sql
 The request body must be a JSON object consisting of the following fields:
 
 * `target`
-* The object to connect to. This is a mandatory value and the\
+* The object to connect to. This is a mandatory value and the
   given value must be the name of a valid server, service or listener in\
   MaxScale or the value `odbc` if an ODBC connection is being made.
 * `user`
-* The username to use when creating the connection. This is a mandatory value\
+* The username to use when creating the connection. This is a mandatory value
   when connecting to an object in MaxScale.
 * `password`
-* The password for the user. This is a mandatory value when connecting to an\
+* The password for the user. This is a mandatory value when connecting to an
   object in MaxScale.
 * `db`
-* The default database for the connection. By default the connection will have\
+* The default database for the connection. By default the connection will have
   no default database. This is ignored by ODBC connections.
 * `timeout`
-* Connection timeout in seconds. The default connection timeout is 10\
-  seconds. This controls how long the SQL connection creation can take before\
+* Connection timeout in seconds. The default connection timeout is 10
+  seconds. This controls how long the SQL connection creation can take before
   an error is returned. This is accepted by all connection types.
 * `connection_string`
-* Connection string that defines the ODBC connection. This is a required value\
+* Connection string that defines the ODBC connection. This is a required value
   for ODBC type connections and is ignored by all other connection types.
 
 Here is an example request body:
@@ -163,7 +163,7 @@ Here is an example request body:
 }
 ```
 
-And here is an example request that uses an ODBC driver to connect to a remote\
+And here is an example request that uses an ODBC driver to connect to a remote
 server:
 
 ```
@@ -173,16 +173,16 @@ server:
 }
 ```
 
-The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token\
-is stored in cookies instead of the metadata object and the response body will\
+The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token
+is stored in cookies instead of the metadata object and the response body will
 not contain the token.
 
-The location of the newly created connection will be stored at `links.self` in\
+The location of the newly created connection will be stored at `links.self` in
 the response body as well as in the `Location` header.
 
-The token must be given to all subsequent requests that use the connection. It\
-must be either given in the `token` parameter of a request or it must be stored\
-in the cookies. If both a `token` parameter and a cookie exist at the same time,\
+The token must be given to all subsequent requests that use the connection. It
+must be either given in the `token` parameter of a request or it must be stored
+in the cookies. If both a `token` parameter and a cookie exist at the same time,
 the `token` parameter will be used instead of the cookie.
 
 **Request Parameters**
@@ -191,12 +191,12 @@ This endpoint supports the following request parameters.
 
 * `persist`
 * Store the connection token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie
   where the `<id>` part is replaced by the ID of the connection.
 * `max-age`
-* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or\
-  a non-integer value is found, the parameter is ignored. Once the token age\
-  exceeds the configured maximum value, the token can no longer be used and a\
+* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or
+  a non-integer value is found, the parameter is ignored. Once the token age
+  exceeds the configured maximum value, the token can no longer be used and a
   new connection must be created.
 
 **Response**
@@ -256,12 +256,12 @@ Missing or invalid connection token:
 POST /v1/sql/:id/reconnect
 ```
 
-Reconnects an existing connection. This can also be used if the connection to\
+Reconnects an existing connection. This can also be used if the connection to
 the backend server was lost due to a network error.
 
 The connection will use the same credentials that were passed to the `POST /v1/sql` endpoint. The new connection will still have the same ID in the REST\
-API but will be treated as a new connection by the database. A reconnection\
-re-initializes the connection and resets the session state. Reconnections cannot\
+API but will be treated as a new connection by the database. A reconnection
+re-initializes the connection and resets the session state. Reconnections cannot
 take place while a transaction is open.
 
 **Response**
@@ -284,17 +284,17 @@ Missing or invalid connection token:
 POST /v1/sql/:id/clone
 ```
 
-Clones an existing connection. This is done by opening a new connection using\
+Clones an existing connection. This is done by opening a new connection using
 the credentials and configuration from the given connection.
 
 **Request Parameters**
 
-This endpoint supports the same request parameters as the `POST /v1/sql`\
+This endpoint supports the same request parameters as the `POST /v1/sql`
 endpoint.
 
 **Response**
 
-The response is identical to the one in the `POST /v1/sql` endpoint. In\
+The response is identical to the one in the `POST /v1/sql` endpoint. In
 addition, this endpoint can return the following responses.
 
 Connection is already in use:
@@ -311,7 +311,7 @@ Missing or invalid connection token:
 POST /v1/sql/:id/queries
 ```
 
-The request body must be a JSON object with the value of the `sql` field set to\
+The request body must be a JSON object with the value of the `sql` field set to
 the SQL to be executed:
 
 ```
@@ -324,23 +324,23 @@ the SQL to be executed:
 The request body must be a JSON object consisting of the following fields:
 
 * `sql`
-* The SQL to be executed. If the SQL contain multiple statements, multiple\
+* The SQL to be executed. If the SQL contain multiple statements, multiple
   results are returned in the response body.
 * `max_rows`
-* The maximum number of rows returned in the response. By default this is 1000\
-  rows. Setting the value to 0 means no limit. Any extra rows in the result\
+* The maximum number of rows returned in the response. By default this is 1000
+  rows. Setting the value to 0 means no limit. Any extra rows in the result
   will be discarded.
 
-By default, the complete result is returned in the response body. If the SQL\
-query returns more than one result, the `results` array will contain all the\
-results. If the `async=true` request option is used, the query is queued for\
+By default, the complete result is returned in the response body. If the SQL
+query returns more than one result, the `results` array will contain all the
+results. If the `async=true` request option is used, the query is queued for
 execution.
 
-The `results` array can have three types of objects: resultsets, errors, and OK\
+The `results` array can have three types of objects: resultsets, errors, and OK
 responses.
 
-* A resultset consists of the `data` field with the result data stored as a two\
-  dimensional array. The names of the fields are stored in an array in the`fields` field and the field types and other metadata are stored in the`metadata` field. These types of results will be returned for any operation\
+* A resultset consists of the `data` field with the result data stored as a two
+  dimensional array. The names of the fields are stored in an array in the`fields` field and the field types and other metadata are stored in the`metadata` field. These types of results will be returned for any operation
   that returns rows (i.e. `SELECT` statements)
 
 ```
@@ -389,7 +389,7 @@ responses.
 }
 ```
 
-* An error consists of an object with the `errno` field set to the MariaDB error\
+* An error consists of an object with the `errno` field set to the MariaDB error
   code, the `message` field set to the human-readable error message and the`sqlstate` field set to the current SQLSTATE of the connection.
 
 ```
@@ -415,9 +415,9 @@ responses.
 }
 ```
 
-* An OK response is returned for any result that completes successfully but not\
-  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`\
-  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field\
+* An OK response is returned for any result that completes successfully but not
+  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`
+  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field
   contains the number of warnings raised by the operation.
 
 ```
@@ -443,17 +443,17 @@ responses.
 }
 ```
 
-It is also possible for the fields of the error response to be present in the\
-resultset response if the result ended with an error but still generated some\
-data. Usually this happens when query execution is interrupted but a partial\
+It is also possible for the fields of the error response to be present in the
+resultset response if the result ended with an error but still generated some
+data. Usually this happens when query execution is interrupted but a partial
 result was generated by the server.
 
 **Request Parameters**
 
 * `async`
-* If set to `true`, the query is queued for asynchronous execution and the\
-  results must be retrieved later from the URL stored in `links.self` field\
-  of the response. The HTTP response code is set to HTTP 202 Accepted if the\
+* If set to `true`, the query is queued for asynchronous execution and the
+  results must be retrieved later from the URL stored in `links.self` field
+  of the response. The HTTP response code is set to HTTP 202 Accepted if the
   query was successfully queued for execution.
 
 **Response**
@@ -530,7 +530,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 #### Get Asynchronous Query Results
@@ -539,10 +539,10 @@ Fatal connection error:
 GET /v1/sql/:id/queries/:query_id
 ```
 
-The results are only available if a `POST /v1/sql/:id/queries` was executed with\
-the `async` field set to `true`. The result of any asynchronous query can be\
-read multiple times. Only the latest result is stored: executing a new query\
-will cause the latest result to be erased. Results can be explicitly erased\
+The results are only available if a `POST /v1/sql/:id/queries` was executed with
+the `async` field set to `true`. The result of any asynchronous query can be
+read multiple times. Only the latest result is stored: executing a new query
+will cause the latest result to be erased. Results can be explicitly erased
 with a `DELETE` request.
 
 **Response**
@@ -603,7 +603,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 #### Erase Asynchronous Query Results
@@ -612,7 +612,7 @@ Fatal connection error:
 DELETE /v1/sql/:id/queries/:query_id
 ```
 
-Erases the latest result of an asynchronously executed query. All asynchronous\
+Erases the latest result of an asynchronously executed query. All asynchronous
 results are erased when the connection that owns them is closed.
 
 **Response**
@@ -635,12 +635,12 @@ Missing connection token:
 POST /v1/sql/:id/cancel
 ```
 
-This endpoint cancels the current query being executed by this connection. If no\
+This endpoint cancels the current query being executed by this connection. If no
 query is being done and the connection is idle, no action is taken.
 
-If the connection is busy but it is not executing a query, an attempt to cancel\
-is still made: in this case the results of this operation are undefined for ODBC\
-connections, for MariaDB connections this will cause a `KILL QUERY` command to\
+If the connection is busy but it is not executing a query, an attempt to cancel
+is still made: in this case the results of this operation are undefined for ODBC
+connections, for MariaDB connections this will cause a `KILL QUERY` command to
 be executed.
 
 **Response**
@@ -663,9 +663,9 @@ Missing connection token:
 GET /v1/sql/odbc/drivers
 ```
 
-Get the list of configured ODBC drivers found by the driver manager. The list of\
-drivers includes all drivers known to the driver manager for which an installed\
-library was found (i.e. `Driver` or `Driver64` in `/etc/odbcinst.ini` points to\
+Get the list of configured ODBC drivers found by the driver manager. The list of
+drivers includes all drivers known to the driver manager for which an installed
+library was found (i.e. `Driver` or `Driver64` in `/etc/odbcinst.ini` points to
 a file).
 
 **Response**
@@ -700,14 +700,14 @@ The response contains a resource collection with all available drivers.
 POST /v1/sql/:id/etl/prepare
 ```
 
-The ETL operation requires two connections: an ODBC connection to a remote\
-server (source connection) and a connection to a server in MaxScale (destination\
+The ETL operation requires two connections: an ODBC connection to a remote
+server (source connection) and a connection to a server in MaxScale (destination
 connection). All ETL operations must be done on the ODBC connection.
 
 The ETL operations require that the MariaDB ODBC driver is installed on the\
-MaxScale server. This driver is often available in the package manager of your\
-operating system but it can also be downloaded from the MariaDB\
-website. Installation instructions for installing the driver manually can be\
+MaxScale server. This driver is often available in the package manager of your
+operating system but it can also be downloaded from the MariaDB
+website. Installation instructions for installing the driver manually can be
 found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#installing-mariadb-connectorodbc-on-linux).
 
 The request body must be a JSON object consisting of the following fields:
@@ -715,12 +715,12 @@ The request body must be a JSON object consisting of the following fields:
 * `target`
 
 The target connection ID that defines the destination server. This must be the\
-ID of a connection (i.e. `data.attributes.id` ) to a server in MaxScale\
+ID of a connection (i.e. `data.attributes.id` ) to a server in MaxScale
 created via the `POST /v1/sql/` endpoint.
 
 * `type`
 
-The type of the ETL data source. The value must be a string with one of the\
+The type of the ETL data source. The value must be a string with one of the
 following values:
 
 ```
@@ -748,48 +748,48 @@ following values:
 
 * `tables`
 
-An array of objects, each of which must define a `table` and a `schema`\
+An array of objects, each of which must define a `table` and a `schema`
 field. The `table` field defines the name of the table to be imported and the`schema` field defines the schema it is in. If the objects contain a value for`create`, `select` or `insert`, the SQL generation for that part is skipped.
 
 * `connection_string`
 
-Extra connection string that is appended to the destination server's\
-connection string. This connection will always use the MariaDB ODBC\
+Extra connection string that is appended to the destination server's
+connection string. This connection will always use the MariaDB ODBC
 driver. The list of supported options can be found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#parameters).
 
 * `threads`
 
-The number of parallel connections used during the ETL operation. By default\
+The number of parallel connections used during the ETL operation. By default
 the ETL operation will use up to 16 connections.
 
 * `timeout`
 
-The connection and query timeout in seconds. By default a timeout of 30\
+The connection and query timeout in seconds. By default a timeout of 30
 seconds is used.
 
 * `create_mode`
 
-A string with either `normal`, `ignore` or `replace` which controls how tables\
+A string with either `normal`, `ignore` or `replace` which controls how tables
 are handled that already exist on the destination server.
 
-If left undefined or set to `normal`, the tables are created using a normal`CREATE TABLE` statement. This will cause an error to be reported if the table\
-already exist and will prevent the ETL from proceeding past the object\
+If left undefined or set to `normal`, the tables are created using a normal`CREATE TABLE` statement. This will cause an error to be reported if the table
+already exist and will prevent the ETL from proceeding past the object
 creation stage.
 
-If set to `ignore` the tables are created with `CREATE TABLE IF NOT EXISTS`\
-which will ignore any existing tables and assume that they are compatible with\
-the rest of the ETL operation. This mode can be used to continuously load data\
+If set to `ignore` the tables are created with `CREATE TABLE IF NOT EXISTS`
+which will ignore any existing tables and assume that they are compatible with
+the rest of the ETL operation. This mode can be used to continuously load data
 from an external source into MariaDB.
 
-If set to `replace`, the tables are created with `CREATE OR REPLACE TABLE`\
-which will cause existing tables to be dropped if they exist. This is not a\
+If set to `replace`, the tables are created with `CREATE OR REPLACE TABLE`
+which will cause existing tables to be dropped if they exist. This is not a
 reversible process so caution should be taken when this mode is used.
 
 * `catalog`
 
 The catalog for the tables. This is only used when `type` is set to`generic`. In all other cases this value is ignored.
 
-Here is an example payload that prepares the table `test.t1` for extraction from\
+Here is an example payload that prepares the table `test.t1` for extraction from
 a MariaDB server.
 
 ```
@@ -805,9 +805,9 @@ a MariaDB server.
 }
 ```
 
-The token for the source connection is provided the same way it is\
-provided for all other `/v1/sql` endpoints: in the `token` request\
-parameter or in the cookies. The destination connection token is\
+The token for the source connection is provided the same way it is
+provided for all other `/v1/sql` endpoints: in the `token` request
+parameter or in the cookies. The destination connection token is
 provided either in the `target_token` request parameter or as a cookie.
 
 ### Request Parameters
@@ -815,8 +815,8 @@ provided either in the `target_token` request parameter or as a cookie.
 This endpoints supports the following additional request parameters.
 
 * `target_token`
-* The connection token for the destination connection. If provided, the value\
-  is unconditionally used even if a cookie with a valid token exists for the\
+* The connection token for the destination connection. If provided, the value
+  is unconditionally used even if a cookie with a valid token exists for the
   destination connection.
 
 **Response**
@@ -825,7 +825,7 @@ ETL operation prepared:
 
 `Status: 202 Accepted`
 
-Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the\
+Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the
 following result.
 
 ```
@@ -867,32 +867,32 @@ Invalid payload or missing connection token:
 POST /v1/sql/:id/etl/start
 ```
 
-The behavior of this endpoint is identical to the preparation but instead of\
-preparing the operation, this endpoint will execute the prepared ETL and load\
+The behavior of this endpoint is identical to the preparation but instead of
+preparing the operation, this endpoint will execute the prepared ETL and load
 the data into MariaDB.
 
-The intended way of doing an ETL operation is to first prepare it using the`/v1/sql/:id/etl/prepare` endpoint to retrieve the SQL statements that define\
-the ETL operation. Then if the ETL preparation is successful, the`data.attributes.results.tables` value from the response is used as the `tables`\
+The intended way of doing an ETL operation is to first prepare it using the`/v1/sql/:id/etl/prepare` endpoint to retrieve the SQL statements that define
+the ETL operation. Then if the ETL preparation is successful, the`data.attributes.results.tables` value from the response is used as the `tables`
 value for the ETL start operation, done on the `/v1/sql/:id/etl/start` endpoint.
 
-If any of the `create`, `select` or `insert` fields for a table in the `tables`\
-list have not been defined, the SQL will be automatically generated by querying\
-the source server, similarly to how the preparation generates the SQL\
-statements. This means that the preparation step is optional if there is no need\
+If any of the `create`, `select` or `insert` fields for a table in the `tables`
+list have not been defined, the SQL will be automatically generated by querying
+the source server, similarly to how the preparation generates the SQL
+statements. This means that the preparation step is optional if there is no need
 to adjust the automatically generated SQL.
 
-The ETL operation can be canceled using the `/v1/sql/:id/cancel` endpoint which\
-will roll back the ETL operation. Any tables that were created during the ETL\
-operation are not deleted on the destination server and must be manually cleaned\
+The ETL operation can be canceled using the `/v1/sql/:id/cancel` endpoint which
+will roll back the ETL operation. Any tables that were created during the ETL
+operation are not deleted on the destination server and must be manually cleaned
 up.
 
-If the ETL fails to extract the SQL from the source server or an error was\
-encountered during table creation, the response will have the `"ok"` field set\
-to false. Both the top-level object as well as the individual tables can have\
+If the ETL fails to extract the SQL from the source server or an error was
+encountered during table creation, the response will have the `"ok"` field set
+to false. Both the top-level object as well as the individual tables can have
 the `"error"` field set to the error message. This field is filled during the\
 ETL operation which means errors are visible even if the ETL is still ongoing.
 
-During the ETL operation, tables that have been fully processed will have a`"execution_time"` field. This field has the total time in seconds it took to\
+During the ETL operation, tables that have been fully processed will have a`"execution_time"` field. This field has the total time in seconds it took to
 execute the data loading step.
 
 **Response**
@@ -901,7 +901,7 @@ ETL operation started:
 
 `Status: 202 Accepted`
 
-Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the\
+Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the
 following result.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-avrorouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-avrorouter.md
@@ -1,13 +1,13 @@
 # MaxScale 24.02 Avrorouter
 
-The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes\
+The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes
 binary logs from a local directory and transforms them into a set of Avro files.\
 These files can then be queried by clients for various purposes.
 
 This router is intended to be used in tandem with the [Binlog Server](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md).\
 The Binlog Server can connect to a primary server and request binlog records.\
-These records can then consumed by the avrorouter directly from the binlog cache\
-of the Binlog Server. This allows MariaDB MaxScale to automatically transform\
+These records can then consumed by the avrorouter directly from the binlog cache
+of the Binlog Server. This allows MariaDB MaxScale to automatically transform
 binlog events on the primary to local Avro format files.
 
 ```mermaid
@@ -64,25 +64,25 @@ flowchart LR
 ```
 _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog events are converted to Avro-formatted change data and streamed to CDC clients, Kafka, and Hadoop._
 
-The avrorouter can also consume binary logs straight from the primary. This will\
-remove the need to configure the Binlog Server but it will increase the disk space\
+The avrorouter can also consume binary logs straight from the primary. This will
+remove the need to configure the Binlog Server but it will increase the disk space
 requirement on the primary server by at least a factor of two.
 
-The converted Avro files can be requested with the CDC protocol. This protocol\
-should be used to communicate with the avrorouter and currently it is the only\
-supported protocol. The clients can request either Avro or JSON format data\
+The converted Avro files can be requested with the CDC protocol. This protocol
+should be used to communicate with the avrorouter and currently it is the only
+supported protocol. The clients can request either Avro or JSON format data
 streams from a database table.
 
 ### Direct Replication Mode
 
-MaxScale 2.4.0 added a direct replication mode that connects the avrorouter\
-directly to a MariaDB server. This mode is an improvement over the binlogrouter\
-based replication as it provides a more space-efficient and faster conversion\
-process. This is the recommended method of using the avrorouter as it is faster,\
+MaxScale 2.4.0 added a direct replication mode that connects the avrorouter
+directly to a MariaDB server. This mode is an improvement over the binlogrouter
+based replication as it provides a more space-efficient and faster conversion
+process. This is the recommended method of using the avrorouter as it is faster,
 more efficient and less prone to errors caused by missing DDL events.
 
-To enable the direct replication mode, add either the `servers` or the `cluster`\
-parameter to the avrorouter service. The avrorouter will then use one of the\
+To enable the direct replication mode, add either the `servers` or the `cluster`
+parameter to the avrorouter service. The avrorouter will then use one of the
 servers as the replication source.
 
 Here is a minimal avrorouter direct replication configuration:
@@ -110,12 +110,12 @@ protocol=CDC
 port=4001
 ```
 
-In direct replication mode, the avrorouter stores the latest replicated GTID in\
-the `current_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove\
+In direct replication mode, the avrorouter stores the latest replicated GTID in
+the `current_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove
 the file.
 
-Additionally, the avrorouter will attempt to automatically create any missing\
-schema files for tables that have data events for them but the DDL for those\
+Additionally, the avrorouter will attempt to automatically create any missing
+schema files for tables that have data events for them but the DDL for those
 tables is not contained in the binlogs.
 
 ### Configuration
@@ -131,24 +131,24 @@ For information about common service parameters, refer to the [Configuration Gui
 * Dynamic: No
 * Default: `""`
 
-The GTID where avrorouter starts the replication from in direct replication\
-mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where\
-the first number is the replication domain, the second the server\_id value of\
+The GTID where avrorouter starts the replication from in direct replication
+mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where
+the first number is the replication domain, the second the server\_id value of
 the server and the last is the GTID sequence number.
 
-This parameter has no effect in the traditional mode. If this parameter is\
-defined, the replication will start from the implicit GTID that the primary first\
+This parameter has no effect in the traditional mode. If this parameter is
+defined, the replication will start from the implicit GTID that the primary first
 serves.
 
-Starting in MaxScale 24.02, the special values `newest` and `oldest` can be\
+Starting in MaxScale 24.02, the special values `newest` and `oldest` can be
 used:
 
-* `newest` uses the current value of `@@gtid_binlog_pos` as the GTID where the\
+* `newest` uses the current value of `@@gtid_binlog_pos` as the GTID where the
   replication is started from.
-* `oldest` uses the oldest binlog that's available in `SHOW BINARY LOGS` and\
+* `oldest` uses the oldest binlog that's available in `SHOW BINARY LOGS` and
   then extracting the oldest GTID from it with `SHOW BINLOG EVENTS`.
 
-Once the replication has started and a GTID position has been recorded, this\
+Once the replication has started and a GTID position has been recorded, this
 parameter will be ignored. To reset the recorded GTID position, delete the`current_gtid.txt` file located in `/var/lib/maxscale/<SERVICE>/` where`<SERVICE>` is the name of the Avrorouter service.
 
 **`server_id`**
@@ -158,7 +158,7 @@ parameter will be ignored. To reset the recorded GTID position, delete the`curre
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
 used when replicating from the primary in direct replication mode.
 
 **`codec`**
@@ -172,7 +172,7 @@ used when replicating from the primary in direct replication mode.
 The compression codec to use. By default, the avrorouter does not use compression.
 
 This parameter takes one of the following two values; _null_ or\_deflate\_. These are the mandatory compression algorithms required by the\
-Avro specification. For more information about the compression types,\
+Avro specification. For more information about the compression types,
 refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specification/#required-codecs).
 
 **`match` and `exclude`**
@@ -182,13 +182,13 @@ refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specificat
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+These [regular expression settings](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 filter events for processing depending on table names. Avrorouter does not support the\_options\_-parameter for regular expressions.
 
-To prevent excessive matching of similarly named tables, surround each table\
-name with the `^` and `$` tokens. For example, to match the `test.clients` table\
-but not `test.clients_old` table use `match=^test[.]clients$`. For multiple\
-tables, surround each table in parentheses and add a pipe character between\
+To prevent excessive matching of similarly named tables, surround each table
+name with the `^` and `$` tokens. For example, to match the `test.clients` table
+but not `test.clients_old` table use `match=^test[.]clients$`. For multiple
+tables, surround each table in parentheses and add a pipe character between
 them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 
 **`binlogdir`**
@@ -198,8 +198,8 @@ them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location of the binary log files. This is the first mandatory parameter\
-and it defines where the module will read binlog files from. Read access to\
+The location of the binary log files. This is the first mandatory parameter
+and it defines where the module will read binlog files from. Read access to
 this directory is required.
 
 **`avrodir`**
@@ -209,14 +209,14 @@ this directory is required.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location where the Avro files are stored. This is the second mandatory\
-parameter and it governs where the converted files are stored. This directory\
-will be used to store the Avro files, plain-text Avro schemas and other files\
-needed by the avrorouter. The user running MariaDB MaxScale will need both read and\
+The location where the Avro files are stored. This is the second mandatory
+parameter and it governs where the converted files are stored. This directory
+will be used to store the Avro files, plain-text Avro schemas and other files
+needed by the avrorouter. The user running MariaDB MaxScale will need both read and
 write access to this directory.
 
-The avrorouter will also use the _avrodir_ to store various internal\
-files. These files are named _avro.index_ and _avro-conversion.ini_. By default,\
+The avrorouter will also use the _avrodir_ to store various internal
+files. These files are named _avro.index_ and _avro-conversion.ini_. By default,
 the default data directory, _/var/lib/maxscale/_, is used. Before version 2.1 of\
 MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 
@@ -227,7 +227,7 @@ MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 * Dynamic: No
 * Default: `mysql-bin`
 
-The base name of the binlog files. The binlog files are assumed to follow the\
+The base name of the binlog files. The binlog files are assumed to follow the
 naming schema _._ where is the binlog number and is the value of this router option.
 
 For example, with the following parameters:
@@ -247,11 +247,11 @@ The first binlog file the avrorouter would look for is `/var/lib/mysql/binlogs/m
 * Default: `1`
 
 The starting index number of the binlog file. The default value is 1.\
-For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_\
+For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_
 the index would be 5.
 
-If you need to start from a binlog file other than 1, you need to set the value\
-of this option to the correct index. The avrorouter will always start from the\
+If you need to start from a binlog file other than 1, you need to set the value
+of this option to the correct index. The avrorouter will always start from the
 beginning of the binary log file.
 
 #### `cooperative_replication`
@@ -261,39 +261,39 @@ beginning of the binary log file.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
-cluster. This is a boolean parameter and is disabled by default. It was\
+Controls whether multiple instances cooperatively replicate from the same
+cluster. This is a boolean parameter and is disabled by default. It was
 added in MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`),\
-the replication is only active if the monitor owns the cluster it is\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`),
+the replication is only active if the monitor owns the cluster it is
 monitoring.
 
-With this feature, multiple MaxScale instances can replicate from the same set\
-of servers and only one of them actively processes the replication stream. This\
-allows the avrorouter instances to be made highly-available without having to\
+With this feature, multiple MaxScale instances can replicate from the same set
+of servers and only one of them actively processes the replication stream. This
+allows the avrorouter instances to be made highly-available without having to
 have them all process the events at the same time.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID processed by that\
-instance. This means that if the instance hasn't replicated events that have\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID processed by that
+instance. This means that if the instance hasn't replicated events that have
 been purged from the binary logs, the replication cannot continue.
 
 **Avro File Related Parameters**
 
 These options control how large the Avro file data blocks can get.\
-Increasing or lowering the block size could have a positive effect\
-depending on your use case. For more information about the Avro file\
+Increasing or lowering the block size could have a positive effect
+depending on your use case. For more information about the Avro file
 format and how it organizes data, refer to the [Avro documentation](https://avro.apache.org/docs/current/).
 
-The avrorouter will flush a block and start a new one when either `group_trx`\
-transactions or `group_rows` row events have been processed. Changing these\
-options will also allow more frequent updates to stored data but this\
+The avrorouter will flush a block and start a new one when either `group_trx`
+transactions or `group_rows` row events have been processed. Changing these
+options will also allow more frequent updates to stored data but this
 will cause a small increase in file size and search times.
 
-It is highly recommended to keep the block sizes relatively large to allow\
-larger chunks of memory to be flushed to disk at one time. This will make\
+It is highly recommended to keep the block sizes relatively large to allow
+larger chunks of memory to be flushed to disk at one time. This will make
 the conversion process noticeably faster.
 
 **`group_trx`**
@@ -303,7 +303,7 @@ the conversion process noticeably faster.
 * Dynamic: No
 * Default: `1`
 
-Controls the number of transactions that are grouped into a single Avro\
+Controls the number of transactions that are grouped into a single Avro
 data block.
 
 **`group_rows`**
@@ -313,7 +313,7 @@ data block.
 * Dynamic: No
 * Default: `1000`
 
-Controls the number of row events that are grouped into a single Avro\
+Controls the number of row events that are grouped into a single Avro
 data block.
 
 **`block_size`**
@@ -323,10 +323,10 @@ data block.
 * Dynamic: Yes
 * Default: `16KiB`
 
-The Avro data block size in bytes. The default is 16 kilobytes. Increase this\
-value if individual events in the binary logs are very large. The value is a\
+The Avro data block size in bytes. The default is 16 kilobytes. Increase this
+value if individual events in the binary logs are very large. The value is a
 size type parameter which means that it can also be defined with an SI suffix.\
-Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 for more details about size type parameters and how to use them.
 
 **`max_file_size`**
@@ -336,17 +336,17 @@ for more details about size type parameters and how to use them.
 * Dynamic: No
 * Default: 0
 
-If the size of a single Avro data file exceeds this limit, the avrorouter will\
-rotate to a new file. This is done by closing the existing file and creating a\
-new one with the next version number. By default the avrorouter does not rotate\
-files based on their size. Setting the value to 0 disables file rotation based on\
+If the size of a single Avro data file exceeds this limit, the avrorouter will
+rotate to a new file. This is done by closing the existing file and creating a
+new one with the next version number. By default the avrorouter does not rotate
+files based on their size. Setting the value to 0 disables file rotation based on
 size.
 
-This uses the size of the file as reported by the operating system. The check\
-for the file size is done after a transaction has been processed which means\
+This uses the size of the file as reported by the operating system. The check
+for the file size is done after a transaction has been processed which means
 that large transactions can still cause the file size to exceed the given limit.
 
-File rotation only works with the direct replication mode. The legacy file based\
+File rotation only works with the direct replication mode. The legacy file based
 replication mode does not support this.
 
 **`max_data_age`**
@@ -356,17 +356,17 @@ replication mode does not support this.
 * Dynamic: No
 * Default: 0s
 
-When enabled, the avrorouter will automatically purge any files that only have\
-data that is older than the given limit. This means that all data files with at\
-least one event that is newer than the configured limit will not be removed,\
-even if the age of all the other events is above the limit. The purge operation\
-is only done when a file rotation takes place (either manual or automatic) or\
+When enabled, the avrorouter will automatically purge any files that only have
+data that is older than the given limit. This means that all data files with at
+least one event that is newer than the configured limit will not be removed,
+even if the age of all the other events is above the limit. The purge operation
+is only done when a file rotation takes place (either manual or automatic) or
 when a schema change is detected.
 
-This parameter is best combined with `max_file_size` to provide automatic\
+This parameter is best combined with `max_file_size` to provide automatic
 removal of stale data.
 
-Automatic file purging only works with the direct replication mode. The legacy\
+Automatic file purging only works with the direct replication mode. The legacy
 file based replication mode does not support this.
 
 **Example configuration**
@@ -389,94 +389,94 @@ avrodir=/var/lib/maxscale
 
 ### Module commands
 
-Read [Module Commands](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md) documentation for\
+Read [Module Commands](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md) documentation for
 details about module commands.
 
 The avrorouter supports the following module commands.
 
 #### `avrorouter::convert SERVICE {start | stop}`
 
-Start or stop the binary log to Avro conversion. The first parameter is the name\
-of the service to stop and the second parameter tells whether to start the\
+Start or stop the binary log to Avro conversion. The first parameter is the name
+of the service to stop and the second parameter tells whether to start the
 conversion process or to stop it.
 
 #### `avrorouter::purge SERVICE`
 
 This command will delete all files created by the avrorouter. This includes all\
-.avsc schema files and .avro data files as well as the internal state tracking\
+.avsc schema files and .avro data files as well as the internal state tracking
 files. Use this to completely reset the conversion process.
 
-**Note:** Once the command has completed, MaxScale must be restarted to restart\
+**Note:** Once the command has completed, MaxScale must be restarted to restart
 the conversion process. Issuing a `convert start` command **will not work**.
 
-**WARNING:** You will lose any and all converted data when this command is\
+**WARNING:** You will lose any and all converted data when this command is
 executed.
 
 ### Files Created by the Avrorouter
 
-The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store\
-the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains\
-the last converted position and GTID in the binlogs. If you need to reset the\
+The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store
+the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains
+the last converted position and GTID in the binlogs. If you need to reset the
 conversion process, delete these two files and restart MaxScale.
 
 ### Resetting the Conversion Process
 
-To reset the binlog conversion process, issue the `purge` module command by\
-executing it via MaxCtrl and stop MaxScale. If manually created schema files\
+To reset the binlog conversion process, issue the `purge` module command by
+executing it via MaxCtrl and stop MaxScale. If manually created schema files
 were used, they need to be recreated once MaxScale is stopped. After stopping\
-MaxScale and optionally creating the schema files, the conversion process can be\
+MaxScale and optionally creating the schema files, the conversion process can be
 started by starting MaxScale.
 
 ### Stopping the Avrorouter
 
-The safest way to stop the avrorouter when used with the binlogrouter is to\
+The safest way to stop the avrorouter when used with the binlogrouter is to
 follow the following steps:
 
 * Issue `STOP SLAVE` on the binlogrouter
 * Wait for the avrorouter to process all files
 * Stop MaxScale with `systemctl stop maxscale`
 
-This guarantees that the conversion process halts at a known good position in\
+This guarantees that the conversion process halts at a known good position in
 the latest binlog file.
 
 ### Example Client
 
 The avrorouter comes with an example client program, _cdc.py_, written in Python 3.\
-This client can connect to a MaxScale configured with the CDC protocol and the\
+This client can connect to a MaxScale configured with the CDC protocol and the
 avrorouter.
 
-Before using this client, you will need to install the Python 3 interpreter and\
-add users to the service with the _cdc\_users.py_ script. Fore more details about\
-the user creation, please refer to the [CDC Protocol](../maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-change-data-capture-cdc-protocol.md)\
+Before using this client, you will need to install the Python 3 interpreter and
+add users to the service with the _cdc\_users.py_ script. Fore more details about
+the user creation, please refer to the [CDC Protocol](../maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-change-data-capture-cdc-protocol.md)
 and [CDC Users](../maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-change-data-capture-cdc-users.md) documentation.
 
-Read the output of `cdc.py --help` for a full list of supported options\
+Read the output of `cdc.py --help` for a full list of supported options
 and a short usage description of the client program.
 
 ### Avro Schema Generator
 
-The avrorouter needs to have access to the CREATE TABLE statement for all tables\
-for which there are data events in the binary logs. If the CREATE TABLE\
-statements for the tables aren't present in the current binary logs, the schema\
+The avrorouter needs to have access to the CREATE TABLE statement for all tables
+for which there are data events in the binary logs. If the CREATE TABLE
+statements for the tables aren't present in the current binary logs, the schema
 files must be created.
 
-In the direct replication mode, avrorouter will automatically create the missing\
-schema files by connecting to the database and executing a `SHOW CREATE TABLE`\
-statement. If a connection cannot be made or the service user lacks the\
-permission, an error will be logged and the data events for that table will not\
+In the direct replication mode, avrorouter will automatically create the missing
+schema files by connecting to the database and executing a `SHOW CREATE TABLE`
+statement. If a connection cannot be made or the service user lacks the
+permission, an error will be logged and the data events for that table will not
 be processed.
 
-For the legacy binlog mode, the files must be generated with a schema file\
+For the legacy binlog mode, the files must be generated with a schema file
 generator. There are currently two methods to generate the .avsc schema files.
 
 #### Simple Schema Generator
 
-The `cdc_one_schema.py` generates a schema file for a single table by reading a\
-tab separated list of field and type names from the standard input. This is the\
-recommended schema generation tool as it does not directly communicate with the\
+The `cdc_one_schema.py` generates a schema file for a single table by reading a
+tab separated list of field and type names from the standard input. This is the
+recommended schema generation tool as it does not directly communicate with the
 database thus making it more flexible.
 
-The only requirement to run the script is that a Python interpreter is\
+The only requirement to run the script is that a Python interpreter is
 installed.
 
 To use this script, pipe the output of the `mysql` command line into the`cdc_one_schema.py` script:
@@ -485,15 +485,15 @@ To use this script, pipe the output of the `mysql` command line into the`cdc_one
 mysql -ss -u <user> -p -h <host> -P <port> -e 'DESCRIBE `<database>`.`<table>`'|./cdc_one_schema.py <database> <table>
 ```
 
-Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with\
-appropriate values and run the command. Note that the `-ss` parameter is\
-mandatory as that will generate the tab separated output instead of the default\
+Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with
+appropriate values and run the command. Note that the `-ss` parameter is
+mandatory as that will generate the tab separated output instead of the default
 pretty-printed output.
 
-An .avsc file named after the database and table name will be generated in the\
+An .avsc file named after the database and table name will be generated in the
 current working directory. Copy this file to the location pointed by the`avrodir` parameter of the avrorouter.
 
-Alternatively, you can also copy the output of the `mysql` command to a file and\
+Alternatively, you can also copy the output of the `mysql` command to a file and
 feed it into the script if you cannot execute the SQL command directly:
 
 ```
@@ -516,31 +516,31 @@ usage: cdc_schema.py [--help] [-h HOST] [-P PORT] [-u USER] [-p PASSWORD] DATABA
 The _cdc\_schema.py_ executable is installed as a part of MaxScale. This is a\
 Python 3 script that generates Avro schema files from an existing database.
 
-The script will generate the .avsc schema files into the current directory. Run\
-the script for all required databases copy the generated .avsc files to the\
+The script will generate the .avsc schema files into the current directory. Run
+the script for all required databases copy the generated .avsc files to the
 directory where the avrorouter stores the .avro files (the value of `avrodir`).
 
 #### Go Schema Generator
 
-The _cdc\_schema.go_ example Go program is provided with MaxScale. This file\
-can be used to create Avro schemas for the avrorouter by connecting to a\
-database and reading the table definitions. You can find the file in MaxScale's\
+The _cdc\_schema.go_ example Go program is provided with MaxScale. This file
+can be used to create Avro schemas for the avrorouter by connecting to a
+database and reading the table definitions. You can find the file in MaxScale's
 share directory in `/usr/share/maxscale/`.
 
-You'll need to install the Go compiler and run `go get` to resolve Go\
-dependencies before you can use the _cdc\_schema_ program. After resolving the\
-dependencies you can run the program with `go run cdc_schema.go`. The program\
-will create .avsc files in the current directory. These files should be moved\
-to the location pointed by the _avrodir_ option of the avrorouter if they are\
+You'll need to install the Go compiler and run `go get` to resolve Go
+dependencies before you can use the _cdc\_schema_ program. After resolving the
+dependencies you can run the program with `go run cdc_schema.go`. The program
+will create .avsc files in the current directory. These files should be moved
+to the location pointed by the _avrodir_ option of the avrorouter if they are
 to be used by the router itself.
 
-Read the output of `go run cdc_schema.go -help` for more information on how\
+Read the output of `go run cdc_schema.go -help` for more information on how
 to run the program.
 
 ### Examples
 
-The [Avrorouter Tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-avrorouter-tutorial.md) shows you how\
-the Avrorouter works with the Binlog Server to convert binlogs from a primary server\
+The [Avrorouter Tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-avrorouter-tutorial.md) shows you how
+the Avrorouter works with the Binlog Server to convert binlogs from a primary server
 into easy to process Avro data.
 
 Here is a simple configuration example which reads binary logs locally from`/var/lib/mysql/` and stores them as Avro files in `/var/lib/maxscale/avro/`.\
@@ -570,7 +570,7 @@ Python script. It queries the table _test.mytable_ for all change records.
 cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytable
 ```
 
-You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change\
+You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change
 records to a Kafka broker.
 
 ```
@@ -578,28 +578,28 @@ cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytab
 cdc_kafka_producer.py --kafka-broker 127.0.0.1:9092 --kafka-topic test.mytable
 ```
 
-For more information on how to use these scripts, see the output of `cdc.py -h`\
+For more information on how to use these scripts, see the output of `cdc.py -h`
 and `cdc_kafka_producer.py -h`.
 
 ### Building Avrorouter
 
-To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development\
+To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development
 headers. When configuring MaxScale with CMake, you will need to add`-DBUILD_CDC=Y` to build the CDC module set.
 
-The Avro C library needs to be build with position independent code enabled. You\
-can do this by adding the following flags to the CMake invocation when\
+The Avro C library needs to be build with position independent code enabled. You
+can do this by adding the following flags to the CMake invocation when
 configuring the Avro C library.
 
 ```
 -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC
 ```
 
-For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-building-mariadb-maxscale-from-source-code.md)\
+For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-building-mariadb-maxscale-from-source-code.md)
 document.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for an avrorouter service contains the following\
+The `router_diagnostics` output for an avrorouter service contains the following
 fields.
 
 * `infofile`: File where the avrorouter stores the conversion process state.
@@ -619,8 +619,8 @@ The avrorouter does not support the following data types, conversions or SQL sta
 * Fields CAST from integer types to string types
 * [CREATE TABLE ... AS SELECT statements](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/tables/create-table)
 
-The avrorouter does not do any crash recovery. This means that the avro files\
-need to be removed or truncated to valid block lengths before starting the\
+The avrorouter does not do any crash recovery. This means that the avro files
+need to be removed or truncated to valid block lengths before starting the
 avrorouter.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-binlogrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-binlogrouter.md
@@ -1,37 +1,37 @@
 # MaxScale 24.02 Binlogrouter
 
-The binlogrouter is a router that acts as a replication proxy for MariaDB\
-primary-replica replication. The router connects to a primary, retrieves the binary\
-logs and stores them locally. Replica servers can connect to MaxScale like they\
-would connect to a normal primary server. If the primary server goes down,\
-replication between MaxScale and the replicas can still continue up to the latest\
-point to which the binlogrouter replicated to. The primary can be changed without\
-disconnecting the replicas and without them noticing that the primary server has\
+The binlogrouter is a router that acts as a replication proxy for MariaDB
+primary-replica replication. The router connects to a primary, retrieves the binary
+logs and stores them locally. Replica servers can connect to MaxScale like they
+would connect to a normal primary server. If the primary server goes down,
+replication between MaxScale and the replicas can still continue up to the latest
+point to which the binlogrouter replicated to. The primary can be changed without
+disconnecting the replicas and without them noticing that the primary server has
 changed. This allows for a more highly available replication setup.
 
-In addition to the high availability benefits, the binlogrouter creates only one\
-connection to the primary whereas with normal replication each individual replica\
-will create a separate connection. This reduces the amount of work the primary\
-database has to do which can be significant if there are a large number of\
+In addition to the high availability benefits, the binlogrouter creates only one
+connection to the primary whereas with normal replication each individual replica
+will create a separate connection. This reduces the amount of work the primary
+database has to do which can be significant if there are a large number of
 replicating replicas.
 
 ### Binlog purge, archive and compress
 
-File purge and archive are mutually exclusive. Archiving simply means that\
-a binlog is moved to another directory. That directory can be mounted to another\
+File purge and archive are mutually exclusive. Archiving simply means that
+a binlog is moved to another directory. That directory can be mounted to another
 file system for backups or, for example, a locally mounted S3 bucket.
 
-If archiving is started from a primary that still has all its history intact, a\
+If archiving is started from a primary that still has all its history intact, a
 full copy of the primary can be archived.
 
-File compression preserves disk space and makes archiving faster. All\
-binlogs except the very last one, which is the one being logged to, can be\
-compressed. The overhead of reading from a compressed binlog is small, and\
-is typically only needed when a replica goes down, reconnects and is far\
+File compression preserves disk space and makes archiving faster. All
+binlogs except the very last one, which is the one being logged to, can be
+compressed. The overhead of reading from a compressed binlog is small, and
+is typically only needed when a replica goes down, reconnects and is far
 enough behind the current GTID that an older file needs to be opened.
 
-There is no automated way as of yet for the binlogrouter to use archived files,\
-but should the need arise files can be copied from the archive to the binlog\
+There is no automated way as of yet for the binlogrouter to use archived files,
+but should the need arise files can be copied from the archive to the binlog
 directory. See ['Modifying binlog files manually'](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#modifying-binlog-files-manually).
 
 The related configuration options, which are explained in more detail in the configuration section are:
@@ -42,10 +42,10 @@ The related configuration options, which are explained in more detail in the con
 * [expire\_log\_minimum\_files](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#expire_log_minimum_files) The minimum number of binlogs to keep before purge or archive is allowed.
 * [expire\_log\_duration](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#expire_log_duration) Duration from the last file modification until the binlog is eligible for purge or archive.
 * [compression\_algorithm](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#compression_algorithm) Select a compression algorithm or `none` for no compression. Currently only zstandard is supported.
-* [number\_of\_noncompressed\_files](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#number_of_noncompressed_files) The minimum number of\
+* [number\_of\_noncompressed\_files](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#number_of_noncompressed_files) The minimum number of
   binlogs not to compress.
 
-Following are example settings where it is expected that a\
+Following are example settings where it is expected that a
 replica is down for no more than 24 hours.
 
 ```
@@ -60,26 +60,26 @@ number_of_noncompressed_files=2
 ### Modifying binlog files manually
 
 There is usually no reason to modify the contents of the binlog directory.\
-Changing the contents can cause **failures** if not done correctly. Never make\
+Changing the contents can cause **failures** if not done correctly. Never make
 any changes if running a version prior to 23.08, except when a [bootstrap](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#bootstrap-binlogrouter) is needed.
 
-A binlog file has the name .\<sequence\_number>. The basename is decided\
-by the primary server. The sequence number increases by one for each file and is six\
+A binlog file has the name .\<sequence\_number>. The basename is decided
+by the primary server. The sequence number increases by one for each file and is six
 digits long. The first file has the name .000001
 
-The file `binlog.index` contains the view of the current state of the binlogs\
-as a list of file names ordered by the file sequence number. `binlog.index` is\
+The file `binlog.index` contains the view of the current state of the binlogs
+as a list of file names ordered by the file sequence number. `binlog.index` is
 automatically generated any time the contents of `datadir` changes.
 
-Older files can be manually deleted and should be deleted in the order they\
+Older files can be manually deleted and should be deleted in the order they
 were created, lowest to highest sequence number. Prefer to use purge configuration.
 
-Archived files can be copied back to `datadir`, but care should be taken to copy\
+Archived files can be copied back to `datadir`, but care should be taken to copy
 them back in the reverse order they were created, highest to lowest sequence number.\
-The copied over files will be re-archived once `expire_log_duration` time has\
+The copied over files will be re-archived once `expire_log_duration` time has
 passed.
 
-Never leave a gap in the sequence numbers, and always preserve the name of a\
+Never leave a gap in the sequence numbers, and always preserve the name of a
 binlog file if copied. Do not copy binlog files on top of existing binlog files.
 
 As of version 24.02 any binlog except the latest one can be manually compressed, .e.g:
@@ -90,11 +90,11 @@ zstd --rm -z binlog.001234
 
 ### Supported SQL Commands
 
-The binlogrouter supports a subset of the SQL constructs that the MariaDB server\
+The binlogrouter supports a subset of the SQL constructs that the MariaDB server
 supports. The following commands are supported:
 
 * `CHANGE MASTER TO`
-* The binlogrouter supports the same syntax as the MariaDB server but only the\
+* The binlogrouter supports the same syntax as the MariaDB server but only the
   following values are allowed:
   * `MASTER_HOST`
   * `MASTER_PORT`
@@ -111,7 +111,7 @@ supports. The following commands are supported:
   * `MASTER_SSL_CIPHER`
   * `MASTER_SSL_VERIFY_SERVER_CERT`
 
-NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported\
+NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported
 as binlogrouter only supports GTID based replication.
 
 * `STOP SLAVE`
@@ -119,56 +119,56 @@ as binlogrouter only supports GTID based replication.
 * `START SLAVE`
 * Starts replication, same as MariaDB.
 * `RESET SLAVE`
-* Resets replication. Note that the `RESET SLAVE ALL` form that is supported\
+* Resets replication. Note that the `RESET SLAVE ALL` form that is supported
   by MariaDB isn't supported by the binlogrouter.
 * `SHOW BINARY LOGS`
-* Lists the current files and their sizes. These will be different from the\
-  ones listed by the original primary where the binlogrouter is replicating\
+* Lists the current files and their sizes. These will be different from the
+  ones listed by the original primary where the binlogrouter is replicating
   from.
 * `PURGE { BINARY | MASTER } LOGS TO <filename>`
-* Purges binary logs up to but not including the given file. The file name\
-  must be one of the names shown in `SHOW BINARY LOGS`. The version of this\
+* Purges binary logs up to but not including the given file. The file name
+  must be one of the names shown in `SHOW BINARY LOGS`. The version of this
   command which accepts a timestamp is not currently supported.\
-  Automatic purging is supported using the configuration\
+  Automatic purging is supported using the configuration
   parameter [expire\_log\_duration](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#expire_log_duration).\
-  The files are purged in the order they were created. If a file to be purged\
-  is detected to be in use, the purge stops. This means that the purge will\
+  The files are purged in the order they were created. If a file to be purged
+  is detected to be in use, the purge stops. This means that the purge will
   stop at the oldest file that a replica is still reading.\
-  NOTE: You should still take precaution not to purge files that a potential\
-  replica will need in the future. MaxScale can only detect that a file is\
+  NOTE: You should still take precaution not to purge files that a potential
+  replica will need in the future. MaxScale can only detect that a file is
   in active use when a replica is connected, and requesting events from it.
 * `SHOW MASTER STATUS`
-* Shows the name and position of the file to which the binlogrouter will write\
-  the next replicated data. The name and position do not correspond to the\
+* Shows the name and position of the file to which the binlogrouter will write
+  the next replicated data. The name and position do not correspond to the
   name and position in the primary.
 * `SHOW SLAVE STATUS`
-* Shows the replica status information similar to what a normal MariaDB replica\
-  server shows. Some of the values are replaced with constants values that\
+* Shows the replica status information similar to what a normal MariaDB replica
+  server shows. Some of the values are replaced with constants values that
   never change. The following values are not constant:
-  * `Slave_IO_State`: Set to `Waiting for primary to send event` when\
+  * `Slave_IO_State`: Set to `Waiting for primary to send event` when
     replication is ongoing.
   * `Master_Host`: Address of the current primary.
   * `Master_User`: The user used to replicate.
   * `Master_Port`: The port the primary is listening on.
-  * `Master_Log_File`: The name of the latest file that the binlogrouter is\
+  * `Master_Log_File`: The name of the latest file that the binlogrouter is
     writing to.
-  * `Read_Master_Log_Pos`: The current position where the last event was\
+  * `Read_Master_Log_Pos`: The current position where the last event was
     written in the latest binlog.
-  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's\
+  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's
     not.
-  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's\
+  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's
     not.
   * `Exec_Master_Log_Pos`: Same as `Read_Master_Log_Pos`.
   * `Gtid_IO_Pos`: The latest replicated GTID.
 * `SELECT { Field } ...`
-* The binlogrouter implements a small subset of the MariaDB SELECT syntax as\
-  it is mainly used by the replicating replicas to query various parameters. If\
-  a field queried by a client is not known to the binlogrouter, the value\
-  will be returned back as-is. The following list of functions and variables\
+* The binlogrouter implements a small subset of the MariaDB SELECT syntax as
+  it is mainly used by the replicating replicas to query various parameters. If
+  a field queried by a client is not known to the binlogrouter, the value
+  will be returned back as-is. The following list of functions and variables
   are understood by the binlogrouter and are replaced with actual values:
-  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of\
+  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of
     these return the latest GTID replicated from the primary.
-  * `version()` or `@@version`: The version string returned by MaxScale when\
+  * `version()` or `@@version`: The version string returned by MaxScale when
     a client connects to it.
   * `UNIX_TIMESTAMP()`: The current timestamp.
   * `@@version_comment`: Always `pinloki`.
@@ -196,27 +196,27 @@ as binlogrouter only supports GTID based replication.
   * `@@tx_isolation`: Always `REPEATABLE-READ`
   * `@@wait_timeout`: Always `28800`
 * `SET`
-* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should\
+* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should
   start replicating. E.g. `SET @@global.gtid_slave_pos="0-1000-1234,1-1001-5678"`
 * `SHOW VARIABLES LIKE '...'`
-* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`\
-  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`\
-  is not currently supported. In addition, the `LIKE` operator in\
+* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`
+  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`
+  is not currently supported. In addition, the `LIKE` operator in
   binlogrouter only supports exact matches.\
-  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID\
-  coordinates of the binlogrouter. In addition to these, the `server_id`\
+  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID
+  coordinates of the binlogrouter. In addition to these, the `server_id`
   variable will return the configured server ID of the binlogrouter.
 
 ### Semi-sync replication
 
-If the server from which the binlogrouter replicates from is using semi-sync\
+If the server from which the binlogrouter replicates from is using semi-sync
 replication, the binlogrouter will acknowledge the replicated events.
 
 ### Configuration Parameters
 
 The binlogrouter is configured similarly to how normal routers are configured in\
-MaxScale. It requires at least one listener where clients can connect to and one\
-server from which the database user information can be retrieved. An example\
+MaxScale. It requires at least one listener where clients can connect to and one
+server from which the database user information can be retrieved. An example
 configuration can be found in the [example](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#example) section of this document.
 
 #### `datadir`
@@ -237,7 +237,7 @@ Directory where binary log files are stored.
 
 Mandatory if `expiration_mode=archive`
 
-The directory to where files are archived. This is presumably a directory\
+The directory to where files are archived. This is presumably a directory
 mounted to a remote file system or an S3 bucket. Ensure that the user running\
 MaxScale (typically "maxscale") has sufficient privileges on the archive directory.\
 S3 buckets mounted with s3fs may require setting permissions manually:
@@ -255,7 +255,7 @@ The directory must exist when MaxScale starts.
 * Dynamic: No
 * Default: `1234`
 
-The server ID that MaxScale uses when connecting to the primary and when serving\
+The server ID that MaxScale uses when connecting to the primary and when serving
 binary logs to the replicas.
 
 #### `net_timeout`
@@ -276,26 +276,26 @@ Network connection and read timeout for the connection to the primary.
 
 Automatically select the primary server to replicate from.
 
-When this feature is enabled, the primary which binlogrouter will replicate\
+When this feature is enabled, the primary which binlogrouter will replicate
 from will be selected from the servers defined by a monitor `cluster=TheMonitor`.\
-Alternatively servers can be listed in `servers`. The servers should be monitored\
-by a monitor. Only servers with the `Master` status are used. If multiple primary\
+Alternatively servers can be listed in `servers`. The servers should be monitored
+by a monitor. Only servers with the `Master` status are used. If multiple primary
 servers are available, the first available primary server will be used.
 
-If a `CHANGE MASTER TO` command is received while `select_master` is on, the\
+If a `CHANGE MASTER TO` command is received while `select_master` is on, the
 command will be honored and `select_master` turned off until the next reboot.\
 This allows the Monitor to perform failover, and more importantly, switchover.\
-It also allows the user to manually redirect the Binlogrouter. The current\
+It also allows the user to manually redirect the Binlogrouter. The current
 primary is "sticky", meaning that the same primary will be chosen on reboot.
 
-**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is\
-monitoring a binlogrouter. The binlogrouter does not support all the SQL\
-commands that the monitor will send and the rejoin will fail. This restriction\
+**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is
+monitoring a binlogrouter. The binlogrouter does not support all the SQL
+commands that the monitor will send and the rejoin will fail. This restriction
 will be lifted in a future version.
 
 The GTID the replication will start from, will be based on the latest replicated\
-GTID. If no GTID has been replicated, the router will start replication from the\
-start. Manual configuration of the GTID can be done by first configuring the\
+GTID. If no GTID has been replicated, the router will start replication from the
+start. Manual configuration of the GTID can be done by first configuring the
 replication manually with `CHANGE MASTER TO`.
 
 #### `expiration_mode`
@@ -321,9 +321,9 @@ A value of `0s` turns off purging.
 
 [expire\_log\_days](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#expire_logs_days).
 
-The duration is measured from the last modification of the log file. Files are\
-purged in the order they were created. The automatic purge works in a similar\
-manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if\
+The duration is measured from the last modification of the log file. Files are
+purged in the order they were created. The automatic purge works in a similar
+manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if
 an eligible file is in active use, i.e. being read by a replica.
 
 #### `expire_log_minimum_files`
@@ -333,7 +333,7 @@ an eligible file is in active use, i.e. being read by a replica.
 * Dynamic: No
 * Default: `2`
 
-The minimum number of log files the automatic purge keeps. At least one file\
+The minimum number of log files the automatic purge keeps. At least one file
 is always kept.
 
 #### `compression_algorithm`
@@ -351,7 +351,7 @@ is always kept.
 * Dynamic: No
 * Default: `2`
 
-The minimum number of log files that are not compressed. At least one file\
+The minimum number of log files that are not compressed. At least one file
 is not compressed.
 
 #### `ddl_only`
@@ -363,9 +363,9 @@ is not compressed.
 
 When enabled, only DDL events are written to the binary logs. This means that`CREATE`, `ALTER` and `DROP` events are written but `INSERT`, `UPDATE` and`DELETE` events are not.
 
-This mode can be used to keep a record of all the schema changes that occur on a\
-database. As only the DDL events are stored, it becomes very easy to set up an\
-empty server with no data in it by simply pointing it at a binlogrouter instance\
+This mode can be used to keep a record of all the schema changes that occur on a
+database. As only the DDL events are stored, it becomes very easy to set up an
+empty server with no data in it by simply pointing it at a binlogrouter instance
 that has `ddl_only` enabled.
 
 #### `encryption_key_id`
@@ -376,23 +376,23 @@ that has `ddl_only` enabled.
 * Default: `""`
 
 Encryption key ID used to encrypt the binary logs. If configured, an [Encryption\
-Key Manager](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
-must also be configured and it must contain the key with the given ID. If the\
-encryption key manager supports versioning, new binary logs will be encrypted\
-using the latest encryption key. Old binlogs will remain encrypted with older\
-key versions and remain readable as long as the key versions used to encrypt\
+Key Manager](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
+must also be configured and it must contain the key with the given ID. If the
+encryption key manager supports versioning, new binary logs will be encrypted
+using the latest encryption key. Old binlogs will remain encrypted with older
+key versions and remain readable as long as the key versions used to encrypt
 them are available.
 
-Once binary log encryption has been enabled, the encryption key ID cannot be\
-changed and the key must remain available to MaxScale in order for replication\
-to work. If an encryption key is not available or the key manager fails to\
-retrieve it, the replication from the currently selected primary server will\
-stop. If the replication is restarted manually, the encryption key retrieval is\
+Once binary log encryption has been enabled, the encryption key ID cannot be
+changed and the key must remain available to MaxScale in order for replication
+to work. If an encryption key is not available or the key manager fails to
+retrieve it, the replication from the currently selected primary server will
+stop. If the replication is restarted manually, the encryption key retrieval is
 attempted again.
 
-Re-encryption of binlogs using another encryption key is not possible. However,\
-this is possible if the data is replicated to a second MaxScale server that uses\
-a different encryption key. The same approach can also be used to decrypt\
+Re-encryption of binlogs using another encryption key is not possible. However,
+this is possible if the data is replicated to a second MaxScale server that uses
+a different encryption key. The same approach can also be used to decrypt
 binlogs.
 
 #### `encryption_cipher`
@@ -403,7 +403,7 @@ binlogs.
 * Values: `AES_CBC`, `AES_CTR`, `AES_GCM`
 * Default: `AES_GCM`
 
-The encryption cipher to use. The encryption key size also affects which mode is\
+The encryption cipher to use. The encryption key size also affects which mode is
 used: only 128, 192 and 256 bit encryption keys are currently supported.
 
 Possible values are:
@@ -422,16 +422,16 @@ Possible values are:
 * Default: false
 * Dynamic: Yes
 
-Enable [semi-synchronous](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
-replication when replicating from a MariaDB server. If enabled, the binlogrouter\
-will send acknowledgment for each received event. Note that the [rpl\_semi\_sync\_master\_enabled](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication#rpl_semi_sync_master_enabled)\
-parameter must be enabled in the MariaDB server where the replication is done\
+Enable [semi-synchronous](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
+replication when replicating from a MariaDB server. If enabled, the binlogrouter
+will send acknowledgment for each received event. Note that the [rpl\_semi\_sync\_master\_enabled](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication#rpl_semi_sync_master_enabled)
+parameter must be enabled in the MariaDB server where the replication is done
 from for the semi-synchronous replication to take place.
 
 ### New installation
 
 1. Configure and start MaxScale.
-2. If you have not configured `select_master=true` (automatic\
+2. If you have not configured `select_master=true` (automatic
    primary selection), issue a `CHANGE MASTER TO` command to binlogrouter.
 
 ```
@@ -453,34 +453,34 @@ SHOW SLAVE STATUS \G
 
 ### Upgrading from legacy versions
 
-Binlogrouter does not read any of the data that a version prior to 2.5\
-has saved. By default binlogrouter will request the replication stream\
-from the blank state (from the start of time), which is basically meant\
-for new systems. If a system is live, the entire replication data probably\
-does not exist, and if it does, it is not necessary for binlogrouter to read\
+Binlogrouter does not read any of the data that a version prior to 2.5
+has saved. By default binlogrouter will request the replication stream
+from the blank state (from the start of time), which is basically meant
+for new systems. If a system is live, the entire replication data probably
+does not exist, and if it does, it is not necessary for binlogrouter to read
 and store all the data.
 
 #### Before you start
 
 * Binlogrouter uses [inotify](https://man7.org/linux/man-pages/man7/inotify.7.html) which has three kernel limits.\
-  While Binlogrouter uses a modest number of inotify instances, the limit `max_user_instances` applies to the total\
-  number of instances for the user and has a low default value on many systems. A double or triple of the\
-  default value should suffice. The other two limits, `max_queued_events` and `max_user_watches` are usually high\
+  While Binlogrouter uses a modest number of inotify instances, the limit `max_user_instances` applies to the total
+  number of instances for the user and has a low default value on many systems. A double or triple of the
+  default value should suffice. The other two limits, `max_queued_events` and `max_user_watches` are usually high
   enough, but it is sensible to double (triple) them if `max_user_instances` was doubled (tripled).
 * Note that binlogrouter only supports GTID based replication.
-* Make sure that the configured data directory for the new binlogrouter\
+* Make sure that the configured data directory for the new binlogrouter
   is different from the old one, or move old data away.\
   See [datadir](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#datadir).
-* If the primary contains binlogs from the blank state, and there\
+* If the primary contains binlogs from the blank state, and there
   is a large amount of data, consider purging old binlogs.\
   See [Using and Maintaining the Binary Log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log).
 
 #### Deployment
 
-The method described here inflicts the least downtime. Assuming you have\
+The method described here inflicts the least downtime. Assuming you have
 configured MaxScale version 2.5 or newer, and it is ready to go:
 
-1. Redirect each replica that replicates from Binlogrouter to replicate from the\
+1. Redirect each replica that replicates from Binlogrouter to replicate from the
    primary.
 
 ```
@@ -503,7 +503,7 @@ master_user=USER,master_password="PASSWORD", master_use_gtid=slave_pos;
 ```
 
 1. Run `maxctrl list servers`. Make sure all your servers are accounted for.\
-   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and\
+   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and
    issue this command to Binlogrouter:
 
 ```
@@ -512,8 +512,8 @@ SET @@global.gtid_slave_pos = "0-1000-1234,1-1001-5678";
 START SLAVE
 ```
 
-**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos\
-if any binlog files have been purged on the primary. The server will only stream\
+**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos
+if any binlog files have been purged on the primary. The server will only stream
 from the start of time if the first binlog file is present.\
 See [select\_master](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#select_master).
 
@@ -531,19 +531,19 @@ SHOW SLAVE STATUS \G
 
 #### Bootstrap binlogrouter
 
-If for any reason you need to "bootstrap" the binlogrouter you can change\
+If for any reason you need to "bootstrap" the binlogrouter you can change
 the `datadir` or delete the entire binglog directory (`datadir`) when\
-MaxScale is NOT running. This could be necessary if files are accidentally\
+MaxScale is NOT running. This could be necessary if files are accidentally
 deleted or the file system becomes corrupt.
 
 No changes are required to the attached replicas.
 
-if [select\_master](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#select_master) is set to `true` and the primary contains\
+if [select\_master](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#select_master) is set to `true` and the primary contains
 the entire binlog history, a simple restart of MaxScale sufficies.
 
-In the normal case, the primary does not have the entire history and\
-you will need to set the GTID position to a starting value, usually the\
-earliest gtid state of all replicas. Once MaxScale has been restarted\
+In the normal case, the primary does not have the entire history and
+you will need to set the GTID position to a starting value, usually the
+earliest gtid state of all replicas. Once MaxScale has been restarted
 connect to the binlogrouter from the command line.
 
 If [select\_master](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#select_master) is set to true issue:
@@ -566,7 +566,7 @@ START SLAVE;
 
 ### Galera cluster
 
-When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#select_master) must be\
+When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2402-maxscale-2402-binlogrouter.md#select_master) must be
 set to true, and the servers must be monitored by the [Galera Monitor](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-galera-monitor.md).\
 Configuring binlogrouter is the same as described above.
 
@@ -635,8 +635,8 @@ port=3306
 
 ### Limitations
 
-* Old-style replication with binlog name and file offset is not supported\
-  and the replication must be started by setting up the GTID to replicate\
+* Old-style replication with binlog name and file offset is not supported
+  and the replication must be started by setting up the GTID to replicate
   from.
 * Only replication from MariaDB servers (including Galera) is supported.
 * Old encrypted binary logs are not re-encrypted with newer key versions ([MXS-4140](https://jira.mariadb.org/browse/MXS-4140))

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-cat.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-cat.md
@@ -2,8 +2,8 @@
 
 The `cat` router is a special router that concatenates result sets.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Configuration
@@ -12,28 +12,28 @@ The router has no special parameters. To use it, define a service with`router=ca
 
 ### Behavior
 
-The order the servers are defined in is the order in which the servers are\
-queried. This means that the results are ordered based on the `servers`\
-parameter of the service. The result will only be completed once all servers\
+The order the servers are defined in is the order in which the servers are
+queried. This means that the results are ordered based on the `servers`
+parameter of the service. The result will only be completed once all servers
 have executed this.
 
-All commands executed via this router will be executed on all servers. This\
-means that an INSERT through the `cat` router will send it to all servers. In\
-the case of commands that do not return resultsets, the response of the last\
-server is sent to the client. This means that if one of the earlier servers\
+All commands executed via this router will be executed on all servers. This
+means that an INSERT through the `cat` router will send it to all servers. In
+the case of commands that do not return resultsets, the response of the last
+server is sent to the client. This means that if one of the earlier servers
 returns a different result, the client will not see it.
 
-As the intended use-case of the router is to mainly reduce multiple result sets\
-into one, it has no mechanisms to prevent writes from being executed on slave\
-servers (which would cause data corruption or replication failure). Take great\
+As the intended use-case of the router is to mainly reduce multiple result sets
+into one, it has no mechanisms to prevent writes from being executed on slave
+servers (which would cause data corruption or replication failure). Take great
 care when performing administrative operations though this router.
 
-If a connection to one of the servers is lost, the client connection will also\
+If a connection to one of the servers is lost, the client connection will also
 be closed.
 
 ### Example
 
-Here is a simple example service definition that uses the servers from the [Configuring Servers](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-configuring-servers.md) tutorial and the\
+Here is a simple example service definition that uses the servers from the [Configuring Servers](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-configuring-servers.md) tutorial and the
 credentials from the [MaxScale Tutorial](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-setting-up-mariadb-maxscale.md).
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-hintrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-hintrouter.md
@@ -4,27 +4,27 @@ HintRouter was introduced in 2.2 and is still beta.
 
 ### Overview
 
-The **HintRouter** module is a simple router intended to operate in conjunction\
-with the NamedServerFilter. The router looks at the hints embedded in a packet\
-buffer and attempts to route the packet according to the hint. The user can also\
-set a default action to be taken when a query has no hints or when the hints\
+The **HintRouter** module is a simple router intended to operate in conjunction
+with the NamedServerFilter. The router looks at the hints embedded in a packet
+buffer and attempts to route the packet according to the hint. The user can also
+set a default action to be taken when a query has no hints or when the hints
 could not be applied.
 
-If a packet has multiple hints attached, the router will read them in order and\
-attempt routing. Any successful routing ends the process and any further hints\
+If a packet has multiple hints attached, the router will read them in order and
+attempt routing. Any successful routing ends the process and any further hints
 are ignored for the packet.
 
 ### Configuration
 
-The HintRouter is a rather simple router and only accepts a few configuration\
+The HintRouter is a rather simple router and only accepts a few configuration
 settings.
 
 ```
 default_action=<master|slave|named|all>
 ```
 
-This setting defines what happens when a query has no routing hint or applying\
-the routing hint(s) fails. If also the default action fails, the routing will\
+This setting defines what happens when a query has no routing hint or applying
+the routing hint(s) fails. If also the default action fails, the routing will
 end in error and the session closes. The different values are:
 
 | Value  | Description                                                                |
@@ -34,40 +34,40 @@ end in error and the session closes. The different values are:
 | named  | Route to a named server. The name is given in the default\_server-setting. |
 | all    | Default value. Route to all connected servers.                             |
 
-Note that setting default action to anything other than `all` means that session\
+Note that setting default action to anything other than `all` means that session
 variable write commands are by default not routed to all backends.
 
 ```
 default_server=<server-name>
 ```
 
-Defines the default backend name if `default_action=named`. `<server-name>` must\
+Defines the default backend name if `default_action=named`. `<server-name>` must
 be a valid backend name.
 
 ```
 max_slaves=<limit>
 ```
 
-`<limit>` should be an integer, -1 by default. Defines how many backend replica\
-servers a session should attempt to connect to. Having less replicas defined in\
-the services and/or less successful connections during session creation is not\
-an error. The router will attempt to distribute replicas evenly between sessions\
-by assigning them in a round robin fashion. The session will always try to\
-connect to a primary regardless of this setting, although not finding one is not\
+`<limit>` should be an integer, -1 by default. Defines how many backend replica
+servers a session should attempt to connect to. Having less replicas defined in
+the services and/or less successful connections during session creation is not
+an error. The router will attempt to distribute replicas evenly between sessions
+by assigning them in a round robin fashion. The session will always try to
+connect to a primary regardless of this setting, although not finding one is not
 an error.
 
-Negative values activate default mode, in which case this value is set to the\
-number of backends in the service - 1, so that the sessions are connected to all\
+Negative values activate default mode, in which case this value is set to the
+number of backends in the service - 1, so that the sessions are connected to all
 replicas.
 
-If the hints or the `default_action` point to a named server, this setting is\
-probably best left to default to ensure that the specific server is connected to\
-at session creation. The router will not attempt to connect to additional\
+If the hints or the `default_action` point to a named server, this setting is
+probably best left to default to ensure that the specific server is connected to
+at session creation. The router will not attempt to connect to additional
 servers after session creation.
 
 ### Examples
 
-A minimal configuration doesn't require any parameters as all settings have\
+A minimal configuration doesn't require any parameters as all settings have
 reasonable defaults.
 
 ```
@@ -77,7 +77,7 @@ router=hintrouter
 servers=replica1,replica2,replica3
 ```
 
-If packets should be routed to the primary server by default and only a few\
+If packets should be routed to the primary server by default and only a few
 connections are required, the configuration might be as follows.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-kafkacdc.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-kafkacdc.md
@@ -2,10 +2,10 @@
 
 ### Overview
 
-The KafkaCDC module reads data changes in MariaDB via replication and converts\
+The KafkaCDC module reads data changes in MariaDB via replication and converts
 them into JSON objects that are then streamed to a Kafka broker.
 
-DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the\
+DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the
 following format (example created by `CREATE TABLE test.t1(id INT)`):
 
 ```
@@ -65,10 +65,10 @@ following format (example created by `CREATE TABLE test.t1(id INT)`):
 }
 ```
 
-The `domain`, `server_id` and `sequence` fields contain the GTID that this event\
-belongs to. The `event_number` field is the sequence number of events inside the\
-transaction starting from 1. The `timestamp` field is the UNIX timestamp when\
-the event occurred. The `event_type` field contains the type of the event, one\
+The `domain`, `server_id` and `sequence` fields contain the GTID that this event
+belongs to. The `event_number` field is the sequence number of events inside the
+transaction starting from 1. The `timestamp` field is the UNIX timestamp when
+the event occurred. The `event_type` field contains the type of the event, one
 of:
 
 * `insert`: the event is the data that was added to MariaDB
@@ -76,13 +76,13 @@ of:
 * `update_before`: the event contains the data before an update statement modified it
 * `update_after`: the event contains the data after an update statement modified it
 
-All remaining fields contains data from the table. In the example event this\
+All remaining fields contains data from the table. In the example event this
 would be the fields `id` and `data`.
 
 The sending of these schema objects is optional and can be disabled using`send_schema=false`.
 
-DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that\
-follow the format specified in the DDL event. The objects are in the following\
+DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that
+follow the format specified in the DDL event. The objects are in the following
 format (example created by `INSERT INTO test.t1 VALUES (1)`):
 
 ```
@@ -99,28 +99,28 @@ format (example created by `INSERT INTO test.t1 VALUES (1)`):
 }
 ```
 
-The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These\
+The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These
 contain the table name and schema the event targets.
 
-The router stores table metadata in the MaxScale data directory. The\
-default value is `/var/lib/maxscale/<service name>`. If data for a table\
-is replicated before a DDL event for it is replicated, the CREATE TABLE\
+The router stores table metadata in the MaxScale data directory. The
+default value is `/var/lib/maxscale/<service name>`. If data for a table
+is replicated before a DDL event for it is replicated, the CREATE TABLE
 will be queried from the primary server.
 
-During shutdown, the Kafka event queue is flushed. This can take up to 60\
+During shutdown, the Kafka event queue is flushed. This can take up to 60
 seconds if the network is slow or there are network problems.
 
 ### Configuration
 
-* In order for `kafkacdc` to work, the binary logging on the source server must\
-  be configured to use row-based replication and the row image must be set to\
+* In order for `kafkacdc` to work, the binary logging on the source server must
+  be configured to use row-based replication and the row image must be set to
   full by configuring `binlog_format=ROW` and `binlog_row_image=FULL`.
-* The `servers` parameter defines the set of servers where the data is\
-  replicated from. The replication will be done from the first primary server\
+* The `servers` parameter defines the set of servers where the data is
+  replicated from. The replication will be done from the first primary server
   that is found.
-* The `user` and `password` of the service will be used to connect to the\
+* The `user` and `password` of the service will be used to connect to the
   primary. This user requires the `REPLICATION SLAVE` grant.
-* The KafkaCDC service must not be configured to use listeners. If a listener is\
+* The KafkaCDC service must not be configured to use listeners. If a listener is
   configured, all attempts to start a session will fail.
 
 ### Parameters
@@ -131,7 +131,7 @@ seconds if the network is slow or there are network problems.
 * Mandatory: Yes
 * Dynamic: No
 
-The list of Kafka brokers to use in `host:port` format. Multiple values\
+The list of Kafka brokers to use in `host:port` format. Multiple values
 can be separated with commas. This is a mandatory parameter.
 
 #### `topic`
@@ -140,7 +140,7 @@ can be separated with commas. This is a mandatory parameter.
 * Mandatory: Yes
 * Dynamic: No
 
-The Kafka topic where the replicated events will be sent. This is a\
+The Kafka topic where the replicated events will be sent. This is a
 mandatory parameter.
 
 #### `enable_idempotence`
@@ -150,22 +150,22 @@ mandatory parameter.
 * Dynamic: No
 * Default: `false`
 
-Enable idempotent producer mode. This feature requires Kafka version 0.11 or\
+Enable idempotent producer mode. This feature requires Kafka version 0.11 or
 newer to work and is disabled by default.
 
-When enabled, the Kafka producer enters a strict mode which avoids event\
-duplication due to broker outages or other network errors. In HA scenarios where\
-there are more than two MaxScale instances, event duplication can still happen\
+When enabled, the Kafka producer enters a strict mode which avoids event
+duplication due to broker outages or other network errors. In HA scenarios where
+there are more than two MaxScale instances, event duplication can still happen
 as there is no synchronization between the MaxScale instances.
 
-The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),\
+The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),
 describes the parameter as follows:
 
-When set to true, the producer will ensure that messages are successfully\
-produced exactly once and in the original produce order. The following\
-configuration properties are adjusted automatically (if not modified by the\
-user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must\
-be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),\
+When set to true, the producer will ensure that messages are successfully
+produced exactly once and in the original produce order. The following
+configuration properties are adjusted automatically (if not modified by the
+user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must
+be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),
 acks=all, queuing.strategy=fifo.
 
 #### `timeout`
@@ -184,20 +184,20 @@ The connection and read timeout for the replication stream.
 * Dynamic: No
 * Default: `""`
 
-The initial GTID position from where the replication is started. By default the\
-replication is started from the beginning. The value of this parameter is only\
-used if no previously replicated events with GTID positions can be retrieved\
+The initial GTID position from where the replication is started. By default the
+replication is started from the beginning. The value of this parameter is only
+used if no previously replicated events with GTID positions can be retrieved
 from Kafka.
 
-Starting in MaxScale 24.02, the special values `newest` and `oldest` can be\
+Starting in MaxScale 24.02, the special values `newest` and `oldest` can be
 used:
 
-* `newest` uses the current value of `@@gtid_binlog_pos` as the GTID where the\
+* `newest` uses the current value of `@@gtid_binlog_pos` as the GTID where the
   replication is started from.
-* `oldest` uses the oldest binlog that's available in `SHOW BINARY LOGS` and\
+* `oldest` uses the oldest binlog that's available in `SHOW BINARY LOGS` and
   then extracting the oldest GTID from it with `SHOW BINLOG EVENTS`.
 
-Once the replication has started and a GTID position has been recorded, this\
+Once the replication has started and a GTID position has been recorded, this
 parameter will be ignored. To reset the recorded GTID position, delete the`current_gtid.txt` file located in `/var/lib/maxscale/<SERVICE>/` where`<SERVICE>` is the name of the KafkaCDC service.
 
 #### `server_id`
@@ -207,8 +207,8 @@ parameter will be ignored. To reset the recorded GTID position, delete the`curre
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
-used when replicating from the primary in direct replication mode. The default\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
+used when replicating from the primary in direct replication mode. The default
 value is 1234. This parameter was added in MaxScale 2.5.7.
 
 #### `match`
@@ -222,13 +222,13 @@ Only include data from tables that match this pattern.
 
 For example, if configured with `match=accounts[.].*`, only data from the`accounts` database is sent to Kafka.
 
-The pattern is matched against the combined database and table name separated by\
-a period. This means that the event for the table `t1` in the `test` database\
-would appear as `test.t1`. The behavior is the same even if the database or the\
-table name contains a period. This means that an event for the `test.table`\
+The pattern is matched against the combined database and table name separated by
+a period. This means that the event for the table `t1` in the `test` database
+would appear as `test.t1`. The behavior is the same even if the database or the
+table name contains a period. This means that an event for the `test.table`
 table in the `my.data` database would appear as `my.data.test.table`.
 
-Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are\
+Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are
 filtered out using the `exclude` parameter.
 
 ```
@@ -253,11 +253,11 @@ exclude=db1 [.](accounts|users)
 
 Exclude data from tables that match this pattern.
 
-For example, if configured with `exclude=mydb[.].*`, all data from the tables in\
+For example, if configured with `exclude=mydb[.].*`, all data from the tables in
 the `mydb` database is not sent to Kafka.
 
-The pattern matching works the same way for both of the `exclude` and `match`\
-parameters. See [match](mariadb-maxscale-2402-maxscale-2402-kafkacdc.md#match) for an explanation on how the patterns are\
+The pattern matching works the same way for both of the `exclude` and `match`
+parameters. See [match](mariadb-maxscale-2402-maxscale-2402-kafkacdc.md#match) for an explanation on how the patterns are
 matched against the database and table names.
 
 #### `cooperative_replication`
@@ -267,22 +267,22 @@ matched against the database and table names.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
+Controls whether multiple instances cooperatively replicate from the same
 cluster. This is a boolean parameter and is disabled by default. It was added in\
 MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`), the\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`), the
 replication is only active if the monitor owns the cluster it is monitoring.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID that was delivered\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID that was delivered
 to Kafka.
 
-This means that multiple MaxScale instances can replicate from the same set of\
-servers and the event is only processed once. This feature does not provide\
-exactly-once semantics for the Kafka event delivery. However, it does provide\
-high-availability for the `kafkacdc` instances which allows automated failover\
+This means that multiple MaxScale instances can replicate from the same set of
+servers and the event is only processed once. This feature does not provide
+exactly-once semantics for the Kafka event delivery. However, it does provide
+high-availability for the `kafkacdc` instances which allows automated failover
 between multiple MaxScale instances.
 
 #### `send_schema`
@@ -292,12 +292,12 @@ between multiple MaxScale instances.
 * Dynamic: Yes
 * Default: true
 
-Send JSON schema object into the stream whenever the table schema changes. These\
-events, as described [here](mariadb-maxscale-2402-maxscale-2402-kafkacdc.md#overview), can be used to detect whenever the\
+Send JSON schema object into the stream whenever the table schema changes. These
+events, as described [here](mariadb-maxscale-2402-maxscale-2402-kafkacdc.md#overview), can be used to detect whenever the
 format of the data being sent changes.
 
-If this information in these schema change events is not needed or the code that\
-processes the Kafka stream can't handle them, they can be disabled with this\
+If this information in these schema change events is not needed or the code that
+processes the Kafka stream can't handle them, they can be disabled with this
 parameter.
 
 #### `read_gtid_from_kafka`
@@ -307,10 +307,10 @@ parameter.
 * Dynamic: No
 * Default: `true`
 
-On startup, the latest GTID is by default read from the Kafka cluster. This\
+On startup, the latest GTID is by default read from the Kafka cluster. This
 makes it possible to recover the replication position stored by another\
-MaxScale. Sometimes this is not desirable and the GTID should only be read from\
-the local file or started anew. Examples of these are when the GTIDs are reset\
+MaxScale. Sometimes this is not desirable and the GTID should only be read from
+the local file or started anew. Examples of these are when the GTIDs are reset
 or the replication topology has changed.
 
 #### `kafka_ssl`
@@ -320,7 +320,7 @@ or the replication topology has changed.
 * Dynamic: No
 * Default: `false`
 
-Enable SSL for Kafka connections. This is a boolean parameter and is disabled by\
+Enable SSL for Kafka connections. This is a boolean parameter and is disabled by
 default.
 
 #### `kafka_ssl_ca`
@@ -330,7 +330,7 @@ default.
 * Dynamic: No
 * Default: `""`
 
-Path to the certificate authority file in PEM format. If this is not provided,\
+Path to the certificate authority file in PEM format. If this is not provided,
 the default system certificates will be used.
 
 #### `kafka_ssl_cert`
@@ -342,8 +342,8 @@ the default system certificates will be used.
 
 Path to the public certificate in PEM format.
 
-The client must provide a certificate if the Kafka server performs authentication\
-of the client certificates. This feature is enabled by default in Kafka and is\
+The client must provide a certificate if the Kafka server performs authentication
+of the client certificates. This feature is enabled by default in Kafka and is
 controlled by [ssl.endpoint.identification.algorithm](https://kafka.apache.org/documentation/#brokerconfigs_ssl.endpoint.identification.algorithm).
 
 If `kafka_ssl_cert` is provided, `kafka_ssl_key` must also be provided.
@@ -389,8 +389,8 @@ If `kafka_sasl_password` is provided, `kafka_sasl_user` must also be provided.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-The SASL mechanism used. The default value is `PLAIN` which uses plaintext\
-authentication. It is recommended to enable SSL whenever plaintext\
+The SASL mechanism used. The default value is `PLAIN` which uses plaintext
+authentication. It is recommended to enable SSL whenever plaintext
 authentication is used.
 
 Allowed values are:
@@ -404,7 +404,7 @@ Kafka broker.
 
 ### Example Configuration
 
-The following configuration defines the minimal setup for streaming replication\
+The following configuration defines the minimal setup for streaming replication
 events from MariaDB into Kafka as JSON:
 
 ```
@@ -436,8 +436,8 @@ topic=my-cdc-topic
 
 ### Limitations
 
-* The KafkaCDC module provides at-least-once semantics for the generated\
-  events. This means that each replication event is delivered to kafka at least\
+* The KafkaCDC module provides at-least-once semantics for the generated
+  events. This means that each replication event is delivered to kafka at least
   once but there can be duplicate events in case of failures.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-kafkaimporter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-kafkaimporter.md
@@ -3,8 +3,8 @@
 ### Overview
 
 The KafkaImporter module reads messages from Kafka and streams them into a\
-MariaDB server. The messages are inserted into a table designated by either the\
-topic name or the message key (see [table\_name\_in](mariadb-maxscale-2402-maxscale-2402-kafkaimporter.md#table_name_in) for\
+MariaDB server. The messages are inserted into a table designated by either the
+topic name or the message key (see [table\_name\_in](mariadb-maxscale-2402-maxscale-2402-kafkaimporter.md#table_name_in) for
 details). By default the table will be automatically created with the following\
 SQL:
 
@@ -15,31 +15,31 @@ CREATE TABLE IF NOT EXISTS my_table (
 );
 ```
 
-The payload of the message is inserted into the `data` field from which the `id`\
-field is calculated. The payload must be a valid JSON object and it must either\
-contain a unique `_id` field or it must not exist or the value must be a JSON\
-null. This is similar to the MongoDB document format where the `_id` field is\
+The payload of the message is inserted into the `data` field from which the `id`
+field is calculated. The payload must be a valid JSON object and it must either
+contain a unique `_id` field or it must not exist or the value must be a JSON
+null. This is similar to the MongoDB document format where the `_id` field is
 the primary key of the document collection.
 
-If a message is read from Kafka and the insertion into the table fails due to a\
-violation of one of the constraints, the message is ignored. Similarly, messages\
-with duplicate `_id` value are also ignored: this is done to avoid inserting the\
-same document multiple times whenever the connection to either Kafka or MariaDB\
+If a message is read from Kafka and the insertion into the table fails due to a
+violation of one of the constraints, the message is ignored. Similarly, messages
+with duplicate `_id` value are also ignored: this is done to avoid inserting the
+same document multiple times whenever the connection to either Kafka or MariaDB
 is lost.
 
-The limitations on the data can be removed by either creating the table before\
-the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`\
-does nothing, or by altering the structure of the existing table. The minimum\
-requirement that must be met is that the table contains the `data` field to\
+The limitations on the data can be removed by either creating the table before
+the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`
+does nothing, or by altering the structure of the existing table. The minimum
+requirement that must be met is that the table contains the `data` field to
 which string values can be inserted into.
 
-The database server where the data is inserted is chosen from the set of servers\
-available to the service. The first server labeled as the `Master` with the best\
+The database server where the data is inserted is chosen from the set of servers
+available to the service. The first server labeled as the `Master` with the best
 rank will be chosen. This means that a monitor must be configured for the\
 MariaDB server where the data is to be inserted.
 
-In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 24.08.2\
-the `_id` field is not required to be present. Older versions of MaxScale used\
+In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 24.08.2
+the `_id` field is not required to be present. Older versions of MaxScale used
 the following SQL where the `_id` field was mandatory:
 
 ```
@@ -80,9 +80,9 @@ The comma separated list of topics to subscribe to.
 * Dynamic: Yes
 * Default: `100`
 
-Maximum number of uncommitted records. The KafkaImporter will buffer records\
-into batches and commit them once either enough records are gathered (controlled\
-by this parameter) or when the KafkaImporter goes idle. Any uncommitted records\
+Maximum number of uncommitted records. The KafkaImporter will buffer records
+into batches and commit them once either enough records are gathered (controlled
+by this parameter) or when the KafkaImporter goes idle. Any uncommitted records
 will be read again if a reconnection to either Kafka or MariaDB occurs.
 
 #### `kafka_sasl_mechanism`
@@ -93,7 +93,7 @@ will be read again if a reconnection to either Kafka or MariaDB occurs.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-SASL mechanism to use. The Kafka broker must be configured with the same\
+SASL mechanism to use. The Kafka broker must be configured with the same
 authentication scheme.
 
 #### `kafka_sasl_user`
@@ -112,7 +112,7 @@ SASL username used for authentication. If this parameter is defined,`kafka_sasl_
 * Dynamic: Yes
 * Default: `""`
 
-SASL password for the user. If this parameter is defined, `kafka_sasl_user` must\
+SASL password for the user. If this parameter is defined, `kafka_sasl_user` must
 also be provided.
 
 #### `kafka_ssl`
@@ -131,7 +131,7 @@ Enable SSL for Kafka connections.
 * Dynamic: Yes
 * Default: `""`
 
-SSL Certificate Authority file in PEM format. If this parameter is not\
+SSL Certificate Authority file in PEM format. If this parameter is not
 defined, the system default CA certificate is used.
 
 #### `kafka_ssl_cert`
@@ -165,14 +165,14 @@ The Kafka message part that is used to locate the table to insert the data into.
 Enumeration Values:
 
 * `topic`: The topic named is used as the fully qualified table name.
-* `key`: The message key is used as the fully qualified table name. If the Kafka\
+* `key`: The message key is used as the fully qualified table name. If the Kafka
   message does not have a key, the message is ignored.
 
-For example, all messages with a fully qualified table name of `my_db.my_table`\
-will be inserted into the table `my_table` located in the `my_db` database. If\
-the table or database names have special characters that must be escaped to make\
-them valid identifiers, the name must also contain those escape characters. For\
-example, to insert into a table named `my table` in the database `my database`,\
+For example, all messages with a fully qualified table name of `my_db.my_table`
+will be inserted into the table `my_table` located in the `my_db` database. If
+the table or database names have special characters that must be escaped to make
+them valid identifiers, the name must also contain those escape characters. For
+example, to insert into a table named `my table` in the database `my database`,
 the name would be:
 
 ```
@@ -197,20 +197,20 @@ Timeout for both Kafka and MariaDB network communication.
 
 The storage engine used for tables that are created by the KafkaImporter.
 
-This defines the `ENGINE` table option and must be the name of a valid storage\
-engine in MariaDB. When the storage engine is something other than `InnoDB`, the\
+This defines the `ENGINE` table option and must be the name of a valid storage
+engine in MariaDB. When the storage engine is something other than `InnoDB`, the
 table is created without the generated column and the check constraints:
 
 ```
 CREATE TABLE IF NOT EXISTS my_table (data JSON NOT NULL);
 ```
 
-This is done to avoid conflicts where the custom engine does not support all the\
+This is done to avoid conflicts where the custom engine does not support all the
 features that InnoDB supports.
 
 ### Limitations
 
-* The backend servers used by this service must be MariaDB version 10.2 or\
+* The backend servers used by this service must be MariaDB version 10.2 or
   newer.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-mirror.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-mirror.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-The `mirror` router is designed for data consistency and database behavior\
-verification during system upgrades. It allows statement duplication to multiple\
+The `mirror` router is designed for data consistency and database behavior
+verification during system upgrades. It allows statement duplication to multiple
 servers in a manner similar to that of the [Tee filter](../maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-tee-filter.md) with exporting of collected query metrics.
 
-For each executed query the router exports a JSON object that describes the\
+For each executed query the router exports a JSON object that describes the
 query results and has the following fields:
 
 | Key       | Description                                              |
@@ -17,7 +17,7 @@ query results and has the following fields:
 | query\_id | Query sequence number, starts from 1                     |
 | results   | Array of query result objects                            |
 
-The objects in the `results` array describe an individual query result and have\
+The objects in the `results` array describe an individual query result and have
 the following fields:
 
 | Key      | Description                                |
@@ -37,12 +37,12 @@ the following fields:
 * Mandatory: Yes
 * Dynamic: Yes
 
-The main target from which results are returned to the client. This is a\
+The main target from which results are returned to the client. This is a
 mandatory parameter and must define one of the targets configured in the`targets` parameter of the service.
 
-If the connection to the main target cannot be created or is lost mid-session,\
-the client connection will be closed. Connection failures to other targets are\
-not fatal errors and any open connections to them will be closed. The router\
+If the connection to the main target cannot be created or is lost mid-session,
+the client connection will be closed. Connection failures to other targets are
+not fatal errors and any open connections to them will be closed. The router
 does not create new connections after the initial connections are created.
 
 #### `exporter`
@@ -52,7 +52,7 @@ does not create new connections after the initial connections are created.
 * Dynamic: Yes
 * Values: `log`, `file`, `kafka`
 
-The exporter where the data is exported. This is a mandatory parameter. Possible\
+The exporter where the data is exported. This is a mandatory parameter. Possible
 values are:
 
 * `log`
@@ -60,7 +60,7 @@ values are:
 * `file`
 * Exports metrics to a file. Configured with the [file](mariadb-maxscale-2402-maxscale-2402-mirror.md#file) parameter.
 * `kafka`
-* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2402-maxscale-2402-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2402-maxscale-2402-mirror.md#kafka_topic)\
+* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2402-maxscale-2402-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2402-maxscale-2402-mirror.md#kafka_topic)
   parameters.
 
 #### `file`
@@ -70,12 +70,12 @@ values are:
 * Mandatory: No
 * Dynamic: Yes
 
-The output file where the metrics will be written. The file must be writable by\
+The output file where the metrics will be written. The file must be writable by
 the user that is running MaxScale, usually the `maxscale` user.
 
-When the `file` parameter is altered at runtime, the old file is closed before\
-the new file is opened. This makes it a convenient way of rotating the file\
-where the metrics are exported. Note that the file name alteration must change\
+When the `file` parameter is altered at runtime, the old file is closed before
+the new file is opened. This makes it a convenient way of rotating the file
+where the metrics are exported. Note that the file name alteration must change
 the value for it to take effect.
 
 This is a mandatory parameter when configured with `exporter=file`.
@@ -87,7 +87,7 @@ This is a mandatory parameter when configured with `exporter=file`.
 * Mandatory: No
 * Dynamic: Yes
 
-The Kafka broker list. Must be given as a comma-separated list of broker hosts\
+The Kafka broker list. Must be given as a comma-separated list of broker hosts
 with optional ports in `host:port` format.
 
 This is a mandatory parameter when configured with `exporter=kafka`.
@@ -114,12 +114,12 @@ This is a mandatory parameter when configured with `exporter=kafka`.
 What to do when a backend network connection fails. Accepted values are:
 
 * `ignore`
-* Ignore the failing backend if it's not the backend that the `main` parameter\
+* Ignore the failing backend if it's not the backend that the `main` parameter
   points to.
 * `close`
 * Close the client connection when the first backend fails.
 
-This parameter was added in MaxScale 6.0. Older versions always ignored\
+This parameter was added in MaxScale 6.0. Older versions always ignored
 failing backends.
 
 #### `report`
@@ -137,7 +137,7 @@ When to report the result of the queries. Accepted values are:
 * `on_conflict`
 * Only report when one or more backends returns a conflicting result.
 
-This parameter was added in MaxScale 6.0. Older versions always reported the\
+This parameter was added in MaxScale 6.0. Older versions always reported the
 result.
 
 ### Example Configuration
@@ -182,8 +182,8 @@ port=3306
 * Broken network connections are not recreated.
 * Prepared statements are not supported.
 * Contents of non-SQL statements are not added to the exported metrics.
-* Data synchronization in dynamic environments (e.g. when replication is in use)\
-  is not guaranteed. This means that result mismatches can be reported when the\
+* Data synchronization in dynamic environments (e.g. when replication is in use)
+  is not guaranteed. This means that result mismatches can be reported when the
   data is only eventually consistent.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readconnroute.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readconnroute.md
@@ -1,29 +1,29 @@
 # MaxScale 24.02 Readconnroute
 
-This document provides an overview of the **readconnroute** router module\
-and its intended use case scenarios. It also displays all router\
+This document provides an overview of the **readconnroute** router module
+and its intended use case scenarios. It also displays all router
 configuration parameters with their descriptions.
 
 ### Overview
 
-The readconnroute router provides simple and lightweight load balancing\
-across a set of servers. The router can also be configured to balance\
+The readconnroute router provides simple and lightweight load balancing
+across a set of servers. The router can also be configured to balance
 connections based on a weighting parameter defined in the server's section.
 
 Note that \*_readconnroute_ balances _connections_ and not _statements_.\
-When a client connects, the router selects a server based upon the router\
-configuration and current server load, but the single created connection\
-is fixed and will not be changed for the duration of the session. If the\
-connection between MaxScale and the server breaks, the connection cannot\
-be re-established and the session will be closed. The fact that the server\
+When a client connects, the router selects a server based upon the router
+configuration and current server load, but the single created connection
+is fixed and will not be changed for the duration of the session. If the
+connection between MaxScale and the server breaks, the connection cannot
+be re-established and the session will be closed. The fact that the server
 is fixed when the client connects also means that routing hints are ignored.
 
-**Warning:** `readconnroute` will not prevent writes from being done even if you\
-define `router_options=slave`. The client application is responsible for\
-making sure that it only performs read-only queries in such\
-cases. `readconnroute` is simple by design: it selects a server for each\
-client connection and routes all queries there. If something more complex is\
-required, the [readwritesplit](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md) router is usually the right\
+**Warning:** `readconnroute` will not prevent writes from being done even if you
+define `router_options=slave`. The client application is responsible for
+making sure that it only performs read-only queries in such
+cases. `readconnroute` is simple by design: it selects a server for each
+client connection and routes all queries there. If something more complex is
+required, the [readwritesplit](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md) router is usually the right
 choice.
 
 ### Configuration
@@ -38,8 +38,8 @@ For more details about the standard service parameters, refer to the [Configurat
 * Values: `master`, `slave`, `synced`, `running`
 * Default: `running`
 
-**`router_options`** can contain a comma separated list of valid server\
-roles. These roles are used as the valid types of servers the router will\
+**`router_options`** can contain a comma separated list of valid server
+roles. These roles are used as the valid types of servers the router will
 form connections to when new sessions are created.
 
 Examples:
@@ -58,14 +58,14 @@ Here is a list of all possible values for the `router_options`.
 | synced  | A Galera cluster node which is in a synced state with the cluster.                                                                                                                                                           |
 | running | A server that is up and running. All servers that MariaDB MaxScale can connect to are labeled as running.                                                                                                                    |
 
-If no `router_options` parameter is configured in the service definition,\
-the router will use the default value of `running`. This means that it will\
-load balance connections across all running servers defined in the `servers`\
+If no `router_options` parameter is configured in the service definition,
+the router will use the default value of `running`. This means that it will
+load balance connections across all running servers defined in the `servers`
 parameter of the service.
 
-When a connection is being created and the candidate server is being chosen,\
-the list of servers is processed in from first entry to last. This means\
-that if two servers with equal weight and status are found, the one that's\
+When a connection is being created and the candidate server is being chosen,
+the list of servers is processed in from first entry to last. This means
+that if two servers with equal weight and status are found, the one that's
 listed first in the _servers_ parameter for the service is chosen.
 
 #### `master_accept_reads`
@@ -76,8 +76,8 @@ listed first in the _servers_ parameter for the service is chosen.
 * Default: true
 
 This option can be used to prevent queries from being sent to the current primary.\
-If `router_options` does not contain `master`, the readconnroute instance is\
-usually meant for reading. Setting `master_accept_reads=false` excludes the primary\
+If `router_options` does not contain `master`, the readconnroute instance is
+usually meant for reading. Setting `master_accept_reads=false` excludes the primary
 from server selection (and thus from receiving reads).
 
 If `router_options` contains `master`, the setting of `master_accept_reads` has no effect.
@@ -91,22 +91,22 @@ By default `master_accept_reads=true`.
 * Dynamic: Yes
 * Default: 0s
 
-The maximum acceptable replication lag. The value is in seconds and is specified\
-as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). The\
+The maximum acceptable replication lag. The value is in seconds and is specified
+as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). The
 default value is `0s`, which means that the lag is ignored.
 
-The replication lag of a server must be less than the configured value in order\
-for it to be used for routing. To configure the router to not allow any lag, use\
+The replication lag of a server must be less than the configured value in order
+for it to be used for routing. To configure the router to not allow any lag, use
 the smallest duration larger than 0, that is, `max_replication_lag=1s`.
 
 ### Examples
 
-The most common use for the readconnroute is to provide either a read or\
-write port for an application. This provides a more lightweight routing\
-solution than the more complex readwritesplit router but requires the\
+The most common use for the readconnroute is to provide either a read or
+write port for an application. This provides a more lightweight routing
+solution than the more complex readwritesplit router but requires the
 application to be able to use distinct write and read ports.
 
-To configure a read-only service that tolerates primary failures, we first\
+To configure a read-only service that tolerates primary failures, we first
 need to add a new section into the configuration file.
 
 ```
@@ -117,11 +117,11 @@ servers=replica1,replica2,replica3
 router_options=slave
 ```
 
-Here the `router_options` designates replicas as the only valid server\
-type. With this configuration, the queries are load balanced across the\
+Here the `router_options` designates replicas as the only valid server
+type. With this configuration, the queries are load balanced across the
 replica servers.
 
-For more complex examples of the readconnroute router, take a look at the\
+For more complex examples of the readconnroute router, take a look at the
 examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
 
 ### Router Diagnostics

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
@@ -1,52 +1,52 @@
 # MaxScale 24.02 Readwritesplit
 
-This document provides a short overview of the **readwritesplit** router module\
-and its intended use case scenarios. It also displays all router configuration\
-parameters with their descriptions. A list of current limitations of the module\
+This document provides a short overview of the **readwritesplit** router module
+and its intended use case scenarios. It also displays all router configuration
+parameters with their descriptions. A list of current limitations of the module
 is included and use examples are provided.
 
 ### Overview
 
-The **readwritesplit** router is designed to increase the read-only processing\
-capability of a cluster while maintaining consistency. This is achieved by\
-splitting the query load into read and write queries. Read queries, which do not\
-modify data, are spread across multiple nodes while all write queries will be\
+The **readwritesplit** router is designed to increase the read-only processing
+capability of a cluster while maintaining consistency. This is achieved by
+splitting the query load into read and write queries. Read queries, which do not
+modify data, are spread across multiple nodes while all write queries will be
 sent to a single node.
 
-The router is designed to be used with a traditional Primary-Replica replication\
-cluster. It automatically detects changes in the primary server and will use the\
-current primary server of the cluster. With a Galera cluster, one can achieve a\
+The router is designed to be used with a traditional Primary-Replica replication
+cluster. It automatically detects changes in the primary server and will use the
+current primary server of the cluster. With a Galera cluster, one can achieve a
 resilient setup and easy primary failover by using one of the Galera nodes as a\
-Write-Primary node, where all write queries are routed, and spreading the read\
+Write-Primary node, where all write queries are routed, and spreading the read
 load over all the nodes.
 
 ### Interaction with servers in `Maintenance` and `Draining` state
 
-When a server that readwritesplit uses is put into maintenance mode, any ongoing\
-requests are allowed to finish before the connection is closed. If the server\
-that is put into maintenance mode is a primary, open transaction are allowed to\
-complete before the connection is closed. Note that this means neither idle\
-session nor long-running transactions will be closed by readwritesplit. To\
+When a server that readwritesplit uses is put into maintenance mode, any ongoing
+requests are allowed to finish before the connection is closed. If the server
+that is put into maintenance mode is a primary, open transaction are allowed to
+complete before the connection is closed. Note that this means neither idle
+session nor long-running transactions will be closed by readwritesplit. To
 forcefully close the connections, use the following command:
 
 ```
 maxctrl set server <server> maintenance --force
 ```
 
-If a server is put into the `Draining` state while a connection is open, the\
-connection will be used normally. Whenever a new connection needs to be created,\
-whether that be due to a network error or when a new session being opened, only\
+If a server is put into the `Draining` state while a connection is open, the
+connection will be used normally. Whenever a new connection needs to be created,
+whether that be due to a network error or when a new session being opened, only
 servers that are neither `Draining` nor `Drained` will be used.
 
 ### Configuration
 
-Readwritesplit router-specific settings are specified in the configuration file\
-of MariaDB MaxScale in its specific section. The section can be freely named but\
+Readwritesplit router-specific settings are specified in the configuration file
+of MariaDB MaxScale in its specific section. The section can be freely named but
 the name is used later as a reference in a listener section.
 
 For more details about the standard service parameters, refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
 
-Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be\
+Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be
 taken into use by new sessions.
 
 ### Parameters
@@ -58,45 +58,45 @@ taken into use by new sessions.
 * Dynamic: Yes
 * Default: 255
 
-`max_slave_connections` sets the maximum number of replicas a router session uses\
-at any moment. The default is to use at most 255 replica connections per client\
-connection. In older versions the default was to use all available replicas with\
+`max_slave_connections` sets the maximum number of replicas a router session uses
+at any moment. The default is to use at most 255 replica connections per client
+connection. In older versions the default was to use all available replicas with
 no limit.
 
 For MaxScale 2.5.12 and newer, the minimum value is 0.
 
-For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions\
-suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that\
-causes the parameter to accept any values but only function when a value greater\
+For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions
+suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that
+causes the parameter to accept any values but only function when a value greater
 than one was given.
 
-Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be\
+Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be
 removed in a future release.
 
-For example, if you have configured MaxScale with one primary and three replicas\
-and set `max_slave_connections=2`, for each client connection a connection to\
-the primary and two replica connections would be opened. The read query load\
-balancing is then done between these two replicas and writes are sent to the\
+For example, if you have configured MaxScale with one primary and three replicas
+and set `max_slave_connections=2`, for each client connection a connection to
+the primary and two replica connections would be opened. The read query load
+balancing is then done between these two replicas and writes are sent to the
 primary.
 
-By tuning this parameter, you can control how dynamic the load balancing is at\
-the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of\
-possible replica servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more\
-resources but load balancing will almost always give the best single query\
+By tuning this parameter, you can control how dynamic the load balancing is at
+the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of
+possible replica servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more
+resources but load balancing will almost always give the best single query
 response time and performance. Longer sessions are less affected by a high`max_slave_connections` as the relative cost of opening a connection is lower.
 
 **Behavior of `max_slave_connections=0`**
 
-When readwritesplit is configured with `max_slave_connections=0`, readwritesplit\
-will behave slightly differently in that it will route all reads to the current\
-master server. This is a convenient way to force all of the traffic to go to a\
-single node while still being able to leverage the replay and reconnection\
+When readwritesplit is configured with `max_slave_connections=0`, readwritesplit
+will behave slightly differently in that it will route all reads to the current
+master server. This is a convenient way to force all of the traffic to go to a
+single node while still being able to leverage the replay and reconnection
 features of readwritesplit.
 
-In this mode, the behavior of `master_failure_mode=fail_on_write` also changes\
-slightly. If the current `Master` server fails and a read is done when there's\
-no other `Master` server available, the connection will be closed. This is done\
-to prevent an extra slave connection from being opened that would not be closed\
+In this mode, the behavior of `master_failure_mode=fail_on_write` also changes
+slightly. If the current `Master` server fails and a read is done when there's
+no other `Master` server available, the connection will be closed. This is done
+to prevent an extra slave connection from being opened that would not be closed
 if a new `Master` server would arrive.
 
 #### `slave_connections`
@@ -106,17 +106,17 @@ if a new `Master` server would arrive.
 * Dynamic: Yes
 * Default: 255
 
-This parameter controls how many replica connections each new session starts\
+This parameter controls how many replica connections each new session starts
 with. The default value is 255 which is the same as the default value of`max_slave_connections`.
 
-In contrast to `max_slave_connections`, `slave_connections` serves as a\
-soft limit on how many replica connections are created. The number of replica\
-connections can exceed `slave_connections` if the load balancing algorithm\
+In contrast to `max_slave_connections`, `slave_connections` serves as a
+soft limit on how many replica connections are created. The number of replica
+connections can exceed `slave_connections` if the load balancing algorithm
 finds an unconnected replica server better than all other replicas.
 
-Setting this parameter to 1 allows faster connection creation and improved\
-resource usage due to the smaller amount of initial backend\
-connections. It is recommended to use `slave_connections=1` when the\
+Setting this parameter to 1 allows faster connection creation and improved
+resource usage due to the smaller amount of initial backend
+connections. It is recommended to use `slave_connections=1` when the
 lifetime of the client connections is short.
 
 #### `max_replication_lag`
@@ -126,38 +126,38 @@ lifetime of the client connections is short.
 * Dynamic: Yes
 * Default: 0s
 
-**NOTE** Up until 23.02, this parameter was called `max_slave_replication_lag`,\
+**NOTE** Up until 23.02, this parameter was called `max_slave_replication_lag`,
 which has been deprecated but still works as an alias for `max_replication_lag`.
 
-Specify how many seconds a replica is allowed to be behind the primary. The lag of\
-a replica must be less than the configured value in order for it to be used for\
+Specify how many seconds a replica is allowed to be behind the primary. The lag of
+a replica must be less than the configured value in order for it to be used for
 routing. If set to `0s` (the default value), the feature is disabled.
 
-The replica lag must be less than `max_replication_lag`. This means that it\
-is possible to define, with `max_replication_lag=1s`, that all replicas must\
+The replica lag must be less than `max_replication_lag`. This means that it
+is possible to define, with `max_replication_lag=1s`, that all replicas must
 be up to date in order for them to be used for routing.
 
-Note that this feature does not guarantee that writes done on the primary are\
-visible for reads done on the replica. This is mainly due to the method of\
+Note that this feature does not guarantee that writes done on the primary are
+visible for reads done on the replica. This is mainly due to the method of
 replication lag measurement. For a feature that guarantees this, refer to [causal\_reads](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#causal_reads).
 
-The lag is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). Note that since\
-the granularity of the lag is seconds, a lag specified in milliseconds will be\
+The lag is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). Note that since
+the granularity of the lag is seconds, a lag specified in milliseconds will be
 rejected, even if the duration is longer than a second.
 
-The Readwritesplit-router does not detect the replication lag itself. A monitor\
-such as the MariaDB-monitor for a Primary-Replica cluster is required. This option\
-only affects Primary-Replica clusters. Galera clusters do not have a concept of\
-replica lag even if the application of write sets might have lag. When a server is\
-disqualified from routing because of replication lag, a warning is logged. Similarly,\
-when the server has caught up enough to be a valid routing target, another warning\
-is logged. These messages are only logged when a query is being routed and the\
+The Readwritesplit-router does not detect the replication lag itself. A monitor
+such as the MariaDB-monitor for a Primary-Replica cluster is required. This option
+only affects Primary-Replica clusters. Galera clusters do not have a concept of
+replica lag even if the application of write sets might have lag. When a server is
+disqualified from routing because of replication lag, a warning is logged. Similarly,
+when the server has caught up enough to be a valid routing target, another warning
+is logged. These messages are only logged when a query is being routed and the
 replication state changes.
 
-Starting with MaxScale versions 23.08.7, 24.02.3 and 24.08.1, readwritesplit\
-will discard connections to any servers that have excessive replication lag. The\
-connection will be discarded if a server is lagging behind by more than twice\
-the amount of `max_replication_lag` and the server is behind by more than 300\
+Starting with MaxScale versions 23.08.7, 24.02.3 and 24.08.1, readwritesplit
+will discard connections to any servers that have excessive replication lag. The
+connection will be discarded if a server is lagging behind by more than twice
+the amount of `max_replication_lag` and the server is behind by more than 300
 seconds (`replication lag > MAX(300, 2 * max_replication_lag)`).
 
 #### `use_sql_variables_in`
@@ -168,8 +168,8 @@ seconds (`replication lag > MAX(300, 2 * max_replication_lag)`).
 * Values: `master`, `all`
 * Default: `all`
 
-This parameter controls how `SELECT` statements that use SQL user variables are\
-handled. Here is an example of such a query that uses it to return an increasing\
+This parameter controls how `SELECT` statements that use SQL user variables are
+handled. Here is an example of such a query that uses it to return an increasing
 row number for a resultset:
 
 ```
@@ -177,31 +177,31 @@ SET @rownum := 0;
 SELECT @rownum := @rownum + 1 AS rownum, user, host FROM mysql.user;
 ```
 
-By default MaxScale will route both the `SET` and `SELECT` statements to all\
+By default MaxScale will route both the `SET` and `SELECT` statements to all
 nodes. Any future reads of the user variables can also be performed on any node.
 
 The possible values for this parameter are:
 
 * `all` (default)
-* Modifications to user variables inside `SELECT` statements as well as reads\
+* Modifications to user variables inside `SELECT` statements as well as reads
   of user variables are routed to all servers.\
-  Versions before MaxScale 22.08 returned an error if a user variable was\
-  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was\
-  used. MaxScale 22.08 will instead route the query to all servers and discard\
+  Versions before MaxScale 22.08 returned an error if a user variable was
+  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was
+  used. MaxScale 22.08 will instead route the query to all servers and discard
   the extra results.
 * `master`
-* Modifications to user variables inside `SELECT` statements as well as reads\
-  of user variables are routed to the primary server. This forces more of the\
-  traffic onto the primary server but it reduces the amount of data that is\
-  discarded for any `SELECT` statement that also modifies a user\
-  variable. With this mode, the state of user variables is not deterministic\
-  if they are modified inside of a `SELECT` statement. `SET` statements that\
+* Modifications to user variables inside `SELECT` statements as well as reads
+  of user variables are routed to the primary server. This forces more of the
+  traffic onto the primary server but it reduces the amount of data that is
+  discarded for any `SELECT` statement that also modifies a user
+  variable. With this mode, the state of user variables is not deterministic
+  if they are modified inside of a `SELECT` statement. `SET` statements that
   modify user variables are still routed to all servers.
 
-DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user\
-variables are still treated as writes and are only routed to the primary\
-server. For example, after the following query the value of `@myid` is no longer\
-the same on all servers and the `SELECT` statement can return different values\
+DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user
+variables are still treated as writes and are only routed to the primary
+server. For example, after the following query the value of `@myid` is no longer
+the same on all servers and the `SELECT` statement can return different values
 depending where it ends up being executed:
 
 ```
@@ -221,27 +221,27 @@ Allow the primary server to change mid-session. This feature requires that`disab
 
 Starting with MaxScale 24.02, if `disable_sescmd_history` is enabled,`master_reconnection` will be automatically disabled.
 
-When a readwritesplit session starts, it will pick a primary server as the\
-current primary server of that session. When `master_reconnection` is disabled,\
-when this primary server is lost or changes to another server, the connection\
+When a readwritesplit session starts, it will pick a primary server as the
+current primary server of that session. When `master_reconnection` is disabled,
+when this primary server is lost or changes to another server, the connection
 will be closed.
 
-When `master_reconnection` is enabled, readwritesplit can sometimes recover a\
+When `master_reconnection` is enabled, readwritesplit can sometimes recover a
 lost connection to the primary server. This largely depends on the value of`master_failure_mode`.
 
-With `master_failure_mode=fail_instantly`, the primary server is only allowed to\
-change to another server. This change must happen without a loss of the primary\
+With `master_failure_mode=fail_instantly`, the primary server is only allowed to
+change to another server. This change must happen without a loss of the primary
 server.
 
-With `master_failure_mode=fail_on_write`, the loss of the primary server is no\
-longer a fatal error: if a replacement primary server appears before any write\
-queries are received, readwritesplit will transparently reconnect to the new\
+With `master_failure_mode=fail_on_write`, the loss of the primary server is no
+longer a fatal error: if a replacement primary server appears before any write
+queries are received, readwritesplit will transparently reconnect to the new
 primary server.
 
-In both cases the change in the primary server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet\
+In both cases the change in the primary server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet
 been exceeded and the session does not have an open transaction.
 
-The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance\
+The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance
 without any risk to the consistency of the database.
 
 #### `slave_selection_criteria`
@@ -252,8 +252,8 @@ without any risk to the consistency of the database.
 * Values: `least_current_operations`, `adaptive_routing`, `least_behind_master`, `least_router_connections`, `least_global_connections`
 * Default: `least_current_operations`
 
-This option controls how the readwritesplit router chooses the replicas it\
-connects to and how the load balancing is done. The default behavior is to route\
+This option controls how the readwritesplit router chooses the replicas it
+connects to and how the load balancing is done. The default behavior is to route
 read queries to the replica server with the lowest amount of ongoing queries i.e.`least_current_operations`.
 
 The option syntax:
@@ -270,45 +270,45 @@ Where `<criteria>` is one of the following values.
 * `least_global_connections`, the replica with least connections from MariaDB MaxScale
 * `least_router_connections`, the replica with least connections from this service
 
-`least_current_operations` uses the current number of active operations\
-(i.e. SQL queries) as the load balancing metric and it optimizes for maximal\
-query throughput. Each query gets routed to the server with the least active\
+`least_current_operations` uses the current number of active operations
+(i.e. SQL queries) as the load balancing metric and it optimizes for maximal
+query throughput. Each query gets routed to the server with the least active
 operations which results in faster servers processing more traffic.
 
-`adaptive_routing` uses the server response time and current estimated server\
-load as the load balancing metric. The server that is estimated to finish an\
-additional query first is chosen. A modified average response time for each\
-server is continuously updated to allow slow servers at least some traffic and\
-quickly react to changes in server load conditions. This selection criteria is\
-designed for heterogeneous clusters: servers of differing hardware, differing\
-network distances, or when other loads are running on the servers (including a\
-backup). If the servers are queried by other clients than MaxScale, the load\
+`adaptive_routing` uses the server response time and current estimated server
+load as the load balancing metric. The server that is estimated to finish an
+additional query first is chosen. A modified average response time for each
+server is continuously updated to allow slow servers at least some traffic and
+quickly react to changes in server load conditions. This selection criteria is
+designed for heterogeneous clusters: servers of differing hardware, differing
+network distances, or when other loads are running on the servers (including a
+backup). If the servers are queried by other clients than MaxScale, the load
 caused by them is indirectly taken into account.
 
-`least_behind_master` uses the measured replication lag as the load balancing\
-metric. This means that servers that are more up-to-date are favored which\
-increases the likelihood of the data being read being up-to-date. However, this\
-is not as effective as `causal_reads` would be as there's no guarantee that\
-writes done by the same connection will be routed to a server that has\
+`least_behind_master` uses the measured replication lag as the load balancing
+metric. This means that servers that are more up-to-date are favored which
+increases the likelihood of the data being read being up-to-date. However, this
+is not as effective as `causal_reads` would be as there's no guarantee that
+writes done by the same connection will be routed to a server that has
 replicated those changes. The recommended approach is to use`LEAST_CURRENT_OPERATIONS` or `ADAPTIVE_ROUTING` in combination with`causal_reads`
 
-**NOTE**: `least_global_connections` and `least_router_connections` should not\
-be used, they are legacy options that exist only for backwards\
-compatibility. Using them will result in skewed load balancing as the algorithm\
-uses a metric that's too coarse (number of connections) to load balance\
+**NOTE**: `least_global_connections` and `least_router_connections` should not
+be used, they are legacy options that exist only for backwards
+compatibility. Using them will result in skewed load balancing as the algorithm
+uses a metric that's too coarse (number of connections) to load balance
 something that's finer (individual SQL queries).
 
-The `least_global_connections` and `least_router_connections` use the\
-connections from MariaDB MaxScale to the server, not the amount of connections\
+The `least_global_connections` and `least_router_connections` use the
+connections from MariaDB MaxScale to the server, not the amount of connections
 reported by the server itself.
 
-Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,\
-lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid\
+Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,
+lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid
 values.
 
-Starting with MaxScale 23.08.1, the legacy uppercase values have been\
-deprecated. All runtime modifications of the parameter will now be persisted in\
-lowercase. The uppercase values are still accepted but will be removed in a\
+Starting with MaxScale 23.08.1, the legacy uppercase values have been
+deprecated. All runtime modifications of the parameter will now be persisted in
+lowercase. The uppercase values are still accepted but will be removed in a
 future MaxScale release.
 
 #### `master_accept_reads`
@@ -318,13 +318,13 @@ future MaxScale release.
 * Dynamic: Yes
 * Default: false
 
-Enables the primary server to be used for reads. This is a useful option to\
-enable if you are using a small number of servers and wish to use the primary\
-for reads as well and the load on it does not reduce the write throughput of the\
+Enables the primary server to be used for reads. This is a useful option to
+enable if you are using a small number of servers and wish to use the primary
+for reads as well and the load on it does not reduce the write throughput of the
 cluster.
 
-By default, no reads are sent to the primary as long as there is a valid replica\
-server available. If no replicas are available, reads are sent to the primary\
+By default, no reads are sent to the primary as long as there is a valid replica
+server available. If no replicas are available, reads are sent to the primary
 regardless of the value of `master_accept_reads`.
 
 ```
@@ -339,15 +339,15 @@ master_accept_reads=true
 * Dynamic: Yes
 * Default: false
 
-When a client executes a multi-statement query, it will be treated as if it were\
-a DML statement and routed to the primary. If the option is enabled, all queries\
-after a multi-statement query will be routed to the primary to guarantee a\
+When a client executes a multi-statement query, it will be treated as if it were
+a DML statement and routed to the primary. If the option is enabled, all queries
+after a multi-statement query will be routed to the primary to guarantee a
 consistent session state.
 
-If the feature is disabled, queries are routed normally after a multi-statement\
+If the feature is disabled, queries are routed normally after a multi-statement
 query.
 
-**Warning:** Enable the strict mode only if you know that the clients will send\
+**Warning:** Enable the strict mode only if you know that the clients will send
 statements that cause inconsistencies in the session state.
 
 ```
@@ -362,7 +362,7 @@ strict_multi_stmt=true
 * Dynamic: Yes
 * Default: false
 
-Similar to `strict_multi_stmt`, this option allows all queries after a CALL\
+Similar to `strict_multi_stmt`, this option allows all queries after a CALL
 operation on a stored procedure to be routed to the primary.
 
 All warnings and restrictions that apply to `strict_multi_stmt` also apply to`strict_sp_calls`.
@@ -374,15 +374,15 @@ All warnings and restrictions that apply to `strict_multi_stmt` also apply to`st
 * Dynamic: Yes
 * Default: true (>= MaxScale 24.02), false (<= MaxScale 23.08)
 
-When `strict_tmp_tables` is disabled, all temporary tables are lost when a\
-reconnection of the primary node occurs. This means that if a reconnection to\
-the primary takes place, temporary tables might appear to disappear in the\
+When `strict_tmp_tables` is disabled, all temporary tables are lost when a
+reconnection of the primary node occurs. This means that if a reconnection to
+the primary takes place, temporary tables might appear to disappear in the
 middle of a connection.
 
-When `strict_tmp_tables` is enabled, reconnections are prevented as long as a\
-temporary tables exist. In this case if the primary node is lost and temporary\
-table exist, the session is closed. If a session creates temporary tables but\
-does not drop them, this behavior will effectively disable reconnections until\
+When `strict_tmp_tables` is enabled, reconnections are prevented as long as a
+temporary tables exist. In this case if the primary node is lost and temporary
+table exist, the session is closed. If a session creates temporary tables but
+does not drop them, this behavior will effectively disable reconnections until
 the session is closed.
 
 #### `master_failure_mode`
@@ -395,7 +395,7 @@ the session is closed.
 
 This option controls how the failure of a primary server is handled.
 
-The following table describes the values for this option and how they treat the\
+The following table describes the values for this option and how they treat the
 loss of a primary server.
 
 | Value            | Description                                                                                                                      |
@@ -404,22 +404,22 @@ loss of a primary server.
 | fail\_on\_write  | The client connection is closed if a write query is received when no primary is available.                                       |
 | error\_on\_write | If no primary is available and a write query is received, an error is returned stating that the connection is in read-only mode. |
 
-These also apply to new sessions created after the primary has failed. This means\
-that in `fail_on_write` or `error_on_write` mode, connections are accepted as\
+These also apply to new sessions created after the primary has failed. This means
+that in `fail_on_write` or `error_on_write` mode, connections are accepted as
 long as replica servers are available.
 
-When configured with `fail_on_write` or `error_on_write`, sessions that are idle\
-will not be closed even if all backend connections for that session have\
-failed. This is done in the hopes that before the next query from the idle\
-session arrives, a reconnection to one of the replicas is made. However, this can\
-leave idle connections around unless the client application actively closes\
-them. To prevent this, use the [connection\_timeout](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+When configured with `fail_on_write` or `error_on_write`, sessions that are idle
+will not be closed even if all backend connections for that session have
+failed. This is done in the hopes that before the next query from the idle
+session arrives, a reconnection to one of the replicas is made. However, this can
+leave idle connections around unless the client application actively closes
+them. To prevent this, use the [connection\_timeout](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 parameter.
 
-**Note:** If `master_failure_mode` is set to `error_on_write` and the connection\
-to the primary is lost, by default, clients will not be able to execute write\
-queries without reconnecting to MariaDB MaxScale once a new primary is\
-available. If [master\_reconnection](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#master_reconnection) is enabled, the\
+**Note:** If `master_failure_mode` is set to `error_on_write` and the connection
+to the primary is lost, by default, clients will not be able to execute write
+queries without reconnecting to MariaDB MaxScale once a new primary is
+available. If [master\_reconnection](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#master_reconnection) is enabled, the
 session can recover if one of the replicas is promoted as the primary.
 
 #### `retry_failed_reads`
@@ -431,13 +431,13 @@ session can recover if one of the replicas is promoted as the primary.
 
 This option controls whether autocommit selects are retried in case of failure.
 
-When a simple autocommit select is being executed outside of a transaction and\
-the replica server where the query is being executed fails, readwritesplit can\
-retry the read on a replacement server. This makes the failure of a replica\
+When a simple autocommit select is being executed outside of a transaction and
+the replica server where the query is being executed fails, readwritesplit can
+retry the read on a replacement server. This makes the failure of a replica
 transparent to the client.
 
-If a part of the result was already delivered to the client, the query will not\
-be retried. The retrying of queries with partially delivered results is only\
+If a part of the result was already delivered to the client, the query will not
+be retried. The retrying of queries with partially delivered results is only
 possible when `transaction_replay` is enabled.
 
 #### `delayed_retry`
@@ -449,31 +449,31 @@ possible when `transaction_replay` is enabled.
 
 Retry queries over a period of time.
 
-When this feature is enabled, a failure to route a query due to a connection\
-problem will not immediately result in an error. The routing of the query is\
-delayed until either a valid candidate server is available or the retry timeout\
-is reached. If a candidate server becomes available before the timeout is\
-reached, the query is routed normally and no connection error is returned. If no\
-candidates are found and the timeout is exceeded, the router returns to normal\
+When this feature is enabled, a failure to route a query due to a connection
+problem will not immediately result in an error. The routing of the query is
+delayed until either a valid candidate server is available or the retry timeout
+is reached. If a candidate server becomes available before the timeout is
+reached, the query is routed normally and no connection error is returned. If no
+candidates are found and the timeout is exceeded, the router returns to normal
 behavior and returns an error.
 
-When combined with the `master_reconnection` parameter, failures of writes done\
-outside of transactions can be hidden from the client connection. This allows a\
+When combined with the `master_reconnection` parameter, failures of writes done
+outside of transactions can be hidden from the client connection. This allows a
 primary to be replaced while writes are being sent.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, `delayed_retry` will no longer attempt to retry a query if it was\
-already sent to the database. If a query is received while a valid target server\
-is not available, the execution of the query is delayed until a valid target is\
-found or the delayed retry timeout is hit. If a query was already sent, it will\
+24.08.1, `delayed_retry` will no longer attempt to retry a query if it was
+already sent to the database. If a query is received while a valid target server
+is not available, the execution of the query is delayed until a valid target is
+found or the delayed retry timeout is hit. If a query was already sent, it will
 not be replayed to prevent duplicate execution of statements.
 
-In older versions of MaxScale, duplicate execution of a statement can occur if\
-the connection to the server is lost or the server crashes but the server comes\
-back up before the timeout for the retrying is exceeded. At this point, if the\
-server managed to read the client's statement, it will be executed. For this\
+In older versions of MaxScale, duplicate execution of a statement can occur if
+the connection to the server is lost or the server crashes but the server comes
+back up before the timeout for the retrying is exceeded. At this point, if the
+server managed to read the client's statement, it will be executed. For this
 reason, it is recommended to only enable `delayed_retry` for older versions of\
-MaxScale when the possibility of duplicate statement execution is an acceptable\
+MaxScale when the possibility of duplicate statement execution is an acceptable
 risk.
 
 #### `delayed_retry_timeout`
@@ -485,10 +485,10 @@ risk.
 
 The duration to wait until an error is returned to the client when`delayed_retry` is enabled.
 
-The timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `transaction_replay`
@@ -500,20 +500,20 @@ even if the duration is longer than a second.
 
 Replay interrupted transactions.
 
-Enabling this parameter enables both `delayed_retry` and `master_reconnection`\
-and sets `master_failure_mode` to `fail_on_write`, thereby overriding any\
+Enabling this parameter enables both `delayed_retry` and `master_reconnection`
+and sets `master_failure_mode` to `fail_on_write`, thereby overriding any
 configured values for these parameters.
 
-When the server where the transaction is in progress fails, readwritesplit can\
-migrate the transaction to a replacement server. This can completely hide the\
+When the server where the transaction is in progress fails, readwritesplit can
+migrate the transaction to a replacement server. This can completely hide the
 failure of a primary node without any visible effects to the client.
 
 If no replacement node becomes available, the client connection is closed.
 
 To control how long a transaction replay can take, use`transaction_replay_timeout`.
 
-Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#transaction-replay-limitations) section for\
-a more detailed explanation of what should and should not be done with\
+Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#transaction-replay-limitations) section for
+a more detailed explanation of what should and should not be done with
 transaction replay.
 
 #### `transaction_replay_max_size`
@@ -523,19 +523,19 @@ transaction replay.
 * Dynamic: Yes
 * Default: 1 MiB
 
-The limit on transaction size for transaction replay in bytes. Any transaction\
-that exceeds this limit will not be replayed. The default value is 1 MiB. This\
-limit applies at a session level which means that the total peak memory\
-consumption can be `transaction_replay_max_size` times the number of client\
+The limit on transaction size for transaction replay in bytes. Any transaction
+that exceeds this limit will not be replayed. The default value is 1 MiB. This
+limit applies at a session level which means that the total peak memory
+consumption can be `transaction_replay_max_size` times the number of client
 connections.
 
-The amount of memory needed to store a particular transaction will be slightly\
-larger than the length in bytes of the SQL used in the transaction. If the limit\
+The amount of memory needed to store a particular transaction will be slightly
+larger than the length in bytes of the SQL used in the transaction. If the limit
 is ever exceeded, a message will be logged at the info level.
 
 The number of times that this limit has been exceeded is shown in`maxctrl show service` as `trx_max_size_exceeded`.
 
-Read [the configuration guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+Read [the configuration guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 for more details on size type parameters in MaxScale.
 
 #### `transaction_replay_attempts`
@@ -545,13 +545,13 @@ for more details on size type parameters in MaxScale.
 * Dynamic: Yes
 * Default: 5
 
-The upper limit on how many times a transaction replay is attempted before\
+The upper limit on how many times a transaction replay is attempted before
 giving up.
 
-A transaction replay failure can happen if the server where the transaction is\
-being replayed fails while the replay is in progress. In practice this parameter\
-controls how many server and network failures a single transaction replay\
-tolerates. If a transaction is replayed successfully, the counter for failed\
+A transaction replay failure can happen if the server where the transaction is
+being replayed fails while the replay is in progress. In practice this parameter
+controls how many server and network failures a single transaction replay
+tolerates. If a transaction is replayed successfully, the counter for failed
 attempts is reset.
 
 #### `transaction_replay_timeout`
@@ -561,27 +561,27 @@ attempts is reset.
 * Dynamic: Yes
 * Default: 30s (>= MaxScale 24.02), 0s (<= MaxScale 23.08)
 
-The time how long transactions are attempted for. To explicitly disable this\
+The time how long transactions are attempted for. To explicitly disable this
 feature, set the value to 0 seconds.
 
-The timeout is [a duration type](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+The timeout is [a duration type](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 and the value must include a unit for the duration.
 
-When `transaction_replay_timeout` is enabled, the time a transaction replay can\
-take is controlled solely by this parameter. This is a more convenient and\
-predictable method of controlling how long a transaction replay can be attempted\
+When `transaction_replay_timeout` is enabled, the time a transaction replay can
+take is controlled solely by this parameter. This is a more convenient and
+predictable method of controlling how long a transaction replay can be attempted
 before the connection is closed.
 
-If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set\
+If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set
 to the same value.
 
-Without `transaction_replay_timeout` the time how long a transaction can be\
-retried is controlled by `delayed_retry_timeout` and`transaction_replay_attempts`. This can result in a maximum replay time limit of`delayed_retry_timeout` multiplied by `transaction_replay_attempts`, by default\
-this is 50 seconds. The minimum replay time limit can be as low as`transaction_replay_attempts` seconds (5 seconds by default) in cases where the\
-connection fails after it was created. Usually this happens due to problems like\
+Without `transaction_replay_timeout` the time how long a transaction can be
+retried is controlled by `delayed_retry_timeout` and`transaction_replay_attempts`. This can result in a maximum replay time limit of`delayed_retry_timeout` multiplied by `transaction_replay_attempts`, by default
+this is 50 seconds. The minimum replay time limit can be as low as`transaction_replay_attempts` seconds (5 seconds by default) in cases where the
+connection fails after it was created. Usually this happens due to problems like
 the max\_connections limit being hit on the database server.
 
-`transaction_replay_timeout` is the recommended method of controlling the\
+`transaction_replay_timeout` is the recommended method of controlling the
 timeouts for transaction replay and is by default set to 30 seconds in MaxScale\
 24.02.
 
@@ -594,10 +594,10 @@ timeouts for transaction replay and is by default set to 30 seconds in MaxScale\
 
 Enable automatic retrying of transactions that end up in a deadlock.
 
-If this feature is enabled and a transaction returns a deadlock error\
-(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),\
-the transaction is automatically retried. If the retrying of the transaction\
-results in another deadlock error, it is retried until it either succeeds or a\
+If this feature is enabled and a transaction returns a deadlock error
+(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),
+the transaction is automatically retried. If the retrying of the transaction
+results in another deadlock error, it is retried until it either succeeds or a
 transaction checksum error is encountered.
 
 #### `transaction_replay_safe_commit`
@@ -607,19 +607,19 @@ transaction checksum error is encountered.
 * Dynamic: Yes
 * Default: true
 
-If a transaction is ending and the `COMMIT` statement at the end of it is\
-interrupted, there is a risk of duplicating the transaction if it is\
-replayed. This parameter prevents the retrying of transactions that are about to\
+If a transaction is ending and the `COMMIT` statement at the end of it is
+interrupted, there is a risk of duplicating the transaction if it is
+replayed. This parameter prevents the retrying of transactions that are about to
 commit.
 
-This parameter was added in MaxScale 23.08.0 and is enabled by default. The\
-older version of MaxScale always attempted to replay the transaction even if\
+This parameter was added in MaxScale 23.08.0 and is enabled by default. The
+older version of MaxScale always attempted to replay the transaction even if
 there was a risk of duplicating the transaction.
 
-If the data that is about to be modified is read before it is modified and it is\
-locked in an appropriate manner (e.g. with `SELECT ... FOR UPDATE` or with the`SERIALIZABLE` isolation level), it is safe to replay a transaction that was\
-about to commit. This is because the checksum of the transaction will mismatch\
-if the original transaction ended up committing on the server. Disabling this\
+If the data that is about to be modified is read before it is modified and it is
+locked in an appropriate manner (e.g. with `SELECT ... FOR UPDATE` or with the`SERIALIZABLE` isolation level), it is safe to replay a transaction that was
+about to commit. This is because the checksum of the transaction will mismatch
+if the original transaction ended up committing on the server. Disabling this
 feature can enable more robust delivery of transactions but it requires that the\
 SQL is correctly formed and compatible with this behavior.
 
@@ -632,8 +632,8 @@ SQL is correctly formed and compatible with this behavior.
 
 Retry transactions that end in checksum mismatch.
 
-When enabled, any replayed transactions that end with a checksum mismatch are\
-retried until they either succeeds or one of the transaction replay limits is\
+When enabled, any replayed transactions that end with a checksum mismatch are
+retried until they either succeeds or one of the transaction replay limits is
 reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_replay_attempts`).
 
 #### `transaction_replay_checksum`
@@ -644,30 +644,30 @@ reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_re
 * Values: `full`, `result_only`, `no_insert_id`
 * Default: `full`
 
-Selects which transaction checksum method is used to verify the result of the\
+Selects which transaction checksum method is used to verify the result of the
 replayed transaction.
 
-Note that only `transaction_replay_checksum=full` is guaranteed to retain the\
+Note that only `transaction_replay_checksum=full` is guaranteed to retain the
 consistency of the replayed transaction.
 
 Possible values are:
 
 * `full` (default)
-* All responses from the server are included in the checksum. This retains the\
-  full consistency guarantee of the replayed transaction as it must match\
+* All responses from the server are included in the checksum. This retains the
+  full consistency guarantee of the replayed transaction as it must match
   exactly the one that was already returned to the client.
 * `result_only`
-* Only resultsets and errors are included in the checksum. OK packets\
-  (i.e. successful queries that do not return results) are ignored. This mode\
+* Only resultsets and errors are included in the checksum. OK packets
+  (i.e. successful queries that do not return results) are ignored. This mode
   is intended to be used in cases where the extra information (auto-generated\
-  ID, warnings etc.) returned in the OK packet is not used by the\
+  ID, warnings etc.) returned in the OK packet is not used by the
   application.\
-  This mode is safe to use only if the auto-generated ID is not actually used\
-  by any following queries. An example of such behavior would be a transaction\
+  This mode is safe to use only if the auto-generated ID is not actually used
+  by any following queries. An example of such behavior would be a transaction
   that ends with an `INSERT` into a table with an `AUTO_INCREMENT` field.
 * `no_insert_id`
-* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the\
-  result of the query is not used by any subsequent statement in the\
+* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the
+  result of the query is not used by any subsequent statement in the
   transaction.
 
 #### `optimistic_trx`
@@ -677,21 +677,21 @@ Possible values are:
 * Dynamic: Yes
 * Default: false
 
-Enable optimistic transaction execution. This parameter controls whether normal\
-transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across\
+Enable optimistic transaction execution. This parameter controls whether normal
+transactions (i.e. `START TRANSACTION` or `BEGIN`) are load balanced across
 replicas. This feature is disabled by default and enabling it implicitly enables`transaction_replay`, `delayed_retry` and `master_reconnection` parameters.
 
-When this mode is enabled, all transactions are first attempted on replica\
-servers. If the transaction contains no statements that modify data, it is\
-completed on the replica. If the transaction contains statements that modify data,\
-it is rolled back on the replica server and restarted on the primary. The rollback\
-is initiated the moment a data modifying statement is intercepted by\
+When this mode is enabled, all transactions are first attempted on replica
+servers. If the transaction contains no statements that modify data, it is
+completed on the replica. If the transaction contains statements that modify data,
+it is rolled back on the replica server and restarted on the primary. The rollback
+is initiated the moment a data modifying statement is intercepted by
 readwritesplit so only read-only statements are executed on replica servers.
 
-As with `transaction_replay` and transactions that are replayed, if the results\
-returned by the primary server are not identical to the ones returned by the\
-replica up to the point where the first data modifying statement was executed, the\
-connection is closed. If the execution of ROLLBACK statement on the replica fails,\
+As with `transaction_replay` and transactions that are replayed, if the results
+returned by the primary server are not identical to the ones returned by the
+replica up to the point where the first data modifying statement was executed, the
+connection is closed. If the execution of ROLLBACK statement on the replica fails,
 the connection to that replica is closed.
 
 All limitations that apply to `transaction_replay` also apply to`optimistic_trx`.
@@ -706,12 +706,12 @@ All limitations that apply to `transaction_replay` also apply to`optimistic_trx`
 
 Enable causal reads. This feature requires MariaDB 10.2.16 or newer to function.
 
-If a client connection modifies the database and `causal_reads` is enabled, any\
-subsequent reads performed on replica servers will be done in a manner that\
+If a client connection modifies the database and `causal_reads` is enabled, any
+subsequent reads performed on replica servers will be done in a manner that
 prevents replication lag from affecting the results.
 
-The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#implementation-of-causal_reads) for more\
-information on what a sync consists of and why minimizing the number of them is\
+The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#implementation-of-causal_reads) for more
+information on what a sync consists of and why minimizing the number of them is
 important.
 
 | Mode            | Level of Causality | Latency                                                  |
@@ -723,16 +723,16 @@ important.
 | universal       | Cluster            | High, one sync per read plus a roundtrip to the primary. |
 | fast\_universal | Cluster            | Low, one roundtrip to the primary.                       |
 
-The `fast`, `fast_global` and `fast_universal` modes should only be used when\
-low latency is more important than proper distribution of reads. These modes\
-should only be used when the workload is mostly read-only with only occasional\
-writes. If used with a mixed or a write-heavy workload, the traffic will end up\
+The `fast`, `fast_global` and `fast_universal` modes should only be used when
+low latency is more important than proper distribution of reads. These modes
+should only be used when the workload is mostly read-only with only occasional
+writes. If used with a mixed or a write-heavy workload, the traffic will end up
 being routed almost exclusively to the primary server.
 
-**Note:** This feature also enables multi-statement execution of SQL in the\
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)\
+**Note:** This feature also enables multi-statement execution of SQL in the
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
-Connector/C. The _Implementation of causal\_reads_ section explains why this is\
+Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.
 
 The possible values for this parameter are:
@@ -740,94 +740,94 @@ The possible values for this parameter are:
 * `none` (default)
 * Read causality is disabled.
 * `local`
-* Writes are locally visible. Writes are guaranteed to be visible only to the\
-  connection that does it. Unrelated modifications done by other connections\
-  are not visible. This mode improves read scalability at the cost of latency\
-  and reduces the overall load placed on the primary server without breaking\
+* Writes are locally visible. Writes are guaranteed to be visible only to the
+  connection that does it. Unrelated modifications done by other connections
+  are not visible. This mode improves read scalability at the cost of latency
+  and reduces the overall load placed on the primary server without breaking
   causality guarantees.
 * `global`
-* Writes are globally visible. If one connection writes a value, all\
-  connections to the same service will see it. In general this mode is slower\
-  than the `local` mode due to the extra synchronization it has to do. This\
-  guarantees global happens-before ordering of reads when all transactions are\
-  inside a single GTID domain.This mode gives similar benefits as the `local`\
+* Writes are globally visible. If one connection writes a value, all
+  connections to the same service will see it. In general this mode is slower
+  than the `local` mode due to the extra synchronization it has to do. This
+  guarantees global happens-before ordering of reads when all transactions are
+  inside a single GTID domain.This mode gives similar benefits as the `local`
   mode in that it improves read scalability at the cost of latency.\
-  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads\
-  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this\
-  was fixed and all the GTID coordinates are passed alongside all requests\
+  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads
+  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this
+  was fixed and all the GTID coordinates are passed alongside all requests
   which makes multi-domain GTIDs safe to use. However, this does mean that the\
-  GTID coordinates will never be reset: if replication is reset and GTID\
-  coordinates go "backwards", readwritesplit will not consider these as being\
-  newer than the ones already stored. To reset the stored GTID coordinates in\
+  GTID coordinates will never be reset: if replication is reset and GTID
+  coordinates go "backwards", readwritesplit will not consider these as being
+  newer than the ones already stored. To reset the stored GTID coordinates in
   readwritesplit, MaxScale must be restarted.\
-  MaxScale 6.4.11 added the new `reset-gtid` module command to\
+  MaxScale 6.4.11 added the new `reset-gtid` module command to
   readwritesplit. This allows the global GTID state used by`causal_reads=global` to be reset without having to restart MaxScale.
 * `fast`
-* This mode is similar to the `local` mode where it will only affect the\
-  connection that does the write but where the `local` mode waits for a replica\
-  server to catch up, the `fast` mode will only use servers that are known to\
-  have replicated the write. This means that if no replica has replicated the\
-  write, the primary where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication\
-  state is only updated by the mariadbmon monitor whenever the servers are\
-  monitored. This means that a smaller `monitor_interval` provides faster\
+* This mode is similar to the `local` mode where it will only affect the
+  connection that does the write but where the `local` mode waits for a replica
+  server to catch up, the `fast` mode will only use servers that are known to
+  have replicated the write. This means that if no replica has replicated the
+  write, the primary where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication
+  state is only updated by the mariadbmon monitor whenever the servers are
+  monitored. This means that a smaller `monitor_interval` provides faster
   replication state updates and possibly better overall usage of servers.\
-  This mode is the inverse of the `local` mode in the sense that it improves\
-  read latency at the cost of read scalability while still retaining the\
-  causality guarantees for reads. This functionality can also be considered an\
+  This mode is the inverse of the `local` mode in the sense that it improves
+  read latency at the cost of read scalability while still retaining the
+  causality guarantees for reads. This functionality can also be considered an
   improved version of the functionality that the [CCRFilter](../maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-consistent-critical-read-filter.md) module provides.
 * `fast_global`
 * This mode is identical to the `fast` mode except that it uses the global\
-  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`\
-  is ignored in this mode. Currently the replication state is only updated by\
-  the mariadbmon monitor whenever the servers are monitored. This means that a\
-  smaller `monitor_interval` provides faster replication state updates and\
+  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`
+  is ignored in this mode. Currently the replication state is only updated by
+  the mariadbmon monitor whenever the servers are monitored. This means that a
+  smaller `monitor_interval` provides faster replication state updates and
   possibly better overall usage of servers.
 * `universal`
-* The universal mode guarantees that all SELECT statements always see the\
-  latest observable transaction state on a database cluster. The basis of this\
-  is the `@@gtid_current_pos` variable which is read from the current primary\
-  server before each read. This guarantees that if a transaction was visible\
-  at the time the read is received by readwritesplit, the transaction is\
+* The universal mode guarantees that all SELECT statements always see the
+  latest observable transaction state on a database cluster. The basis of this
+  is the `@@gtid_current_pos` variable which is read from the current primary
+  server before each read. This guarantees that if a transaction was visible
+  at the time the read is received by readwritesplit, the transaction is
   guaranteed to be complete on the replica server where the read is done.\
-  This mode is the most consistent of all the modes. It provides consistency\
-  regardless of where a write originated from but it comes at the cost of\
-  increased latency. For every read, a round trip to the current primary server\
-  is done. This means that the latency of any given SELECT statement increases\
-  by roughly twice the network latency between MaxScale and the database\
-  cluster. In addition, an extra SELECT statement is always executed on the\
+  This mode is the most consistent of all the modes. It provides consistency
+  regardless of where a write originated from but it comes at the cost of
+  increased latency. For every read, a round trip to the current primary server
+  is done. This means that the latency of any given SELECT statement increases
+  by roughly twice the network latency between MaxScale and the database
+  cluster. In addition, an extra SELECT statement is always executed on the
   primary which places some load on the server.
 * `fast_universal`
-* A mix of `fast` and `universal`. This mode that guarantees that all SELECT\
-  statements always see the latest observable transaction state but unlike the`universal` mode that waits on the server to catch up, this mode behaves\
-  like `fast` and routes the query to the current primary if no replicas are\
+* A mix of `fast` and `universal`. This mode that guarantees that all SELECT
+  statements always see the latest observable transaction state but unlike the`universal` mode that waits on the server to catch up, this mode behaves
+  like `fast` and routes the query to the current primary if no replicas are
   available that have caught up.\
-  This mode provides the same consistency guarantees of `universal` with a\
-  constant latency overhead of one extra roundtrip. However, this also puts\
-  the most load on the primary node as even a moderate write load can cause\
+  This mode provides the same consistency guarantees of `universal` with a
+  constant latency overhead of one extra roundtrip. However, this also puts
+  the most load on the primary node as even a moderate write load can cause
   the GTIDs of replicas to lag too far behind.
 
-Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean\
+Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean
 parameter. False values translated to `none` and true values translated to`local`. The use of boolean parameters is deprecated but still accepted in\
 MaxScale 2.5.0.
 
 **Implementation of `causal_reads`**
 
-This feature is based on the `MASTER_GTID_WAIT` function and the tracking of\
-server-side status variables. By tracking the latest GTID that each statement\
-generates, readwritesplit can then perform a synchronization operation with the\
+This feature is based on the `MASTER_GTID_WAIT` function and the tracking of
+server-side status variables. By tracking the latest GTID that each statement
+generates, readwritesplit can then perform a synchronization operation with the
 help of the `MASTER_GTID_WAIT` function.
 
-If the replica has not caught up to the primary within the configured time, as\
-specified by [causal\_reads\_timeout](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#causal_reads_timeout), it will\
+If the replica has not caught up to the primary within the configured time, as
+specified by [causal\_reads\_timeout](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#causal_reads_timeout), it will
 be retried on the primary.
 
-The exception to this rule is the `fast` mode which does not do any\
-synchronization at all. This can be done as any reads that would go to\
+The exception to this rule is the `fast` mode which does not do any
+synchronization at all. This can be done as any reads that would go to
 out-of-date servers will be re-routed to the current primary.
 
 **Normal SQL**
 
-A practical example can be given by the following set of SQL commands executed\
+A practical example can be given by the following set of SQL commands executed
 with `autocommit=1`.
 
 ```
@@ -835,17 +835,17 @@ INSERT INTO test.t1 (id) VALUES (1);
 SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-As the statements are not executed inside a transaction, from the load balancer's\
-point of view, the latter statement can be routed to a replica server. The problem\
-with this is that if the value that was inserted on the primary has not yet\
-replicated to the server where the SELECT statement is being performed, it can\
+As the statements are not executed inside a transaction, from the load balancer's
+point of view, the latter statement can be routed to a replica server. The problem
+with this is that if the value that was inserted on the primary has not yet
+replicated to the server where the SELECT statement is being performed, it can
 appear as if the value we just inserted is not there.
 
-By prefixing these types of SELECT statements with a command that guarantees\
-consistent results for the reads, read scalability can be improved without\
+By prefixing these types of SELECT statements with a command that guarantees
+consistent results for the reads, read scalability can be improved without
 sacrificing consistency.
 
-The set of example SQL above will be translated by MaxScale into the following\
+The set of example SQL above will be translated by MaxScale into the following
 statements.
 
 ```
@@ -859,18 +859,18 @@ SET @maxscale_secret_variable=(
     END); SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-The `SET` command will synchronize the replica to a certain logical point in the\
-replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more\
-details). If the synchronization fails, the query will not run and it will be\
+The `SET` command will synchronize the replica to a certain logical point in the
+replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more
+details). If the synchronization fails, the query will not run and it will be
 retried on the server where the transaction was originally done.
 
 **Prepared Statements**
 
-Binary protocol prepared statements are handled in a different manner. Instead\
-of adding the synchronization SQL into the original SQL query, it is sent as a\
+Binary protocol prepared statements are handled in a different manner. Instead
+of adding the synchronization SQL into the original SQL query, it is sent as a
 separate packet before the prepared statement is executed.
 
-We'll use the same example SQL but use a binary protocol prepared statement for\
+We'll use the same example SQL but use a binary protocol prepared statement for
 the SELECT:
 
 ```
@@ -888,20 +888,20 @@ COM_QUERY:         IF (MASTER_GTID_WAIT('0-3000-8', 10) <> 0) THEN KILL (SELECT 
 COM_STMT_EXECUTE:  ? = 123
 ```
 
-Both the synchronization query and the execution of the prepared statement are\
-sent at the same time. This is done to remove the need to wait for the result of\
-the synchronization query before routing the execution of the prepared\
-statement. This keeps the performance of causal\_reads for prepared statements\
+Both the synchronization query and the execution of the prepared statement are
+sent at the same time. This is done to remove the need to wait for the result of
+the synchronization query before routing the execution of the prepared
+statement. This keeps the performance of causal\_reads for prepared statements
 the same as it is for normal SQL queries.
 
-As a result of this, each time the synchronization query times out, the\
-connection will be killed by the `KILL` statement and readwritesplit will retry\
-the query on the primary. This is done to prevent the execution of the prepared\
+As a result of this, each time the synchronization query times out, the
+connection will be killed by the `KILL` statement and readwritesplit will retry
+the query on the primary. This is done to prevent the execution of the prepared
 statement that follows the synchronization query from being processed by the\
 MariaDB server.
 
-It is recommend that the session command history is enabled whenever prepared\
-statements are used with `causal_reads`. This allows new connections to be\
+It is recommend that the session command history is enabled whenever prepared
+statements are used with `causal_reads`. This allows new connections to be
 created whenever a causal read times out.
 
 A failed causal read inside of a read-only transaction started with`START TRANSACTION READ ONLY` will return the following error:
@@ -912,22 +912,22 @@ SQLSTATE: 25006
 Message:  Causal read timed out while in a read-only transaction, cannot retry command.
 ```
 
-Older versions of MaxScale attempted to retry the command on the current primary\
+Older versions of MaxScale attempted to retry the command on the current primary
 server which would cause the connection to be closed and a warning to be logged.
 
 **Limitations of Causal Reads**
 
-* Starting with MaxScale 24.02.5, the fast modes `fast`, `fast_global` and`fast_universal` work with Galera clusters. In older versions, none of the`causal_reads` modes worked with Galera. The non-fast modes that rely on the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)\
-  function still do not work with Galera. This is because Galera does not\
+* Starting with MaxScale 24.02.5, the fast modes `fast`, `fast_global` and`fast_universal` work with Galera clusters. In older versions, none of the`causal_reads` modes worked with Galera. The non-fast modes that rely on the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)
+  function still do not work with Galera. This is because Galera does not
   implement a mechanism that allows a client to wait for a particular GTID.
-* If the combination of the original SQL statement and the modifications\
-  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),\
+* If the combination of the original SQL statement and the modifications
+  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),
   the causal read will not be attempted and a non-causal read is done instead.\
-  This applies only to text protocol queries as the binary protocol queries use\
+  This applies only to text protocol queries as the binary protocol queries use
   a different synchronization mechanism.
-* SQL like `INSERT ... RETURNING` that commits a transaction and returns a\
+* SQL like `INSERT ... RETURNING` that commits a transaction and returns a
   resultset will only work with causal reads if the connector supports the\
-  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB\
+  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB
   connectors and whether they support the protocol feature.
 
 | Connector         | Supported | Version |
@@ -948,10 +948,10 @@ server which would cause the connection to be closed and a warning to be logged.
 
 The timeout for the replica synchronization done by `causal_reads`.
 
-The timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `lazy_connect`
@@ -961,24 +961,24 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Lazy connection creation causes connections to backend servers to be opened only\
-when they are needed. This reduces the load that is placed on the backend\
+Lazy connection creation causes connections to backend servers to be opened only
+when they are needed. This reduces the load that is placed on the backend
 servers when the client connections are short.
 
-Normally readwritesplit opens as many connections as it can when the session is\
-first opened. This makes the execution of the first query faster when all\
-available connections are already created. When `lazy_connect` is enabled, this\
-initial connection creation is skipped. If the client executes only read\
-queries, no connection to the primary is made. If only write queries are made,\
+Normally readwritesplit opens as many connections as it can when the session is
+first opened. This makes the execution of the first query faster when all
+available connections are already created. When `lazy_connect` is enabled, this
+initial connection creation is skipped. If the client executes only read
+queries, no connection to the primary is made. If only write queries are made,
 only the primary connection is used.
 
-In MaxScale 23.08.2, if a [session command](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#routing-to-every-session-backend)\
-is received as the first command, the default behavior is to execute it on a\
-replica. If [master\_accept\_reads](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#master_accept_reads) is enabled, the query is\
-executed on the primary server, if one is available. In practice this means that\
+In MaxScale 23.08.2, if a [session command](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#routing-to-every-session-backend)
+is received as the first command, the default behavior is to execute it on a
+replica. If [master\_accept\_reads](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#master_accept_reads) is enabled, the query is
+executed on the primary server, if one is available. In practice this means that
 workloads which are mostly reads with infrequent writes should disable`master_accept_reads` if they also use `lazy_connect`.
 
-Older versions of MaxScale always tried to execute all session commands on the\
+Older versions of MaxScale always tried to execute all session commands on the
 primary node if one was available.
 
 #### `reuse_prepared_statements`
@@ -988,21 +988,21 @@ primary node if one was available.
 * Dynamic: Yes
 * Default: false
 
-Reuse identical prepared statements inside the same client connection. This\
+Reuse identical prepared statements inside the same client connection. This
 feature only applies to binary protocol prepared statements.
 
-When this parameter is enabled and the connection prepares an identical prepared\
-statement multiple times, instead of preparing it on the server the existing\
-prepared statement handle is reused. This also means that whenever prepared\
+When this parameter is enabled and the connection prepares an identical prepared
+statement multiple times, instead of preparing it on the server the existing
+prepared statement handle is reused. This also means that whenever prepared
 statements are closed by the client, they will be left open by readwritesplit.
 
-Enabling this feature will increase memory usage of a session. The amount of\
-memory stored per prepared statement is proportional to the length of the\
+Enabling this feature will increase memory usage of a session. The amount of
+memory stored per prepared statement is proportional to the length of the
 prepared SQL statement and the number of parameters the statement has.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a readwritesplit service contains the\
+The `router_diagnostics` output for a readwritesplit service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -1023,48 +1023,48 @@ following fields.
 
 ### Server Ranks
 
-The general rule with server ranks is that primary servers will be used before\
-secondary servers. Readwritesplit is an exception to this rule. The following\
+The general rule with server ranks is that primary servers will be used before
+secondary servers. Readwritesplit is an exception to this rule. The following
 rules govern how readwritesplit behaves with servers that have different ranks.
 
-* Sessions will use the current primary server as long as possible. This means\
-  that sessions with a secondary primary will not use the main primary as long\
+* Sessions will use the current primary server as long as possible. This means
+  that sessions with a secondary primary will not use the main primary as long
   as the secondary primary is available.
-* All replica connections will use the same rank as the primary connection. Any\
+* All replica connections will use the same rank as the primary connection. Any
   stale connections with a different rank than the primary will be discarded.
-* If no primary connection is available and `master_reconnection` is enabled, a\
-  connection to the best primary is created. If the new primary has a different\
-  priority than existing connections have, the connections with a different rank\
+* If no primary connection is available and `master_reconnection` is enabled, a
+  connection to the best primary is created. If the new primary has a different
+  priority than existing connections have, the connections with a different rank
   will be discarded.
-* If open connections exist, these will be used for routing. This means that if\
-  the primary is lost but the session still has replica servers with the same rank,\
+* If open connections exist, these will be used for routing. This means that if
+  the primary is lost but the session still has replica servers with the same rank,
   they will remain in use.
 * If no open connections exist, the servers with the best rank will used.
 
 ### Routing hints
 
-The readwritesplit router supports routing hints. For a detailed guide on hint\
-syntax and functionality, please read [this](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-hint-syntax.md)\
+The readwritesplit router supports routing hints. For a detailed guide on hint
+syntax and functionality, please read [this](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-hint-syntax.md)
 document.
 
-**Note**: Routing hints will always have the highest priority when a routing\
-decision is made. This means that it is possible to cause inconsistencies in\
-the session state and the actual data in the database by adding routing hints\
-to DDL/DML statements which are then directed to replica servers. Only use routing\
+**Note**: Routing hints will always have the highest priority when a routing
+decision is made. This means that it is possible to cause inconsistencies in
+the session state and the actual data in the database by adding routing hints
+to DDL/DML statements which are then directed to replica servers. Only use routing
 hints when you are sure that they can cause no harm.
 
-An exception to this rule is `transaction_replay`: when it is enabled, all\
-routing hints inside transaction are ignored. This is done to prevent changes\
-done inside a re-playable transaction from affecting servers outside of the\
-transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed\
+An exception to this rule is `transaction_replay`: when it is enabled, all
+routing hints inside transaction are ignored. This is done to prevent changes
+done inside a re-playable transaction from affecting servers outside of the
+transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed
 routing hints to override the transaction logic.
 
 #### Known Limitations of Routing Hints
 
-* If a `SELECT` statement with a `maxscale route to slave` hint is received\
-  while autocommit is disabled, the query will be routed to a replica server. This\
-  causes some metadata locks to be acquired on the database in question which\
-  will block DDL statements on the server until either the connection is closed\
+* If a `SELECT` statement with a `maxscale route to slave` hint is received
+  while autocommit is disabled, the query will be routed to a replica server. This
+  causes some metadata locks to be acquired on the database in question which
+  will block DDL statements on the server until either the connection is closed
   or autocommit is enabled again.
 
 ### Module Commands
@@ -1073,11 +1073,11 @@ The readwritesplit router implements the following module commands.
 
 #### `reset-gtid`
 
-The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is\
-reverted to an earlier state and the GTIDs recorded in MaxScale are no longer\
+The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is
+reverted to an earlier state and the GTIDs recorded in MaxScale are no longer
 valid.
 
-The first and only argument to the command is the router name. For example, to\
+The first and only argument to the command is the router name. For example, to
 reset the GTID state of a readwritesplit named `My-RW-Router`, the following\
 MaxCtrl command should be used:
 
@@ -1091,12 +1091,12 @@ Examples of the readwritesplit router in use can be found in the [Tutorials](htt
 
 ### Readwritesplit routing decisions
 
-Here is a small explanation which shows what kinds of queries are routed to\
+Here is a small explanation which shows what kinds of queries are routed to
 which type of server.
 
 #### Routing to Primary
 
-Routing to primary is important for data consistency and because majority of\
+Routing to primary is important for data consistency and because majority of
 writes are written to binlog and thus become replicated to replicas.
 
 The following operations are routed to primary:
@@ -1117,32 +1117,32 @@ The following operations are routed to primary:
 * `@@last_insert_id`
 * `@@identity`
 
-In addition to these, if the **readwritesplit** service is configured with the`max_replication_lag` parameter, and if all replicas suffer from too much\
-replication lag, then statements will be routed to the primary. (There might be\
-other similar configuration parameters in the future which limit the number of\
+In addition to these, if the **readwritesplit** service is configured with the`max_replication_lag` parameter, and if all replicas suffer from too much
+replication lag, then statements will be routed to the primary. (There might be
+other similar configuration parameters in the future which limit the number of
 statements that will be routed to replicas.)
 
 **Transaction Isolation Level Tracking**
 
-If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB\
-server, readwritesplit will track the transaction isolation level and lock the\
-session to the primary when the isolation level is set to serializable. This\
-retains the correctness of the isolation level which can otherwise cause\
+If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB
+server, readwritesplit will track the transaction isolation level and lock the
+session to the primary when the isolation level is set to serializable. This
+retains the correctness of the isolation level which can otherwise cause
 problems.
 
-Starting with MaxScale 23.08, once the transaction isolation level is set to\
-something other than `SERIALIZABLE`, the session is no longer locked to the\
-primary and returns to its normal state. Older versions of MaxScale remain\
-locked to the primary even if the session goes out of the `SERIALIZABLE`\
+Starting with MaxScale 23.08, once the transaction isolation level is set to
+something other than `SERIALIZABLE`, the session is no longer locked to the
+primary and returns to its normal state. Older versions of MaxScale remain
+locked to the primary even if the session goes out of the `SERIALIZABLE`
 isolation level.
 
 #### Routing to Replicas
 
-The ability to route some statements to replicas is important because it also\
-decreases the load targeted to _primary_. Moreover, it is possible to have multiple\
+The ability to route some statements to replicas is important because it also
+decreases the load targeted to _primary_. Moreover, it is possible to have multiple
 replicas to share the load in contrast to single primary.
 
-Queries which can be routed to replicas must be auto committed and belong to one\
+Queries which can be routed to replicas must be auto committed and belong to one
 of the following group:
 
 * Read-only statements (i.e. `SELECT`) that only use read-only built-in functions
@@ -1153,10 +1153,10 @@ The list of supported built-in functions can be found [here](https://github.com/
 
 #### Routing to every session backend
 
-A third class of statements includes those which modify session data, such as\
-session system variables, user-defined variables, the default database, etc. We\
-call them session commands, and they must be replicated as they affect the\
-future results of read and write operations. They must be executed on all\
+A third class of statements includes those which modify session data, such as
+session system variables, user-defined variables, the default database, etc. We
+call them session commands, and they must be replicated as they affect the
+future results of read and write operations. They must be executed on all
 servers that could execute statements on behalf of this client.
 
 Session commands include for example:
@@ -1166,26 +1166,26 @@ Session commands include for example:
 * Binary protocol prepared statements
 * Other miscellaneous commands (COM\_QUIT, COM\_PING etc.)
 
-**NOTE**: if variable assignment is embedded in a write statement it is routed\
-to _primary_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be\
+**NOTE**: if variable assignment is embedded in a write statement it is routed
+to _primary_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be
 routed to _primary_ only.
 
-The router stores all of the executed session commands so that in case of a\
-replica failure, a replacement replica can be chosen and the session command history\
-can be repeated on that new replica. This means that the router stores each\
-executed session command for the duration of the session. Applications that use\
-long-running sessions might cause MariaDB MaxScale to consume a growing amount\
-of memory unless the sessions are closed. This can be solved by adjusting the\
+The router stores all of the executed session commands so that in case of a
+replica failure, a replacement replica can be chosen and the session command history
+can be repeated on that new replica. This means that the router stores each
+executed session command for the duration of the session. Applications that use
+long-running sessions might cause MariaDB MaxScale to consume a growing amount
+of memory unless the sessions are closed. This can be solved by adjusting the
 value of `max_sescmd_history`.
 
 #### Routing to previous target
 
-In the following cases, a query is routed to the same server where the previous\
-query was executed. If no previous target is found, the query is routed to the\
+In the following cases, a query is routed to the same server where the previous
+query was executed. If no previous target is found, the query is routed to the
 current primary.
 
-* If a query uses the `FOUND_ROWS()` function, it will be routed to the server\
-  where the last query was executed. This is done with the assumption that a\
+* If a query uses the `FOUND_ROWS()` function, it will be routed to the server
+  where the last query was executed. This is done with the assumption that a
   query with `SQL_CALC_FOUND_ROWS` was previously executed.
 * COM\_STMT\_FETCH\_ROWS will always be routed to the same server where the\
   COM\_STMT\_EXECUTE was routed.
@@ -1200,90 +1200,90 @@ Read queries are routed to the primary server in the following situations:
 
 #### Prepared Statement Limitations
 
-If a prepared statement targets a temporary table on the primary, the replica\
-servers will fail to execute it. This will cause all replica connections to be\
+If a prepared statement targets a temporary table on the primary, the replica
+servers will fail to execute it. This will cause all replica connections to be
 closed (MXS-1816).
 
 #### Transaction Replay Limitations
 
-When transaction replay is enabled, readwritesplit calculates a checksum of the\
-server responses for each transaction. This is used to determine whether a\
+When transaction replay is enabled, readwritesplit calculates a checksum of the
+server responses for each transaction. This is used to determine whether a
 replayed transaction was identical to the original transaction. Starting with\
-MaxScale 23.08, a 128-bit xxHash checksum is stored for each statement that is\
-in the transaction. Older versions of MaxScale used a single 160-bit SHA1\
+MaxScale 23.08, a 128-bit xxHash checksum is stored for each statement that is
+in the transaction. Older versions of MaxScale used a single 160-bit SHA1
 checksum for the whole transaction.
 
-If the results from the replacement server are not identical when the\
-transaction is replayed, the client connection is closed. This means that any\
-transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot\
+If the results from the replacement server are not identical when the
+transaction is replayed, the client connection is closed. This means that any
+transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot
 be replayed successfully but it will still be attempted.
 
-If a transaction reads data before updating it, the rows should be locked by\
-using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when\
+If a transaction reads data before updating it, the rows should be locked by
+using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when
 multiple transactions are being replayed that modify the same set of rows.
 
-If the connection to the server where the transaction is being executed is\
-lost when the final `COMMIT` is being executed, it is impossible to know\
-whether the transaction was successfully committed. This means that there\
-is a possibility for duplicate transaction execution which can result in\
+If the connection to the server where the transaction is being executed is
+lost when the final `COMMIT` is being executed, it is impossible to know
+whether the transaction was successfully committed. This means that there
+is a possibility for duplicate transaction execution which can result in
 data duplication in certain cases.
 
-In MaxScale 23.08, the `transaction_replay_safe_commit` variable controls\
-whether a replay is attempted or not whenever a `COMMIT` is interrupted. By\
-default the transaction will not be replayed. Older versions of MaxScale always\
+In MaxScale 23.08, the `transaction_replay_safe_commit` variable controls
+whether a replay is attempted or not whenever a `COMMIT` is interrupted. By
+default the transaction will not be replayed. Older versions of MaxScale always
 replayed the transaction.
 
-Data duplication can happen if the transaction consists of the following\
+Data duplication can happen if the transaction consists of the following
 statement types:
 
 * INSERT of rows into a table that does not have an auto-increment primary key
 * A "blind update" of one or more rows e.g. `UPDATE t SET c = c + 1 WHERE id = 123`
 * A "blind delete" e.g. `DELETE FROM t LIMIT 100`
 
-This is not an exhaustive list and any operations that do not check the row\
+This is not an exhaustive list and any operations that do not check the row
 contents before performing the operation on them might face this problem.
 
-In all cases the problem of duplicate transaction execution can be avoided by\
-including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that\
-in the case that the transaction fails when it is being committed, the row is\
+In all cases the problem of duplicate transaction execution can be avoided by
+including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that
+in the case that the transaction fails when it is being committed, the row is
 only modified if it matches the expected contents.
 
-Similarly, a connection loss during `COMMIT` can also result in transaction\
-replay failure. This happens due to the same reason as duplicate transaction\
-execution but the retried transaction will not be committed. This can be\
-considered a success case as the transaction replay detected that the results of\
-the two transactions are different. In these cases readwritesplit will abort the\
+Similarly, a connection loss during `COMMIT` can also result in transaction
+replay failure. This happens due to the same reason as duplicate transaction
+execution but the retried transaction will not be committed. This can be
+considered a success case as the transaction replay detected that the results of
+the two transactions are different. In these cases readwritesplit will abort the
 transaction and close the client connection.
 
-Statements that result in an implicit commit do not reset the transaction when\
-transaction\_replay is enabled. This means that if the transaction is replayed,\
-the transaction will be committed twice due to the implicit commit being\
-present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the\
+Statements that result in an implicit commit do not reset the transaction when
+transaction\_replay is enabled. This means that if the transaction is replayed,
+the transaction will be committed twice due to the implicit commit being
+present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the
 transaction to be correctly reset.
 
-In older versions of MaxScale, if a connection to a server is lost while a\
-statement is being executed and the result was partially delivered to the\
-client, readwritesplit would immediately close the session without attempting to\
-replay the failing statement. Starting with MaxScale 23.08, this limitation no\
+In older versions of MaxScale, if a connection to a server is lost while a
+statement is being executed and the result was partially delivered to the
+client, readwritesplit would immediately close the session without attempting to
+replay the failing statement. Starting with MaxScale 23.08, this limitation no
 longer applies if the statement was done inside of a transaction and`transaction_replay` is enabled\
 ([MXS-4549](https://jira.mariadb.org/browse/MXS-4549)).
 
-If the connection to the server where a transaction is being executed is lost\
-while a `ROLLBACK` is being executed, readwritesplit will still attempt to\
-replay the transaction in the hopes that the real response can be delivered to\
-the client. However, this does mean that it is possible that a rolled back\
-transaction which gets replayed ends up with a conflict and is reported as a\
-replay failure when in reality a rolled back transaction could be safely\
+If the connection to the server where a transaction is being executed is lost
+while a `ROLLBACK` is being executed, readwritesplit will still attempt to
+replay the transaction in the hopes that the real response can be delivered to
+the client. However, this does mean that it is possible that a rolled back
+transaction which gets replayed ends up with a conflict and is reported as a
+replay failure when in reality a rolled back transaction could be safely
 ignored.
 
 **Limitations in Session State Modifications**
 
-Any changes to the session state (e.g. autocommit state, SQL mode) done inside a\
-transaction will remain in effect even if the connection to the server where the\
-transaction is being executed fails. When readwritesplit creates a new\
-connection to a server to replay the transaction, it will first restore the\
-session state by executing all session commands that were executed. This means\
-that if the session state is changed mid-transaction in a way that affects the\
+Any changes to the session state (e.g. autocommit state, SQL mode) done inside a
+transaction will remain in effect even if the connection to the server where the
+transaction is being executed fails. When readwritesplit creates a new
+connection to a server to replay the transaction, it will first restore the
+session state by executing all session commands that were executed. This means
+that if the session state is changed mid-transaction in a way that affects the
 results, transaction replay will fail.
 
 The following partial transaction demonstrates the problem by using [SQL\_MODE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) inside a transaction.
@@ -1296,7 +1296,7 @@ SET SQL_MODE='ANSI_QUOTES'; -- A session command
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-If this transaction has to be replayed the actual SQL that gets executed is the\
+If this transaction has to be replayed the actual SQL that gets executed is the
 following.
 
 ```
@@ -1307,38 +1307,38 @@ SELECT "hello world";       -- Returns an error
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-First the session state is restored by executing all commands that changed the\
+First the session state is restored by executing all commands that changed the
 state after which the actual transaction is replayed. Due to the fact that the\
-SQL\_MODE was changed mid-transaction, one of the queries will now return an\
+SQL\_MODE was changed mid-transaction, one of the queries will now return an
 error instead of the result we expected leading to a transaction replay failure.
 
 **Limitations in Service-to-Service Routing**
 
-In a service-to-service configuration (i.e. a service using another service in\
-its `targets` list ), if the topmost service starts a transaction, all\
-lower-level readwritesplit services will also behave as if a transaction is\
-open. If a connection to a backend database fails during this, it can result in\
-unnecessary transaction replays which in turn can end up with checksum\
-conflicts. The recommended approach is to not use any commands inside a\
+In a service-to-service configuration (i.e. a service using another service in
+its `targets` list ), if the topmost service starts a transaction, all
+lower-level readwritesplit services will also behave as if a transaction is
+open. If a connection to a backend database fails during this, it can result in
+unnecessary transaction replays which in turn can end up with checksum
+conflicts. The recommended approach is to not use any commands inside a
 transaction that would be routed to more than one node.
 
 **Limitations in multi-statement handling**
 
-When a multi-statement query is executed through the readwritesplit router, it\
-will always be routed to the primary. See [strict\_multi\_stmt](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md) for more\
+When a multi-statement query is executed through the readwritesplit router, it
+will always be routed to the primary. See [strict\_multi\_stmt](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md) for more
 details.
 
-If the multi-statement query creates a temporary table, it will not be\
-detected and reads to this table can be routed to replica servers. To\
-prevent this, always execute the temporary table creation as an individual\
+If the multi-statement query creates a temporary table, it will not be
+detected and reads to this table can be routed to replica servers. To
+prevent this, always execute the temporary table creation as an individual
 statement.
 
 **Limitations in client session handling**
 
-Some of the queries that a client sends are routed to all backends instead of\
-just to one. These queries include `USE <db name>` and `SET autocommit=0`, among\
-many others. Readwritesplit sends a copy of these queries to each backend server\
-and forwards the primary's reply to the client. Below is a list of MySQL commands\
+Some of the queries that a client sends are routed to all backends instead of
+just to one. These queries include `USE <db name>` and `SET autocommit=0`, among
+many others. Readwritesplit sends a copy of these queries to each backend server
+and forwards the primary's reply to the client. Below is a list of MySQL commands
 which are classified as session commands.
 
 ```
@@ -1360,19 +1360,19 @@ SELECT ..INTO variable|OUTFILE|DUMPFILE
 SET autocommit=1|0
 ```
 
-Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were\
+Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were
 not supported and caused the session to be closed.
 
-There is a possibility for misbehavior. If `USE mytable` is executed in one of\
-the replicas and fails, it may be due to replication lag rather than the database\
-not existing. Thus, the same command may produce different result in different\
-backend servers. The replicas which fail to execute a session command will be\
-dropped from the active list of replicas for this session to guarantee a\
-consistent session state across all the servers used by the session. In\
-addition, the server will not be used again for routing for the duration of the\
+There is a possibility for misbehavior. If `USE mytable` is executed in one of
+the replicas and fails, it may be due to replication lag rather than the database
+not existing. Thus, the same command may produce different result in different
+backend servers. The replicas which fail to execute a session command will be
+dropped from the active list of replicas for this session to guarantee a
+consistent session state across all the servers used by the session. In
+addition, the server will not be used again for routing for the duration of the
 session.
 
-The above-mentioned behavior for user variables can be partially controlled with\
+The above-mentioned behavior for user variables can be partially controlled with
 the configuration parameter `use_sql_variables_in`:
 
 ```
@@ -1381,10 +1381,10 @@ use_sql_variables_in=[master|all] (default: all)
 
 **WARNING**
 
-If a SELECT query modifies a user variable when the `use_sql_variables_in`\
-parameter is set to `all`, it will not be routed and the client will receive an\
-error. A log message is written into the log further explaining the reason for\
-the error. Here is an example use of a SELECT query which modifies a user\
+If a SELECT query modifies a user variable when the `use_sql_variables_in`
+parameter is set to `all`, it will not be routed and the client will receive an
+error. A log message is written into the log further explaining the reason for
+the error. Here is an example use of a SELECT query which modifies a user
 variable and how MariaDB MaxScale responds to it.
 
 ```
@@ -1395,7 +1395,7 @@ MySQL [(none)]> SELECT @id := @id + 1 FROM test.t1;
 ERROR 1064 (42000): Routing query to backend failed. See the error log for further details.
 ```
 
-Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user\
+Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user
 variables to the primary.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-schemarouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-schemarouter.md
@@ -1,15 +1,15 @@
 # MaxScale 24.02 SchemaRouter
 
-The SchemaRouter provides an easy and manageable sharding solution by\
-building a single logical database server from multiple separate ones. Each\
-database is shown to the client and queries targeting unique databases are\
-routed to their respective servers. In addition to providing simple\
-database-based sharding, the schemarouter also enables cross-node\
-session variable usage by routing all queries that modify the session to all\
+The SchemaRouter provides an easy and manageable sharding solution by
+building a single logical database server from multiple separate ones. Each
+database is shown to the client and queries targeting unique databases are
+routed to their respective servers. In addition to providing simple
+database-based sharding, the schemarouter also enables cross-node
+session variable usage by routing all queries that modify the session to all
 nodes.
 
-By default the SchemaRouter assumes that each database and table is only located\
-on one server. If it finds the same database or table on multiple servers, it\
+By default the SchemaRouter assumes that each database and table is only located
+on one server. If it finds the same database or table on multiple servers, it
 will close the session with the following error:
 
 ```
@@ -18,67 +18,67 @@ ERROR 5000 (DUPDB): Error: duplicate tables found on two different shards.
 
 The exception to this rule are the system tables `mysql`, `information_schema`,`performance_schema`, `sys` that are never treated as duplicates.
 
-If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2402-maxscale-2402-schemarouter.md#ignore_tables_regex) parameter to controls which\
+If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2402-maxscale-2402-schemarouter.md#ignore_tables_regex) parameter to controls which
 duplicate tables are allowed. To disable the duplicate database detection, use`ignore_tables_regex=.*`.
 
-Schemarouter compares table and database names case-insensitively. This means\
+Schemarouter compares table and database names case-insensitively. This means
 that the tables `test.t1` and `test.T1` are assumed to refer to the same table.
 
-The main limitation of SchemaRouter is that aside from session variable writes\
-and some specific queries, a query can only target one server. This means that\
+The main limitation of SchemaRouter is that aside from session variable writes
+and some specific queries, a query can only target one server. This means that
 queries which depend on results from multiple servers give incorrect results.\
 See [Limitations](mariadb-maxscale-2402-maxscale-2402-schemarouter.md#limitations) for more information.
 
 From 2.3.0 onwards, SchemaRouter is capable of limited table family sharding.
 
-Older versions of MaxScale required that the `auth_all_servers` parameter was\
-enabled in order for the schemarouter services to load the authentication data\
-from all servers instead of just one server. Starting with MaxScale 24.02, the\
-schemarouter automatically fetches the authentication data from all servers and\
-joins it together. At the same time, the `auth_all_servers` parameter has been\
+Older versions of MaxScale required that the `auth_all_servers` parameter was
+enabled in order for the schemarouter services to load the authentication data
+from all servers instead of just one server. Starting with MaxScale 24.02, the
+schemarouter automatically fetches the authentication data from all servers and
+joins it together. At the same time, the `auth_all_servers` parameter has been
 deprecated and is ignored if present in the configuration.
 
 ### Routing Logic
 
-* If a command modifies the session state by modifying any session or user\
-  variables, the query is routed to all nodes. These statements include `SET`\
-  statements as well as any other statements that modify the behavior of the\
+* If a command modifies the session state by modifying any session or user
+  variables, the query is routed to all nodes. These statements include `SET`
+  statements as well as any other statements that modify the behavior of the
   client.
-* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers\
-  that contain the database. This same logic applies when a client connects with\
-  a default database: the default database is set only on servers that actually\
+* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers
+  that contain the database. This same logic applies when a client connects with
+  a default database: the default database is set only on servers that actually
   contain it.
-* If a query targets one or more tables that the schemarouter has discovered\
-  during the database mapping phase, the query is only routed if a server is\
-  found that contains all of the tables that the query uses. If no such server\
-  is found, the query is routed to the server that was previously used or to the\
-  first available backend if none have been used. If a query uses a table but\
-  doesn't define the database it is in, it is assumed to be located on the\
+* If a query targets one or more tables that the schemarouter has discovered
+  during the database mapping phase, the query is only routed if a server is
+  found that contains all of the tables that the query uses. If no such server
+  is found, the query is routed to the server that was previously used or to the
+  first available backend if none have been used. If a query uses a table but
+  doesn't define the database it is in, it is assumed to be located on the
   default database of the connection.
-* If a query targets a table or a database that is present on all nodes\
-  (e.g. `information_schema`) and the connection is using a default database,\
-  the query is routed based on the default database. This makes it possible to\
-  control where queries that do match a specific node are routed. If the\
-  connection is not using a default database, the query is routed based solely\
+* If a query targets a table or a database that is present on all nodes
+  (e.g. `information_schema`) and the connection is using a default database,
+  the query is routed based on the default database. This makes it possible to
+  control where queries that do match a specific node are routed. If the
+  connection is not using a default database, the query is routed based solely
   on the tables it contains.
-* If a query uses a table that is unknown to the schemarouter or executes a\
-  command that doesn't target a table, the query is routed to a server contains\
-  the current active default database. If the connection does not have a default\
-  database, the query is routed to the backend that was last used or to the\
-  first available backend if none have been used. If the query contains a\
+* If a query uses a table that is unknown to the schemarouter or executes a
+  command that doesn't target a table, the query is routed to a server contains
+  the current active default database. If the connection does not have a default
+  database, the query is routed to the backend that was last used or to the
+  first available backend if none have been used. If the query contains a
   routing hint that directs it to a server, the query is routed there.
 
-This means that all administrative commands, replication related command as\
-well as certain transaction control statements (XA transaction) are routed to\
-the first available server in certain cases. To avoid problems, use routing\
+This means that all administrative commands, replication related command as
+well as certain transaction control statements (XA transaction) are routed to
+the first available server in certain cases. To avoid problems, use routing
 hints to direct where these statements should go.
 
-* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`\
-  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the\
-  queries to the first available backend. This means that cross-shard\
-  transactions are technically possible but, without external synchronization,\
+* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`
+  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the
+  queries to the first available backend. This means that cross-shard
+  transactions are technically possible but, without external synchronization,
   the transactions are not guaranteed to be globally consistent.
-* `LOAD DATA LOCAL INFILE` commands are routed to the first available server\
+* `LOAD DATA LOCAL INFILE` commands are routed to the first available server
   that contains the tables listed in the query.
 
 #### Custom SQL Commands
@@ -95,24 +95,24 @@ db1.t2   |MyServer1    |
 db2.t1   |MyServer2    |
 ```
 
-The schemarouter will also intercept the `SHOW DATABASES` command and generate\
-it based on its internal data. This means that newly created databases will not\
-show up immediately and will only be visible when the cached data has been\
+The schemarouter will also intercept the `SHOW DATABASES` command and generate
+it based on its internal data. This means that newly created databases will not
+show up immediately and will only be visible when the cached data has been
 updated.
 
 #### Database Mapping
 
-The schemarouter maps each of the servers to know where each database and table\
-is located. As each user has access to a different set of tables and databases,\
-the result is unique to the username and the set of servers that the service\
-uses. These results are cached by the schemarouter. The lifetime of the cached\
+The schemarouter maps each of the servers to know where each database and table
+is located. As each user has access to a different set of tables and databases,
+the result is unique to the username and the set of servers that the service
+uses. These results are cached by the schemarouter. The lifetime of the cached
 result is controlled by the `refresh_interval` parameter.
 
-When a server needs to be mapped, the schemarouter will route a query to each of\
-the servers using the client's credentials. While this query is being executed,\
-all other sessions that would otherwise share the cached result will wait for\
-the update to complete. This waiting functionality was added in MaxScale 2.4.19,\
-older versions did not wait for existing updates to finish and would perform\
+When a server needs to be mapped, the schemarouter will route a query to each of
+the servers using the client's credentials. While this query is being executed,
+all other sessions that would otherwise share the cached result will wait for
+the update to complete. This waiting functionality was added in MaxScale 2.4.19,
+older versions did not wait for existing updates to finish and would perform
 parallel database mapping queries.
 
 ### Configuration
@@ -128,24 +128,24 @@ user=myuser
 password=mypwd
 ```
 
-The module generates the list of databases based on the servers parameter\
-using the connecting client's credentials. The user and password parameters\
-define the credentials that are used to fetch the authentication data from\
-the database servers. The credentials used only require the same grants as\
+The module generates the list of databases based on the servers parameter
+using the connecting client's credentials. The user and password parameters
+define the credentials that are used to fetch the authentication data from
+the database servers. The credentials used only require the same grants as
 mentioned in the configuration documentation.
 
-The list of databases is built by sending a SHOW DATABASES query to all the\
-servers. This requires the user to have at least USAGE and SELECT grants on\
+The list of databases is built by sending a SHOW DATABASES query to all the
+servers. This requires the user to have at least USAGE and SELECT grants on
 the databases that need be sharded.
 
-If you are connecting directly to a database or have different users on some\
-of the servers, you need to get the authentication data from all the\
-servers. You can control this with the `auth_all_servers` parameter. With\
-this parameter, MariaDB MaxScale forms a union of all the users and their\
-grants from all the servers. By default, the schemarouter will fetch the\
+If you are connecting directly to a database or have different users on some
+of the servers, you need to get the authentication data from all the
+servers. You can control this with the `auth_all_servers` parameter. With
+this parameter, MariaDB MaxScale forms a union of all the users and their
+grants from all the servers. By default, the schemarouter will fetch the
 authentication data from all servers.
 
-For example, if two servers have the database `shard` and the following\
+For example, if two servers have the database `shard` and the following
 rights are granted only on one server, all queries targeting the database`shard` would be routed to the server where the grants were given.
 
 ```
@@ -156,9 +156,9 @@ CREATE USER 'john'@'%' IDENTIFIED BY 'password';
 GRANT SELECT,USAGE ON shard.* TO 'john'@'%';
 ```
 
-This would in effect allow the user 'john' to only see the database 'shard'\
+This would in effect allow the user 'john' to only see the database 'shard'
 on this server. Take notice that these grants are matched against MariaDB\
-MaxScale's hostname instead of the client's hostname. Only user\
+MaxScale's hostname instead of the client's hostname. Only user
 authentication uses the client's hostname and all other grants use MariaDB\
 MaxScale's hostname.
 
@@ -171,7 +171,7 @@ MaxScale's hostname.
 * Dynamic: Yes
 * Default: `""`
 
-List of full table names (e.g. db1.t1) to ignore when checking for duplicate\
+List of full table names (e.g. db1.t1) to ignore when checking for duplicate
 tables. By default no tables are ignored.
 
 This parameter was once called `ignore_databases`.
@@ -183,11 +183,11 @@ This parameter was once called `ignore_databases`.
 * Dynamic: No
 * Default: `""`
 
-A [PCRE2 regular expression](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+A [PCRE2 regular expression](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 that is matched against database names when checking for duplicate databases.\
 By default no tables are ignored.
 
-The following configuration ignores duplicate tables in the databases `db1` and `db2`,\
+The following configuration ignores duplicate tables in the databases `db1` and `db2`,
 and all tables starting with "t" in `db3`.
 
 ```
@@ -204,12 +204,12 @@ This parameter was once called `ignore_databases_regex`.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+This parameter has been moved to [the MaxScale core](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)\
+This parameter has been moved to [the MaxScale core](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
 in MaxScale 6.0.
 
 #### `refresh_databases`
@@ -219,11 +219,11 @@ in MaxScale 6.0.
 * Dynamic: No
 * Default: `false`
 
-Enable database map refreshing mid-session. These are triggered by a failure to\
+Enable database map refreshing mid-session. These are triggered by a failure to
 change the database i.e. `USE ...` queries. This feature is disabled by default.
 
-Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0\
-release of MaxScale this parameter now works again but it is disabled by default\
+Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0
+release of MaxScale this parameter now works again but it is disabled by default
 to retain the same behavior as in older releases.
 
 #### `refresh_interval`
@@ -233,13 +233,13 @@ to retain the same behavior as in older releases.
 * Dynamic: Yes
 * Default: `300s`
 
-The minimum interval between database map refreshes in seconds. The default\
+The minimum interval between database map refreshes in seconds. The default
 value is 300 seconds.
 
-The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `max_staleness`
@@ -249,28 +249,28 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: 150s
 
-The time how long stale database map entries can be used while an update is in\
-progress. When a database map entry goes stale, the next connection to be\
-created will start an update of the database map. While this update is ongoing,\
-other connections can use the stale entry for up to `max_staleness` seconds. If\
-this limit is exceeded and the update still hasn't completed, new connections\
+The time how long stale database map entries can be used while an update is in
+progress. When a database map entry goes stale, the next connection to be
+created will start an update of the database map. While this update is ongoing,
+other connections can use the stale entry for up to `max_staleness` seconds. If
+this limit is exceeded and the update still hasn't completed, new connections
 will instead block and wait for the update to finish.
 
-This feature was added in MaxScale 23.08.0. Older versions of MaxScale\
-always waited for the update to complete when the database map entry\
+This feature was added in MaxScale 23.08.0. Older versions of MaxScale
+always waited for the update to complete when the database map entry
 went stale.
 
 ### Table Family Sharding
 
 This functionality was introduced in 2.3.0.
 
-If the same database exists on multiple servers, but the database contains different\
-tables in each server, SchemaRouter is capable of routing queries to the right server,\
+If the same database exists on multiple servers, but the database contains different
+tables in each server, SchemaRouter is capable of routing queries to the right server,
 depending on which table is being addressed.
 
-As an example, suppose the database `db` exists on servers _server1_ and _server2_, but\
-that the database on _server1_ contains the table `tbl1` and on _server2_ contains the\
-table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table\
+As an example, suppose the database `db` exists on servers _server1_ and _server2_, but
+that the database on _server1_ contains the table `tbl1` and on _server2_ contains the
+table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table
 names must be qualified with the database names for table-level sharding to work.\
 Specifically, the query series below is not supported.
 
@@ -281,7 +281,7 @@ SELECT * FROM tbl1; // May be routed to an incorrect backend if using table shar
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a schemarouter service contains the\
+The `router_diagnostics` output for a schemarouter service contains the
 following fields.
 
 * `shard_map_hits`: Cache hits for the shard map cache.
@@ -291,72 +291,72 @@ In MaxScale 24.02, the `queries` `sescmd_percentage`, `longest_sescmd_chain`,`ti
 
 ### Module commands
 
-Read [Module Commands](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md) documentation for\
+Read [Module Commands](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-module-commands.md) documentation for
 details about module commands.
 
 The schemarouter supports the following module commands.
 
 #### `invalidate SERVICE`
 
-Invalidates the database map cache of the given service. This can be used to schedule\
-the updates to the database maps to happen at off-peak hours by configuring a\
+Invalidates the database map cache of the given service. This can be used to schedule
+the updates to the database maps to happen at off-peak hours by configuring a
 high value for `refresh_interval` and invalidating the cache externally.
 
 #### `clear SERVICE`
 
-Clears the database map cache of the given service. This forces new connections\
+Clears the database map cache of the given service. This forces new connections
 to use a freshly retrieved entry.
 
-If the set of databases and tables in each shard is very large, the update can\
-take some time. If there are stale cache entries and `max_staleness` is\
-configured to be higher than the time it takes to update the database map, the\
-invalidation will only slow down one client connection that ends up doing the\
-update. When the cache is cleared completely, all clients will have to wait for\
-the update to complete. In general, cache invalidation should be preferred over\
+If the set of databases and tables in each shard is very large, the update can
+take some time. If there are stale cache entries and `max_staleness` is
+configured to be higher than the time it takes to update the database map, the
+invalidation will only slow down one client connection that ends up doing the
+update. When the cache is cleared completely, all clients will have to wait for
+the update to complete. In general, cache invalidation should be preferred over
 cache clearing.
 
 ### Limitations
 
-* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the\
-  first explicit database in the query, the current database in use or to the first\
+* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the
+  first explicit database in the query, the current database in use or to the first
   available database, depending on which succeeds.
-* Without a default database, queries that do not use fully qualified table\
-  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will\
-  be routed to the first available server. This includes queries such as explicit\
-  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`\
-  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`\
-  statements that do not directly refer to a table. `CREATE` commands should be\
-  done directly on the node or the router should be equipped with the hint filter\
-  and a routing hint should be used. Queries that modify the session state\
-  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the\
-  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,\
-  otherwise routing hints are required to correctly route the transaction control\
-  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the\
-  routing of transaction control commands to route them to all servers used by the\
+* Without a default database, queries that do not use fully qualified table
+  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will
+  be routed to the first available server. This includes queries such as explicit
+  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`
+  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`
+  statements that do not directly refer to a table. `CREATE` commands should be
+  done directly on the node or the router should be equipped with the hint filter
+  and a routing hint should be used. Queries that modify the session state
+  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the
+  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,
+  otherwise routing hints are required to correctly route the transaction control
+  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the
+  routing of transaction control commands to route them to all servers used by the
   schemarouter.
-* SELECT queries that modify session variables are not supported because uniform results\
-  cannot be guaranteed. If such a query is executed, the behavior of the router is\
+* SELECT queries that modify session variables are not supported because uniform results
+  cannot be guaranteed. If such a query is executed, the behavior of the router is
   undefined. To work around this limitation, the query must be executed in separate parts.
-* If a query targets a database the SchemaRouter has not mapped to a server, the\
-  query will be routed to the first available server. This possibly returns an\
+* If a query targets a database the SchemaRouter has not mapped to a server, the
+  query will be routed to the first available server. This possibly returns an
   error about database rights instead of a missing database.
-* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the\
+* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the
   correct backend if the statement is known and only requires one backend server. EXECUTE\
-  IMMEDIATE is not supported and is routed to the first available backend and may give\
+  IMMEDIATE is not supported and is routed to the first available backend and may give
   wrong results. Similarly, preparing a statement from a variable (e.g. `PREPARE stmt FROM @a`) is not supported and may be routed wrong.
-* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only\
-  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are\
+* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only
+  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are
   ignored. Starting with MaxScale 22.08, the database names will always be in lowercase.
-* `SHOW TABLES` is routed to the server with the current database. If using\
-  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table\
+* `SHOW TABLES` is routed to the server with the current database. If using
+  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table
   sharding. Use `SHOW SHARDS` to get results from the router itself. Starting with\
   MaxScale 22.08, the database names will always be in lowercase.
-* `USE db1` is routed to the server with `db1`. If the database is divided to multiple\
+* `USE db1` is routed to the server with `db1`. If the database is divided to multiple
   servers, only one server will get the command.
 
 ### Examples
 
-[Here](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-simple-sharding-with-two-servers.md) is a small tutorial on how\
+[Here](../maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-simple-sharding-with-two-servers.md) is a small tutorial on how
 to set up a sharded database.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-smartrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-smartrouter.md
@@ -2,20 +2,20 @@
 
 ### Overview
 
-SmartRouter is the query router of the SmartQuery framework. Based on the type\
-of the query, each query is routed to the server or cluster that can best\
+SmartRouter is the query router of the SmartQuery framework. Based on the type
+of the query, each query is routed to the server or cluster that can best
 handle it.
 
 For workloads where both transactional and analytical queries are needed,\
-SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into\
-a single entry point in MaxScale. This allows a MaxScale client to freely mix\
-transactional and analytical queries using the same connection. This is known\
+SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into
+a single entry point in MaxScale. This allows a MaxScale client to freely mix
+transactional and analytical queries using the same connection. This is known
 as Hybrid Transactional and Analytical Processing, HTAP.
 
 ### Configuration
 
-SmartRouter is configured as a service that either routes to other MaxScale\
-routers or plain servers. Although one can configure SmartRouter to use a plain\
+SmartRouter is configured as a service that either routes to other MaxScale
+routers or plain servers. Although one can configure SmartRouter to use a plain
 server directly, we refer to the configured "servers" as clusters.
 
 For details about the standard service parameters, refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
@@ -26,10 +26,10 @@ For details about the standard service parameters, refer to the [Configuration G
 * Mandatory: Yes
 * Dynamic: No
 
-One of the clusters must be designated as the **`master`**. All writes go to the\
+One of the clusters must be designated as the **`master`**. All writes go to the
 primary cluster, which for all practical purposes should be a primary-replica\
-ReadWriteSplit. This document does not go into details about setting up\
-primary-replica clusters, but suffice to say, that when setting up the ColumnStore\
+ReadWriteSplit. This document does not go into details about setting up
+primary-replica clusters, but suffice to say, that when setting up the ColumnStore
 servers they should be configured to be replicas of a MariaDB server running an\
 InnoDB engine.\
 The ReadWriteSplit [documentation](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md) has more on primary-replica setup.
@@ -85,8 +85,8 @@ service = SmartQuery
 port = <port>
 ```
 
-Note that the SmartQuery listener listens on a port, while the Row and Column\
-service listeners listen on Unix domain sockets. The reason is that there is a\
+Note that the SmartQuery listener listens on a port, while the Row and Column
+service listeners listen on Unix domain sockets. The reason is that there is a
 significant performance benefit when SmartRouter accesses the services over a\
 Unix domain socket compared to accessing them over a TCP/IP socket.
 
@@ -94,31 +94,31 @@ A complete configuration example can be found at the end of this document.
 
 ### Cluster selection - how queries are routed
 
-SmartRouter keeps track of the performance, or the execution time, of queries to\
+SmartRouter keeps track of the performance, or the execution time, of queries to
 the clusters. Measurements are stored with the canonical of a query as the key.\
-The canonical of a query is the sql with all user-defined constants replaced with\
-question marks. When SmartRouter sees a read-query whose canonical has not been\
-seen before, it will send the query to all clusters. The first response from a\
-cluster will designate that cluster as the best one for that canonical. Also,\
-when the first response is received, the other queries are cancelled. The\
-response is sent to the client once all clusters have responded to the query\
+The canonical of a query is the sql with all user-defined constants replaced with
+question marks. When SmartRouter sees a read-query whose canonical has not been
+seen before, it will send the query to all clusters. The first response from a
+cluster will designate that cluster as the best one for that canonical. Also,
+when the first response is received, the other queries are cancelled. The
+response is sent to the client once all clusters have responded to the query
 or the cancel.
 
-There is obviously overhead when a new canonical is seen. This means that\
-queries after a MaxScale start will be slightly slower than normal. The\
-execution time of a query depends on the database engine, and on the contents\
-of the tables being queried. As a result, MaxScale will periodically re-measure\
+There is obviously overhead when a new canonical is seen. This means that
+queries after a MaxScale start will be slightly slower than normal. The
+execution time of a query depends on the database engine, and on the contents
+of the tables being queried. As a result, MaxScale will periodically re-measure
 queries.
 
-The performance behavior of queries under dynamic conditions, and their effect\
-on different storage engines is being studied at MariaDB. As we learn more, we\
+The performance behavior of queries under dynamic conditions, and their effect
+on different storage engines is being studied at MariaDB. As we learn more, we
 will be able to better categorize queries and move that knowledge into\
 SmartRouter.
 
 ### Limitations
 
 * `LOAD DATA LOCAL INFILE` is not supported.
-* The performance data is not persisted. The measurements will be performed\
+* The performance data is not persisted. The measurements will be performed
   anew after each startup.
 
 ### Complete configuration example

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-automatic-failover-with-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-automatic-failover-with-mariadb-monitor.md
@@ -1,23 +1,23 @@
 # MaxScale 24.02 Automatic Failover With MariaDB Monitor
 
-The [MariaDB Monitor](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md) is not only capable\
-of monitoring the state of a MariaDB primary-replica cluster but is also\
-capable of performing _failover_ and _switchover_. In addition, in some\
-circumstances it is capable of _rejoining_ a primary that has gone down and\
+The [MariaDB Monitor](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md) is not only capable
+of monitoring the state of a MariaDB primary-replica cluster but is also
+capable of performing _failover_ and _switchover_. In addition, in some
+circumstances it is capable of _rejoining_ a primary that has gone down and
 later reappears.
 
-Note that the failover (and switchover and rejoin) functionality is only\
-supported in conjunction with GTID-based replication and initially only\
+Note that the failover (and switchover and rejoin) functionality is only
+supported in conjunction with GTID-based replication and initially only
 for simple topologies, that is, 1 primary and several replicas.
 
-The failover, switchover and rejoin functionality are inherent parts of\
-the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin\
+The failover, switchover and rejoin functionality are inherent parts of
+the _MariaDB Monitor_, but neither automatic failover nor automatic rejoin
 are enabled by default.
 
-The following examples have been written with the assumption that there\
-are four servers - `server1`, `server2`, `server3` and `server4` - of\
+The following examples have been written with the assumption that there
+are four servers - `server1`, `server2`, `server3` and `server4` - of
 which `server1` is the initial primary and the other servers are replicas.\
-In addition there is a monitor called _TheMonitor_ that monitors those\
+In addition there is a monitor called _TheMonitor_ that monitors those
 servers.
 
 Somewhat simplified, the MaxScale configuration file would look like:
@@ -46,7 +46,7 @@ servers=server1,server2,server3,server4
 
 ## Manual Failover
 
-If everything is in order, the state of the cluster will look something\
+If everything is in order, the state of the cluster will look something
 like this:
 
 ```
@@ -64,7 +64,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If the primary now for any reason goes down, then the cluster state will\
+If the primary now for any reason goes down, then the cluster state will
 look like this:
 
 ```
@@ -84,7 +84,7 @@ $ maxctrl list servers
 
 Note that the status for `server1` is _Down_.
 
-Since failover is by default _not_ enabled, the failover mechanism must be\
+Since failover is by default _not_ enabled, the failover mechanism must be
 invoked manually:
 
 ```
@@ -99,11 +99,11 @@ There are quite a few arguments, so let's look at each one separately:
 * `failover` is the command we want to invoke, and
 * `TheMonitor` is the first and only argument to that command, the name of the monitor as specified in the configuration file.
 
-The MariaDB Monitor will now autonomously deduce which replica is the most\
-appropriate one to be promoted to primary, promote it to primary and modify\
+The MariaDB Monitor will now autonomously deduce which replica is the most
+appropriate one to be promoted to primary, promote it to primary and modify
 the other replicas accordingly.
 
-If we now check the cluster state we will see that one of the remaining\
+If we now check the cluster state we will see that one of the remaining
 replicas has been made into primary.
 
 ```
@@ -121,7 +121,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, it will not be rejoined to the cluster, as\
+If `server1` now reappears, it will not be rejoined to the cluster, as
 shown by the following output:
 
 ```
@@ -139,15 +139,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Had `auto_rejoin=true` been specified in the monitor section, then an\
+Had `auto_rejoin=true` been specified in the monitor section, then an
 attempt to rejoin `server1` would have been made.
 
-In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a\
+In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a
 subsequent version a command to that effect will be provided.
 
 ## Automatic Failover
 
-To enable automatic failover, simply add `auto_failover=true` to the\
+To enable automatic failover, simply add `auto_failover=true` to the
 monitor section in the configuration file.
 
 ```
@@ -176,7 +176,7 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now goes down, failover will automatically be performed and\
+If `server1` now goes down, failover will automatically be performed and
 an existing replica promoted to new primary.
 
 ```
@@ -194,12 +194,12 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴────────────────────────┘
 ```
 
-If you are continuously monitoring the server states, you may notice for a\
+If you are continuously monitoring the server states, you may notice for a
 brief period that the state of `server1` is _Down_ and the state of`server2` is still _Slave, Running_.
 
 ## Rejoin
 
-To enable automatic rejoin, simply add `auto_rejoin=true` to the\
+To enable automatic rejoin, simply add `auto_rejoin=true` to the
 monitor section in the configuration file.
 
 ```
@@ -211,7 +211,7 @@ auto_rejoin=true
 ...
 ```
 
-When automatic rejoin is enabled, the MariaDB Monitor will attempt to\
+When automatic rejoin is enabled, the MariaDB Monitor will attempt to
 rejoin a failed primary as a replica, if it reappears.
 
 When everything is running fine, the cluster state looks like follows:
@@ -231,8 +231,8 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-Assuming `auto_failover=true` has been specified in the configuration\
-file, when `server1` goes down for some reason, failover will be performed\
+Assuming `auto_failover=true` has been specified in the configuration
+file, when `server1` goes down for some reason, failover will be performed
 and we end up with the following cluster state:
 
 ```
@@ -250,15 +250,15 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
-If `server1` now reappears, the MariaDB Monitor will detect that and\
+If `server1` now reappears, the MariaDB Monitor will detect that and
 attempt to rejoin the old primary as a replica.
 
-Whether rejoining will succeed depends upon the actual state of the old\
-primary. For instance, if the old primary was modified and the changes had\
-not been replicated to the new primary, before the old primary went down,\
+Whether rejoining will succeed depends upon the actual state of the old
+primary. For instance, if the old primary was modified and the changes had
+not been replicated to the new primary, before the old primary went down,
 then automatic rejoin will not be possible.
 
-If rejoining can be performed, then the cluster state will end up looking\
+If rejoining can be performed, then the cluster state will end up looking
 like:
 
 ```
@@ -278,11 +278,11 @@ $ maxctrl list servers
 
 ## Switchover
 
-Switchover is for cases when you explicitly want to move the primary\
+Switchover is for cases when you explicitly want to move the primary
 role from one server to another.
 
-If we continue from the cluster state at the end of the previous example\
-and want to make `server1` primary again, then we must issue the following\
+If we continue from the cluster state at the end of the previous example
+and want to make `server1` primary again, then we must issue the following
 command:
 
 ```
@@ -299,7 +299,7 @@ There are quite a few arguments, so let's look at each one separately:
 * `server1` is the second argument to the command, the name of the server we want to make into _primary_, and
 * `server2` is the third argument to the command, the name of the _current primary_.
 
-If the command executes successfully, we will end up with the following\
+If the command executes successfully, we will end up with the following
 cluster state:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-avrorouter-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-avrorouter-tutorial.md
@@ -1,11 +1,11 @@
 # MaxScale 24.02 Avrorouter Tutorial
 
-This tutorial is a short introduction to the [Avrorouter](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-avrorouter.md), how to set it up and how it interacts\
+This tutorial is a short introduction to the [Avrorouter](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-avrorouter.md), how to set it up and how it interacts
 with the binlogrouter.
 
-The first part configures the services and sets them up for the binary log to Avro\
-file conversion. The second part of this tutorial uses the client listener\
-interface for the avrorouter and shows how to communicate with the service\
+The first part configures the services and sets them up for the binary log to Avro
+file conversion. The second part of this tutorial uses the client listener
+interface for the avrorouter and shows how to communicate with the service
 over the network.
 
 ```mermaid
@@ -66,8 +66,8 @@ _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog
 
 ### Preparing the primary server
 
-The primary server where we will be replicating from needs to have binary logging\
-enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_\
+The primary server where we will be replicating from needs to have binary logging
+enabled, `binlog_format` set to `row` and `binlog_row_image` set to`full`. These can be enabled by adding the two following lines to the _my.cnf_
 file of the primary.
 
 ```
@@ -79,9 +79,9 @@ _You can find out more about replication formats from the_[_MariaDB documentatio
 
 ### Configuring MaxScale
 
-We start by adding two new services into the configuration file. The first\
-service is the binlogrouter service which will read the binary logs from the\
-primary server. The second service will read the binlogs as they are streamed\
+We start by adding two new services into the configuration file. The first
+service is the binlogrouter service which will read the binary logs from the
+primary server. The second service will read the binlogs as they are streamed
 from the primary and convert them into Avro format files.
 
 ```
@@ -117,13 +117,13 @@ protocol=CDC
 port=4001
 ```
 
-The `source` parameter in the _avro-service_ points to the _replication-service_\
-we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog\
-number to start from. With these parameters, the avrorouter will start reading\
+The `source` parameter in the _avro-service_ points to the _replication-service_
+we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog
+number to start from. With these parameters, the avrorouter will start reading
 events from binlog `binlog.000015`.
 
-Note that the _filestem_ and _start\_index_ must point to the file that is the\
-first binlog that the binlogrouter will replicate. For example, if the first\
+Note that the _filestem_ and _start\_index_ must point to the file that is the
+first binlog that the binlogrouter will replicate. For example, if the first
 file you are replicating is `my-binlog-file.001234`, set the parameters to`filestem=my-binlog-file` and `start_index=1234`.
 
 For more information on the avrorouter options, read the [Avrorouter\
@@ -131,31 +131,31 @@ Documentation](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-avro
 
 ## Preparing the data in the primary server
 
-Before starting the MaxScale process, we need to make sure that the binary logs\
-of the primary server contain the DDL statements that define the table\
-layouts. What this means is that the `CREATE TABLE` statements need to be in the\
+Before starting the MaxScale process, we need to make sure that the binary logs
+of the primary server contain the DDL statements that define the table
+layouts. What this means is that the `CREATE TABLE` statements need to be in the
 binary logs before the conversion process is started.
 
-If the binary logs contain data modification events for tables that aren't\
-created in the binary logs, the Avro schema of the table needs to be manually\
+If the binary logs contain data modification events for tables that aren't
+created in the binary logs, the Avro schema of the table needs to be manually
 created. There are multiple ways to do this:
 
-* Dump the database to a replica, configure it to replicate from the primary and\
-  point MaxScale to this replica (this is the recommended method as it requires no\
+* Dump the database to a replica, configure it to replicate from the primary and
+  point MaxScale to this replica (this is the recommended method as it requires no
   extra steps)
-* Use the [cdc\_schema Go utility](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-avrorouter.md)\
+* Use the [cdc\_schema Go utility](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-avrorouter.md)
   and copy the generated .avsc files to the avrodir
-* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)\
+* Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py)
   and copy the generated .avsc files to the avrodir
 
-If you used the schema generator scripts, all Avro schema files for tables that\
-are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of\
+If you used the schema generator scripts, all Avro schema files for tables that
+are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of
 the _test.t1_ table would be `test.t1.0000001.avsc`.
 
 ## Starting MariaDB MaxScale
 
-The next step is to start MariaDB MaxScale and set up the binlogrouter. We do\
-that by connecting to the MySQL listener of the _replication\_router_ service and\
+The next step is to start MariaDB MaxScale and set up the binlogrouter. We do
+that by connecting to the MySQL listener of the _replication\_router_ service and
 executing a few commands.
 
 ```
@@ -169,22 +169,22 @@ CHANGE MASTER TO MASTER_HOST='172.18.0.1',
 START SLAVE;
 ```
 
-**NOTE:** GTID replication is not currently supported and file-and-position\
+**NOTE:** GTID replication is not currently supported and file-and-position
 replication must be used.
 
 This will start the replication of binary logs from the primary server at\
-172.18.0.1 listening on port 3000. The first file that the binlogrouter\
-replicates is `binlog.000015`. This is the same file that was configured as the\
+172.18.0.1 listening on port 3000. The first file that the binlogrouter
+replicates is `binlog.000015`. This is the same file that was configured as the
 starting file in the avrorouter.
 
 For more details about the SQL commands, refer to the [Binlogrouter](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-binlogrouter.md) documentation.
 
-After the binary log streaming has started, the avrorouter will automatically\
+After the binary log streaming has started, the avrorouter will automatically
 start processing the binlogs.
 
 ## Creating and Processing Data
 
-Next, create a simple test table and populated it with some data by executing\
+Next, create a simple test table and populated it with some data by executing
 the following statements.
 
 ```
@@ -192,21 +192,21 @@ CREATE TABLE test.t1 (id INT);
 INSERT INTO test.t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 ```
 
-To use the _cdc.py_ command line client to connect to the CDC service, we must first\
+To use the _cdc.py_ command line client to connect to the CDC service, we must first
 create a user. This can be done via maxctrl by executing the following command.
 
 ```
 maxctrl call command cdc add_user avro-service maxuser maxpwd
 ```
 
-This will create the _maxuser:maxpwd_ credentials which can then be used to\
+This will create the _maxuser:maxpwd_ credentials which can then be used to
 request a JSON data stream of the `test.t1` table that was created earlier.
 
 ```
 cdc.py -u maxuser -p maxpwd -h 127.0.0.1 -P 4001 test.t1
 ```
 
-The output is a stream of JSON events describing the changes done to the\
+The output is a stream of JSON events describing the changes done to the
 database.
 
 ```
@@ -223,8 +223,8 @@ database.
 {"domain": 0, "server_id": 3000, "sequence": 11, "event_number": 10, "timestamp": 1537429419, "event_type": "insert", "id": 10}
 ```
 
-The first record is always the JSON format schema for the table describing the\
-types and names of the fields. All records that follow it represent the changes\
+The first record is always the JSON format schema for the table describing the
+types and names of the fields. All records that follow it represent the changes
 that have happened on the database.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-configuring-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-configuring-servers.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Configuring Servers
 
-The first step is to define the servers that make up the cluster. These servers\
+The first step is to define the servers that make up the cluster. These servers
 will be used by the services and are monitored by the monitor.
 
 ```
@@ -24,10 +24,10 @@ The `address` and `port` parameters tell where the server is located.
 
 ### Enabling TLS
 
-To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`\
+To enable encryption for the MaxScale-to-MariaDB communication, add `ssl=true`
 to the server section. To enable server certificate verification, add`ssl_verify_peer_certificate=true`.
 
-The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line\
+The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line
 client.
 
 For more information about TLS, refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-configuring-the-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-configuring-the-galera-monitor.md
@@ -16,19 +16,19 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
-This monitor module will assign one node within the Galera Cluster as the\
-current primary and other nodes as replica. Only those nodes that are active\
-members of the cluster are considered when making the choice of primary node. The\
+This monitor module will assign one node within the Galera Cluster as the
+current primary and other nodes as replica. Only those nodes that are active
+members of the cluster are considered when making the choice of primary node. The
 primary node will be the node with the lowest value of `wsrep_local_index`.
 
 ### Monitor User
 
-The monitor user does not require any special grants to monitor a Galera\
+The monitor user does not require any special grants to monitor a Galera
 cluster. To create a user for the monitor, execute the following SQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-configuring-the-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-configuring-the-mariadb-monitor.md
@@ -1,6 +1,6 @@
 # MaxScale 24.02 Configuring the MariaDB Monitor
 
-This document describes how to configure a MariaDB primary-replica cluster monitor\
+This document describes how to configure a MariaDB primary-replica cluster monitor
 to be used with MaxScale.
 
 ### Configuring the Monitor
@@ -17,14 +17,14 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
 ### Monitor User
 
-The monitor user requires the REPLICATION CLIENT privileges to do basic\
+The monitor user requires the REPLICATION CLIENT privileges to do basic
 monitoring. To create a user with the proper grants, execute the following SQL.
 
 ```
@@ -32,7 +32,7 @@ CREATE USER 'monitor_user'@'%' IDENTIFIED BY 'my_password';
 GRANT REPLICATION CLIENT ON *.* TO 'monitor_user'@'%';
 ```
 
-**Note:** If the automatic failover of the MariaDB Monitor will used, the user\
+**Note:** If the automatic failover of the MariaDB Monitor will used, the user
 will require additional grants. Execute the following SQL to grant them.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-connection-routing-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-connection-routing-with-mariadb-maxscale.md
@@ -1,7 +1,7 @@
 # MaxScale 24.02 Connection Routing with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that has two ports available, one for\
-write connections and another for read connections. The read connections are load-\
+The goal of this tutorial is to configure a system that has two ports available, one for
+write connections and another for read connections. The read connections are load-
 balanced across replica servers.
 
 ### Setting up MariaDB MaxScale
@@ -11,11 +11,11 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring services
 
-We want two services and ports to which the client application can connect. One service\
-routes client connections to the primary server, the other load balances between replica\
+We want two services and ports to which the client application can connect. One service
+routes client connections to the primary server, the other load balances between replica
 servers. To achieve this, we need to define two services in the configuration file.
 
-Create the following two sections in your configuration file. The section names are the\
+Create the following two sections in your configuration file. The section names are the
 names of the services and should be meaningful. For this tutorial, we use the names_Write-Service_ and _Read-Service_.
 
 ```
@@ -36,18 +36,18 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readconnroute_ for\
+_router_ defines the routing module used. Here we use _readconnroute_ for
 connection-level routing.
 
-A service needs a list of servers to route queries to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers to route queries to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _router\_options_-parameter tells the _readconnroute_-module which servers it should\
-route a client connection to. For the write service we use the `master`-type and for the\
+The _router\_options_-parameter tells the _readconnroute_-module which servers it should
+route a client connection to. For the write service we use the `master`-type and for the
 read service the `slave`-type.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2402-maxscale-2402-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2402-maxscale-2402-encrypting-passwords.md).
@@ -55,7 +55,7 @@ For increased security, see [password encryption](mariadb-maxscale-2402-maxscale
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one per service is enough.
 
 ```
@@ -70,13 +70,13 @@ service=Read-Service
 port=3307
 ```
 
-The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set\
+The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set
 it to _Read-Service_.
 
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-encrypting-passwords.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-encrypting-passwords.md
@@ -1,23 +1,23 @@
 # MaxScale 24.02 Encrypting Passwords
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
-There are two options for representing the password, either plain text or\
-encrypted passwords may be used. In order to use encrypted passwords a set of\
-keys must be generated that will be used by the encryption and decryption\
+There are two options for representing the password, either plain text or
+encrypted passwords may be used. In order to use encrypted passwords a set of
+keys must be generated that will be used by the encryption and decryption
 process. To generate the keys, use the `maxkeys` command.
 
 ```
 maxkeys
 ```
 
-By default the key file will be generated in `/var/lib/maxscale`. If a different\
-directory is required, it can be given as the first argument to the program. For\
+By default the key file will be generated in `/var/lib/maxscale`. If a different
+directory is required, it can be given as the first argument to the program. For
 more information, see `maxkeys --help`.
 
-Once the keys have been created the `maxpasswd` command can be used to generate\
+Once the keys have been created the `maxpasswd` command can be used to generate
 the encrypted password.
 
 ```
@@ -25,10 +25,10 @@ maxpasswd plainpassword
 96F99AA1315BDC3604B006F427DD9484
 ```
 
-The username and password, either encrypted or plain text, are stored in the\
+The username and password, either encrypted or plain text, are stored in the
 service section using the `user` and `password` parameters.
 
-If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For\
+If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For
 more information, see `maxkeys --help`.
 
 Here is an example configuration that uses an encrypted password.
@@ -43,7 +43,7 @@ user=maxscale
 password=96F99AA1315BDC3604B006F427DD9484
 ```
 
-If the key file is not in the default location, the [datadir](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) parameter must be\
+If the key file is not in the default location, the [datadir](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) parameter must be
 set to the directory that contains it.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-administration-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-administration-tutorial.md
@@ -1,46 +1,46 @@
 # MaxScale 24.02 MariaDB MaxScale Administration Tutorial
 
-The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator\
-to a few of the common administration tasks. This is intended to be an\
-introduction for administrators who are new to MariaDB MaxScale and not a\
+The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator
+to a few of the common administration tasks. This is intended to be an
+introduction for administrators who are new to MariaDB MaxScale and not a
 reference to all the tasks that may be performed.
 
 ### Administration audit file
 
-The REST API calls that MaxCtrl and MaxGui issue to MaxScale can be logged\
+The REST API calls that MaxCtrl and MaxGui issue to MaxScale can be logged
 by enabling [admin\_audit](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
 
 The generated file is a csv file that can be opened in most spread sheet programs.
 
 \[Rotating Log Files]\(#Rotating Log Files) also applies to the audit file.\
-The admin audit file will never be overwritten as a result of a rotate, unlike the\
+The admin audit file will never be overwritten as a result of a rotate, unlike the
 regular log file (in case a rotate is issued, but the file name has not been moved).\
-There is also the option to change the audit file name, which effectively rotates it\
+There is also the option to change the audit file name, which effectively rotates it
 independently of the regular log file.
 
 For e.g. `maxctrl alter maxscale admin_audit_file=/var/log/maxscale/admin_audit.march.csv`.
 
 ### Starting and Stopping MariaDB MaxScale
 
-MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,\
+MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,
 use `systemctl start maxscale`. To stop it, use `systemctl stop maxscale`.
 
 The systemd service file for MaxScale is located in`/lib/systemd/system/maxscale.service`.
 
 #### Additional Options for MaxScale
 
-Additional command line options and other systemd configuration options\
-can be given to MariaDB MaxScale by creating a drop-in file for the\
-service unit file. You can do this with the `systemctl edit maxscale.service`\
-command. For more information about systemd drop-in\
-files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)\
+Additional command line options and other systemd configuration options
+can be given to MariaDB MaxScale by creating a drop-in file for the
+service unit file. You can do this with the `systemctl edit maxscale.service`
+command. For more information about systemd drop-in
+files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)
 and [the systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html).
 
 ### Checking The Status Of The MariaDB MaxScale Services
 
-It is possible to use the maxctrl command to obtain statistics about the\
-services that are running within MaxScale. The maxctrl command `list services`\
-will give very basic information regarding services. This command may be either\
+It is possible to use the maxctrl command to obtain statistics about the
+services that are running within MaxScale. The maxctrl command `list services`
+will give very basic information regarding services. This command may be either
 run in interactive mode or passed on the maxctrl command line.
 
 ```
@@ -60,16 +60,16 @@ $ maxctrl list services
 └────────────────────────┴────────────────┴─────────────┴───────────────────┴────────────────────────────────────┘
 ```
 
-Network listeners count as a user of the service, therefore there will always be\
-one user per network port in which the service listens. More details can be\
+Network listeners count as a user of the service, therefore there will always be
+one user per network port in which the service listens. More details can be
 obtained by using the "show service" command.
 
 ### What Clients Are Connected To MariaDB MaxScale
 
-To determine what client are currently connected to MariaDB MaxScale, you can\
-use the `list sessions` command within maxctrl. This will give you IP address\
-and the ID of the session for that connection. As with any maxctrl\
-command this can be passed on the command line or typed interactively in\
+To determine what client are currently connected to MariaDB MaxScale, you can
+use the `list sessions` command within maxctrl. This will give you IP address
+and the ID of the session for that connection. As with any maxctrl
+command this can be passed on the command line or typed interactively in
 maxctrl.
 
 ```
@@ -83,32 +83,32 @@ $ maxctrl list sessions
 
 ### Rotating Log Files
 
-Log rotation applies to the MaxScale log file, admin audit file and\
+Log rotation applies to the MaxScale log file, admin audit file and
 qlafilter files.
 
 MariaDB MaxScale logs messages of different priority into a single log file.\
-With the exception if error messages that are always logged, whether messages of\
-a particular priority should be logged or not can be enabled via the maxctrl\
-interface or in the configuration file. By default, MaxScale keeps on writing to\
-the same log file. To prevent the file from growing indefinitely, the\
+With the exception if error messages that are always logged, whether messages of
+a particular priority should be logged or not can be enabled via the maxctrl
+interface or in the configuration file. By default, MaxScale keeps on writing to
+the same log file. To prevent the file from growing indefinitely, the
 administrator must take action.
 
-The name of the log file is maxscale.log. When the log is rotated, MaxScale\
+The name of the log file is maxscale.log. When the log is rotated, MaxScale
 closes the current log file and opens a new one using the same name.
 
-Log file rotation is achieved by use of the `rotate logs` command\
+Log file rotation is achieved by use of the `rotate logs` command
 in maxctrl.
 
 ```
 maxctrl rotate logs
 ```
 
-As there currently is only the maxscale log, that is the only one that will be\
+As there currently is only the maxscale log, that is the only one that will be
 rotated.
 
-This may be integrated into the Linux _logrotate_ mechanism by adding a\
-configuration file to the /etc/logrotate.d directory. If we assume we want to\
-rotate the log files once per month and wish to keep 5 log files worth of\
+This may be integrated into the Linux _logrotate_ mechanism by adding a
+configuration file to the /etc/logrotate.d directory. If we assume we want to
+rotate the log files once per month and wish to keep 5 log files worth of
 history, the configuration file would look as follows.
 
 ```
@@ -127,7 +127,7 @@ endscript
 }
 ```
 
-MariaDB MaxScale will also rotate all of its log files if it receives the USR1\
+MariaDB MaxScale will also rotate all of its log files if it receives the USR1
 signal. Using this the logrotate configuration script can be rewritten as
 
 ```
@@ -143,41 +143,41 @@ endscript
 }
 ```
 
-In older versions MaxScale renamed the log file, behavior which is not fully\
-compliant with the assumptions of logrotate and may lead to issues, depending on\
-the used logrotate configuration file. From version 2.1 onward, MaxScale will\
-not itself rename the log file, but when the log is rotated, MaxScale will\
-simply close and reopen the same log file. That will make the behavior fully\
+In older versions MaxScale renamed the log file, behavior which is not fully
+compliant with the assumptions of logrotate and may lead to issues, depending on
+the used logrotate configuration file. From version 2.1 onward, MaxScale will
+not itself rename the log file, but when the log is rotated, MaxScale will
+simply close and reopen the same log file. That will make the behavior fully
 compliant with logrotate.
 
 ### Taking Objects Temporarily Out of Use
 
 #### Putting Servers into Maintenance
 
-MariaDB MaxScale supports the concept of maintenance mode for servers within a\
-cluster. This allows for planned, temporary removal of a database from the\
+MariaDB MaxScale supports the concept of maintenance mode for servers within a
+cluster. This allows for planned, temporary removal of a database from the
 cluster without the need to change the MariaDB MaxScale configuration.
 
 ```
 maxctrl set server db-server-3 maintenance
 ```
 
-To achieve this, you can use the `set server` command in maxctrl to set the\
-maintenance mode flag for the server. This may be done interactively within\
+To achieve this, you can use the `set server` command in maxctrl to set the
+maintenance mode flag for the server. This may be done interactively within
 maxctrl or by passing the command on the command line.
 
-This will cause MariaDB MaxScale to stop routing any new requests to the server,\
-however if there are currently requests executing on the server these will not\
-be interrupted. Connections to servers in maintenance mode are closed as soon as\
-the next request arrives. To close them immediately, use the `--force` option\
+This will cause MariaDB MaxScale to stop routing any new requests to the server,
+however if there are currently requests executing on the server these will not
+be interrupted. Connections to servers in maintenance mode are closed as soon as
+the next request arrives. To close them immediately, use the `--force` option
 for `maxctrl set server`.
 
 ```
 maxctrl clear server db-server-3 maintenance
 ```
 
-Clearing the maintenance mode for a server will bring it back into use. If\
-multiple MariaDB MaxScale instances are configured to use the node then\
+Clearing the maintenance mode for a server will bring it back into use. If
+multiple MariaDB MaxScale instances are configured to use the node then
 maintenance mode must be set within each MariaDB MaxScale instance.
 
 ### Stopping and Starting Services
@@ -186,16 +186,16 @@ maintenance mode must be set within each MariaDB MaxScale instance.
 maxctrl stop service db-service
 ```
 
-Services can be stopped to temporarily halt their use. Stopping a service will\
-cause it to stop accepting new connections until it is started. New connections\
-are not refused if the service is stopped and are queued instead. This means\
+Services can be stopped to temporarily halt their use. Stopping a service will
+cause it to stop accepting new connections until it is started. New connections
+are not refused if the service is stopped and are queued instead. This means
 that connecting clients will wait until the service is started again.
 
 ```
 maxctrl start service db-service
 ```
 
-Starting a service will cause it to accept all queued connections that were\
+Starting a service will cause it to accept all queued connections that were
 created while it was stopped.
 
 #### Stopping and Starting Monitors
@@ -204,35 +204,35 @@ created while it was stopped.
 maxctrl stop monitor db-monitor
 ```
 
-Stopping a monitor will cause it to stop monitoring the state of the servers\
-assigned to it. This is useful when the state of the servers is assigned\
+Stopping a monitor will cause it to stop monitoring the state of the servers
+assigned to it. This is useful when the state of the servers is assigned
 manually with `maxctrl set server`.
 
 ```
 maxctrl start monitor db-monitor
 ```
 
-Starting a monitor will make it resume monitoring of the servers. Any manually\
+Starting a monitor will make it resume monitoring of the servers. Any manually
 assigned states will be overwritten by the monitor.
 
 ### Runtime Configuration Modification
 
-The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,\
+The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,
 modify or destroy objects (servers, services, monitors etc.) inside\
-MaxScale. The exact syntax for each of the commands and any additional options\
+MaxScale. The exact syntax for each of the commands and any additional options
 that they take can be seen with `maxctrl --help <command>`.
 
-Not all parameters can be modified at runtime. Refer to the module documentation\
-for more information on which parameters can be modified at runtime. If a\
-parameter cannot be modified at runtime, the object can be destroyed and\
+Not all parameters can be modified at runtime. Refer to the module documentation
+for more information on which parameters can be modified at runtime. If a
+parameter cannot be modified at runtime, the object can be destroyed and
 recreated in order to change it.
 
-All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime\
-persist through restarts. Any changes done to objects in the main configuration\
+All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime
+persist through restarts. Any changes done to objects in the main configuration
 file are ignored if a persisted entry is found for it.
 
-For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete\
-configuration for the object. To remove all runtime changes for all objects,\
+For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete
+configuration for the object. To remove all runtime changes for all objects,
 remove all files found in `/var/lib/maxscale/maxscale.cnf.d`.
 
 #### Core Parameter Configuration
@@ -243,7 +243,7 @@ Modify global MaxScale parameters:
 maxctrl alter maxscale auth_connect_timeout 5s
 ```
 
-Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) for a full list\
+Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md) for a full list
 of parameters that can be modified at runtime.
 
 #### Managing Servers
@@ -266,8 +266,8 @@ maxctrl alter server db-server-1 port 3307
 maxctrl destroy server db-server-1
 ```
 
-A server can only be destroyed if it is not used by any services or monitors. To\
-automatically remove the server from the services and monitors that use it, use\
+A server can only be destroyed if it is not used by any services or monitors. To
+automatically remove the server from the services and monitors that use it, use
 the `--force` flag.
 
 **Drain a Server**
@@ -276,9 +276,9 @@ the `--force` flag.
 maxctrl set server db-server-1 drain
 ```
 
-When a server is set into the `drain` state, no new connections to it are\
-created. Unlike to the `maintenance` state which immediately stops all new\
-requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them\
+When a server is set into the `drain` state, no new connections to it are
+created. Unlike to the `maintenance` state which immediately stops all new
+requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them
 in order to be gracefully closed once the client disconnects.
 
 To remove the `drain` state, use `clear server` command:
@@ -287,7 +287,7 @@ To remove the `drain` state, use `clear server` command:
 maxctrl clear server db-server-1 drain
 ```
 
-Servers with the `Master` state cannot be drained. To drain them, first perform\
+Servers with the `Master` state cannot be drained. To drain them, first perform
 a switchover to another node and then drain the server.
 
 #### Managing Monitors
@@ -322,7 +322,7 @@ maxctrl unlink monitor db-monitor db-server-1
 maxctrl destroy monitor db-monitor
 ```
 
-A monitor can only be destroyed if it is not monitoring any servers. To\
+A monitor can only be destroyed if it is not monitoring any servers. To
 automatically remove the servers from the monitor, use the `--force` flag.
 
 #### Managing Services
@@ -345,7 +345,7 @@ maxctrl alter service db-service user new-db-user
 maxctrl link service db-service db-server1
 ```
 
-Any servers added to services will only be used by new sessions. Existing\
+Any servers added to services will only be used by new sessions. Existing
 sessions will use the servers that were available when they connected.
 
 **Remove Servers from a Service**
@@ -354,8 +354,8 @@ sessions will use the servers that were available when they connected.
 maxctrl unlink service db-service db-server1
 ```
 
-Similarly to adding servers, removing servers from a service will only affect\
-new sessions. Existing sessions keep using the servers even if they are removed\
+Similarly to adding servers, removing servers from a service will only affect
+new sessions. Existing sessions keep using the servers even if they are removed
 from a service.
 
 **Change the Filters of a Service**
@@ -364,9 +364,9 @@ from a service.
 maxctrl alter service-filters my-regexfilter my-qlafilter
 ```
 
-The order of the filters is significant: the first filter will be the first to\
-receive the query. The new set of filters will only be used by new\
-sessions. Existing sessions will keep using the filters that were configured\
+The order of the filters is significant: the first filter will be the first to
+receive the query. The new set of filters will only be used by new
+sessions. Existing sessions will keep using the filters that were configured
 when they connected.
 
 **Destroy a Service**
@@ -375,9 +375,9 @@ when they connected.
 maxctrl destroy service db-service
 ```
 
-The service can only be destroyed if it uses no servers or clusters and has no\
-listeners associated with it. To force destruction of a service even if it does\
-use servers or has listeners, use the `--force` flag. This will also destroy any\
+The service can only be destroyed if it uses no servers or clusters and has no
+listeners associated with it. To force destruction of a service even if it does
+use servers or has listeners, use the `--force` flag. This will also destroy any
 listeners associated with the service.
 
 #### Managing Filters
@@ -394,11 +394,11 @@ maxctrl create filter regexfilter match=ENGINE=MyISAM replace=ENGINE=InnoDB
 maxctrl destroy filter my-regexfilter
 ```
 
-A filter can only be destroyed if it is not used by any services. To\
-automatically remove the filter from all services using it, use the `--force`\
+A filter can only be destroyed if it is not used by any services. To
+automatically remove the filter from all services using it, use the `--force`
 flag.
 
-Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters\
+Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters
 of a filter, destroy it and recreate it with the modified parameters.
 
 #### Managing Listeners
@@ -415,16 +415,16 @@ maxctrl create listener db-listener db-service 4006
 maxctrl destroy listener db-listener
 ```
 
-Destroying a listener will close the network socket and stop it from accepting\
-new connections. Existing connections that were created through it will keep\
+Destroying a listener will close the network socket and stop it from accepting
+new connections. Existing connections that were created through it will keep
 displaying it as the originating listener.
 
-Listeners cannot be moved from one service to another. In order to do this, the\
+Listeners cannot be moved from one service to another. In order to do this, the
 listener must be destroyed and then recreated with the new service.
 
 ### Managing MaxCtrl and REST API Users
 
-MaxCtrl uses the same credentials as the MaxScale REST API. These users can be\
+MaxCtrl uses the same credentials as the MaxScale REST API. These users can be
 managed via MaxCtrl.
 
 #### Create a New MaxCtrl User
@@ -433,14 +433,14 @@ managed via MaxCtrl.
 maxctrl create user basic-user basic-password
 ```
 
-By default new users are only allowed to read data. To make the account an\
+By default new users are only allowed to read data. To make the account an
 administrative account, add the `--type=admin` option to the command:
 
 ```
 maxctrl create user admin-user admin-password --type=admin
 ```
 
-Administrative accounts are allowed to use all MaxCtrl commands and modify any\
+Administrative accounts are allowed to use all MaxCtrl commands and modify any
 parts of MaxScale.
 
 #### Change the Password of an Existing User

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-read-write-splitting-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-read-write-splitting-with-mariadb-maxscale.md
@@ -1,7 +1,7 @@
 # MaxScale 24.02 Read-Write Splitting with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that appears to the client as a single\
-database. MariaDB MaxScale will split the statements such that write statements are sent\
+The goal of this tutorial is to configure a system that appears to the client as a single
+database. MariaDB MaxScale will split the statements such that write statements are sent
 to the primary server and read statements are balanced across the replica servers.
 
 ### Setting up MariaDB MaxScale
@@ -11,9 +11,9 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring the service
 
-After configuring the servers and the monitor, we create a read-write-splitter service\
-configuration. Create the following section in your configuration file. The section name\
-is also the name of the service and should be meaningful. For this tutorial, we use the\
+After configuring the servers and the monitor, we create a read-write-splitter service
+configuration. Create the following section in your configuration file. The section name
+is also the name of the service and should be meaningful. For this tutorial, we use the
 name _Splitter-Service_.
 
 ```
@@ -25,14 +25,14 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readwritesplit_ for\
+_router_ defines the routing module used. Here we use _readwritesplit_ for
 query-level read-write-splitting.
 
-A service needs a list of servers where queries will be routed to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers where queries will be routed to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2402-maxscale-2402-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2402-maxscale-2402-encrypting-passwords.md).
@@ -40,7 +40,7 @@ For increased security, see [password encryption](mariadb-maxscale-2402-maxscale
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one is enough.
 
 ```
@@ -55,7 +55,7 @@ The _service_ parameter tells which service the listener connects to. For the_Sp
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-rest-api-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-rest-api-tutorial.md
@@ -1,22 +1,22 @@
 # MaxScale 24.02 REST API Tutorial
 
-This tutorial is a quick overview of what the MaxScale REST API offers, how it\
-can be used to inspect the state of MaxScale and how to use it to modify the\
-runtime configuration of MaxScale. The tutorial uses the `curl` command line\
+This tutorial is a quick overview of what the MaxScale REST API offers, how it
+can be used to inspect the state of MaxScale and how to use it to modify the
+runtime configuration of MaxScale. The tutorial uses the `curl` command line
 client to demonstrate how the API is used.
 
 ### Configuration and Hardening
 
-The MaxScale REST API listens on port 8989 on the local host. The `admin_port`\
-and `admin_host` parameters control which port and address the REST API listens\
-on. Note that for security reasons the API only listens for local connections\
-with the default configuration. It is critical that the default credentials are\
-changed and TLS/SSL encryption is configured before exposing the REST API to a\
+The MaxScale REST API listens on port 8989 on the local host. The `admin_port`
+and `admin_host` parameters control which port and address the REST API listens
+on. Note that for security reasons the API only listens for local connections
+with the default configuration. It is critical that the default credentials are
+changed and TLS/SSL encryption is configured before exposing the REST API to a
 network.
 
-The default user for the REST API is `admin` and the password is `mariadb`. The\
-easiest way to secure the REST API is to use the `maxctrl` command line client\
-to create a new admin user and delete the default one. To do this, run the\
+The default user for the REST API is `admin` and the password is `mariadb`. The
+easiest way to secure the REST API is to use the `maxctrl` command line client
+to create a new admin user and delete the default one. To do this, run the
 following commands:
 
 ```
@@ -24,13 +24,13 @@ maxctrl create user my_user my_password --type=admin
 maxctrl destroy user admin
 ```
 
-This will create the user `my_user` with the password `my_password` that is an\
-administrative account. After this account is created, the default `admin`\
+This will create the user `my_user` with the password `my_password` that is an
+administrative account. After this account is created, the default `admin`
 account is removed with the next command.
 
-The next step is to enable TLS encryption. To do this, you need a CA\
-certificate, a private key and a public certificate file all in PEM format. Add\
-the following three parameters under the `[maxscale]` section of the MaxScale\
+The next step is to enable TLS encryption. To do this, you need a CA
+certificate, a private key and a public certificate file all in PEM format. Add
+the following three parameters under the `[maxscale]` section of the MaxScale
 configuration file and restart MaxScale.
 
 ```
@@ -39,15 +39,15 @@ admin_ssl_cert=/certs/server-cert.pem
 admin_ssl_ca_cert=/certs/ca-cert.pem
 ```
 
-Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our\
-server certificates are self-signed so the `--tls-verify-server-cert=false`\
+Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our
+server certificates are self-signed so the `--tls-verify-server-cert=false`
 option is required.
 
 ```
 maxctrl --user=my_user --password=my_password --secure --tls-ca-cert=/certs/ca-cert.pem --tls-verify-server-cert=false show maxscale
 ```
 
-If no errors are raised, this means that the communication via the REST API is\
+If no errors are raised, this means that the communication via the REST API is
 now secure and can be used across networks.
 
 ### Requesting Data
@@ -55,8 +55,8 @@ now secure and can be used across networks.
 **Note:** For the sake of brevity, the rest of this tutorial will omit the\
 TLS/SSL options from the `curl` command line. For more information, refer to the`curl` manpage.
 
-The most basic task to do with the REST API is to see whether MaxScale is up and\
-running. To do this, we do a HTTP request on the root resource (the `-i` option\
+The most basic task to do with the REST API is to see whether MaxScale is up and
+running. To do this, we do a HTTP request on the root resource (the `-i` option
 shows the HTTP headers).
 
 `curl -i 127.0.0.1:8989/v1/`
@@ -70,7 +70,7 @@ ETag: "0"
 Date: Mon, 04 Mar 19 08:29:41 GMT
 ```
 
-To query a resource collection endpoint, append it to the URL. The `/v1/filters/`\
+To query a resource collection endpoint, append it to the URL. The `/v1/filters/`
 endpoint shows the list of filters configured in MaxScale. This is a _resource collection_ endpoint: it contains the list of all resources of a particular type.
 
 `curl 127.0.0.1:8989/v1/filters`
@@ -145,17 +145,17 @@ endpoint shows the list of filters configured in MaxScale. This is a _resource c
 }
 ```
 
-The `data` holds the actual list of resources: the `Hint` and `Logger`\
-filters. Each object has the `id` field which is the unique name of that\
+The `data` holds the actual list of resources: the `Hint` and `Logger`
+filters. Each object has the `id` field which is the unique name of that
 object. It is the same as the section name in `maxscale.cnf`.
 
-Each resource in the list has a `relationships` object. This shows the\
-relationship links between resources. In our example, the `Hint` filter is used\
-by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in\
+Each resource in the list has a `relationships` object. This shows the
+relationship links between resources. In our example, the `Hint` filter is used
+by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in
 use.
 
-To request an individual resource, we add the object name to the resource\
-collection URL. For example, if we want to get only the `Logger` filter we\
+To request an individual resource, we add the object name to the resource
+collection URL. For example, if we want to get only the `Logger` filter we
 execute the following command.
 
 `curl 127.0.0.1:8989/v1/filters/Logger`
@@ -204,18 +204,18 @@ execute the following command.
 }
 ```
 
-Note that this time the `data` member holds an object instead of an array of\
-objects. All other parts of the response are similar to what was shown in the\
+Note that this time the `data` member holds an object instead of an array of
+objects. All other parts of the response are similar to what was shown in the
 previous example.
 
 ### Creating Objects
 
-One of the uses of the REST API is to create new objects in MaxScale at\
-runtime. This allows new servers, services, filters, monitor and listeners to be\
+One of the uses of the REST API is to create new objects in MaxScale at
+runtime. This allows new servers, services, filters, monitor and listeners to be
 created without restarting MaxScale.
 
-For example, to create a new server in MaxScale the JSON definition of a server\
-must be sent to the REST API at the `/v1/servers/` endpoint. The request body\
+For example, to create a new server in MaxScale the JSON definition of a server
+must be sent to the REST API at the `/v1/servers/` endpoint. The request body
 defines the server name as well as the parameters for it.
 
 To create objects with `curl`, first write the JSON definition into a file.
@@ -241,9 +241,9 @@ To send the data, use the following command.
 curl -X POST -d @new_server.txt 127.0.0.1:8989/v1/servers
 ```
 
-The `-d` option takes a file name prefixed with a `@` as an argument. Here we\
-have `@new_server.txt` which is the name of the file where the JSON definition\
-was stored. The `-X` option defines the HTTP verb to use and to create a new\
+The `-d` option takes a file name prefixed with a `@` as an argument. Here we
+have `@new_server.txt` which is the name of the file where the JSON definition
+was stored. The `-X` option defines the HTTP verb to use and to create a new
 object we must use the POST verb.
 
 To verify the data request the newly created object.
@@ -254,18 +254,18 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Modifying Data
 
-The easiest way to modify an object is to first request it, store the result in\
+The easiest way to modify an object is to first request it, store the result in
 a file, edit it and then send the updated object back to the REST API.
 
-Let's say we want to modify the port that the server we created earlier listens\
+Let's say we want to modify the port that the server we created earlier listens
 on. First we request the current object and store the result in a file.
 
 ```
 curl 127.0.0.1:8989/v1/servers/server1 > server1.txt
 ```
 
-After that we edit the file and change the port from 3003 to 3306. Next the\
-modified JSON object is sent to the REST API as a PATCH command. To do this,\
+After that we edit the file and change the port from 3003 to 3306. Next the
+modified JSON object is sent to the REST API as a PATCH command. To do this,
 execute the following command.
 
 ```
@@ -280,12 +280,12 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Object Relationships
 
-To continue with our previous example, we add the updated server to a\
-service. To do this, the `relationships` object of the server must be modified\
+To continue with our previous example, we add the updated server to a
+service. To do this, the `relationships` object of the server must be modified
 to include the service we want to add the server to.
 
-To define a relationship between a server and a service, the `data` member must\
-have the `relationships` field and it must contain an object with the `services`\
+To define a relationship between a server and a service, the `data` member must
+have the `relationships` field and it must contain an object with the `services`
 field (some fields omitted for brevity).
 
 ```
@@ -308,13 +308,13 @@ field (some fields omitted for brevity).
 }
 ```
 
-The `data.relationships.services.data` field contains a list of objects that\
-define the `id` and `type` fields. The id is the name of the object (a service\
-or a monitor for servers) and the type tells which type it is. Only `services`\
+The `data.relationships.services.data` field contains a list of objects that
+define the `id` and `type` fields. The id is the name of the object (a service
+or a monitor for servers) and the type tells which type it is. Only `services`
 type objects should be present in the `services` object.
 
-In our example we are linking the `server1` server to the `RW-Split-Router`\
-service. As was seen with the previous example, the easiest way to do this is to\
+In our example we are linking the `server1` server to the `RW-Split-Router`
+service. As was seen with the previous example, the easiest way to do this is to
 store the result, edit it and then send it back with a HTTP PATCH.
 
 If we want to remove a server from _all_ services and monitors, we can set the`data` member of the `services` and `monitors` relationships to an empty array:
@@ -334,39 +334,39 @@ If we want to remove a server from _all_ services and monitors, we can set the`d
 }
 ```
 
-This is useful if you want to delete the server which can only be done if it has\
+This is useful if you want to delete the server which can only be done if it has
 no relationships to other objects.
 
 ### Deleting Objects
 
-To delete an object, simply execute a HTTP DELETE request on the resource you\
-want to delete. For example, to delete the `server1` server, execute the\
+To delete an object, simply execute a HTTP DELETE request on the resource you
+want to delete. For example, to delete the `server1` server, execute the
 following command.
 
 ```
 curl -X DELETE 127.0.0.1:8989/v1/servers/server1
 ```
 
-In order to delete an object, it must not have any relationships to other\
+In order to delete an object, it must not have any relationships to other
 objects.
 
 ### Further Reading
 
 The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md).
 
-The `maxctrl` command line client is self-documenting and the `maxctrl help`\
-command is a good tool for exploring the various commands that are available in\
-it. The `maxctrl api get` command can be useful way to explore the REST API as\
+The `maxctrl` command line client is self-documenting and the `maxctrl help`
+command is a good tool for exploring the various commands that are available in
+it. The `maxctrl api get` command can be useful way to explore the REST API as
 it provides a way to easily extract values out of the JSON data generated by the\
 REST API.
 
-There is a multitude of REST API clients readily available and most of them are\
-far more convenient to use than `curl`. We recommend investigating what you need\
-and how you intend to either integrate or use the MaxScale REST API. Most modern\
-languages either have a built-in HTTP library or there exists a de facto\
+There is a multitude of REST API clients readily available and most of them are
+far more convenient to use than `curl`. We recommend investigating what you need
+and how you intend to either integrate or use the MaxScale REST API. Most modern
+languages either have a built-in HTTP library or there exists a de facto
 standard library.
 
-The MaxScale REST API follows the JSON API specification and there exist\
+The MaxScale REST API follows the JSON API specification and there exist
 libraries that are built specifically for these sorts of APIs
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-setting-up-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-setting-up-mariadb-maxscale.md
@@ -3,26 +3,26 @@
 This document is designed as a quick introduction to setting up MariaDB MaxScale.
 
 The installation and configuration of the MariaDB Server is not covered in this document.\
-See the following MariaDB documentation articles for more information on setting up a\
-primary-replica-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)\
+See the following MariaDB documentation articles for more information on setting up a
+primary-replica-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)
 and [Getting Started With MariaDB Galera Cluster](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster)\
 .
 
-This tutorial assumes that one of the standard MaxScale binary distributions is used and\
+This tutorial assumes that one of the standard MaxScale binary distributions is used and
 that MaxScale is installed using default options.
 
 Building from source code in GitHub is covered in [Building from Source](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-building-mariadb-maxscale-from-source-code.md).
 
 ### Installing MaxScale
 
-The precise installation process varies from one distribution to another. Details on\
+The precise installation process varies from one distribution to another. Details on
 package installation can be found in the [Installation Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-installation-guide.md).
 
 ### Creating a user account for MaxScale
 
-MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve\
-user authentication information from the backend databases. Create a special user\
-account for this purpose by executing the following SQL commands on the primary server of\
+MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve
+user authentication information from the backend databases. Create a special user
+account for this purpose by executing the following SQL commands on the primary server of
 your database cluster. The following tutorials will use these credentials.
 
 ```
@@ -41,12 +41,12 @@ MariaDB versions 10.2.2 to 10.2.10 also require `GRANT SELECT ON mysql.* TO 'max
 
 ### Creating client user accounts
 
-Because MariaDB MaxScale sits between the clients and the backend databases, the backend\
-databases will see all clients as if they were connecting from MaxScale's address. This\
+Because MariaDB MaxScale sits between the clients and the backend databases, the backend
+databases will see all clients as if they were connecting from MaxScale's address. This
 usually means that two sets of grants for each user are required.
 
 For example, assume that the user _'jdoe'@'client-host'_ exists and MaxScale is located at _maxscale-host_. If _'jdoe'@'client-host'_ needs to be able to connect through MaxScale,
-another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the\
+another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the
 same password and similar grants as _'jdoe'@'client-host'_.
 
 The quickest way to do this is to first create the new user:
@@ -73,18 +73,18 @@ Then copy the same grants to the `'jdoe'@'maxscale-host'` user.
 GRANT SELECT, INSERT, UPDATE, DELETE ON *.* TO 'jdoe'@'maxscale-host';
 ```
 
-An alternative to generating two separate accounts is to use one account with a wildcard\
-host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than\
+An alternative to generating two separate accounts is to use one account with a wildcard
+host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than
 having specific user accounts as it allows access from all hosts.
 
 ### Creating the configuration file
 
-MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is\
+MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is
 provided with the MaxScale installation.
 
-A global _maxscale_ section is included in every MaxScale configuration file. This section\
-sets the values of various global parameters, such as the number of threads MaxScale uses\
-to handle client requests. To set thread count to the number of available cpu cores, set\
+A global _maxscale_ section is included in every MaxScale configuration file. This section
+sets the values of various global parameters, such as the number of threads MaxScale uses
+to handle client requests. To set thread count to the number of available cpu cores, set
 the following.
 
 ```
@@ -94,7 +94,7 @@ threads=auto
 
 ### Configuring the servers
 
-Read the [Configuring Servers](mariadb-maxscale-2402-maxscale-2402-configuring-servers.md) mini-tutorial for server\
+Read the [Configuring Servers](mariadb-maxscale-2402-maxscale-2402-configuring-servers.md) mini-tutorial for server
 configuration instructions.
 
 ### Configuring the monitor
@@ -111,7 +111,7 @@ For a simple connection based setup, read the [Connection Routing Tutorial](mari
 
 ### Starting MaxScale
 
-After configuration is complete, MariaDB MaxScale is ready to start. For systems that\
+After configuration is complete, MariaDB MaxScale is ready to start. For systems that
 use systemd, use the _systemctl_ command.
 
 ```
@@ -124,13 +124,13 @@ For older SysV systems, use the _service_ command.
 sudo service maxscale start
 ```
 
-If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see\
+If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see
 if any errors are detected in the configuration file.
 
 ### Checking MaxScale status with MaxCtrl
 
-The _maxctrl_-command can be used to confirm that MaxScale is running and the services,\
-listeners and servers have been correctly configured. The following shows expected output\
+The _maxctrl_-command can be used to confirm that MaxScale is running and the services,
+listeners and servers have been correctly configured. The following shows expected output
 when using a read-write-splitting configuration.
 
 ```
@@ -163,7 +163,7 @@ when using a read-write-splitting configuration.
 └───────────────────┴──────┴──────┴─────────┘
 ```
 
-MariaDB MaxScale is now ready to start accepting client connections and route queries to\
+MariaDB MaxScale is now ready to start accepting client connections and route queries to
 the backend cluster.
 
 More options can be found in the [Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md),[readwritesplit module documentation](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md) and [readconnroute module documentation](../maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readconnroute.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-simple-sharding-with-two-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-simple-sharding-with-two-servers.md
@@ -1,15 +1,15 @@
 # MaxScale 24.02 Simple Sharding with Two Servers
 
-Sharding is the method of splitting a single logical database server into\
-separate physical databases. This tutorial describes a very simple way of\
+Sharding is the method of splitting a single logical database server into
+separate physical databases. This tutorial describes a very simple way of
 sharding. Each schema is located on a different database server and MariaDB\
-MaxScale's schemarouter module is used to combine them into a single logical\
+MaxScale's schemarouter module is used to combine them into a single logical
 database server.
 
 ### Environment
 
-This tutorial was written for Ubuntu 22.04, MaxScale 23.08 and [MariaDB 10.11](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/what-is-mariadb-1011). In addition to\
-the MaxScale server, you'll need two MariaDB servers which will be used for the\
+This tutorial was written for Ubuntu 22.04, MaxScale 23.08 and [MariaDB 10.11](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/what-is-mariadb-1011). In addition to
+the MaxScale server, you'll need two MariaDB servers which will be used for the
 sharding. The installation of MariaDB is not covered by this tutorial.
 
 ### Installing MaxScale
@@ -26,13 +26,13 @@ apt -y install maxscale
 
 ### Creating Users
 
-This tutorial uses a broader set of grants than is required for the sake of\
+This tutorial uses a broader set of grants than is required for the sake of
 brevity and backwards compatibility. For the minimal set of grants, refer to the [MaxScale Configuration Guide](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md).
 
-All MaxScale configurations require at least two accounts: one for reading\
-authentication data and another for monitoring the state of the\
-database. Services will use the first one and monitors will use the second\
-one. In addition to this, we want to have a separate account that our\
+All MaxScale configurations require at least two accounts: one for reading
+authentication data and another for monitoring the state of the
+database. Services will use the first one and monitors will use the second
+one. In addition to this, we want to have a separate account that our
 application will use.
 
 ```
@@ -57,8 +57,8 @@ All of the users must be created on both of the MariaDB servers.
 
 ### Creating the Schemas and Tables
 
-Each server will hold one unique schema which contains the data of one specific\
-customer. We'll also create a shared schema that is present on all shards that\
+Each server will hold one unique schema which contains the data of one specific
+customer. We'll also create a shared schema that is present on all shards that
 the shard-local tables can be joined into.
 
 Create the tables on the first server:
@@ -91,8 +91,8 @@ INSERT INTO shared_info.account_types VALUES (1, 'admin'), (2, 'user');
 
 The MaxScale configuration is stored in `/etc/maxscale.cnf`.
 
-First, we configure two servers we will use to shard our database. The `db-01`\
-server has the `customer_01` schema and the `db-02` server has the `customer_02`\
+First, we configure two servers we will use to shard our database. The `db-01`
+server has the `customer_01` schema and the `db-02` server has the `customer_02`
 schema.
 
 ```
@@ -123,7 +123,7 @@ password=secret
 ignore_tables_regex=.*
 ```
 
-After this we configure a listener for the service. The listener is the actual\
+After this we configure a listener for the service. The listener is the actual
 port that the user connects to. We will use the port 4000.
 
 ```
@@ -133,11 +133,11 @@ service=Sharded-Service
 port=4000
 ```
 
-The final step is to configure a monitor which will monitor the state of the\
-servers. The monitor will notify MariaDB MaxScale if the servers are down. We\
-add the two servers to the monitor and use the `monitor_user` credentials. For\
-the sharding use-case, the `galeramon` module is suitable even if we're not\
-using a Galera cluster. The `schemarouter` is only interested in whether the\
+The final step is to configure a monitor which will monitor the state of the
+servers. The monitor will notify MariaDB MaxScale if the servers are down. We
+add the two servers to the monitor and use the `monitor_user` credentials. For
+the sharding use-case, the `galeramon` module is suitable even if we're not
+using a Galera cluster. The `schemarouter` is only interested in whether the
 server is in the `Running` state or in the `Down` state.
 
 ```
@@ -192,12 +192,12 @@ systemctl start maxscale.service
 
 ### Testing the Sharding
 
-MariaDB MaxScale is now ready to start accepting client connections and routing\
-them. Queries are routed to the right servers based on the database they target\
-and switching between the shards is seamless since MariaDB MaxScale keeps the\
+MariaDB MaxScale is now ready to start accepting client connections and routing
+them. Queries are routed to the right servers based on the database they target
+and switching between the shards is seamless since MariaDB MaxScale keeps the
 session state intact between servers.
 
-To test, we query the schema that's located on the local shard and join it to\
+To test, we query the schema that's located on the local shard and join it to
 the shared table.
 
 ```
@@ -270,8 +270,8 @@ MariaDB [customer_02]> SELECT * FROM customer_01.accounts UNION SELECT * FROM cu
 ERROR 1146 (42S02): Table 'customer_01.accounts' doesn't exist
 ```
 
-In most multi-tenant situations, this is an acceptable limitation. If you do\
-need cross-shard joins, the [Spider](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/spider/spider-storage-engine-overview) storage\
+In most multi-tenant situations, this is an acceptable limitation. If you do
+need cross-shard joins, the [Spider](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/spider/spider-storage-engine-overview) storage
 engine will provide you this.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This tutorial is an overview of what the MaxGUI offers as an alternative\
+This tutorial is an overview of what the MaxGUI offers as an alternative
 solution to [MaxCtrl](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-2402-maxctrl.md).
 
 ## Dashboard
@@ -12,11 +12,11 @@ solution to [MaxCtrl](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-
 ### Annotation
 
 1. [MaxScale object](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md). i.e.\
-   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate\
+   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate
    to its detail page)
 2. Create a new MaxScale object.
 3. Dashboard Tab Navigation.
-4. Search Input. This can be used as a quick way to search for a keyword in\
+4. Search Input. This can be used as a quick way to search for a keyword in
    tables.
 5. Dashboard graphs. Refresh interval is 10 seconds.
 
@@ -30,18 +30,18 @@ solution to [MaxCtrl](../maxscale-24-02reference/mariadb-maxscale-2402-maxscale-
 
 ### Create a new MaxScale object
 
-Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating\
+Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating
 a new object.
 
 ### View Replication Status
 
-The replication status of a server monitored by [MariaDB-Monitor](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md) can be viewed by mousing over\
+The replication status of a server monitored by [MariaDB-Monitor](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md) can be viewed by mousing over
 the server name. A tooltip will be displayed with the following information:\
 replication\_state, seconds\_behind\_master, slave\_io\_running, slave\_sql\_running.
 
 ### How to kill a session
 
-A session can be killed easily on the "Current Sessions" list which can be\
+A session can be killed easily on the "Current Sessions" list which can be
 found on the [Dashboard](mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md#dashboard), Server detail, and Service detail page.
 
 ![](../../../../.gitbook/assets/MaxGUI-kill-session.png.png)
@@ -53,34 +53,34 @@ found on the [Dashboard](mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutori
 
 ## Detail
 
-This page shows information on each MaxScale object and allow to edit its\
-parameter, relationships and perform other manipulation operations. Most of the\
+This page shows information on each MaxScale object and allow to edit its
+parameter, relationships and perform other manipulation operations. Most of the
 control buttons will be shown on the mouse hover. Below is a screenshot of a\
-Monitor Detail page, other Detail pages also have a similar layout structure so\
+Monitor Detail page, other Detail pages also have a similar layout structure so
 this is used for illustration purpose.
 
 ![](../../../../.gitbook/assets/MaxGUI-detail.png.png)
 
 ### Annotation
 
-1. Settings option. Clicking on the gear icon will show icons allowing to do\
+1. Settings option. Clicking on the gear icon will show icons allowing to do
    different operations depending on the type of the Detail page.
 
 * Monitor Detail page, there are icons to Stop, Start, and Destroy monitor.
 * Service Detail page, there are icons to Stop, Start, and Destroy service.
-* Server Detail page, there are icons to Set maintenance mode, Clear server\
+* Server Detail page, there are icons to Set maintenance mode, Clear server
   state, Drain and Delete server.
-* Filter and Listener Detail page, there is a delete icon to delete the\
+* Filter and Listener Detail page, there is a delete icon to delete the
   object.
 
-1. Switchover button. This button is shown on the mouse hover allowing to\
+1. Switchover button. This button is shown on the mouse hover allowing to
    swap the running primary server with a designated secondary server.
-2. Edit parameters button. This button is shown on the mouse hover allowing\
-   to edit the MaxScale object's parameter. Clicking on it will enable editable\
+2. Edit parameters button. This button is shown on the mouse hover allowing
+   to edit the MaxScale object's parameter. Clicking on it will enable editable
    mode on the table. After finishing editing the parameters, simply click the\
    Done Editing button.
-3. A Detail page has tables showing "Relationship" between other MaxScale\
-   object. This "unlink" icon is shown on the mouse hover allowing to\
+3. A Detail page has tables showing "Relationship" between other MaxScale
+   object. This "unlink" icon is shown on the mouse hover allowing to
    remove the relationship between two objects.
 4. This button is used to link other MaxScale objects to the relationship.
 
@@ -96,12 +96,12 @@ This page visualizes MaxScale configuration as shown in the figure below.
 
 #### Annotation
 
-1. A MaxScale object (a node graph). The position of the node in the graph can\
+1. A MaxScale object (a node graph). The position of the node in the graph can
    be changed by dragging and dropping it.
-2. Anchor link. The detail page of each MaxScale object can be accessed by\
+2. Anchor link. The detail page of each MaxScale object can be accessed by
    clicking on the name of the node.
-3. Filter visualization button. By default, if the number of filters used by a\
-   service is larger than 3, filter nodes aren't visualized as shown in the\
+3. Filter visualization button. By default, if the number of filters used by a
+   service is larger than 3, filter nodes aren't visualized as shown in the
    figure. Clicking this button will visualize them.
 4. Hide filter visualization button.
 5. Refresh rate dropdown. The frequency with which the data is refreshed.
@@ -110,42 +110,42 @@ This page visualizes MaxScale configuration as shown in the figure below.
 ### Clusters
 
 This page shows all monitor clusters using [mariadbmon](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md) module in a card-like view.\
-Clicking on the card will visualize the cluster into a tree graph as shown in\
+Clicking on the card will visualize the cluster into a tree graph as shown in
 the figure below.
 
 ![](../../../../.gitbook/assets/MaxGUI-cluster-visualization.png.png)
 
 #### Annotation
 
-1. Drag a secondary server on top of a primary server to promote the secondary\
+1. Drag a secondary server on top of a primary server to promote the secondary
    server as the new primary server.
-2. Server manipulation operations button. Showing a dropdown with the following\
+2. Server manipulation operations button. Showing a dropdown with the following
    operations:
 
 * Set maintenance mode: Setting a server to a maintenance mode.
 * Clear server state: Clear current server state.
 * Drain server: Drain the server of connections.
 
-1. Quick access to query editor button. Opening the `Query Editor` page for\
-   this server. If the connection is already created for that server, it'll use\
-   it. Otherwise, it creates a blank worksheet and shows a connection dialog to\
+1. Quick access to query editor button. Opening the `Query Editor` page for
+   this server. If the connection is already created for that server, it'll use
+   it. Otherwise, it creates a blank worksheet and shows a connection dialog to
    connect to that server.
-2. Carousel navigation button. Viewing more information about the server in the\
+2. Carousel navigation button. Viewing more information about the server in the
    next slide.
 3. Collapse the carousel.
-4. Anchor link of the server. Opening the detail page of the server in a new\
+4. Anchor link of the server. Opening the detail page of the server in a new
    tab.
 5. Collapse its children nodes.
-6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be\
+6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be
    manually rejoined by dragging it on top of the primary server.
-7. Monitor manipulation operations button. Showing a dropdown with the\
+7. Monitor manipulation operations button. Showing a dropdown with the
    following operations:
 
 * Stop monitor.
 * Start monitor.
 * Reset Replication.
 * Release Locks.
-* Master failover. Manually performing a primary failover. This option is\
+* Master failover. Manually performing a primary failover. This option is
   visible only when the `auto_failover` parameter is disabled.
 
 1. Refresh rate dropdown. The frequency with which the data is refreshed.
@@ -159,11 +159,11 @@ This page shows and allows editing of MaxScale parameters.
 
 ### Annotation
 
-1. Edit parameters button. This button is shown on the mouse hover allowing\
-   to edit the MaxScale parameter. Clicking on it will enable editable mode on\
+1. Edit parameters button. This button is shown on the mouse hover allowing
+   to edit the MaxScale parameter. Clicking on it will enable editable mode on
    the table..
 2. Editable parameters are visible as it's illustrated in the screenshot.
-3. After finishing editing the parameters, simply click the Done Editing\
+3. After finishing editing the parameters, simply click the Done Editing
    button.
 
 ## Logs Archive
@@ -186,7 +186,7 @@ On this page, you may add numerous worksheets, each of which can be used for\
 
 ### Run Queries
 
-Clicking on the "Run Queries" card will open a dialog, providing options\
+Clicking on the "Run Queries" card will open a dialog, providing options
 to establish a connection to different MaxScale object types, including\
 "Listener, Server, Service".
 
@@ -200,10 +200,10 @@ There are various features in the Query Editor worksheet, the most notable ones 
 
 **Create a new connection**
 
-If the connection of the Query Editor expires, or if you wish to make\
-a new connection for the active worksheet, simply clicking on the button\
-located on the right side of the query tabs navigation bar which features a\
-server icon and an active connection name as a label. This will open the\
+If the connection of the Query Editor expires, or if you wish to make
+a new connection for the active worksheet, simply clicking on the button
+located on the right side of the query tabs navigation bar which features a
+server icon and an active connection name as a label. This will open the
 connection dialog and allow you to create a new connection.
 
 **Schemas objects sidebar**
@@ -213,7 +213,7 @@ connection dialog and allow you to create a new connection.
 There are two ways to set the current database:
 
 * Double-click on the name of the database.
-* Right-click on the name of the database to show the context menu, then select\
+* Right-click on the name of the database to show the context menu, then select
   the `Use database` option.
 
 **Preview table data of the top 1000 rows**
@@ -221,7 +221,7 @@ There are two ways to set the current database:
 There are two ways to preview data of a table:
 
 * Click on the name of the table.
-* Right-click on the name of the table to show the context menu, then select\
+* Right-click on the name of the table to show the context menu, then select
   the `Preview Data (top 1000)` option.
 
 **Describe table**
@@ -230,7 +230,7 @@ Right-click on the name of the table to show the context menu, then select the`V
 
 **Alter/Drop/Truncate table**
 
-Right-click on the name of the table to show the context menu, then select the\
+Right-click on the name of the table to show the context menu, then select the
 desired option.
 
 **Quickly insert an object into the editor**
@@ -238,13 +238,13 @@ desired option.
 There are two ways to quickly insert an object to the editor:
 
 * Drag the object and drop it in the desire position in the editor.
-* Right-click on the object to show the context menu, then mouse\
+* Right-click on the object to show the context menu, then mouse
   hover the `Place to Editor` option and select the desired insert option.
 
 **Show object creation statement and insights info**
 
-To view the statement that creates the given object in the [Schemas objects sidebar](mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md#schemas-objects-sidebar), right-clicking on schema or table node and\
-select the `View Insights` option. For other objects such as view, stored\
+To view the statement that creates the given object in the [Schemas objects sidebar](mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md#schemas-objects-sidebar), right-clicking on schema or table node and
+select the `View Insights` option. For other objects such as view, stored
 procedure, function and trigger, select the `Show Create` option.
 
 **Editor**
@@ -254,50 +254,50 @@ Visual Studio Code.
 
 To see the command palette, press F1 while the cursor is active on the editor.
 
-The editor also comes with various options to assist your querying tasks. To see\
+The editor also comes with various options to assist your querying tasks. To see
 available options, right-click on the editor to show the context menu.
 
 **Re-execute old queries**
 
 Every executed query will be saved in the browser's storage (IndexedDB).\
 Query history can be seen in the `History/Snippets` tab.\
-To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)\
+To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)
 and click the execute query button in the editor.
 
 **Create query snippet**
 
 Press CTRL/CMD + D to save the current SQL in the editor to the snippets storage.\
-A snippet is created with a prefix keyword, so when that keyword is typed in\
+A snippet is created with a prefix keyword, so when that keyword is typed in
 the editor, it will be suggested in the "code completion" menu.
 
 **Generate an ERD**
 
-To initiate the process, either right-click on the schema name and select the`Generate ERD` option, or click on the icon button that resembles a line graph,\
-located on the schemas sidebar. This will open a dialog for selecting the\
+To initiate the process, either right-click on the schema name and select the`Generate ERD` option, or click on the icon button that resembles a line graph,
+located on the schemas sidebar. This will open a dialog for selecting the
 tables for the diagram.
 
 ### Data Migration
 
-Clicking on the "Data Migration" card will open a dialog, providing an option\
-to name the task. The Data Migration worksheet will be rendered in the active\
+Clicking on the "Data Migration" card will open a dialog, providing an option
+to name the task. The Data Migration worksheet will be rendered in the active
 worksheet after clicking the `Create` button in the dialog.
 
 #### Data Migration worksheet
 
-MaxScale uses ODBC for extracting and loading from the data source to a server\
-in MaxScale. Before starting a migration, ensure that you have set up the\
-necessary configurations on the MaxScale server. Instruction can be found [here](../maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-sql-resource.md)\
+MaxScale uses ODBC for extracting and loading from the data source to a server
+in MaxScale. Before starting a migration, ensure that you have set up the
+necessary configurations on the MaxScale server. Instruction can be found [here](../maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-sql-resource.md)
 and limitations [here](../maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale.md).
 
 **Connections**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-data-migration-set-up-connections.png.png)
 
-Source connection shows the most common parameter inputs for creating\
-an ODBC connection. For extra parameters, enable the `Advanced` mode\
+Source connection shows the most common parameter inputs for creating
+an ODBC connection. For extra parameters, enable the `Advanced` mode
 to manually edit the `Connection String` input.
 
-After successfully connected to both source and destination servers,\
+After successfully connected to both source and destination servers,
 click on the `Select objects to migrate` to navigate to the next stage.
 
 **Objects Selection**
@@ -306,76 +306,76 @@ click on the `Select objects to migrate` to navigate to the next stage.
 
 Select the objects you wish to migrate to the MariaDB server.
 
-After selecting the desired objects, click on the `Prepare Migration Script` to\
-navigate to the next stage. The migration scripts will be generated\
-differently based on the value selected for the `Create mode` input. Hover over\
+After selecting the desired objects, click on the `Prepare Migration Script` to
+navigate to the next stage. The migration scripts will be generated
+differently based on the value selected for the `Create mode` input. Hover over
 the question icon for additional information on the modes.
 
 **Migration**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-data-migration-migration-script.png.png)
 
-As shown in the screenshot, you can quickly modify the script for each object\
-by selecting the corresponding object in the table and using the editors on the\
+As shown in the screenshot, you can quickly modify the script for each object
+by selecting the corresponding object in the table and using the editors on the
 right-hand side to make any necessary changes.
 
-After clicking the `Start Migration` button, the script for each object will be\
+After clicking the `Start Migration` button, the script for each object will be
 executed in parallel.
 
 **Migration report**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-data-migration-migration-report.png.png)
 
-If errors are reported for certain objects, review the output messages and\
+If errors are reported for certain objects, review the output messages and
 adjust the script accordingly. Then, click the `Manage` button and select `Restart`.
 
-To migrate additional objects, click the `Manage` button and select`Migrate other objects`. Doing so will replace the current migration\
+To migrate additional objects, click the `Manage` button and select`Migrate other objects`. Doing so will replace the current migration
 report for the current object with a new one.
 
 To retain the report and terminate open connections after migration, click the`Manage` button, then select `Disconnect`, and finally delete the worksheet.
 
-Deleting the worksheet will not delete the migration task. To clean-up\
+Deleting the worksheet will not delete the migration task. To clean-up
 everything after migration, click the `Manage` button, then select`Delete`.
 
 ### Create an ERD
 
-There are various features in the ERD worksheet, the most notable ones are\
+There are various features in the ERD worksheet, the most notable ones are
 listed below.
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-erd.png.png)
 
 #### ERD worksheet
 
-From an empty new worksheet, clicking on the "Create an ERD" card will open a\
-connection dialog. After connecting successfully, the ERD worksheet will be\
-rendered in the active worksheet. The connection is required to retrieve\
+From an empty new worksheet, clicking on the "Create an ERD" card will open a
+connection dialog. After connecting successfully, the ERD worksheet will be
+rendered in the active worksheet. The connection is required to retrieve
 essential metadata, such as engines, character sets, and collation.
 
 **Generate an ERD from the existing databases**
 
-Click on the icon button featured as a line graph, located on the top\
-toolbar next to the connection button. This will open a dialog for selecting\
+Click on the icon button featured as a line graph, located on the top
+toolbar next to the connection button. This will open a dialog for selecting
 the tables for the diagram.
 
 **Create a new ERD**
 
 New tables can be created by using either of the following methods:
 
-* Click on the icon button that resembles a line graph, located on the\
+* Click on the icon button that resembles a line graph, located on the
   top toolbar.
-* Right-click on the diagram board and select the `Create Table`\
+* Right-click on the diagram board and select the `Create Table`
   option.
 
 **Entity options**
 
-Two options are available: `Edit Table` and `Remove from Diagram`. These\
+Two options are available: `Edit Table` and `Remove from Diagram`. These
 options can be accessed using either of the following methods:
 
 * Right-click on the entity and choose the desired option.
-* Hover over the entity, click the gear icon button, and select the desired\
+* Hover over the entity, click the gear icon button, and select the desired
   option.
 
-For quickly editing or viewing the table definitions, double-clicking on the\
+For quickly editing or viewing the table definitions, double-clicking on the
 entity. The entity editor will be shown at the bottom of the worksheet.
 
 **Foreign keys quick common options**
@@ -384,42 +384,42 @@ entity. The entity editor will be shown at the bottom of the worksheet.
 
 * Edit Foreign Key, this opens an editor for viewing/editing foreign keys.
 * Remove Foreign Key.
-* `Change to One To One` or `Change to One To Many`. Toggling the uniqueness\
+* `Change to One To One` or `Change to One To Many`. Toggling the uniqueness
   of the foreign key column.
 * `Set FK Column Mandatory` or `Set FK Column Optional`. Toggling the`NOT NULL` option of the foreign key column.
 * `Set Referenced Column Mandatory` or `Set Referenced Column Optional`\
   Toggling the `NOT NULL` option of the referenced column.
 
-To show the above foreign key common options, perform a right-click on the link\
+To show the above foreign key common options, perform a right-click on the link
 within the diagram.
 
 **Viewing foreign key constraint SQL**
 
-Hover over the link in the diagram, the constraint SQL of that foreign key will\
+Hover over the link in the diagram, the constraint SQL of that foreign key will
 be shown in a tooltip.
 
 **Quickly draw a foreign key link**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-erd-fk-quick-option.png.png)
 
-As shown in the screenshot, a foreign key can be quickly established by\
+As shown in the screenshot, a foreign key can be quickly established by
 performing the following actions:
 
 1. Click on the entity that will have the foreign key.
-2. Click on the connecting point of the desired foreign key column and drag\
+2. Click on the connecting point of the desired foreign key column and drag
    it over the desired referenced column.
 
 **Entity editor**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-erd-entity-editor.png.png)
 
-Table columns, foreign keys and indexes can be modified via\
-the entity editor which can be accessed quickly by double-clicking\
+Table columns, foreign keys and indexes can be modified via
+the entity editor which can be accessed quickly by double-clicking
 on the entity.
 
 **Export options**
 
-Three options are available: `Copy script to clipboard`, `Export script` and`Export as jpeg`. These options can be accessed using either of the following\
+Three options are available: `Copy script to clipboard`, `Export script` and`Export as jpeg`. These options can be accessed using either of the following
 methods:
 
 * Right-click on the diagram board and choose the desired option.
@@ -436,7 +436,7 @@ editor within the dialog.
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-erd-visual-enhancements.png.png)
 
-The first section of the top toolbar, there are options to improve the visual of\
+The first section of the top toolbar, there are options to improve the visual of
 the diagram as follows:
 
 * Change the shape of links

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-ed25519-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-ed25519-authenticator.md
@@ -2,20 +2,20 @@
 
 ## Ed25519 Authenticator
 
-Ed25519 is a highly secure authentication method based on public key\
+Ed25519 is a highly secure authentication method based on public key
 cryptography. It is used with the auth\_ed25519-plugin of MariaDB Server.
 
-When a client authenticates via ed25519, MaxScale first sends them a random\
-message. The client signs the message using their password as private key and\
-sends the signature back. MaxScale then checks the signature using the public\
-key fetched from the _mysql.user_-table. The client password or an equivalent\
+When a client authenticates via ed25519, MaxScale first sends them a random
+message. The client signs the message using their password as private key and
+sends the signature back. MaxScale then checks the signature using the public
+key fetched from the _mysql.user_-table. The client password or an equivalent
 token is never exposed. For more information, see [server documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-ed25519).
 
-The security of this authentication scheme presents a problem for a proxy such\
-as MaxScale since MaxScale needs to log in to backend servers on behalf of the\
-client. Since each server will generate their own random messages, MaxScale\
-cannot simply forward the original signature. Either the real password is\
-required, or a different authentication scheme must be used between MaxScale\
+The security of this authentication scheme presents a problem for a proxy such
+as MaxScale since MaxScale needs to log in to backend servers on behalf of the
+client. Since each server will generate their own random messages, MaxScale
+cannot simply forward the original signature. Either the real password is
+required, or a different authentication scheme must be used between MaxScale
 and backends. The MaxScale ed25519auth-plugin supports both alternatives.
 
 ### Configuration
@@ -30,17 +30,17 @@ service=Read-Write-Service
 authenticator=ed25519auth
 ```
 
-MaxScale will now authenticate incoming clients with ed25519 if their user\
-account has _plugin_ set to "ed25519" in the _mysql.user_-table. However,\
-routing queries will fail since MaxScale cannot authenticate to backends. To\
-continue, either use a mapping file or enable sha256-mode. Sha256-mode is\
+MaxScale will now authenticate incoming clients with ed25519 if their user
+account has _plugin_ set to "ed25519" in the _mysql.user_-table. However,
+routing queries will fail since MaxScale cannot authenticate to backends. To
+continue, either use a mapping file or enable sha256-mode. Sha256-mode is
 enabled with the following settings.
 
 #### `ed_mode`
 
 This setting defines the authentication mode used. Two values are supported:
 
-* `ed25519` (default) Digital signature based authentication. Requires mapping\
+* `ed25519` (default) Digital signature based authentication. Requires mapping
   for backend support.
 * `sha256` Authenticate client with caching\_sha2\_password-plugin instead.\
   Requires either SSL or configured RSA-keys.
@@ -51,7 +51,7 @@ authenticator_options=ed_mode=sha256
 
 #### `ed_rsa_privkey_path` and `ed_rsa_pubkey_path`
 
-Defines the RSA-keys used for encrypting the client password if SSL is not in\
+Defines the RSA-keys used for encrypting the client password if SSL is not in
 use. Should point to files with the private and public keys.
 
 ```
@@ -62,13 +62,13 @@ authenticator_options=ed_mode=sha256,
 
 ### Using a mapping file
 
-To enable MaxScale to authenticate to backends,[user mapping](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+To enable MaxScale to authenticate to backends,[user mapping](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 can be used. The mapping and backend passwords are given in a json-file.\
-The client can map to an identical username or to another user, and the backend\
+The client can map to an identical username or to another user, and the backend
 authentication scheme can be something else than ed25519.
 
-The following example maps user "alpha" to "beta" and MaxScale then uses\
-standard authentication to log into backends as "beta". User "alpha"\
+The following example maps user "alpha" to "beta" and MaxScale then uses
+standard authentication to log into backends as "beta". User "alpha"
 authenticates to MaxScale using whatever method configured in the server.\
 User "gamma" does not map to another user, just the password is given.
 
@@ -114,16 +114,16 @@ user_mapping_file=/home/joe/mapping.json
 
 ### Using sha256-authentication
 
-The mapping-based solution requires the DBA to maintain a file with user\
+The mapping-based solution requires the DBA to maintain a file with user
 passwords, which has security and upkeep implications. To avoid this,\
-MaxScale can instead use the caching\_sha2\_password-plugin to authenticate\
-the client. This authentication scheme transmits the client password to MaxScale\
-in full, allowing MaxScale to log into backends using ed25519. MaxScale\
-effectively lies to the client about its authentication plugin and then uses\
-the correct plugin with the backends. Enable sha256-authentication by setting\
+MaxScale can instead use the caching\_sha2\_password-plugin to authenticate
+the client. This authentication scheme transmits the client password to MaxScale
+in full, allowing MaxScale to log into backends using ed25519. MaxScale
+effectively lies to the client about its authentication plugin and then uses
+the correct plugin with the backends. Enable sha256-authentication by setting
 authentication option _ed\_mode_ to "sha256".
 
-sha256-authentication is best used with encrypted connections. The example\
+sha256-authentication is best used with encrypted connections. The example
 below shows a listener configured for sha256-mode and SSL.
 
 ```
@@ -141,9 +141,9 @@ ssl_ca=/tmp/myCA.pem
 
 If SSL is not in use, caching\_sha2\_password transmits the password using\
 RSA-encryption. In this case, MaxScale needs the public and private RSA-keys.\
-MaxScale sends the public key to the client if they don't already have it and\
-the client uses it to encrypt the password. MaxScale then uses the private key\
-to decrypt the password. The example below shows a listener configured for\
+MaxScale sends the public key to the client if they don't already have it and
+the client uses it to encrypt the password. MaxScale then uses the private key
+to decrypt the password. The example below shows a listener configured for
 sha256-mode without SSL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-gssapi-client-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-gssapi-client-authenticator.md
@@ -4,25 +4,25 @@
 
 ## GSSAPI Client Authenticator
 
-GSSAPI is an authentication protocol that is commonly implemented with Kerberos\
-on Unix or Active Directory on Windows. This document describes GSSAPI\
+GSSAPI is an authentication protocol that is commonly implemented with Kerberos
+on Unix or Active Directory on Windows. This document describes GSSAPI
 authentication in MaxScale. The authentication module name in MaxScale is_GSSAPIAuth_.
 
 ### Preparing the GSSAPI system
 
-For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short\
+For Unix systems, the usual GSSAPI implementation is Kerberos. This is a short
 guide on how to set up Kerberos for MaxScale.
 
-The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB\
-documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)\
+The first step is to configure MariaDB to use GSSAPI authentication. The MariaDB
+documentation for the [GSSAPI Authentication Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-gssapi)
 is a good example on how to set it up.
 
-The next step is to copy the keytab file from the server where MariaDB is\
-installed to the server where MaxScale is located. The keytab file must be\
-placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an\
+The next step is to copy the keytab file from the server where MariaDB is
+installed to the server where MaxScale is located. The keytab file must be
+placed in the configured default location which almost always is`/etc/krb5.keytab`. Alternatively, the keytab filepath can be given as an
 authenticator option.
 
-The location of the keytab file can be changed with the KRB5\_KTNAME environment\
+The location of the keytab file can be changed with the KRB5\_KTNAME environment
 variable: [keytab\_def.html](https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html)
 
 To take GSSAPI authentication into use, add the following to the listener.
@@ -43,10 +43,10 @@ The principal name should be the same as on the MariaDB servers.
 * Dynamic: No
 * Default: `mariadb/localhost.localdomain`
 
-The service principal name to send to the client. This parameter is a string\
+The service principal name to send to the client. This parameter is a string
 parameter which is used by the client to request the token.
 
-This parameter _must_ be the same as the principal name that the backend MariaDB\
+This parameter _must_ be the same as the principal name that the backend MariaDB
 server uses.
 
 #### `gssapi_keytab_path`
@@ -56,10 +56,10 @@ server uses.
 * Dynamic: No
 * Default: Kerberos Default
 
-Keytab file location. This should be an absolute path to the file containing the\
-keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that\
+Keytab file location. This should be an absolute path to the file containing the
+keytab. If not defined, Kerberos will search from a default location, usually`/etc/krb5.keytab`. This path is set to an environment variable. This means that
 multiple listeners with GSSAPIAuth will override each other. If using multiple\
-GSSAPI authenticators, either do not set this option or use the same value for\
+GSSAPI authenticators, either do not set this option or use the same value for
 all listeners.
 
 ```
@@ -68,23 +68,23 @@ authenticator_options=principal_name=mymariadb@EXAMPLE.COM,gssapi_keytab_path=/h
 
 ### Implementation details
 
-Read the [Authentication Modules](https://github.com/mariadb-corporation/docs-server/blob/test/en/maxscale-25-01-authentication-modules/README.md) document for more\
+Read the [Authentication Modules](https://github.com/mariadb-corporation/docs-server/blob/test/en/maxscale-25-01-authentication-modules/README.md) document for more
 details on how authentication modules work in MaxScale.
 
 #### GSSAPI authentication
 
-The GSSAPI plugin authentication starts when the database server sends the\
-service principal name in the AuthSwitchRequest packet. The principal name will\
+The GSSAPI plugin authentication starts when the database server sends the
+service principal name in the AuthSwitchRequest packet. The principal name will
 usually be in the form `service@REALM.COM`.
 
-The client searches its local cache for a token for the service or may request\
-it from the GSSAPI server. If found, the client sends the token to the database\
-server. The database server verifies the authenticity of the token using its\
+The client searches its local cache for a token for the service or may request
+it from the GSSAPI server. If found, the client sends the token to the database
+server. The database server verifies the authenticity of the token using its
 keytab file and sends the final OK packet to the client.
 
 ### Building the module
 
-The GSSAPI authenticator modules require the GSSAPI development libraries\
+The GSSAPI authenticator modules require the GSSAPI development libraries
 (krb5-devel on CentOS 7).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-mariadbmysql-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-mariadbmysql-authenticator.md
@@ -4,37 +4,37 @@
 
 ## MariaDB/MySQL Authenticator
 
-The _MariaDBAuth_-module implements the client and backend authentication for the\
-server plugin _mysql\_native\_password_. This is the default authentication\
+The _MariaDBAuth_-module implements the client and backend authentication for the
+server plugin _mysql\_native\_password_. This is the default authentication
 plugin used by both MariaDB and MySQL.
 
 ### Settings
 
-The following settings may be given in the _authenticator\_options_ of the\
+The following settings may be given in the _authenticator\_options_ of the
 listener.
 
 #### `clear_pw_passthrough`
 
 Boolean, default value is "false". Activates passthrough-mode. In this mode,\
-MaxScale does not check client credentials at all and defers authentication to\
-the backend server. It may be useful in any situation where MaxScale\
+MaxScale does not check client credentials at all and defers authentication to
+the backend server. It may be useful in any situation where MaxScale
 cannot check the existence of client user account nor authenticate the client.
 
-When a client connects to a listener with this setting enabled, MaxScale will\
-change authentication method to "mysql\_clear\_password", causing the client to\
-send their cleartext password to MaxScale. MaxScale will then attempt to use\
-the password to authenticate to backends. The authentication result of the\
+When a client connects to a listener with this setting enabled, MaxScale will
+change authentication method to "mysql\_clear\_password", causing the client to
+send their cleartext password to MaxScale. MaxScale will then attempt to use
+the password to authenticate to backends. The authentication result of the
 first backend to respond will be sent to the client. The backend may ask\
-MaxScale for either cleartext password or standard ("mysql\_native\_password")\
-authentication token. MaxScale can work with both backend plugins since it has\
+MaxScale for either cleartext password or standard ("mysql\_native\_password")
+authentication token. MaxScale can work with both backend plugins since it has
 the original password.
 
-This feature is incompatible with service setting _lazy\_connect_. Either leave\
-it unspecified or set `lazy_connect=false` in the linked service. Also,\
-multiple client authenticators are not allowed on the listener when\
+This feature is incompatible with service setting _lazy\_connect_. Either leave
+it unspecified or set `lazy_connect=false` in the linked service. Also,
+multiple client authenticators are not allowed on the listener when
 passthrough-mode is on.
 
-Because passwords are sent in cleartext, the listener should be configured for\
+Because passwords are sent in cleartext, the listener should be configured for
 ssl.
 
 ```
@@ -53,10 +53,10 @@ ssl=true
 * Dynamic: No
 * Default: `false`
 
-The service setting _log\_auth\_warnings_ must\
-also be enabled for this setting to have effect. When both settings are enabled,\
-password hashes are logged if a client gives a wrong password. This feature may\
-be useful when diagnosing authentication issues. It should only be enabled on a\
+The service setting _log\_auth\_warnings_ must
+also be enabled for this setting to have effect. When both settings are enabled,
+password hashes are logged if a client gives a wrong password. This feature may
+be useful when diagnosing authentication issues. It should only be enabled on a
 secure system as the logging of password hashes may be a security risk.
 
 #### `cache_dir`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-pam-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-pam-authenticator.md
@@ -3,15 +3,15 @@
 ## PAM Authenticator
 
 Pluggable authentication module (PAM) is a general purpose authentication API.\
-An application using PAM can authenticate a user without knowledge about the\
-underlying authentication implementation. The actual authentication scheme is\
-defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be\
-quite elaborate. MaxScale supports a very limited form of the PAM protocol,\
+An application using PAM can authenticate a user without knowledge about the
+underlying authentication implementation. The actual authentication scheme is
+defined in the operating system PAM config (e.g. `/etc/pam.d/`), and can be
+quite elaborate. MaxScale supports a very limited form of the PAM protocol,
 which this document details.
 
 ### Configuration
 
-The MaxScale PAM module requires little configuration. All that is required\
+The MaxScale PAM module requires little configuration. All that is required
 is to change the listener authenticator module to "PAMAuth".
 
 ```
@@ -27,14 +27,14 @@ address=123.456.789.10
 port=12345
 ```
 
-MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_\
-set to "pam" in the _mysql.user_-table. The PAM service name of a user is read\
-from the _authentication\_string_-column. The matching PAM service in the\
-operating system PAM config is used for authenticating the user. If the\_authentication\_string\_ for a user is empty, the fallback service "mysql" is\
+MaxScale uses the PAM authenticator plugin to authenticate users with _plugin_
+set to "pam" in the _mysql.user_-table. The PAM service name of a user is read
+from the _authentication\_string_-column. The matching PAM service in the
+operating system PAM config is used for authenticating the user. If the\_authentication\_string\_ for a user is empty, the fallback service "mysql" is
 used.
 
-PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)\
-for more information. A simple service definition used for testing this module\
+PAM service configuration is out of the scope of this document, see [The Linux-PAM System Administrators' Guide](https://www.linux-pam.org/Linux-PAM-html/Linux-PAM_SAG.html)
+for more information. A simple service definition used for testing this module
 is below.
 
 ```
@@ -52,8 +52,8 @@ account         required        pam_unix.so
 * Default: `false`
 
 If enabled, MaxScale communicates with the client as if using [mysql\_clear\_password](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/1-connecting/connection#mysql_clear_password-plugin).\
-This setting has no effect on MaxScale-to-backend communication, which adapts to\
-either "dialog" or "mysql\_clear\_password", depending on which one the backend\
+This setting has no effect on MaxScale-to-backend communication, which adapts to
+either "dialog" or "mysql\_clear\_password", depending on which one the backend
 suggests. This setting is meant to be used with the similarly named MariaDB\
 Server setting.
 
@@ -79,23 +79,23 @@ This setting defines the authentication mode used. Two values are supported:
 authenticator_options=pam_mode=password_2FA
 ```
 
-If set to _password\_2FA_, any users authenticating via PAM will be asked two\
-passwords ("Password" and "Verification code") during login. MaxScale uses the\
+If set to _password\_2FA_, any users authenticating via PAM will be asked two
+passwords ("Password" and "Verification code") during login. MaxScale uses the
 normal password when either the local PAM api or a backend asks for "Password".\
-MaxScale answers any other password prompt (e.g. "Verification code") with the\
-second password. See [the limitations section](mariadb-maxscale-2501-maxscale-2501-pam-authenticator.md#implementation-details-and-limitations)\
+MaxScale answers any other password prompt (e.g. "Verification code") with the
+second password. See [the limitations section](mariadb-maxscale-2501-maxscale-2501-pam-authenticator.md#implementation-details-and-limitations)
 for more details. Two-factor mode is incompatible with\_pam\_use\_cleartext\_plugin\_.
 
-If set to _suid_, MaxScale will launch a separate subprocess for every client to\
-handle pam authentication. This subprocess runs the binary`maxscale_pam_auth_tool` (installed in the binary directory), which calls the\
-system pam libraries. The binary is installed with the SUID bit set, which means\
-that it runs with root-privileges regardless of the user launching it. This\
-should bypass any file grant issues (e.g. reading `etc/shadow`) that may arise\
-with the _password_ or _password\_2FA_ options. The _suid_-option may also\
-perform faster if many clients authenticate with pam simultaneously due\
-to better separation of clients. It may also resist buggy pam plugins crashing,\
-as the crash would be limited to the subprocess only. The MariaDB Server uses\
-a similar pam authentication scheme. _suid_-mode supports two-factor\
+If set to _suid_, MaxScale will launch a separate subprocess for every client to
+handle pam authentication. This subprocess runs the binary`maxscale_pam_auth_tool` (installed in the binary directory), which calls the
+system pam libraries. The binary is installed with the SUID bit set, which means
+that it runs with root-privileges regardless of the user launching it. This
+should bypass any file grant issues (e.g. reading `etc/shadow`) that may arise
+with the _password_ or _password\_2FA_ options. The _suid_-option may also
+perform faster if many clients authenticate with pam simultaneously due
+to better separation of clients. It may also resist buggy pam plugins crashing,
+as the crash would be limited to the subprocess only. The MariaDB Server uses
+a similar pam authentication scheme. _suid_-mode supports two-factor
 authentication.
 
 #### `pam_backend_mapping`
@@ -106,7 +106,7 @@ authentication.
 * Values: `none`, `mariadb`
 * Default: `none`
 
-Defines backend authentication mapping, i.e. switch of authentication method\
+Defines backend authentication mapping, i.e. switch of authentication method
 between client-to-MaxScale and MaxScale-to-backend. Supported values:
 
 * `none` No mapping
@@ -116,28 +116,28 @@ between client-to-MaxScale and MaxScale-to-backend. Supported values:
 authenticator_options=pam_backend_mapping=mariadb
 ```
 
-If set to "mariadb", MaxScale will authenticate clients to backends using\
+If set to "mariadb", MaxScale will authenticate clients to backends using
 standard MariaDB authentication. Authentication to MaxScale itself still uses\
-PAM. MaxScale asks the local PAM system if the client username was mapped\
-to another username during authentication, and use the mapped username when\
-logging in to backends. Passwords for the mapped users can be given in a file,\
-see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to\
-authenticate without a password. Because of this, normal PAM users and mapped\
+PAM. MaxScale asks the local PAM system if the client username was mapped
+to another username during authentication, and use the mapped username when
+logging in to backends. Passwords for the mapped users can be given in a file,
+see `pam_mapped_pw_file` below. If passwords are not given, MaxScale will try to
+authenticate without a password. Because of this, normal PAM users and mapped
 users cannot be used on the same listener.
 
-Because the client still needs to authenticate to MaxScale normally, an\
-anonymous user may be required. If the backends do not allow such a user, one\
+Because the client still needs to authenticate to MaxScale normally, an
+anonymous user may be required. If the backends do not allow such a user, one
 can be manually added using the service setting [user\_accounts\_file](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
 
-To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be\
-installed separately. It is included in recent MariaDB Server packages and can\
-also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)\
-for more information on how to configure the module. If the goal is to only map\
-users from PAM to MariaDB in MaxScale, then configuring user mapping\
+To map usernames, the PAM service needs to use a module such as\_pam\_user\_map.so\_. This module is not a standard Linux component and needs to be
+installed separately. It is included in recent MariaDB Server packages and can
+also be compiled from source. See [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam)
+for more information on how to configure the module. If the goal is to only map
+users from PAM to MariaDB in MaxScale, then configuring user mapping
 on just the machine running MaxScale is enough.
 
-Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md),\
-as it is easier to configure. `pam_backend_mapping` should only be used when\
+Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md),
+as it is easier to configure. `pam_backend_mapping` should only be used when
 the user mapping needs to be defined by pam.
 
 #### `pam_mapped_pw_file`
@@ -147,19 +147,19 @@ the user mapping needs to be defined by pam.
 * Dynamic: No
 * Default: None
 
-Path to a json-text file with user passwords. Default value is empty, which\
+Path to a json-text file with user passwords. Default value is empty, which
 disables the feature.
 
 ```
 authenticator_options=pam_mapped_pw_file=/home/root/passwords.json,pam_backend_mapping=mariadb
 ```
 
-This feature only works together with `pam_backend_mapping=mariadb`. The file is\
-only read during listener creation (typically MaxScale start) or when a listener\
-is modified during runtime. The file should contain passwords for the mapped\
-users. When a client is authenticating, MaxScale searches the password data for a\
-matching username. If one is found, MaxScale uses the supplied password when\
-logging in to backends. Otherwise, MaxScale tries to authenticate without a\
+This feature only works together with `pam_backend_mapping=mariadb`. The file is
+only read during listener creation (typically MaxScale start) or when a listener
+is modified during runtime. The file should contain passwords for the mapped
+users. When a client is authenticating, MaxScale searches the password data for a
+matching username. If one is found, MaxScale uses the supplied password when
+logging in to backends. Otherwise, MaxScale tries to authenticate without a
 password.
 
 One array, "users\_and\_passwords", is read from the file. Each array element in the array must define the following fields:
@@ -186,105 +186,105 @@ An example file is below.
 
 ### Anonymous user mapping
 
-When backend authenticator mapping is not in use\
-(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator\
+When backend authenticator mapping is not in use
+(`authenticator_options=pam_backend_mapping=none`), the PAM authenticator
 supports a limited version of [user mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
 It requires less configuration but is also less accurate than proper mapping.\
 Anonymous mapping is enabled in MaxScale if the following user exists:
 
 * Empty username (e.g. `''@'%'` or `''@'myhost.com'`)
 * `plugin = 'pam'`
-* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one\
+* Proxy grant is on (The query `SHOW GRANTS FOR user@host;` returns at least one
   row with `GRANT PROXY ON ...`)
 
-When the authenticator detects such users, anonymous account mapping is enabled\
-for the hosts of the anonymous users. To verify this, enable the info log\
-(`log_info=1` in MaxScale config file). When a client is logging in using the\
-anonymous user account, MaxScale will log a message starting with "Found\
+When the authenticator detects such users, anonymous account mapping is enabled
+for the hosts of the anonymous users. To verify this, enable the info log
+(`log_info=1` in MaxScale config file). When a client is logging in using the
+anonymous user account, MaxScale will log a message starting with "Found
 matching anonymous user ...".
 
-When mapping is on, the MaxScale PAM authenticator does not require client\
-accounts to exist in the `mysql.user`-table received from the backend. MaxScale\
-only requires that the hostname of the incoming client matches the host field of\
-one of the anonymous users (comparison performed using `LIKE`). If a match is\
-found, MaxScale attempts to authenticate the client to the local machine with\
-the username and password supplied. The PAM service used for authentication is\
-read from the `authentication_string`-field of the anonymous user. If\
-authentication was successful, MaxScale then uses the username and password to\
+When mapping is on, the MaxScale PAM authenticator does not require client
+accounts to exist in the `mysql.user`-table received from the backend. MaxScale
+only requires that the hostname of the incoming client matches the host field of
+one of the anonymous users (comparison performed using `LIKE`). If a match is
+found, MaxScale attempts to authenticate the client to the local machine with
+the username and password supplied. The PAM service used for authentication is
+read from the `authentication_string`-field of the anonymous user. If
+authentication was successful, MaxScale then uses the username and password to
 log to the backends.
 
-Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2501-maxscale-2501-pam-authenticator.md#configuration). This means,\
-that if a user is found and the authentication fails, anonymous authentication\
-is not attempted even when it could use a different PAM service with a different\
+Anonymous mapping is only attempted if the client username is not found in the`mysql.user`-table as explained in [Configuration](mariadb-maxscale-2501-maxscale-2501-pam-authenticator.md#configuration). This means,
+that if a user is found and the authentication fails, anonymous authentication
+is not attempted even when it could use a different PAM service with a different
 outcome.
 
-Setting up PAM group mapping for the MariaDB server is a more involved process\
+Setting up PAM group mapping for the MariaDB server is a more involved process
 as the server requires details on which Unix user or group is mapped to which\
-MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)\
-for more details. Performing all the steps in the guide also on the MaxScale\
-machine is not required, as the MaxScale PAM plugin only checks that the client\
-host matches an anonymous user and that the client (with the username and\
-password it provided) can log into the local PAM configuration. If using normal\
-password authentication, simply generating the Unix user and password should be\
+MariaDB user. See [this guide](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/configuring-pam-authentication-and-user-mapping-with-unix-authentication)
+for more details. Performing all the steps in the guide also on the MaxScale
+machine is not required, as the MaxScale PAM plugin only checks that the client
+host matches an anonymous user and that the client (with the username and
+password it provided) can log into the local PAM configuration. If using normal
+password authentication, simply generating the Unix user and password should be
 enough.
 
 ### Implementation details and limitations
 
 The general PAM authentication scheme is difficult for a proxy such as MaxScale.\
-An application using the PAM interface needs to define a _conversation function_\
-to allow the OS PAM modules to communicate with the client, possibly exchanging\
-multiple messages. This works when a client logs in to a normal server, but not\
+An application using the PAM interface needs to define a _conversation function_
+to allow the OS PAM modules to communicate with the client, possibly exchanging
+multiple messages. This works when a client logs in to a normal server, but not
 with MaxScale since it needs to autonomously log into multiple backends. For\
-MaxScale to successfully log into the servers, the messages and answers need to\
-be predefined. The passwords given to MaxScale need to work as is when MaxScale\
+MaxScale to successfully log into the servers, the messages and answers need to
+be predefined. The passwords given to MaxScale need to work as is when MaxScale
 logs into the backends. This requirement prevents the use of one-time passwords.
 
-The MaxScale PAM authentication module supports two password modes. In normal\
+The MaxScale PAM authentication module supports two password modes. In normal
 mode, client authentication begins with MaxScale sending an\
-AuthSwitchRequest packet. In addition to the command, the packet contains the\
-client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)\
-and the message "Password: ". In the next packet, the client should send the\
-password, which MaxScale will forward to the PAM api running on the local\
-machine. If the password is correct, an OK packet is sent to the client. If the\
-local PAM api asks for additional credentials as is typical in two-factor\
-authentication schemes, authentication fails. Informational messages such as\
-password expiration notifications are allowed. These are simply printed to the\
+AuthSwitchRequest packet. In addition to the command, the packet contains the
+client plugin name ("dialog" or "mysql\_clear\_password"), a message type byte (4)
+and the message "Password: ". In the next packet, the client should send the
+password, which MaxScale will forward to the PAM api running on the local
+machine. If the password is correct, an OK packet is sent to the client. If the
+local PAM api asks for additional credentials as is typical in two-factor
+authentication schemes, authentication fails. Informational messages such as
+password expiration notifications are allowed. These are simply printed to the
 log.
 
-On the backend side, MaxScale expects the servers to act as MaxScale did towards\
-the client. The servers should send an AuthSwitchRequest packet as defined\
-above, MaxScale responds with the password received by the client authenticator\
-and finally backend replies with OK. Informational messages from backends are\
+On the backend side, MaxScale expects the servers to act as MaxScale did towards
+the client. The servers should send an AuthSwitchRequest packet as defined
+above, MaxScale responds with the password received by the client authenticator
+and finally backend replies with OK. Informational messages from backends are
 only printed to the info-log.
 
 #### Two-factor authentication support
 
-MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the\
-client to log in to the local PAM api as well as all the backends, the code must\
-be reusable. This prevents the use of any kind of centrally checked one-use\
-codes. Time-based codes work, assuming the backends are checking the codes\
+MaxScale supports a limited form of two-factor authentication with the`pam_mode=password_2FA`-option. Since MaxScale uses the 2FA-code given by the
+client to log in to the local PAM api as well as all the backends, the code must
+be reusable. This prevents the use of any kind of centrally checked one-use
+codes. Time-based codes work, assuming the backends are checking the codes
 independently of each other. Automatic reconnection features (e.g.\
-readwritesplit-router) will not work, as the code has likely changed since\
+readwritesplit-router) will not work, as the code has likely changed since
 original authentication.
 
-Optionally, the PAM configuration on the backend servers can be weakened such\
-that the servers only asks for the normal password. This way, MaxScale will\
-check the 2FA-code of the incoming client, while MaxScale logs into the backends\
+Optionally, the PAM configuration on the backend servers can be weakened such
+that the servers only asks for the normal password. This way, MaxScale will
+check the 2FA-code of the incoming client, while MaxScale logs into the backends
 using only the password.
 
-Due to technical reasons, MaxScale does not forward the password prompts from\
+Due to technical reasons, MaxScale does not forward the password prompts from
 the PAM api to the client. MaxScale will always ask for "Password" and\
-"Verification code", even if the PAM api asks for other items. This prevents the\
+"Verification code", even if the PAM api asks for other items. This prevents the
 use of authentication schemes where a specific question must be answered (e.g.\
-"Input code Nr. 5"). This is not a significant limitation, as such schemes would\
+"Input code Nr. 5"). This is not a significant limitation, as such schemes would
 not work with backend servers anyway.
 
 ### Test tool
 
-MaxScale binary directory contains the _test\_pam\_login_-executable. This simple\
-program asks for a username, password and PAM service and then uses the given\
-credentials to login to the given service. _test\_pam\_login_ uses the same code\
-as MaxScale itself to communicate with the OS PAM interface and may be useful\
+MaxScale binary directory contains the _test\_pam\_login_-executable. This simple
+program asks for a username, password and PAM service and then uses the given
+credentials to login to the given service. _test\_pam\_login_ uses the same code
+as MaxScale itself to communicate with the OS PAM interface and may be useful
 for diagnosing PAM login issues.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-connectors/mariadb-maxscale-2501-maxscale-2501-maxscale-cdc-connector.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-connectors/mariadb-maxscale-2501-maxscale-2501-maxscale-cdc-connector.md
@@ -6,29 +6,29 @@ The C++ connector for the [MariaDB MaxScale](https://mariadb.com/products/techno
 
 ### Usage
 
-The CDC connector is a single-file connector which allows it to be relatively\
+The CDC connector is a single-file connector which allows it to be relatively
 easily embedded into existing applications.
 
-To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
+To start using the connector, either download it from the [MariaDB website](https://mariadb.com/downloads/mariadb-tx/connector) or [configure the MaxScale repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
 and install the `maxscale-cdc-connector` package.
 
 ### API Overview
 
-A CDC connection object is prepared by instantiating the `CDC::Connection`\
-class. To create the actual connection, call the `CDC::Connection::connect`\
+A CDC connection object is prepared by instantiating the `CDC::Connection`
+class. To create the actual connection, call the `CDC::Connection::connect`
 method of the class.
 
-After the connection has been created, call the `CDC::Connection::read` method\
-to get a row of data. The `CDC::Row::length` method tells how many values a row\
-has and `CDC::Row::value` is used to access that value. The field name of a\
-value can be extracted with the `CDC::Row::key` method and the current GTID of a\
+After the connection has been created, call the `CDC::Connection::read` method
+to get a row of data. The `CDC::Row::length` method tells how many values a row
+has and `CDC::Row::value` is used to access that value. The field name of a
+value can be extracted with the `CDC::Row::key` method and the current GTID of a
 row of data is retrieved with the `CDC::Row::gtid` method.
 
 To close the connection, destroy the instantiated object.
 
 ### Examples
 
-The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)\
+The source code [contains an example](https://github.com/mariadb-corporation/MaxScale/blob/2.2/connectors/cdc-connector/examples/main.cpp)
 that demonstrates basic usage of the MaxScale CDC Connector.
 
 ### Dependencies
@@ -67,7 +67,7 @@ sudo zypper install -y libjansson-devel openssl-devel cmake make gcc-c++ git
 
 ### Building and Packaging
 
-To build and package the connector as a library, follow MaxScale build\
+To build and package the connector as a library, follow MaxScale build
 instructions with the exception of adding `-DTARGET_COMPONENT=devel` to the\
 CMake call.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-binlog-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-binlog-filter.md
@@ -6,22 +6,22 @@ This filter was introduced in MariaDB MaxScale 2.3.0.
 
 ### Overview
 
-The `binlogfilter` can be combined with a `binlogrouter` service to selectively\
+The `binlogfilter` can be combined with a `binlogrouter` service to selectively
 replicate the binary log events to replica servers.
 
-The filter uses two settings, _match_ and _exclude_, to determine which events\
-are replicated. If a binlog event does not match or is excluded, the event is\
-replaced with an empty data event. The empty event is always 35 bytes which\
+The filter uses two settings, _match_ and _exclude_, to determine which events
+are replicated. If a binlog event does not match or is excluded, the event is
+replaced with an empty data event. The empty event is always 35 bytes which
 translates to a space reduction in most cases.
 
-When statement-based replication is used, any query events that are filtered out\
-are replaced with a SQL comment. This causes the query event to do nothing and\
-thus the event will not modify the contents of the database. The GTID position\
-of the replicating database will still advance which means that downstream\
+When statement-based replication is used, any query events that are filtered out
+are replaced with a SQL comment. This causes the query event to do nothing and
+thus the event will not modify the contents of the database. The GTID position
+of the replicating database will still advance which means that downstream
 servers replicating from it keep functioning correctly.
 
-The filter works with both row based and statement based replication but we\
-recommend using row based replication with the binlogfilter. This guarantees\
+The filter works with both row based and statement based replication but we
+recommend using row based replication with the binlogfilter. This guarantees
 that there are no ambiguities in the event filtering.
 
 ### Settings
@@ -44,18 +44,18 @@ Include queries that match the regex. See next entry, `exclude`, for more inform
 
 Exclude queries that match the regex.
 
-If neither `match` nor `exclude` are defined, the filter does nothing and all events\
-are replicated. This filter does not accept regular expression options as a separate\
-setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for\
+If neither `match` nor `exclude` are defined, the filter does nothing and all events
+are replicated. This filter does not accept regular expression options as a separate
+setting, such settings must be defined in the patterns themselves. See the [PCRE2 api documentation](https://www.pcre.org/current/doc/html/pcre2api.html#SEC20) for
 more information.
 
-The two settings are matched against the database and table name concatenated\
-with a period. For example, the string the patterns are matched against for the\
+The two settings are matched against the database and table name concatenated
+with a period. For example, the string the patterns are matched against for the
 database `test` and table `t1` is `test.t1`.
 
-For statement based replication, the pattern is matched against all the tables\
-in the statements. If any of the tables matches the _match_ pattern, the event\
-is replicated. If any of the tables matches the _exclude_ pattern, the event is\
+For statement based replication, the pattern is matched against all the tables
+in the statements. If any of the tables matches the _match_ pattern, the event
+is replicated. If any of the tables matches the _exclude_ pattern, the event is
 not replicated.
 
 #### `rewrite_src`
@@ -75,28 +75,28 @@ See the next entry, `rewrite_dest`, for more information.
 * Default: None
 
 `rewrite_src` and `rewrite_dest` control the statement rewriting of the binlogfilter.\
-The `rewrite_src` setting is a PCRE2 regular expression that is matched against\
-the default database and the SQL of statement based replication events (query\
+The `rewrite_src` setting is a PCRE2 regular expression that is matched against
+the default database and the SQL of statement based replication events (query
 events). `rewrite_dest` is the replacement string which supports the normal\
-PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,\
+PCRE2 backreferences (e.g the first capture group is `$1`, the second is `$2`,
 etc.).
 
 Both `rewrite_src` and `rewrite_dest` must be defined to enable statement rewriting.
 
-When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)\
-must be used. The filter will disallow replication for all replicas that attempt\
+When statement rewriting is enabled [GTID-based replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/gtid)
+must be used. The filter will disallow replication for all replicas that attempt
 to replicate with traditional file-and-position based replication.
 
-The replacement is done both on the default database as well as the SQL\
-statement in the query event. This means that great care must be taken when\
-defining the rewriting rules. To prevent accidental modification of the SQL into\
-a form that is no longer valid, use database and table names that never occur in\
+The replacement is done both on the default database as well as the SQL
+statement in the query event. This means that great care must be taken when
+defining the rewriting rules. To prevent accidental modification of the SQL into
+a form that is no longer valid, use database and table names that never occur in
 the inserted data and is never used as a constant value.
 
 ### Example Configuration
 
-With the following configuration, only events belonging to database `customers`\
-are replicated. In addition to this, events for the table `orders` are excluded\
+With the following configuration, only events belonging to database `customers`
+are replicated. In addition to this, events for the table `orders` are excluded
 and thus are not replicated.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md
@@ -6,34 +6,34 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-From MaxScale version 2.2.11 onwards, the cache filter is no longer\
-considered experimental. The following changes to the default behaviour\
+From MaxScale version 2.2.11 onwards, the cache filter is no longer
+considered experimental. The following changes to the default behaviour
 have also been made:
 
 * The default value of `cached_data` is now `thread_specific` (used to be`shared`).
 * The default value of `selects` is now `assume_cacheable` (used to be`verify_cacheable`).
 
 The cache filter is a simple cache that is capable of caching the result of\
-SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,\
+SELECTs, so that subsequent identical SELECTs are served directly by MaxScale,
 without the queries being routed to any server.
 
 By _default_ the cache will be used and populated in the following circumstances:
 
 * There is no explicit transaction active, that is, autocommit is used,
 * there is an explicitly read-only transaction (that is,`START TRANSACTION READ ONLY`) active, or
-* there is a transaction active and no statement that modifies the database\
+* there is a transaction active and no statement that modifies the database
   has been performed.
 
-In practice, the last bullet point basically means that if a transaction has\
+In practice, the last bullet point basically means that if a transaction has
 been started with `BEGIN`, `START TRANSACTION` or `START TRANSACTION READ WRITE`, then the cache will be used and populated until the first `UPDATE`,`INSERT` or `DELETE` statement is encountered.
 
-That is, in default mode the cache effectively causes the system to behave\
-as if the _isolation level_ would be `READ COMMITTED`, irrespective of what\
+That is, in default mode the cache effectively causes the system to behave
+as if the _isolation level_ would be `READ COMMITTED`, irrespective of what
 the isolation level of the backends actually is.
 
 The default behaviour can be altered using the configuration parameter [cache\_in\_transactions](mariadb-maxscale-2501-maxscale-2501-cache.md#cache_in_transactions).
 
-By default it is assumed that all `SELECT` statements are cacheable, which\
+By default it is assumed that all `SELECT` statements are cacheable, which
 means that also statements like `SELECT LOCALTIME` are cached. Please check [selects](mariadb-maxscale-2501-maxscale-2501-cache.md#selects) for how to change the default behaviour.
 
 ### Limitations
@@ -52,34 +52,34 @@ Multi-statements are always sent to the backend and their result is**not** cache
 
 The cache is **not** aware of grants.
 
-The implication is that unless the cache has been explicitly configured\
-who the caching should apply to, the presence of the cache may provide\
+The implication is that unless the cache has been explicitly configured
+who the caching should apply to, the presence of the cache may provide
 a user with access to data he should not have access to.
 
 Please read the section [Security](mariadb-maxscale-2501-maxscale-2501-cache.md#security-1) for more detailed information.
 
-However, from 2.5 onwards it is possible to configure the cache to cache\
-the data of each user separately, which effectively means that there can\
-be no unintended sharing. Please see [users](mariadb-maxscale-2501-maxscale-2501-cache.md#users) for how to change\
+However, from 2.5 onwards it is possible to configure the cache to cache
+the data of each user separately, which effectively means that there can
+be no unintended sharing. Please see [users](mariadb-maxscale-2501-maxscale-2501-cache.md#users) for how to change
 the default behaviour.
 
 #### `information_schema`
 
-When [invalidation](mariadb-maxscale-2501-maxscale-2501-cache.md#invalidation) is enabled, SELECTs targeting tables\
-in `information_schema` are not cached. The reason is that as the content\
-of the tables changes as the side-effect of something else, the cache would\
+When [invalidation](mariadb-maxscale-2501-maxscale-2501-cache.md#invalidation) is enabled, SELECTs targeting tables
+in `information_schema` are not cached. The reason is that as the content
+of the tables changes as the side-effect of something else, the cache would
 not know when to invalidate the cache-entries.
 
 ### Invalidation
 
-Since MaxScale 2.5, the cache is capable of invalidating entries in the\
-cache when a modification (UPDATE, INSERT or DELETE) that may affect those\
+Since MaxScale 2.5, the cache is capable of invalidating entries in the
+cache when a modification (UPDATE, INSERT or DELETE) that may affect those
 entries is made.
 
-The cache invalidation works on the table-level, that is, a modification\
-made to a particular table will cause all cache entries that refer to that\
-table to be invalidated, irrespective of whether the modification actually\
-has an impact on the cache entries or not. For instance, suppose the result\
+The cache invalidation works on the table-level, that is, a modification
+made to a particular table will cause all cache entries that refer to that
+table to be invalidated, irrespective of whether the modification actually
+has an impact on the cache entries or not. For instance, suppose the result
 of the following SELECT has been cached
 
 ```
@@ -92,55 +92,55 @@ An insert like
 INSERT INTO t SET a=42;
 ```
 
-will cause the cache entry containing the result of that SELECT to be\
+will cause the cache entry containing the result of that SELECT to be
 invalidated even if the INSERT actually does not affect it. Please see [invalidate](mariadb-maxscale-2501-maxscale-2501-cache.md#invalidate) for how to enable the invalidation.
 
-When invalidation has been enabled MaxScale must be able to completely\
-parse a SELECT statement for its results to be stored in the cache. The\
-reason is that in order to be able to invalidate cache entries, MaxScale\
-must know what tables a SELECT statement depends upon. Consequently, if\
-(and only if) invalidation has been enabled and MaxScale fails to parse a\
+When invalidation has been enabled MaxScale must be able to completely
+parse a SELECT statement for its results to be stored in the cache. The
+reason is that in order to be able to invalidate cache entries, MaxScale
+must know what tables a SELECT statement depends upon. Consequently, if
+(and only if) invalidation has been enabled and MaxScale fails to parse a
 statement, the result of that particular statement will not be cached.
 
 When invalidation has been enabled, MaxScale will also parse all UPDATE,\
-INSERT and DELETE statements, in order to find out what tables are\
-modified. If that parsing fails, MaxScale will _by default_ clear the\
-entire cache. The reason is that unless MaxScale can completely parse\
-the statement it cannot know what tables are modified and hence not what\
-cache entries should be invalidated. Consequently, to prevent stale data\
-from being returned, the entire cache is cleared. The default behaviour\
+INSERT and DELETE statements, in order to find out what tables are
+modified. If that parsing fails, MaxScale will _by default_ clear the
+entire cache. The reason is that unless MaxScale can completely parse
+the statement it cannot know what tables are modified and hence not what
+cache entries should be invalidated. Consequently, to prevent stale data
+from being returned, the entire cache is cleared. The default behaviour
 can be changed using the configuration parameter [clear\_cache\_on\_parse\_errors](mariadb-maxscale-2501-maxscale-2501-cache.md#clear_cache_on_parse_errors).
 
-Note that what threading approach is used has a big impact on the\
-invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2501-maxscale-2501-cache.md#threads-users-and-invalidation)\
+Note that what threading approach is used has a big impact on the
+invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2501-maxscale-2501-cache.md#threads-users-and-invalidation)
 for how the threading approach affects the invalidation.
 
-Note also that since the invalidation may not, depending on how the\
-cache has been configured, be visible to all sessions of all users, it\
+Note also that since the invalidation may not, depending on how the
+cache has been configured, be visible to all sessions of all users, it
 is still important to configure a reasonable [soft](mariadb-maxscale-2501-maxscale-2501-cache.md#soft_ttl) and [hard](mariadb-maxscale-2501-maxscale-2501-cache.md#hard_ttl) TTL.
 
 #### Best Efforts
 
-The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the\
-cache in all circumstances reflects the state in the actual database,\
-would require that the operations involving the cache and the MariaDB\
+The invalidation offered by the MaxScale cache can be said to be of_best efforts_ quality. The reason is that in order to ensure that the
+cache in all circumstances reflects the state in the actual database,
+would require that the operations involving the cache and the MariaDB
 server are synchronized, which would cause an unacceptable overhead.
 
 What _best efforts_ means in this context is best illustrated using an example.
 
-Suppose a client executes the statement `SELECT * FROM tbl` and that the result\
-is cached. Next time that or any other client executes the same statement, the\
-result is returned from the cache and the MariaDB server will not be accessed\
+Suppose a client executes the statement `SELECT * FROM tbl` and that the result
+is cached. Next time that or any other client executes the same statement, the
+result is returned from the cache and the MariaDB server will not be accessed
 at all.
 
-If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the\
-cached value for the `SELECT` statement above and all other statements that are\
-dependent upon `tbl` will be invalidated. That is, the next time someone executes\
+If a client now executes the statement `INSERT INTO tbl VALUES (...)`, the
+cached value for the `SELECT` statement above and all other statements that are
+dependent upon `tbl` will be invalidated. That is, the next time someone executes
 the statement `SELECT * FROM tbl` the result will again be fetched from the\
 MariaDB server and stored to the cache.
 
-However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`\
-at the same time someone else executes the `INSERT ...` statement. A possible\
+However, suppose some client executes the statement `SELECT COUNT(*) FROM tbl`
+at the same time someone else executes the `INSERT ...` statement. A possible
 chain of events is as follows:
 
 ```
@@ -151,7 +151,7 @@ MaxScale -> DB                                   SELECT COUNT(*) FROM tbl
 MaxScale -> DB        INSERT ...
 ```
 
-That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of\
+That is, the `SELECT` is performed in the database server _before_ the`INSERT`. However, since the timelines are proceeding independently of
 each other, the events may be re-ordered as far as the cache is concerned.
 
 ```
@@ -159,16 +159,16 @@ MaxScale -> Cache     Delete invalidated values
 MaxScale -> Cache                                Store result and invalidation key
 ```
 
-That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the\
+That is, the cached value for `SELECT COUNT(*) FROM tbl` will reflect the
 situation _before_ the insert and will thus not be correct.
 
-The stale result will be returned until the value has reached its _time-to-live_\
+The stale result will be returned until the value has reached its _time-to-live_
 or its invalidation is caused by some update operation.
 
 ### Configuration
 
-The cache is simple to add to any existing service. However, some experimentation\
-may be required in order to find the configuration settings that provide\
+The cache is simple to add to any existing service. However, some experimentation
+may be required in order to find the configuration settings that provide
 the maximum benefit.
 
 ```
@@ -186,21 +186,21 @@ type=service
 filters=Cache
 ```
 
-Each configured cache filter uses a storage of its own. That is, if there\
-are two services, each configured with a specific cache filter, then,\
-even if queries target the very same servers the cached data will not\
+Each configured cache filter uses a storage of its own. That is, if there
+are two services, each configured with a specific cache filter, then,
+even if queries target the very same servers the cached data will not
 be shared.
 
-Two services can use the same cache filter, but then either the services\
-should use the very same servers _or_ a completely different set of servers,\
-where the used table names are different. Otherwise there can be unintended\
+Two services can use the same cache filter, but then either the services
+should use the very same servers _or_ a completely different set of servers,
+where the used table names are different. Otherwise there can be unintended
 sharing.
 
 ### Settings
 
 The cache filter has no mandatory parameters but a range of optional ones.\
-Note that it is advisable to specify `max_size` to prevent the cache from\
-using up all memory there is, in case there is very little overlap among the\
+Note that it is advisable to specify `max_size` to prevent the cache from
+using up all memory there is, in case there is very little overlap among the
 queries.
 
 #### `storage`
@@ -210,8 +210,8 @@ queries.
 * Dynamic: No
 * Default: `storage_inmemory`
 
-The name of the module that provides the storage for the cache. That\
-module will be loaded and provided with the value of `storage_options` as\
+The name of the module that provides the storage for the cache. That
+module will be loaded and provided with the value of `storage_options` as
 argument. For instance:
 
 ```
@@ -229,11 +229,11 @@ See [Storage](mariadb-maxscale-2501-maxscale-2501-cache.md#storage-1) for what s
 
 **NOTE** Deprecated in 23.02.
 
-A string that is provided verbatim to the storage module specified in `storage`,\
-when the module is loaded. Note that the needed arguments and their format depend\
+A string that is provided verbatim to the storage module specified in `storage`,
+when the module is loaded. Note that the needed arguments and their format depend
 upon the specific module.
 
-From 23.02 onwards, the storage module configuration should be provided using\
+From 23.02 onwards, the storage module configuration should be provided using
 nested parameters.
 
 #### `hard_ttl`
@@ -243,8 +243,8 @@ nested parameters.
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Hard time to live_; the maximum amount of time the cached\
-result is used before it is discarded and the result is fetched from the\
+_Hard time to live_; the maximum amount of time the cached
+result is used before it is discarded and the result is fetched from the
 backend (and cached). See also [soft\_ttl](mariadb-maxscale-2501-maxscale-2501-cache.md#soft_ttl).
 
 ```
@@ -258,21 +258,21 @@ hard_ttl=60s
 * Dynamic: No
 * Default: `0s` (no limit)
 
-_Soft time to live_; the amount of time - in seconds - the cached result is\
-used before it is refreshed from the server. When `soft_ttl` has passed, the\
+_Soft time to live_; the amount of time - in seconds - the cached result is
+used before it is refreshed from the server. When `soft_ttl` has passed, the
 result will be refreshed when the _first_ client requests the value.
 
-However, as long as [hard\_ttl](mariadb-maxscale-2501-maxscale-2501-cache.md#hard_ttl) has not passed, _all_ other clients\
-requesting the same value will use the result from the cache while it is being\
-fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`\
-has passed, even if several clients request the same value at the same time,\
+However, as long as [hard\_ttl](mariadb-maxscale-2501-maxscale-2501-cache.md#hard_ttl) has not passed, _all_ other clients
+requesting the same value will use the result from the cache while it is being
+fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`
+has passed, even if several clients request the same value at the same time,
 there will be just one request to the backend.
 
 ```
 soft_ttl=60s
 ```
 
-If the value of `soft_ttl` is larger than `hard_ttl` it will be adjusted\
+If the value of `soft_ttl` is larger than `hard_ttl` it will be adjusted
 down to the same value.
 
 #### `max_resultset_rows`
@@ -282,7 +282,7 @@ down to the same value.
 * Dynamic: No
 * Default: `0` (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 stored in the cache. A resultset larger than this, will not be stored.
 
 ```
@@ -297,14 +297,14 @@ max_resultset_rows=1000
 * Default: `0` (no limit)
 
 Specifies the maximum size of a resultset, for it to be stored in the cache.\
-A resultset larger than this, will not be stored. The size can be specified\
+A resultset larger than this, will not be stored. The size can be specified
 as described [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
 
 ```
 max_resultset_size=128Ki
 ```
 
-Note that the value of `max_resultset_size` should not be larger than the\
+Note that the value of `max_resultset_size` should not be larger than the
 value of `max_size`.
 
 #### `max_count`
@@ -314,12 +314,12 @@ value of `max_size`.
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum number of items the cache may contain. If the limit has been\
+The maximum number of items the cache may contain. If the limit has been
 reached and a new item should be stored, then an older item will be evicted.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
-is used, then the total number of cached items is #threads \* the value\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
+is used, then the total number of cached items is #threads \* the value
 of `max_count`.
 
 ```
@@ -333,11 +333,11 @@ max_count=1000
 * Dynamic: No
 * Default: `0` (no limit)
 
-The maximum size the cache may occupy. If the limit has been reached and a new\
+The maximum size the cache may occupy. If the limit has been reached and a new
 item should be stored, then some older item(s) will be evicted to make space.
 
-Note that if `cached_data` is `thread_specific` then this limit will be\
-applied to each cache _separately_. That is, if a thread specific cache\
+Note that if `cached_data` is `thread_specific` then this limit will be
+applied to each cache _separately_. That is, if a thread specific cache
 is used, then the total size is #threads \* the value of `max_size`.
 
 ```
@@ -351,15 +351,15 @@ max_size=100Mi
 * Dynamic: Yes
 * Default: `""` (no rules)
 
-Specifies the path of the file where the caching rules are stored. A relative\
+Specifies the path of the file where the caching rules are stored. A relative
 path is interpreted relative to the _data directory_ of MariaDB MaxScale.
 
 ```
 rules=/path/to/rules-file
 ```
 
-Note that the rules will be reloaded, and applied if different, every time\
-a dynamic configuration change is made. Thus, to cause a reloading of the\
+Note that the rules will be reloaded, and applied if different, every time
+a dynamic configuration change is made. Thus, to cause a reloading of the
 rules, alter the rules parameter to the same value it has.
 
 ```
@@ -374,22 +374,22 @@ maxctrl alter filter MyCache rules='/path/to/rules-file'
 * Values: `shared`, `thread_specific`
 * Default: `thread_specific`
 
-An enumeration option specifying how data is shared between threads. The\
+An enumeration option specifying how data is shared between threads. The
 allowed values are:
 
-* `shared`: The cached data is shared between threads. On the one hand\
-  it implies that there will be synchronization between threads, on\
+* `shared`: The cached data is shared between threads. On the one hand
+  it implies that there will be synchronization between threads, on
   the other hand that all threads will use data fetched by any thread.
-* `thread_specific`: The cached data is specific to a thread. On the\
-  one hand it implies that no synchronization is needed between threads,\
-  on the other hand that the very same data may be fetched and stored\
+* `thread_specific`: The cached data is specific to a thread. On the
+  one hand it implies that no synchronization is needed between threads,
+  on the other hand that the very same data may be fetched and stored
   multiple times.
 
 ```
 cached_data=shared
 ```
 
-Default is `thread_specific`. See `max_count` and `max_size` what implication\
+Default is `thread_specific`. See `max_count` and `max_size` what implication
 changing this setting to `shared` has.
 
 #### `selects`
@@ -400,35 +400,35 @@ changing this setting to `shared` has.
 * Values: `assume_cacheable`, `verify_cacheable`
 * Default: `assume_cacheable`
 
-An enumeration option specifying what approach the cache should take with\
+An enumeration option specifying what approach the cache should take with
 respect to `SELECT` statements. The allowed values are:
 
-* `assume_cacheable`: The cache can assume that all `SELECT` statements,\
+* `assume_cacheable`: The cache can assume that all `SELECT` statements,
   without exceptions, are cacheable.
-* `verify_cacheable`: The cache can not assume that all `SELECT`\
+* `verify_cacheable`: The cache can not assume that all `SELECT`
   statements are cacheable, but must verify that.
 
 ```
 selects=verify_cacheable
 ```
 
-Default is `assume_cacheable`. In this case, all `SELECT` statements are\
-assumed to be cacheable and will be parsed _only_ if some specific rule\
+Default is `assume_cacheable`. In this case, all `SELECT` statements are
+assumed to be cacheable and will be parsed _only_ if some specific rule
 requires that.
 
-If `verify_cacheable` is specified, then all `SELECT` statements will be\
-parsed and only those that are safe for caching - e.g. do _not_ call any\
-non-cacheable functions or access any non-cacheable variables - will be\
+If `verify_cacheable` is specified, then all `SELECT` statements will be
+parsed and only those that are safe for caching - e.g. do _not_ call any
+non-cacheable functions or access any non-cacheable variables - will be
 subject to caching.
 
-If `verify_cacheable` has been specified, the cache will not be used in\
+If `verify_cacheable` has been specified, the cache will not be used in
 the following circumstances:
 
 * The `SELECT` uses any of the following functions: `BENCHMARK`,`CONNECTION_ID`, `CONVERT_TZ`, `CURDATE`, `CURRENT_DATE`, `CURRENT_TIMESTAMP`,`CURTIME`, `DATABASE`, `ENCRYPT`, `FOUND_ROWS`, `GET_LOCK`, `IS_FREE_LOCK`,`IS_USED_LOCK`, `LAST_INSERT_ID`, `LOAD_FILE`, `LOCALTIME`, `LOCALTIMESTAMP`,`MASTER_POS_WAIT`, `NOW`, `RAND`, `RELEASE_LOCK`, `SESSION_USER`, `SLEEP`,`SYSDATE`, `SYSTEM_USER`, `UNIX_TIMESTAMP`, `USER`, `UUID`, `UUID_SHORT`.
 * The `SELECT` accesses any of the following fields: `CURRENT_DATE`,`CURRENT_TIMESTAMP`, `LOCALTIME`, `LOCALTIMESTAMP`
 * The `SELECT` uses system or user variables.
 
-Note that parsing all `SELECT` statements carries a performance\
+Note that parsing all `SELECT` statements carries a performance
 cost. Please read [performance](mariadb-maxscale-2501-maxscale-2501-cache.md#performance) for more details.
 
 #### `cache_in_transactions`
@@ -439,21 +439,21 @@ cost. Please read [performance](mariadb-maxscale-2501-maxscale-2501-cache.md#per
 * Values: `never`, `read_only_transactions`, `all_transactions`
 * Default: `all_transactions`
 
-An enumeration option specifying how the cache should behave when there\
+An enumeration option specifying how the cache should behave when there
 are active transactions:
 
-* `never`: When there is an active transaction, no data will be returned\
+* `never`: When there is an active transaction, no data will be returned
   from the cache, but all requests will always be sent to the backend.\
   The cache will be populated inside explicitly read-only transactions.\
-  Inside transactions that are not explicitly read-only, the cache will\
+  Inside transactions that are not explicitly read-only, the cache will
   be populated until the first non-SELECT statement.
-* `read_only_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be populated, but not used\
+* `read_only_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be populated, but not used
   until the first non-SELECT statement.
-* `all_transactions`: The cache will be used and populated inside\
-  explicitly read-only transactions. Inside transactions that are not\
-  explicitly read-only, the cache will be used and populated until the\
+* `all_transactions`: The cache will be used and populated inside
+  explicitly read-only transactions. Inside transactions that are not
+  explicitly read-only, the cache will be used and populated until the
   first non-SELECT statement.
 
 ```
@@ -462,7 +462,7 @@ cache_in_transactions=never
 
 Default is `all_transactions`.
 
-The values `read_only_transactions` and `all_transactions` have roughly the\
+The values `read_only_transactions` and `all_transactions` have roughly the
 same effect as changing the isolation level of the backend to `read_committed`.
 
 #### `debug`
@@ -472,8 +472,8 @@ same effect as changing the isolation level of the backend to `read_committed`.
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the cache\
-can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the cache
+can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -502,9 +502,9 @@ Specifies whether the cache is initially enabled or disabled.
 enabled=false
 ```
 
-The value affects the initial state of the MaxScale user\
-variables using which the behaviour of the cache can be modified\
-at runtime. Please see [Runtime Configuration](mariadb-maxscale-2501-maxscale-2501-cache.md#runtime-configuration)\
+The value affects the initial state of the MaxScale user
+variables using which the behaviour of the cache can be modified
+at runtime. Please see [Runtime Configuration](mariadb-maxscale-2501-maxscale-2501-cache.md#runtime-configuration)
 for details.
 
 #### `invalidate`
@@ -515,7 +515,7 @@ for details.
 * Values: `never`, `current`
 * Default: `never`
 
-An enumeration option specifying how the cache should invalidate\
+An enumeration option specifying how the cache should invalidate
 cache entries.
 
 ```
@@ -526,18 +526,18 @@ cache entries.
   not.
 ```
 
-The effect of `current` depends upon the value of `cached_data`. If the value\
-is `shared`, that is, all threads share the same cache, then the effect of an\
+The effect of `current` depends upon the value of `cached_data`. If the value
+is `shared`, that is, all threads share the same cache, then the effect of an
 invalidation is immediately visible to all sessions, as there is just one cache.\
-However, if the value is `thread_specific`, then an invalidation will affect only\
+However, if the value is `thread_specific`, then an invalidation will affect only
 the cache that the session happens to be using.
 
-If it is important and _sufficient_ that an application immediately sees a change\
-that it itself has caused, then a combination of `invalidate=current`\
+If it is important and _sufficient_ that an application immediately sees a change
+that it itself has caused, then a combination of `invalidate=current`
 and `cached_data=thread_specific` can be used.
 
-If it is important that an application _immediately_ sees all changes, irrespective\
-of who has caused them, then a combination of `invalidate=current`\
+If it is important that an application _immediately_ sees all changes, irrespective
+of who has caused them, then a combination of `invalidate=current`
 and `cached_data=shared` _must_ be used.
 
 #### `clear_cache_on_parse_errors`
@@ -547,18 +547,18 @@ and `cached_data=shared` _must_ be used.
 * Dynamic: No
 * Default: `true`
 
-This boolean option specifies how the cache should behave in case of\
+This boolean option specifies how the cache should behave in case of
 parsing errors when invalidation has been enabled.
 
-* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE\
+* `true`: If the cache fails to parse an UPDATE/INSERT/DELETE
   statement then all cached data will be cleared.
-* `false`: A failure to parse an UPDATE/INSERT/DELETE statement\
+* `false`: A failure to parse an UPDATE/INSERT/DELETE statement
   is ignored and no invalidation will take place due that statement.
 
 The default value is `true`.
 
-Changing the value to `false` may mean that stale data is returned from\
-the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement\
+Changing the value to `false` may mean that stale data is returned from
+the cache, if an UPDATE/INSERT/DELETE cannot be parsed and the statement
 affects entries in the cache.
 
 #### `users`
@@ -569,7 +569,7 @@ affects entries in the cache.
 * Values: `mixed`, `isolated`
 * Default: `mixed`
 
-An enumeration option specifying how the cache should cache data for\
+An enumeration option specifying how the cache should cache data for
 different users.
 
 ```
@@ -580,11 +580,11 @@ different users.
   no unintended sharing.
 ```
 
-Note that if `isolated` has been specified, then each user will\
-conceptually have a cache of his own, which is populated\
-independently from each other. That is, if two users make the\
-same query, then the data will be fetched twice and also stored\
-twice. So, a `isolated` cache will in general use more memory and\
+Note that if `isolated` has been specified, then each user will
+conceptually have a cache of his own, which is populated
+independently from each other. That is, if two users make the
+same query, then the data will be fetched twice and also stored
+twice. So, a `isolated` cache will in general use more memory and
 cause more traffic to the backend compared to a `mixed` cache.
 
 #### `timeout`
@@ -594,7 +594,7 @@ cause more traffic to the backend compared to a `mixed` cache.
 * Dynamic: No
 * Default: `5s`
 
-The _timeout_ used when performing operations to distributed storages\
+The _timeout_ used when performing operations to distributed storages
 such as _redis_ or _memcached_.
 
 ```
@@ -603,19 +603,19 @@ timeout=7000ms
 
 ### Runtime Configuration
 
-The cache filter can be configured at runtime by executing SQL commands. If\
-there is more than one cache filter in a service, only the first cache filter\
-will be able to process the variables. The remaining filters will not see them\
+The cache filter can be configured at runtime by executing SQL commands. If
+there is more than one cache filter in a service, only the first cache filter
+will be able to process the variables. The remaining filters will not see them
 and thus configuring them at runtime is not possible.
 
 #### `@maxscale.cache.populate`
 
-Using the variable `@maxscale.cache.populate` it is possible to specify at\
-runtime whether the cache should be populated or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.populate` it is possible to specify at
+runtime whether the cache should be populated or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be populated.
 
 ```
@@ -625,10 +625,10 @@ SET @maxscale.cache.populate=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-In the example above, the first `SELECT` will always be sent to the\
-server and the result will be cached, provided the actual cache rules\
-specifies that it should be. The second `SELECT` may be served from the\
-cache, depending on the value of `@maxscale.cache.use` (and the cache\
+In the example above, the first `SELECT` will always be sent to the
+server and the result will be cached, provided the actual cache rules
+specifies that it should be. The second `SELECT` may be served from the
+cache, depending on the value of `@maxscale.cache.use` (and the cache
 rules).
 
 The value of `@maxscale.cache.populate` can be queried
@@ -641,12 +641,12 @@ but only _after_ it has been explicitly set once.
 
 #### `@maxscale.cache.use`
 
-Using the variable `@maxscale.cache.use` it is possible to specify at\
-runtime whether the cache should be used or not. Its initial value is\
-the value of the configuration parameter `enabled`. That is, by default the\
+Using the variable `@maxscale.cache.use` it is possible to specify at
+runtime whether the cache should be used or not. Its initial value is
+the value of the configuration parameter `enabled`. That is, by default the
 value is `true`.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement whether the cache should be used.
 
 ```
@@ -656,15 +656,15 @@ SET @maxscale.cache.use=FALSE;
 SELECT a, b FROM tbl;
 ```
 
-The first `SELECT` will be served from the cache, providing the rules\
-specify that the statement should be cached, the cache indeed contains\
+The first `SELECT` will be served from the cache, providing the rules
+specify that the statement should be cached, the cache indeed contains
 the result and the date is not stale (as specified by the _TTL_).
 
-If the data is stale, the `SELECT` will be sent to the server **and**\
+If the data is stale, the `SELECT` will be sent to the server **and**
 the cache entry will be updated, irrespective of the value of`@maxscale.cache.populate`.
 
-If `@maxscale.cache.use` is `true` but the result is not found in the\
-cache, and the result is subsequently fetched from the server, the\
+If `@maxscale.cache.use` is `true` but the result is not found in the
+cache, and the result is subsequently fetched from the server, the
 result will **not** be added to the cache, unless`@maxscale.cache.populate` is also `true`.
 
 The value of `@maxscale.cache.use` can be queried
@@ -677,12 +677,12 @@ but only after it has explicitly been set once.
 
 #### `@maxscale.cache.soft_ttl`
 
-Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime\
-to specify _in seconds_ what _soft ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `soft_ttl`. That is,\
+Using the variable `@maxscale.cache.soft_ttl` it is possible at runtime
+to specify _in seconds_ what _soft ttl_ should be applied. Its initial
+value is the value of the configuration parameter `soft_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _soft ttl_ should be applied.
 
 ```
@@ -692,13 +692,13 @@ SET @maxscale.cache.soft_ttl=60;
 SELECT c, d FROM important;
 ```
 
-When data is `SELECT`ed from the unimportant table `unimportant`, the data\
-will be returned from the cache provided it is no older than 10 minutes,\
-but when data is `SELECT`ed from the important table `important`, the\
+When data is `SELECT`ed from the unimportant table `unimportant`, the data
+will be returned from the cache provided it is no older than 10 minutes,
+but when data is `SELECT`ed from the important table `important`, the
 data will be returned from the cache provided it is no older than 1 minute.
 
-Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`\
-in the sense that if the former is less that the latter, then _soft ttl_\
+Note that `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`
+in the sense that if the former is less that the latter, then _soft ttl_
 will, when used, be adjusted down to the value of _hard ttl_.
 
 The value of `@maxscale.cache.soft_ttl` can be queried
@@ -711,16 +711,16 @@ but only after it has explicitly been set once.
 
 #### `@maxscale.cache.hard_ttl`
 
-Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime\
-to specify _in seconds_ what _hard ttl_ should be applied. Its initial\
-value is the value of the configuration parameter `hard_ttl`. That is,\
+Using the variable `@maxscale.cache.hard_ttl` it is possible at runtime
+to specify _in seconds_ what _hard ttl_ should be applied. Its initial
+value is the value of the configuration parameter `hard_ttl`. That is,
 by default the value is 0.
 
-The purpose of this variable is make it possible for an application to decide\
+The purpose of this variable is make it possible for an application to decide
 statement by statement what _hard ttl_ should be applied.
 
-Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,\
-is important to ensure that the former is at least as large as the latter\
+Note that as `@maxscale.cache.hard_ttl` overrules `@maxscale.cache.soft_ttl`,
+is important to ensure that the former is at least as large as the latter
 and for best overall performance that it is larger.
 
 ```
@@ -740,11 +740,11 @@ but only after it has explicitly been set once.
 
 ### Client Driven Caching
 
-With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible\
+With `@maxscale.cache.populate` and `@maxscale.cache.use` is it possible
 to make the caching completely client driven.
 
-Provide no `rules` file, which means that _all_ `SELECT` statements are\
-subject to caching and that all users receive data from the cache. Set\
+Provide no `rules` file, which means that _all_ `SELECT` statements are
+subject to caching and that all users receive data from the cache. Set
 the startup mode of the cache to _disabled_.
 
 ```
@@ -764,10 +764,10 @@ SELECT e, f FROM tbl3;
 SET @maxscale.cache.populate=FALSE;
 ```
 
-Note that those `SELECT`s must return something in order for the\
+Note that those `SELECT`s must return something in order for the
 statement to be _marked_ for caching.
 
-After this, the value of `@maxscale.cache.use` will decide whether\
+After this, the value of `@maxscale.cache.use` will decide whether
 or not the cache is considered.
 
 ```
@@ -776,12 +776,12 @@ SELECT a, b FROM tbl1;
 SET @maxscale.cache.use=FALSE;
 ```
 
-With `@maxscale.cache.use` being `true`, the cache is considered\
-and the result returned from there, if not stale. If it is stale,\
+With `@maxscale.cache.use` being `true`, the cache is considered
+and the result returned from there, if not stale. If it is stale,
 the result is fetched from the server and the cached entry is updated.
 
-By setting a very long _TTL_ it is possible to prevent the cache\
-from ever considering an entry to be stale and instead manually\
+By setting a very long _TTL_ it is possible to prevent the cache
+from ever considering an entry to be stale and instead manually
 cause the cache to be updated when needed.
 
 ```
@@ -793,8 +793,8 @@ SET @maxscale.cache.populate=FALSE;
 
 ### Threads, Users and Invalidation
 
-What caching approach is used and how different users are treated\
-has a significant impact on the behaviour of the cache. In the\
+What caching approach is used and how different users are treated
+has a significant impact on the behaviour of the cache. In the
 following the implication of different combinations is explained.
 
 | cached\_data/users | mixed                                                                                                                          | isolated                                                                                                                        |
@@ -804,14 +804,14 @@ following the implication of different combinations is explained.
 
 #### Invalidation
 
-Invalidation takes place only in the current cache, so how _visible_\
+Invalidation takes place only in the current cache, so how _visible_
 the invalidation is, depends upon the configuration value of`cached_data`.
 
 **`cached_data=thread_specific`**
 
-The invalidation is visible only to the sessions that are handled by\
-the same worker thread where the invalidation occurred. Sessions of the\
-same or other users that are handled by different worker threads will\
+The invalidation is visible only to the sessions that are handled by
+the same worker thread where the invalidation occurred. Sessions of the
+same or other users that are handled by different worker threads will
 not see the new value before the TTL causes the value to be refreshed.
 
 **`cache_data=shared`**
@@ -822,8 +822,8 @@ The invalidation is immediately visible to all sessions of all users.
 
 The caching rules are expressed as a JSON object or as an array of JSON objects.
 
-There are two decisions to be made regarding the caching; in what circumstances\
-should data be stored to the cache and in what circumstances should the data in\
+There are two decisions to be made regarding the caching; in what circumstances
+should data be stored to the cache and in what circumstances should the data in
 the cache be used.
 
 Expressed in JSON this looks as follows
@@ -847,9 +847,9 @@ or, in case an array is used, as
 ]
 ```
 
-The `store` field specifies in what circumstances data should be stored to\
-the cache and the `use` field specifies in what circumstances the data in\
-the cache should be used. In both cases, the value is a JSON array containing\
+The `store` field specifies in what circumstances data should be stored to
+the cache and the `use` field specifies in what circumstances the data in
+the cache should be used. In both cases, the value is a JSON array containing
 objects.
 
 If an array of rule objects is specified, then, when looking for a rule that\
@@ -859,14 +859,14 @@ deciding whether data in the cache should be used.
 
 #### When to Store
 
-By default, if no rules file have been provided or if the `store` field is\
-missing from the object, the results of all queries will be stored to the\
-cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter\
+By default, if no rules file have been provided or if the `store` field is
+missing from the object, the results of all queries will be stored to the
+cache, subject to `max_resultset_rows` and `max_resultset_size` cache filter
 parameters.
 
-By providing a `store` field in the JSON object, the decision whether to\
-store the result of a particular query to the cache can be controlled in\
-a more detailed manner. The decision to cache the results of a query can\
+By providing a `store` field in the JSON object, the decision whether to
+store the result of a particular query to the cache can be controlled in
+a more detailed manner. The decision to cache the results of a query can
 depend upon
 
 * the database,
@@ -890,21 +890,21 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`\
+If _op_ is `=` or `!=` then _value_ is used as a string; if it is `like`
 or `unlike`, then _value_ is interpreted as a _pcre2_ regular expression.\
-Note though that if _attribute_ is `database`, `table` or `column`, then\
-the string is interpreted as a name, where a dot `.` denotes qualification\
+Note though that if _attribute_ is `database`, `table` or `column`, then
+the string is interpreted as a name, where a dot `.` denotes qualification
 or scoping.
 
-The objects in the `store` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `store` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 result of the query in question will be stored to the cache.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then the result of the query is not stored to the cache.
 
-Note that as the query itself is used as the key, although the following\
+Note that as the query itself is used as the key, although the following
 queries
 
 ```
@@ -918,7 +918,7 @@ USE db1;
 SELECT * FROM tbl
 ```
 
-target the same table and produce the same results, they will be cached\
+target the same table and produce the same results, they will be cached
 separately. The same holds for queries like
 
 ```
@@ -931,13 +931,13 @@ and
 SELECT * FROM tbl WHERE b = 3 AND a = 2;
 ```
 
-as well. Although they conceptually are identical, there will be two\
+as well. Although they conceptually are identical, there will be two
 cache entries.
 
-Note that if a column has been specified in a rule, then a statement\
+Note that if a column has been specified in a rule, then a statement
 will match _irrespective_ of where that particular column appears.\
-For instance, if a rule specifies that the result of statements referring\
-to the column _a_ should be cached, then the following statement will\
+For instance, if a rule specifies that the result of statements referring
+to the column _a_ should be cached, then the following statement will
 match
 
 ```
@@ -952,7 +952,7 @@ SELECT b FROM tbl WHERE a > 5;
 
 **Qualified Names**
 
-When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,\
+When using `=` or `!=` in the rule object in conjunction with `database`,`table` and `column`, the provided string is interpreted as a name, that is,
 dot (`.`) denotes qualification or scope.
 
 In practice that means that if _attribute_ is `database` then _value_ may\
@@ -961,20 +961,20 @@ dot, used for separating the database and table names respectively, and\
 if _attribute_ is `column` then _value_ may contain one or two dots, used\
 for separating table and column names, or database, table and column names.
 
-Note that if a qualified name is used as a _value_, then all parts of the\
-name must be available for a match. Currently Maria DB MaxScale may not\
-always be capable of deducing in what table a particular column is. If\
-that is the case, then a value like `tbl.field` may not necessarily\
+Note that if a qualified name is used as a _value_, then all parts of the
+name must be available for a match. Currently Maria DB MaxScale may not
+always be capable of deducing in what table a particular column is. If
+that is the case, then a value like `tbl.field` may not necessarily
 be a match even if the field is `field` and the table actually is `tbl`.
 
 **Implication of the default database**
 
-If the rules concerns the `database`, then only if the statement refers\
+If the rules concerns the `database`, then only if the statement refers
 to _no_ specific database, will the default database be considered.
 
 **Regexp Matching**
 
-The string used for matching the regular expression contains as much\
+The string used for matching the regular expression contains as much
 information as there is available. For instance, in a situation like
 
 ```
@@ -1014,8 +1014,8 @@ Cache all queries _not_ targeting a particular table
 }
 ```
 
-That will exclude queries targeting table _tbl1_ irrespective of which\
-database it is in. To exclude a table in a particular database, specify\
+That will exclude queries targeting table _tbl1_ irrespective of which
+database it is in. To exclude a table in a particular database, specify
 the table name using a qualified name.
 
 ```
@@ -1044,16 +1044,16 @@ Cache all queries containing a WHERE clause
 }
 ```
 
-Note that this will actually cause all queries that contain WHERE anywhere,\
+Note that this will actually cause all queries that contain WHERE anywhere,
 to be cached.
 
 #### When to Use
 
-By default, if no rules file have been provided or if the `use` field is\
+By default, if no rules file have been provided or if the `use` field is
 missing from the object, all users may be returned data from the cache.
 
-By providing a `use` field in the JSON object, the decision whether to use\
-data from the cache can be controlled in a more detailed manner. The decision\
+By providing a `use` field in the JSON object, the decision whether to use
+data from the cache can be controlled in a more detailed manner. The decision
 to use data from the cache can depend upon
 
 * the user.
@@ -1074,7 +1074,7 @@ where,
 * the op can be `=`, `!=`, `like` or `unlike`, and
 * the value a string.
 
-If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account\
+If _op_ is `=` or `!=` then _value_ is interpreted as a MariaDB account
 string, that is, `%` means indicates wildcard, but if _op_ is `like` or`unlike` it is simply assumed _value_ is a pcre2 regular expression.
 
 For instance, the following are equivalent:
@@ -1093,26 +1093,26 @@ For instance, the following are equivalent:
 }
 ```
 
-Note that if _op_ is `=` or `!=` then the usual assumptions apply,\
-that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_\
-or _unlike_ is used, then no assumptions apply, but the string is\
+Note that if _op_ is `=` or `!=` then the usual assumptions apply,
+that is, a value of `bob` is equivalent with `'bob'@'%'`. If _like_
+or _unlike_ is used, then no assumptions apply, but the string is
 used verbatim as a regular expression.
 
-The objects in the `use` array are processed in order. If the result\
-of a comparison is _true_, no further processing will be made and the\
+The objects in the `use` array are processed in order. If the result
+of a comparison is _true_, no further processing will be made and the
 data in the cache will be used, subject to the value of `ttl`.
 
-If the result of the comparison is _false_, then the next object is\
-processed. The process continues until the array is exhausted. If there\
+If the result of the comparison is _false_, then the next object is
+processed. The process continues until the array is exhausted. If there
 is no match, then data in the cache will not be used.
 
-Note that `use` is relevant only if the query is subject to caching,\
-that is, if all queries are cached or if a query matches a particular\
+Note that `use` is relevant only if the query is subject to caching,
+that is, if all queries are cached or if a query matches a particular
 rule in the `store` array.
 
 **Examples**
 
-Use data from the cache for all users except `admin` (actually `'admin'@'%'`),\
+Use data from the cache for all users except `admin` (actually `'admin'@'%'`),
 regardless of what host the `admin` user comes from.
 
 ```
@@ -1129,15 +1129,15 @@ regardless of what host the `admin` user comes from.
 
 ### Security
 
-As the cache is not aware of grants, unless the cache has been explicitly\
-configured who the caching should apply to, the presence of the cache\
+As the cache is not aware of grants, unless the cache has been explicitly
+configured who the caching should apply to, the presence of the cache
 may provide a user with access to data he should not have access to.\
 Note that the following applies _only_ if `users=mixed` has been configured.\
-If `users=isolated` has been configured, then there can never be any\
+If `users=isolated` has been configured, then there can never be any
 unintended sharing between users.
 
-Suppose there is a table `access` that the user _alice_ has access to,\
-but the user _bob_ does not. If _bob_ tries to access the table, he will\
+Suppose there is a table `access` that the user _alice_ has access to,
+but the user _bob_ does not. If _bob_ tries to access the table, he will
 get an error as reply:
 
 ```
@@ -1145,8 +1145,8 @@ MySQL [testdb]> select * from access;
 ERROR 1142 (42000): SELECT command denied to user 'bob'@'localhost' for table 'access'
 ```
 
-If we now setup caching for the table, using the simplest possible rules\
-file, _bob_ will get access to data from the table, provided he executes\
+If we now setup caching for the table, using the simplest possible rules
+file, _bob_ will get access to data from the table, provided he executes
 a select identical with one _alice_ has executed.
 
 For instance, suppose the rules look as follows:
@@ -1163,7 +1163,7 @@ For instance, suppose the rules look as follows:
 }
 ```
 
-If _alice_ now queries the table, she will get the result, which also will\
+If _alice_ now queries the table, she will get the result, which also will
 be cached:
 
 ```
@@ -1175,7 +1175,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-If _bob_ now executes the very same query, and the result is still in the\
+If _bob_ now executes the very same query, and the result is still in the
 cache, it will be returned to him.
 
 ```
@@ -1195,7 +1195,7 @@ MySQL [testdb]> select * from access;
 +------+------+
 ```
 
-That can be prevented, by explicitly declaring in the rules that the caching\
+That can be prevented, by explicitly declaring in the rules that the caching
 should be applied to _alice_ only.
 
 ```
@@ -1217,24 +1217,24 @@ should be applied to _alice_ only.
 }
 ```
 
-With these rules in place, _bob_ is again denied access, since queries\
+With these rules in place, _bob_ is again denied access, since queries
 targeting the table `access` will in his case not be served from the cache.
 
 ### Storage
 
 There are two types of storages that can be used; _local_ and _shared_.
 
-The only _local_ storage implementation is `storage_inmemory` that simply\
-stores the cache values in memory. The storage is not persistent and is\
-destroyed when MaxScale terminates. Since the storage exists in the MaxScale\
+The only _local_ storage implementation is `storage_inmemory` that simply
+stores the cache values in memory. The storage is not persistent and is
+destroyed when MaxScale terminates. Since the storage exists in the MaxScale
 process, it is very fast and provides almost always a performance benefit.
 
-Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)\
+Currently there are two _shared_ storages; `storage_memcached` and`storage_redis` that are implemented using [memcached](https://memcached.org/)
 and [redis](https://redis.io/) respectively.
 
 The shared storages are accessed across the network and consequently it is _not_ self-evident that their use will provide any performance benefit.
-Namely, irrespective of whether the data is fetched from the cache or from\
-the server there will be a network hop and often that network hop is, as far\
+Namely, irrespective of whether the data is fetched from the cache or from
+the server there will be a network hop and often that network hop is, as far
 as the performance goes, what costs the most.
 
 The presence of a shared cache _may_ provide a performance benefit
@@ -1243,12 +1243,12 @@ The presence of a shared cache _may_ provide a performance benefit
 * if the used SELECT statements are heavy (that is, take a significant amount of time) to process for the database server, or
 * if the presence of the cache reduces the overall load of an otherwise overloaded database server.
 
-As a general rule a _shared_ storage should not be used without first\
+As a general rule a _shared_ storage should not be used without first
 assessing its value using a realistic workload.
 
 #### `storage_inmemory`
 
-This simple storage module uses the standard memory allocator for storing\
+This simple storage module uses the standard memory allocator for storing
 the cached data.
 
 ```
@@ -1259,12 +1259,12 @@ This storage module takes no arguments.
 
 #### `storage_memcached`
 
-This storage module uses [memcached](https://memcached.org/) for storing the\
+This storage module uses [memcached](https://memcached.org/) for storing the
 cached data.
 
-Multiple MaxScale instances can share the same memcached server and items\
+Multiple MaxScale instances can share the same memcached server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
@@ -1288,18 +1288,18 @@ If no port is provided, then the default port `11211` will be used.
 * Dynamic: No
 * Default: 1Mi
 
-By default, the maximum size of a value stored to memcached is 1MiB, but that\
-can be configured to something else, in which case this parameter should be\
+By default, the maximum size of a value stored to memcached is 1MiB, but that
+can be configured to something else, in which case this parameter should be
 set accordingly.
 
-The value of `max_value_size` will be used for capping `max_resultset_size`,\
-that is, if memcached has been configured to allow larger values than 1MiB\
-but `max_value_size` has not been set accordingly, only resultsets up to 1MiB\
+The value of `max_value_size` will be used for capping `max_resultset_size`,
+that is, if memcached has been configured to allow larger values than 1MiB
+but `max_value_size` has not been set accordingly, only resultsets up to 1MiB
 in size will be cached.
 
 **Example**
 
-From MaxScale 23.02 onwards, the storage configuration should be provided\
+From MaxScale 23.02 onwards, the storage configuration should be provided
 as nested parameters.
 
 ```
@@ -1311,7 +1311,7 @@ storage_memcached.server=192.168.1.31
 storage_memcached.max_value_size=10M
 ```
 
-Although _deprecated_ in 23.02, the configuration can also be provided\
+Although _deprecated_ in 23.02, the configuration can also be provided
 using `storage_options`:
 
 ```
@@ -1325,39 +1325,39 @@ storage_options="server=192.168.1.31,max_value_size=10M"
 
 **Security**
 
-_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and\
-the memcached server is encrypted. Consequently, _anybody_ with access to the\
+_Neither_ the data in the memcached server _nor_ the traffic between MaxScale and
+the memcached server is encrypted. Consequently, _anybody_ with access to the
 memcached server or to the network have access to the cached data.
 
 #### `storage_redis`
 
-This storage module uses [redis](https://redis.io/) for storing the\
+This storage module uses [redis](https://redis.io/) for storing the
 cached data.
 
-Note that Redis should be configured with no idle timeout or with a timeout that\
-is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which\
+Note that Redis should be configured with no idle timeout or with a timeout that
+is very large. Otherwise MaxScale may have to repeatedly connect to Redis, which
 will hurt both the functionality and the performance.
 
-Multiple MaxScale instances can share the same redis server and items\
+Multiple MaxScale instances can share the same redis server and items
 cached by one MaxScale instance will be used by the other. Note that all\
-MaxScale instances should have exactly the same configuration, as otherwise\
+MaxScale instances should have exactly the same configuration, as otherwise
 there can be unintended sharing.
 
 ```
 storage=storage_redis
 ```
 
-If `storage_redis` cannot connect to the Redis server, caching will silently\
-be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2501-maxscale-2501-cache.md#timeout)\
+If `storage_redis` cannot connect to the Redis server, caching will silently
+be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2501-maxscale-2501-cache.md#timeout)
 interval.
 
-If a timeout error occurs during an operation, reconnecting will be attempted\
-after a delay, which will be an increasing multiple of `timeout`. For example,\
-if `timeout` is the default 5 seconds, then reconnection attempts will first\
-be made after 10 seconds, then after 15 seconds, then 20 and so on. However,\
-once 60 seconds have been reached, the delay will no longer be increased but\
-the delay will stay at one minute. Note that each time a reconnection attempt\
-is made, unless the reason for the timeout has disappeared, the client will be\
+If a timeout error occurs during an operation, reconnecting will be attempted
+after a delay, which will be an increasing multiple of `timeout`. For example,
+if `timeout` is the default 5 seconds, then reconnection attempts will first
+be made after 10 seconds, then after 15 seconds, then 20 and so on. However,
+once 60 seconds have been reached, the delay will no longer be increased but
+the delay will stay at one minute. Note that each time a reconnection attempt
+is made, unless the reason for the timeout has disappeared, the client will be
 stalled for `timeout` seconds.
 
 `storage_redis` has the following parameters:
@@ -1404,7 +1404,7 @@ Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more in
 * Dynamic: No
 * Default: `""`
 
-The SSL client certificate that MaxScale should use with the Redis\
+The SSL client certificate that MaxScale should use with the Redis
 server. The certificate must match the key defined in `ssl_key`.
 
 Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more information.
@@ -1427,7 +1427,7 @@ Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more in
 * Dynamic: No
 * Default: `""`
 
-The Certificate Authority (CA) certificate for the CA that signed the\
+The Certificate Authority (CA) certificate for the CA that signed the
 certificate specified with `ssl_cert`.
 
 Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more information.
@@ -1446,16 +1446,16 @@ then both _username_ and _password_ must be provided.
 
 **SSL**
 
-If `ssl_key`, `ssl_cert` and `ssl_ca` are provided, then SSL/TLS will be used\
+If `ssl_key`, `ssl_cert` and `ssl_ca` are provided, then SSL/TLS will be used
 in the communication with the Redis server, if `ssl` is set to `true`.
 
-Note that the SSL/TLS support is only available in Redis from version 6\
-onwards and that the support is not by default built into Redis, but has\
+Note that the SSL/TLS support is only available in Redis from version 6
+onwards and that the support is not by default built into Redis, but has
 to be specifically enabled at compile time as explained [here](https://redis.io/docs/management/security/encryption/).
 
 **Example**
 
-From MaxScale 23.02 onwards, the storage configuration should be provided\
+From MaxScale 23.02 onwards, the storage configuration should be provided
 as nested parameters.
 
 ```
@@ -1468,7 +1468,7 @@ storage_redis.username=hello
 storage_redis.password=world
 ```
 
-Although _deprecated_ in 23.02, the configuration can also be provided\
+Although _deprecated_ in 23.02, the configuration can also be provided
 using `storage_options`:
 
 ```
@@ -1482,12 +1482,12 @@ storage_options="server=192.168.1.31,username=hello,password=world"
 
 **Invalidation**
 
-`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2501-maxscale-2501-cache.md#best-efforts)\
-are of greater significance since also the communication between the cache and the\
+`storage_redis` supports invalidation, but the caveats documented [here](mariadb-maxscale-2501-maxscale-2501-cache.md#best-efforts)
+are of greater significance since also the communication between the cache and the
 cache storage is asynchronous and takes place over the network.
 
-_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation\
-mode), redis must be flushed as otherwise there will be entries in the cache that\
+_NOTE_ If invalidation is turned on after caching has been used (in non-invalidation
+mode), redis must be flushed as otherwise there will be entries in the cache that
 will not be affected by the invalidation.
 
 ```
@@ -1496,15 +1496,15 @@ $ redis-cli flushall
 
 **Security**
 
-The data in the redis server is _not_ encrypted. Consequently, _anybody_ with\
+The data in the redis server is _not_ encrypted. Consequently, _anybody_ with
 access to the redis server has access to the cached data.
 
-Unless [SSL](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl) has been enabled, _anybody_ with access to the network has\
+Unless [SSL](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl) has been enabled, _anybody_ with access to the network has
 access to the cached data.
 
 ### Example
 
-In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size\
+In the following we define a cache _MyCache_ that uses the cache storage module`storage_inmemory` and whose _soft ttl_ is `30` seconds and whose _hard ttl_ is`45` seconds. The cached data is shared between all threads and the maximum size
 of the cached data is `50` mebibytes. The rules for the cache are in the file`cache_rules.json`.
 
 #### Configuration
@@ -1544,16 +1544,16 @@ The rules specify that the data of the table `sbtest` should be cached.
 
 ### Performance
 
-When the cache filter was introduced, the most significant factor affecting\
+When the cache filter was introduced, the most significant factor affecting
 the performance of the cache was whether the statements needed to be parsed.\
-Initially, all statements were parsed in order to exclude `SELECT` statements\
-that use non-cacheable functions, access non-cacheable variables or refer\
-to system or user variables. Later, the default value of the `selects` parameter\
+Initially, all statements were parsed in order to exclude `SELECT` statements
+that use non-cacheable functions, access non-cacheable variables or refer
+to system or user variables. Later, the default value of the `selects` parameter
 was changed to `assume_cacheable`, to maximize the default performance.
 
-With the default configuration, the cache itself will not cause the statements\
-to be parsed. However, even with `assume_cacheable` configured, a rule referring\
-specifically to a _database_, _table_ or _column_ will still cause the\
+With the default configuration, the cache itself will not cause the statements
+to be parsed. However, even with `assume_cacheable` configured, a rule referring
+specifically to a _database_, _table_ or _column_ will still cause the
 statement to be parsed.
 
 For instance, a simple rule like
@@ -1588,15 +1588,15 @@ If the rule is instead expressed using a regular expression
 
 then the statement will not be parsed.
 
-However, when the [query classifier cache](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
-was introduced, the parsing cost was significantly reduced and\
-currently the cost for parsing and regular expression matching\
+However, when the [query classifier cache](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
+was introduced, the parsing cost was significantly reduced and
+currently the cost for parsing and regular expression matching
 is roughly the same.
 
-In the following is a table with numbers giving a rough picture\
+In the following is a table with numbers giving a rough picture
 of the relative cost of different approaches.
 
-In the table, _regexp match_ means that the cacheable statements\
+In the table, _regexp match_ means that the cacheable statements
 were picked out using a rule like
 
 ```
@@ -1607,7 +1607,7 @@ were picked out using a rule like
 }
 ```
 
-while _exact match_ means that the cacheable statements were picked out using a\
+while _exact match_ means that the cacheable statements were picked out using a
 rule like
 
 ```
@@ -1620,12 +1620,12 @@ rule like
 
 The exact match rule requires all statements to be parsed.
 
-As the purpose of the test is to illustrate the overhead of\
-different approaches, the rules were formulated so that\
+As the purpose of the test is to illustrate the overhead of
+different approaches, the rules were formulated so that
 all SELECT statements would match.
 
 Note that these figures were obtained by running sysbench,\
-MaxScale and the server in the same computer, so they are\
+MaxScale and the server in the same computer, so they are
 only indicative.
 
 | selects           | Rule         | qps |
@@ -1639,18 +1639,18 @@ only indicative.
 
 For comparison, without caching, the qps is `33`.
 
-As can be seen, due to the query classifier cache there is\
+As can be seen, due to the query classifier cache there is
 no difference between exact and regex based matching.
 
 #### Summary
 
 For maximum performance:
 
-* Arrange the situation so that the default `selects=assume_cacheable`\
+* Arrange the situation so that the default `selects=assume_cacheable`
   can be used, and use no rules.
 
-Otherwise it is mostly a personal preference whether exact or regex\
-based rules are used. However, one should always test with real data\
+Otherwise it is mostly a personal preference whether exact or regex
+based rules are used. However, one should always test with real data
 and real queries before choosing one over the other.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-comment-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-comment-filter.md
@@ -4,8 +4,8 @@
 
 ### Overview
 
-With the _comment_ filter it is possible to define comments that are\
-injected before the actual statements. These comments appear as sql\
+With the _comment_ filter it is possible to define comments that are
+injected before the actual statements. These comments appear as sql
 comments when they are received by the server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-consistent-critical-read-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-consistent-critical-read-filter.md
@@ -8,41 +8,41 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Consistent Critical Read (CCR) filter allows consistent critical reads to be\
+The Consistent Critical Read (CCR) filter allows consistent critical reads to be
 done through MaxScale while still allowing scaleout of non-critical reads.
 
-When the filter detects a statement that would modify the database, it attaches\
-a routing hint to all following statements done by that connection. This routing\
-hint guides the routing module to route the statement to the primary server where\
-data is guaranteed to be in an up-to-date state. Writes from one session do not,\
+When the filter detects a statement that would modify the database, it attaches
+a routing hint to all following statements done by that connection. This routing
+hint guides the routing module to route the statement to the primary server where
+data is guaranteed to be in an up-to-date state. Writes from one session do not,
 by default, propagate to other sessions.
 
-_Note:_ This filter does not work with prepared statements. Only text protocol\
+_Note:_ This filter does not work with prepared statements. Only text protocol
 queries are handled by this filter.
 
 #### Controlling the Filter with SQL Comments
 
-The triggering of the filter can be limited further by adding MaxScale supported\
-comments to queries and/or by using regular expressions. The query comments take\
-precedence: if a comment is found it is obeyed even if a regular expression\
+The triggering of the filter can be limited further by adding MaxScale supported
+comments to queries and/or by using regular expressions. The query comments take
+precedence: if a comment is found it is obeyed even if a regular expression
 parameter might give a different result. Even a comment cannot cause a\
-SELECT-query to trigger the filter. Such a comment is considered an error and\
+SELECT-query to trigger the filter. Such a comment is considered an error and
 ignored.
 
-The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-hint-syntax.md)\
-and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a\
-query has a MaxScale supported comment line which defines the parameter `ccr`,\
-that comment is caught by the CCR-filter. Parameter values `match` and `ignore`\
-are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)\
+The comments must follow the [MaxScale hint syntax](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-hint-syntax.md)
+and the _HintFilter_ needs to be in the filter chain before the CCR-filter. If a
+query has a MaxScale supported comment line which defines the parameter `ccr`,
+that comment is caught by the CCR-filter. Parameter values `match` and `ignore`
+are supported, causing the filter to trigger (`match`) or not trigger (`ignore`)
 on receiving the write query. For example, the query
 
 ```
 INSERT INTO departments VALUES ('d1234', 'NewDepartment'); -- maxscale ccr=ignore
 ```
 
-would normally cause the filter to trigger, but does not because of the\
-comment. The `match`-comment typically has no effect, since write queries by\
-default trigger the filter anyway. It can be used to override an ignore-type\
+would normally cause the filter to trigger, but does not because of the
+comment. The `match`-comment typically has no effect, since write queries by
+default trigger the filter anyway. It can be used to override an ignore-type
 regular expression that would otherwise prevent triggering.
 
 ### Settings
@@ -56,19 +56,19 @@ The CCR filter has no mandatory parameters.
 * Dynamic: Yes
 * Default: `60s`
 
-The time window during which queries are routed to the primary. The duration\
-can be specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+The time window during which queries are routed to the primary. The duration
+can be specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 but the value will always be rounded to the nearest second.\
-If no explicit unit has been specified, the value is interpreted as seconds\
+If no explicit unit has been specified, the value is interpreted as seconds
 in MaxScale 2.4. In subsequent versions a value without a unit may be rejected.\
 The default value for this parameter is 60 seconds.
 
-When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new\
-data modifying SQL statement is processed within the time window, the timer is\
+When a data modifying SQL statement is processed, a timer is set to the value of_time_. Once the timer has elapsed, all statements are routed normally. If a new
+data modifying SQL statement is processed within the time window, the timer is
 reset to the value of _time_.
 
-Enabling this parameter in combination with the _count_ parameter causes both\
-the time window and number of queries to be inspected. If either of the two\
+Enabling this parameter in combination with the _count_ parameter causes both
+the time window and number of queries to be inspected. If either of the two
 conditions are met, the query is re-routed to the primary.
 
 #### `count`
@@ -81,10 +81,10 @@ conditions are met, the query is re-routed to the primary.
 The number of SQL statements to route to primary after detecting a data modifying\
 SQL statement. This feature is disabled by default.
 
-After processing a data modifying SQL statement, a counter is set to the value\
-of _count_ and all statements are routed to the primary. Each executed statement\
-after a data modifying SQL statement cause the counter to be decremented. Once\
-the counter reaches zero, the statements are routed normally. If a new data\
+After processing a data modifying SQL statement, a counter is set to the value
+of _count_ and all statements are routed to the primary. Each executed statement
+after a data modifying SQL statement cause the counter to be decremented. Once
+the counter reaches zero, the statements are routed normally. If a new data
 modifying SQL statement is processed, the counter is reset to the value of_count_.
 
 #### `match`
@@ -94,9 +94,9 @@ modifying SQL statement is processed, the counter is reset to the value of_count
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
-control which statements trigger statement re-routing. Only non-SELECT statements are\
-inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works\
+These [regular expression settings](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
+control which statements trigger statement re-routing. Only non-SELECT statements are
+inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works
 similarly.
 
 ```
@@ -131,16 +131,16 @@ Regular expression options for `match` and `ignore`.
 * Dynamic: Yes
 * Default: `false`
 
-`global` is a boolean parameter that when enabled causes writes from one\
-connection to propagate to all other connections. This can be used to work\
-around cases where one connection writes data and another reads it, expecting\
+`global` is a boolean parameter that when enabled causes writes from one
+connection to propagate to all other connections. This can be used to work
+around cases where one connection writes data and another reads it, expecting
 the write done by the other connection to be visible.
 
 This parameter only works with the `time` parameter. The use of `global` and`count` at the same time is not allowed and will be treated as an error.
 
 ### Example Configuration
 
-Here is a minimal filter configuration for the CCRFilter which should solve most\
+Here is a minimal filter configuration for the CCRFilter which should solve most
 problems with critical reads after writes.
 
 ```
@@ -150,13 +150,13 @@ module=ccrfilter
 time=5
 ```
 
-With this configuration, whenever a connection does a write, all subsequent\
+With this configuration, whenever a connection does a write, all subsequent
 reads done by that connection will be forced to the primary for 5 seconds.
 
-This prevents read scaling until the modifications have been replicated to the\
-replicas. For best performance, the value of _time_ should be slightly greater\
-than the actual replication lag between the primary and its replicas. If the number\
-of critical read statements is known, the _count_ parameter could be used to\
+This prevents read scaling until the modifications have been replicated to the
+replicas. For best performance, the value of _time_ should be slightly greater
+than the actual replication lag between the primary and its replicas. If the number
+of critical read statements is known, the _count_ parameter could be used to
 control the number reads that are sent to the primary.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-hintfilter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-hintfilter.md
@@ -6,14 +6,14 @@ This filter adds routing hints to a service. The filter has no parameters.
 
 ## Hint Syntax
 
-**Note:** If a query has more than one comment only the first comment is\
-processed. Always place any MaxScale related comments first before any other\
+**Note:** If a query has more than one comment only the first comment is
+processed. Always place any MaxScale related comments first before any other
 comments that might appear in the query.
 
 ### Comments and comment types
 
-The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and\
-they need to be enabled by passing the `--comments` or `-c` option to it. Most,\
+The client connection will need to have comments enabled. For example the`mariadb` and `mysql` command line clients have comments disabled by default and
+they need to be enabled by passing the `--comments` or `-c` option to it. Most,
 if not all, connectors keep all comments intact in executed queries.
 
 ```
@@ -21,10 +21,10 @@ if not all, connectors keep all comments intact in executed queries.
 mariadb --comments -u my-user -psecret -e "SELECT @@hostname -- maxscale route to server db1"
 ```
 
-For comment types, use either `--` (notice the whitespace after the double\
+For comment types, use either `--` (notice the whitespace after the double
 hyphen) or `#` after the semicolon or `/* ... */` before the semicolon.
 
-Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character\
+Inline comment blocks, i.e. `/* .. */`, do not require a whitespace character
 after the start tag or before the end tag but adding the whitespace is advised.
 
 ### Hint body
@@ -35,12 +35,12 @@ All hints must start with the `maxscale` tag.
 -- maxscale <hint body>
 ```
 
-The hints have two types, ones that define a server type and others that contain\
+The hints have two types, ones that define a server type and others that contain
 name-value pairs.
 
 #### Routing destination hints
 
-These hints will instruct the router to route a query to a certain type of a\
+These hints will instruct the router to route a query to a certain type of a
 server.
 
 ```
@@ -53,8 +53,8 @@ server.
 -- maxscale route to master
 ```
 
-A `master` value in a routing hint will route the query to a primary server. This\
-can be used to direct read queries to a primary server for a up-to-date result\
+A `master` value in a routing hint will route the query to a primary server. This
+can be used to direct read queries to a primary server for a up-to-date result
 with no replication lag.
 
 **Route to replica**
@@ -63,8 +63,8 @@ with no replication lag.
 -- maxscale route to slave
 ```
 
-A `slave` value will route the query to a replica server. Please note that the\
-hints will override any decisions taken by the routers which means that it is\
+A `slave` value will route the query to a replica server. Please note that the
+hints will override any decisions taken by the routers which means that it is
 possible to force writes to a replica server.
 
 **Route to named server**
@@ -73,7 +73,7 @@ possible to force writes to a replica server.
 -- maxscale route to server <server name>
 ```
 
-A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in\
+A `server` value will route the query to a named server. The value of`<server name>` needs to be the same as the server section name in
 maxscale.cnf. If the server is not used by the service, the hint is ignored.
 
 **Route to last used server**
@@ -82,8 +82,8 @@ maxscale.cnf. If the server is not used by the service, the hint is ignored.
 -- maxscale route to last
 ```
 
-A `last` value will route the query to the server that processed the last\
-query. This hint can be used to force certain queries to be grouped to the same\
+A `last` value will route the query to the server that processed the last
+query. This hint can be used to force certain queries to be grouped to the same
 server.
 
 **Name-value hints**
@@ -92,13 +92,13 @@ server.
 -- maxscale <param>=<value>
 ```
 
-These control the behavior and affect the routing decisions made by the\
-router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower\
+These control the behavior and affect the routing decisions made by the
+router. Currently the only accepted parameter is the readwritesplit parameter`max_slave_replication_lag`. This will route the query to a server with a lower
 replication lag than this parameter's value.
 
 ### Hint stack
 
-Hints can be either single-use hints, which makes them affect only one query, or\
+Hints can be either single-use hints, which makes them affect only one query, or
 named hints, which can be pushed on and off a stack of active hints.
 
 Defining named hints:
@@ -125,7 +125,7 @@ You can define and activate a hint in a single command using the following:
 -- maxscale <hint name> begin <hint content>
 ```
 
-You can also push anonymous hints onto the stack which are only used as long as\
+You can also push anonymous hints onto the stack which are only used as long as
 they are on the stack:
 
 ```
@@ -134,14 +134,14 @@ they are on the stack:
 
 ## Prepared Statements
 
-The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared\
+The hintfilter supports routing hints in prepared statements for both the`PREPARE` and `EXECUTE` SQL commands as well as the binary protocol prepared
 statements.
 
 ### Binary Protocol
 
-With binary protocol prepared statements, a routing hint in the prepared\
-statement is applied to the execution of the statement but not the preparation\
-of it. The preparation of the statement is routed normally and is sent to all\
+With binary protocol prepared statements, a routing hint in the prepared
+statement is applied to the execution of the statement but not the preparation
+of it. The preparation of the statement is routed normally and is sent to all
 servers.
 
 For example, when the following prepared statement is prepared with the MariaDB\
@@ -167,13 +167,13 @@ Support for direct execution of prepared statements was added in MaxScale\
 
 ### Text Protocol
 
-Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL\
-commands) behave differently. If a `PREPARE` command has a routing hint, it will\
-be routed according to the routing hint. Any subsequent `EXECUTE` command will\
-not be affected by the routing hint in the `PREPARE` statement. This means they\
+Text protocol prepared statements (i.e. the `PREPARE` and `EXECUTE` SQL
+commands) behave differently. If a `PREPARE` command has a routing hint, it will
+be routed according to the routing hint. Any subsequent `EXECUTE` command will
+not be affected by the routing hint in the `PREPARE` statement. This means they
 must have their own routing hints.
 
-The following example is the recommended method of executing text protocol\
+The following example is the recommended method of executing text protocol
 prepared statements with hints:
 
 ```
@@ -187,7 +187,7 @@ The `PREPARE` is routed normally and will be routed to all servers. The`EXECUTE`
 
 ### Routing `SELECT` queries to primary
 
-In this example, MariaDB MaxScale is configured with the readwritesplit router\
+In this example, MariaDB MaxScale is configured with the readwritesplit router
 and the hint filter.
 
 ```
@@ -204,9 +204,9 @@ type=filter
 module=hintfilter
 ```
 
-Behind MariaDB MaxScale is a primary server and a replica server. If there is\
-replication lag between the primary and the replica, read queries sent to the replica\
-might return old data. To guarantee up-to-date data, we can add a routing hint\
+Behind MariaDB MaxScale is a primary server and a replica server. If there is
+replication lag between the primary and the replica, read queries sent to the replica
+might return old data. To guarantee up-to-date data, we can add a routing hint
 to the query.
 
 ```
@@ -214,9 +214,9 @@ INSERT INTO table1 VALUES ("John","Doe",1);
 SELECT * FROM table1; -- maxscale route to master
 ```
 
-The first INSERT query will be routed to the primary. The following SELECT query\
-would normally be routed to the replica but with the added routing hint it will be\
-routed to the primary. This way we can do an INSERT and a SELECT right after it\
+The first INSERT query will be routed to the primary. The following SELECT query
+would normally be routed to the replica but with the added routing hint it will be
+routed to the primary. This way we can do an INSERT and a SELECT right after it
 and still get up-to-date data.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-ldi-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-ldi-filter.md
@@ -4,14 +4,14 @@
 
 ## LDI Filter
 
-The `ldi` (LOAD DATA INFILE) filter was introduced in MaxScale 23.08.0 and it\
-extends the MariaDB `LOAD DATA INFILE` syntax to support loading data from any\
+The `ldi` (LOAD DATA INFILE) filter was introduced in MaxScale 23.08.0 and it
+extends the MariaDB `LOAD DATA INFILE` syntax to support loading data from any
 object storage that supports the S3 API. This includes cloud offerings like AWS\
 S3 and Google Cloud Storage as well as locally run services like Minio.
 
-If the filename starts with either `S3://` or `gs://`, the path is interpreted\
-as a S3 object file. The prefix is case-insensitive. For example, the following\
-command would load the file `my-data.csv` from the bucket `my-bucket` into the\
+If the filename starts with either `S3://` or `gs://`, the path is interpreted
+as a S3 object file. The prefix is case-insensitive. For example, the following
+command would load the file `my-data.csv` from the bucket `my-bucket` into the
 table `t1`.
 
 ```
@@ -21,7 +21,7 @@ LOAD DATA INFILE 'S3://my-bucket/my-data.csv' INTO TABLE t1
 
 ### How to Upload Data
 
-Here is a minimal configuration for the filter that can be used to load data\
+Here is a minimal configuration for the filter that can be used to load data
 from AWS S3:
 
 ```
@@ -33,11 +33,11 @@ region=us-east-1
 ```
 
 The first step is to move the file to be loaded into the same region that\
-MaxScale and the MariaDB servers are in. One factor in the speed of the upload\
-is the network latency and minimizing it by moving the source and the\
+MaxScale and the MariaDB servers are in. One factor in the speed of the upload
+is the network latency and minimizing it by moving the source and the
 destination closer improves the data loading speed.
 
-The next step is to connect to MaxScale and prepare the session for an upload by\
+The next step is to connect to MaxScale and prepare the session for an upload by
 providing the service account access and secret keys.
 
 ```
@@ -58,17 +58,17 @@ This feature has been removed in MaxScale 24.02.
 
 #### Missing Files
 
-If you are using self-hosted object storage programs like Minio, a common\
-problem is that they do not necessarily support the newer virtual-hosted-style\
-requests that is used by AWS. This usually manifests as an error either about a\
+If you are using self-hosted object storage programs like Minio, a common
+problem is that they do not necessarily support the newer virtual-hosted-style
+requests that is used by AWS. This usually manifests as an error either about a
 missing file or a missing bucket.
 
-If the `host` parameter is set to a hostname, it's assumed that the object\
-storage supports the newer virtual-hosted-style requests. If this not the case,\
+If the `host` parameter is set to a hostname, it's assumed that the object
+storage supports the newer virtual-hosted-style requests. If this not the case,
 the filter must be configured with `protocol_version=1`.
 
-Conversely, if the `host` parameter is set to a plain IP address, it is assumed\
-that it does not support the newer virtual-hosted-style request. If the host\
+Conversely, if the `host` parameter is set to a plain IP address, it is assumed
+that it does not support the newer virtual-hosted-style request. If the host
 does support it, the filter must be configured with `protocol_version=2`.
 
 ### Settings
@@ -102,7 +102,7 @@ This must be either configured in the MaxScale configuration file or set with`SE
 
 The S3 region where the data is located.
 
-The value can be overridden with `SET @maxscale.ldi.s3_region='<region>'` before\
+The value can be overridden with `SET @maxscale.ldi.s3_region='<region>'` before
 starting the data load.
 
 #### `host`
@@ -112,10 +112,10 @@ starting the data load.
 * Dynamic: Yes
 * Default: `s3.amazonaws.com`
 
-The location of the S3 object storage. By default the original AWS S3 host is\
+The location of the S3 object storage. By default the original AWS S3 host is
 used. The corresponding value for Google Cloud Storage is`storage.googleapis.com`.
 
-The value can be overridden with `SET @maxscale.ldi.s3_host='<host>'` before\
+The value can be overridden with `SET @maxscale.ldi.s3_host='<host>'` before
 starting the data load.
 
 #### `port`
@@ -125,11 +125,11 @@ starting the data load.
 * Dynamic: Yes
 * Default: 0
 
-The port on which the S3 object storage is listening. If unset or set to the\
+The port on which the S3 object storage is listening. If unset or set to the
 value of 0, the default S3 port is used.
 
-The value can be overridden with `SET @maxscale.ldi.s3_port=<port>` before\
-starting the data load. Note that unlike the other values, the value for this\
+The value can be overridden with `SET @maxscale.ldi.s3_port=<port>` before
+starting the data load. Note that unlike the other values, the value for this
 variable must be an SQL integer and not an SQL string.
 
 #### `no_verify`
@@ -159,14 +159,14 @@ HTTP instead of HTTPS.
 * Default: 0
 * Values: 0, 1, 2
 
-Which protocol version to use. By default the protocol version is derived from\
-the value of `host` but this automatic protocol version deduction will not\
-always produce the correct result. For the legacy path-style requests used by\
-older S3 storage buckets, the value must be set to 1. All new buckets use the\
+Which protocol version to use. By default the protocol version is derived from
+the value of `host` but this automatic protocol version deduction will not
+always produce the correct result. For the legacy path-style requests used by
+older S3 storage buckets, the value must be set to 1. All new buckets use the
 protocol version 2.
 
-For object storage programs like Minio, the value must be set to 1 as the bucket\
-name cannot be resolved via the subdomain like it is done for object stores in\
+For object storage programs like Minio, the value must be set to 1 as the bucket
+name cannot be resolved via the subdomain like it is done for object stores in
 the cloud.
 
 #### `import_user`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-lua-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-lua-filter.md
@@ -6,34 +6,34 @@
 
 The luafilter is a filter that calls a set of functions in a Lua script.
 
-Read the [Lua language documentation](https://www.lua.org/docs.html) for\
+Read the [Lua language documentation](https://www.lua.org/docs.html) for
 information on how to write Lua scripts.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Settings
 
-The luafilter has two parameters. They control which scripts will be called by\
-the filter. Both parameters are optional but at least one should be defined. If\
-both `global_script` and `session_script` are defined, the entry points in both\
+The luafilter has two parameters. They control which scripts will be called by
+the filter. Both parameters are optional but at least one should be defined. If
+both `global_script` and `session_script` are defined, the entry points in both
 scripts will be called.
 
 #### `global_script`
 
-The global Lua script. The parameter value is a path to a readable Lua script\
+The global Lua script. The parameter value is a path to a readable Lua script
 which will be executed.
 
-This script will always be called with the same global Lua state and it can be\
+This script will always be called with the same global Lua state and it can be
 used to build a global view of the whole service.
 
 #### `session_script`
 
-The session level Lua script. The parameter value is a path to a readable Lua\
+The session level Lua script. The parameter value is a path to a readable Lua
 script which will be executed once for each session.
 
-Each session will have its own Lua state meaning that each session can have a\
+Each session will have its own Lua state meaning that each session can have a
 unique Lua environment. Use this script to do session specific tasks.
 
 ### Lua Script Calling Convention
@@ -41,38 +41,38 @@ unique Lua environment. Use this script to do session specific tasks.
 The entry points for the Lua script expect the following signatures:
 
 * `nil createInstance(name)` - global script only, called when the script is first loaded
-  * When the global script is loaded, it first executes on a global level\
-    before the luafilter calls the createInstance function in the Lua script\
+  * When the global script is loaded, it first executes on a global level
+    before the luafilter calls the createInstance function in the Lua script
     with the filter's name as its argument.
 * `nil newSession(string, string)` - new session is created
-  * After the session script is loaded, the newSession function in the Lua\
-    scripts is called. The first parameter is the username of the client and\
+  * After the session script is loaded, the newSession function in the Lua
+    scripts is called. The first parameter is the username of the client and
     the second parameter is the client's network address.
 * `nil closeSession()` - session is closed
   * The `closeSession` function in the Lua scripts will be called.
 * `(nil | bool | string) routeQuery()` - query is being routed
-  * The Luafilter calls the `routeQuery` functions of both the session and the\
-    global script. The query is passed as a string parameter to the\
-    routeQuery Lua function and the return values of the session specific\
-    function, if any were returned, are interpreted. If the first value is\
-    bool, it is interpreted as a decision whether to route the query or to\
-    send an error packet to the client. If it is a string, the current query\
-    is replaced with the return value and the query will be routed. If nil is\
+  * The Luafilter calls the `routeQuery` functions of both the session and the
+    global script. The query is passed as a string parameter to the
+    routeQuery Lua function and the return values of the session specific
+    function, if any were returned, are interpreted. If the first value is
+    bool, it is interpreted as a decision whether to route the query or to
+    send an error packet to the client. If it is a string, the current query
+    is replaced with the return value and the query will be routed. If nil is
     returned, the query is routed normally.
 * `nil clientReply()` - reply to a query is being routed
   * This function is called with the name of the server that returned the response.
 * `string diagnostic()` - global script only, print diagnostic information
-  * If the Lua function returns a string that is valid JSON, it will be\
-    decoded as JSON and displayed as such in the REST API. If the object does\
+  * If the Lua function returns a string that is valid JSON, it will be
+    decoded as JSON and displayed as such in the REST API. If the object does
     not decode into JSON, it will be stored as a JSON string.
 
-These functions, if found in the script, will be called whenever a call to the\
+These functions, if found in the script, will be called whenever a call to the
 matching entry point is made.
 
 **Script Template**
 
-Here is a script template that can be used to try out the luafilter. Copy it\
-into a file and add `global_script=<path to script>` into the filter\
+Here is a script template that can be used to try out the luafilter. Copy it
+into a file and add `global_script=<path to script>` into the filter
 configuration. Make sure the file is readable by the `maxscale` user.
 
 ```
@@ -103,29 +103,29 @@ end
 
 #### Functions Exposed by the Luafilter
 
-The luafilter exposes the following functions that can be called inside the Lua\
-script API endpoints. The callback function in which they can be called is\
-documented after the function signature. If the functions are called outside of\
+The luafilter exposes the following functions that can be called inside the Lua
+script API endpoints. The callback function in which they can be called is
+documented after the function signature. If the functions are called outside of
 the correct callback function, they raise a Lua error.
 
 * `string mxs_get_sql()` (use: `routeQuery`)
-* Returns the SQL of the query being executed. This returns an empty string\
-  for any query that is not a text protocol query (COM\_QUERY). Support for\
+* Returns the SQL of the query being executed. This returns an empty string
+  for any query that is not a text protocol query (COM\_QUERY). Support for
   prepared statements is not yet implemented.
 * `string mxs_get_type_mask()` (use: `routeQuery`)
-* Returns the type of the current query being executed as a string. The values\
-  are the string versions of the query types defined in query\_classifier.h\
+* Returns the type of the current query being executed as a string. The values
+  are the string versions of the query types defined in query\_classifier.h
   are separated by vertical bars (`|`).\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_operation()` (use: `routeQuery`)
-* Returns the current operation type as a string. The values are defined in\
+* Returns the current operation type as a string. The values are defined in
   query\_classifier.h.\
   This function can only be called from the `routeQuery` entry point.
 * `string mxs_get_canonical()` (use: `routeQuery`)
 * Returns the canonical version of a query by replacing all user-defined constant values with question marks.\
   This function can only be called from the `routeQuery` entry point.
 * `number mxs_get_session_id()` (use: `newSession`, `routeQuery`, `clientReply`, `closeSession`)
-* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return\
+* This function returns the session ID of the current session. Inside the`createInstance` and `diagnostic` endpoints this function will always return
   the value 0.
 * `string mxs_get_db()` (use: `newSession`, `routeQuery`, `clientReply`, `closeSession`)
 * Returns the current default database used by the connection.
@@ -180,10 +180,10 @@ end
 
 ### Limitations
 
-* `mxs_get_sql()` and `mxs_get_canonical()` do not work with queries done with\
+* `mxs_get_sql()` and `mxs_get_canonical()` do not work with queries done with
   the binary protocol.
-* The Lua code is not restricted in any way which means excessively slow\
-  execution of it can cause the MaxScale process to become slower or to be\
+* The Lua code is not restricted in any way which means excessively slow
+  execution of it can cause the MaxScale process to become slower or to be
   aborted due to a SystemD watchdog timeout.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-masking.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-masking.md
@@ -6,15 +6,15 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-With the _masking_ filter it is possible to obfuscate the returned\
+With the _masking_ filter it is possible to obfuscate the returned
 value of a particular column.
 
-For instance, suppose there is a table _person_ that, among other\
-columns, contains the column _ssn_ where the social security number\
+For instance, suppose there is a table _person_ that, among other
+columns, contains the column _ssn_ where the social security number
 of a person is stored.
 
-With the masking filter it is possible to specify that when the _ssn_\
-field is queried, a masked value is returned unless the user making\
+With the masking filter it is possible to specify that when the _ssn_
+field is queried, a masked value is returned unless the user making
 the query is a specific one. That is, when making the query
 
 ```
@@ -43,44 +43,44 @@ the _ssn_ would be masked, as in
 ...
 ```
 
-Note that the masking filter should be viewed as a best-effort solution\
-intended for protecting against accidental misuse rather than malicious\
+Note that the masking filter should be viewed as a best-effort solution
+intended for protecting against accidental misuse rather than malicious
 attacks.
 
 ### Security
 
-From MaxScale 2.3 onwards, the masking filter will reject statements\
+From MaxScale 2.3 onwards, the masking filter will reject statements
 that use functions in conjunction with columns that should be masked.\
-Allowing function usage provides a way for circumventing the masking,\
+Allowing function usage provides a way for circumventing the masking,
 unless a firewall filter is separately configured and installed.
 
-Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2501-maxscale-2501-masking.md#prevent_function_usage)\
+Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2501-maxscale-2501-masking.md#prevent_function_usage)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will check the\
-definition of user variables and reject statements that define a user\
+From MaxScale 2.3.5 onwards, the masking filter will check the
+definition of user variables and reject statements that define a user
 variable using a statement that refers to columns that should be masked.
 
-Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2501-maxscale-2501-masking.md#check_user_variables)\
+Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2501-maxscale-2501-masking.md#check_user_variables)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine unions\
-and if the second or subsequent SELECT refer to columns that should\
+From MaxScale 2.3.5 onwards, the masking filter will examine unions
+and if the second or subsequent SELECT refer to columns that should
 be masked, the statement will be rejected.
 
-Please see the configuration parameter [check\_unions](mariadb-maxscale-2501-maxscale-2501-masking.md#check_unions)\
+Please see the configuration parameter [check\_unions](mariadb-maxscale-2501-maxscale-2501-masking.md#check_unions)
 for how to change the default behaviour.
 
-From MaxScale 2.3.5 onwards, the masking filter will examine subqueries\
-and if a subquery refers to columns that should be masked, the statement\
+From MaxScale 2.3.5 onwards, the masking filter will examine subqueries
+and if a subquery refers to columns that should be masked, the statement
 will be rejected.
 
-Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2501-maxscale-2501-masking.md#check_subqueries)\
+Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2501-maxscale-2501-masking.md#check_subqueries)
 for how to change the default behaviour.
 
-Note that in order to ensure that it is not possible to get access to\
-masked data, the privileges of the users should be minimized. For instance,\
-if a user can create tables and perform inserts, he or she can execute\
+Note that in order to ensure that it is not possible to get access to
+masked data, the privileges of the users should be minimized. For instance,
+if a user can create tables and perform inserts, he or she can execute
 something like
 
 ```
@@ -91,16 +91,16 @@ SELECT revealed_ssn FROM cheat;
 
 to get access to the cleartext version of a masked field `ssn`.
 
-From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that\
+From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that
 cannot be fully parsed.
 
-Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2501-maxscale-2501-masking.md#require_fully_parsed)\
+Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2501-maxscale-2501-masking.md#require_fully_parsed)
 for how to change the default behaviour.
 
-From MaxScale 2.3.7 onwards, the masking filter will treat any strings\
+From MaxScale 2.3.7 onwards, the masking filter will treat any strings
 passed to functions as if they were fields. The reason is that as the\
-MaxScale query classifier is not aware of whether `ANSI_QUOTES` is\
-enabled or not, it is possible to bypass the masking by turning that\
+MaxScale query classifier is not aware of whether `ANSI_QUOTES` is
+enabled or not, it is possible to bypass the masking by turning that
 option on.
 
 ```
@@ -108,32 +108,32 @@ mysql> set @@sql_mode = 'ANSI_QUOTES';
 mysql> select concat("ssn") from managers;
 ```
 
-Before this change, the content of the field `ssn` would have been\
+Before this change, the content of the field `ssn` would have been
 returned in clear text even if the column should have been masked.
 
-Note that this change will mean that there may be false positives\
-if `ANSI_QUOTES` is not enabled and a string argument happens to\
+Note that this change will mean that there may be false positives
+if `ANSI_QUOTES` is not enabled and a string argument happens to
 be the same as the name of a field to be masked.
 
 Please see the configuration parameter\
-\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)\
+\[treat\_string\_arg\_as\_field(#treat\_string\_arg\_as\_field)
 for how to change the default behaviour.
 
 ### Limitations
 
-The masking filter can _only_ be used for masking columns of the following\
-types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no\
+The masking filter can _only_ be used for masking columns of the following
+types: `BINARY`, `VARBINARY`, `CHAR`, `VARCHAR`, `BLOB`, `TINYBLOB`,`MEDIUMBLOB`, `LONGBLOB`, `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, `LONGTEXT`,`ENUM` and `SET`. If the type of the column is something else, then no
 masking will be performed.
 
-Currently, the masking filter can only work on packets whose payload is less\
-than 16MB. If the masking filter encounters a packet whose payload is exactly\
-that, thus indicating a situation where the payload is delivered in multiple\
-packets, the value of the parameter `large_payloads` specifies how the masking\
+Currently, the masking filter can only work on packets whose payload is less
+than 16MB. If the masking filter encounters a packet whose payload is exactly
+that, thus indicating a situation where the payload is delivered in multiple
+packets, the value of the parameter `large_payloads` specifies how the masking
 filter should handle the situation.
 
 ### Configuration
 
-The masking filter is taken into use with the following kind of\
+The masking filter is taken into use with the following kind of
 configuration setup.
 
 ```
@@ -159,7 +159,7 @@ The masking filter has one mandatory parameter - `rules`.
 * Dynamic: Yes
 
 Specifies the path of the file where the masking rules are stored.\
-A relative path is interpreted relative to the _module configuration directory_\
+A relative path is interpreted relative to the _module configuration directory_
 of MariaDB MaxScale. The default module configuration directory is_/etc/maxscale.modules.d_.
 
 ```
@@ -174,8 +174,8 @@ rules=/path/to/rules-file
 * Values: `never`, `always`
 * Default: `never`
 
-With this optional parameter the masking filter can be instructed to log\
-a warning if a masking rule matches a column that is not of one of the\
+With this optional parameter the masking filter can be instructed to log
+a warning if a masking rule matches a column that is not of one of the
 allowed types.
 
 ```
@@ -190,17 +190,17 @@ warn_type_mismatch=always
 * Values: `ignore`, `abort`
 * Default: `abort`
 
-This optional parameter specifies how the masking filter should treat\
-payloads larger than `16MB`, that is, payloads that are delivered in\
+This optional parameter specifies how the masking filter should treat
+payloads larger than `16MB`, that is, payloads that are delivered in
 multiple MySQL protocol packets.
 
-The values that can be used are `ignore`, which means that columns in\
-such payloads are not masked, and `abort`, which means that if such\
-payloads are encountered, the client connection is closed. The default\
+The values that can be used are `ignore`, which means that columns in
+such payloads are not masked, and `abort`, which means that if such
+payloads are encountered, the client connection is closed. The default
 is `abort`.
 
-Note that the aborting behaviour is applied only to resultsets that\
-contain columns that should be masked. There are _no_ limitations on\
+Note that the aborting behaviour is applied only to resultsets that
+contain columns that should be masked. There are _no_ limitations on
 resultsets that do not contain such columns.
 
 ```
@@ -214,23 +214,23 @@ large_payload=ignore
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should behave\
-if a column that should be masked, is used in conjunction with some\
-function. As the masking filter works _only_ on the basis of the\
-information in the returned result-set, if the name of a column is\
-not present in the result-set, then the masking filter cannot mask a\
-value. This means that the masking filter basically can be bypassed\
+This optional parameter specifies how the masking filter should behave
+if a column that should be masked, is used in conjunction with some
+function. As the masking filter works _only_ on the basis of the
+information in the returned result-set, if the name of a column is
+not present in the result-set, then the masking filter cannot mask a
+value. This means that the masking filter basically can be bypassed
 with a query like:
 
 ```
 SELECT CONCAT(masked_column) FROM tbl;
 ```
 
-If the value of `prevent_function_usage` is `true`, then all\
-statements that contain functions referring to masked columns will\
-be rejected. As that means that also queries using potentially\
-harmless functions, such as `LENGTH(masked_column)`, are rejected\
-as well, this feature can be turned off. In that case, the firewall\
+If the value of `prevent_function_usage` is `true`, then all
+statements that contain functions referring to masked columns will
+be rejected. As that means that also queries using potentially
+harmless functions, such as `LENGTH(masked_column)`, are rejected
+as well, this feature can be turned off. In that case, the firewall
 filter should be setup to allow or reject the use of certain functions.
 
 ```
@@ -244,19 +244,19 @@ prevent_function_usage=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
-behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a\
+This optional parameter specifies how the masking filter should
+behave in case any of `prevent_function_usage`, `check_user_variables`,`check_unions` or `check_subqueries` is true and it encounters a
 statement that cannot be fully parsed,
 
-If true, then statements that cannot be fully parsed (due to a\
+If true, then statements that cannot be fully parsed (due to a
 parser limitation) will be blocked.
 
 ```
 require_fully_parsed=false
 ```
 
-Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered\
-less effective, as it with a statement that cannot be fully parsed may be\
+Note that if this parameter is set to false, then `prevent_function_usage`,`check_user_variables`, `check_unions` and `check_subqueries` are rendered
+less effective, as it with a statement that cannot be fully parsed may be
 possible to bypass the protection that they are intended to provide.
 
 #### `treat_string_arg_as_field`
@@ -266,9 +266,9 @@ possible to bypass the protection that they are intended to provide.
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should treat\
-strings used as arguments to functions. If true, they will be handled\
-as fields, which will cause fields to be masked even if `ANSI_QUOTES` has\
+This optional parameter specifies how the masking filter should treat
+strings used as arguments to functions. If true, they will be handled
+as fields, which will cause fields to be masked even if `ANSI_QUOTES` has
 been enabled and `"` is used instead of backtick.
 
 ```
@@ -282,7 +282,7 @@ treat_string_arg_as_field=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to user variables. If true, then a statement like
 
 ```
@@ -302,7 +302,7 @@ check_user_variables=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to UNIONs. If true, then a statement like
 
 ```
@@ -322,7 +322,7 @@ check_unions=false
 * Dynamic: Yes
 * Default: `true`
 
-This optional parameter specifies how the masking filter should\
+This optional parameter specifies how the masking filter should
 behave with respect to subqueries. If true, then a statement like
 
 ```
@@ -339,7 +339,7 @@ check_subqueries=false
 
 The masking rules are expressed as a JSON object.
 
-The top-level object is expected to contain a key `rules` whose\
+The top-level object is expected to contain a key `rules` whose
 value is an array of rule objects.
 
 ```
@@ -348,8 +348,8 @@ value is an array of rule objects.
 }
 ```
 
-Each rule in the rules array is a JSON object, expected to\
-contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two\
+Each rule in the rules array is a JSON object, expected to
+contain the keys `replace`, `with`, `applies_to` and`exempted`. The two former ones are obligatory and the two
 latter ones optional.
 
 ```
@@ -367,15 +367,15 @@ latter ones optional.
 
 #### `replace`
 
-The value of this key is an object that specifies the column\
-whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The\
+The value of this key is an object that specifies the column
+whose values should be masked. The object must contain the key`column` and may contain the keys `table` and `database`. The
 value of these keys must be a string.
 
-If only `column` is specified, then a column with that name\
-matches irrespective of the table and database. If `table`\
-is specified, then the column matches only if it is in a table\
-with the specified name, and if `database` is specified when\
-the column matches only if it is in a database with the\
+If only `column` is specified, then a column with that name
+matches irrespective of the table and database. If `table`
+is specified, then the column matches only if it is in a table
+with the specified name, and if `database` is specified when
+the column matches only if it is in a database with the
 specified name.
 
 ```
@@ -395,10 +395,10 @@ specified name.
 }
 ```
 
-**NOTE** If a rule contains a table/database then if the resultset\
-does _not_ contain table/database information, it will always be\
-considered a match if the column matches. For instance, given the\
-rule above, if there is a table `person2`, also containing an `ssn`\
+**NOTE** If a rule contains a table/database then if the resultset
+does _not_ contain table/database information, it will always be
+considered a match if the column matches. For instance, given the
+rule above, if there is a table `person2`, also containing an `ssn`
 field, then a query like
 
 ```
@@ -411,24 +411,24 @@ will not return masked values, but a query like
 SELECT ssn FROM person UNION SELECT ssn FROM person2;
 ```
 
-will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is\
+will _only_ return masked values, even if the `ssn` values from`person2` in principle should not be masked. The same effect is
 observed even with a nonsensical query like
 
 ```
 SELECT ssn FROM person2 UNION SELECT ssn FROM person2;
 ```
 
-even if nothing from `person2` should be masked. The reason is that\
-as the resultset contains no table information, the values must be\
-masked if the column name matches, as otherwise the masking could\
+even if nothing from `person2` should be masked. The reason is that
+as the resultset contains no table information, the values must be
+masked if the column name matches, as otherwise the masking could
 easily be circumvented with a query like
 
 ```
 SELECT ssn FROM person UNION SELECT ssn FROM person;
 ```
 
-The optional key `match` makes partial replacement of the original\
-value possible: only the matched part would be replaced\
+The optional key `match` makes partial replacement of the original
+value possible: only the matched part would be replaced
 with the fill character.\
 The `match` value must be a valid pcre2 regular expression.
 
@@ -444,14 +444,14 @@ The `match` value must be a valid pcre2 regular expression.
 
 #### `obfuscate`
 
-The obfuscate rule allows the obfuscation of the value\
+The obfuscate rule allows the obfuscation of the value
 by passing it through an obfuscation algorithm.\
 Current solution uses a non-reversible obfuscation approach.
 
-However, note that although it is in principle impossible to obtain the\
-original value from the obfuscated one, if the range of possible original\
-values is limited, it is straightforward to figure out the possible\
-original values by running all possible values through the obfuscation\
+However, note that although it is in principle impossible to obtain the
+original value from the obfuscated one, if the range of possible original
+values is limited, it is straightforward to figure out the possible
+original values by running all possible values through the obfuscation
 algorithm and then comparing the results.
 
 The minimal configuration is:
@@ -476,20 +476,20 @@ SELECT name from db1.tbl1;`
 
 #### `with`
 
-The value of this key is an object that specifies what the value of the matched\
-column should be replaced with for the `replace` rule. Currently, the object\
+The value of this key is an object that specifies what the value of the matched
+column should be replaced with for the `replace` rule. Currently, the object
 is expected to contain either the key `value` or the key `fill`.\
 The value of both must be a string with length greater than zero.\
 If both keys are specified, `value` takes precedence.\
 If `fill` is not specified, the default `X` is used as its value.
 
-If `value` is specified, then its value is used to replace the actual value\
-verbatim and the length of the specified value must match the actual returned\
+If `value` is specified, then its value is used to replace the actual value
+verbatim and the length of the specified value must match the actual returned
 value (from the server) exactly. If the lengths do not match, the value of`fill` is used to mask the actual value.
 
-When the value of `fill` (fill-value) is used for masking the returned value,\
-the fill-value is used as many times as necessary to match the length of the\
-return value. If required, only a part of the fill-value may be used in the end\
+When the value of `fill` (fill-value) is used for masking the returned value,
+the fill-value is used as many times as necessary to match the length of the
+return value. If required, only a part of the fill-value may be used in the end
 of the mask value to get the lengths to match.
 
 ```
@@ -532,8 +532,8 @@ of the mask value to get the lengths to match.
 
 #### `applies_to`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is applied to. Each string\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is applied to. Each string
 should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -549,13 +549,13 @@ should be a MariaDB account string, that is, `%` is a wildcard.
 }
 ```
 
-If this key is not specified, then the masking is performed for all\
+If this key is not specified, then the masking is performed for all
 users, except the ones exempted using the key `exempted`.
 
 #### `exempted`
 
-With this _optional_ key, whose value must be an array of strings,\
-it can be specified what users the rule is _not_ applied to. Each\
+With this _optional_ key, whose value must be an array of strings,
+it can be specified what users the rule is _not_ applied to. Each
 string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ```
@@ -573,14 +573,14 @@ string should be a MariaDB account string, that is, `%` is a wildcard.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md) documentation for details\
+Read [Module Commands](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md) documentation for details
 about module commands.
 
 The masking filter supports the following module commands.
 
 #### `reload`
 
-Reload the rules from the rules file. The new rules are taken into use\
+Reload the rules from the rules file. The new rules are taken into use
 only if the loading succeeds without any errors.
 
 ```
@@ -592,8 +592,8 @@ MariaDB MaxScale configuration file.
 
 ### Example
 
-In the following we configure a masking filter _MyMasking_ that should always log a\
-warning if a masking rule matches a column that is of a type that cannot be masked,\
+In the following we configure a masking filter _MyMasking_ that should always log a
+warning if a masking rule matches a column that is of a type that cannot be masked,
 and that should abort the client connection if a resultset package is larger than\
 16MB. The rules for the masking filter are in the file `masking_rules.json`.
 
@@ -615,9 +615,9 @@ filters=MyMasking
 
 #### `masking_rules.json`
 
-The rules specify that the data of a column whose name is `ssn`, should\
-be replaced with the string _012345-ABCD_. If the length of the data is\
-not exactly the same as the length of the replacement value, then the\
+The rules specify that the data of a column whose name is `ssn`, should
+be replaced with the string _012345-ABCD_. If the length of the data is
+not exactly the same as the length of the replacement value, then the
 data should be replaced with as many _X_ characters as needed.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-maxrows.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-maxrows.md
@@ -6,11 +6,11 @@ This filter was introduced in MariaDB MaxScale 2.1.
 
 ### Overview
 
-The Maxrows filter is capable of restricting the amount of rows that a SELECT,\
+The Maxrows filter is capable of restricting the amount of rows that a SELECT,
 a prepared statement or stored procedure could return to the client application.
 
-If a resultset from a backend server has more rows than the configured limit\
-or the resultset size exceeds the configured size,\
+If a resultset from a backend server has more rows than the configured limit
+or the resultset size exceeds the configured size,
 an empty result will be sent to the client.
 
 ### Configuration
@@ -40,7 +40,7 @@ Optional parameters are:
 * Dynamic: Yes
 * Default: (no limit)
 
-Specifies the maximum number of rows a resultset can have in order to be\
+Specifies the maximum number of rows a resultset can have in order to be
 returned to the user.
 
 If a resultset is larger than this an empty result will be sent instead.
@@ -56,8 +56,8 @@ max_resultset_rows=1000
 * Dynamic: Yes
 * Default: `64Ki`
 
-Specifies the maximum size a resultset can have in order\
-to be sent to the client. A resultset larger than this, will\
+Specifies the maximum size a resultset can have in order
+to be sent to the client. A resultset larger than this, will
 not be sent: an empty resultset will be sent instead.
 
 ```
@@ -72,7 +72,7 @@ max_resultset_size=128Ki
 * Values: `empty`, `error`, `ok`
 * Default: `empty`
 
-Specifies what the filter sends to the client when the\
+Specifies what the filter sends to the client when the
 rows or size limit is hit, possible values:
 
 * an empty result set
@@ -93,8 +93,8 @@ ERROR 1415 (0A000): Row limit/size exceeded for query: select * from test.t4
 * Dynamic: Yes
 * Default: `0`
 
-An integer value, using which the level of debug logging made by the Maxrows\
-filter can be controlled. The value is actually a bitfield with different bits\
+An integer value, using which the level of debug logging made by the Maxrows
+filter can be controlled. The value is actually a bitfield with different bits
 denoting different logging.
 
 * `0` (`0b00000`) No logging is made.
@@ -109,7 +109,7 @@ debug=2
 
 ### Example Configuration
 
-Here is an example of filter configuration where the maximum number of returned\
+Here is an example of filter configuration where the maximum number of returned
 rows is 10000 and maximum allowed resultset size is 256KB
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-named-server-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-named-server-filter.md
@@ -4,25 +4,25 @@
 
 ### Overview
 
-The **namedserverfilter** is a MariaDB MaxScale filter module able to route\
-queries to servers based on regular expression (regex) matches. Since it is a\
+The **namedserverfilter** is a MariaDB MaxScale filter module able to route
+queries to servers based on regular expression (regex) matches. Since it is a
 filter instead of a router, the NamedServerFilter only sets routing suggestions.\
-It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the\
-data packets. This filter uses the _PCRE2_ library for regular expression\
+It requires a compatible router to be effective. Currently, both**readwritesplit** and **hintrouter** take advantage of routing hints in the
+data packets. This filter uses the _PCRE2_ library for regular expression
 matching.
 
 ### Configuration
 
-The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of\
-the modes may be used for a given filter instance. The legacy mode is meant for\
-backwards compatibility and allows only one regular expression and one server\
-name in the configuration. In indexed mode, up to 25 regex-server pairs are\
+The filter accepts settings in two modes: _legacy_ and _indexed_. Only one of
+the modes may be used for a given filter instance. The legacy mode is meant for
+backwards compatibility and allows only one regular expression and one server
+name in the configuration. In indexed mode, up to 25 regex-server pairs are
 allowed in the form _match01_ - _target01_, _match02_ - _target02_ and so on.\
-Also, in indexed mode, the server names (targets) may contain a list of names or\
+Also, in indexed mode, the server names (targets) may contain a list of names or
 special tags `->master` or `->slave`.
 
-All parameters except the deprecated `match` and `target` parameters can\
-be modified at runtime. Any modifications to the filter configuration will\
+All parameters except the deprecated `match` and `target` parameters can
+be modified at runtime. Any modifications to the filter configuration will
 only affect sessions created after the change has completed.
 
 Below is a configuration example for the filter in indexed-mode. The legacy mode\
@@ -63,10 +63,10 @@ NamedServerFilter requires at least one _matchXY_ - _targetXY_ pair.
 * Dynamic: Yes
 * Default: None
 
-_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+_matchXY_ defines a [PCRE2 regular expression](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 against which the incoming SQL query is matched. _XY_ must be a number in the range\
-01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is\
-defined, the other must be defined as well. If a query matches the pattern, the filter\
+01 - 25. Each _match_-setting pairs with a similarly indexed _target_-setting. If one is
+defined, the other must be defined as well. If a query matches the pattern, the filter
 attaches a routing hint defined by the _target_-setting to the query. The _options_-parameter affects how the patterns are compiled.
 
 ```
@@ -82,7 +82,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-[Regular expression options](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+[Regular expression options](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 for `matchXY`.
 
 #### `targetXY`
@@ -101,8 +101,8 @@ accordingly. The target can be one of the following:
 * `->slave` (adds a `HINT_ROUTE_TO_SLAVE` hint)
 * `->all` (adds a `HINT_ROUTE_TO_ALL` hint)
 
-The support for service names was added in MaxScale 6.3.2. Older\
-versions of MaxScale did not accept service names in the `target`\
+The support for service names was added in MaxScale 6.3.2. Older
+versions of MaxScale did not accept service names in the `target`
 parameters.
 
 ```
@@ -116,9 +116,9 @@ target01=MyServer2
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines an IP address or mask which a connecting\
-client's IP address is matched against. Only sessions whose address matches this\
-setting will have this filter active and performing the regex matching. Traffic\
+This optional parameter defines an IP address or mask which a connecting
+client's IP address is matched against. Only sessions whose address matches this
+setting will have this filter active and performing the regex matching. Traffic
 from other client IPs is simply left as is and routed straight through.
 
 ```
@@ -135,7 +135,7 @@ source=192.168.10.%
 
 Note that using `source=%` to match any IP is not allowed.
 
-Since MaxScale 2.3 it's also possible to specify multiple addresses separated\
+Since MaxScale 2.3 it's also possible to specify multiple addresses separated
 by comma. Incoming client connections are subsequently checked against each.
 
 ```
@@ -149,9 +149,9 @@ source=192.168.21.3,192.168.10.%
 * Dynamic: Yes
 * Default: None
 
-This optional parameter defines a username the connecting client username is\
-matched against. Only sessions that are connected using this username will have\
-the match and routing hints applied to them. Traffic from other users is simply\
+This optional parameter defines a username the connecting client username is
+matched against. Only sessions that are connected using this username will have
+the match and routing hints applied to them. Traffic from other users is simply
 left as is and routed straight through.
 
 ```
@@ -162,30 +162,30 @@ user=john
 
 The maximum number of accepted _match_ - _target_ pairs is 25.
 
-In the configuration file, the indexed match and target settings may be in any order\
-and may skip numbers. During SQL-query matching, however, the regexes are tested\
-in ascending order: match01, match02, match03 and so on. As soon as a match is\
-found for a given query, the routing hints are written and the packet is\
-forwarded to the next filter or router. Any remaining match regexes are\
-ignored. This means the _match_ - _target_ pairs should be indexed in priority\
-order, or, if priority is not a factor, in order of decreasing match\
+In the configuration file, the indexed match and target settings may be in any order
+and may skip numbers. During SQL-query matching, however, the regexes are tested
+in ascending order: match01, match02, match03 and so on. As soon as a match is
+found for a given query, the routing hints are written and the packet is
+forwarded to the next filter or router. Any remaining match regexes are
+ignored. This means the _match_ - _target_ pairs should be indexed in priority
+order, or, if priority is not a factor, in order of decreasing match
 probability.
 
-Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching\
-the prepared sql against the _match_-parameters. If a match is found, the\
-routing hints are attached to any execution of that prepared statement. Text-\
-mode prepared statements are not supported in this way. To divert them, use\
+Binary-mode prepared statements (COM\_STMT\_PREPARE) are handled by matching
+the prepared sql against the _match_-parameters. If a match is found, the
+routing hints are attached to any execution of that prepared statement. Text-
+mode prepared statements are not supported in this way. To divert them, use
 regular expressions which match the specific "EXECUTE"-query.
 
 ### Examples
 
 #### Example 1 - Route queries targeting a specific table to a server
 
-This will route all queries matching the regular expression `*from *users` to\
+This will route all queries matching the regular expression `*from *users` to
 the server named _server2_. The filter will ignore character case in queries.
 
-A query like `SELECT * FROM users` would be routed to server2 where as a query\
-like `SELECT * FROM accounts` would be routed according to the normal rules of\
+A query like `SELECT * FROM users` would be routed to server2 where as a query
+like `SELECT * FROM accounts` would be routed according to the normal rules of
 the router.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-optimistic-transaction-execution-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-optimistic-transaction-execution-filter.md
@@ -2,23 +2,23 @@
 
 ## Optimistic Transaction Execution Filter
 
-The `optimistictrx` filter implements optimistic transaction execution. The\
-filter is designed for a use-case where most of the transactions are read-only\
-and writes happen rarely but each set of read-only statements is still grouped\
+The `optimistictrx` filter implements optimistic transaction execution. The
+filter is designed for a use-case where most of the transactions are read-only
+and writes happen rarely but each set of read-only statements is still grouped
 into a read-write transaction (i.e. `START TRANSACTION`, `BEGIN` or`SET autocommit=0`).
 
-This filter will replace the `BEGIN` and `START TRANSACTION` SQL commands with`START TRANSACTION READ ONLY`. If the transaction is fully read-only, the\
-transaction completes normally. However, if a write happens in the middle of a\
-transaction, the filter issues a `ROLLBACK` command and then replays the\
-read-only part of the transaction, including the original `BEGIN` statement. If\
-the results of the replayed read-only part of the transaction is identical to\
-the one that was returned to the client, the transaction proceeds normally. If\
-the result checksum does not match, the connection is closed to prevent a write\
+This filter will replace the `BEGIN` and `START TRANSACTION` SQL commands with`START TRANSACTION READ ONLY`. If the transaction is fully read-only, the
+transaction completes normally. However, if a write happens in the middle of a
+transaction, the filter issues a `ROLLBACK` command and then replays the
+read-only part of the transaction, including the original `BEGIN` statement. If
+the results of the replayed read-only part of the transaction is identical to
+the one that was returned to the client, the transaction proceeds normally. If
+the result checksum does not match, the connection is closed to prevent a write
 with the wrong transaction state from happening.
 
 ## Configuration
 
-To add the filter to a service, define an instance of the filter and then add it\
+To add the filter to a service, define an instance of the filter and then add it
 to a service's `filters` list:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-psreuse.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-psreuse.md
@@ -2,23 +2,23 @@
 
 ## Psreuse
 
-The `psreuse` filter reuses identical prepared statements inside the same client\
-connection. This filter only works with binary protocol prepared statements and\
-not with text protocol prepared statements executed with the `PREPARE` SQL\
+The `psreuse` filter reuses identical prepared statements inside the same client
+connection. This filter only works with binary protocol prepared statements and
+not with text protocol prepared statements executed with the `PREPARE` SQL
 command.
 
-When this filter is enabled and the connection prepares an identical prepared\
-statement multiple times, instead of preparing it on the server the existing\
-prepared statement handle is reused. This also means that whenever prepared\
+When this filter is enabled and the connection prepares an identical prepared
+statement multiple times, instead of preparing it on the server the existing
+prepared statement handle is reused. This also means that whenever prepared
 statements are closed by the client, they will be left open by readwritesplit.
 
-Enabling this feature will increase memory usage of a session. The amount of\
-memory stored per prepared statement is proportional to the length of the\
+Enabling this feature will increase memory usage of a session. The amount of
+memory stored per prepared statement is proportional to the length of the
 prepared SQL statement and the number of parameters the statement has.
 
 ## Configuration
 
-To add the filter to a service, define an instance of the filter and then add it\
+To add the filter to a service, define an instance of the filter and then add it
 to a service's `filters` list:
 
 ```
@@ -33,10 +33,10 @@ filters=PsReuse
 
 ## Limitations
 
-* If the SQL in the prepared statement is larger than 1677723 bytes, the\
+* If the SQL in the prepared statement is larger than 1677723 bytes, the
   prepared statement will not be cached.
-* If the same SQL is prepared more than once at the same time, only one of them\
-  will succeed. This happens as the prepared statement reuse uses the SQL string\
+* If the same SQL is prepared more than once at the same time, only one of them
+  will succeed. This happens as the prepared statement reuse uses the SQL string
   in the comparison to detect if a statement is already prepared.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-query-log-all-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-query-log-all-filter.md
@@ -29,13 +29,13 @@ filters=MyLogFilter
 
 ### Log Rotation
 
-The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`\
-command. This will cause the log files to be reopened when the next message is\
+The `qlafilter` logs can be rotated by executing the `maxctrl rotate logs`
+command. This will cause the log files to be reopened when the next message is
 written to the file. This applies to both unified and session type logging.
 
 ### Settings
 
-The QLA filter has one mandatory parameter, `filebase`, and a number of optional\
+The QLA filter has one mandatory parameter, `filebase`, and a number of optional
 parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 
 #### `filebase`
@@ -44,7 +44,7 @@ parameters. These were introduced in the 1.0 release of MariaDB MaxScale.
 * Mandatory: Yes
 * Dynamic: No
 
-The basename of the output file created for each session. A session index is\
+The basename of the output file created for each session. A session index is
 added to the filename for each written session file. For unified log files,_.unified_ is appended.
 
 ```
@@ -103,7 +103,7 @@ Limit logging to sessions with this client source address.
 * Mandatory: No
 * Dynamic: Yes
 
-Only log queries from users that match this pattern. If the `user` parameter is\
+Only log queries from users that match this pattern. If the `user` parameter is
 used, the value of `user_match` is ignored.
 
 Here is an example pattern that matches the users `alice` and `bob`:
@@ -118,7 +118,7 @@ user_match=/(^alice$)|(^bob$)/
 * Mandatory: No
 * Dynamic: Yes
 
-Exclude all queries from users that match this pattern. If the `user` parameter\
+Exclude all queries from users that match this pattern. If the `user` parameter
 is used, the value of `user_exclude` is ignored.
 
 Here is an example pattern that excludes the users `alice` and `bob`:
@@ -133,10 +133,10 @@ user_exclude=/(^alice$)|(^bob$)/
 * Mandatory: No
 * Dynamic: Yes
 
-Only log queries from hosts that match this pattern. If the `source` parameter\
+Only log queries from hosts that match this pattern. If the `source` parameter
 is used, the value of `source_match` is ignored.
 
-Here is an example pattern that matches the loopback interface as well as the\
+Here is an example pattern that matches the loopback interface as well as the
 address `192.168.0.109`:
 
 ```
@@ -149,10 +149,10 @@ source_match=/(^127[.]0[.]0[.]1)|(^192[.]168[.]0[.]109)/
 * Mandatory: No
 * Dynamic: Yes
 
-Exclude all queries from hosts that match this pattern. If the `source`\
+Exclude all queries from hosts that match this pattern. If the `source`
 parameter is used, the value of `source_exclude` is ignored.
 
-Here is an example pattern that excludes the loopback interface as well as the\
+Here is an example pattern that excludes the loopback interface as well as the
 address `192.168.0.109`:
 
 ```
@@ -204,14 +204,14 @@ Type of data to log in the log files.
 | server             | The server where the query was routed (if any) (v22.08) |
 | command            | The protocol command that was executed (v24.02)         |
 
-The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,\
+The durations _reply\_time_ and _total\_reply\_time_ are by default in milliseconds,
 but can be specified to another unit using _duration\_unit_.
 
 The log entry is written when the last reply from the server is received.\
-Prior to version 6.2 the entry was written when the query was received from\
+Prior to version 6.2 the entry was written when the query was received from
 the client, or if _reply\_time_ was specified, on first reply from the server.
 
-**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_\
+**NOTE** The _error\_msg_ is the raw message from the server. Even if _use\_canonical\_form_
 is set the error message may contain user defined constants. For example:
 
 ```
@@ -221,10 +221,10 @@ that corresponds to your MariaDB server version for the right syntax to
 use near 'password="clear text pwd"' at line 1
 ```
 
-Starting with MaxScale 24.02, the `query` parameter now correctly logs\
+Starting with MaxScale 24.02, the `query` parameter now correctly logs
 the execution of binary protocol commands as SQL\
-([MXS-4959](https://jira.mariadb.org/browse/MXS-4959)). The execution of\
-batched statements (COM\_STMT\_BULK\_LOAD) used by some connectors is not\
+([MXS-4959](https://jira.mariadb.org/browse/MXS-4959)). The execution of
+batched statements (COM\_STMT\_BULK\_LOAD) used by some connectors is not
 logged.
 
 #### `duration_unit`
@@ -245,7 +245,7 @@ This option is available as of MaxScale version 6.2.
 * Dynamic: Yes
 * Default: `false`
 
-When this option is true the canonical form of the query is logged. In the\
+When this option is true the canonical form of the query is logged. In the
 canonical form all user defined constants are replaced with question marks.\
 This option is available as of MaxScale version 6.2.
 
@@ -272,7 +272,7 @@ Flush log files after every write.
 * Dynamic: Yes
 * Default: `","`
 
-Defines the separator string between elements of\
+Defines the separator string between elements of
 log entries. The value should be enclosed in quotes.
 
 #### `newline_replacement`
@@ -282,10 +282,10 @@ log entries. The value should be enclosed in quotes.
 * Dynamic: Yes
 * Default: `" "`
 
-Default value is `" "` (one space). SQL-queries may include line breaks, which, if\
-printed directly to the log, may break automatic parsing. This parameter defines\
-what should be written in the place of a newline sequence (\r, \n or \r\n). If\
-this is set as the empty string, then newlines are not replaced and printed as\
+Default value is `" "` (one space). SQL-queries may include line breaks, which, if
+printed directly to the log, may break automatic parsing. This parameter defines
+what should be written in the place of a newline sequence (\r, \n or \r\n). If
+this is set as the empty string, then newlines are not replaced and printed as
 is to the output. The value should be enclosed in quotes.
 
 ```
@@ -294,19 +294,19 @@ newline_replacement=" NL "
 
 ### Limitations
 
-* Trailing parts of SQL queries that are larger than 16MiB are not\
+* Trailing parts of SQL queries that are larger than 16MiB are not
   logged. This means that the log output might contain truncated SQL.
-* Batched execution using COM\_STMT\_BULK\_EXECUTE is not converted into\
-  their textual form. This is done due to the large volumes of data that\
+* Batched execution using COM\_STMT\_BULK\_EXECUTE is not converted into
+  their textual form. This is done due to the large volumes of data that
   are usually involved with batched execution.
 
 ### Examples
 
 #### Example 1 - Query without primary key
 
-Imagine you have observed an issue with a particular table and you want to\
-determine if there are queries that are accessing that table but not using the\
-primary key of the table. Let's assume the table name is PRODUCTS and the\
+Imagine you have observed an issue with a particular table and you want to
+determine if there are queries that are accessing that table but not using the
+primary key of the table. Let's assume the table name is PRODUCTS and the
 primary key is called PRODUCT\_ID. Add a filter with the following definition:
 
 ```
@@ -326,7 +326,7 @@ password=mypasswd
 filters=ProductsSelectLogger
 ```
 
-The result of using this filter with the service used by the application would\
+The result of using this filter with the service used by the application would
 be a log file of all select queries querying PRODUCTS without using the\
 PRODUCT\_ID primary key in the predicates of the query. Executing `SELECT * FROM PRODUCTS` would log the following into `/var/logs/qla/SelectProducts`:
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-regex-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-regex-filter.md
@@ -4,13 +4,13 @@
 
 ### Overview
 
-The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite\
-query content using regular expression matches and text substitution. The\
+The Regex filter is a filter module for MariaDB MaxScale that is able to rewrite
+query content using regular expression matches and text substitution. The
 regular expressions use the [PCRE2 syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html).
 
-PCRE2 library uses a different syntax than POSIX to refer to capture\
-groups in the replacement string. The main difference is the usage of the dollar\
-character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)\
+PCRE2 library uses a different syntax than POSIX to refer to capture
+groups in the replacement string. The main difference is the usage of the dollar
+character instead of the backslash character for references e.g. `$1` instead of`\1`. For more details about the replacement string differences, please read the [Creating a new string with substitutions](https://www.pcre.org/current/doc/html/pcre2api.html#SEC34)
 chapter in the PCRE2 manual.
 
 ### Configuration
@@ -66,7 +66,7 @@ The _options_-parameter affects how the patterns are compiled as [usual](../mari
 * Mandatory: Yes
 * Dynamic: Yes
 
-This is the text that should replace the part of the SQL-query matching the\
+This is the text that should replace the part of the SQL-query matching the
 pattern defined in _match_.
 
 ```
@@ -80,9 +80,9 @@ replace=ENGINE =
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
-the address from which the client connection to MariaDB MaxScale\
-originates. Only sessions that originate from this address will have the match\
+The optional source parameter defines an address that is used to match against
+the address from which the client connection to MariaDB MaxScale
+originates. Only sessions that originate from this address will have the match
 and replacement applied to them.
 
 ```
@@ -96,9 +96,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will have the match and\
+The optional user parameter defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will have the match and
 replacement applied to them.
 
 ```
@@ -112,9 +112,9 @@ user=john
 * Dynamic: Yes
 * Default: None
 
-The optional log\_file parameter defines a log file in which the filter writes\
-all queries that are not matched and matching queries with their replacement\
-queries. All sessions will log to this file so this should only be used for\
+The optional log\_file parameter defines a log file in which the filter writes
+all queries that are not matched and matching queries with their replacement
+queries. All sessions will log to this file so this should only be used for
 diagnostic purposes.
 
 ```
@@ -128,10 +128,10 @@ log_file=/tmp/regexfilter.log
 * Dynamic: Yes
 * Default: None
 
-The optional log\_trace parameter toggles the logging of non-matching and\
+The optional log\_trace parameter toggles the logging of non-matching and
 matching queries with their replacements into the log file on the _info_ level.\
-This is the preferred method of diagnosing the matching of queries since the log\
-level can be changed at runtime. For more details about logging levels and\
+This is the preferred method of diagnosing the matching of queries since the log
+level can be changed at runtime. For more details about logging levels and
 session specific logging, please read the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
 
 ```
@@ -142,10 +142,10 @@ log_trace=true
 
 #### Example 1 - Replace MySQL 5.1 create table syntax with that for later versions
 
-MySQL 5.1 used the parameter TYPE = to set the storage engine that should be\
-used for a table. In later versions this changed to be ENGINE =. Imagine you\
-have an application that you cannot change for some reason, but you wish to\
-migrate to a newer version of MySQL. The regexfilter can be used to transform\
+MySQL 5.1 used the parameter TYPE = to set the storage engine that should be
+used for a table. In later versions this changed to be ENGINE =. Imagine you
+have an application that you cannot change for some reason, but you wish to
+migrate to a newer version of MySQL. The regexfilter can be used to transform
 the create table statements into the form that could be used by MySQL 5.5
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-rewrite-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-rewrite-filter.md
@@ -5,8 +5,8 @@
 ### Overview
 
 The rewrite filter allows modification of sql queries on the fly.\
-Reasons for modifying queries can be to rewrite a query for performance,\
-or to change a specific query when the client query is incorrect and\
+Reasons for modifying queries can be to rewrite a query for performance,
+or to change a specific query when the client query is incorrect and
 cannot be changed in a timely manner.
 
 The examples will use Rewrite Filter file format. See below.
@@ -21,7 +21,7 @@ Rewriter native syntax uses placeholders to grab and replace parts of text.
 
 The syntax for a plain placeholder is `@{N}` where N is a positive integer.
 
-The syntax for a placeholder regex is `@{N:regex}`. It allows more control\
+The syntax for a placeholder regex is `@{N:regex}`. It allows more control
 when needed.
 
 The below is a valid entry in rf format. For demonstration, all options are set.\
@@ -55,23 +55,23 @@ For a match, the two `@{2}` text grabs must be equal.
 
 The match template is used to match against the sql to be rewritten.
 
-The match template can be partial `from mytable`. But the actual underlying\
-regex match is always for the whole sql. If the match template does not\
-start or end with a placeholder, placeholders are automatically added so\
-that the above becomes `@{1}from mytable@{2}`. The automatically added\
+The match template can be partial `from mytable`. But the actual underlying
+regex match is always for the whole sql. If the match template does not
+start or end with a placeholder, placeholders are automatically added so
+that the above becomes `@{1}from mytable@{2}`. The automatically added
 placeholders cannot be used in the replace template.
 
-Matching the whole input also means that Native syntax does not support\
-(and is not intended to support) scan and replace. Only the first occurrence\
+Matching the whole input also means that Native syntax does not support
+(and is not intended to support) scan and replace. Only the first occurrence
 of the above `from mytable` can be modified in the replace template.\
-However, one can selectively choose to modify e.g. the first through\
+However, one can selectively choose to modify e.g. the first through
 third occurrence of `from mytable` by writing`from mytable @{1} from mytable @{2} from mytable @{3}`.
 
 For scan and replace use a different regex\_grammar (see below).
 
 **Replace template**
 
-The replace template uses the placeholders from the match template to\
+The replace template uses the placeholders from the match template to
 rewrite sql.
 
 ```
@@ -87,11 +87,11 @@ Input: select count(distinct author) from books where entity != "AI"
 Rewritten: select count(*) from (select distinct author from books where entity != "AI") as t123
 ```
 
-An important option for smooth matching is `ignore_whitespace`, which\
-is on (true) by default. It creates the match regex in such a way that\
-the amount and kind of whitespace does not affect matching. However,\
-to make `ignore_whitespace` always work, it is important to add\
-whitespace where allowed. If "id=42" is in the match template then\
+An important option for smooth matching is `ignore_whitespace`, which
+is on (true) by default. It creates the match regex in such a way that
+the amount and kind of whitespace does not affect matching. However,
+to make `ignore_whitespace` always work, it is important to add
+whitespace where allowed. If "id=42" is in the match template then
 only the exact "id=42" can match. But if "id = 42" is used, and`ignore_whitespace` is on, both "id=42" and "id = 42" will match.
 
 Another example, and what not to do:
@@ -108,7 +108,7 @@ Input: select name from mytable where id=42
 Rewritten: select name from mytable force index (myindex) where id=42
 ```
 
-That works, but because the match lacks specific detail about the\
+That works, but because the match lacks specific detail about the
 expected sql, things are likely to break. In this case`show indexes from my_table` would no longer work.
 
 The minimum detail in this case could be:
@@ -121,22 +121,22 @@ The minimum detail in this case could be:
 select @{2} from mytable force index (myindex)
 ```
 
-but if more detail is known, like something specific in the where clause,\
+but if more detail is known, like something specific in the where clause,
 that too should be added.
 
 **Placeholder Regex**
 
 Syntax: @{N:regex}
 
-In a placeholder regex the character `}` must be escaped to `\}`\
-(for literal matching). Plain parenthesis "()" indicate capturing\
+In a placeholder regex the character `}` must be escaped to `\}`
+(for literal matching). Plain parenthesis "()" indicate capturing
 groups, which are internally used by the Native grammar.\
 Thus plain parentheses in a placeholder regex will break matching.\
 However, non-capturing groups can be used: e.g. `@{1:(:?Jane|Joe)}`.\
 To match a literal parenthesis use an escape, e.g. `\(`.
 
 Suppose an application is misbehaving after an upgrade and a quick fix is needed.\
-This query `select zip from address_book where str_id = "AZ-124"` is correct,\
+This query `select zip from address_book where str_id = "AZ-124"` is correct,
 but if the id is an integer the where clause should be `id = 1234`.
 
 ```
@@ -157,7 +157,7 @@ For scan and replace the regex\_grammar must be set to something else than\
 Native. An example will illustrate the usage.
 
 Replace all occurrences of "wrong\_table\_name" with "correct\_table\_name".\
-Further, if the replacement was made then replace all occurrences\
+Further, if the replacement was made then replace all occurrences
 of wrong\_column\_name with correct\_column\_name.
 
 ```
@@ -262,7 +262,7 @@ Ignore whitespace differences in the match template and input sql.
 * Type: boolean
 * Default: false
 
-If a template matches and the replacement is done, continue to the\
+If a template matches and the replacement is done, continue to the
 next template and apply it to the result of the previous rewrite.
 
 #### `what_if`
@@ -270,7 +270,7 @@ next template and apply it to the result of the previous rewrite.
 * Type: boolean
 * Default: false
 
-Do not make the replacement, only log what would have\
+Do not make the replacement, only log what would have
 been replaced (NOTICE level).
 
 ### Rewrite file format
@@ -286,12 +286,12 @@ match template
 replace template
 ```
 
-The character `#` starts a single line comment when it is the\
+The character `#` starts a single line comment when it is the
 first character on a line.
 
 Empty lines are ignored.
 
-The rf format does not need any additional escaping to what the basic\
+The rf format does not need any additional escaping to what the basic
 format requires (see Placeholder Regex).
 
 Options are specified as follows:
@@ -302,11 +302,11 @@ case_sensitive: true
 
 The colon must stick to the option name.
 
-The separators `%` and `%%` must be the exact content of\
+The separators `%` and `%%` must be the exact content of
 their respective separator lines.
 
-The templates can span multiple lines. Whitespace does not\
-matter as long as `ignore_whitespace = true`. Always use space\
+The templates can span multiple lines. Whitespace does not
+matter as long as `ignore_whitespace = true`. Always use space
 where space is allowed to maximize the utility of`ignore_whitespace`.
 
 Example
@@ -326,10 +326,10 @@ and @{3} in (select user from approved_users)
 ### Json file format
 
 The json file format is harder to read and edit manually.\
-It will be needed if support for editing of rewrite templates\
+It will be needed if support for editing of rewrite templates
 is added to the GUI.
 
-All double quotes and escape characters have to be escaped in json,\
+All double quotes and escape characters have to be escaped in json,
 i.e '"' and '\\'.
 
 The same example as above is:
@@ -349,7 +349,7 @@ and @{3} in (select user from approved_users)"
 
 ### Reload template file
 
-The configuration is re-read if any dynamic value is updated\
+The configuration is re-read if any dynamic value is updated
 even if the value does not change.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-tee-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-tee-filter.md
@@ -5,17 +5,17 @@
 ### Overview
 
 The tee filter is a "plumbing" fitting in the MariaDB MaxScale filter toolkit.\
-It can be used in a filter pipeline of a service to make copies of requests from\
+It can be used in a filter pipeline of a service to make copies of requests from
 the client and send the copies to another service within MariaDB MaxScale.
 
-**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a\
-service which uses a tee filter will require a grant for the loopback address,\
+**Please Note:** Starting with MaxScale 2.2.0, any client that connects to a
+service which uses a tee filter will require a grant for the loopback address,
 i.e. `127.0.0.1`.
 
 ### Configuration
 
-The configuration block for the TEE filter requires the minimal filter\
-parameters in its section within the MaxScale configuration file. The service to\
+The configuration block for the TEE filter requires the minimal filter
+parameters in its section within the MaxScale configuration file. The service to
 send the duplicates to must be defined.
 
 ```
@@ -35,7 +35,7 @@ filters=DataMartFilter
 
 ### Settings
 
-The tee filter requires a mandatory parameter to define the service to replicate\
+The tee filter requires a mandatory parameter to define the service to replicate
 statements to and accepts a number of optional parameters.
 
 #### `target`
@@ -45,8 +45,8 @@ statements to and accepts a number of optional parameters.
 * Dynamic: Yes
 * Default: none
 
-The target where the filter will duplicate all queries. The target can be either\
-a service or a server. The duplicate connection that is created to this target\
+The target where the filter will duplicate all queries. The target can be either
+a service or a server. The duplicate connection that is created to this target
 will be referred to as the "branch target" in this document.
 
 #### `service`
@@ -56,8 +56,8 @@ will be referred to as the "branch target" in this document.
 * Dynamic: Yes
 * Default: none
 
-The service where the filter will duplicate all queries. This parameter is\
-deprecated in favor of the `target` parameter and will be removed in a future\
+The service where the filter will duplicate all queries. This parameter is
+deprecated in favor of the `target` parameter and will be removed in a future
 release. Both `target` and `service` cannot be defined.
 
 #### `match`
@@ -107,7 +107,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-The optional source parameter defines an address that is used to match against\
+The optional source parameter defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be replicated.
 
@@ -122,8 +122,8 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-The optional user parameter defines a user name that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
+The optional user parameter defines a user name that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
 sessions that are connected using this username are replicated.
 
 ```
@@ -137,63 +137,63 @@ user=john
 * Dynamic: Yes
 * Default: `false`
 
-Enable synchronous routing mode. When configured with `sync=true`, the filter\
-will queue new queries until the response from both the main and the branch\
-target has been received. This means that for `n` executed queries, `n - 1`\
-queries are guaranteed to be synchronized. Adding one extra statement\
-(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL\
+Enable synchronous routing mode. When configured with `sync=true`, the filter
+will queue new queries until the response from both the main and the branch
+target has been received. This means that for `n` executed queries, `n - 1`
+queries are guaranteed to be synchronized. Adding one extra statement
+(e.g. `SELECT 1`) to a batch of statements guarantees that all previous SQL
 statements have been successfully executed on both targets.
 
-In the synchronous routing mode, a failure of the branch target will cause the\
+In the synchronous routing mode, a failure of the branch target will cause the
 client session to be closed.
 
 ### Limitations
 
-* All statements that are executed on the branch target are done in an\
-  asynchronous manner. This means that when the client receives the response\
-  there is no guarantee that the statement has completed on the branch\
-  target. The `sync` feature provides some synchronization guarantees that can\
+* All statements that are executed on the branch target are done in an
+  asynchronous manner. This means that when the client receives the response
+  there is no guarantee that the statement has completed on the branch
+  target. The `sync` feature provides some synchronization guarantees that can
   be used to verify successful execution on both targets.
-* Any errors on the branch target will cause the connection to it to be\
-  closed. If `target` is a service, it is up to the router to decide whether the\
-  connection is closed. For direct connections to servers, any network errors\
-  cause the connection to be closed. When the connection is closed, no new\
+* Any errors on the branch target will cause the connection to it to be
+  closed. If `target` is a service, it is up to the router to decide whether the
+  connection is closed. For direct connections to servers, any network errors
+  cause the connection to be closed. When the connection is closed, no new
   queries will be routed to the branch target.
 
-With `sync=true`, a failure of the branch target will cause the whole session\
+With `sync=true`, a failure of the branch target will cause the whole session
 to be closed.
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md) documentation for
 details about module commands.
 
 The tee filter supports the following module commands.
 
 #### `tee disable [FILTER]`
 
-This command disables a tee filter instance. A disabled tee filter will not send\
+This command disables a tee filter instance. A disabled tee filter will not send
 any queries to the target service.
 
 #### `tee enable [FILTER]`
 
-Enable a disabled tee filter. This resumes the sending of queries to the target\
+Enable a disabled tee filter. This resumes the sending of queries to the target
 service.
 
 ### Examples
 
 #### Example 1 - Replicate all inserts into the orders table
 
-Assume an order processing system that has a table called orders. You also have\
-another database server, the datamart server, that requires all inserts into\
+Assume an order processing system that has a table called orders. You also have
+another database server, the datamart server, that requires all inserts into
 orders to be replicated to it. Deletes and updates are not, however, required.
 
-Set up a service in MariaDB MaxScale, called Orders, to communicate with the\
-order processing system with the tee filter applied to it. Also set up a service\
-to talk to the datamart server, using the DataMart service. The tee filter would\
+Set up a service in MariaDB MaxScale, called Orders, to communicate with the
+order processing system with the tee filter applied to it. Also set up a service
+to talk to the datamart server, using the DataMart service. The tee filter would
 have as its service entry the DataMart service, by adding a match parameter of\
-"insert into orders" would then result in all requests being sent to the order\
-processing system, and insert statements that include the orders table being\
+"insert into orders" would then result in all requests being sent to the order
+processing system, and insert statements that include the orders table being
 additionally sent to the datamart server.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-throttle.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-throttle.md
@@ -6,13 +6,13 @@ This filter was added in MariaDB MaxScale 2.3
 
 ### Overview
 
-The throttle filter is used to limit the maximum query frequency (QPS - queries\
-per second) of a database session to a configurable value. The main use cases\
-are to prevent a rogue session (client side error) and a DoS attack from\
+The throttle filter is used to limit the maximum query frequency (QPS - queries
+per second) of a database session to a configurable value. The main use cases
+are to prevent a rogue session (client side error) and a DoS attack from
 overloading the system.
 
-The throttling is dynamic. The query frequency is not limited to an absolute\
-value. Depending on the configuration the throttle will allow some amount of\
+The throttling is dynamic. The query frequency is not limited to an absolute
+value. Depending on the configuration the throttle will allow some amount of
 high frequency queries, or especially short bursts with no frequency limitation.
 
 ### Configuration
@@ -33,27 +33,27 @@ filters = Throttle
 ```
 
 This configuration states that the query frequency will be throttled to around\
-500 qps, and that the time limit a query is allowed to stay at the maximum\
-frequency is 60 seconds. All values involving time are configured in\
-milliseconds. With the basic configuration the throttling will be nearly\
-immediate, i.e. a session will only be allowed very short bursts of high\
+500 qps, and that the time limit a query is allowed to stay at the maximum
+frequency is 60 seconds. All values involving time are configured in
+milliseconds. With the basic configuration the throttling will be nearly
+immediate, i.e. a session will only be allowed very short bursts of high
 frequency querying.
 
-When a session has been continuously throttled for `throttling_duration`\
-milliseconds, or 60 seconds in this example, MaxScale will disconnect the\
+When a session has been continuously throttled for `throttling_duration`
+milliseconds, or 60 seconds in this example, MaxScale will disconnect the
 session.
 
 #### Allowing high frequency bursts
 
-The two parameters `max_qps` and `sampling_duration` together define how a\
+The two parameters `max_qps` and `sampling_duration` together define how a
 session is throttled.
 
-Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not\
-an instantaneous measure, but one could say it has a granularity of 10 seconds,\
-we see that over the 10 seconds 10\*400 = 4000 queries are allowed before\
+Suppose max qps is 400 qps and sampling duration is 10 seconds. Since QPS is not
+an instantaneous measure, but one could say it has a granularity of 10 seconds,
+we see that over the 10 seconds 10\*400 = 4000 queries are allowed before
 throttling kicks in.
 
-With these values, a fresh session can start off with a speed of 2000 qps, and\
+With these values, a fresh session can start off with a speed of 2000 qps, and
 maintain that speed for 2 seconds before throttling starts.
 
 If the client continues to query at high speed and throttling duration is set to\
@@ -69,8 +69,8 @@ If the client continues to query at high speed and throttling duration is set to
 
 Maximum queries per second.
 
-This is the frequency to which a session will be limited over a given time\
-period. QPS is not measured as an instantaneous value but over a configurable\
+This is the frequency to which a session will be limited over a given time
+period. QPS is not measured as an instantaneous value but over a configurable
 sampling duration (see `sampling_duration`).
 
 #### `throttling_duration`
@@ -79,7 +79,7 @@ sampling duration (see `sampling_duration`).
 * Mandatory: Yes
 * Dynamic: Yes
 
-This defines how long a session is allowed to be throttled before MaxScale\
+This defines how long a session is allowed to be throttled before MaxScale
 disconnects the session.
 
 #### `sampling_duration`
@@ -89,11 +89,11 @@ disconnects the session.
 * Dynamic: Yes
 * Default: 250ms
 
-Sampling duration defines the window of time over which QPS is measured. This\
-parameter directly affects the amount of time that high frequency queries are\
+Sampling duration defines the window of time over which QPS is measured. This
+parameter directly affects the amount of time that high frequency queries are
 allowed before throttling kicks in.
 
-The lower this value is, the more strict throttling becomes. Conversely, the\
+The lower this value is, the more strict throttling becomes. Conversely, the
 longer this time is, the longer bursts of high frequency querying is allowed.
 
 #### `continuous_duration`
@@ -103,8 +103,8 @@ longer this time is, the longer bursts of high frequency querying is allowed.
 * Dynamic: Yes
 * Default: 2s
 
-This value defines what continuous throttling means. Continuous throttling\
-starts as soon as the filter throttles the frequency. Continuous throttling ends\
+This value defines what continuous throttling means. Continuous throttling
+starts as soon as the filter throttles the frequency. Continuous throttling ends
 when no throttling has been performed in the past `continuous_duration` time.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-top-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-top-filter.md
@@ -4,11 +4,11 @@
 
 ### Overview
 
-The top filter is a filter module for MariaDB MaxScale that monitors every SQL\
-statement that passes through the filter. It measures the duration of that\
-statement, the time between the statement being sent and the first result being\
-returned. The top N times are kept, along with the SQL text itself and a list\
-sorted on the execution times of the query is written to a file upon closure of\
+The top filter is a filter module for MariaDB MaxScale that monitors every SQL
+statement that passes through the filter. It measures the duration of that
+statement, the time between the statement being sent and the first result being
+returned. The top N times are kept, along with the SQL text itself and a list
+sorted on the execution times of the query is written to a file upon closure of
 the client session.
 
 ### Configuration
@@ -31,7 +31,7 @@ filters=MyLogFilter
 
 ### Settings
 
-The top filter has one mandatory parameter, `filebase`, and a number of optional\
+The top filter has one mandatory parameter, `filebase`, and a number of optional
 parameters.
 
 #### `filebase`
@@ -40,15 +40,15 @@ parameters.
 * Mandatory: Yes
 * Dynamic: Yes
 
-The basename of the output file created for each session. The session ID is\
+The basename of the output file created for each session. The session ID is
 added to the filename for each file written. This is a mandatory parameter.
 
 ```
 filebase=/tmp/SqlQueryLog
 ```
 
-The filebase may also be set as the filter, the mechanism to set the filebase\
-via the filter option is superseded by the parameter. If both are set the\
+The filebase may also be set as the filter, the mechanism to set the filebase
+via the filter option is superseded by the parameter. If both are set the
 parameter setting will be used and the filter option ignored.
 
 #### `count`
@@ -71,7 +71,7 @@ count=30
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+[Limits](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 ```
@@ -87,7 +87,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+[Limits](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 #### `options`
@@ -98,7 +98,7 @@ the queries logged by the filter.
 * Values: `ignorecase`, `case`, `extended`
 * Default: `case`
 
-[Regular expression options](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+[Regular expression options](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 for `match` and `exclude`.
 
 #### `source`
@@ -108,7 +108,7 @@ for `match` and `exclude`.
 * Dynamic: Yes
 * Default: None
 
-Defines an address that is used to match against\
+Defines an address that is used to match against
 the address from which the client connection to MariaDB MaxScale originates.\
 Only sessions that originate from this address will be logged.
 
@@ -123,9 +123,9 @@ source=127.0.0.1
 * Dynamic: Yes
 * Default: None
 
-Defines a username that is used to match against\
-the user from which the client connection to MariaDB MaxScale originates. Only\
-sessions that are connected using this username will result in results being\
+Defines a username that is used to match against
+the user from which the client connection to MariaDB MaxScale originates. Only
+sessions that are connected using this username will result in results being
 generated.
 
 ```
@@ -136,8 +136,8 @@ user=john
 
 #### Example 1 - Heavily Contended Table
 
-You have an order system and believe the updates of the PRODUCTS table is\
-causing some performance issues for the rest of your application. You would like\
+You have an order system and believe the updates of the PRODUCTS table is
+causing some performance issues for the rest of your application. You would like
 to know which of the many updates in your application is causing the issue.
 
 Add a filter with the following definition:
@@ -152,12 +152,12 @@ exclude=UPDATE.*PRODUCTS_STOCK.*WHERE
 filebase=/var/logs/top/ProductsUpdate
 ```
 
-Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table\
+Note the exclude entry, this is to prevent updates to the PRODUCTS\_STOCK table
 from being included in the report.
 
 #### Example 2 - One Application Server is Slow
 
-One of your applications servers is slower than the rest, you believe it is\
+One of your applications servers is slower than the rest, you believe it is
 related to database access but you are not sure what is taking the time.
 
 Add a filter with the following definition:
@@ -171,7 +171,7 @@ source=192.168.0.32
 filebase=/var/logs/top/SlowAppServer
 ```
 
-In order to produce a comparison with an unaffected application server you can\
+In order to produce a comparison with an unaffected application server you can
 also add a second filter as a control.
 
 ```
@@ -196,14 +196,14 @@ password=mypasswd
 filters=SlowAppServer | ControlAppServer
 ```
 
-You will then have two sets of logs files written, one which profiles the top 20\
-queries of the slow application server and another that gives you the top 20\
-queries of your control application server. These two sets of files can then be\
+You will then have two sets of logs files written, one which profiles the top 20
+queries of the slow application server and another that gives you the top 20
+queries of your control application server. These two sets of files can then be
 compared to determine what if anything is different between the two.
 
 ### Output Report
 
-The following is an example report for a number of fictitious queries executed\
+The following is an example report for a number of fictitious queries executed
 against the employees example database available for MySQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-transaction-performance-monitoring-filter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-transaction-performance-monitoring-filter.md
@@ -2,22 +2,22 @@
 
 ## Transaction Performance Monitoring Filter
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Overview
 
-The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale\
+The Transaction Performance Monitoring (TPM) filter is a filter module for MaxScale
 that monitors every SQL statement that passes through the filter.\
 The filter groups a series of SQL statements into a transaction by detecting\
-'commit' or 'rollback' statements. It logs all committed transactions with necessary\
-information, such as timestamp, client, SQL statements, latency, etc., which\
+'commit' or 'rollback' statements. It logs all committed transactions with necessary
+information, such as timestamp, client, SQL statements, latency, etc., which
 can be used later for transaction performance analysis.
 
 ### Configuration
 
-The configuration block for the TPM filter requires the minimal filter\
+The configuration block for the TPM filter requires the minimal filter
 options in it's section within the maxscale.cnf file, stored in /etc/maxscale.cnf.
 
 ```
@@ -53,9 +53,9 @@ filename=/tmp/SqlQueryLog
 
 #### Source
 
-The optional `source` parameter defines an address that is used\
-to match against the address from which the client connection\
-to MaxScale originates. Only sessions that originate from this\
+The optional `source` parameter defines an address that is used
+to match against the address from which the client connection
+to MaxScale originates. Only sessions that originate from this
 address will be logged.
 
 ```
@@ -64,9 +64,9 @@ source=127.0.0.1
 
 #### User
 
-The optional `user` parameter defines a user name that is used\
+The optional `user` parameter defines a user name that is used
 to match against the user from which the client connection to\
-MaxScale originates. Only sessions that are connected using\
+MaxScale originates. Only sessions that are connected using
 this username are logged.
 
 ```
@@ -75,7 +75,7 @@ user=john
 
 #### Delimiter
 
-The optional `delimiter` parameter defines a delimiter that is used to\
+The optional `delimiter` parameter defines a delimiter that is used to
 distinguish columns in the log. The default delimiter is **`:::`**.
 
 ```
@@ -84,7 +84,7 @@ delimiter=:::
 
 #### Query\_delimiter
 
-The optional `query_delimiter` defines a delimiter that is used to\
+The optional `query_delimiter` defines a delimiter that is used to
 distinguish different SQL statements in a transaction.\
 The default query delimiter is **`@@@`**.
 
@@ -94,9 +94,9 @@ query_delimiter=@@@
 
 #### Named\_pipe
 
-**`named_pipe`** is the path to a named pipe, which TPM filter uses to\
+**`named_pipe`** is the path to a named pipe, which TPM filter uses to
 communicate with 3rd-party applications (e.g., [DBSeer](https://dbseer.org)).\
-Logging is enabled when the router receives the character '1' and logging is\
+Logging is enabled when the router receives the character '1' and logging is
 disabled when the router receives the character '0' from this named pipe.\
 The default named pipe is **`/tmp/tpmfilter`** and logging is **disabled** by default.
 
@@ -126,7 +126,7 @@ For each transaction, the TPM filter prints its log in the following format:
 
 #### Example 1 - Log Transactions for Performance Analysis
 
-You want to log every transaction with its SQL statements and latency\
+You want to log every transaction with its SQL statements and latency
 for future transaction performance analysis.
 
 Add a filter with the following definition:
@@ -149,7 +149,7 @@ password=mypasswd
 filters=PerformanceLogger
 ```
 
-After the filter reads the character '1' from its named pipe, the following\
+After the filter reads the character '1' from its named pipe, the following
 is an example log that is generated from the above TPM filter with the above configuration:
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-workload-capture-and-replay.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-workload-capture-and-replay.md
@@ -14,8 +14,8 @@ _In essence, the WCAR module not only preserves detailed and valuable traffic da
 
 The _WCAR_ filter (module `wcar`) captures client traffic and stores it in a replayable format.
 
-WCAR is designed to capture traffic on a production MaxScale instance. The captured data can\
-then be used as a reproducible way of generating client traffic without having to write\
+WCAR is designed to capture traffic on a production MaxScale instance. The captured data can
+then be used as a reproducible way of generating client traffic without having to write
 application-specific traffic generators.
 
 The captured workloads can be used:_to verify that upgrades of MariaDB behave as expected._ to repeatedly measure effects of configuration changes, which is useful for database tuning.
@@ -24,10 +24,10 @@ The captured workloads can be used:_to verify that upgrades of MariaDB behave as
 
 ### Prerequisites
 
-* Both the capture MaxScale and replay MaxScale servers must use the same\
-  linux distribution and CPU architecture. For example, if the capture was taken\
+* Both the capture MaxScale and replay MaxScale servers must use the same
+  linux distribution and CPU architecture. For example, if the capture was taken
   on an x86\_64 RHEL 8 instance, the replay should also happen on an x86\_64 RHEL\
-  8 instance. Captured workloads are however usually compatible across different\
+  8 instance. Captured workloads are however usually compatible across different
   linux distributions that use the same CPU architecture.
 * The capture MariaDB instance must have binlogging enabled (`log-bin=1`)
 
@@ -35,10 +35,10 @@ The captured workloads can be used:_to verify that upgrades of MariaDB behave as
 
 #### Quick start
 
-Workload capture can be used without definitions in static configuration files\
+Workload capture can be used without definitions in static configuration files
 and without a MaxScale restart.
 
-If you have an existing routing service named, e.g., `RWS-Router` in your configuration\
+If you have an existing routing service named, e.g., `RWS-Router` in your configuration
 you can attach a capture filter to it dynamically:
 
 ```
@@ -52,7 +52,7 @@ You can then start a capture with
 maxctrl call command wcar start CAPTURE_FLTR <options>
 ```
 
-If limiting options were given the capture will stop automatically when one\
+If limiting options were given the capture will stop automatically when one
 of the limits is triggered. You can also stop the capture at any time with:
 
 ```
@@ -70,9 +70,9 @@ maxctrl destroy filter CAPTURE_FLTR
 
 #### File based configuration
 
-Define a capture filter by adding the following\
-configuration object and add it to each service whose traffic is to be\
-captured. The traffic from all services that use the filter will be combined so\
+Define a capture filter by adding the following
+configuration object and add it to each service whose traffic is to be
+captured. The traffic from all services that use the filter will be combined so
 only use the filter in services that point to the same database cluster.
 
 ```
@@ -86,7 +86,7 @@ start_capture=true  # Start capturing immediately after starting MaxScale
 
 #### Example configuration file
 
-Here is an example configuration for capturing from a single MariaDB server, where capture\
+Here is an example configuration for capturing from a single MariaDB server, where capture
 starts when MaxScale starts and stops when MaxScale is stopped (`start_capture=true`).\
 MaxScale listens on port 4006 and connects to MariaDB on port 3306.
 
@@ -129,22 +129,22 @@ port=4006
 
 This section explains how capture is done with configuration value `start_capture=true`.
 
-Two things are needed to replay a workload: the client traffic that's captured\
-by MaxScale and a backup of the database that is used to initialize the replay\
-server. The backup should be taken from the point in time where the capture starts\
-and the simplest way to achieve this is to take a logical backup by doing the\
+Two things are needed to replay a workload: the client traffic that's captured
+by MaxScale and a backup of the database that is used to initialize the replay
+server. The backup should be taken from the point in time where the capture starts
+and the simplest way to achieve this is to take a logical backup by doing the
 following.
 
 * Stop MaxScale
 * Take a backup of the database with `mariadb-dump --all-databases --system=all`
 * Start MaxScale
 
-Once MaxScale has been started, the captured traffic will be written to files in`/var/lib/maxscale/wcar/<name>` where `<name>` is the name of the filter (`CAPTURE_FLTR`\
+Once MaxScale has been started, the captured traffic will be written to files in`/var/lib/maxscale/wcar/<name>` where `<name>` is the name of the filter (`CAPTURE_FLTR`
 in the examples).
 
-Each capture will generate a number of files named `NAME_YYYY-MM-DD_HHMMSS.SUFFIX`\
-where `NAME` is the capture name (defaults to `capture`), `YYYY-MM-DD` is the\
-date and `HHMMSS` is the time and the `SUFFIX` is one of `.cx`, `.ex` or`.tx`. For example, a capture started on the 18th of April 2024 at 10:26:11\
+Each capture will generate a number of files named `NAME_YYYY-MM-DD_HHMMSS.SUFFIX`
+where `NAME` is the capture name (defaults to `capture`), `YYYY-MM-DD` is the
+date and `HHMMSS` is the time and the `SUFFIX` is one of `.cx`, `.ex` or`.tx`. For example, a capture started on the 18th of April 2024 at 10:26:11
 would generate a file named `capture_2024-04-18_102611.cx`.
 
 #### Stopping the Capture
@@ -157,10 +157,10 @@ maxctrl call command wcar stop CAPTURE_FLTR
 
 where "CAPTURE\_FLTR" is the name given to the filter as in the example configuration above.
 
-To disable capturing altogether, remove the capture filter from the configuration and remove\
+To disable capturing altogether, remove the capture filter from the configuration and remove
 it from all services that it was added to. Restart MaxScale.
 
-If the replay is to take place on another server, the results can be collected\
+If the replay is to take place on another server, the results can be collected
 easily from `/var/lib/maxscale/wcar/` with the following command.
 
 ```
@@ -179,15 +179,15 @@ Each of the commands can be called with the following syntax.
 maxctrl call command wcar <command> <filter> [options]
 ```
 
-The `<filter>` is the name of the filter instance. In the example configuration,\
-the value is `CAPTURE_FLTR`. The `[options]` is a list of optional arguments that\
+The `<filter>` is the name of the filter instance. In the example configuration,
+the value is `CAPTURE_FLTR`. The `[options]` is a list of optional arguments that
 the command might expect.
 
 #### `start <filter> [options]`
 
 Starts a new capture. Issuing a start command will stop any ongoing capture.
 
-The start command supports optional key-value pairs. If the values are also defined in\
+The start command supports optional key-value pairs. If the values are also defined in
 the configuration file the command line options have priority. The supported keys are:
 
 * **prefix** The prefix added to capture files. The default value is `capture`.
@@ -206,7 +206,7 @@ If both duration and size are specified, the one that triggers first, stops the 
 maxctrl call command wcar start CAPTURE_FLTR prefix=Scenario1 size=10G
 ```
 
-Running the same command again, but without size=10G, the `capture_size` used would be that defined\
+Running the same command again, but without size=10G, the `capture_size` used would be that defined
 in the configuration file or no limit if there was no such definition.
 
 #### `stop <filter>`
@@ -221,36 +221,36 @@ maxctrl call command wcar stop CAPTURE_FLTR
 
 #### Installation
 
-Install the required packages on the MaxScale server where the replay is to be\
-done. An additional dependency that must be manually installed is Python,\
-version 3.7 or newer. On most linux distributions a new enough version is\
+Install the required packages on the MaxScale server where the replay is to be
+done. An additional dependency that must be manually installed is Python,
+version 3.7 or newer. On most linux distributions a new enough version is
 available as the default Python interpreter.
 
-The replay consists of restoring the database to the point in time where the\
-capture was started. Start by restoring the replay database to this state. Once\
-the database has been restored from the backup, copy the capture files over to\
+The replay consists of restoring the database to the point in time where the
+capture was started. Start by restoring the replay database to this state. Once
+the database has been restored from the backup, copy the capture files over to
 the replay MaxScale server.
 
 #### Preparing the Replay MariaDB Database
 
 **Full Restore**
 
-Start by restoring the database from the backup to put it at the point in time\
-where the capture was started. The GTID position of the first commit within the\
+Start by restoring the database from the backup to put it at the point in time
+where the capture was started. The GTID position of the first commit within the
 capture can be seen in the output of the summary command:
 
 ```
 maxplayer summary /path/to/capture.cx
 ```
 
-If the captured data has not been transformed to replay format yet, the\
+If the captured data has not been transformed to replay format yet, the
 command will perform the transformation before displaying the summary.
 
-Run `maxplayer --help` to see the command line options. The help output\
+Run `maxplayer --help` to see the command line options. The help output
 is also shown at the end of this file.
 
-The replay also requires a user account using which the captured traffic is\
-replayed. This user must have access to all the tables in question. In practice\
+The replay also requires a user account using which the captured traffic is
+replayed. This user must have access to all the tables in question. In practice
 the simplest way to do this for testing is to create the user as follows:
 
 ```
@@ -260,24 +260,24 @@ GRANT ALL ON *.* TO 'maxreplay'@'%';
 
 **Restore for read-only Replay**
 
-For captures that are intended for read-only Replay, it may not be as important\
-that the servers to be tested against are in the exact GTID the capture server was when\
-capture started. In fact, it may be advantageous that the servers are at the state after\
+For captures that are intended for read-only Replay, it may not be as important
+that the servers to be tested against are in the exact GTID the capture server was when
+capture started. In fact, it may be advantageous that the servers are at the state after
 the capture finished.
 
-On the other hand, Replay also supports write-only. Following the Full Restore\
-procedure above and then running a write-only Replay prepares the replay server(s)\
-for easily running read-only multiple times. This way of running read-only may, for\
+On the other hand, Replay also supports write-only. Following the Full Restore
+procedure above and then running a write-only Replay prepares the replay server(s)
+for easily running read-only multiple times. This way of running read-only may, for
 example, be used when fine tuning server settings.
 
 #### Replaying the Capture
 
 When replay is first done, the capture files will be transformed in-place.\
-Transform can be run separately as well. Depending on the size and structure\
+Transform can be run separately as well. Depending on the size and structure
 of the capture file, Transform can use up to twice the space of the capture.ex file.\
 The files with extension `.ex` contain most of the captured data (events).
 
-Start by copying the replay file tarball created earlier (`captures.tar.gz`) to\
+Start by copying the replay file tarball created earlier (`captures.tar.gz`) to
 the replay MaxScale server and copy it to a directory of your choice (here called`/path/to/capture-dir`).\
 Then extract the files.
 
@@ -292,7 +292,7 @@ After this, replay the workload against the baseline MariaDB setup:
 maxplayer replay --user maxreplay --password replay-pw --host <host:port> --output baseline-result.csv /path/to/capture.cx
 ```
 
-Once the baseline replay results have been generated, run the replay again but\
+Once the baseline replay results have been generated, run the replay again but
 this time against the new MariaDB setup to which the baseline is compared to:
 
 ```
@@ -303,15 +303,15 @@ After both replays have been completed, the results can be post-processed and vi
 
 ### Visualizing
 
-The results of the captured replay must first be post-processed into summaries that\
-the visualization will then use. First, the `canonicals.csv` file must be\
+The results of the captured replay must first be post-processed into summaries that
+the visualization will then use. First, the `canonicals.csv` file must be
 generated that is needed in the post-processing:
 
 ```
 maxplayer canonicals /path/to/capture.cx > canonicals.csv
 ```
 
-After that, the baseline and comparison replay results can be post-processed\
+After that, the baseline and comparison replay results can be post-processed
 into summaries using the `maxpostprocess` command:
 
 ```
@@ -319,9 +319,9 @@ maxpostprocess canonicals.csv baseline-result.csv -o baseline-summary.json
 maxpostprocess canonicals.csv comparison-result.csv -o comparison-summary.json
 ```
 
-The visualization itself is done with the `maxvisualize` program. The\
-visualization will open up a browser window to show the visualization. If no\
-browser opens up, the visualization URL is also printed into the command line\
+The visualization itself is done with the `maxvisualize` program. The
+visualization will open up a browser window to show the visualization. If no
+browser opens up, the visualization URL is also printed into the command line
 which by default should be `http://localhost:8866/`.
 
 ```
@@ -337,7 +337,7 @@ maxvisualize baseline-summary.json comparison-summary.json
 * Mandatory: No
 * Dynamic: No
 
-Directory under which capture directories are stored. Each\
+Directory under which capture directories are stored. Each
 capture directory has the name of the filter.\
 In the examples above the name "CAPTURE\_FLTR" was used.
 
@@ -471,8 +471,8 @@ input file:       capture_2024-09-06_090002.cx
 * COM\_STMT\_EXECUTE that uses a cursor is replayed without a cursor ([MXS-5059](https://jira.mariadb.org/browse/MXS-5059))
 * For MyISAM and Aria tables, this will cause the table level lock to be held for a shorter time.
 * Execution of a COM\_STMT\_SEND\_LONG\_DATA will not work ([MXS-5060](https://jira.mariadb.org/browse/MXS-5060))
-* The capture files are not necessarily compatible with different linux distributions and CPU\
-  architectures than the original capture server has. Different combinations will require further\
+* The capture files are not necessarily compatible with different linux distributions and CPU
+  architectures than the original capture server has. Different combinations will require further
   testing, and once done, this document will be updated.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-building-mariadb-maxscale-from-source-code.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-building-mariadb-maxscale-from-source-code.md
@@ -2,7 +2,7 @@
 
 ## Building MariaDB MaxScale from Source Code
 
-MariaDB MaxScale can be built on any system that meets the requirements. The main\
+MariaDB MaxScale can be built on any system that meets the requirements. The main
 requirements are as follows:
 
 * CMake version 3.16 or later (Packaging requires CMake 3.25.1 or later)
@@ -25,7 +25,7 @@ requirements are as follows:
 * pcre2
 * zstd
 
-This is the minimum set of requirements that must be met to build the MaxScale\
+This is the minimum set of requirements that must be met to build the MaxScale
 core package. Some modules in MaxScale require optional extra dependencies.
 
 * libuuid (binlogrouter)
@@ -36,9 +36,9 @@ core package. Some modules in MaxScale require optional extra dependencies.
 * memcached (storage\_memcached for the cache filter)
 * hiredis (storage\_redis for the cache filter)
 
-Some of these dependencies are not available on all operating systems and are\
-downloaded automatically during the build step. To skip the building of modules\
-that need automatic downloading of the dependencies, use `-DBUNDLE=N` when\
+Some of these dependencies are not available on all operating systems and are
+downloaded automatically during the build step. To skip the building of modules
+that need automatic downloading of the dependencies, use `-DBUNDLE=N` when
 configuring CMake.
 
 ### Quickstart
@@ -64,7 +64,7 @@ For a definitive list of packages, consult the [install\_build\_deps.sh](https:/
 
 The tests and other parts of the build can be controlled via CMake arguments.
 
-Here is a small table with the names of the most common parameters and what\
+Here is a small table with the names of the most common parameters and what
 they control. These should all be given as parameters to the -D switch in _NAME_=_VALUE_ format (e.g. `-DBUILD_TESTS=Y`).
 
 | Argument Name          | Explanation                                                                                                                                                                |
@@ -76,25 +76,25 @@ they control. These should all be given as parameters to the -D switch in _NAME_
 | TARGET\_COMPONENT      | Which component to install, default is the 'core' package. Other targets are 'experimental', which installs experimental packages and 'all' which installs all components. |
 | TARBALL                | Build tar.gz packages, requires PACKAGE=Y                                                                                                                                  |
 
-**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a\
+**Note**: You can look into [defaults.cmake](https://mariadb.com/cmake/defaults.cmake) for a
 list of the CMake variables.
 
 ### Running unit tests
 
-To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,\
+To run the MaxScale unit test suite, configure the build with `-DBUILD_TESTS=Y`,
 compile and then run the `make test` command.
 
 ## Building MariaDB MaxScale packages
 
-If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation\
-and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your\
+If you wish to build packages, just add `-DPACKAGE=Y` to the CMake invocation
+and build the package with `make package` instead of installing MaxScale with`make install`. This process will create a RPM/DEB package depending on your
 system.
 
-To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create\
+To build a tarball, add `-DTARBALL=Y` to the cmake invocation. This will create
 a _maxscale-x.y.z.tar.gz_ file where _x.y.z_ is the version number.
 
-Some Debian and Ubuntu systems suffer from a bug where `make package` fails\
-with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to\
+Some Debian and Ubuntu systems suffer from a bug where `make package` fails
+with errors from dpkg-shlibdeps. This can be fixed by running `make` before`make package` and adding the path to the libmaxscale-common.so library to
 the LD\_LIBRARY\_PATH environment variable.
 
 ```
@@ -104,14 +104,14 @@ LD_LIBRARY_PATH=$PWD/server/core/ make package
 
 ### Installing optional components
 
-The MaxScale build system is split into multiple components. The main component\
-is the `core` MaxScale package which contains MaxScale and all the modules. This\
-is the default component that is build, installed and packaged. There is also\
-the `experimental` component that contains all experimental modules which are\
-not considered as part of the core MaxScale package and are either alpha or beta\
+The MaxScale build system is split into multiple components. The main component
+is the `core` MaxScale package which contains MaxScale and all the modules. This
+is the default component that is build, installed and packaged. There is also
+the `experimental` component that contains all experimental modules which are
+not considered as part of the core MaxScale package and are either alpha or beta
 quality modules.
 
-To build the experimental modules along with the MaxScale core components,\
+To build the experimental modules along with the MaxScale core components,
 invoke CMake with `-DTARGET_COMPONENT=core,experimental`.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-installing-mariadb-maxscale-using-a-tarball.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-installing-mariadb-maxscale-using-a-tarball.md
@@ -2,7 +2,7 @@
 
 ## Installing MariaDB MaxScale using a tarball
 
-MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`\
+MariaDB MaxScale is also made available as a tarball, which is named like`maxscale-x.y.z.OS.tar.gz` where `x.y.z` is the same as the corresponding version and `OS`
 identifies the operating system, e.g. `maxscale-2.5.6.centos.7.tar.gz`.
 
 In order to use the tarball, the following libraries are required:
@@ -19,12 +19,12 @@ The `maxctrl` command line client requires at least Node.js 10. We recommend the
 {% endhint %}
 
 The tarball has been built with the assumption that it will be installed in `/usr/local`.\
-However, it is possible to install it in any directory, but in that case MariaDB MaxScale\
+However, it is possible to install it in any directory, but in that case MariaDB MaxScale
 must be invoked with a flag.
 
 ### Installing as root in `/usr/local`
 
-If you have root access to the system you probably want to install MariaDB MaxScale under\
+If you have root access to the system you probably want to install MariaDB MaxScale under
 the user and group `maxscale`.
 
 The required steps are as follows:
@@ -39,14 +39,14 @@ $ cd maxscale
 $ sudo chown -R maxscale var
 ```
 
-Creating the symbolic link is necessary, since MariaDB MaxScale has been built\
+Creating the symbolic link is necessary, since MariaDB MaxScale has been built
 with the assumption that the plugin directory is `/usr/local/maxscale/lib/maxscale`.
 
 The symbolic link also makes it easy to switch between different versions of\
 MariaDB MaxScale that have been installed side by side in `/usr/local`;\
 just make the symbolic link point to another installation.
 
-In addition, the first time you install MariaDB MaxScale from a tarball\
+In addition, the first time you install MariaDB MaxScale from a tarball
 you need to create the following directories:
 
 ```bash
@@ -75,14 +75,14 @@ When the configuration file has been created, MariaDB MaxScale can be started.
 $ sudo bin/maxscale --user=maxscale -d
 ```
 
-The `-d` flag causes maxscale _not_ to turn itself into a daemon,\
+The `-d` flag causes maxscale _not_ to turn itself into a daemon,
 which is advisable the first time MariaDB MaxScale is started, as it makes it easier to spot problems.
 
 If you want to place the configuration file somewhere else but in `/etc`\
 you can invoke MariaDB MaxScale with the `--config` flag,\
 for instance, `--config=/usr/local/maxscale/etc/maxscale.cnf`.
 
-Note also that if you want to keep _everything_ under `/usr/local/maxscale`\
+Note also that if you want to keep _everything_ under `/usr/local/maxscale`
 you can invoke MariaDB MaxScale using the flag `--basedir`.
 
 ```bash
@@ -110,12 +110,12 @@ $ cd maxscale-x.y.z.OS
 $ bin/maxscale -d --basedir=.
 ```
 
-With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`\
-directories are found. Unless it is specified, MariaDB MaxScale assumes\
-the `lib` directory is found in `/usr/local/maxscale`,\
+With the flag `--basedir`, MariaDB MaxScale is told where the `lib`, `etc` and `var`
+directories are found. Unless it is specified, MariaDB MaxScale assumes
+the `lib` directory is found in `/usr/local/maxscale`,
 and the `var` and `etc` directories in `/`.
 
-It is also possible to specify the directories and the location of\
+It is also possible to specify the directories and the location of
 the configuration file individually. Invoke MaxScale like
 
 ```bash

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md
@@ -4,9 +4,9 @@
 
 ## Introduction
 
-This document describes how to configure MariaDB MaxScale and presents some\
-possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,\
-and consists of an event processing core with various support functions and\
+This document describes how to configure MariaDB MaxScale and presents some
+possible usage scenarios. MariaDB MaxScale is designed with flexibility in mind,
+and consists of an event processing core with various support functions and
 plugin modules that tailor the behavior of the program.
 
 ## Concepts
@@ -26,9 +26,9 @@ plugin modules that tailor the behavior of the program.
 
 #### Server
 
-A server represents an individual database server to which a client can be\
-connected via MariaDB MaxScale. The status of a server varies during the lifetime\
-of the server and typically the status is updated by some monitor. However, it\
+A server represents an individual database server to which a client can be
+connected via MariaDB MaxScale. The status of a server varies during the lifetime
+of the server and typically the status is updated by some monitor. However, it
 is also possible to update the status of a server manually.
 
 | Status                   | Description                                                                                                                                                                                                                                                                                                                |
@@ -47,27 +47,27 @@ For more information on how to manually set these states via MaxCtrl, read the [
 
 #### Monitor
 
-A monitor module is capable of monitoring the state of a particular kind\
+A monitor module is capable of monitoring the state of a particular kind
 of cluster and making that state available to the routers of MaxScale.
 
-Examples of monitor modules are `mariadbmon` that is capable of monitoring\
-a regular primary-replica cluster and in addition of performing both _switchover_\
-and _failover_, `galeramon` that is capable of monitoring a Galera cluster,\
+Examples of monitor modules are `mariadbmon` that is capable of monitoring
+a regular primary-replica cluster and in addition of performing both _switchover_
+and _failover_, `galeramon` that is capable of monitoring a Galera cluster,
 and `csmon` that is capable of monitoring a Columnstore cluster.
 
-Monitor modules have sections of their own in the MaxScale configuration\
+Monitor modules have sections of their own in the MaxScale configuration
 file.
 
 #### Filter
 
-A filter module resides in front of routers in the request processing chain\
-of MaxScale. That is, a filter will see a request before it reaches the router\
-and before a response is sent back to the client. This allows filters to\
+A filter module resides in front of routers in the request processing chain
+of MaxScale. That is, a filter will see a request before it reaches the router
+and before a response is sent back to the client. This allows filters to
 reject, handle, alter or log information about a request.
 
 Examples of filters `cache` that provides query caching according to rules,`regexfilter` that can rewrite requests according to regular expressions, and`qlafilter` that logs information about requests.
 
-Filters have sections of their own in the MaxScale configuration file that are\
+Filters have sections of their own in the MaxScale configuration file that are
 referred to from _services_.
 
 Limitations:
@@ -77,21 +77,21 @@ Limitations:
 
 #### Router
 
-A router module is capable of routing requests to backend servers according to\
-the characteristics of a request and/or the algorithm the router\
+A router module is capable of routing requests to backend servers according to
+the characteristics of a request and/or the algorithm the router
 implements. Examples of routers are `readconnroute` that provides _connection routing_, that is, the server is chosen according to specified rules when the
-session is created and all requests are subsequently routed to that server,\
-and `readwritesplit` that provides _statement routing_, that is, each\
+session is created and all requests are subsequently routed to that server,
+and `readwritesplit` that provides _statement routing_, that is, each
 individual request is routed to the most appropriate server.
 
-Routers do not have sections of their own in the MaxScale configuration file,\
+Routers do not have sections of their own in the MaxScale configuration file,
 but are referred to from _services_.
 
 #### Service
 
-A service abstracts a set of databases and makes them appear as a single one\
-to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular\
-way. If the service uses filters, then all requests will be pre-processed in\
+A service abstracts a set of databases and makes them appear as a single one
+to the client. Depending on what router (e.g. `readconnroute` or`readwritesplit`) the service uses, the servers are used in some particular
+way. If the service uses filters, then all requests will be pre-processed in
 some way before they reach the router.
 
 Services have sections of their own in the MaxScale configuration file.
@@ -103,16 +103,16 @@ Limitations:
 
 #### Listener
 
-A listener defines a port MaxScale listens on. Connection requests arriving on\
-that port will be forwarded to the service the listener is associated with. A\
-listener may be associated with a single service, but several listeners may be\
+A listener defines a port MaxScale listens on. Connection requests arriving on
+that port will be forwarded to the service the listener is associated with. A
+listener may be associated with a single service, but several listeners may be
 associated with the same service.
 
 Listeners have sections of their own in the MaxScale configuration file.
 
 #### Include
 
-An [include section](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#include-1) defines common parameters used in other\
+An [include section](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#include-1) defines common parameters used in other
 configuration sections.
 
 ## Administration
@@ -122,33 +122,33 @@ The administration of MaxScale can be divided in two parts:
 * Writing the MaxScale configuration file, which is described in the following [section](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#configuration).
 * Performing runtime modifications using [MaxCtrl](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-maxctrl.md)
 
-For detailed information about _MaxCtrl_ please refer to the specific\
+For detailed information about _MaxCtrl_ please refer to the specific
 documentation referred to above. In the following it will only be explained how\
 MaxCtrl relate to each other, as far as user credentials go.
 
-**Note**: By default all runtime configuration changes are saved on disk and\
-loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details\
+**Note**: By default all runtime configuration changes are saved on disk and
+loaded on startup. Refer to the [Dynamic Configuration](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more details
 on how it works and how to disable it.
 
 MaxCtrl can connect using TCP/IP sockets. When connecting with MaxCtrl using\
-TCP/IP sockets, the user and password must be provided and are checked against a\
+TCP/IP sockets, the user and password must be provided and are checked against a
 separate user credentials database. By default, that database contains the user`admin` whose password is `mariadb`.
 
-Note that if MaxCtrl is invoked without explicitly providing a user and password\
-then it will by default use `admin` and `mariadb`. That means that when the\
+Note that if MaxCtrl is invoked without explicitly providing a user and password
+then it will by default use `admin` and `mariadb`. That means that when the
 default user is removed, the credentials must always be provided.
 
 ### Administration audit file
 
-The REST API calls to MaxScale can be logged\
+The REST API calls to MaxScale can be logged
 by enabling [admin\_audit](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#admin_audit).
 
-For more detail see the admin audit configuration values `admin_audit`,`admin_audit_file` and `admin_audit_exclude_methods` below\
+For more detail see the admin audit configuration values `admin_audit`,`admin_audit_file` and `admin_audit_exclude_methods` below
 and [Administration Tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-administration-tutorial.md).
 
 ### Static Configuration Parameters
 
-The following list of global configuration parameters can **NOT** be changed at\
+The following list of global configuration parameters can **NOT** be changed at
 runtime and can only be defined in a configuration file:
 
 * `admin_auth`
@@ -191,35 +191,35 @@ runtime and can only be defined in a configuration file:
 * `substitute_variables`
 * `threads_max`
 
-All other parameters that relate to objects can be altered at runtime or can be\
+All other parameters that relate to objects can be altered at runtime or can be
 changed by destroying and recreating the object in question.
 
 ## Configuration
 
-MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If\
-the command line argument `--configdir=<path>` is given, `maxscale.cnf` is\
-searched for in _\<path>_ instead. If the argument `--config=<file>` is given,\
+MaxScale by default reads configuration from the file `/etc/maxscale.cnf`. If
+the command line argument `--configdir=<path>` is given, `maxscale.cnf` is
+searched for in _\<path>_ instead. If the argument `--config=<file>` is given,
 configuration is read from the file _\<file>_.
 
-MaxScale also looks for a directory with the same name as the configuration\
-file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale\
+MaxScale also looks for a directory with the same name as the configuration
+file, followed by ".d" (for example `/etc/maxscale.cnf.d`). If found, MaxScale
 recursively reads all files with the ".cnf" suffix in the directory hierarchy.\
 Other files are ignored.
 
-After loading normal configuration files, MaxScale reads runtime-generated\
+After loading normal configuration files, MaxScale reads runtime-generated
 configuration files, if any, from the [persisted configuration files directory](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#persistdir).
 
 Different configuration sections can be arranged with little restrictions.\
-Global path settings such as `logdir`, `piddir` and `datadir` are only read from\
-the main configuration file. Other global settings are also best left in the\
-main file to ensure they are read before other configuration sections are\
+Global path settings such as `logdir`, `piddir` and `datadir` are only read from
+the main configuration file. Other global settings are also best left in the
+main file to ensure they are read before other configuration sections are
 parsed.
 
 The configuration file format used is [INI](https://en.wikipedia.org/wiki/INI_file), similar to the\
-MariaDB Server. The files contain sections and each section can contain multiple\
+MariaDB Server. The files contain sections and each section can contain multiple
 key-value pairs.
 
-Comments are defined by prefixing a row with a hash (#). Trailing comments are\
+Comments are defined by prefixing a row with a hash (#). Trailing comments are
 not supported.
 
 ```
@@ -227,8 +227,8 @@ not supported.
 some_parameter=123
 ```
 
-A parameter can be defined on multiple lines as shown below. A value spread over\
-multiple lines is simply concatenated. The additional lines of the value\
+A parameter can be defined on multiple lines as shown below. A value spread over
+multiple lines is simply concatenated. The additional lines of the value
 definition need to have at least one whitespace character in the beginning.
 
 ```
@@ -244,24 +244,24 @@ servers=server1,
 
 Section names may not contain whitespace and must not start with the characters`@@`.
 
-As the object names are used to form URLs in the MaxScale REST API, they must be\
+As the object names are used to form URLs in the MaxScale REST API, they must be
 safe for use in URLs. This means that only alphanumeric characters (i.e. `a-zA-Z` and `0-9`) and the special characters `_.~-` can be used.
 
 ### Dynamic Configuration
 
 By default all changes done at runtime via the MaxScale GUI, MaxCtrl or the REST\
-API will be saved on disk, inside the [persistdir](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#persistdir) directory. The\
-changes done at runtime will override the configuration found in the static\
+API will be saved on disk, inside the [persistdir](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#persistdir) directory. The
+changes done at runtime will override the configuration found in the static
 configuration files for that particular object.
 
-This means that if an object that is found in `/etc/maxscale.cnf` is modified at\
-runtime, all future changes to it must also be done at runtime. Any\
-modifications done to `/etc/maxscale.cnf` after a runtime change has been made\
+This means that if an object that is found in `/etc/maxscale.cnf` is modified at
+runtime, all future changes to it must also be done at runtime. Any
+modifications done to `/etc/maxscale.cnf` after a runtime change has been made
 are ignored for that object.
 
-To prevent the saving of runtime changes and to make all runtime changes\
-volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`\
-section. This will make MaxScale behave like the MariaDB server does: any\
+To prevent the saving of runtime changes and to make all runtime changes
+volatile, add [persist\_runtime\_changes=false](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#persist_runtime_changes) and [load\_persisted\_configs=false](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#load_persisted_configs) under the `[maxscale]`
+section. This will make MaxScale behave like the MariaDB server does: any
 changes done with `SET GLOBAL` statements are lost if the process is restarted.
 
 ### Special Parameter Types
@@ -269,16 +269,16 @@ changes done with `SET GLOBAL` statements are lost if the process is restarted.
 #### Booleans
 
 Boolean type parameters interpret the values `true`, `yes`, `on` and `1` as\_true\_ values and `false`, `no`, `off` and `0` as _false_ values. Starting with\
-MaxScale 23.02, the REST API also accepts the same boolean values for boolean\
+MaxScale 23.02, the REST API also accepts the same boolean values for boolean
 type parameters.
 
 #### Sizes
 
-Where _specifically noted_, a number denoting a size can be suffixed by a subset\
-of the IEC binary prefixes or the SI prefixes. In the former case the number\
-will be interpreted as a certain multiple of 1024 and in the latter case as a\
-certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`\
-and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,\
+Where _specifically noted_, a number denoting a size can be suffixed by a subset
+of the IEC binary prefixes or the SI prefixes. In the former case the number
+will be interpreted as a certain multiple of 1024 and in the latter case as a
+certain multiple of 1000. The supported IEC binary suffixes are `Ki`, `Mi`, `Gi`
+and `Ti` and the supported SI suffixes are `k`, `M`, `G` and `T`. In both cases,
 the matching is case-insensitive.
 
 For instance, the following entries
@@ -303,8 +303,8 @@ max_size=1T
 
 #### Durations
 
-A number denoting a duration can be suffixed by one of the case-insensitive\
-suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,\
+A number denoting a duration can be suffixed by one of the case-insensitive
+suffixes `h`, `m` or `min`, `s` and `ms`, for specifying durations in hours,
 minutes, seconds and milliseconds, respectively.
 
 For instance, the following entries
@@ -319,8 +319,8 @@ soft_ttl=3600000ms
 
 are equivalent.
 
-Note that if an explicit unit is not specified, then it is specific to the\
-configuration parameter whether the duration is interpreted as seconds or\
+Note that if an explicit unit is not specified, then it is specific to the
+configuration parameter whether the duration is interpreted as seconds or
 milliseconds.
 
 _Not_ providing an explicit unit has been deprecated in MaxScale 2.4.
@@ -337,71 +337,71 @@ some_param=42%
 
 #### Regular Expressions
 
-Many modules have settings which accept a regular expression. In most cases, these\
+Many modules have settings which accept a regular expression. In most cases, these
 settings are named either _match_ or _exclude_, and are used to filter users or queries.\
-MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching\
+MaxScale uses the [PCRE2-library](https://www.pcre.org/current/doc/html/) for matching
 regular expressions.
 
-When writing a regular expression (regex) type parameter to a MaxScale configuration file,\
-the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This\
-clarifies where the pattern begins and ends, even if it includes whitespace. Without\
-slashes the configuration loader trims the pattern from the ends. The slashes are removed\
-before compiling the pattern. For backwards compatibility, the slashes are not yet\
-mandatory. Omitting them is, however, deprecated and will be rejected in a future release\
-of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_\
-accept parameters in this type of regular expression form. Some other modules may not\
+When writing a regular expression (regex) type parameter to a MaxScale configuration file,
+the pattern string should be enclosed in slashes e.g. `^select` -> `match=/^select/`. This
+clarifies where the pattern begins and ends, even if it includes whitespace. Without
+slashes the configuration loader trims the pattern from the ends. The slashes are removed
+before compiling the pattern. For backwards compatibility, the slashes are not yet
+mandatory. Omitting them is, however, deprecated and will be rejected in a future release
+of MaxScale. Currently, _binlogfilter_, _ccrfilter_, _qlafilter_, _tee_ and _avrorouter_
+accept parameters in this type of regular expression form. Some other modules may not
 handle the slashes yet correctly.
 
-PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses\
-regular expressions simply, only checking whether the pattern and subject match at some\
-point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to\
-accept any query with the text "SELECT" somewhere within. To force the pattern to only\
+PCRE2 supports a complicated regular expression [syntax](https://www.pcre.org/current/doc/html/pcre2syntax.html). MaxScale typically uses
+regular expressions simply, only checking whether the pattern and subject match at some
+point. For example, using the QLAFilter and setting `match=/SELECT/` causes the filter to
+accept any query with the text "SELECT" somewhere within. To force the pattern to only
 match at the beginning of the query, set `match=/^SELECT/`. To only match the end, set`match=/SELECT$/`.
 
-Modules which accept regular expression parameters also often accept options which affect\
-how the patterns are compiled. Typically, this setting is called _options_ and accepts\
+Modules which accept regular expression parameters also often accept options which affect
+how the patterns are compiled. Typically, this setting is called _options_ and accepts
 values such as `ignorecase`, `case` and `extended`.
 
-* `ignorecase`: Causes the regular expression matcher to ignore letter case, and\
+* `ignorecase`: Causes the regular expression matcher to ignore letter case, and
   is often on by default. When enabled, `/SELECT/` would match both `SELECT` and`select`.
-* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this\
+* `extended`: Ignores whitespace and `#` comments in the pattern. Note that this
   is not the same as the extended regular expression syntax that for example`grep -E` uses.
-* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not\
+* `case`: Turns on case-sensitive matching. This means that `/SELECT/` will not
   match `select`.
 
-These settings can also be defined in the pattern itself, so they can be\
-used even in modules without pattern compilation settings. The pattern\
-settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)\
+These settings can also be defined in the pattern itself, so they can be
+used even in modules without pattern compilation settings. The pattern
+settings are `(?i)` for `ignorecase` and `(?x)` for `extended`. See the [PCRE2 syntax documentation](https://www.pcre.org/current/doc/html/pcre2syntax.html#SEC16)
 for more information.
 
 **Standard regular expression settings for filters**
 
-Many filters use the settings _match_, _exclude_ and _options_. Since these settings are\
-used in a similar way across these filters, the settings are explained here. The\
-documentation of the filters link here and describe any exceptions to this\
+Many filters use the settings _match_, _exclude_ and _options_. Since these settings are
+used in a similar way across these filters, the settings are explained here. The
+documentation of the filters link here and describe any exceptions to this
 generalized explanation.
 
-These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the\
+These settings typically limit the queries the filter module acts on. _match_ and\_exclude\_ define PCRE2 regular expression patterns while _options_ affects how both of the
 patterns are compiled. _options_ works as explained above, accepting the values`ignorecase`, `case` and `extended`, with `ignorecase` being the default.
 
-The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is\
+The queries are matched as they arrive to the filter on their way to a routing module. If\_match\_ is defined, the filter only acts on queries matching that pattern. If _match_ is
 not defined, all queries are considered to match.
 
 If _exclude_ is defined, the filter only acts on queries not matching that pattern. If\_exclude\_ is not defined, nothing is excluded.
 
 If both are defined, the query needs to match _match_ but not match _exclude_.
 
-Even if a filter does not act on a query, the query is not lost. The query is simply\
+Even if a filter does not act on a query, the query is not lost. The query is simply
 passed on to the next module in the processing chain as if the filter was not there.
 
 #### Enumerations
 
-Enumeration type parameters have a pre-defined set of accepted values. For types\
-declared as `enum`, only one value is accepted. For `enum_mask` types, multiple\
+Enumeration type parameters have a pre-defined set of accepted values. For types
+declared as `enum`, only one value is accepted. For `enum_mask` types, multiple
 values can be defined by separating them with commas. All enumeration values in\
 MaxScale are case-sensitive.
 
-For example the `router_options` parameter in the `readconnroute` router is a\
+For example the `router_options` parameter in the `readconnroute` router is a
 mask type enumeration:
 
 ```
@@ -410,7 +410,7 @@ router_options=master,slave
 
 #### Path Lists
 
-A `pathlist` type parameter expects one or more filesystem paths separated by\
+A `pathlist` type parameter expects one or more filesystem paths separated by
 colons. The value must not include space between the separators.
 
 Here is an example path list parameter that points to `/tmp/something.log` and`/var/log/maxscale/maxscale.log`:
@@ -421,8 +421,8 @@ path_list_parameter=/tmp/something.log:/var/log/maxscale/maxscale.log
 
 ### Global Settings
 
-The global settings, in a section named `[MaxScale]`, allow various parameters\
-that affect MariaDB MaxScale as a whole to be tuned. This section must be\
+The global settings, in a section named `[MaxScale]`, allow various parameters
+that affect MariaDB MaxScale as a whole to be tuned. This section must be
 defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 
 #### `core_file`
@@ -431,9 +431,9 @@ defined in the root configuration file which by default is `/etc/maxscale.cnf`.
 * Default: true
 * Dynamic: No
 
-This parameter specifies whether a core file should be generated if MaxScale\
-crashes. The default is `true` although usually a core file is not needed,\
-as MaxScale is capable of logging the full stack trace of all threads\
+This parameter specifies whether a core file should be generated if MaxScale
+crashes. The default is `true` although usually a core file is not needed,
+as MaxScale is capable of logging the full stack trace of all threads
 when it crashes.
 
 #### `auto_tune`
@@ -444,7 +444,7 @@ when it crashes.
 * Mandatory: No
 * Dynamic: No
 
-An _auto tunable_ parameter is a parameter whose value can be derived from a\
+An _auto tunable_ parameter is a parameter whose value can be derived from a
 particular server variable. With this parameter it can be specified whether`all` or a specific set of parameters should automatically be set.
 
 The current auto tunable parameters are:
@@ -454,13 +454,13 @@ The current auto tunable parameters are:
 | [connection\_keepalive](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#connection_keepalive) | 80% of the smallest value of the servers used by the service                                                                                                                                     |
 | [wait\_timeout](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#wait_timeout)                 | The smallest [wait\_timeout](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#wait_timeout) value of the servers used by the service |
 
-The values of the server variables are collected by monitors, which means that\
-if the servers of a service are not monitored by a monitor, then the parameters\
+The values of the server variables are collected by monitors, which means that
+if the servers of a service are not monitored by a monitor, then the parameters
 of that service will not be auto tuned.
 
-Note that even if `auto_tune` is set to `all`, the auto tunable parameters\
+Note that even if `auto_tune` is set to `all`, the auto tunable parameters
 can still be set in the configuration file and modified with _maxctrl_.\
-However, the specified value will be overwritten at the next auto tuning\
+However, the specified value will be overwritten at the next auto tuning
 round, but only if the servers of the service are monitored by a monitor.
 
 #### `threads`
@@ -470,12 +470,12 @@ round, but only if the servers of the service are monitored by a monitor.
 * Dynamic: No
 * Default: `auto`
 
-This parameter controls the number of worker threads that are used for\
-routing client traffic. The default is `auto` which uses as many threads\
-as there are virtual CPU cores available to MaxScale, rounded up to the\
-nearest integer. If no limitations have been set using CPU affinities or\
+This parameter controls the number of worker threads that are used for
+routing client traffic. The default is `auto` which uses as many threads
+as there are virtual CPU cores available to MaxScale, rounded up to the
+nearest integer. If no limitations have been set using CPU affinities or
 cgroup CPU quotas, this will be the same as the number of CPU cores.\
-In general, as of 24.08, MaxScale will use the appropriate number of\
+In general, as of 24.08, MaxScale will use the appropriate number of
 threads, also when it is running in a container.
 
 The maximum value for `threads` is specified by [threads\_max](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#threads_max).
@@ -492,7 +492,7 @@ From 23.02 onwards it is possible to change the number threads at runtime.\
 Please see [Threads](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#threads-1) for more details.
 
 Additional threads will be created to execute other internal services within\
-MariaDB MaxScale. This setting is used to configure the number of threads that\
+MariaDB MaxScale. This setting is used to configure the number of threads that
 will be used to manage the user connections.
 
 #### `threads_max`
@@ -501,11 +501,11 @@ will be used to manage the user connections.
 * Default: 256
 * Dynamic: No
 
-This parameter specifies the hard limit for the number of worker threads,\
+This parameter specifies the hard limit for the number of worker threads,
 which is specified using [threads](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#threads).
 
-At startup, if the value of `threads` is larger than that of `threads_max`,\
-the value of `threads` will be reduced to that. At runtime, an attempt to\
+At startup, if the value of `threads` is larger than that of `threads_max`,
+the value of `threads` will be reduced to that. At runtime, an attempt to
 increase the value of `threads` beyond that of `threads_max` is an error.
 
 #### `rebalance_period`
@@ -515,19 +515,19 @@ increase the value of `threads` beyond that of `threads_max` is an error.
 * Dynamic: Yes
 * Default: `0s`
 
-This duration parameter controls how often the load of the worker threads\
-should be checked. The default value is 0, which means that no checks and\
+This duration parameter controls how often the load of the worker threads
+should be checked. The default value is 0, which means that no checks and
 no rebalancing will be performed.
 
 ```
 rebalance_period=10s
 ```
 
-Note that the value of `rebalance_period` should not be smaller than the\
+Note that the value of `rebalance_period` should not be smaller than the
 value of `rebalance_window` whose default value is 10.
 
-If the value of `rebalance_period` is significantly shorter than that\
-of `rebalance_window`, it may lead to oscillation where work is constantly\
+If the value of `rebalance_period` is significantly shorter than that
+of `rebalance_window`, it may lead to oscillation where work is constantly
 moved from one thread to another.
 
 #### `rebalance_threshold`
@@ -537,21 +537,21 @@ moved from one thread to another.
 * Dynamic: Yes
 * Default: `20`
 
-This integer parameter controls at which point MaxScale should start\
+This integer parameter controls at which point MaxScale should start
 moving work from one worker thread to another.
 
 If the difference in load between the thread with the maximum load and\
 the thread with the minimum load is larger than the value of this parameter,\
 then work will be moved from the former to the latter.
 
-Although the load of a thread can vary between 0 and 100, the value of this\
+Although the load of a thread can vary between 0 and 100, the value of this
 parameter must be between 5 and 100.
 
 ```
 rebalance_threshold=15
 ```
 
-Note that rebalancing will not be performed unless `rebalance_period`\
+Note that rebalancing will not be performed unless `rebalance_period`
 has been specified.
 
 #### `rebalance_window`
@@ -561,11 +561,11 @@ has been specified.
 * Dynamic: Yes
 * Default: `10`
 
-This integer parameter controls how many seconds of load should be\
-taken into account when deciding whether work should be moved from\
+This integer parameter controls how many seconds of load should be
+taken into account when deciding whether work should be moved from
 one thread to another.
 
-The default value is 10, which means that the load during the last 10\
+The default value is 10, which means that the load during the last 10
 seconds is considered when deciding whether work should be moved.
 
 The minimum value is 1 and the maximum 60.
@@ -577,8 +577,8 @@ The minimum value is 1 and the maximum 60.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether reverse domain name lookups are made to convert\
-client IP addresses to hostnames. If enabled, client IP addresses will not be\
+This parameter controls whether reverse domain name lookups are made to convert
+client IP addresses to hostnames. If enabled, client IP addresses will not be
 resolved to hostnames during authentication or for the REST API even if requested.
 
 If you have database users that use a hostname in the host part of the user\
@@ -593,13 +593,13 @@ an IP address.
 * Default: 128
 * Dynamic: Yes
 
-How many hostname entries are stored in the reverse name lookup cache. Each\
-thread in MaxScale has a cache for the reverse name resolution of client IP\
-addresses to hostnames. Whenever the client authentication requires that a\
-hostname lookup is done, the cache is consulted first. If an entry is found and\
+How many hostname entries are stored in the reverse name lookup cache. Each
+thread in MaxScale has a cache for the reverse name resolution of client IP
+addresses to hostnames. Whenever the client authentication requires that a
+hostname lookup is done, the cache is consulted first. If an entry is found and
 it was updated less than 300 seconds ago, the cached result is used.
 
-With `host_cache_size=0`, the cache is disabled and a fresh reverse name\
+With `host_cache_size=0`, the cache is disabled and a fresh reverse name
 lookup is always done.
 
 #### `auth_connect_timeout`
@@ -609,8 +609,8 @@ lookup is always done.
 * Dynamic: Yes
 * Default: `10s`
 
-Duration, default 10s. This setting defines the connection timeout when\
-attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same\
+Duration, default 10s. This setting defines the connection timeout when
+attempting to fetch MariaDB/MySQL/Clustrix users from a backend server. The same
 value is also used for read and write timeouts. Increasing this value causes\
 MaxScale to wait longer for a response from a server before user fetching fails.\
 Other servers may then be attempted.
@@ -619,10 +619,10 @@ Other servers may then be attempted.
 auth_connect_timeout=10s
 ```
 
-The value is given as [a duration](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,\
-the value is interpreted as seconds. In subsequent versions a value without a\
-unit may be rejected. Since the granularity of the timeout is seconds, a timeout\
-specified in milliseconds will be rejected even if the given value is longer\
+The value is given as [a duration](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided,
+the value is interpreted as seconds. In subsequent versions a value without a
+unit may be rejected. Since the granularity of the timeout is seconds, a timeout
+specified in milliseconds will be rejected even if the given value is longer
 than a second.
 
 #### `auth_read_timeout`
@@ -640,14 +640,14 @@ Deprecated and ignored as of MaxScale 2.5.0. See _auth\_connect\_timeout_ above.
 * Dynamic: No
 * Default: `1`
 
-The number of times an interrupted internal query will be retried. The default\
-is to retry the query once. This feature was added in MaxScale 2.1.10 and was\
+The number of times an interrupted internal query will be retried. The default
+is to retry the query once. This feature was added in MaxScale 2.1.10 and was
 disabled by default until MaxScale 2.3.0.
 
-An interrupted query is any query that is interrupted by a network\
-error. Connection timeouts are included in network errors and thus is it\
-advisable to make sure that the value of `query_retry_timeout` is set to an\
-adequate value. Internal queries are only used to retrieve authentication data\
+An interrupted query is any query that is interrupted by a network
+error. Connection timeouts are included in network errors and thus is it
+advisable to make sure that the value of `query_retry_timeout` is set to an
+adequate value. Internal queries are only used to retrieve authentication data
 and monitor the servers.
 
 #### `query_retry_timeout`
@@ -657,16 +657,16 @@ and monitor the servers.
 * Dynamic: Yes
 * Default: `10s`
 
-The total timeout in seconds for any retried queries. The default value is 5\
+The total timeout in seconds for any retried queries. The default value is 5
 seconds.
 
-An interrupted query is retried for either the configured amount of attempts or\
+An interrupted query is retried for either the configured amount of attempts or
 until the configured timeout is reached.
 
-The value is specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `passive`
@@ -676,14 +676,14 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `false`
 
-Deprecated since MariaDB MaxScale 25.01. Use [cooperative monitoring](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md)\
+Deprecated since MariaDB MaxScale 25.01. Use [cooperative monitoring](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md)
 instead.
 
-Controls whether MaxScale is a passive node in a cluster of multiple MaxScale\
+Controls whether MaxScale is a passive node in a cluster of multiple MaxScale
 instances.
 
-This parameter is intended to be used with multiple MaxScale instances that use\
-failover functionality to manipulate the cluster in some form. Passive nodes\
+This parameter is intended to be used with multiple MaxScale instances that use
+failover functionality to manipulate the cluster in some form. Passive nodes
 only observe the clusters being monitored and take no direct actions.
 
 The following functionality is disabled when passive mode is enabled:
@@ -692,8 +692,8 @@ The following functionality is disabled when passive mode is enabled:
 * Automatic rejoin in the `mariadbmon` module
 * Launching of monitor scripts
 
-**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and\
-route any traffic sent to it. The **only** operations affected by the passive\
+**NOTE:** Even if MaxScale is in passive mode, it will still accept clients and
+route any traffic sent to it. The **only** operations affected by the passive
 mode are the ones listed above.
 
 #### `ms_timestamp`
@@ -703,7 +703,7 @@ mode are the ones listed above.
 * Dynamic: Yes
 * Default: `false`
 
-Enable or disable the high precision timestamps in logfiles. Enabling this adds\
+Enable or disable the high precision timestamps in logfiles. Enabling this adds
 millisecond precision to all logfile timestamps.
 
 #### `syslog`
@@ -713,10 +713,10 @@ millisecond precision to all logfile timestamps.
 * Dynamic: Yes
 * Default: `false`
 
-Log messages to the system journal. This logs messages using the native SystemD\
+Log messages to the system journal. This logs messages using the native SystemD
 journal interface. The logs can be viewed with `journalctl`.
 
-MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be\
+MaxScale 22.08 changed the default value of `syslog` from `true` to`false`. This was done to remove the redundant logging that it caused as both`syslog` and `maxlog` were enabled by default. This caused each message to be
 logged twice: once into the system journal and once into MaxScale's own logfile.
 
 #### `maxlog`
@@ -737,8 +737,8 @@ Log messages to MariaDB MaxScale's log file. The name of the log file is`maxscal
 
 Log messages whose syslog priority is _warning_.
 
-MaxScale logs warning level messages whenever a condition is encountered that\
-the user should be notified of but does not require immediate action or it\
+MaxScale logs warning level messages whenever a condition is encountered that
+the user should be notified of but does not require immediate action or it
 indicates a minor problem.
 
 #### `log_notice`
@@ -750,8 +750,8 @@ indicates a minor problem.
 
 Log messages whose syslog priority is _notice_.
 
-These messages contain information that is helpful for the user and they usually\
-do not indicate a problem. These are logged whenever something worth nothing\
+These messages contain information that is helpful for the user and they usually
+do not indicate a problem. These are logged whenever something worth nothing
 happens in either MaxScale or in the servers it monitors.
 
 #### `log_info`
@@ -764,10 +764,10 @@ happens in either MaxScale or in the servers it monitors.
 Log messages whose syslog priority is _info_.
 
 These messages provide detailed information about the internal workings of\
-MariaDB MaxScale. These messages should only be enabled when there is a need to\
-inspect the internal logic of MaxScale. A common use-case is to see why a\
-particular query was handled in a certain way. Almost all modules log some\
-messages on the info level and this can be very helpful when trying to solve\
+MariaDB MaxScale. These messages should only be enabled when there is a need to
+inspect the internal logic of MaxScale. A common use-case is to see why a
+particular query was handled in a certain way. Almost all modules log some
+messages on the info level and this can be very helpful when trying to solve
 routing related problems.
 
 #### `log_debug`
@@ -779,11 +779,11 @@ routing related problems.
 
 Log messages whose syslog priority is _debug_.
 
-These messages are intended for development purposes and are disabled by\
+These messages are intended for development purposes and are disabled by
 default. These are rarely useful outside of debugging core MaxScale issues.
 
-**Note:** If MariaDB MaxScale has been built in release mode, then debug\
-messages are excluded from the build and this setting will not have any\
+**Note:** If MariaDB MaxScale has been built in release mode, then debug
+messages are excluded from the build and this setting will not have any
 effect. If an attempt to enable these is made, a warning is logged.
 
 #### `trace_file_dir`
@@ -794,19 +794,19 @@ effect. If an attempt to enable these is made, a warning is logged.
 
 Path to a directory where trace files will be generated to.
 
-The trace logging offers a low overhead alternative to `log_info` that is\
-designed to be placed on a local in-memory file system. By placing the files in\
-a location that is not persistent, the overhead of writing to the files is\
+The trace logging offers a low overhead alternative to `log_info` that is
+designed to be placed on a local in-memory file system. By placing the files in
+a location that is not persistent, the overhead of writing to the files is
 minimal while still allowing the trace logs to be processed as normal log files.
 
-If this parameter is defined along with `trace_file_size`, MaxScale will write\
-all log messages from all log levels into a set of trace files located in this\
-directory. The files are named `maxscale.trace.N` where `N` is an increasing\
-number and whenever a new file is created the oldest one is removed if there are\
+If this parameter is defined along with `trace_file_size`, MaxScale will write
+all log messages from all log levels into a set of trace files located in this
+directory. The files are named `maxscale.trace.N` where `N` is an increasing
+number and whenever a new file is created the oldest one is removed if there are
 more than 10 trace files.
 
-Starting with MaxScale 24.08.1, the `maxscale.trace` symlink will be created in [the log directory](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#logdir) that will point to the latest log file. This\
-symlink can be used with `tail -F` to interactively monitor the trace stream or\
+Starting with MaxScale 24.08.1, the `maxscale.trace` symlink will be created in [the log directory](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#logdir) that will point to the latest log file. This
+symlink can be used with `tail -F` to interactively monitor the trace stream or
 to copy the trace output directly into a compressed file:
 
 ```
@@ -815,9 +815,9 @@ to copy the trace output directly into a compressed file:
 tail -F /var/log/maxscale/maxscale.trace | gzip > maxscale.trace.gz
 ```
 
-The trace files differ from the normal log file written by MaxScale in that they\
-do not contain the local timestamp and instead contain a raw fractional UNIX\
-timestamp. The format of the trace file is subject to change and it may in the\
+The trace files differ from the normal log file written by MaxScale in that they
+do not contain the local timestamp and instead contain a raw fractional UNIX
+timestamp. The format of the trace file is subject to change and it may in the
 future be identical to the normal log generated by MaxScale.
 
 #### `trace_file_size`
@@ -826,12 +826,12 @@ future be identical to the normal log generated by MaxScale.
 * Mandatory: No
 * Dynamic: Yes
 
-The desired amount of log data to keep in the trace files. Each individual trace\
-file will be one tenth the size of `trace_file_size` and once they exceed this\
-amount, a trace log rotation will occur. For example with`trace_file_size=100Mi`, roughly 100MiB of log data is kept in 10 files with\
+The desired amount of log data to keep in the trace files. Each individual trace
+file will be one tenth the size of `trace_file_size` and once they exceed this
+amount, a trace log rotation will occur. For example with`trace_file_size=100Mi`, roughly 100MiB of log data is kept in 10 files with
 about 10MiB of data in each file.
 
-Individual trace files may sometimes exceed this limit and under heavy load the\
+Individual trace files may sometimes exceed this limit and under heavy load the
 system may end up temporarily using more space than is intended.
 
 #### `log_warn_super_user`
@@ -841,10 +841,10 @@ system may end up temporarily using more space than is intended.
 * Dynamic: No
 * Default: `false`
 
-When enabled, a warning is logged whenever a client with SUPER-privilege\
-successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The\
-setting is intended for diagnosing situations where a client interferes with a\
-primary server switchover. Super-users bypass the _read\_only_-flag which\
+When enabled, a warning is logged whenever a client with SUPER-privilege
+successfully authenticates. This also applies to COM\_CHANGE\_USER-commands. The
+setting is intended for diagnosing situations where a client interferes with a
+primary server switchover. Super-users bypass the _read\_only_-flag which
 switchover uses to block writes to the primary.
 
 #### `log_augmentation`
@@ -854,9 +854,9 @@ switchover uses to block writes to the primary.
 * Dynamic: Yes
 * Default: `0`
 
-Enable or disable the augmentation of messages. If this is enabled, then each\
-logged message is appended with the name of the function where the message was\
-logged. This is primarily for development purposes and hence is disabled by\
+Enable or disable the augmentation of messages. If this is enabled, then each
+logged message is appended with the name of the function where the message was
+logged. This is primarily for development purposes and hence is disabled by
 default.
 
 ```
@@ -874,10 +874,10 @@ To disable the augmentation use the value 0 and to enable it use the value 1.
 * Dynamic: Yes
 * Default: `10, 1000ms, 10000ms`
 
-It is possible that a particular error (or warning) is logged over and over\
-again, if the cause for the error persistently remains. To prevent the log from\
-flooding, it is possible to specify how many times a particular error may be\
-logged within a time period, before the logging of that error is suppressed for\
+It is possible that a particular error (or warning) is logged over and over
+again, if the cause for the error persistently remains. To prevent the log from
+flooding, it is possible to specify how many times a particular error may be
+logged within a time period, before the logging of that error is suppressed for
 a while.
 
 ```
@@ -893,18 +893,18 @@ log_throttling=8, 2s, 15000ms
 In the example above, the logging of a particular error will be suppressed for\
 15 seconds if the error has been logged 8 times in 2 seconds.
 
-The default is `10, 1000ms, 10000ms`, which means that if the same error is\
-logged 10 times in one second, the logging of that error is suppressed for the\
+The default is `10, 1000ms, 10000ms`, which means that if the same error is
+logged 10 times in one second, the logging of that error is suppressed for the
 following 10 seconds.
 
-Whenever an error message that is being throttled is logged within the\
-triggering window (the second argument), the suppression window is\
-extended. This continues until there is a pause in the messages that is longer\
+Whenever an error message that is being throttled is logged within the
+triggering window (the second argument), the suppression window is
+extended. This continues until there is a pause in the messages that is longer
 than the triggering window.
 
-For example, with the default configuration the messages must pause for at least\
-one second in order for the throttling to eventually stop. This mechanism\
-prevents long-lasting error conditions from slowly filling up the log with short\
+For example, with the default configuration the messages must pause for at least
+one second in order for the throttling to eventually stop. This mechanism
+prevents long-lasting error conditions from slowly filling up the log with short
 bursts of messages.
 
 To disable log throttling, add an entry with an empty value
@@ -919,8 +919,8 @@ or one where any of the integers is 0.
 log_throttling=0, 0, 0
 ```
 
-The durations can be specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit\
-unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In\
+The durations can be specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit
+unit is provided, the value is interpreted as milliseconds in MaxScale 2.4. In
 subsequent versions a value without a unit may be rejected.
 
 Note that _notice_, _info_ and _debug_ messages are never throttled.
@@ -932,7 +932,7 @@ Note that _notice_, _info_ and _debug_ messages are never throttled.
 * Dynamic: No
 * Default: `/var/log/maxscale`
 
-Set the directory where the logfiles are stored. The folder needs to be both\
+Set the directory where the logfiles are stored. The folder needs to be both
 readable and writable by the user running MariaDB MaxScale.
 
 ```
@@ -947,10 +947,10 @@ logdir=/var/log/maxscale/
 * Default: `/var/lib/maxscale`
 
 Set the directory where the data files used by MariaDB MaxScale are stored.\
-Modules can write to this directory and for example the binlogrouter uses this\
+Modules can write to this directory and for example the binlogrouter uses this
 folder as the default location for storing binary logs.
 
-This is also the directory where the password encryption key is read from that\
+This is also the directory where the password encryption key is read from that
 is generated by `maxkeys`.
 
 ```
@@ -964,10 +964,10 @@ datadir=/var/lib/maxscale/
 * Dynamic: No
 * Default: `""`
 
-The location where the `.secrets` file is read from. If `secretsdir` is not\
+The location where the `.secrets` file is read from. If `secretsdir` is not
 defined, the file is read from [datadir](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#datadir).
 
-This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6\
+This parameter was added in MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6
 and 24.02.2.
 
 #### `libdir`
@@ -977,12 +977,12 @@ and 24.02.2.
 * Dynamic: No
 * Default: OS Dependent
 
-Set the directory where MariaDB MaxScale looks for modules. The library\
-directory is the only directory that MariaDB MaxScale uses when it searches for\
-modules. If you have custom modules for MariaDB MaxScale, make sure you have\
+Set the directory where MariaDB MaxScale looks for modules. The library
+directory is the only directory that MariaDB MaxScale uses when it searches for
+modules. If you have custom modules for MariaDB MaxScale, make sure you have
 them in this folder.
 
-The default value depends on the operating system. For RHEL versions the value\
+The default value depends on the operating system. For RHEL versions the value
 is `/usr/lib64/maxscale/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/`
 
 ```
@@ -998,14 +998,14 @@ libdir=/usr/lib64/maxscale/
 
 Sets the directory where static data assets are loaded.
 
-The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI\
-files have been manually moved somewhere else, this path must be configured to\
+The MaxScale GUI static files are located in the `gui/` subdirectory. If the GUI
+files have been manually moved somewhere else, this path must be configured to
 point to the parent directory of the `gui/` subdirectory.
 
-The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path\
-resolves to outside of this directory are not served by the MaxScale GUI: this\
+The MaxScale REST API only serves files for the GUI that are located in the`gui/` subdirectory of the configured `sharedir`. Any files whose real path
+resolves to outside of this directory are not served by the MaxScale GUI: this
 is done to prevent other files from being accessible via the MaxScale REST\
-API. This means that path to the GUI source directory can contain symbolic links\
+API. This means that path to the GUI source directory can contain symbolic links
 but all parts after the `/gui/` directory must reside inside it.
 
 #### `cachedir`
@@ -1028,12 +1028,12 @@ cachedir=/var/cache/maxscale/
 * Dynamic: No
 * Default: `/run/maxscale`
 
-Configure the directory for the PID file for MariaDB MaxScale. This file\
+Configure the directory for the PID file for MariaDB MaxScale. This file
 contains the Process ID for the running MariaDB MaxScale process.
 
-MaxScale versions before 24.08.1 used the path `/var/run/maxscale/` for the PID\
-files. This was a legacy path according to the Filesystem Hierarchy Standard\
-and starting with MaxScale 24.08.1, the appropriate modern PID file path is\
+MaxScale versions before 24.08.1 used the path `/var/run/maxscale/` for the PID
+files. This was a legacy path according to the Filesystem Hierarchy Standard
+and starting with MaxScale 24.08.1, the appropriate modern PID file path is
 used.
 
 #### `execdir`
@@ -1043,8 +1043,8 @@ used.
 * Dynamic: No
 * Default: `/usr/bin`
 
-Configure the directory where the executable files reside. All internal\
-processes which are launched will use this directory to look for executable\
+Configure the directory where the executable files reside. All internal
+processes which are launched will use this directory to look for executable
 files.
 
 ```
@@ -1058,13 +1058,13 @@ execdir=/usr/bin/
 * Dynamic: No
 * Default: OS Dependent
 
-Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C\
-used in MaxScale can use this directory to load authentication plugins. The\
-versions of the plugins must be binary compatible with the connector version\
+Location of the MariaDB Connector-C plugin directory. The MariaDB Connector-C
+used in MaxScale can use this directory to load authentication plugins. The
+versions of the plugins must be binary compatible with the connector version
 that MaxScale was built with.
 
-Starting with version 6.2.0, the plugins are bundled with MaxScale and the\
-default value now points to the bundled plugins. The location where the plugins\
+Starting with version 6.2.0, the plugins are bundled with MaxScale and the
+default value now points to the bundled plugins. The location where the plugins
 are stored depends on the operating system. For RHEL versions the value is`/usr/lib64/maxscale/plugin/`. For Debian and Ubuntu it is`/usr/lib/x86_64-linux-gnu/maxscale/plugin/`.
 
 Older versions of MaxScale used `/usr/lib/mysql/plugin/` as the default value.
@@ -1080,10 +1080,10 @@ connector_plugindir=/usr/lib64/maxscale/plugin/
 * Dynamic: No
 * Default: `/var/lib/maxscale/maxscale.cnf.d/`
 
-Configure the directory where persisted configurations are stored. When a new\
-object is created via MaxCtrl, it will be stored in this directory. Do not use\
-this directory for normal configuration files, use _/etc/maxscale.cnf.d/_\
-instead. The user MaxScale is running as must be able to write into this\
+Configure the directory where persisted configurations are stored. When a new
+object is created via MaxCtrl, it will be stored in this directory. Do not use
+this directory for normal configuration files, use _/etc/maxscale.cnf.d/_
+instead. The user MaxScale is running as must be able to write into this
 directory.
 
 ```
@@ -1097,16 +1097,16 @@ persistdir=/var/lib/maxscale/maxscale.cnf.d/
 * Dynamic: No
 * Default: `/etc/maxscale.modules.d/`
 
-Configure the directory where module configurations are stored. Path arguments\
-are resolved relative to this directory. This directory should be used to store\
+Configure the directory where module configurations are stored. Path arguments
+are resolved relative to this directory. This directory should be used to store
 module specific configurations.
 
-Any configuration parameter that is not an absolute path will be interpreted as\
-a relative path. The relative paths use the module configuration directory as\
+Any configuration parameter that is not an absolute path will be interpreted as
+a relative path. The relative paths use the module configuration directory as
 the working directory.
 
-For example, the configuration parameter `file=my_file.txt` would be interpreted\
-as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would\
+For example, the configuration parameter `file=my_file.txt` would be interpreted
+as `/etc/maxscale.modules.d/my_file.txt` whereas `file=/home/user/my_file.txt` would
 be interpreted as `/home/user/my_file.txt`.
 
 ```
@@ -1120,7 +1120,7 @@ module_configdir=/etc/maxscale.modules.d/
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will\
+Set the folder where the errmsg.sys file is located in. MariaDB MaxScale will
 look for the errmsg.sys file installed with MariaDB MaxScale from this folder.
 
 ```
@@ -1139,20 +1139,20 @@ Deprecated since MariaDB MaxScale 23.08.
 * Default: System Dependent
 
 Specifies the maximum size of the query classifier cache. The default limit is\
-15% of _available_ system memory. The available system memory may be less than\
-the _total_ system memory, if MaxScale is running in a container whose resources\
+15% of _available_ system memory. The available system memory may be less than
+the _total_ system memory, if MaxScale is running in a container whose resources
 have been limited.
 
-When the query classifier cache has been enabled, MaxScale will, after a\
-statement has been parsed, store the classification result using the\
+When the query classifier cache has been enabled, MaxScale will, after a
+statement has been parsed, store the classification result using the
 canonicalized version of the statement as the key.
 
-If the classification result for a statement is needed, MaxScale will first\
-canonicalize the statement and check whether the result can be found in the\
-cache. If it can, the statement will not be parsed at all but the cached result\
+If the classification result for a statement is needed, MaxScale will first
+canonicalize the statement and check whether the result can be found in the
+cache. If it can, the statement will not be parsed at all but the cached result
 is used.
 
-The configuration parameter takes one integer that specifies the maximum size of\
+The configuration parameter takes one integer that specifies the maximum size of
 the cache. The size of the cache can be specified as explained [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#sizes).
 
 ```
@@ -1160,17 +1160,17 @@ the cache. The size of the cache can be specified as explained [here](mariadb-ma
 query_classifier_cache_size=1MB
 ```
 
-Note that MaxScale uses a separate cache for each worker thread. To obtain the\
-amount of memory available for each thread, divide the cache size with the value\
-of `threads`. If statements are evicted from the cache (visible in the\
+Note that MaxScale uses a separate cache for each worker thread. To obtain the
+amount of memory available for each thread, divide the cache size with the value
+of `threads`. If statements are evicted from the cache (visible in the
 diagnostic output), consider increasing the cache size.
 
-Note also that limit is not a hard limit, but an approximate one. Namely, although\
-the memory needed for storing the canonicalized statement and the classification\
-result is correctly accounted for, there is additional overhead whose size is not\
+Note also that limit is not a hard limit, but an approximate one. Namely, although
+the memory needed for storing the canonicalized statement and the classification
+result is correctly accounted for, there is additional overhead whose size is not
 exactly known and over which we do not have direct control.
 
-Using `maxctrl show threads` it is possible to check what the actual size of\
+Using `maxctrl show threads` it is possible to check what the actual size of
 the cache is and to see performance statistics.
 
 | Key                | Meaning                                                                                                                 |
@@ -1192,15 +1192,15 @@ Deprecated since MariaDB MaxScale 23.08.
 * Dynamic: No
 * Default: `false`
 
-Enable or disable the substitution of environment variables in the MaxScale\
-configuration file. If the substitution of variables is enabled and a\
+Enable or disable the substitution of environment variables in the MaxScale
+configuration file. If the substitution of variables is enabled and a
 configuration line like
 
 ```
 some_parameter=$SOME_VALUE
 ```
 
-is encountered, then `$SOME_VALUE` will be replaced with the actual value\
+is encountered, then `$SOME_VALUE` will be replaced with the actual value
 of the environment variable `SOME_VALUE`. Note: _Variable substitution will be made only if '$' is the first character of the value._ _Everything_ following '$' is interpreted as the name of the environment
 variable.
 
@@ -1210,9 +1210,9 @@ variable.
 substitute_variables=true
 ```
 
-The setting of `substitute_variables` will have an effect on all parameters\
-in the all other sections, irrespective of where the `[maxscale]` section\
-is placed in the configuration file. However, in the `[maxscale]` section,\
+The setting of `substitute_variables` will have an effect on all parameters
+in the all other sections, irrespective of where the `[maxscale]` section
+is placed in the configuration file. However, in the `[maxscale]` section,
 to ensure that substitution will take place, place the`substitute_variables=true` line first.
 
 #### `sql_mode`
@@ -1223,7 +1223,7 @@ to ensure that substitution will take place, place the`substitute_variables=true
 * Values: `default`, `oracle`
 * Default: `default`
 
-Specifies whether the query classifier parser should initially expect _MariaDB_\
+Specifies whether the query classifier parser should initially expect _MariaDB_
 or _PL/SQL_ kind of SQL.
 
 The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`oracle` : The parser expects PL/SQL.
@@ -1232,7 +1232,7 @@ The allowed values are:`default`: The parser expects regular _MariaDB_ SQL.`orac
 sql_mode=oracle
 ```
 
-**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume\
+**NOTE** If `sql_mode` is set to `oracle`, then MaxScale will also assume
 that `autocommit` initially is off.
 
 At runtime, MariaDB MaxScale will recognize statements like
@@ -1249,12 +1249,12 @@ set sql_mode=default;
 
 and change mode accordingly.
 
-**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also\
-behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave\
+**NOTE** If `set sql_mode=oracle;` is encountered, then MaxScale will also
+behave as if `autocommit` had been turned off and conversely, if`set sql_mode=default;` is encountered, then MaxScale will also behave
 as if `autocommit` had been turned on.
 
-Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of\
-the server, so the value of `sql_mode` should reflect the sql mode used\
+Note that MariaDB MaxScale is **not** explicitly aware of the sql mode of
+the server, so the value of `sql_mode` should reflect the sql mode used
 when the server is started.
 
 #### `local_address`
@@ -1266,15 +1266,15 @@ when the server is started.
 
 What specific local address/interface to use when connecting to servers.
 
-This can be used for ensuring that MaxScale uses a particular interface\
-when connecting to servers, in case the computer MaxScale is running on\
+This can be used for ensuring that MaxScale uses a particular interface
+when connecting to servers, in case the computer MaxScale is running on
 has multiple interfaces.
 
 ```
 local_address=192.168.1.254
 ```
 
-If given as a hostname, MaxScale will perform name lookup on the address\
+If given as a hostname, MaxScale will perform name lookup on the address
 when starting and reuse the result.
 
 #### `users_refresh_time`
@@ -1284,27 +1284,27 @@ when starting and reuse the result.
 * Dynamic: Yes
 * Default: `30s`
 
-How often, in seconds, MaxScale at most may refresh the users from the\
+How often, in seconds, MaxScale at most may refresh the users from the
 backend server.
 
-MaxScale will at startup load the users from the backend server, but if\
-the authentication of a user fails, MaxScale assumes it is because a new\
-user has been created and will thus refresh the users. By default, MaxScale\
-will do that at most once per 30 seconds and with this configuration option\
-that can be changed. A value of 0 allows infinite refreshes and a negative\
+MaxScale will at startup load the users from the backend server, but if
+the authentication of a user fails, MaxScale assumes it is because a new
+user has been created and will thus refresh the users. By default, MaxScale
+will do that at most once per 30 seconds and with this configuration option
+that can be changed. A value of 0 allows infinite refreshes and a negative
 value disables the refreshing entirely.
 
 ```
 users_refresh_time=120s
 ```
 
-The value is specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds\
+In MaxScale 2.3.9 and older versions, the minimum allowed value was 10 seconds
 but, due to a bug, the default value was 0 which allowed infinite refreshes.
 
 #### `users_refresh_interval`
@@ -1314,12 +1314,12 @@ but, due to a bug, the default value was 0 which allowed infinite refreshes.
 * Dynamic: Yes
 * Default: `0s`
 
-How often, in seconds, MaxScale will automatically refresh the users from the\
+How often, in seconds, MaxScale will automatically refresh the users from the
 backend server.
 
-This configuration is used to periodically refresh the backend users, making sure\
-they are up to date. The default value for this setting is 0, meaning the users\
-are not periodically refreshed. However, they can still be refreshed in case of\
+This configuration is used to periodically refresh the backend users, making sure
+they are up to date. The default value for this setting is 0, meaning the users
+are not periodically refreshed. However, they can still be refreshed in case of
 failed authentication depending on `users_refresh_time`.
 
 ```
@@ -1333,13 +1333,13 @@ users_refresh_interval=2h
 * Dynamic: Yes
 * Default: `0`
 
-How many statements MaxScale should store for each session. This is for\
-debugging purposes, as in case of problems it is often of value to be able\
-to find out exactly what statements were sent before a particular\
+How many statements MaxScale should store for each session. This is for
+debugging purposes, as in case of problems it is often of value to be able
+to find out exactly what statements were sent before a particular
 problem turned up.
 
-**Note:** See also `dump_last_statements` using which the actual dumping\
-of the statements is enabled. Unless both of the parameters are defined,\
+**Note:** See also `dump_last_statements` using which the actual dumping
+of the statements is enabled. Unless both of the parameters are defined,
 the statement dumping mechanism doesn't work.
 
 ```
@@ -1354,10 +1354,10 @@ retain_last_statements=20
 * Values: `on_close`, `on_error`, `never`
 * Default: `never`
 
-With this configuration item it is specified in what circumstances MaxScale\
-should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never\
-logged, with `on_error` they are logged if the client closes the connection\
-improperly, and with `on_close` they are always logged when a client session\
+With this configuration item it is specified in what circumstances MaxScale
+should dump the last statements that a client sent. The allowed values are`never`, `on_error` and `on_close`. With `never` the statements are never
+logged, with `on_error` they are logged if the client closes the connection
+improperly, and with `on_close` they are always logged when a client session
 is closed.
 
 ```
@@ -1365,7 +1365,7 @@ dump_last_statements=on_error
 ```
 
 Note that you need to specify with `retain_last_statements` how many statements\
-MaxScale should retain for each session. Unless it has been set to another value\
+MaxScale should retain for each session. Unless it has been set to another value
 than `0`, this configuration setting will not have an effect.
 
 #### `session_trace`
@@ -1375,8 +1375,8 @@ than `0`, this configuration setting will not have an effect.
 * Dynamic: Yes
 * Default: `0`
 
-How many log entries are stored in the session specific trace log. This log is\
-written to disk when a session ends abnormally and can be used for debugging\
+How many log entries are stored in the session specific trace log. This log is
+written to disk when a session ends abnormally and can be used for debugging
 purposes. Currently the session trace log is written to the log in the following situations:
 
 * When MaxScale receives a fatal signal and is about to crash.
@@ -1384,8 +1384,8 @@ purposes. Currently the session trace log is written to the log in the following
 * If the session is not closed gracefully (i.e. client doesn't send a COM\_QUIT packet)
 * Whenever readwritesplit receives a response that is was not expecting.
 
-It would be good to enable this if a session is disconnected and the log is not\
-detailed enough. In this case the info log might reveal the true cause of why\
+It would be good to enable this if a session is disconnected and the log is not
+detailed enough. In this case the info log might reveal the true cause of why
 the connection was closed.
 
 ```
@@ -1397,9 +1397,9 @@ Default is `0`.
 The session trace log is also exposed by REST API and is shown with`maxctrl show sessions`.
 
 The order in which the session trace messages are logged into the log changed in\
-MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal\
-log order" of older events coming first and newer events appearing later in the\
-file. Older versions of MaxScale logged the trace dump in the reverse order with\
+MaxScale 6.4.9 (MXS-4716). Newer versions will log the messages in the "normal
+log order" of older events coming first and newer events appearing later in the
+file. Older versions of MaxScale logged the trace dump in the reverse order with
 the newest messages first and oldest ones last.
 
 #### `session_trace_match`
@@ -1409,17 +1409,17 @@ the newest messages first and oldest ones last.
 * Dynamic: Yes
 * Default: None
 
-If both `session_trace` and `session_trace_match` are defined, and a trace log\
-entry of a session matches the regular expression, the trace log is written to\
+If both `session_trace` and `session_trace_match` are defined, and a trace log
+entry of a session matches the regular expression, the trace log is written to
 disk. The check for the match is done when the session is stopping.
 
-The most effective way to debug MaxScale related issues is to turn on `log_info`\
-and observe the events written into the MaxScale log. The only problem with this\
-approach is that it can cause a severe performance bottleneck and can easily\
-fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged\
+The most effective way to debug MaxScale related issues is to turn on `log_info`
+and observe the events written into the MaxScale log. The only problem with this
+approach is that it can cause a severe performance bottleneck and can easily
+fill up the disk as the amount of data written to it is significant. With`session_trace` and `session_trace_match`, the content that actually gets logged
 can be filtered to only what is needed.
 
-For example, the following configuration would only log the trace log messages\
+For example, the following configuration would only log the trace log messages
 from sessions that execute SQL queries with syntax errors:
 
 ```
@@ -1427,10 +1427,10 @@ session_trace=1000
 session_trace_match=/You have an error in your SQL syntax/
 ```
 
-This could be used to easily identify which applications execute the queries\
-without having to gather the info level log output from all the sessions that\
-connect to MaxScale. For every session that ends up logging a syntax error\
-message, the last 1000 lines of log output done by that session is written into\
+This could be used to easily identify which applications execute the queries
+without having to gather the info level log output from all the sessions that
+connect to MaxScale. For every session that ends up logging a syntax error
+message, the last 1000 lines of log output done by that session is written into
 the MaxScale log.
 
 #### `writeq_high_water`
@@ -1440,17 +1440,17 @@ the MaxScale log.
 * Dynamic: Yes
 * Default: `65536`
 
-High water mark for network write buffer. When the size of the outbound network\
-buffer in MaxScale for a single connection exceeds this value, network traffic\
-throttling for that connection is started. The parameter accepts [size type\
+High water mark for network write buffer. When the size of the outbound network
+buffer in MaxScale for a single connection exceeds this value, network traffic
+throttling for that connection is started. The parameter accepts [size type
 values](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#sizes). The default value was 16777216 bytes before 22.08.4.
 
-More specifically, if the client side write queue is above this value, it will\
-block traffic coming from backend servers. If the backend side write queue is\
+More specifically, if the client side write queue is above this value, it will
+block traffic coming from backend servers. If the backend side write queue is
 above this value, it will block traffic from client.
 
-The buffer that this parameter controls is the buffer internal to MaxScale and\
-is not the kernel TCP send buffer. This means that the total amount of buffered\
+The buffer that this parameter controls is the buffer internal to MaxScale and
+is not the kernel TCP send buffer. This means that the total amount of buffered
 data is determined by both the kernel TCP buffers and the value of`writeq_high_water`.
 
 Network throttling is only enabled when `writeq_high_water` is non-zero. In\
@@ -1463,8 +1463,8 @@ MaxScale 23.02 and earlier, also `writeq_low_water` had to be non-zero.
 * Dynamic: Yes
 * Default: `1024`
 
-Low water mark for network write buffer. Once the traffic throttling is enabled,\
-it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#sizes). The\
+Low water mark for network write buffer. Once the traffic throttling is enabled,
+it will only be disabled when the network write buffer is below`writeq_low_water` bytes. The parameter accepts [size type values](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#sizes). The
 default value was 8192 bytes before 22.08.4.
 
 The value of `writeq_high_water` must always be greater than the value of`writeq_low_water`.
@@ -1477,10 +1477,10 @@ The value of `writeq_high_water` must always be greater than the value of`writeq
 
 Persist changes done at runtime. This parameter was added in MaxScale 22.08.0.
 
-When `persist_runtime_changes` is enabled, runtime configuration changes done\
-with the GUI, MaxCtrl or via the REST API cause a new configuration file to be\
-saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is\
-enabled, these files will be applied on top of any existing values found in\
+When `persist_runtime_changes` is enabled, runtime configuration changes done
+with the GUI, MaxCtrl or via the REST API cause a new configuration file to be
+saved in `/var/lib/maxscale/maxscale.cnf.d/`. If `load_persisted_configs` is
+enabled, these files will be applied on top of any existing values found in
 static configuration files whenever MaxScale is starting up.
 
 #### `load_persisted_configs`
@@ -1493,11 +1493,11 @@ static configuration files whenever MaxScale is starting up.
 Load persisted runtime changes on startup. This parameter was added in MaxScale\
 2.3.6.
 
-All runtime configuration changes are persisted in generated configuration files\
-located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on\
-startup after main configuration files have been read. To make runtime\
-configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores\
-the current runtime state of MaxScale. This makes problem analysis easier if an\
+All runtime configuration changes are persisted in generated configuration files
+located by default in `/var/lib/maxscale/maxscale.cnf.d/` and are loaded on
+startup after main configuration files have been read. To make runtime
+configurations volatile (i.e. they are lost when maxscale is restarted), use`load_persisted_configs=false`. All changes are still persisted since it stores
+the current runtime state of MaxScale. This makes problem analysis easier if an
 unexpected outage happens.
 
 #### `max_auth_errors_until_block`
@@ -1507,14 +1507,14 @@ unexpected outage happens.
 * Dynamic: Yes
 * Default: `10`
 
-The maximum number of authentication failures that are tolerated before a host\
-is temporarily blocked. The default value is 10 failures. After a host is\
-blocked, connections from it are rejected for 60 seconds. To disable this\
+The maximum number of authentication failures that are tolerated before a host
+is temporarily blocked. The default value is 10 failures. After a host is
+blocked, connections from it are rejected for 60 seconds. To disable this
 feature, set the value to 0.
 
-Note that the configured value is not a hard limit. The number of tolerated\
-failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the\
-configured value of this parameter and `threads` is the number of configured\
+Note that the configured value is not a hard limit. The number of tolerated
+failures is between `max_auth_errors_until_block` and `threads * max_auth_errors_until_block` where `max_auth_errors_until_block` is the
+configured value of this parameter and `threads` is the number of configured
 threads.
 
 #### `debug`
@@ -1524,16 +1524,16 @@ threads.
 * Dynamic: No
 * Default: `""`
 
-Define debug options from the --debug command line option. Either the command\
-line option or the parameter should be used, not both. The debug options are\
+Define debug options from the --debug command line option. Either the command
+line option or the parameter should be used, not both. The debug options are
 only for testing purposes and are not to be used in production.
 
 #### REST API Configuration
 
-The MaxScale REST API is an HTTP interface that provides JSON format data\
+The MaxScale REST API is an HTTP interface that provides JSON format data
 intended to be consumed by monitoring applications and visualization tools.
 
-The following options must be defined under the `[maxscale]` section in the\
+The following options must be defined under the `[maxscale]` section in the
 configuration file.
 
 #### `admin_host`
@@ -1562,8 +1562,8 @@ The port where the REST API listens on. The default value is port 8989.
 * Dynamic: No
 * Default: `true`
 
-Enable REST API authentication using HTTP Basic Access\
-authentication. This is not a secure method of authentication without HTTPS but\
+Enable REST API authentication using HTTP Basic Access
+authentication. This is not a secure method of authentication without HTTPS but
 it does add a small layer of security.
 
 For more information, read the [REST API documentation](../mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-rest-api.md).
@@ -1577,7 +1577,7 @@ For more information, read the [REST API documentation](../mariadb-maxscale-25-0
 
 The path to the TLS private key in PEM format for the admin interface.
 
-If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin\
+If the `admin_ssl_key` and `admin_ssl_cert` options are all defined, the admin
 interface will use encrypted HTTPS instead of plain HTTP.
 
 #### `admin_ssl_cert`
@@ -1587,7 +1587,7 @@ interface will use encrypted HTTPS instead of plain HTTP.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS public certificate in PEM format. See `admin_ssl_key`\
+The path to the TLS public certificate in PEM format. See `admin_ssl_key`
 documentation for more details.
 
 #### `admin_ssl_ca_cert`
@@ -1601,11 +1601,11 @@ Deprecated since MariaDB MaxScale 22.08. See `admin_ssl_ca`.
 * Dynamic: No
 * Default: `""`
 
-The path to the TLS CA certificate in PEM format. If defined, the client\
-certificate, if provided, will be validated against it. This parameter is\
+The path to the TLS CA certificate in PEM format. If defined, the client
+certificate, if provided, will be validated against it. This parameter is
 optional starting with MaxScale 2.3.19.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `admin_ssl_ca_cert`,
 which is still accepted as an alias for `admin_ssl_ca`.
 
 #### `admin_ssl_version`
@@ -1616,7 +1616,7 @@ which is still accepted as an alias for `admin_ssl_ca`.
 * Values: `MAX`, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`, `TLSv10`, `TLSv11`, `TLSv12`, `TLSv13`
 * Default: `MAX`
 
-This parameter controls the enabled TLS versions in the REST API. Accepted\
+This parameter controls the enabled TLS versions in the REST API. Accepted
 values are:
 
 * `TLSv10`
@@ -1625,7 +1625,7 @@ values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -1633,19 +1633,19 @@ releases accept also the following alias values:
 * `TLSv1.2`
 * `TLSv1.3` (not supported on OpenSSL 1.0)
 
-The default value is `MAX` which negotiates the highest level of encryption that\
-both the client and server support. The list of supported TLS versions depends\
+The default value is `MAX` which negotiates the highest level of encryption that
+both the client and server support. The list of supported TLS versions depends
 on the operating system and what TLS versions the GnuTLS library supports.
 
 For example, to enable only TLSv1.1 and TLSv1.3, use`admin_ssl_version=TLSv1.1,TLSv1.3`.
 
 This parameter was added in MaxScale 2.5.7.
 
-Older versions of MaxScale interpreted `admin_ssl_version` as the minimum\
+Older versions of MaxScale interpreted `admin_ssl_version` as the minimum
 allowed TLS version. In those versions, `admin_ssl_version=TLSv1.2` allowed both\
-TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2\
-and all newer versions, the value is a enumeration of accepted TLS protocol\
-versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To\
+TLSv1.2 and TLSv1.3. In MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2
+and all newer versions, the value is a enumeration of accepted TLS protocol
+versions. In these versions, `admin_ssl_version=TLSv1.2` only allows TLSv1.2. To
 retain the old behavior, specify all the accepted values with`admin_ssl_version=TLSv1.2,TLSv1.3`
 
 #### `admin_ssl_cipher`
@@ -1654,11 +1654,11 @@ retain the old behavior, specify all the accepted values with`admin_ssl_version=
 * Mandatory: No
 * Dynamic: No
 
-Additional TLS cipher settings. The configured value is prepended to [admin\_ssl\_version](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#admin_ssl_version)\
+Additional TLS cipher settings. The configured value is prepended to [admin\_ssl\_version](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#admin_ssl_version)
 and the resulting string is given as is to [gnutls\_priority\_init](https://gnutls.org/manual/html_node/Priority-Strings.html).\
 If left undefined, `NORMAL` is used.
 
-Adding unrecognized elements to this setting will cause REST-API startup to fail\
+Adding unrecognized elements to this setting will cause REST-API startup to fail
 with the error:
 
 ```
@@ -1666,7 +1666,7 @@ REST API HTTP daemon error: Setting priorities to ... failed: The request is inv
 ```
 
 The value should typically start with a collection of ciphersuites, such as\
-"NORMAL" or "SECURE256". Then, add or remove algorithms with more specific\
+"NORMAL" or "SECURE256". Then, add or remove algorithms with more specific
 cipher definitions such as "+AES-128-GCM" or "-AES-128-GCM".
 
 ```
@@ -1680,7 +1680,7 @@ admin_ssl_cipher=SECURE256:-ECDHE-RSA:-AES-256-CCM:+AES-128-GCM
 * Dynamic: No
 * Default: `true`
 
-Enable or disable the admin interface. This allows the admin interface to\
+Enable or disable the admin interface. This allows the admin interface to
 be completely disabled to prevent access to it.
 
 #### `admin_gui`
@@ -1693,9 +1693,9 @@ be completely disabled to prevent access to it.
 Enable or disable the admin graphical user interface.
 
 MaxScale provides a GUI for administrative operations via the REST API. When the\
-GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will\
-serve the GUI. When disabled, the REST API will respond with a 200 OK to the\
-request. By disabling the GUI, the root resource can be used as a low overhead\
+GUI is enabled, the root REST API resource (i.e. `http://localhost:8989/`) will
+serve the GUI. When disabled, the REST API will respond with a 200 OK to the
+request. By disabling the GUI, the root resource can be used as a low overhead
 health check.
 
 #### `admin_secure_gui`
@@ -1707,10 +1707,10 @@ health check.
 
 Whether to serve the GUI only over secure HTTPS connections.
 
-To be secure by default, the GUI is only served over HTTPS connections as\
+To be secure by default, the GUI is only served over HTTPS connections as
 it uses a token authentication scheme. This also controls whether the`/auth` endpoint requires an encrypted connection.
 
-To allow use of the GUI without having to configure TLS certificates for\
+To allow use of the GUI without having to configure TLS certificates for
 the MaxScale REST API, set this parameter to false.
 
 #### `admin_log_auth_failures`
@@ -1729,17 +1729,17 @@ Log authentication failures for the admin interface.
 * Dynamic: No
 * Default: `""`
 
-Use Pluggable Authentication Modules (PAM) for REST API authentication. This\
-setting and `admin_pam_readonly_service` accept a PAM service name which is\
+Use Pluggable Authentication Modules (PAM) for REST API authentication. This
+setting and `admin_pam_readonly_service` accept a PAM service name which is
 used during authentication if normal authentication fails.`admin_pam_readwrite_service` should accept users who can do any\
-MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only\
-do read operations. Because REST-API does not support back and forth communication between\
-the client and MaxScale, the PAM services must be simple. They should only ask for the\
+MaxCtrl/REST-API-operation. `admin_pam_readonly_service` should accept users who can only
+do read operations. Because REST-API does not support back and forth communication between
+the client and MaxScale, the PAM services must be simple. They should only ask for the
 password and nothing else.
 
-If only `admin_pam_readwrite_service` is configured, both read and write operations can be\
-authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read\
-operations can be authenticated by PAM. If both are set, the service used is determined by\
+If only `admin_pam_readwrite_service` is configured, both read and write operations can be
+authenticated by PAM. If only `admin_pam_readonly_service` is configured, only read
+operations can be authenticated by PAM. If both are set, the service used is determined by
 the requested operation. Leave or set both empty to disable PAM for REST-API.
 
 #### `admin_pam_readonly_service`
@@ -1758,32 +1758,32 @@ See [admin\_pam\_readwrite\_service](mariadb-maxscale-2501-maxscale-2501-mariadb
 * Dynamic: No
 * Default: `%`
 
-Limit REST-API logins to specific source addresses/hosts. Supports\
+Limit REST-API logins to specific source addresses/hosts. Supports
 a comma-separated list of addresses and hostnames. Addresses can be given in\
 CIDR-notation. Admin clients still need to supply credentials as usual.\
-By default, all source addresses are allowed. `admin_readwrite_hosts` lists\
+By default, all source addresses are allowed. `admin_readwrite_hosts` lists
 the hosts from which any operation is allowed.
 
 ```
 admin_readwrite_hosts=192.168.1.1,127.0.0.1/21
 ```
 
-When listing hostnames, `%` and `_` act as wildcards, similar to the hostname\
-component in MariaDB Server user accounts. `localhost` is a reserved hostname\
+When listing hostnames, `%` and `_` act as wildcards, similar to the hostname
+component in MariaDB Server user accounts. `localhost` is a reserved hostname
 and will not match any connection (use `127.0.0.1` for loopback connections).
 
-When checking the source host of the incoming REST-API client, MaxScale first\
-compares against addresses and address masks. If a match was not found and the\
-setting values contain hostnames, reverse name lookup is performed on the\
-client address. The lookup can take a while in rare cases. To prevent such\
+When checking the source host of the incoming REST-API client, MaxScale first
+compares against addresses and address masks. If a match was not found and the
+setting values contain hostnames, reverse name lookup is performed on the
+client address. The lookup can take a while in rare cases. To prevent such
 slowdown, use only IP-addresses in the host lists.
 
 `skip_name_resolve` cannot be enabled if `admin_readwrite_hosts` or`admin_readonly_hosts` includes hostname patterns, as these would not work.
 
 #### `admin_readonly_hosts`
 
-Works similar to `admin_readwrite_hosts`. Lists the hosts from which only read\
-operations are allowed. An admin client can do a read operation if their source\
+Works similar to `admin_readwrite_hosts`. Lists the hosts from which only read
+operations are allowed. An admin client can do a read operation if their source
 address matches either `admin_readwrite_hosts` or `admin_readonly_hosts`.
 
 ```
@@ -1801,47 +1801,47 @@ admin_readonly_hosts=mydomain%.com
 The signature algorithm used by the MaxScale REST API when generating JSON Web\
 Tokens.
 
-For more information about the tokens and how they work, refer to [the REST API\
+For more information about the tokens and how they work, refer to [the REST API
 documentation](../mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-rest-api.md).
 
-If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale\
-will generate a random encryption key on startup and use that to sign the\
+If a symmetric algorithm is used (i.e. `HS256`, `HS384` or `HS512`), MaxScale
+will generate a random encryption key on startup and use that to sign the
 messages. The symmetric key can also be retrieved from an [Encryption Key\
 Manager](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#encryption-key-managers) if the `admin_jwt_key` parameter is defined.
 
-If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must\
-contain a private key and a public certificate of the correct type. If the wrong\
+If an asymmetric algorithm (i.e. public key authentication) is used, both the`admin_ssl_cert` and `admin_ssl_key` parameters must be defined and they must
+contain a private key and a public certificate of the correct type. If the wrong
 key type, key length or elliptic curve is used, MaxScale will refuse to start.
 
-Asymmetric key algorithms make it possible for the clients of the REST API to\
+Asymmetric key algorithms make it possible for the clients of the REST API to
 validate that the token was indeed generated by the correct entity.
 
-Symmetric algorithms make it easy to share the same tokens between\
-multiple MaxScale instances as the shared secret can be stored in a key\
+Symmetric algorithms make it easy to share the same tokens between
+multiple MaxScale instances as the shared secret can be stored in a key
 management system.
 
 The possible values for this parameter are:
 
 * `auto`
-* MaxScale will attempt to detect the best algorithm to use for\
+* MaxScale will attempt to detect the best algorithm to use for
   signatures. The algorithm used depends on the private key type: RSA keys use`PS256`, EC keys use the `ES256`, `ES384` or `ES512` depending on the curve,\
-  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot\
+  Ed25519 keys use `ED25519` and Ed448 keys uses `ED448`. If MaxScale cannot
   auto-detect the key type, it falls back to `HS256` as the default algorithm.
 * `HS256`, `HS384` or `HS512`
 * [HMAC with SHA-2\
-  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct\
+  Functions](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). If`admin_jwt_key` is not defined, uses a random encryption key of the correct
   size.
 * `RS256`, `RS384` or `RS512`
 * [Digital Signature with\
-  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires\
+  RSASSA-PKCS1-v1\_5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3). Requires
   at least a 2048-bit RSA key.
 * `PS256`, `PS384` or `PS512`
 * [Digital Signature with\
-  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires\
+  RSASSA-PSS](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5). Requires
   at least a 2048-bit RSA key.
 * `ES256`, `ES384` or `ES512`
 * [Digital Signature with\
-  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires\
+  ECDSA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4). Requires
   an EC key with the correct curve: P-256 for `ES256`, P-384 for `ES384` and\
   P-512 for `ES512`.
 * `ED25519` or `ED448`
@@ -1856,15 +1856,15 @@ The possible values for this parameter are:
 * Dynamic: No
 * Default: `""`
 
-The ID for the encryption key used to sign the JSON Web Tokens. If configured,\
-an [Encryption Key Manager](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured\
-and it must contain the key with the given ID. If no key is defined, MaxScale\
-will use a random encryption key whenever a symmetric signature algorithm is\
+The ID for the encryption key used to sign the JSON Web Tokens. If configured,
+an [Encryption Key Manager](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#encryption-key-managers) must also be configured
+and it must contain the key with the given ID. If no key is defined, MaxScale
+will use a random encryption key whenever a symmetric signature algorithm is
 used.
 
-Currently, the encryption key is only read on startup. This means that the\
+Currently, the encryption key is only read on startup. This means that the
 tokens will be signed by the latest key version that is available on startup:\
-rotating the encryption key in the key management system will not cause the JWTs\
+rotating the encryption key in the key management system will not cause the JWTs
 to be signed with newer versions of the key.
 
 #### `admin_jwt_max_age`
@@ -1876,11 +1876,11 @@ to be signed with newer versions of the key.
 
 The maximum lifetime of a token generated by the `/auth` endpoint.
 
-If a client requests for a token with a lifetime that exceeds the configured\
-value, the token lifetime is silently truncated to this value. This can be used\
+If a client requests for a token with a lifetime that exceeds the configured
+value, the token lifetime is silently truncated to this value. This can be used
 to control the maximum length of a MaxGUI session.
 
-This also acts as the effective maximum age of any database connection created\
+This also acts as the effective maximum age of any database connection created
 from the `/sql` endpoint.
 
 #### `admin_oidc_url`
@@ -1892,14 +1892,14 @@ from the `/sql` endpoint.
 
 The URL to a OpenID Connect server that is used for JWT validation.
 
-If defined, any tokens signed by this server are accepted as valid bearer tokens\
-for the MaxScale REST API. The `"sub"` field of the token is assumed to be the\
-username of an administrative user in MaxScale and the `"account"` claim is\
-assumed to be the type of the user: `"admin"` for administrative users with full\
+If defined, any tokens signed by this server are accepted as valid bearer tokens
+for the MaxScale REST API. The `"sub"` field of the token is assumed to be the
+username of an administrative user in MaxScale and the `"account"` claim is
+assumed to be the type of the user: `"admin"` for administrative users with full
 access to the REST-API and `"basic"` for users with read-only access to the\
 REST-API. This means that all users must be first created with `maxctrl create user` before the tokens are accepted if the OIDC provider is not able to add the`"account"` claim.
 
-If this URL is changed at runtime, the new certificates will not be\
+If this URL is changed at runtime, the new certificates will not be
 fetched until a `maxctrl reload tls` command is executed.
 
 #### `admin_verify_url`
@@ -1911,19 +1911,19 @@ fetched until a `maxctrl reload tls` command is executed.
 
 URL to a server to which the REST API token verification is delegated.
 
-If the URL is defined, any tokens passed to the REST API will be validated by\
-doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client\
+If the URL is defined, any tokens passed to the REST API will be validated by
+doing a GET request to the URL with the client's token as a bearer token. The`Referer` header of the request is set to the URL being requested by the client
 and the custom `X-Referrer-Method` header is set to the HTTP method being used\
 (PUT, GET etc.).
 
-**Note**: When `admin_verify_url` is used and the remote server cannot\
-be accessed, all REST API access that uses tokens will be disabled. The\
-only way to use the REST API with tokens is to remove `admin_verify_url`\
-from the configuration which requires restarting MaxScale. The REST API\
-still accepts HTTP Basic Access authentication even if the remote server\
+**Note**: When `admin_verify_url` is used and the remote server cannot
+be accessed, all REST API access that uses tokens will be disabled. The
+only way to use the REST API with tokens is to remove `admin_verify_url`
+from the configuration which requires restarting MaxScale. The REST API
+still accepts HTTP Basic Access authentication even if the remote server
 cannot be reached.
 
-By delegating the authentication and authorization of the REST API to an\
+By delegating the authentication and authorization of the REST API to an
 external server, users can implement custom access control systems for the\
 MaxScale REST API.
 
@@ -1934,9 +1934,9 @@ MaxScale REST API.
 * Dynamic: No
 * Default: `maxscale`
 
-The issuer (`"iss"`) claim of all JWTs generated by MaxScale. This can be set\
-to a custom value to uniquely identify which MaxScale issued a JWT. This is\
-especially useful for cases where the MaxScale GUI is used from behind\
+The issuer (`"iss"`) claim of all JWTs generated by MaxScale. This can be set
+to a custom value to uniquely identify which MaxScale issued a JWT. This is
+especially useful for cases where the MaxScale GUI is used from behind
 a reverse proxy.
 
 #### `admin_audit`
@@ -1957,8 +1957,8 @@ Enable logging of incoming REST API calls.
 
 The file where the REST API auditing information is logged.
 
-If a non-default value is used, the directory where the file resides must\
-exist. For example, with `/var/log/maxscale/audit_files/audit.csv`, the\
+If a non-default value is used, the directory where the file resides must
+exist. For example, with `/var/log/maxscale/audit_files/audit.csv`, the
 directory `/var/log/maxscale/audit_files` must exist.
 
 #### `admin_audit_exclude_methods`
@@ -1972,9 +1972,9 @@ directory `/var/log/maxscale/audit_files` must exist.
 List of comma separated HTTP methods to exclude from logging\
 Currently MaxScale does not use `CONNECT` or `TRACE`.
 
-Resetting to log all methods can be done in the configuration file by\
+Resetting to log all methods can be done in the configuration file by
 writing `admin_audit_exclude_methods=` or at runtime with`maxctrl alter maxscale admin_audit_exclude_methods=`.\
-Remember that once a runtime change has been made, the entry for that\
+Remember that once a runtime change has been made, the entry for that
 setting is ignored in the main configuration file (usually maxscale.cnf).
 
 #### `config_sync_cluster`
@@ -1984,10 +1984,10 @@ setting is ignored in the main configuration file (usually maxscale.cnf).
 * Dynamic: Yes
 * Default: None
 
-This parameter controls which cluster (i.e. monitor) is used to synchronize\
+This parameter controls which cluster (i.e. monitor) is used to synchronize
 configuration changes between MaxScale instances. The first server labeled`Master` will be used for the synchronization.
 
-By default configuration synchronization is not enabled and it must be\
+By default configuration synchronization is not enabled and it must be
 explicitly enabled by defining a monitor name for `config_sync_cluster`.
 
 When `config_sync_cluster` is defined, `config_sync_user` and`config_sync_password` must also be defined.
@@ -2002,8 +2002,8 @@ Synchronization](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configurat
 * Dynamic: Yes
 * Default: None
 
-The username for the account that is used to synchronize configuration changes\
-across MaxScale instances. Both this parameter and `config_sync_password` are\
+The username for the account that is used to synchronize configuration changes
+across MaxScale instances. Both this parameter and `config_sync_password` are
 required if `config_sync_cluster` is configured.
 
 This account must have the following grants:
@@ -2012,7 +2012,7 @@ This account must have the following grants:
 GRANT SELECT, INSERT, UPDATE, CREATE ON `mysql`.`maxscale_config`
 ```
 
-The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`\
+The `mysql.maxscale_config` table can be pre-created in which case the `CREATE`
 grant is not needed by the user configured in `config_sync_user`. The following\
 SQL is used to create the table.
 
@@ -2026,7 +2026,7 @@ CREATE TABLE IF NOT EXISTS mysql.maxscale_config(
 ) ENGINE=InnoDB;
 ```
 
-If the database where the table is created is changed with `config_sync_db`, the\
+If the database where the table is created is changed with `config_sync_db`, the
 grants must be adjusted to target that database instead.
 
 #### `config_sync_password`
@@ -2036,8 +2036,8 @@ grants must be adjusted to target that database instead.
 * Dynamic: Yes
 * Default: None
 
-The password for `config_sync_user`. Both this parameter and `config_sync_user`\
-are required if `config_sync_cluster` is configured. This password can\
+The password for `config_sync_user`. Both this parameter and `config_sync_user`
+are required if `config_sync_cluster` is configured. This password can
 optionally be encrypted using `maxpasswd`.
 
 #### `config_sync_db`
@@ -2047,13 +2047,13 @@ optionally be encrypted using `maxpasswd`.
 * Dynamic: No
 * Default: `mysql`
 
-The database where the `maxscale_config` table is created. By default the table\
-is created in the `mysql` database. This parameter was added in MaxScale\
+The database where the `maxscale_config` table is created. By default the table
+is created in the `mysql` database. This parameter was added in MaxScale
 versions 6.4.6 and 22.08.5.
 
-As tables in the `mysql` database cannot have triggers on them, the database\
+As tables in the `mysql` database cannot have triggers on them, the database
 must be changed to a user-created one in order to create triggers on the table.\
-An example use-case for triggers on this table is to track all configuration\
+An example use-case for triggers on this table is to track all configuration
 changes done to MaxScale by inserting them into a separate table.
 
 #### `config_sync_interval`
@@ -2065,9 +2065,9 @@ changes done to MaxScale by inserting them into a separate table.
 
 How often to synchronize the configuration with the cluster.
 
-As the synchronization involves selecting the configuration version from the\
-database, this value should not be set to an unreasonably low value. The default\
-value of 5 second should provide a good compromise between responsiveness and\
+As the synchronization involves selecting the configuration version from the
+database, this value should not be set to an unreasonably low value. The default
+value of 5 second should provide a good compromise between responsiveness and
 how much load it places on the database.
 
 #### `config_sync_timeout`
@@ -2077,8 +2077,8 @@ how much load it places on the database.
 * Dynamic: Yes
 * Default: `10s`
 
-Timeout for all SQL operations done during the configuration synchronization. If\
-an operation exceeds this timeout, the configuration change is treated as failed\
+Timeout for all SQL operations done during the configuration synchronization. If
+an operation exceeds this timeout, the configuration change is treated as failed
 and an error is reported to the client that did the change.
 
 #### `key_manager`
@@ -2093,13 +2093,13 @@ The encryption key manager to use. The available encryption key managers are:
 * `none` - No key manager, encryption keys are not available.
 * `file` - [File-based key manager](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#file-based-key-manager)
 * `kmip` - [KMIP key manager](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#kmip-key-manager)
-* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This\
-  key manager is only included on systems with GCC 9 or newer which\
+* `vault` - [HashiCorp Vault key manager](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#hashicorp-vault-key-manager). This
+  key manager is only included on systems with GCC 9 or newer which
   means it cannot be used on Ubuntu 18.04.
 
-Refer to the [Encryption Key Managers](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for\
-more information on how to configure the key managers. The key managers each\
-have their configuration in their own namespace and must have their name as a\
+Refer to the [Encryption Key Managers](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#encryption-key-managers) section for
+more information on how to configure the key managers. The key managers each
+have their configuration in their own namespace and must have their name as a
 prefix.
 
 For example to configure the `file` key manager, the following must be used:
@@ -2111,16 +2111,16 @@ file.keyfile=/path/to/keyfile
 
 ### Events
 
-MaxScale logs warnings and errors for various reasons and often it is self-\
-evident and generally applicable whether some occurrence should warrant a\
+MaxScale logs warnings and errors for various reasons and often it is self-
+evident and generally applicable whether some occurrence should warrant a
 warning or an error, or perhaps just an info-level message.
 
-However, there are events whose seriousness is not self-evident. For\
-instance, in some environments an authentication failure may simply indicate\
-that someone has made a typo, while in some other environment that can only\
+However, there are events whose seriousness is not self-evident. For
+instance, in some environments an authentication failure may simply indicate
+that someone has made a typo, while in some other environment that can only
 happen in case there has been a security breech.
 
-To handle events like these, MaxScale defines _events_ whose logging\
+To handle events like these, MaxScale defines _events_ whose logging
 facility and level can be controlled by the administrator. Given an event`X`, its facility and level are controlled in the following manner:
 
 ```
@@ -2128,21 +2128,21 @@ event.X.facility=LOG_LOCAL0
 event.X.level=LOG_ERR
 ```
 
-The above means that if event _X_ occurs, then that is logged using the\
+The above means that if event _X_ occurs, then that is logged using the
 facility `LOG_LOCAL0` and the level `LOG_ERR`.
 
-The valid values of facility`are the facility values reported by`man\
+The valid values of facility`are the facility values reported by`man
 syslog`, e.g.`LOG\_AUTH`,`LOG\_LOCAL0`and`LOG\_USER`. Likewise, the valid values for`level`are the ones also reported by`man syslog`, e.g.`LOG\_WARNING`,`LOG\_ERR`and`LOG\_CRIT\`.
 
-Note that MaxScale does not act upon the level, that is, even if the level\
-of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut\
+Note that MaxScale does not act upon the level, that is, even if the level
+of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut
 down if that event occurs.
 
 The default facility is `LOG_USER` and the default level is `LOG_WARNING`.
 
-Note that you may also have to configure `rsyslog` to ensure that the\
-event can be logged to the intended log file. For instance, if the facility\
-is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line\
+Note that you may also have to configure `rsyslog` to ensure that the
+event can be logged to the intended log file. For instance, if the facility
+is chosen to be `LOG_AUTH`, then `/etc/rsyslog.conf` should contain a line
 like
 
 ```
@@ -2164,22 +2164,22 @@ event.authentication_failure.level=LOG_CRIT
 
 ### Service
 
-A service represents the database service that MariaDB MaxScale offers to the\
-clients. In general a service consists of a set of backend database servers and\
-a routing algorithm that determines how MariaDB MaxScale decides to send\
+A service represents the database service that MariaDB MaxScale offers to the
+clients. In general a service consists of a set of backend database servers and
+a routing algorithm that determines how MariaDB MaxScale decides to send
 statements or route connections to those backend servers.
 
-A service may be considered as a virtual database server that MariaDB MaxScale\
+A service may be considered as a virtual database server that MariaDB MaxScale
 makes available to its clients.
 
 Several different services may be defined using the same set of backend servers.\
-For example a connection based routing service might be used by clients that\
-already performed internal read/write splitting, whilst a different statement\
-based router may be used by clients that are not written with this functionality\
-in place. Both sets of applications could access the same data in the same\
+For example a connection based routing service might be used by clients that
+already performed internal read/write splitting, whilst a different statement
+based router may be used by clients that are not written with this functionality
+in place. Both sets of applications could access the same data in the same
 databases.
 
-A service is identified by a service name, which is the name of the\
+A service is identified by a service name, which is the name of the
 configuration file section and a type parameter of service.
 
 ```
@@ -2187,9 +2187,9 @@ configuration file section and a type parameter of service.
 type=service
 ```
 
-In order for MariaDB MaxScale to forward any requests it must have at least one\
-service defined within the configuration file. The definition of a service alone\
-is not enough to allow MariaDB MaxScale to forward requests however, the service\
+In order for MariaDB MaxScale to forward any requests it must have at least one
+service defined within the configuration file. The definition of a service alone
+is not enough to allow MariaDB MaxScale to forward requests however, the service
 is merely present to link together the other configuration elements.
 
 #### `router`
@@ -2198,15 +2198,15 @@ is merely present to link together the other configuration elements.
 * Mandatory: Yes
 * Dynamic: No
 
-The router parameter of a service defines the name of the router module that\
+The router parameter of a service defines the name of the router module that
 will be used to implement the routing algorithm between the client of MariaDB\
-MaxScale and the backend databases. Additionally routers may also be passed a\
-comma separated list of options that are used to control the behavior of the\
-routing algorithm. The two parameters that control the routing choice are router\
-and router\_options. The router options are specific to a particular router and\
-are used to modify the behavior of the router. The read connection router can be\
-passed options of `master`, `slave` or `synced`, an example of configuring a service\
-to use this router and limiting the choice of servers to those in `slave` state\
+MaxScale and the backend databases. Additionally routers may also be passed a
+comma separated list of options that are used to control the behavior of the
+routing algorithm. The two parameters that control the routing choice are router
+and router\_options. The router options are specific to a particular router and
+are used to modify the behavior of the router. The read connection router can be
+passed options of `master`, `slave` or `synced`, an example of configuring a service
+to use this router and limiting the choice of servers to those in `slave` state
 would be as follows.
 
 ```
@@ -2214,7 +2214,7 @@ router=readconnroute
 router_options=slave
 ```
 
-To change the router to connect on to servers in the `master` state as well as\
+To change the router to connect on to servers in the `master` state as well as
 slave servers, the router options can be modified to include the `master` state.
 
 ```
@@ -2222,7 +2222,7 @@ router=readconnroute
 router_options=master,slave
 ```
 
-A more complete description of router options and what is available for a given\
+A more complete description of router options and what is available for a given
 router is included with the documentation of the router itself.
 
 #### `filters`
@@ -2232,17 +2232,17 @@ router is included with the documentation of the router itself.
 * Dynamic: Yes
 * Default: None
 
-The filters option allow a set of filters to be defined for a service; requests\
-from the client are passed through these filters before being sent to the router\
-for dispatch to the backend server. The filters parameter takes one or more\
-filter names, as defined within the filter definition section of the\
+The filters option allow a set of filters to be defined for a service; requests
+from the client are passed through these filters before being sent to the router
+for dispatch to the backend server. The filters parameter takes one or more
+filter names, as defined within the filter definition section of the
 configuration file. Multiple filters are separated using the | character.
 
 ```
 filters=counter | QLA
 ```
 
-The requests pass through the filters from left to right in the order defined in\
+The requests pass through the filters from left to right in the order defined in
 the configuration parameter.
 
 #### `targets`
@@ -2252,7 +2252,7 @@ the configuration parameter.
 * Dynamic: Yes
 * Default: None
 
-The `targets` parameter is a comma separated list of server and/or service names\
+The `targets` parameter is a comma separated list of server and/or service names
 that comprise the routing targets of the service. This parameter was added in\
 MaxScale 2.5.0.
 
@@ -2260,9 +2260,9 @@ MaxScale 2.5.0.
 targets=My-Service,server2
 ```
 
-This parameter allows nested service configurations to be defined without having\
-to configure listeners for all services. For example, one use-case is to use\
-multiple readwritesplit services behind a schemarouter service to have both the\
+This parameter allows nested service configurations to be defined without having
+to configure listeners for all services. For example, one use-case is to use
+multiple readwritesplit services behind a schemarouter service to have both the
 sharding of schemarouter with the high-availability of readwritesplit.
 
 **NOTE:** The `targets` parameter is mutually exclusive with the `cluster` and`servers` parameters.
@@ -2274,8 +2274,8 @@ sharding of schemarouter with the high-availability of readwritesplit.
 * Dynamic: Yes
 * Default: None
 
-The servers parameter in a service definition provides a comma separated list of\
-the backend servers that comprise the service. The server names are those used\
+The servers parameter in a service definition provides a comma separated list of
+the backend servers that comprise the service. The server names are those used
 in the name section of a block with a type parameter of server (see below).
 
 ```
@@ -2291,7 +2291,7 @@ servers=server1,server2,server3
 * Dynamic: Yes
 * Default: None
 
-The servers the service uses are defined by the monitor specified as value\
+The servers the service uses are defined by the monitor specified as value
 of this configuration parameter.
 
 ```
@@ -2306,7 +2306,7 @@ cluster=TheMonitor
 * Mandatory: Yes
 * Dynamic: Yes
 
-This setting defines the _user_ the service uses to fetch user account\
+This setting defines the _user_ the service uses to fetch user account
 information from backends. A _password_ is specified using [password](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#password).
 
 ```
@@ -2314,8 +2314,8 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-25-01-authenticators/README.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-25-01-authenticators/README.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
 #### `password`
@@ -2324,9 +2324,9 @@ regarding user account management and client authentication.
 * Mandatory: Yes
 * Dynamic: Yes
 
-This settings defines the _password_ the service uses to fetch user account\
-information from backends. The _password_ may be either a plain text password or\
-an [encrypted password](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified\
+This settings defines the _password_ the service uses to fetch user account
+information from backends. The _password_ may be either a plain text password or
+an [encrypted password](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#encrypting-passwords). The _user_ is specified
 using [user](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#user).
 
 ```
@@ -2334,20 +2334,20 @@ user=maxscale
 password=Mhu87p2D
 ```
 
-See [MySQL protocol authentication documentation](../mariadb-maxscale-25-01-authenticators/README.md)\
-for more information (such as required grants) and troubleshooting tips\
+See [MySQL protocol authentication documentation](../mariadb-maxscale-25-01-authenticators/README.md)
+for more information (such as required grants) and troubleshooting tips
 regarding user account management and client authentication.
 
-From 23.08.0 onwards, MaxScale will remember the previous password when the\
-password is changed. If the fetching of the user account information fails\
-using the new password, it will be attempted using the previous one. The purpose\
-of this change is to make it a smoother operation to change the password of\
+From 23.08.0 onwards, MaxScale will remember the previous password when the
+password is changed. If the fetching of the user account information fails
+using the new password, it will be attempted using the previous one. The purpose
+of this change is to make it a smoother operation to change the password of
 the service user. The steps are as follows:
 
 1. `$ maxctrl alter service MyService password=TheNewPassword`
 2. `MariaDB [(none)]> set password for TheServiceUser = password('TheNewPassword');`
 
-Since the old password is remembered and used if the new password does not\
+Since the old password is remembered and used if the new password does not
 work, it is no longer necessary to perform those steps simultaneously.
 
 #### `enable_root_user`
@@ -2371,7 +2371,7 @@ Deprecated and ignored.
 * Dynamic: No
 * Default: None
 
-This parameter sets a custom version string that is sent in the MySQL Handshake\
+This parameter sets a custom version string that is sent in the MySQL Handshake
 from MariaDB MaxScale to clients.
 
 Example:
@@ -2380,13 +2380,13 @@ Example:
 version_string=10.11.2-MariaDB-RWsplit
 ```
 
-If not set, MaxScale will attempt to use a version string from the\
-backend databases by selecting the version string of the database with\
+If not set, MaxScale will attempt to use a version string from the
+backend databases by selecting the version string of the database with
 the lowest version number. If the selected version is from the MariaDB\
 10 series, a `5.5.5-` prefix will be added to it similarly to how the\
 MariaDB 10 series versions added it.
 
-If MaxScale has not been able to connect to a single database and the\
+If MaxScale has not been able to connect to a single database and the
 versions are unknown, the default value of `5.5.5-10.4.32 <MaxScale version>-maxscale` is used where `<MaxScale version>` is the version of\
 MaxScale.
 
@@ -2397,15 +2397,15 @@ MaxScale.
 * Dynamic: Yes
 * Default: `false`
 
-This parameter controls whether only a single server or all of the servers are\
+This parameter controls whether only a single server or all of the servers are
 used when loading the users from the backend servers.
 
-By default MaxScale uses the first server labeled as `Master` as the source of\
-the authentication data. When this option is enabled, the authentication data is\
+By default MaxScale uses the first server labeled as `Master` as the source of
+the authentication data. When this option is enabled, the authentication data is
 loaded from all the servers and combined into one big data set.
 
-**Note:** This parameter was deprecated in MaxScale 24.02.0 but it was then\
-un-deprecated as there were still uses for it. Modules that required this to\
+**Note:** This parameter was deprecated in MaxScale 24.02.0 but it was then
+un-deprecated as there were still uses for it. Modules that required this to
 function correctly (e.g. schemarouter) now automatically enable it.
 
 #### `strip_db_esc`
@@ -2415,7 +2415,7 @@ function correctly (e.g. schemarouter) now automatically enable it.
 * Dynamic: Yes
 * Default: `true`
 
-**Note:** This parameter has been deprecated in MaxScale 23.08. The stripping of\
+**Note:** This parameter has been deprecated in MaxScale 23.08. The stripping of
 escape characters is in all known cases the correct thing to do.
 
 This setting controls whether escape characters (`\`) are removed from database\
@@ -2423,12 +2423,12 @@ names when loading user grants from a backend server. When enabled, a grant\
 such as `grant select on` test\_`.* to 'user'@'%';` is read as `grant select on` test\_`.* to 'user'@'%';`
 
 This setting has no effect on database-level grants fetched from a MariaDB\
-Server. The database names of a MariaDB Server are compared using the LIKE\
-operator to properly handle wildcards and escaped wildcards. This setting may\
-affect database names in table and column level grants, although these typically\
+Server. The database names of a MariaDB Server are compared using the LIKE
+operator to properly handle wildcards and escaped wildcards. This setting may
+affect database names in table and column level grants, although these typically
 do not contain backlashes.
 
-Some visual database management tools automatically escape some characters and\
+Some visual database management tools automatically escape some characters and
 this might cause conflicts when MaxScale tries to authenticate users.
 
 #### `log_auth_warnings`
@@ -2438,8 +2438,8 @@ this might cause conflicts when MaxScale tries to authenticate users.
 * Dynamic: Yes
 * Default: `true`
 
-Enable or disable the logging of authentication failures and warnings. If\
-enabled, messages about failed authentication attempts will be logged with\
+Enable or disable the logging of authentication failures and warnings. If
+enabled, messages about failed authentication attempts will be logged with
 details about who tried to connect to MariaDB MaxScale and from where.
 
 #### `log_warning`
@@ -2449,10 +2449,10 @@ details about who tried to connect to MariaDB MaxScale and from where.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log warning messages even if the global\
+When enabled, this allows a service to log warning messages even if the global
 log level configuration disables them.
 
-Note that disabling the service level logging does not override the global\
+Note that disabling the service level logging does not override the global
 logging configuration: with `log_warning=false` in the service and`log_warning=true` globally, warnings will still be logged for all services.
 
 #### `log_notice`
@@ -2462,7 +2462,7 @@ logging configuration: with `log_warning=false` in the service and`log_warning=t
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log notice messages even if the global\
+When enabled, this allows a service to log notice messages even if the global
 log level configuration disables them.
 
 #### `log_info`
@@ -2472,7 +2472,7 @@ log level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log info messages even if the global log\
+When enabled, this allows a service to log info messages even if the global log
 level configuration disables them.
 
 #### `log_debug`
@@ -2482,10 +2482,10 @@ level configuration disables them.
 * Dynamic: Yes
 * Default: `false`
 
-When enabled, this allows a service to log debug messages even if the global log\
+When enabled, this allows a service to log debug messages even if the global log
 level configuration disables them.
 
-Debug messages are only enabled for debug builds. Enabling `log_debug` in a\
+Debug messages are only enabled for debug builds. Enabling `log_debug` in a
 release build does nothing.
 
 #### `wait_timeout`
@@ -2496,33 +2496,33 @@ release build does nothing.
 * Default: `28800s` (>= MaxScale 24.02.5, 25.01.2), `0s` (<= MaxScale 24.02.4, 25.01.1)
 * Auto tune: [Yes](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#auto_tune)
 
-The wait\_timeout parameter is used to disconnect sessions to MariaDB MaxScale\
-that have been idle for too long. The session timeout is set to 28800 seconds by\
+The wait\_timeout parameter is used to disconnect sessions to MariaDB MaxScale
+that have been idle for too long. The session timeout is set to 28800 seconds by
 default. A value of zero is interpreted as no timeout.
 
-This parameter used to be called `connection_timeout` and this name is still\
+This parameter used to be called `connection_timeout` and this name is still
 accepted as an alias for `wait_timeout`. The old name has been deprecated in\
 MaxScale 23.08.
 
-The default value of `wait_timeout` changed from `0s` to `28800s` in MaxScale\
+The default value of `wait_timeout` changed from `0s` to `28800s` in MaxScale
 versions 24.02.5 and 25.01.2 to match the default value of MariaDB\
 ([MXS-5530](https://jira.mariadb.org/browse/MXS-5530)).
 
-Note that since the granularity of the timeout is seconds, a timeout specified\
+Note that since the granularity of the timeout is seconds, a timeout specified
 in milliseconds will be rejected, even if the duration is longer than a second.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `wait_timeout` for those is not used.
 
-The value of `wait_timeout` in MaxScale should be lower than the lowest`wait_timeout` value on the backend servers. This way idle clients are\
-disconnected by MaxScale before the backend servers have to close them. Any\
-client-side idle timeouts (e.g. maximum lifetime for connection pools) should be\
-lower than `wait_timeout` in both MaxScale and MariaDB. This way the client\
-application will end up closing the connection itself which most of the time\
+The value of `wait_timeout` in MaxScale should be lower than the lowest`wait_timeout` value on the backend servers. This way idle clients are
+disconnected by MaxScale before the backend servers have to close them. Any
+client-side idle timeouts (e.g. maximum lifetime for connection pools) should be
+lower than `wait_timeout` in both MaxScale and MariaDB. This way the client
+application will end up closing the connection itself which most of the time
 results in better and more helpful error messages.
 
-**Warning:** If a connection is idle for longer than the configured connection\
+**Warning:** If a connection is idle for longer than the configured connection
 timeout, it will be forcefully disconnected and a warning will be logged in the\
 MaxScale log file.
 
@@ -2542,15 +2542,15 @@ wait_timeout=300s
 * Minimum: 0 in MaxScale, 1 in MaxScale Lite.
 * Maximum: Unlimited in MaxScale, 15 in MaxScale Lite.
 
-The maximum number of simultaneous connections MaxScale should permit to this\
-service. Any attempt to make more connections after the limit is reached will\
+The maximum number of simultaneous connections MaxScale should permit to this
+service. Any attempt to make more connections after the limit is reached will
 result in a "Too many connections" error being returned.
 
-A value of 0 means no limit, which is the default for MaxScale. MaxScale Lite\
+A value of 0 means no limit, which is the default for MaxScale. MaxScale Lite
 is limited to a maximum of 15 connections per service.
 
-**Warning**: In MaxScale 2.5, it is possible that the number of concurrent\
-connections temporarily exceeds the value of `max_connections`. This has been\
+**Warning**: In MaxScale 2.5, it is possible that the number of concurrent
+connections temporarily exceeds the value of `max_connections`. This has been
 fixed in MaxScale 6.
 
 Example:
@@ -2567,25 +2567,25 @@ max_connections=100
 * Dynamic: Yes
 * Default: `false`
 
-\*_Note:_ This parameter has been deprecated in MaxScale 23.08 as the feature is\
-now used automatically if needed. In addition, the session tracking no longer\
-needs to be enabled in MariaDB for the transaction state tracking to work\
+\*_Note:_ This parameter has been deprecated in MaxScale 23.08 as the feature is
+now used automatically if needed. In addition, the session tracking no longer
+needs to be enabled in MariaDB for the transaction state tracking to work
 correctly.
 
 Enable transaction state tracking by offloading it to the backend servers.\
-Getting the transaction state from the server will be more accurate for stored\
-procedures or multi-statement SQL that modifies the transaction state\
+Getting the transaction state from the server will be more accurate for stored
+procedures or multi-statement SQL that modifies the transaction state
 non-atomically.
 
-In general, it is better to avoid using this type of SQL as tracking the\
-transaction state via the server responses is not compatible with features such\
-as `transaction_replay` in readwritesplit. `session_track_trx_state` should only\
-be enabled if the default transaction tracking done by MaxScale does not produce\
+In general, it is better to avoid using this type of SQL as tracking the
+transaction state via the server responses is not compatible with features such
+as `transaction_replay` in readwritesplit. `session_track_trx_state` should only
+be enabled if the default transaction tracking done by MaxScale does not produce
 the desired outcome.
 
-This is only supported by MariaDB versions 10.3 or newer. The following must be\
-configured in the MariaDB server in order for this feature to work. Not\
-configuring the MariaDB server with it can result in the transaction state being\
+This is only supported by MariaDB versions 10.3 or newer. The following must be
+configured in the MariaDB server in order for this feature to work. Not
+configuring the MariaDB server with it can result in the transaction state being
 wrong in MaxScale which can result in data inconsistency.
 
 ```
@@ -2602,12 +2602,12 @@ session_track_transaction_info = CHARACTERISTICS
 
 How many statements MaxScale should store for each session of this service.\
 This overrides the value of the global setting with the same name. If`retain_last_statements` has been specified in the global section of the\
-MaxScale configuration file, then if it has _not_ been explicitly specified\
-for the service, the global value holds, otherwise the service specific\
-value rules. That is, it is possible to enable the setting globally and\
+MaxScale configuration file, then if it has _not_ been explicitly specified
+for the service, the global value holds, otherwise the service specific
+value rules. That is, it is possible to enable the setting globally and
 turn it off for a specific service, or just enable it for specific services.
 
-The value of this parameter can be changed at runtime using `maxctrl` and the\
+The value of this parameter can be changed at runtime using `maxctrl` and the
 new value will take effect for sessions created thereafter.
 
 ```
@@ -2622,38 +2622,38 @@ maxctrl alter service MyService retain_last_statements 5
 * Default: `300s`
 * Auto tune: [Yes](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#auto_tune)
 
-Keep idle connections alive by sending pings to backend servers. This feature\
-was introduced in MaxScale 2.5.0 where it was changed from a\
-readwritesplit-specific feature to a generic service feature. The default value\
+Keep idle connections alive by sending pings to backend servers. This feature
+was introduced in MaxScale 2.5.0 where it was changed from a
+readwritesplit-specific feature to a generic service feature. The default value
 for this parameter is 300 seconds. To disable this feature, set the value to 0.
 
-The keepalive interval is specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no\
+The keepalive interval is specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no
 explicit unit is provided, the value is interpreted as seconds in MaxScale\
-2.5. In subsequent versions a value without a unit may be rejected. Note that\
-since the granularity of the keepalive is seconds, a keepalive specified in\
+2.5. In subsequent versions a value without a unit may be rejected. Note that
+since the granularity of the keepalive is seconds, a keepalive specified in
 milliseconds will be rejected, even if the duration is longer than a second.
 
-The parameter value is the interval in seconds between each keepalive ping. A\
-keepalive ping will be sent to a backend server if the connection has been idle\
+The parameter value is the interval in seconds between each keepalive ping. A
+keepalive ping will be sent to a backend server if the connection has been idle
 for longer than the configured keepalive interval.
 
-Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client\
-has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings\
+Starting with MaxScale 2.5.21 and 6.4.0, the keepalive pings are not sent if the client
+has been idle for longer than the configured value of`connection_keepalive`. Older versions of MaxScale sent the keepalive pings
 regardless of the client state.
 
-This parameter only takes effect in top-level services. A top-level service is\
-the service where the listener that the client connected to points (i.e. the\
+This parameter only takes effect in top-level services. A top-level service is
+the service where the listener that the client connected to points (i.e. the
 value of `service` in the listener). If a service defines other services in its`targets` parameter, the `connection_keepalive` for those is not used.
 
-If the value of `connection_keepalive` is changed at runtime, the change in the\
+If the value of `connection_keepalive` is changed at runtime, the change in the
 value takes effect immediately.
 
-As the connection keepalive pings must be done only when there's no ongoing\
-query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that\
-rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the\
+As the connection keepalive pings must be done only when there's no ongoing
+query, all requests and responses must be tracked by MaxScale. In the case of`readconnroute`, this will incur a small drop in performance. For routers that
+rely on result tracking (e.g. `readwritesplit` and `schemarouter`), the
 performance will be the same with or without `connection_keepalive`.
 
-If you want to avoid the performance cost and you don't need the connection\
+If you want to avoid the performance cost and you don't need the connection
 keepalive feature, you can disable it with `connection_keepalive=0s`.
 
 #### `force_connection_keepalive`
@@ -2663,16 +2663,16 @@ keepalive feature, you can disable it with `connection_keepalive=0s`.
 * Dynamic: Yes
 * Default: `false`
 
-By default, connection keepalive pings are only sent if the client is either\
-executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are\
-unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can\
-be used to emulate the pre-2.5.21 behavior if long-lived application connections\
+By default, connection keepalive pings are only sent if the client is either
+executing a query or has been idle for less than the duration configured in`connection_keepalive`. When this parameter is enabled, keepalive pings are
+unconditionally sent to any backends that have been idle for longer than`connection_keepalive` seconds. This option was added in MaxScale 6.4.9 and can
+be used to emulate the pre-2.5.21 behavior if long-lived application connections
 rely on the old unconditional keepalive pings.
 
 _Note:_ if `force_connection_keepalive` is enabled and `connection_keepalive` in\
-MaxScale is set to a lower value than the `wait_timeout` on the database, the\
-client idle timeouts that `wait_timeout` control are no longer effective. This\
-happens because MaxScale unconditionally sends the pings which make the client\
+MaxScale is set to a lower value than the `wait_timeout` on the database, the
+client idle timeouts that `wait_timeout` control are no longer effective. This
+happens because MaxScale unconditionally sends the pings which make the client
 behave like it is not idle and thus the connections will never be killed due to`wait_timeout`.
 
 #### `net_write_timeout`
@@ -2682,17 +2682,17 @@ behave like it is not idle and thus the connections will never be killed due to`
 * Dynamic: Yes
 * Default: `0s`
 
-This parameter controls how long a network write to the client can stay\
+This parameter controls how long a network write to the client can stay
 buffered. This feature is disabled by default.
 
-When `net_write_timeout` is configured and data is buffered on the client\
-network connection, if the time since the last successful network write exceeds\
+When `net_write_timeout` is configured and data is buffered on the client
+network connection, if the time since the last successful network write exceeds
 the configured limit, the client connection will be disconnected.
 
-The value is specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The value is specified as documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `max_sescmd_history`
@@ -2702,45 +2702,45 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `50`
 
-`max_sescmd_history` sets a limit on how many distinct session commands are\
-stored in the session command history. When the history limit is exceeded, the\
-history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server\
+`max_sescmd_history` sets a limit on how many distinct session commands are
+stored in the session command history. When the history limit is exceeded, the
+history is either pruned to the last `max_sescmd_history` command (when`prune_sescmd_history` is enabled) or the history is disabled and server
 reconnections are no longer possible.
 
-The required history size can be estimated by counting the total number of\
-session state modifying commands (e.g `SET NAMES`) that are used by a\
-client. Note that connectors usually add some commands that aren't visible to\
-the application developer which means a safety margin should be added. A good\
-rule of thumb is to count the expected number of statements and double that\
-number. The default value of 50 is a value that'll work for most applications\
+The required history size can be estimated by counting the total number of
+session state modifying commands (e.g `SET NAMES`) that are used by a
+client. Note that connectors usually add some commands that aren't visible to
+the application developer which means a safety margin should be added. A good
+rule of thumb is to count the expected number of statements and double that
+number. The default value of 50 is a value that'll work for most applications
 that do not rely heavily on user variables.
 
-Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4\
-and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol\
-prepared statements opened by the client are also kept open by MaxScale and are\
+Starting with MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4
+and 24.08.1, binary protocol prepared statements do not count towards the`max_sescmd_history` limit. In practice this means that all binary protocol
+prepared statements opened by the client are also kept open by MaxScale and are
 restored whenever a reconnection to a server happens. The limits imposed by`max_sescmd_history` apply to other text protocol commands e.g. `SET NAMES`.\
-Note that text protocol prepared statements count as text protocol commands and\
-are thus potentially pruned when history pruning happens. If an application uses\
+Note that text protocol prepared statements count as text protocol commands and
+are thus potentially pruned when history pruning happens. If an application uses
 a lot of `PREPARE stmt FROM <sql>` commands, it is recommended that the value of`max_sescmd_history` is increased accordingly.
 
-In older versions of MaxScale, binary protocol prepared statements were limited\
-by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this\
-caused problems when the binary protocol prepared statement were pruned while\
-they were still open from the client's point of view. In older versions, the\
-recommended value of `max_sescmd_history` is the number of state modifying\
-commands plus the maximum number of open prepared statements that any application\
+In older versions of MaxScale, binary protocol prepared statements were limited
+by `max_sescmd_history` and were also pruned by `prune_sescmd_history` but this
+caused problems when the binary protocol prepared statement were pruned while
+they were still open from the client's point of view. In older versions, the
+recommended value of `max_sescmd_history` is the number of state modifying
+commands plus the maximum number of open prepared statements that any application
 may use.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
-In addition to limiting the number of commands to store, it also acts as a hard\
-limit on the number of packets that may be queued up on a backend before it is\
-closed. Packets are queued while the TCP socket is being opened and when\
-prepared statements are being prepared. In certain rare cases, a slow server may\
-fall behind and not catch up to the rest of the cluster and a backlog of packets\
-forms. In these cases, if more than `max_sescmd_history` packets are queued, the\
+In addition to limiting the number of commands to store, it also acts as a hard
+limit on the number of packets that may be queued up on a backend before it is
+closed. Packets are queued while the TCP socket is being opened and when
+prepared statements are being prepared. In certain rare cases, a slow server may
+fall behind and not catch up to the rest of the cluster and a backlog of packets
+forms. In these cases, if more than `max_sescmd_history` packets are queued, the
 connection to the server is closed.
 
 #### `prune_sescmd_history`
@@ -2750,24 +2750,24 @@ connection to the server is closed.
 * Dynamic: Yes
 * Default: `true`
 
-This option enables pruning of the session command history when it exceeds the\
-value configured in `max_sescmd_history`. When this option is enabled, only a\
-set number of statements are stored in the history. This limits the per-session\
+This option enables pruning of the session command history when it exceeds the
+value configured in `max_sescmd_history`. When this option is enabled, only a
+set number of statements are stored in the history. This limits the per-session
 memory use while still allowing safe reconnections.
 
-This parameter is intended to be used with pooled connections that remain in use\
-for a very long time. Most connection pool implementations do not reset the\
-session state and instead re-initialize it with new values. This causes the\
-session command history to grow at roughly a constant rate for the lifetime of\
+This parameter is intended to be used with pooled connections that remain in use
+for a very long time. Most connection pool implementations do not reset the
+session state and instead re-initialize it with new values. This causes the
+session command history to grow at roughly a constant rate for the lifetime of
 the pooled connection.
 
-Starting with MaxScale 23.08, the session command history is also simplified\
-before being stored. The simplification is done by removing repeated occurrences\
-of the same command and only executing the latest one of them. The order in\
-which the commands are executed still remains the same but inter-dependencies\
+Starting with MaxScale 23.08, the session command history is also simplified
+before being stored. The simplification is done by removing repeated occurrences
+of the same command and only executing the latest one of them. The order in
+which the commands are executed still remains the same but inter-dependencies
 between commands are not preserved.
 
-For example, the following set of commands demonstrates how the history\
+For example, the following set of commands demonstrates how the history
 simplification works and how inter-dependencies can be lost.
 
 ```
@@ -2776,45 +2776,45 @@ SET @my_home='My home is: ' || @my_planet;         -- Command #1 in the history
 SET @my_planet='Earth';                            -- Command #2 in the history
 ```
 
-In the example, the value of `@my_home` has a dependency on the value of`@my_planet` which is lost when the same statement is executed again and\
+In the example, the value of `@my_home` has a dependency on the value of`@my_planet` which is lost when the same statement is executed again and
 the history simplification removes the earlier one.
 
-This same problem can occur even in older versions of MaxScale that used\
-a sliding window of the history when the window moves past the statement\
-that later statement depended on. If inter-dependent session commands\
+This same problem can occur even in older versions of MaxScale that used
+a sliding window of the history when the window moves past the statement
+that later statement depended on. If inter-dependent session commands
 are being used, the history pruning should be disabled.
 
-Each client-side session that uses a pooled connection only executes a finite\
-amount of session commands. By retaining a shorter history that encompasses all\
-session commands the individual clients execute, the session state of a pooled\
+Each client-side session that uses a pooled connection only executes a finite
+amount of session commands. By retaining a shorter history that encompasses all
+session commands the individual clients execute, the session state of a pooled
 connection can be accurately recreated on another server.
 
-When the session command history pruning is enabled, there is a theoretical\
-possibility that upon server reconnection the session states of the connections\
-are inconsistent. This can only happen if the length of the stored history is\
-shorter than the list of relevant statements that affect the session state. In\
-practice the default value of 50 session commands is a fairly reasonable value\
+When the session command history pruning is enabled, there is a theoretical
+possibility that upon server reconnection the session states of the connections
+are inconsistent. This can only happen if the length of the stored history is
+shorter than the list of relevant statements that affect the session state. In
+practice the default value of 50 session commands is a fairly reasonable value
 and the risk of inconsistent session state is relatively low.
 
-In case the default history length is too short for safe pruning, set the value\
-of `max_sescmd_history` to the total number of commands that affect the session\
-state plus a safety margin of 10. The safety margin reserves some extra space\
-for new commands that might be executed due to changes in the client side\
+In case the default history length is too short for safe pruning, set the value
+of `max_sescmd_history` to the total number of commands that affect the session
+state plus a safety margin of 10. The safety margin reserves some extra space
+for new commands that might be executed due to changes in the client side
 application.
 
-Starting with MaxScale 24.02.1, the execution of simple session commands done\
-with binary protocol prepared statements are also stored in the history. A\
+Starting with MaxScale 24.02.1, the execution of simple session commands done
+with binary protocol prepared statements are also stored in the history. A
 simple session command in the binary protocol is one that:
 
 * Takes no parameters
 * Modifies the session state
 * Is executed while the original prepared statement is still in the history
 
-The same limitations that apply to the text protocol session commands apply to\
+The same limitations that apply to the text protocol session commands apply to
 the binary protocol session commands.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `disable_sescmd_history`
@@ -2824,17 +2824,17 @@ history. Currently only `readwritesplit` and `schemarouter` support it.
 * Dynamic: Yes
 * Default: `false`
 
-This option disables the session command history. This way no history is stored\
-and if a replica server fails, the router will not try to replace the failed\
-replica. Disabling session command history will allow long-lived connections\
+This option disables the session command history. This way no history is stored
+and if a replica server fails, the router will not try to replace the failed
+replica. Disabling session command history will allow long-lived connections
 without causing a constant growth in the memory consumption.
 
-This parameter should only be used when either the memory footprint must be as\
-small as possible or when the pruning of the session command history is not\
+This parameter should only be used when either the memory footprint must be as
+small as possible or when the pruning of the session command history is not
 acceptable.
 
-This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter\
-can be configured for all routers that support the session command\
+This parameter was moved into the MaxScale core in MaxScale 6.0. The parameter
+can be configured for all routers that support the session command
 history. Currently only `readwritesplit` and `schemarouter` support it.
 
 #### `user_accounts_file`
@@ -2851,25 +2851,25 @@ Default value is empty, which disables the feature.
 user_accounts_file=/home/root/users.json
 ```
 
-In addition to querying the backends, MaxScale can read users from a file. This\
-feature is useful when backends have limitations on the type of users that can\
-be created, or if MaxScale needs to allow users to log in even\
-when backends are down (e.g. binlog router). The users read from the file are\
-only present on MaxScale, so logging into backends can still fail. The format of\
-the file is protocol-specific. The following only applies to MariaDB-protocol,\
+In addition to querying the backends, MaxScale can read users from a file. This
+feature is useful when backends have limitations on the type of users that can
+be created, or if MaxScale needs to allow users to log in even
+when backends are down (e.g. binlog router). The users read from the file are
+only present on MaxScale, so logging into backends can still fail. The format of
+the file is protocol-specific. The following only applies to MariaDB-protocol,
 which is also the only protocol supporting this feature.
 
-The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which\
-contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at\
-least the string fields _user_ and _host_, which define the user account to add\
+The file contains json text. Three objects are read from it: _user_, _db_ and\_roles\_mapping\_, none of which are mandatory. These objects must be arrays which
+contain user information similar to the _mysql.user_, _mysql.db_ and\_mysql.roles\_mapping\_ tables on the server. Each array element must define at
+least the string fields _user_ and _host_, which define the user account to add
 or modify.
 
-The elements in the _user_-array may contain the following additional fields. If\
+The elements in the _user_-array may contain the following additional fields. If
 a field is not defined, it is assumed either empty (string) or false (boolean).
 
 * password: String. Password hash, similar to the equivalent column on server.
 * plugin: String. Authentication plugin used by client, similar to server.
-* authentication\_string: String. Additional authentication info, similar to\
+* authentication\_string: String. Additional authentication info, similar to
   server.
 * default\_role: String. Default role of user, similar to server.
 * super\_priv: Boolean. True if user has SUPER grant.
@@ -2879,17 +2879,17 @@ a field is not defined, it is assumed either empty (string) or false (boolean).
 
 The elements in the _db_-array must contain the following additional field:
 
-* db: String. Database which the user can access. Can contain % and \_\
+* db: String. Database which the user can access. Can contain % and \_
   wildcards.
 
-The elements in the _roles\_mapping_-array must contain the following additional\
+The elements in the _roles\_mapping_-array must contain the following additional
 field:
 
 * role: String. Role the user can access.
 
 When users are read from both servers and the file, the server takes priority.\
 That is, if user `'joe'@'%'` is defined on both, the file-version is discarded.\
-The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant\
+The file can still affect the database grants and roles of `'joe'@'%'`, as the\_db\_ and _roles\_mapping_-arrays are read separately and added to existing grant
 and role lists.
 
 An example users file is below.
@@ -2948,9 +2948,9 @@ Defines when _user\_accounts\_file_ is read. The value is an enum, either\
 read from a server. The file contents are then added to the server-based data.\
 If reading from server fails (e.g. servers are down), the file is ignored.
 
-"file\_only\_always" means that users are not read from the servers at all and the\
-file contents is all that matters. The state of the servers is ignored. This\
-mode can be useful with the binlog router, as it allows clients to log in and\
+"file\_only\_always" means that users are not read from the servers at all and the
+file contents is all that matters. The state of the servers is ignored. This
+mode can be useful with the binlog router, as it allows clients to log in and
 fetch binary logs from MaxScale even when backend servers are down.
 
 ```
@@ -2964,36 +2964,36 @@ user_accounts_file_usage=file_only_always
 * Dynamic: Yes
 * Default: `-1s`
 
-Normally, MaxScale only pools backend connections when\
-a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections\
+Normally, MaxScale only pools backend connections when
+a session is closed (controlled by server settings _persistpoolmax_ and\_persistmaxtime\_). Other sessions can use the pooled connections
 instead of creating new connections to backends. If connection sharing is enabled,\
-MaxScale can pool backend connections also from running sessions, and\
-re-attach a pooled connection when a session is doing a query. This effectively\
+MaxScale can pool backend connections also from running sessions, and
+re-attach a pooled connection when a session is doing a query. This effectively
 allows multiple sessions to share backend connections.
 
-_idle\_session\_pool\_time_ defines the amount of time a session must be idle\
-before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in\
+_idle\_session\_pool\_time_ defines the amount of time a session must be idle
+before its backend connections may be pooled. To enable connection sharing, set\_idle\_session\_pool\_time\_ to zero or greater. The value can be given in
 seconds or milliseconds.
 
-This feature has a significant drawback: when a backend connection is reused, it\
-needs to be restored to the correct state. This means reauthenticating and\
-replaying session commands. This can add a significant delay before the\
-connection is actually ready for a query. If the session command history size\
-exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for\
+This feature has a significant drawback: when a backend connection is reused, it
+needs to be restored to the correct state. This means reauthenticating and
+replaying session commands. This can add a significant delay before the
+connection is actually ready for a query. If the session command history size
+exceeds the value of _max\_sescmd\_history_, connection sharing is disabled for
 the session.
 
-This feature should only be used when limiting the backend connection count is\
-a priority, even at the cost of query delay and throughput. This feature only\
+This feature should only be used when limiting the backend connection count is
+a priority, even at the cost of query delay and throughput. This feature only
 works when the following server settings are also set in MaxScale configuration:
 
 1. [max\_routing\_connections](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#max_routing_connections)
 2. [persistpoolmax](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#persistpoolmax)
 3. [persistmaxtime](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#persistmaxtime)
 
-Since reusing a backend connection is an expensive operation, MaxScale only\
-pools connections when another session requires them. _idle\_session\_pool\_time_\
-thus effectively limits the frequency at which a connection can be moved from\
-one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to\
+Since reusing a backend connection is an expensive operation, MaxScale only
+pools connections when another session requires them. _idle\_session\_pool\_time_
+thus effectively limits the frequency at which a connection can be moved from
+one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to
 move connections as soon as possible.
 
 ```
@@ -3005,57 +3005,57 @@ See below for more information on configuring connection sharing.
 **Details, limitations and suggestions for connection sharing**
 
 As noted above, when a connection is pooled and reused its state is lost.\
-Although session variables and prepared statements are restored by replaying\
+Although session variables and prepared statements are restored by replaying
 session commands, some state information cannot be transferred.
 
-The most common such state is a transaction. When a transaction is on,\
+The most common such state is a transaction. When a transaction is on,
 connection sharing is disabled for that session until the transaction completes.\
-Other similar situations may not be properly detected, and it's the\
-responsibility of the user to avoid introducing such state to the session when\
+Other similar situations may not be properly detected, and it's the
+responsibility of the user to avoid introducing such state to the session when
 using connection sharing. This means that the following should not be used:
 
-* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that\
+* Statements such as `LOCK TABLES` and `GET LOCK` or any other statement that
   introduces state into the connection.
-* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector\
+* Temporary tables and some problematic user or session variables such as`LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector
   must be used instead of the variable.
 * Stored procedures that cause session level side-effects.
 
-Several settings affect connection sharing and its effectiveness. Reusing a\
-connection is an expensive operation so its frequency should be minimized. The\
+Several settings affect connection sharing and its effectiveness. Reusing a
+connection is an expensive operation so its frequency should be minimized. The
 important configuration settings in addition to _idle\_session\_pool\_time_ are\
 MaxScale server settings [persistpoolmax](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#persistpoolmax),[persistmaxtime](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#persistmaxtime) and [max\_routing\_connections](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#max_routing_connections).\
-The service settings [max\_sescmd\_history](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These\
+The service settings [max\_sescmd\_history](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#max_sescmd_history),[prune\_sescmd\_history](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These
 settings should be tuned according to the use case.
 
-_persistpoolmax_ limits how many connections can be kept in a pool for a given\
-server. If the pool is full, no more connections are detached from sessions even\
-if they are idle and required. The pool size should be large enough to contain\
+_persistpoolmax_ limits how many connections can be kept in a pool for a given
+server. If the pool is full, no more connections are detached from sessions even
+if they are idle and required. The pool size should be large enough to contain
 any connections being transferred between sessions, but not be greater than _max\_routing\_connections_. Using the value of _max\_routing\_connections_ is a
 reasonable starting point.
 
-_persistmaxtime_ limits the time a connection may stay in the pool. This should\
-be high enough so that pooled connections are not unnecessarily closed. Cleaning\
+_persistmaxtime_ limits the time a connection may stay in the pool. This should
+be high enough so that pooled connections are not unnecessarily closed. Cleaning
 up clearly unneeded connections from the pool may be useful when _max\_routing\_connections_ is restrictively tuned. Because each MaxScale routing
-thread has its own connection pool, one thread can monopolize access to a\
-server. For example, if the pool of thread 1 has 100 connections to _ServerA_\
-with `max_routing_connections=100`, other threads can no longer connect to the\
-server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as\
-it would cause unneeded connections in the pool to be closed faster. Such\
-connection slots then become available to other routing threads. Reducing the\
-number of [routing threads](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool\
-fragmentation. This may reduce overall throughput, though. When using connection\
+thread has its own connection pool, one thread can monopolize access to a
+server. For example, if the pool of thread 1 has 100 connections to _ServerA_
+with `max_routing_connections=100`, other threads can no longer connect to the
+server. In such a situation, reducing _persistmaxtime_ of _ServerA_ may help as
+it would cause unneeded connections in the pool to be closed faster. Such
+connection slots then become available to other routing threads. Reducing the
+number of [routing threads](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#threads) may also help, as it reduces pool
+fragmentation. This may reduce overall throughput, though. When using connection
 sharing, backend connections are only in the pool momentarily. Consequently,_persistmaxtime_ can be set quite low, e.g. 10s.
 
-If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is\
-disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find\
-a backend connection. This can be avoided with _prune\_sescmd\_history_. However,\
-pruning means that old session commands will not be replayed when a pooled\
-connection is reused. If the pruned commands are important\
+If a client session exceeds _max\_sescmd\_history_ (default 50), pooling is
+disabled for that session. If many sessions do this and\_max\_routing\_connections\_ is set, other sessions will stall as they cannot find
+a backend connection. This can be avoided with _prune\_sescmd\_history_. However,
+pruning means that old session commands will not be replayed when a pooled
+connection is reused. If the pruned commands are important
 (e.g. statement preparations), the session may fail later on.
 
 If the number of clients actively running queries is greater than _max\_routing\_connections_, query throughput will suffer as clients will need to
-take turns. In this situation, it's imperative to minimize the number of\
-backend connections a single session uses. The settings to achieve this depend\
+take turns. In this situation, it's imperative to minimize the number of
+backend connections a single session uses. The settings to achieve this depend
 on the router. For ReadWriteSplit the following should be used:
 
 ```
@@ -3064,12 +3064,12 @@ lazy_connect=1
 transaction_replay=true
 ```
 
-The above settings mean that MaxScale can process roughly\
-(_number of replica servers_ X _max\_routing\_connections_) read queries\
-simultaneously. Write queries will still need to take turns as there is only one\
+The above settings mean that MaxScale can process roughly
+(_number of replica servers_ X _max\_routing\_connections_) read queries
+simultaneously. Write queries will still need to take turns as there is only one
 primary server.
 
-The following configuration snippet shows example server and service\
+The following configuration snippet shows example server and service
 configurations for connection sharing with ReadWriteSplit.
 
 ```
@@ -3096,11 +3096,11 @@ lazy_connect=1
 * Dynamic: Yes
 * Default: `60s`
 
-When connection sharing (as described above) is on, clients\
-may have to wait for their turn to use a backend connection. If too much time\
-passes without a connection becoming available, MaxScale returns an error to\
-the client, usually also ending the session. _multiplex\_timeout_ sets this\
-timeout. Increase it if queries are failing with "Timed out when waiting for a\
+When connection sharing (as described above) is on, clients
+may have to wait for their turn to use a backend connection. If too much time
+passes without a connection becoming available, MaxScale returns an error to
+the client, usually also ending the session. _multiplex\_timeout_ sets this
+timeout. Increase it if queries are failing with "Timed out when waiting for a
 connection". Decrease it if failing early is preferable to stalling.
 
 ```
@@ -3109,10 +3109,10 @@ multiplex_timeout=33s
 
 ### Server
 
-Server sections define the backend database servers MaxScale uses. A server is\
-identified by its section name in the configuration file. The only mandatory\
-parameter of a server is _type_, but _address_ and _port_ are also usually\
-defined. A server may be a member of one or more services. A server may only be\
+Server sections define the backend database servers MaxScale uses. A server is
+identified by its section name in the configuration file. The only mandatory
+parameter of a server is _type_, but _address_ and _port_ are also usually
+defined. A server may be a member of one or more services. A server may only be
 monitored by at most one monitor.
 
 ```
@@ -3134,12 +3134,12 @@ Limitations:
 * Dynamic: Yes
 * Default: `""`
 
-The IP-address or hostname of the machine running the database server. MaxScale\
+The IP-address or hostname of the machine running the database server. MaxScale
 uses this address to connect to the server.
 
 Either _address_ or _socket_ must be defined, but not both.\
-If the address is given as a hostname, MaxScale will\
-perform name lookup on the hostname when starting and update the result every\
+If the address is given as a hostname, MaxScale will
+perform name lookup on the hostname when starting and update the result every
 minute and when the address changes.
 
 #### `port`
@@ -3149,7 +3149,7 @@ minute and when the address changes.
 * Dynamic: Yes
 * Default: `3306`
 
-The port the backend server listens on for incoming connections. MaxScale uses\
+The port the backend server listens on for incoming connections. MaxScale uses
 this port to connect to the server.
 
 #### `socket`
@@ -3159,7 +3159,7 @@ this port to connect to the server.
 * Dynamic: Yes
 * Default: `""`
 
-The absolute path to a UNIX domain socket the MariaDB server is listening\
+The absolute path to a UNIX domain socket the MariaDB server is listening
 on.
 
 #### `private_address`
@@ -3169,8 +3169,8 @@ on.
 * Dynamic: Yes
 * Default: `""`
 
-Alternative IP-address or hostname for the server. This is currently only used\
-by MariaDB Monitor to detect and set up replication. See [MariaDB Monitor documentation](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md)\
+Alternative IP-address or hostname for the server. This is currently only used
+by MariaDB Monitor to detect and set up replication. See [MariaDB Monitor documentation](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md)
 for more information.
 
 #### `monitoruser`
@@ -3180,9 +3180,9 @@ for more information.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitorpasswd](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -3197,9 +3197,9 @@ monitorpw=mymonitorpasswd
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitoruser](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific\
-credentials for monitoring the server. Monitors typically use the credentials in their\
-own configuration sections to connect to all servers. If server-specific settings are\
+This setting together with [monitoruser](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#monitoruser) define server-specific
+credentials for monitoring the server. Monitors typically use the credentials in their
+own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
 
 ```
@@ -3207,7 +3207,7 @@ monitoruser=mymonitoruser
 monitorpw=mymonitorpasswd
 ```
 
-`monitorpw` may be either a plain text password or an encrypted password. See\
+`monitorpw` may be either a plain text password or an encrypted password. See
 the section [encrypting passwords](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#encrypting-passwords) for more information.
 
 #### `extra_port`
@@ -3217,19 +3217,19 @@ the section [encrypting passwords](mariadb-maxscale-2501-maxscale-2501-mariadb-m
 * Dynamic: Yes
 * Default: `0`
 
-An alternative port used for administrative connections to the server. If this\
-setting is defined, MaxScale uses it for monitoring the server and to fetch user\
+An alternative port used for administrative connections to the server. If this
+setting is defined, MaxScale uses it for monitoring the server and to fetch user
 accounts. Client sessions will still use the normal port.
 
-Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on\
-the backend server has been reached. Extra-port connections have their own\
-connection limit, which is one by default. This needs to be increased to allow\
+Defining _extra\_port_ allows MaxScale to connect even when _max\_connections_ on
+the backend server has been reached. Extra-port connections have their own
+connection limit, which is one by default. This needs to be increased to allow
 both monitor and user account manager to connect.
 
-If the connection to the extra-port fails due to connection number limit or if\
+If the connection to the extra-port fails due to connection number limit or if
 the port is not open on the server, normal port is used.
 
-For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)\
+For more information, see [extra\_port](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables)
 and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-pool/thread-pool-system-status-variables#extra_max_connections).
 
 #### `persistpoolmax`
@@ -3240,15 +3240,15 @@ and [extra\_max\_connections](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-
 * Default: `0`
 
 Sets the size of the server connection pool. Disabled by default. When enabled,\
-MaxScale places unused connections to the server to a pool and reuses them\
-later. Connections typically become unused when a session closes. If the size of\
+MaxScale places unused connections to the server to a pool and reuses them
+later. Connections typically become unused when a session closes. If the size of
 the pool reaches _persistpoolmax_, unused connections are closed instead.
 
-Every routing thread has its own pool. As of version 6.3.0, MaxScale will round\
+Every routing thread has its own pool. As of version 6.3.0, MaxScale will round
 up _persistpoolmax_ so that every thread has an equal size pool.
 
-When a MariaDB-protocol connection is taken from the pool to be used in a new\
-session, the state of the connection is dependent on the router. ReadWriteSplit\
+When a MariaDB-protocol connection is taken from the pool to be used in a new
+session, the state of the connection is dependent on the router. ReadWriteSplit
 restores the connection to match the session state. Other routers do not.
 
 #### `persistmaxtime`
@@ -3258,15 +3258,15 @@ restores the connection to match the session state. Other routers do not.
 * Dynamic: Yes
 * Default: `0s`
 
-The `persistmaxtime` parameter defaults to zero but can be set to a duration as\
-documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is\
-interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a\
-unit may be rejected. Note that since the granularity of the parameter is\
-seconds, a value specified in milliseconds will be rejected, even if the\
+The `persistmaxtime` parameter defaults to zero but can be set to a duration as
+documented [here](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit is provided, the value is
+interpreted as seconds in MaxScale 2.4. In subsequent versions a value without a
+unit may be rejected. Note that since the granularity of the parameter is
+seconds, a value specified in milliseconds will be rejected, even if the
 duration is longer than a second.
 
-A DCB placed in the persistent pool for a server will only be reused if the\
-elapsed time since it joined the pool is less than the given value. Otherwise,\
+A DCB placed in the persistent pool for a server will only be reused if the
+elapsed time since it joined the pool is less than the given value. Otherwise,
 the DCB will be discarded and the connection closed.
 
 #### `max_routing_connections`
@@ -3278,19 +3278,19 @@ the DCB will be discarded and the connection closed.
 * Minimum: 0 in MaxScale, 1 in MaxScale Lite.
 * Maximum: Unlimited in MaxScale, 15 in MaxScale Lite.
 
-Maximum number of routing connections to this server. Connections held in a pool\
-also count towards this maximum. Does not limit monitor connections or user\
+Maximum number of routing connections to this server. Connections held in a pool
+also count towards this maximum. Does not limit monitor connections or user
 account fetching. A value of 0 means no limit, which is the default for MaxScale.\
 MaxScle Lite is limited to a maximum of 15 connections per server.
 
-Since every client session can generate a connection to a server, the server may\
-run out of memory when the number of clients is high enough. This setting limits\
-server memory use caused by MaxScale. The effect depends on if the service\
-setting [idle\_session\_pool\_time](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection\
+Since every client session can generate a connection to a server, the server may
+run out of memory when the number of clients is high enough. This setting limits
+server memory use caused by MaxScale. The effect depends on if the service
+setting [idle\_session\_pool\_time](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection
 sharing, is enabled or not.
 
 If connection sharing is not on, _max\_routing\_connections_ simply sets a limit.\
-Any sessions attempting to exceed this limit will fail to connect to the\
+Any sessions attempting to exceed this limit will fail to connect to the
 backend. The client can still connect to MaxScale, but queries will fail.
 
 If connection sharing is on, sessions exceeding the limit will be put on hold\
@@ -3308,37 +3308,37 @@ max_routing_connections=1234
 * Dynamic: Yes
 * Default: `false`
 
-If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-header when connecting client sessions to the server. The header contains the\
-original client IP address and port, as seen by MaxScale. The server will then\
-read the header and perform authentication as if the connection originated from\
-this address instead of MaxScale's IP address. With this feature, the user\
-accounts on the backend server can be simplified to only contain the actual\
+If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+header when connecting client sessions to the server. The header contains the
+original client IP address and port, as seen by MaxScale. The server will then
+read the header and perform authentication as if the connection originated from
+this address instead of MaxScale's IP address. With this feature, the user
+accounts on the backend server can be simplified to only contain the actual
 client hosts and not the MaxScale host.
 
-**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy\
-protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#proxy_protocol_networks) in MaxScale. This also needs\
-to be done whenever one MaxScale may connect to another Maxscale and the\
+**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy
+protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#proxy_protocol_networks) in MaxScale. This also needs
+to be done whenever one MaxScale may connect to another Maxscale and the
 connecting MaxScale has `proxy_protocol` enabled.
 
-PROXY protocol will be supported by MariaDB 10.3, which this feature has been\
-tested with. To use it, enable the PROXY protocol in MaxScale for every\
-compatible server and configure the MariaDB servers themselves to accept the\
-protocol headers from MaxScale's IP address. On the server side, the protocol\
-should be enabled only for trusted IPs, as it allows the sender to spoof the\
-connection origin. If a proxy header is sent to a server not expecting it, the\
-connection will fail. Usually PROXY protocol should be enabled for every\
+PROXY protocol will be supported by MariaDB 10.3, which this feature has been
+tested with. To use it, enable the PROXY protocol in MaxScale for every
+compatible server and configure the MariaDB servers themselves to accept the
+protocol headers from MaxScale's IP address. On the server side, the protocol
+should be enabled only for trusted IPs, as it allows the sender to spoof the
+connection origin. If a proxy header is sent to a server not expecting it, the
+connection will fail. Usually PROXY protocol should be enabled for every
 server in a cluster, as they typically have similar grants.
 
-Other SQL-servers may support PROXY protocol as well, but the implementation may\
-be highly restricting. Strict adherence to the protocol requires that the\
-backend server does not allow mixing of un-proxied and proxied connections from\
-a given IP. MaxScale requires normal connections to backends for monitoring and\
-authentication data queries, which would be blocked. To bypass this restriction,\
-the server monitor needs to be disabled and the service listener needs to be\
+Other SQL-servers may support PROXY protocol as well, but the implementation may
+be highly restricting. Strict adherence to the protocol requires that the
+backend server does not allow mixing of un-proxied and proxied connections from
+a given IP. MaxScale requires normal connections to backends for monitoring and
+authentication data queries, which would be blocked. To bypass this restriction,
+the server monitor needs to be disabled and the service listener needs to be
 configured to disregard authentication errors (`skip_authentication=true`).\
-Server states also need to be set manually in MaxCtrl. These steps are _not_\
-required for MariaDB 10.3, since its implementation is more flexible and allows\
+Server states also need to be set manually in MaxCtrl. These steps are _not_
+required for MariaDB 10.3, since its implementation is more flexible and allows
 both PROXY-headered and headerless connections from a proxy-enabled IP.
 
 #### `disk_space_threshold`
@@ -3348,30 +3348,30 @@ both PROXY-headered and headerless connections from a proxy-enabled IP.
 * Dynamic: No
 * Default: None
 
-This parameter specifies how full a disk may be, before MaxScale should start\
-logging warnings or take other actions (e.g. perform a switchover). This\
+This parameter specifies how full a disk may be, before MaxScale should start
+logging warnings or take other actions (e.g. perform a switchover). This
 functionality will only work with MariaDB server versions 10.1.32, 10.2.14 and\
 10.3.6 onwards, if the `DISKS` _information schema plugin_ has been installed.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-A limit is specified as a path followed by a colon and a percentage specifying\
+A limit is specified as a path followed by a colon and a percentage specifying
 how full the corresponding disk may be, before action is taken. E.g. an entry like
 
 ```
 /data:80
 ```
 
-specifies that the disk that has been mounted on `/data` may be used until 80%\
-of the total space has been consumed. Multiple entries can be specified by\
-separating them by a comma. If the path is specified using `*`, then the limit\
-applies to all disks. However, the value of `*` is only applied if there is not\
+specifies that the disk that has been mounted on `/data` may be used until 80%
+of the total space has been consumed. Multiple entries can be specified by
+separating them by a comma. If the path is specified using `*`, then the limit
+applies to all disks. However, the value of `*` is only applied if there is not
 an exact match.
 
-Note that if a particular disk has been mounted on several paths, only one path\
-need to be specified. If several are specified, then the one with the smallest\
+Note that if a particular disk has been mounted on several paths, only one path
+need to be specified. If several are specified, then the one with the smallest
 percentage will be applied.
 
 Examples:
@@ -3383,7 +3383,7 @@ disk_space_threshold=/data1:80,/data2:60,*:90
 ```
 
 The last line means that the disk mounted at `/data1` may be used up to\
-80%, the disk mounted at `/data2` may be used up to 60% and all other disks\
+80%, the disk mounted at `/data2` may be used up to 60% and all other disks
 mounted at any paths may be used up until 90% of maximum capacity, before\
 MaxScale starts to warn to take action.
 
@@ -3400,7 +3400,7 @@ Note that the path to be used, is one of the paths returned by:
 ...
 ```
 
-There is no default value, but this parameter must be explicitly specified\
+There is no default value, but this parameter must be explicitly specified
 if the disk space situation should be monitored.
 
 #### `rank`
@@ -3411,20 +3411,20 @@ if the disk space situation should be monitored.
 * Values: `primary`, `secondary`
 * Default: `primary`
 
-This parameter controls the order in which servers are used. Valid values for\
+This parameter controls the order in which servers are used. Valid values for
 this parameter are `primary` and `secondary`. The default value is`primary`.
 
-This behavior depends on the router implementation but the general rule of thumb\
+This behavior depends on the router implementation but the general rule of thumb
 is that primary servers will be used before secondary servers.
 
-Readconnroute will always use primary servers before secondary servers as long\
+Readconnroute will always use primary servers before secondary servers as long
 as they match the configured server type.
 
-Readwritesplit will pick servers that have the same rank as the current\
-primary. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md)\
+Readwritesplit will pick servers that have the same rank as the current
+primary. Read the [readwritesplit documentation on server ranks](../mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md)
 for a detailed description of the behavior.
 
-The following example server configuration demonstrates how `rank` can be used\
+The following example server configuration demonstrates how `rank` can be used
 to exclude `DR-site` servers from routing.
 
 ```
@@ -3449,7 +3449,7 @@ address=192.168.0.22
 rank=secondary
 ```
 
-The `main-site-primary` and `main-site-replica` servers will be used as long as\
+The `main-site-primary` and `main-site-replica` servers will be used as long as
 they are available. When they are no longer available, the `DR-site-primary` and`DR-site-replica` will be used.
 
 #### `priority`
@@ -3459,11 +3459,11 @@ they are available. When they are no longer available, the `DR-site-primary` and
 * Dynamic: Yes
 * Default: 0
 
-Server priority. Currently only used by galeramon to choose the order in which\
-nodes are selected as the current primary server. Refer to the [Server Priorities](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-galera-monitor.md)\
+Server priority. Currently only used by galeramon to choose the order in which
+nodes are selected as the current primary server. Refer to the [Server Priorities](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-galera-monitor.md)
 section of the galeramon documentation for more information on how to use it.
 
-Starting with MaxScale 2.5.21, this parameter also accepts negative values. In\
+Starting with MaxScale 2.5.21, this parameter also accepts negative values. In
 older versions, the parameter only accepted non-negative values.
 
 #### `replication_custom_options`
@@ -3473,33 +3473,33 @@ older versions, the parameter only accepted non-negative values.
 * Dynamic: Yes
 
 Server-specific custom string added to "CHANGE MASTER TO"-commands sent by\
-MariaDB Monitor. Overrides `replication_custom_options` setting set in\
-the monitor. This setting affects the server where the command is ran at, not\
-the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-\
-command to server A telling it to replicate from server B, the setting value\
+MariaDB Monitor. Overrides `replication_custom_options` setting set in
+the monitor. This setting affects the server where the command is ran at, not
+the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-
+command to server A telling it to replicate from server B, the setting value
 from MaxScale configuration for server A would be used.
 
-See [MariaDB Monitor documentation](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md)\
+See [MariaDB Monitor documentation](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md)
 for more information.
 
 ### Monitor
 
-Monitor sections are used to define the monitoring module that watches a set of\
+Monitor sections are used to define the monitoring module that watches a set of
 servers. Each server can only be monitored by one monitor.
 
 Common monitor parameters [can be found here](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md).
 
 ### Listener
 
-A listener defines a port MaxScale listens on for incoming connections. Accepted\
-connections are linked with a MaxScale service. Multiple listeners can feed the\
-same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface\
+A listener defines a port MaxScale listens on for incoming connections. Accepted
+connections are linked with a MaxScale service. Multiple listeners can feed the
+same service. Mandatory parameters are _type_, _service_ and _protocol_._address_ is optional, it limits connections to a certain network interface
 only. _socket_ is also optional and is used for Unix socket connections.
 
-The network socket where the listener listens may have a backlog of\
+The network socket where the listener listens may have a backlog of
 connections. The size of this backlog is controlled by the\_net.ipv4.tcp\_max\_syn\_backlog\_ and _net.core.somaxconn_ kernel parameters.
 
-Increasing the size of the backlog by modifying the kernel parameters helps with\
+Increasing the size of the backlog by modifying the kernel parameters helps with
 sudden connection spikes and rejected connections. For more information see [listen(2)](https://man7.org/linux/man-pages/man2/listen.2.html).
 
 ```
@@ -3515,7 +3515,7 @@ port=3006
 * Mandatory: Yes
 * Dynamic: No
 
-The service to which the listener is associated. This is the name of a service\
+The service to which the listener is associated. This is the name of a service
 that is defined elsewhere in the configuration file.
 
 #### `protocol`
@@ -3528,11 +3528,11 @@ that is defined elsewhere in the configuration file.
 The name of the protocol module used for communication between the client and\
 MaxScale. The same protocol is also used for backend communication.
 
-Usually this does not need to be defined as the default protocol is the MariaDB\
+Usually this does not need to be defined as the default protocol is the MariaDB
 network protocol that is used by SQL connections.
 
-For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL\
-protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md) module\
+For NoSQL client connections, the protocol must be set to`protocol=nosqlprotocol`. For more details on how to configure the NoSQL
+protocol, refer to the [NoSQL Protocol](../mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md) module
 documentation.
 
 #### `address`
@@ -3542,8 +3542,8 @@ documentation.
 * Dynamic: No
 * Default: `"::"`
 
-This sets the address the listening socket is bound to. The address may be\
-specified as an IP address in 'dot notation' or as a hostname. If left undefined\
+This sets the address the listening socket is bound to. The address may be
+specified as an IP address in 'dot notation' or as a hostname. If left undefined
 the listener will bind to all network interfaces.
 
 #### `port`
@@ -3553,7 +3553,7 @@ the listener will bind to all network interfaces.
 * Dynamic: No
 * Default: `0`
 
-The port the listener listens on. If left undefined a default port for the\
+The port the listener listens on. If left undefined a default port for the
 protocol is used.
 
 #### `socket`
@@ -3563,10 +3563,10 @@ protocol is used.
 * Dynamic: No
 * Default: `""`
 
-If defined, the listener uses Unix domain sockets to listen for incoming\
+If defined, the listener uses Unix domain sockets to listen for incoming
 connections. The parameter value is the name of the socket to use.
 
-If you want to use both network ports and UNIX domain sockets with a service,\
+If you want to use both network ports and UNIX domain sockets with a service,
 define two separate listeners that connect to the same service.
 
 #### `authenticator`
@@ -3576,9 +3576,9 @@ define two separate listeners that connect to the same service.
 * Dynamic: No
 * Default: `""`
 
-The authenticator module to use. Each protocol module defines a default\
+The authenticator module to use. Each protocol module defines a default
 authentication module, which is used if the setting is left undefined.\
-MariaDB and PostgreSQL protocols support multiple authenticators and they can\
+MariaDB and PostgreSQL protocols support multiple authenticators and they can
 be used simultaneously by giving a comma-separated list e.g.`authenticator=PAMAuth,mariadbauth,gssapiauth`
 
 #### `authenticator_options`
@@ -3588,8 +3588,8 @@ be used simultaneously by giving a comma-separated list e.g.`authenticator=PAMAu
 * Dynamic: No
 * Default: `""`
 
-This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of\
-this parameter should be a comma-separated list of key-value pairs. See\
+This defines additional options for authentication. As of MaxScale 2.5.0, only\_MariaDBClient\_ and its authenticators support additional options. The value of
+this parameter should be a comma-separated list of key-value pairs. See
 authenticator specific documentation for more details.
 
 #### `sql_mode`
@@ -3605,33 +3605,33 @@ If both are used this setting will override the global setting for this listener
 
 #### `proxy_protocol_networks`
 
-Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)\
-when connecting. The proxy header contains the original client IP-address and\
+Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+when connecting. The proxy header contains the original client IP-address and
 port, and MaxScale will use that information in its internal bookkeeping.\
-This means the client is authenticated as if it was connecting from the host\
-in the proxy header. If proxy protocol is also enabled in MaxScale server\
-settings, MaxScale will relay the original client address and port to\
+This means the client is authenticated as if it was connecting from the host
+in the proxy header. If proxy protocol is also enabled in MaxScale server
+settings, MaxScale will relay the original client address and port to
 the server. See [server settings](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#proxy_protocol) for more information.
 
-This setting may be useful if a compatible load balancer is relaying client\
-connections to MaxScale. If proxy headers are used, both MaxScale and the\
+This setting may be useful if a compatible load balancer is relaying client
+connections to MaxScale. If proxy headers are used, both MaxScale and the
 backends will know where the client originally came from.
 
-The `proxy_protocol_networks`-setting works similarly to the equivalent setting\
+The `proxy_protocol_networks`-setting works similarly to the equivalent setting
 in [MariaDB Server](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/server-client-software/client-libraries/proxy-protocol-support).\
 The value can be a single IP or subnetwork, or a comma-separated list of them.\
-Subnetworks are given in CIDR-format, e.g. "192.168.0.0/16". "\*" is a valid\
-value, allowing anyone to send the header. "localhost" allows proxy headers\
+Subnetworks are given in CIDR-format, e.g. "192.168.0.0/16". "\*" is a valid
+value, allowing anyone to send the header. "localhost" allows proxy headers
 from domain socket connections.
 
-Only trusted IPs should be added to the list, as the proxy header may affect\
+Only trusted IPs should be added to the list, as the proxy header may affect
 authentication results.
 
 ```
 proxy_protocol_networks=192.168.0.1,198.168.0.0/16
 ```
 
-Similar to MariaDB Server, MaxScale will also accept normal connections even\
+Similar to MariaDB Server, MaxScale will also accept normal connections even
 if `proxy_protocol_networks` is configured for the listener.
 
 #### `connection_init_sql_file`
@@ -3641,10 +3641,10 @@ if `proxy_protocol_networks` is configured for the listener.
 * Dynamic: Yes
 * Default: `""`
 
-Path to a text file with sql queries. Any sessions created from the listener\
-will send the contents of the file to backends after authentication. Each\
-non-empty line in the file is interpreted as a query. Each query must succeed\
-for the backend connection to be usable for client queries. The queries should\
+Path to a text file with sql queries. Any sessions created from the listener
+will send the contents of the file to backends after authentication. Each
+non-empty line in the file is interpreted as a query. Each query must succeed
+for the backend connection to be usable for client queries. The queries should
 not return any data.
 
 ```
@@ -3665,28 +3665,28 @@ set @myvar2 = 4;
 * Dynamic: Yes
 * Default: `""`
 
-Path to a json-text file with user and group mapping, as well as server\
-credentials. Only affects MariaDB-protocol based listeners. Default value is\
+Path to a json-text file with user and group mapping, as well as server
+credentials. Only affects MariaDB-protocol based listeners. Default value is
 empty, which disables the feature.
 
 ```
 user_mapping_file=/home/root/mapping.json
 ```
 
-Should not be used together with [PAM Authenticator](../mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-pam-authenticator.md)\
-settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite\
-the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on\
+Should not be used together with [PAM Authenticator](../mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-pam-authenticator.md)
+settings `pam_backend_mapping` or `pam_mapped_pw_file`, as these may overwrite
+the mapped credentials. Is most powerful when combined with service setting`user_accounts_file`, as then MaxScale can accept users that do not exist on
 backends and map them to backend users.
 
 This file functions very similar to [PAM-based mapping](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam).\
-Both user-to-user and group-to-user mappings can be defined. Also, the password\
-and authentication plugin for the mapped users can be added. The file is only\
-read during listener creation (typically MaxScale start) or when a listener is\
-modified during runtime. When a client logs into MaxScale, their username is\
+Both user-to-user and group-to-user mappings can be defined. Also, the password
+and authentication plugin for the mapped users can be added. The file is only
+read during listener creation (typically MaxScale start) or when a listener is
+modified during runtime. When a client logs into MaxScale, their username is
 searched from the mapping data. If the name matches either a name mapping or a\
-Linux group mapping, the username is replaced by the mapped name. The mapped\
-name is then used when logging into backends. If the file also contains\
-credentials for the mapped user, then those are used. Otherwise, MaxScale tries\
+Linux group mapping, the username is replaced by the mapped name. The mapped
+name is then used when logging into backends. If the file also contains
+credentials for the mapped user, then those are used. Otherwise, MaxScale tries
 to log in with an empty password and default MariaDB authentication.
 
 Three arrays are read from the file: _user\_map_, _group\_map_ and\_server\_credentials\_, none of which are mandatory.
@@ -3701,25 +3701,25 @@ Each array element in the _group\_map_-array must define the following fields:
 * original\_group: String. Incoming client Linux group.
 * mapped\_user: String. Username the client is mapped to.
 
-Each array element in the _server\_credentials_-array can define the following\
+Each array element in the _server\_credentials_-array can define the following
 fields:
 
 * mapped\_user: String. The mapped username this password is for.
-* password: String. Backend server password. Can be encrypted with\
+* password: String. Backend server password. Can be encrypted with
   maxpasswd.
-* plugin: String, optional. Authentication plugin to use. Must be enabled on\
-  the listener. Defaults to empty, which results in standard MariaDB\
+* plugin: String, optional. Authentication plugin to use. Must be enabled on
+  the listener. Defaults to empty, which results in standard MariaDB
   authentication.
 
-When a client successfully logs into MaxScale, MaxScale first searches for\
-name-based mapping. The incoming client does not need to be a Linux user for\
-name-based mapping to take place. If the name is not found, MaxScale checks if\
-the client is a Linux user with a group membership matching an element in the\
-group mapping array. If the client is a member of more than 100 groups, this\
+When a client successfully logs into MaxScale, MaxScale first searches for
+name-based mapping. The incoming client does not need to be a Linux user for
+name-based mapping to take place. If the name is not found, MaxScale checks if
+the client is a Linux user with a group membership matching an element in the
+group mapping array. If the client is a member of more than 100 groups, this
 check may fail.
 
-If a mapping is found, MaxScale searches the credentials array for a matching\
-username, and uses the password and plugin listed. The plugin need not be the\
+If a mapping is found, MaxScale searches the credentials array for a matching
+username, and uses the password and plugin listed. The plugin need not be the
 same as the one the original user used. Currently, "mysql\_native\_password" and\
 "pam" are supported as mapped plugins.
 
@@ -3765,35 +3765,35 @@ An example mapping file is below.
 * Dynamic: Yes
 * Mandatory: No
 
-Metadata that's sent to all connecting clients. The value must be a\
-comma-separated list of key-value arguments. The keys or values cannot contain\
+Metadata that's sent to all connecting clients. The value must be a
+comma-separated list of key-value arguments. The keys or values cannot contain
 commas in them.
 
-Any values that are set to `auto` will be substituted with the value of the\
-corresponding MariaDB system variable. Any system variables that do not\
-exist or have empty or null values will not be sent to the client. The system\
-variable values are read from the first `Master` server that's reachable from\
-the listener's service. If no `Master` server is reachable, the value is read\
-from the first `Slave` server and if no `Slave` servers are available, from the\
-first `Running` server. If no running servers are available, the system\
+Any values that are set to `auto` will be substituted with the value of the
+corresponding MariaDB system variable. Any system variables that do not
+exist or have empty or null values will not be sent to the client. The system
+variable values are read from the first `Master` server that's reachable from
+the listener's service. If no `Master` server is reachable, the value is read
+from the first `Slave` server and if no `Slave` servers are available, from the
+first `Running` server. If no running servers are available, the system
 variables are not sent.
 
-The exception to this is the `maxscale=auto` value where the `auto` will be\
-replaced with the MaxScale version string. This is useful for detecting whether\
-a client is connected to MaxScale. To make MaxScale completely transparent to\
+The exception to this is the `maxscale=auto` value where the `auto` will be
+replaced with the MaxScale version string. This is useful for detecting whether
+a client is connected to MaxScale. To make MaxScale completely transparent to
 the client application, the `maxscale=auto` value can be removed from`connection_metadata`.
 
-MaxScale will always send a metadata value for `threads_connected` that contains\
-the current number of connections to the service that the listener points to and\
-for `connection_id` that contains the 64-bit connection ID value. The values can\
+MaxScale will always send a metadata value for `threads_connected` that contains
+the current number of connections to the service that the listener points to and
+for `connection_id` that contains the 64-bit connection ID value. The values can
 be overridden by defining them with some value, for example,`connection_metadata=threads_connected=0,connection_id=0`.
 
-The metadata is implemented using [the session state information](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/4-server-response-packets/ok_packet#session-state-info)\
-that is embedded in the OK packets that are generated by MaxScale. The values\
-are encoded as system variables changes. This information can be accessed by all\
-connectors that support reading the session state information. One example of\
-this is the MariaDB Connector/C that implements it with the [mysql\_session\_track\_get\_first](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_first)\
-and [mysql\_session\_track\_get\_next](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_next)\
+The metadata is implemented using [the session state information](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/4-server-response-packets/ok_packet#session-state-info)
+that is embedded in the OK packets that are generated by MaxScale. The values
+are encoded as system variables changes. This information can be accessed by all
+connectors that support reading the session state information. One example of
+this is the MariaDB Connector/C that implements it with the [mysql\_session\_track\_get\_first](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_first)
+and [mysql\_session\_track\_get\_next](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/mysql_session_track_get_next)
 functions.
 
 The following example demonstrates the use of `connection_metadata`:
@@ -3802,20 +3802,20 @@ The following example demonstrates the use of `connection_metadata`:
 connection_metadata=redirect_url=localhost:3306,service_name=my-service,max_allowed_packet=auto
 ```
 
-The configuration has three variables, `redirect_url`, `service_name` and`max_allowed_packet` that have the values `localhost:3306`, `my-service` and`auto`. The `auto` value is special and gets replaced with the`max_allowed_packet` value from the MariaDB server. This means that the final\
+The configuration has three variables, `redirect_url`, `service_name` and`max_allowed_packet` that have the values `localhost:3306`, `my-service` and`auto`. The `auto` value is special and gets replaced with the`max_allowed_packet` value from the MariaDB server. This means that the final
 metadata that is sent to the client would be `redirect_url=localhost:3306`,`service_name=my-service` and `max_allowed_packet=16777216`.
 
 #### Version-specific Behavior
 
-If the `connection_metadata` variable list contains the `tx_isolation` variable\
+If the `connection_metadata` variable list contains the `tx_isolation` variable
 and the backend MariaDB server from which the variable is retrieved is MariaDB\
-11 or newer, the value is renamed to `transaction_isolation`. The `tx_isolation`\
+11 or newer, the value is renamed to `transaction_isolation`. The `tx_isolation`
 parameter was deprecated in favor of `transaction_isolation` in MariaDB 11\
 (MDEV-21921).
 
 ### Include
 
-An _include_ section defined common parameters used in other configuration\
+An _include_ section defined common parameters used in other configuration
 sections. Consider the following configuration.
 
 ```
@@ -3843,7 +3843,7 @@ servers=Server3, Server4
 ```
 
 The two monitor sections are identical except for the `servers` setting.\
-If they otherwise should remain identical, a change must be made in two\
+If they otherwise should remain identical, a change must be made in two
 places. With an `include` section the situation can be simplified.
 
 ```
@@ -3868,20 +3868,20 @@ type=monitor
 servers=Server3, Server3
 ```
 
-With an `include` section, all common settings can be defined in one\
+With an `include` section, all common settings can be defined in one
 place, and then included to any number of other sections using the`@include` parameter.
 
-The `@include` parameter takes a list of section names, so the settings\
+The `@include` parameter takes a list of section names, so the settings
 can be distributed across several `include` sections.
 
 ```
 @include=Some-Common-Attributes, Other-Common-Attributes
 ```
 
-It is permissible to specify in the _including_ section, parameters\
-that have already been specified in the _included_ section and they\
-will take precedence. For instance, if `Monitor2` in the example\
-above should have a longer backend connect timeout it can be\
+It is permissible to specify in the _including_ section, parameters
+that have already been specified in the _included_ section and they
+will take precedence. For instance, if `Monitor2` in the example
+above should have a longer backend connect timeout it can be
 specified as follows.
 
 ```
@@ -3892,9 +3892,9 @@ servers=Server3, Server3
 backend_connect_timeout = 5s
 ```
 
-Note that an included section **must** be an `include` section and\
-that an `include` section **cannot** include another `include`\
-section. For instance, both of the following sections would cause\
+Note that an included section **must** be an `include` section and
+that an `include` section **cannot** include another `include`
+section. For instance, both of the following sections would cause
 an error at startup.
 
 ```
@@ -3909,22 +3909,22 @@ type=monitor
 ...
 ```
 
-Note also that if an included parameter is changed using `maxctrl`,\
-it will be changed _only_ on the actual object the change is applied\
-on, not on the `include` section where the parameter is originally\
+Note also that if an included parameter is changed using `maxctrl`,
+it will be changed _only_ on the actual object the change is applied
+on, not on the `include` section where the parameter is originally
 specified.
 
 ## Available Protocols
 
-Protocol modules in MaxScale define what kind of clients can connect to a\
-listener and what type of backend servers are supported. Protocol is defined in\
-listener settings, and affects both the listener and any services the listener\
+Protocol modules in MaxScale define what kind of clients can connect to a
+listener and what type of backend servers are supported. Protocol is defined in
+listener settings, and affects both the listener and any services the listener
 is linked to.
 
 ### `MariaDB` or `MariaDBClient`
 
-Implements MariaDB protocol. The listener will accept MariaDB/MySQL connections\
-from clients and route the client queries through a linked MaxScale service\
+Implements MariaDB protocol. The listener will accept MariaDB/MySQL connections
+from clients and route the client queries through a linked MaxScale service
 to backend servers. The backends used by the service should be\
 MariaDB servers or compatible.
 
@@ -3935,55 +3935,55 @@ See [Change Data Capture Protocol](../mariadb-maxscale-25-01-protocols/mariadb-m
 ### `Postgresql` or `Postgresprotocol`
 
 Implements [Postgresql protocol](https://www.postgresql.org/docs/current/protocol.html).\
-The listener will accept Postgresql connections from clients and route the\
-client queries through a linked MaxScale service to backend servers. The\
+The listener will accept Postgresql connections from clients and route the
+client queries through a linked MaxScale service to backend servers. The
 backends used by the service should be PostgreSQL servers or compatible.
 
 ### `nosqlprotocol`
 
 Accepts MongoDB® connections, yet stores and fetches results to/from\
-MariaDB servers. See [NoSQL documentation](../mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md)\
+MariaDB servers. See [NoSQL documentation](../mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md)
 for more information.
 
 ## TLS/SSL encryption
 
-This section describes configuration parameters for both servers and listeners\
-that control the TLS/SSL encryption method and the various certificate files\
+This section describes configuration parameters for both servers and listeners
+that control the TLS/SSL encryption method and the various certificate files
 involved in it.
 
 To enable TLS/SSL for a listener, you must set the `ssl` parameter to`true` and provide at least the `ssl_cert` and `ssl_key` parameters.
 
-To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification\
+To enable TLS/SSL for a server, you must set the `ssl` parameter to`true`. If the backend database server has certificate verification
 enabled, the `ssl_cert` and `ssl_key` parameters must also be defined.
 
-Custom CA certificates can be defined with the `ssl_ca` parameter. If`ssl_verify_peer_certificate` is enabled yet `ssl_ca` is not set, MaxScale\
+Custom CA certificates can be defined with the `ssl_ca` parameter. If`ssl_verify_peer_certificate` is enabled yet `ssl_ca` is not set, MaxScale
 will load CA certificates from the system default location.
 
-After this, MaxScale connections between the server and/or the client will be\
-encrypted. Note that the database must also be configured to use TLS/SSL\
+After this, MaxScale connections between the server and/or the client will be
+encrypted. Note that the database must also be configured to use TLS/SSL
 connections if backend connection encryption is used.
 
-**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on\
+**Note:** MaxScale does not allow mixed use of TLS/SSL and normal connections on
 the same port.
 
-If TLS encryption is enabled for a listener, any unencrypted connections to it\
-will be rejected. MaxScale does this to improve security by preventing\
+If TLS encryption is enabled for a listener, any unencrypted connections to it
+will be rejected. MaxScale does this to improve security by preventing
 accidental creation of unencrypted connections.
 
 The separation of secure and insecure connections differs from the MariaDB\
 Server which allows both secure and insecure connections on the same port. As\
-MaxScale is the gateway through which all connections go, MaxScale enforces\
-a stricter security policy than MariaDB Server. Multiple listeners with\
+MaxScale is the gateway through which all connections go, MaxScale enforces
+a stricter security policy than MariaDB Server. Multiple listeners with
 different configurations can be created to enable different encryption schemes.
 
-TLS encryption must be enabled for listeners when they are created. For servers,\
+TLS encryption must be enabled for listeners when they are created. For servers,
 the TLS can be enabled after creation but it cannot be disabled or altered.
 
 Starting with MaxScale 2.5.20, if the TLS certificate given to MaxScale has the\
-X509v3 extended key usage information, MaxScale will check it and refuse to use\
-a certificate with the wrong usage. This means that a certificate with only\
-clientAuth can only be used with servers and a certificate with only serverAuth\
-can only be used with listeners. In order to use the same certificate for both\
+X509v3 extended key usage information, MaxScale will check it and refuse to use
+a certificate with the wrong usage. This means that a certificate with only
+clientAuth can only be used with servers and a certificate with only serverAuth
+can only be used with listeners. In order to use the same certificate for both
 listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 ### Settings for TLS/SSL Encryption
@@ -3997,12 +3997,12 @@ listeners and servers, it must have both the clientAuth and serverAuth usages.
 
 This enables SSL connections when set to true. The legacy values `required` and`disabled` were removed in MaxScale 6.0.
 
-If enabled, the certificate files mentioned above must also be\
+If enabled, the certificate files mentioned above must also be
 supplied. MaxScale connections to will then be encrypted with TLS/SSL.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require\
-ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created\
+24.08.1, if ssl is disabled for a listener, MariaDB user accounts that require
+ssl cannot log in through that listener. Any user account with a non-empty\_ssl\_type\_-field in _mysql.user_-table is blocked. This includes users created
 with `REQUIRE SSL` or `REQUIRE X509`.
 
 #### `ssl_key`
@@ -4012,8 +4012,8 @@ with `REQUIRE SSL` or `REQUIRE X509`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client private key MaxScale should use. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client private key MaxScale should use. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_cert`
@@ -4023,9 +4023,9 @@ parameter for listeners but an optional parameter for servers.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be the SSL client certificate MaxScale should use with the server. The\
-certificate must match the key defined in `ssl_key`. This is a required\
+A string giving a file path that identifies an existing readable file. The file
+must be the SSL client certificate MaxScale should use with the server. The
+certificate must match the key defined in `ssl_key`. This is a required
 parameter for listeners but an optional parameter for servers.
 
 #### `ssl_ca_cert`
@@ -4039,12 +4039,12 @@ Deprecated since MariaDB MaxScale 22.08. See `ssl_ca`.
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be a Certificate Authority (CA) certificate. It will be used to verify\
+A string giving a file path that identifies an existing readable file. The file
+must be a Certificate Authority (CA) certificate. It will be used to verify
 that the peer certificate (sent by either client or a MariaDB Server) is valid.\
 The CA certificate can consist of a certificate chain.
 
-**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,\
+**NOTE** Up until MariaDB MaxScale 6, the parameter was called `ssl_ca_cert`,
 which is still accepted as an alias for `ssl_ca`.
 
 #### `ssl_version`
@@ -4063,7 +4063,7 @@ This parameter controls the allowed TLS version. Accepted values are:
 * `TLSv13` (not supported on OpenSSL 1.0)
 * `MAX`
 
-MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer\
+MaxScale versions 6.4.16, 22.08.13, 23.02.10, 23.08.6, 24.02.2 and all newer
 releases accept also the following alias values:
 
 * `TLSv1.0`
@@ -4075,18 +4075,18 @@ The default setting (MAX) allows all supported versions. MaxScale supports\
 TLSv1.0, TLSv1.1, TLSv1.2 and TLSv1.3 depending on the OpenSSL library version.\
 TLSv1.0 and TLSv1.1 are considered deprecated and should not be used, so setting`ssl_version=TLSv1.2,TLSv1.3` or `ssl_version=TLSv1.3` is recommended.
 
-In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this\
-setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would\
+In MaxScale versions 6.4.13, 22.08.11, 23.02.7, 23.08.3 and earlier, this
+setting defined the _only_ allowed TLS version, e.g. `ssl_version=TLSv12` would
 only enable TLSv12. The interpretation changed in MaxScale versions 6.4.14,\
-22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while\
-allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`\
+22.08.12, 23.02.8, 23.08.4 to enable the user to disable old versions while
+allowing multiple recent TLS versions. In these versions, `ssl_version=TLSv1.2`
 enabled both TLSv1.2 and TLSv1.3.
 
 The interpretation changed again in MaxScale versions 6.4.16, 22.08.13,\
-23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an\
-enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior\
-from the previous releases where the newer versions were automatically enabled,\
-the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)\
+23.02.10, 23.08.6, 24.02.2. In these versions the value of `ssl_version` is an
+enumeration of accepted TLS protocol versions. This means that`admin_ssl_version=TLSv1.2` again only allows TLSv1.2. To retain the behavior
+from the previous releases where the newer versions were automatically enabled,
+the protocol versions must be explicitly listed, for example`admin_ssl_version=TLSv1.2,TLSv1.3`. The change was done to make the`ssl_version` behave identically to how the MariaDB [tls\_version](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/ssltls-system-variables#tls_version)
 parameter works.
 
 #### `ssl_cipher`
@@ -4096,8 +4096,8 @@ parameter works.
 * Dynamic: Yes
 * Default: `""`
 
-Set the list of TLS ciphers. By default, no explicit ciphers are defined and the\
-system defaults are used. Note that this parameter does not modify TLSv1.3\
+Set the list of TLS ciphers. By default, no explicit ciphers are defined and the
+system defaults are used. Note that this parameter does not modify TLSv1.3
 ciphers.
 
 #### `ssl_cert_verify_depth`
@@ -4107,8 +4107,8 @@ ciphers.
 * Dynamic: Yes
 * Default: `9`
 
-The maximum length of the certificate authority chain that will be accepted. The\
-default value is 9, same as the OpenSSL default. The configured value must be\
+The maximum length of the certificate authority chain that will be accepted. The
+default value is 9, same as the OpenSSL default. The configured value must be
 larger than 0.
 
 #### `ssl_verify_peer_certificate`
@@ -4118,11 +4118,11 @@ larger than 0.
 * Dynamic: Yes
 * Default: `false`
 
-Peer certificate verification. This functionality is disabled by default. In\
+Peer certificate verification. This functionality is disabled by default. In
 versions prior to 2.3.17 the feature was enabled by default.
 
-When this feature is enabled, the peer (client or MariaDB Server) must send a\
-certificate. The certificate sent by the peer is verified against the\
+When this feature is enabled, the peer (client or MariaDB Server) must send a
+certificate. The certificate sent by the peer is verified against the
 configured Certificate Authority to ensure the peer is who they claim to be.\
 For listeners, this behaves as if `REQUIRE X509` was defined for all users.
 
@@ -4136,8 +4136,8 @@ For listeners, this behaves as if `REQUIRE X509` was defined for all users.
 Peer host verification.
 
 When this feature is enabled, the peer (client or MariaDB Server) hostname or\
-IP is verified against the certificate sent by the peer. If the IP address or\
-the hostname does not match the one in the certificate, the connection is\
+IP is verified against the certificate sent by the peer. If the IP address or
+the hostname does not match the one in the certificate, the connection is
 closed.
 
 If the peer does not provide a certificate, host verification is skipped.\
@@ -4158,8 +4158,8 @@ behaves like the `--ssl-verify-server-cert` command line option for the`mysql` c
 * Dynamic: Yes
 * Default: `""`
 
-A string giving a file path that identifies an existing readable file. The file\
-must be a Certificate Revocation List in the PEM format that defines the revoked\
+A string giving a file path that identifies an existing readable file. The file
+must be a Certificate Revocation List in the PEM format that defines the revoked
 certificates. This parameter is only accepted by listeners.
 
 **Example SSL enabled server configuration**
@@ -4175,7 +4175,7 @@ ssl_key=/usr/local/mariadb/maxscale/ssl/key.max-client.pem
 ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
-This example configuration requires all connections to this server to be\
+This example configuration requires all connections to this server to be
 encrypted with SSL. The paths to the certificate files and the Certificate\
 Authority file are also provided.
 
@@ -4193,18 +4193,18 @@ ssl_ca_cert=/usr/local/mariadb/maxscale/ssl/crt.ca.maxscale.pem
 ```
 
 This example configuration requires all connections to be encrypted with\
-SSL. The paths to the certificate files and the Certificate Authority file are\
+SSL. The paths to the certificate files and the Certificate Authority file are
 also provided.
 
 ## Module Types
 
 ### Routing Modules
 
-The main task of MariaDB MaxScale is to accept database connections from client\
-applications and route the connections or the statements sent over those\
+The main task of MariaDB MaxScale is to accept database connections from client
+applications and route the connections or the statements sent over those
 connections to the various services supported by MariaDB MaxScale.
 
-Currently a number of routing modules are available, these are designed for a\
+Currently a number of routing modules are available, these are designed for a
 range of different needs.
 
 Connection based load balancing:
@@ -4225,18 +4225,18 @@ Binary log server:
 
 ### Monitor Modules
 
-Monitor modules are used by MariaDB MaxScale to internally monitor the state of\
-the backend databases in order to set the server flags for each of those\
-servers. The router modules then use these flags to determine if the particular\
-server is a suitable destination for routing connections for particular query\
+Monitor modules are used by MariaDB MaxScale to internally monitor the state of
+the backend databases in order to set the server flags for each of those
+servers. The router modules then use these flags to determine if the particular
+server is a suitable destination for routing connections for particular query
 classifications. The monitors are run within separate threads of MariaDB\
 MaxScale and do not affect MariaDB MaxScale's routing performance.
 
 * [MariaDB Monitor](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md)
 * [Galera Monitor](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-galera-monitor.md)
 
-The use of monitors in MaxScale is not absolutely mandatory: it is possible to\
-run MariaDB MaxScale without a monitor module. In this case an external\
+The use of monitors in MaxScale is not absolutely mandatory: it is possible to
+run MariaDB MaxScale without a monitor module. In this case an external
 monitoring system must the status of each server via MaxCtrl or the REST\
 API. **Only do this if you know what you are doing.**
 
@@ -4270,10 +4270,10 @@ flowchart LR
 _A client's query passes through the router session's QLA and Regex filters on its way to the backend server, with QLA also logging the query._
 
 Filters provide a means to manipulate or process requests as they pass through\
-MariaDB MaxScale between the client side protocol and the query router. A full\
+MariaDB MaxScale between the client side protocol and the query router. A full
 explanation of each filter's functionality can be found in its documentation.
 
-The [Filter Tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-filters.md) document shows how you\
+The [Filter Tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-filters.md) document shows how you
 can add a filter to a service and combine multiple filters in one service.
 
 * [Query Log All (QLA) Filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-query-log-all-filter.md)
@@ -4286,8 +4286,8 @@ can add a filter to a service and combine multiple filters in one service.
 
 Passwords stored in the maxscale.cnf file may optionally be encrypted for added security.\
 This is done by creation of an encryption key on installation of MariaDB MaxScale.\
-Encryption keys may be created manually by executing the maxkeys utility with the argument\
-of the filename to store the key. The default location MariaDB MaxScale stores\
+Encryption keys may be created manually by executing the maxkeys utility with the argument
+of the filename to store the key. The default location MariaDB MaxScale stores
 the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES CBC encryption.
 
 ```
@@ -4295,16 +4295,16 @@ the keys is `/var/lib/maxscale`. The passwords are encrypted using 256-bit AES C
 maxkeys /var/lib/maxscale/
 ```
 
-Changing the encryption key for MariaDB MaxScale will invalidate any currently\
+Changing the encryption key for MariaDB MaxScale will invalidate any currently
 encrypted keys stored in the maxscale.cnf file.
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
 ### Creating Encrypted Passwords
 
-Encrypted passwords are created by executing the maxpasswd command with the location\
+Encrypted passwords are created by executing the maxpasswd command with the location
 of the .secrets file and the password you require to encrypt as an argument.
 
 ```
@@ -4313,9 +4313,9 @@ maxpasswd /var/lib/maxscale/ MaxScalePw001
 61DD955512C39A4A8BC4BB1E5F116705
 ```
 
-The output of the maxpasswd command is a hexadecimal string, this should be inserted\
+The output of the maxpasswd command is a hexadecimal string, this should be inserted
 into the maxscale.cnf file in place of the ordinary, plain text, password.\
-MariaDB MaxScale will determine this as an encrypted password and automatically decrypt\
+MariaDB MaxScale will determine this as an encrypted password and automatically decrypt
 it before sending it the database server.
 
 ```
@@ -4329,7 +4329,7 @@ password=61DD955512C39A4A8BC4BB1E5F116705
 
 ## Runtime Configuration Changes
 
-Read the following documents for different methods of altering the MaxScale\
+Read the following documents for different methods of altering the MaxScale
 configuration at runtime.
 
 * MaxCtrl
@@ -4340,88 +4340,88 @@ configuration at runtime.
 * [alter](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-maxctrl.md)
 * [REST API](../mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-rest-api.md) documentation
 
-All changes to the configuration done via MaxCtrl are persisted as individual\
-configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these\
-files will override any configurations found in the main configuration file or\
+All changes to the configuration done via MaxCtrl are persisted as individual
+configuration files in `/var/lib/maxscale/maxscale.cnf.d/`. The content of these
+files will override any configurations found in the main configuration file or
 any auxiliary configuration files.
 
-Refer to the [Dynamic Configuration](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more\
+Refer to the [Dynamic Configuration](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#dynamic-configuration) section for more
 details on how this mechanism works and how to disable it.
 
 ### Configuration Synchronization
 
-The configuration synchronization mechanism is intended for synchronizing\
-configuration changes done on one MaxScale to all other MaxScales. This is done\
+The configuration synchronization mechanism is intended for synchronizing
+configuration changes done on one MaxScale to all other MaxScales. This is done
 by propagating the changes via the database cluster used by Maxscale.
 
-When configuring configuration synchronization for the first time, the same\
-static configuration files should be used on all MaxScale instances that use the\
+When configuring configuration synchronization for the first time, the same
+static configuration files should be used on all MaxScale instances that use the
 same cluster: the value of `config_sync_cluster` must be the same on all\
-MaxScale instances and the cluster (i.e. the monitor) pointed by it and its\
+MaxScale instances and the cluster (i.e. the monitor) pointed by it and its
 servers must be the same in every configuration.
 
-Whenever the MaxScale configuration is modified at runtime, the latest\
-configuration is stored in the database cluster in the `mysql.maxscale_config`\
-table. The table is created when the first modification to the configuration is\
+Whenever the MaxScale configuration is modified at runtime, the latest
+configuration is stored in the database cluster in the `mysql.maxscale_config`
+table. The table is created when the first modification to the configuration is
 done. A local copy of the configuration is stored in the data directory to allow\
-MaxScale to function even if a connection to the cluster cannot be made. By\
+MaxScale to function even if a connection to the cluster cannot be made. By
 default this file is stored at `/var/lib/maxscale/maxscale-config.json`.
 
-Whenever MaxScale starts up, it checks if a local version of this configuration\
-exists. If it does and it is a valid cached configuration, the static\
-configuration file as well as any other generated configuration files are\
-ignored. The exception is the `[maxscale]` section of the main static\
+Whenever MaxScale starts up, it checks if a local version of this configuration
+exists. If it does and it is a valid cached configuration, the static
+configuration file as well as any other generated configuration files are
+ignored. The exception is the `[maxscale]` section of the main static
 configuration file which is always read.
 
-Each configuration has a version number with the initial configuration being\
-version 0. Each time the configuration is modified, the version number is\
-incremented. This version number is used to detect when MaxScale needs to update\
+Each configuration has a version number with the initial configuration being
+version 0. Each time the configuration is modified, the version number is
+incremented. This version number is used to detect when MaxScale needs to update
 its configuration.
 
 #### Error Handling in Configuration Synchronization
 
-When doing a configuration change on the local MaxScale, if the configuration\
-change completes on MaxScale but fails to be committed to the database, MaxScale\
+When doing a configuration change on the local MaxScale, if the configuration
+change completes on MaxScale but fails to be committed to the database, MaxScale
 will attempt to revert the local configuration change. If this attempt fails,\
 MaxScale will discard the cached configuration and abort the process.
 
-When synchronizing with the cluster, if MaxScale fails to apply a configuration\
-retrieved from the cluster, it attempts to revert the configuration to the\
-previous version. If successful, the failed configuration update is ignored. If\
-the configuration update that fails cannot be reverted, the MaxScale\
-configuration will be in an indeterminate state. When this happens, MaxScale\
+When synchronizing with the cluster, if MaxScale fails to apply a configuration
+retrieved from the cluster, it attempts to revert the configuration to the
+previous version. If successful, the failed configuration update is ignored. If
+the configuration update that fails cannot be reverted, the MaxScale
+configuration will be in an indeterminate state. When this happens, MaxScale
 will discard the cached configuration and abort the process.
 
-When loading a locally cached configuration during startup, if any errors are\
-found in the cached configuration, it is discarded and the MaxScale process will\
-attempt to restart by exiting with code 75 from the main process. If MaxScale is\
+When loading a locally cached configuration during startup, if any errors are
+found in the cached configuration, it is discarded and the MaxScale process will
+attempt to restart by exiting with code 75 from the main process. If MaxScale is
 being used as a SystemD service, this will automatically trigger a restart of\
 MaxScale and no further actions are needed.
 
-The most common reason for a failed configuration update is missing files. For\
-example, if a configuration update adds encrypted connections to a server and\
-the TLS certificates it uses were not copied over to all MaxScale nodes before\
-the change was done, the operation will fail on all nodes that do not have these\
+The most common reason for a failed configuration update is missing files. For
+example, if a configuration update adds encrypted connections to a server and
+the TLS certificates it uses were not copied over to all MaxScale nodes before
+the change was done, the operation will fail on all nodes that do not have these
 files.
 
-If the synchronization of the configuration change fails at the step when the\
-database transaction is being committed, the new configuration can be\
-momentarily visible to the local MaxScale. This means the changes are not\
-guaranteed to be atomic on the local MaxScale but are atomic from the cluster's\
+If the synchronization of the configuration change fails at the step when the
+database transaction is being committed, the new configuration can be
+momentarily visible to the local MaxScale. This means the changes are not
+guaranteed to be atomic on the local MaxScale but are atomic from the cluster's
 point of view.
 
 #### Synchronization of Encrypted Passwords
 
-Starting with MaxScale 6.4.9, any passwords that are transmitted by the\
-configuration synchronization are encrypted if password encryption has been\
-enabled in MaxScale. This means that all MaxScale nodes in the same\
-configuration cluster must be configured to use password encryption and they\
+Starting with MaxScale 6.4.9, any passwords that are transmitted by the
+configuration synchronization are encrypted if password encryption has been
+enabled in MaxScale. This means that all MaxScale nodes in the same
+configuration cluster must be configured to use password encryption and they
 need to all use the same encryption keys that were created with `maxkeys`.
 
 #### Managing Configuration Synchronization
 
-The output of `maxctrl show maxscale` contains the `Config Sync` field with\
-information about the current configuration state of the local Maxscale as well\
+The output of `maxctrl show maxscale` contains the `Config Sync` field with
+information about the current configuration state of the local Maxscale as well
 as the state of any other nodes using this cluster.
 
 ```
@@ -4439,17 +4439,17 @@ as the state of any other nodes using this cluster.
 ├──────────────┼─────────────────────────────────────────────────────────────┤
 ```
 
-The `version` field is the logical configuration version and the `origin` is the\
-node that originates the latest configuration change. The `checksum` field is\
+The `version` field is the logical configuration version and the `origin` is the
+node that originates the latest configuration change. The `checksum` field is
 the checksum of the logical configuration and can be used to compare whether two\
-Maxscale instances are in the same configuration state. The `nodes` field\
-contains the status of each MaxScale instance mapped to the hostname of the\
-server. This field is updated whenever MaxScale reads the configuration from the\
-cluster and can thus be used to detect which MaxScales have updated their\
+Maxscale instances are in the same configuration state. The `nodes` field
+contains the status of each MaxScale instance mapped to the hostname of the
+server. This field is updated whenever MaxScale reads the configuration from the
+cluster and can thus be used to detect which MaxScales have updated their
 configuration.
 
-The `mysql.maxscale_config` table where the configuration changes are stored\
-must not be modified manually. The only case when the table should be modified\
+The `mysql.maxscale_config` table where the configuration changes are stored
+must not be modified manually. The only case when the table should be modified
 is when resetting the configuration synchronization.
 
 To reset the configuration synchronization:
@@ -4459,71 +4459,71 @@ To reset the configuration synchronization:
 3. Drop the `mysql.maxscale_config` table
 4. Start all MaxScale instances
 
-To disable configuration synchronization, remove `config_sync_cluster` from the\
-configuration file or set it to an empty string: `config_sync_cluster=""`. This\
+To disable configuration synchronization, remove `config_sync_cluster` from the
+configuration file or set it to an empty string: `config_sync_cluster=""`. This
 can be done at runtime with MaxCtrl by passing an empty string to`config_sync_cluster`:
 
 ```
 maxctrl alter maxscale config_sync_cluster ""
 ```
 
-If MaxScale cannot create a connection to the database cluster, configuration\
-changes are not possible until communication with the database is possible. To\
-override this behavior and force the changes to be done, use the `--skip-sync`\
-option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any\
-updates done with `--skip-sync` will overwritten by changes coming from the\
+If MaxScale cannot create a connection to the database cluster, configuration
+changes are not possible until communication with the database is possible. To
+override this behavior and force the changes to be done, use the `--skip-sync`
+option for maxctrl or the `sync=false` HTTP parameter for the REST API. Any
+updates done with `--skip-sync` will overwritten by changes coming from the
 cluster.
 
 #### Limitations in Configuration Synchronization
 
-Only the MaxScale configuration is synchronized. Any external files (TLS\
-certificates, configuration files for modules or data generated by MaxScale) are\
-not synchronized. For example, the rule files for the cache filter must be\
+Only the MaxScale configuration is synchronized. Any external files (TLS
+certificates, configuration files for modules or data generated by MaxScale) are
+not synchronized. For example, the rule files for the cache filter must be
 synchronized separately if the filter itself is modified.
 
-Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers\
-and modifications to the administrative users will be synchronized. In older\
-versions servers had to be put into maintenance mode and users had to be\
+Starting with MaxScale 22.08, the `Maintenance` and `Draining` states of servers
+and modifications to the administrative users will be synchronized. In older
+versions servers had to be put into maintenance mode and users had to be
 modified separately on each MaxScale.
 
-* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not\
+* ([MXS-3619](https://jira.mariadb.org/browse/MXS-3619)) External files are not
   synchronized.
-* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`\
-  option will not export the cluster configuration and instead exports only the\
-  static configuration files. To start a new MaxScale based off of a clustered\
-  configuration, copy the static configuration files as well as the JSON\
-  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale\
+* ([MXS-4276](https://jira.mariadb.org/browse/MXS-4276)) The `--export-config`
+  option will not export the cluster configuration and instead exports only the
+  static configuration files. To start a new MaxScale based off of a clustered
+  configuration, copy the static configuration files as well as the JSON
+  configuration in `/var/lib/maxscale/maxscale-config.json` to the new MaxScale
   instance.
 
 ### Backing Up Configuration Changes
 
-The combination of configuration files can be done either manually\
-(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line\
+The combination of configuration files can be done either manually
+(e.g. `rsync`) or with the `maxscale --export-config=FILE` command line
 option. See `maxscale --help` for more information about how to use the`--export-config` flag.
 
-For example, to export the current runtime configuration, run the following\
+For example, to export the current runtime configuration, run the following
 command.
 
 ```
 maxscale --export-config=/tmp/maxscale.cnf.combined
 ```
 
-This will create the `/tmp/maxscale.cnf.combined` file and write the current\
-configuration into the it. This allows new MaxScale instances to be easily set\
-up without requiring copying of all runtime configuration files. The user\
-executing the command must be able to read all MaxScale configuration files as\
+This will create the `/tmp/maxscale.cnf.combined` file and write the current
+configuration into the it. This allows new MaxScale instances to be easily set
+up without requiring copying of all runtime configuration files. The user
+executing the command must be able to read all MaxScale configuration files as
 well as create and write the provided filename.
 
 ## Encryption Key Managers
 
-The encryption key managers are how MaxScale retrieves symmetric encryption keys\
-from a key management system. Some parts of MaxScale require the `key_manager`\
-to be configured in order to work. The key manager that is used is selected with\
-the [key\_manager](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is\
+The encryption key managers are how MaxScale retrieves symmetric encryption keys
+from a key management system. Some parts of MaxScale require the `key_manager`
+to be configured in order to work. The key manager that is used is selected with
+the [key\_manager](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is
 configured by placing the parameters in the `[maxscale]` section.
 
-The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key\
-management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration\
+The encryption key managers can be enabled at runtime using `maxctrl alter maxscale` but cannot be disabled once enabled. To disable the encryption key
+management, stop Maxscale, remove any persisted configuration files and remove`key_manager` as well as any key manager options from the static configuration
 files.
 
 ### File-based Key Manager
@@ -4531,13 +4531,13 @@ files.
 The encryption keys are stored in a text file stored on a local filesystem.
 
 The file uses the same format as the MariaDB server [File Key Management\
-Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file\
-consisting of an encryption key ID number and the hex-encoded encryption key\
+Encryption Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin): a file
+consisting of an encryption key ID number and the hex-encoded encryption key
 separated by a semicolon. Read [Creating the Key\
-File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)\
+File](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin#creating-the-key-file)
 for more details on how to create the file.
 
-For example, to configure encryption for the `nosqlprotocol` shared credentials\
+For example, to configure encryption for the `nosqlprotocol` shared credentials
 using the file-based encryption key:
 
 1. Create the key file with `(echo -n '1;' ; openssl rand -hex 32) | cat > /var/lib/maxscale/encryption.key`
@@ -4574,9 +4574,9 @@ nosqlprotocol.authentication_password=my_password
 * Mandatory: Yes
 * Dynamic: Yes
 
-Path to the file that contains the encryption keys. The user MaxScale runs as\
-(almost always `maxscale`) must be able to read this file. Encryption keys are\
-read from disk only during startup or when any global MaxScale parameter is\
+Path to the file that contains the encryption keys. The user MaxScale runs as
+(almost always `maxscale`) must be able to read this file. Encryption keys are
+read from disk only during startup or when any global MaxScale parameter is
 modified at runtime.
 
 ### KMIP Key Manager
@@ -4588,7 +4588,7 @@ The KMIP key manager has been verified to work with the PyKMIP server.
 #### Limitations
 
 * Key versioning is not supported
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the KMIP server.
 
 #### Settings for KMIP Key Manager
@@ -4635,17 +4635,17 @@ The CA certificate to use. By default the system default certificates are used.
 
 ### HashiCorp Vault Key Manager
 
-Encryption keys are read from a local or remote Vault server using the secret\
-engine included in the Vault. This key manager supports versioned keys. Only\
+Encryption keys are read from a local or remote Vault server using the secret
+engine included in the Vault. This key manager supports versioned keys. Only
 version 2 key-value stores are supported.
 
 The encryption keys use the same format as the MariaDB [HashiCorp Vault Key\
 Management Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/hashicorp-key-management-plugin):\
-The key-value secret for each encryption key ID must contain the field `data`\
-which must contain a hex-encoded string that is either 32, 48 or 64 characters\
+The key-value secret for each encryption key ID must contain the field `data`
+which must contain a hex-encoded string that is either 32, 48 or 64 characters
 long.
 
-An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit\
+An easy way to generate a correct encryption key is to use the `vault` and`openssl` command line clients. The following command creates a 256-bit
 encryption key using `openssl` and stores it using the key ID `1`:
 
 ```
@@ -4665,7 +4665,7 @@ version            1
 
 #### Limitations
 
-* Encryption keys are not cached locally: whenever MaxScale needs an encryption\
+* Encryption keys are not cached locally: whenever MaxScale needs an encryption
   key, it retrieves it from the Vault server.
 
 #### Settings for HashiCorp Vault Key Manager
@@ -4676,7 +4676,7 @@ version            1
 * Mandatory: Yes
 * Dynamic: Yes
 
-The authentication token used to connect to the Vault server. This can be\
+The authentication token used to connect to the Vault server. This can be
 encrypted using `maxpasswd`, similar to how other passwords are encrypted.
 
 **`vault.host`**
@@ -4709,7 +4709,7 @@ The CA certificate to use. By default the system default certificates are used.
 * Default: true
 * Dynamic: Yes
 
-Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating\
+Whether to use encrypted connections (i.e. HTTPS or HTTP) when communicating
 with the Vault server.
 
 **`vault.mount`**
@@ -4718,7 +4718,7 @@ with the Vault server.
 * Default: `secret`
 * Dynamic: Yes
 
-The Key-Value mount where the secret is stored. By default the `secret` mount is\
+The Key-Value mount where the secret is stored. By default the `secret` mount is
 used which is present by default in most Vault installations.
 
 **`vault.timeout`**
@@ -4731,30 +4731,30 @@ The connection and request timeout used with the Vault server.
 
 ## Threads
 
-For routing, MaxScale uses asynchronous I/O and a fixed number of threads\
+For routing, MaxScale uses asynchronous I/O and a fixed number of threads
 (aka _routing workers_), whose number up until 23.02 was fixed at startup.\
-From 23.02 onwards the number of threads can be altered at runtime, which\
-is convenient, for instance, if MaxScale is running in a container whose\
+From 23.02 onwards the number of threads can be altered at runtime, which
+is convenient, for instance, if MaxScale is running in a container whose
 properties are changed during the lifetime of the container.
 
 A thread can be in three different states:
 
-* **Active**: The thread is routing client traffic and is listening\
+* **Active**: The thread is routing client traffic and is listening
   for new connections.
-* **Draining**: The thread is routing client traffic but is **not**\
+* **Draining**: The thread is routing client traffic but is **not**
   listening for new connections.
-* **Dormant**: The thread is not routing client traffic (all sessions\
-  have ended), and is not listening for new connections, and is waiting\
+* **Dormant**: The thread is not routing client traffic (all sessions
+  have ended), and is not listening for new connections, and is waiting
   to be terminated.
 
-All threads start as _Active_ and may become _Draining_ if the number of\
-threads is reduced. A draining thread will eventually become _Dormant_,\
+All threads start as _Active_ and may become _Draining_ if the number of
+threads is reduced. A draining thread will eventually become _Dormant_,
 unless the number of threads is increased while the thread is still _Draining_.
 
-Note that it is not possible to terminate a specific thread, but it is only\
-possible to specify the _number_ of threads that MaxScale should use, and\
-that the threads will be terminated from the end. This has implications\
-if the number of threads is reduced by more than 1, as a _Dormant_ thread\
+Note that it is not possible to terminate a specific thread, but it is only
+possible to specify the _number_ of threads that MaxScale should use, and
+that the threads will be terminated from the end. This has implications
+if the number of threads is reduced by more than 1, as a _Dormant_ thread
 will not be terminated before it is the last thread.
 
 In the following, MaxScale has been started with `threads=4`.
@@ -4783,8 +4783,8 @@ $ bin/maxctrl show threads
 ...
 ```
 
-we will see that the threads 2 and 3 are now _Draining_. The reason is\
-that threads 2 and 3 still handle client sessions. If some client sessions\
+we will see that the threads 2 and 3 are now _Draining_. The reason is
+that threads 2 and 3 still handle client sessions. If some client sessions
 now end, the situation may become like
 
 ```
@@ -4796,13 +4796,13 @@ now end, the situation may become like
 ...
 ```
 
-That is, thread 2 is _Dormant_ and thread 3 is _Draining_. All client sessions\
-that were handled by thread 2 have ended and the thread is ready to be\
-terminated. However, as thread 3 is still _Draining_, thread 2 will not be\
+That is, thread 2 is _Dormant_ and thread 3 is _Draining_. All client sessions
+that were handled by thread 2 have ended and the thread is ready to be
+terminated. However, as thread 3 is still _Draining_, thread 2 will not be
 terminated but stay _Dormant_.
 
-If the sessions handled by thread 3 end, then it will become _Dormant_ at\
-which point first thread 3 will be terminated and immediately after that\
+If the sessions handled by thread 3 end, then it will become _Dormant_ at
+which point first thread 3 will be terminated and immediately after that
 thread 2.
 
 ```
@@ -4827,7 +4827,7 @@ $ bin/maxctrl show threads
 ...
 ```
 
-that is, the number of threads was 4 but has been reduced to 2, and while\
+that is, the number of threads was 4 but has been reduced to 2, and while
 thread 2 has become drained it stays as _Dormant_ since thread 3 is still _Draining_, it is possible to make thread 2 _Active_ again by increasing the
 number of threads to 3.
 
@@ -4857,8 +4857,8 @@ $ bin/maxctrl show threads
 
 ## Error Reporting
 
-MariaDB MaxScale is designed to be executed as a service, therefore all error\
-reports, including configuration errors, are written to the MariaDB MaxScale\
+MariaDB MaxScale is designed to be executed as a service, therefore all error
+reports, including configuration errors, are written to the MariaDB MaxScale
 error log file. By default, MariaDB MaxScale will log to a file in`/var/log/maxscale` and the system log.
 
 ## Limitations
@@ -4867,31 +4867,31 @@ The current limitations of MaxScale are listed in the [Limitations](../../../../
 
 ## Performance Optimization
 
-* Tune `query_classifier_cache_size` to allow maximal use of the query\
-  classifier cache. Increase the value and/or system memory until the set of\
-  unique SQL patterns fits into memory. By default at most 15% of the system\
-  memory is used for this cache. To detect if the SQL statements fit into\
-  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to\
-  see how many evictions take place. If it keeps increasing, increase the size\
-  of the query classifier cache. Using the query classifier cache with a CPU\
-  bound workload gives a roughly 20% improvement in performance compared to when\
+* Tune `query_classifier_cache_size` to allow maximal use of the query
+  classifier cache. Increase the value and/or system memory until the set of
+  unique SQL patterns fits into memory. By default at most 15% of the system
+  memory is used for this cache. To detect if the SQL statements fit into
+  memory, monitor the `QC cache evictions` value in `maxctrl show threads` to
+  see how many evictions take place. If it keeps increasing, increase the size
+  of the query classifier cache. Using the query classifier cache with a CPU
+  bound workload gives a roughly 20% improvement in performance compared to when
   it is turned off.
-* A faster CPU with more CPU cores is better. This is true for most applications\
+* A faster CPU with more CPU cores is better. This is true for most applications
   but especially for MaxScale as it is mostly limited by the speed of the\
   CPU. Using `threads=auto` is recommended (the default starting with MaxScale\
   6\).
-* Network throughput between the client, MaxScale and the database nodes governs\
-  how much traffic can be handled. The client-to-MaxScale network is likely to\
-  be saturated first: having multiple MaxScales in front of the cluster is an\
+* Network throughput between the client, MaxScale and the database nodes governs
+  how much traffic can be handled. The client-to-MaxScale network is likely to
+  be saturated first: having multiple MaxScales in front of the cluster is an
   easy way of solving this problem.
-* Certain MaxScale modules store data on disk. A faster disk improves their\
-  performance but depending on the module, this might not be a big enough of a\
-  problem to worry about. Filters like the `qlafilter` that write information to\
+* Certain MaxScale modules store data on disk. A faster disk improves their
+  performance but depending on the module, this might not be a big enough of a
+  problem to worry about. Filters like the `qlafilter` that write information to
   disk for every SQL query can cause performance bottlenecks.
 
 ### MaxScale Diagnostics using MaxCtrl
 
-From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with\
+From 22.08.2 onwards, `maxctrl show maxscale` shows a `System` object with
 information about the system MaxScale is running on. The fields are:
 
 | Field                                   | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -4910,34 +4910,34 @@ In addition there is an `os` object that contains what the Linux command `uname`
 
 **`threads`**
 
-If `threads` has not been specified at all in the MaxScale configuration file,\
-or if its value is `auto`, then MaxScale will use as many routing threads as\
-there are physical cores on the machine. This is the right choice, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
+If `threads` has not been specified at all in the MaxScale configuration file,
+or if its value is `auto`, then MaxScale will use as many routing threads as
+there are physical cores on the machine. This is the right choice, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
 in any way.
 
-However, if the number of cores available to MaxScale have been restricted or\
-if MaxScale is running in a container whose CPU quota and period have been\
-limited, then it will lead to MaxScale using more routing threads than what\
+However, if the number of cores available to MaxScale have been restricted or
+if MaxScale is running in a container whose CPU quota and period have been
+limited, then it will lead to MaxScale using more routing threads than what
 is appropriate in the environment where it is running.
 
-If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`\
-should be specified explicitly in the MaxScale configuration file and its value\
-should be that of `machine.cores_virtual` rounded up to the nearest integer. If\
+If `machine.cores_virtual` is less than `machine.cores_physical`, then `threads`
+should be specified explicitly in the MaxScale configuration file and its value
+should be that of `machine.cores_virtual` rounded up to the nearest integer. If
 that value is `1` it may be beneficial to check whether `2` gives better performance.
 
 **`query_classifier_cache_size`**
 
-If `query_classifier_cache_size` has not been specified in the MaxScale\
-configuration file, then MaxScale will use at most 15% of the amount of physical\
-memory in the machine for the cache. This is a good starting point, if MaxScale\
-is running on a dedicated machine or in a container that has not been restricted\
-in any way. Note that the amount specifies how much memory the cache at maximum\
+If `query_classifier_cache_size` has not been specified in the MaxScale
+configuration file, then MaxScale will use at most 15% of the amount of physical
+memory in the machine for the cache. This is a good starting point, if MaxScale
+is running on a dedicated machine or in a container that has not been restricted
+in any way. Note that the amount specifies how much memory the cache at maximum
 is allowed to use, not what would immediately be allocated for the cache.
 
-However, if the amount of memory available to MaxScale has been restricted,\
-which may be the case if MaxScale is running in a container, this may cause the\
-cache to grow beyond what is available, which will lead to a crash or MaxScale\
+However, if the amount of memory available to MaxScale has been restricted,
+which may be the case if MaxScale is running in a container, this may cause the
+cache to grow beyond what is available, which will lead to a crash or MaxScale
 being killed.
 
 If the value of `machine.memory_available` is less than that of`machine.memory_physical`, then `query_classifier_cache_size` should be explicitly\
@@ -4976,7 +4976,7 @@ $ maxctrl show maxscale
 As can be seen, `maxscale.threads` is larger than `machine.cores_virtual` and thus,`threads=4` should explicitly be specified in the MaxScale configuration file.
 
 `maxscale.query_classifier_cache_size` is the default 15% of `machine.memory_physical`\
-but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be\
+but as `machine.memory_available` is just half of that, something like`query_classifier_cache_size=3100000000` (\~15% of `machine.memory_available`) should be
 added to the configuration file.
 
 ```
@@ -4988,12 +4988,12 @@ query_classifier_cache_size=3100000000
 
 ## Troubleshooting
 
-For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)\
+For a list of common problems and their solutions, read the [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 article on the MariaDB documentation.
 
 ### Systemd Watchdog
 
-If MaxScale is running as a systemd service, the systemd Watchdog will be\
+If MaxScale is running as a systemd service, the systemd Watchdog will be
 enabled by default. To configure it, change the `WatchdogSec` option in the\
 Service section of the maxscale systemd configuration file located in`/lib/systemd/system/maxscale.service`:
 
@@ -5001,8 +5001,8 @@ Service section of the maxscale systemd configuration file located in`/lib/syste
 WatchdogSec=30s
 ```
 
-It is not recommended to use a watchdog timeout less than 30 seconds. When\
-enabled MaxScale will check that all threads are running and notify systemd\
+It is not recommended to use a watchdog timeout less than 30 seconds. When
+enabled MaxScale will check that all threads are running and notify systemd
 with a "keep-alive ping".
 
 Systemd reference: [systemd.service.html](https://www.freedesktop.org/software/systemd/man/systemd.service.html)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-installation-guide.md
@@ -2,15 +2,15 @@
 
 ## MariaDB MaxScale Installation Guide
 
-We recommend to install MaxScale on a separate server, to ensure that there\
-can be no competition of resources between MaxScale and a MariaDB Server that\
+We recommend to install MaxScale on a separate server, to ensure that there
+can be no competition of resources between MaxScale and a MariaDB Server that
 it manages.
 
 ### Install MariaDB MaxScale From MariaDB Repositories
 
-The recommended approach is to use [the MariaDB package\
-repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)\
-to install MaxScale. After enabling the repository by following the\
+The recommended approach is to use [the MariaDB package
+repository](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
+to install MaxScale. After enabling the repository by following the
 instructions, MaxScale can be installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install maxscale`.
@@ -19,9 +19,9 @@ instructions, MaxScale can be installed with the following commands.
 
 ### Install MariaDB MaxScale From a RPM/DEB Package
 
-Download the correct MaxScale package for your CPU architecture and operating\
-system from [the MariaDB Downloads\
-page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be\
+Download the correct MaxScale package for your CPU architecture and operating
+system from [the MariaDB Downloads
+page](https://mariadb.com/downloads/community/maxscale/). MaxScale can be
 installed with the following commands.
 
 * For RHEL/Rocky Linux/Alma Linux, use `dnf install /path/to/maxscale-*.rpm`
@@ -31,7 +31,7 @@ installed with the following commands.
 ### Install MariaDB MaxScale Using a Tarball
 
 MaxScale can also be installed using a tarball.\
-That may be required if you are using a Linux distribution for which there\
+That may be required if you are using a Linux distribution for which there
 exist no installation package or if you want to install many different\
 MaxScale versions side by side. For instructions on how to do that, please refer to [Install MariaDB MaxScale using a Tarball](mariadb-maxscale-2501-maxscale-2501-installing-mariadb-maxscale-using-a-tarball.md).
 
@@ -44,20 +44,20 @@ To do this, refer to the separate document [Building MariaDB MaxScale from Sourc
 
 #### Memory allocation behavior
 
-MaxScale assumes that memory allocations always succeed and in general does\
-not check for memory allocation failures. This assumption is compatible with\
-the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)\
+MaxScale assumes that memory allocations always succeed and in general does
+not check for memory allocation failures. This assumption is compatible with
+the Linux kernel parameter [vm.overcommit\_memory](https://www.kernel.org/doc/Documentation/vm/overcommit-accounting)
 having the value `0`, which is also the default on most systems.
 
-With `vm.overcommit_memory` being `0`, memory _allocations_ made by an\
-application never fail, but instead the application may be killed by the\
-so-called OOM (out-of-memory) killer if, by the time the application\
-actually attempts to _use_ the allocated memory, there is not available\
+With `vm.overcommit_memory` being `0`, memory _allocations_ made by an
+application never fail, but instead the application may be killed by the
+so-called OOM (out-of-memory) killer if, by the time the application
+actually attempts to _use_ the allocated memory, there is not available
 free memory on the system.
 
-If the value is `2`, then a memory allocation made by an application may\
-fail and unless the application is prepared for that possibility, it will\
-likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory\
+If the value is `2`, then a memory allocation made by an application may
+fail and unless the application is prepared for that possibility, it will
+likely crash with a SIGSEGV. As MaxScale is not prepared to handle memory
 allocation failures, it will crash in this situation.
 
 The current value of `vm.overcommit_memory` can be checked with
@@ -74,36 +74,36 @@ cat /proc/sys/vm/overcommit_memory
 
 ### Configuring MariaDB MaxScale
 
-[The MaxScale Tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-setting-up-mariadb-maxscale.md) covers the first\
-steps in configuring your MariaDB MaxScale installation. Follow this tutorial\
+[The MaxScale Tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-setting-up-mariadb-maxscale.md) covers the first
+steps in configuring your MariaDB MaxScale installation. Follow this tutorial
 to learn how to configure and start using MaxScale.
 
-For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) and the module specific documents\
+For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) and the module specific documents
 listed in the [Documentation Contents](../mariadb-maxscale-2501-maxscale-2501-contents.md).
 
 ### Encrypting Passwords
 
-Read the [Encrypting Passwords](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
-section of the configuration guide to set up password encryption for the\
+Read the [Encrypting Passwords](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
+section of the configuration guide to set up password encryption for the
 configuration file.
 
 ### Administration Of MariaDB MaxScale
 
 There are various administration tasks that may be done with MariaDB MaxScale.\
-A command line tools is available, [maxctrl](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-maxctrl.md), that will\
+A command line tools is available, [maxctrl](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-maxctrl.md), that will
 interact with a running MariaDB MaxScale and allow the status of MariaDB\
-MaxScale to be monitored and give some control of the MariaDB MaxScale\
+MaxScale to be monitored and give some control of the MariaDB MaxScale
 functionality.
 
-[The administration tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-administration-tutorial.md)\
+[The administration tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-administration-tutorial.md)
 covers the common administration tasks that need to be done with MariaDB MaxScale.
 
 ### Copying or Backing Up MaxScale
 
-The main configuration file for MaxScale is in `/etc/maxscale.cnf` and\
+The main configuration file for MaxScale is in `/etc/maxscale.cnf` and
 additional user-created configuration files are in`/etc/maxscale.cnf.d/`. Objects created or modified at runtime are stored in`/var/lib/maxscale/maxscale.cnf.d/`. Some modules also store internal data in`/var/lib/maxscale/` named after the module or the configuration object.
 
-The simplest way to back up the configuration and runtime data of a MaxScale\
+The simplest way to back up the configuration and runtime data of a MaxScale
 installation is to create an archive from the following files and directories:
 
 * `/etc/maxscale.cnf`
@@ -116,7 +116,7 @@ This can be done with the following command:
 tar -caf maxscale-backup.tar.gz /etc/maxscale.cnf /etc/maxscale.cnf.d/ /var/lib/maxscale/
 ```
 
-If MaxScale is configured to store data in custom locations, these should be\
+If MaxScale is configured to store data in custom locations, these should be
 included in the backup as well.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-maxgui-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-maxgui-guide.md
@@ -8,27 +8,27 @@ _MaxGUI_ is a browser-based interface for MaxScale REST-API and query execution.
 
 ## Enabling MaxGUI
 
-To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale\
+To enable MaxGUI in a testing mode, add `admin_host=0.0.0.0` and`admin_secure_gui=false` under the `[maxscale]` section of the MaxScale
 configuration file. Once enabled, MaxGUI will be available on port 8989:`http://127.0.0.1:8989/`
 
 ### Securing the GUI
 
 To make MaxGUI secure, set `admin_secure_gui=true` and configure both the`admin_ssl_key` and `admin_ssl_cert` parameters.
 
-See [Configuration Guide](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-rest-api-tutorial.md)\
+See [Configuration Guide](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) and [Configuration and Hardening](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-rest-api-tutorial.md)
 for instructions on how to harden your MaxScale installation for production use.
 
 ## Authentication
 
-MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`\
+MaxGUI uses the same credentials as `maxctrl`. The default username is `admin`
 with `mariadb` as the password.
 
-Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the\
-authentication method for persisting the user's session. If the _Remember me_\
-checkbox is ticked, the session will persist for 24 hours. Otherwise, the\
+Internally, MaxGUI uses [JSON Web Tokens](https://jwt.io/introduction/) as the
+authentication method for persisting the user's session. If the _Remember me_
+checkbox is ticked, the session will persist for 24 hours. Otherwise, the
 session will expire as soon as MaxGUI is closed.
 
-To log out, simply click the username section in the top right corner of the\
+To log out, simply click the username section in the top right corner of the
 page header to access the logout menu.
 
 ## Pages
@@ -42,7 +42,7 @@ By default, the refresh interval is 10 seconds.
 
 ### Detail
 
-This page shows information on each [MaxScale object](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) and allow to edit its\
+This page shows information on each [MaxScale object](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) and allow to edit its
 parameter, relationships and perform other manipulation operations.
 
 Access this page by clicking on the MaxScale object name on the [dashboard page](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-maxgui-guide.md#dashboard)
@@ -52,8 +52,8 @@ Access this page by clicking on the MaxScale object name on the [dashboard page]
 This page visualizes MaxScale configuration and clusters.
 
 * Configuration: Visualizing MaxScale configuration.
-* Cluster: Visualizing a replication cluster into a tree graph and provides\
-  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the\
+* Cluster: Visualizing a replication cluster into a tree graph and provides
+  manual cluster manipulation operations such as`switchover, reset-replication, release-locks, failover, rejoin` . At the
   moment, it supports only servers monitored by Monitor using [mariadbmon](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md) module.
 
 Access this page by clicking the graph icon on the sidebar navigation.
@@ -66,30 +66,30 @@ Access this page by clicking the gear icon on the sidebar navigation.
 
 ### Logs Archive
 
-Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar\
+Realtime MaxScale logs can be accessed by clicking the logs icon on the sidebar
 navigation.
 
 ### Workspace
 
-The "Workspace" page offers a versatile set of tools for effectively managing\
+The "Workspace" page offers a versatile set of tools for effectively managing
 data and database interactions. It includes the following key tasks:
 
 #### 1. Run Queries
 
-Execute queries on various servers, services, or listeners to retrieve data and\
-perform database operations. Visualize query results using different graph\
-types such as line, bar, or scatter graphs. Export query results in formats\
+Execute queries on various servers, services, or listeners to retrieve data and
+perform database operations. Visualize query results using different graph
+types such as line, bar, or scatter graphs. Export query results in formats
 like CSV or JSON for further analysis and sharing.
 
 #### 2. Data Migration
 
-The "Data Migration" feature facilitates seamless transitions from PostgreSQL\
-to MariaDB. Transfer data and database structures between the two systems while\
+The "Data Migration" feature facilitates seamless transitions from PostgreSQL
+to MariaDB. Transfer data and database structures between the two systems while
 ensuring data integrity and consistency throughout the process.
 
 #### 3. Create an ERD
 
-Generating Entity-Relationship Diagrams (ERDs) to gain insights regarding data\
+Generating Entity-Relationship Diagrams (ERDs) to gain insights regarding data
 structure, optimizing database design for both efficiency and clarity.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-change-data-capture-cdc-protocol.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-change-data-capture-cdc-protocol.md
@@ -2,15 +2,15 @@
 
 ## Change Data Capture (CDC) Protocol
 
-The CDC protocol was deprecated in MaxScale 24.08 and will be removed\
-in the next major release. [KafkaCDC](../mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-kafkacdc.md) can be\
+The CDC protocol was deprecated in MaxScale 24.08 and will be removed
+in the next major release. [KafkaCDC](../mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-kafkacdc.md) can be
 used instead.
 
-CDC is a new protocol that allows compatible clients to authenticate and\
-register for Change Data Capture events. The new protocol must be use in\
+CDC is a new protocol that allows compatible clients to authenticate and
+register for Change Data Capture events. The new protocol must be use in
 conjunction with AVRO router which currently converts MariaDB binlog events into\
-AVRO records. Change Data Capture protocol is used by clients in order to\
-interact with stored AVRO file and also allows registered clients to be notified\
+AVRO records. Change Data Capture protocol is used by clients in order to
+interact with stored AVRO file and also allows registered clients to be notified
 with the new events coming from MariaDB 10.0/10.1 database.
 
 ### Creating Users
@@ -53,12 +53,12 @@ In the future, optional flags could be implemented.
 
 #### Authentication
 
-The authentication starts when the client sends the hexadecimal representation\
+The authentication starts when the client sends the hexadecimal representation
 of the username concatenated with a colon (`:`) and the SHA1 of the password.
 
 `bin2hex(username + ':' + SHA1(password))`
 
-For example the user _foobar_ with a password of _foopasswd_ should send the\
+For example the user _foobar_ with a password of _foopasswd_ should send the
 following hexadecimal string
 
 ```
@@ -89,9 +89,9 @@ Server returns `OK` on success and `ERR` on failure.
 
 `REQUEST-DATA DATABASE.TABLE[.VERSION] [GTID]`
 
-This command fetches data from specified table in a database and returns the\
-output in the requested format (AVRO or JSON). Data records are sent to clients\
-and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new\
+This command fetches data from specified table in a database and returns the
+output in the requested format (AVRO or JSON). Data records are sent to clients
+and if new AVRO versions are found (e.g. _mydb.mytable.0000002.avro_) the new
 schema and data will be sent as well.
 
 The data will be streamed until the client closes the connection.
@@ -108,7 +108,7 @@ REQUEST-DATA db2.table4 0-11-345
 
 ### Example Client
 
-MaxScale includes an example CDC client application written in Python 3. You can\
+MaxScale includes an example CDC client application written in Python 3. You can
 find the source code for it [in the MaxScale repository](https://github.com/mariadb-corporation/MaxScale/tree/2.0/server/modules/protocol/examples/cdc.py).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-change-data-capture-cdc-users.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-change-data-capture-cdc-users.md
@@ -2,13 +2,13 @@
 
 ## Change Data Capture (CDC) users
 
-Change Data Capture (CDC) is a new MaxScale protocol that allows compatible\
-clients to authenticate and register for Change Data Capture events. The new\
+Change Data Capture (CDC) is a new MaxScale protocol that allows compatible
+clients to authenticate and register for Change Data Capture events. The new
 protocol must be use in conjunction with AVRO router which currently converts\
-MariaDB binlog events into AVRO records. Clients connect to CDC listener and\
+MariaDB binlog events into AVRO records. Clients connect to CDC listener and
 authenticate using credentials provided in a format described in the [CDC Protocol documentation](mariadb-maxscale-2501-maxscale-2501-change-data-capture-cdc-protocol.md).
 
-**Note**: If no users are found in that file or if it doesn't exist, the only\
+**Note**: If no users are found in that file or if it doesn't exist, the only
 available user will be the _service user_:
 
 ```
@@ -28,7 +28,7 @@ Starting with MaxScale 2.1, users can also be created through maxctrl:
 maxctrl call command cdc add_user <service> <name> <password>
 ```
 
-The should be the service name where the user is created. Older\
+The should be the service name where the user is created. Older
 versions of MaxScale should use the _cdc\_users.py_ script.
 
 ```
@@ -41,7 +41,7 @@ The output of this command should be appended to the _cdcusers_ file at`/var/lib
 bash$ cdc_users.py user1 pass1 >> /var/lib/maxscale/avro-service/cdcusers
 ```
 
-Users can be deleted by removing the related rows in 'cdcusers' file. For\
+Users can be deleted by removing the related rows in 'cdcusers' file. For
 more details on the format of the _cdcusers_ file, read the [CDC Protocol documentation](mariadb-maxscale-2501-maxscale-2501-change-data-capture-cdc-protocol.md).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-mariadb-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-mariadb-protocol-module.md
@@ -4,7 +4,7 @@
 
 The `mariadbprotocol` module implements the MariaDB client-server protocol.
 
-The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all\
+The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all
 aliases to `mariadbprotocol`.
 
 * [MariaDB Protocol Module](mariadb-maxscale-2501-maxscale-2501-mariadb-protocol-module.md#mariadb-protocol-module)
@@ -14,7 +14,7 @@ aliases to `mariadbprotocol`.
 
 ### Configuration
 
-Protocol level parameters are defined in the listeners. They must be defined\
+Protocol level parameters are defined in the listeners. They must be defined
 using the scoped parameter syntax where the protocol name is used as the prefix.
 
 ```
@@ -37,8 +37,8 @@ For the MariaDB protocol module, the prefix is always `mariadbprotocol`.
 * Dynamic: Yes
 * Default: true
 
-Whether the use of the replication protocol is allowed through this listener. If\
-disabled with `mariadbprotocol.allow_replication=false`, all attempts to start\
+Whether the use of the replication protocol is allowed through this listener. If
+disabled with `mariadbprotocol.allow_replication=false`, all attempts to start
 replication will be rejected with a ER\_FEATURE\_DISABLED error (error number\
 1289\).
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md
@@ -2,21 +2,21 @@
 
 ## NoSQL Protocol Module
 
-The `nosqlprotocol` module allows a MariaDB server or cluster to be\
+The `nosqlprotocol` module allows a MariaDB server or cluster to be
 used as the backend of an application using a MongoDB® client library.\
 Internally, all documents are stored in a table containing two columns;\
 an `id` column for the object id and a `doc` column for the document itself.
 
-When the MongoDB® client application issues MongoDB protocol _commands_,\
-either directly or indirectly via the client library, they are transparently\
+When the MongoDB® client application issues MongoDB protocol _commands_,
+either directly or indirectly via the client library, they are transparently
 converted into the equivalent SQL and executed against the MariaDB backend.\
-The MariaDB responses are then in turn converted into the format expected by\
+The MariaDB responses are then in turn converted into the format expected by
 the MongoDB® client library and application.
 
 ### Configuring
 
-There are a number of [parameters](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#parameters) with which the behavior\
-of _nosqlprotocol_ can be adjusted. A minimal configuration looks\
+There are a number of [parameters](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#parameters) with which the behavior
+of _nosqlprotocol_ can be adjusted. A minimal configuration looks
 like:
 
 ```
@@ -33,13 +33,13 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-`nosqlprotocol.user` and `nosqlprotocol.password` specify the\
-credentials that will be used when accessing the backend database or\
+`nosqlprotocol.user` and `nosqlprotocol.password` specify the
+credentials that will be used when accessing the backend database or
 cluster. Note that the same credentials will be used for _all_ connecting\
 MongoDB® clients.
 
-Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which\
-the client requests will be sent. _Nosqlprotocol_ places no limitations\
+Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which
+the client requests will be sent. _Nosqlprotocol_ places no limitations
 on what filters, routers or backends can be used.
 
 To configure the same listener with MaxCtrl, the parameters must be passed in a\
@@ -49,7 +49,7 @@ JSON object in the following manner:
 maxctrl create listener TheService MongoDB-Listener --protocol=nosqlprotocol 'nosqlprotocol={"user":"the_user", "password": "the_password"}'
 ```
 
-All the parameters that the nosqlprotocol module takes must be passed in the\
+All the parameters that the nosqlprotocol module takes must be passed in the
 same JSON object.
 
 A complete example can be found at the [end](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#example) of this document.
@@ -59,18 +59,18 @@ A complete example can be found at the [end](mariadb-maxscale-2501-maxscale-2501
 Nosqlprotocol supports _SCRAM_ _authentication_ as implemented by MongoDB®.\
 The mechanisms `SCRAM-SHA-1` and `SCRAM-SHA-256` are both supported.
 
-If nosqlprotocol has been setup so that no authentication is required, then\
-when connecting only the host and port should be provided, but neither a\
+If nosqlprotocol has been setup so that no authentication is required, then
+when connecting only the host and port should be provided, but neither a
 username nor a password.
 
-For instance, if the _MongoDB Node.JS Driver_ is used, then the connection\
+For instance, if the _MongoDB Node.JS Driver_ is used, then the connection
 string should look like:
 
 ```
 const uri = "mongodb://127.0.0.1:17017"
 ```
 
-Similarly, if the _Mongo Shell_ is used, only the host and port should\
+Similarly, if the _Mongo Shell_ is used, only the host and port should
 be provided:
 
 ```
@@ -82,26 +82,26 @@ MongoDB shell version v4.4.1
 
 #### NoSQL and MariaDB Users
 
-A MariaDB user consists of a name and a host part. A user `'user'@'%'`\
-and a user `'user'@'127.0.0.1'` are completely different. The host part\
-specifies where a user may connect from, with `%` being a wildcard that\
-matches all hosts. What data a user is allowed to access and modify is\
+A MariaDB user consists of a name and a host part. A user `'user'@'%'`
+and a user `'user'@'127.0.0.1'` are completely different. The host part
+specifies where a user may connect from, with `%` being a wildcard that
+matches all hosts. What data a user is allowed to access and modify is
 specified by what _privileges_ are granted to the user.
 
-A NoSQL user is somewhat different. It is created in the context of a\
-particular database, so there may be a user `userx` in the database `dbA`\
-and different user with the same name `userx` in the database `dbB`. What\
-hosts a user may connect from can be restricted, but that is a property of\
-the user and not an implicit part of it. What data a user is allowed to\
-access and modify is specified by the _roles_ that have been assigned to\
+A NoSQL user is somewhat different. It is created in the context of a
+particular database, so there may be a user `userx` in the database `dbA`
+and different user with the same name `userx` in the database `dbB`. What
+hosts a user may connect from can be restricted, but that is a property of
+the user and not an implicit part of it. What data a user is allowed to
+access and modify is specified by the _roles_ that have been assigned to
 the user.
 
-From the above it should be clear that there is not a 1-to-1\
-correspondence between the concept of a user in NoSQL and the concept\
+From the above it should be clear that there is not a 1-to-1
+correspondence between the concept of a user in NoSQL and the concept
 of a user in MariaDB, but that some additional conventions are needed.
 
-To make it possible to have different NoSQL users with the same name,\
-the database in whose context the user is created is prepended to the\
+To make it possible to have different NoSQL users with the same name,
+the database in whose context the user is created is prepended to the
 user name, separated with a dot, when the MariaDB user is created.
 
 This is perhaps easiest to illustrate using an example:
@@ -117,7 +117,7 @@ MariaDB [(none)]> select user, host from mysql.user;
 2 rows in set (0.001 sec)
 ```
 
-Currently there are two user accounts defined. Even though there is\
+Currently there are two user accounts defined. Even though there is
 a user `bob`, creating a NoSQL user `bob` succeeds.
 
 ```
@@ -141,20 +141,20 @@ MariaDB [(none)]> select user, host from mysql.user;
 3 rows in set (0.001 sec)
 ```
 
-The MariaDB user corresponding to the NoSQL user `bob`, created in the\
+The MariaDB user corresponding to the NoSQL user `bob`, created in the
 context of the database `test`, has `test` as a prefix.
 
 **The `mariadb` database**
 
-The fact that NoSQL users have the database embedded in the MariaDB\
-name may be inconvenient if the same data is accessed both as NoSQL\
-via nosqlprotocol and as SQL directly from MariaDB. It also makes\
+The fact that NoSQL users have the database embedded in the MariaDB
+name may be inconvenient if the same data is accessed both as NoSQL
+via nosqlprotocol and as SQL directly from MariaDB. It also makes
 it impossible to use an existing MariaDB account from NoSQL.
 
-To provide a solution for this problem, the database `mariadb` is treated\
-in a specific fashion. A user created in the context of the `mariadb`\
+To provide a solution for this problem, the database `mariadb` is treated
+in a specific fashion. A user created in the context of the `mariadb`
 database is created in the MariaDB server without the database prefix.\
-If we now try to create a user `bob` in the `mariadb` database it will fail,\
+If we now try to create a user `bob` in the `mariadb` database it will fail,
 because the user `'bob'@'%'` exists already.
 
 ```
@@ -197,7 +197,7 @@ we will see that `alice` was created without a database prefix.
 
 When creating a user nosqlprotocol accepts all roles as predefined by\
 MongoDB®, but not all of them are translated into GRANT privileges.\
-The following table shows what privilege(s) a particular role is\
+The following table shows what privilege(s) a particular role is
 converted to.
 
 | Role      | Privileges                                    |
@@ -214,21 +214,21 @@ The following roles are shorthands for several other roles.
 | dbOwner | dbAdmin, readWrite, userAdmin |
 | root    | dbAdmin, readWrite, userAdmin |
 
-`dbOwner` differs from `root` in that the privileges of the former\
-apply only to a particular database, while the privileges of the\
-latter apply to _all_ databases. However, the role `root` can\
+`dbOwner` differs from `root` in that the privileges of the former
+apply only to a particular database, while the privileges of the
+latter apply to _all_ databases. However, the role `root` can
 only be assigned to a user in the `admin` database.
 
-In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in\
-the `admin` database. If so, then the privilege is granted on `*.*`,\
+In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in
+the `admin` database. If so, then the privilege is granted on `*.*`,
 otherwise on `<db>.*`.
 
-If the `root` role is assigned to a user in the `admin` database,\
+If the `root` role is assigned to a user in the `admin` database,
 then the privileges are granted on `*.*`, otherwise on `<db>.*`.
 
-Other pre-defined roles are recognized and stored in the local\
-nosqlprotocol account database, but they do not affect what privileges\
-are granted to the MariaDB user. Currently user-defined roles are\
+Other pre-defined roles are recognized and stored in the local
+nosqlprotocol account database, but they do not affect what privileges
+are granted to the MariaDB user. Currently user-defined roles are
 not supported.
 
 #### Client Authentication
@@ -241,11 +241,11 @@ Authenticationwise nosqlprotocol can be used in three different ways:
 
 **Anonymously**
 
-If there is an anonymous user on the MariaDB server and if nosqlprotocol\
-is configured without a user/password, then all nosqlprotocol clients will\
+If there is an anonymous user on the MariaDB server and if nosqlprotocol
+is configured without a user/password, then all nosqlprotocol clients will
 access the MariaDB server as anonymous users.
 
-Note that the anonymous MariaDB user is only intended for testing and\
+Note that the anonymous MariaDB user is only intended for testing and
 should in general not be used, but deleted.
 
 **Shared Credentials**
@@ -259,18 +259,18 @@ nosqlprotocol.password=thepassword
 ```
 
 then each MongoDB® client will use those credentials when accessing the\
-MariaDB server. Note that from the perspective of the MariaDB server, it\
+MariaDB server. Note that from the perspective of the MariaDB server, it
 is not possible to distinguish between different MongoDB® clients.
 
 **Unique Credentials**
 
-If nosqlprotocol authentication has been taken into use and a MongoDB®\
-client authenticates, either when connecting or later, then the credentials\
+If nosqlprotocol authentication has been taken into use and a MongoDB®
+client authenticates, either when connecting or later, then the credentials
 of MongoDB® client will be used when accessing the MariaDB server.
 
-Note that even if nosqlprotocol authentication has been enabled, authentication\
-is not required, and if the MongoDB® client has not authenticated itself, the\
-credentials specified with `nosqlprotocol.[user|password]` (or the anonymous\
+Note that even if nosqlprotocol authentication has been enabled, authentication
+is not required, and if the MongoDB® client has not authenticated itself, the
+credentials specified with `nosqlprotocol.[user|password]` (or the anonymous
 user) will be used when accessing the MariaDB server.
 
 **Enforce Authentication**
@@ -281,14 +281,14 @@ To enforce authentication, specify
 nosqlprotocol.authentication_required=true
 ```
 
-in the configuration. If authentication is required, then any command\
-that requires access to the MariaDB server will fail, unless the client\
+in the configuration. If authentication is required, then any command
+that requires access to the MariaDB server will fail, unless the client
 has authenticated.
 
 #### Authorization
 
-By default nosqlprotocol does no authorization. However, a nosqlprotocol\
-client is _always_ subject to the authorization performed by the MariaDB\
+By default nosqlprotocol does no authorization. However, a nosqlprotocol
+client is _always_ subject to the authorization performed by the MariaDB
 server.
 
 When nosqlprotocol authorization is enabled by adding
@@ -297,8 +297,8 @@ When nosqlprotocol authorization is enabled by adding
 nosqlprotocol.authorization_enabled=true
 ```
 
-to the configuration file, some commands will be subject to authorization,\
-by nosqlprotocol. The following table lists the commands and what role they\
+to the configuration file, some commands will be subject to authorization,
+by nosqlprotocol. The following table lists the commands and what role they
 require.
 
 | Command                                                                                                   | Role      |
@@ -313,27 +313,27 @@ require.
 | [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#updateUser)                   | userAdmin |
 | [usersInfo](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#usersInfo)                     | userAdmin |
 
-It is important to note that even if nosqlprotocol authorization\
-is enabled, the MariaDB server has the final word. That is, even if the\
-roles of a user would be sufficient for a particular operation, if the\
-granted privileges are not, the operation will not succeed. There may\
-be a mismatch between roles and grants, for instance, if the wrong roles\
-were specified when the user was added, or if the grants have been\
+It is important to note that even if nosqlprotocol authorization
+is enabled, the MariaDB server has the final word. That is, even if the
+roles of a user would be sufficient for a particular operation, if the
+granted privileges are not, the operation will not succeed. There may
+be a mismatch between roles and grants, for instance, if the wrong roles
+were specified when the user was added, or if the grants have been
 altered directly and not via nosqlprotocol.
 
 #### Bootstrapping the Authentication/Authorization
 
-The authentication/authorization can be bootstrapped explicitly\
-or implicitly. Bootstrapping explicitly provides more control, while\
+The authentication/authorization can be bootstrapped explicitly
+or implicitly. Bootstrapping explicitly provides more control, while
 bootstrapping implicitly is much more convenient.
 
 **Explicit bootstrapping**
 
-In order to enable authorization you need to have NoSQL users and\
-those can be created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) or added\
+In order to enable authorization you need to have NoSQL users and
+those can be created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) or added
 with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#addUser).
 
-If you want to _create_ a user, then you first need to configure\
+If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
 
 ```
@@ -341,7 +341,7 @@ nosqlprotocol.user = user_with_privileges_for_creating_a_user
 nosqlprotocol.password = the_users_password
 ```
 
-At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that\
+At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that
 as those are their default values, they do not have to be specified.
 
 Start MaxScale and connect to it with the MongoDB® command line client
@@ -361,8 +361,8 @@ switched to db admin
 { "ok" : 1 }
 ```
 
-Alternatively you can add an existing user. Note that it should be\
-added to the `mariadb` database, unless it was created with the\
+Alternatively you can add an existing user. Note that it should be
+added to the `mariadb` database, unless it was created with the
 convention of having the database as a prefix, e.g. `db.bob`.
 
 ```
@@ -381,12 +381,12 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but\
-as they will be ignored with `nosqlprotocol.authentication_required=true`\
+The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but
+as they will be ignored with `nosqlprotocol.authentication_required=true`
 being present, it is not mandatory.
 
-If you now try to create a user when not having been authenticated or\
-when authenticated as a user without the `userAdmin` role, the result\
+If you now try to create a user when not having been authenticated or
+when authenticated as a user without the `userAdmin` role, the result
 will be:
 
 ```
@@ -401,105 +401,105 @@ switched to db test
 }
 ```
 
-**NOTE** When a client authenticates, the password will not be\
-transferred in cleartext over the network, so, even without SSL,\
-it is not possible to gain access to a password by monitoring the\
+**NOTE** When a client authenticates, the password will not be
+transferred in cleartext over the network, so, even without SSL,
+it is not possible to gain access to a password by monitoring the
 network traffic.
 
-However, when a user is created or added (or the password is changed),\
-the password will be transferred in _cleartext_. To prevent eavesdropping,\
+However, when a user is created or added (or the password is changed),
+the password will be transferred in _cleartext_. To prevent eavesdropping,
 create/add users when connecting over a domain socket, or use [TLS/SSL](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#tlsssl)
 
 **Implicit bootstrapping**
 
-With implicit bootstrapping, you should first create the MariaDB\
-user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#nosql-and-mariadb-users), the concept of a user is somewhat\
-different in MariaDB and NoSQL, which means that certain factors\
-must be taken into account when creating the MariaDB user. Then\
+With implicit bootstrapping, you should first create the MariaDB
+user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#nosql-and-mariadb-users), the concept of a user is somewhat
+different in MariaDB and NoSQL, which means that certain factors
+must be taken into account when creating the MariaDB user. Then
 at first startup, nosqlprotocol will create the corresponding\
-NoSQL user, which will enable the authenticated and authorized\
+NoSQL user, which will enable the authenticated and authorized
 use of nosqlprotocol.
 
 When MaxScale is started, if the following hold
 
-* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration\
+* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration
   section of the nosqlprotocol listener,
 * `nosqlprotocol.user` and `nosqlprotocol.password` are provided, and
 * there are no NoSQL users in the NoSQL account database.
 
 then, MaxScale will
 
-* wait until the primary of the service pointed to by the listener\
+* wait until the primary of the service pointed to by the listener
   is available,
-* connect using the credentials specified in `nosqlprotocol.user`\
+* connect using the credentials specified in `nosqlprotocol.user`
   and `nosqlprotocol.password`,
 * execute `SHOW GRANTS`,
 * translate the privileges into the equivalent NoSQL roles, and
 * create a corresponding NoSQL user into the NoSQL account database.
 
-Immediately thereafter it is possible to connect to the nosqlprotocol\
+Immediately thereafter it is possible to connect to the nosqlprotocol
 port with a MongoDB® client using the specified credentials.
 
-Note that after the bootstrapping, nosqlprotocol will not use\
+Note that after the bootstrapping, nosqlprotocol will not use
 the `user` and `password` settings and they can be removed.
 
 **Grants**
 
-When a NoSQL user is created using [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser)\
-the MariaDB grants are obtained from the specified NoSQL roles\
+When a NoSQL user is created using [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser)
+the MariaDB grants are obtained from the specified NoSQL roles
 as explained [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#Roles_and_privileges).
 
 When implicitly creating a NoSQL user from an existing user in\
-MariaDB, the inverse operation must be performed. There are\
-many factors that affect what NoSQL roles the grants of a user\
+MariaDB, the inverse operation must be performed. There are
+many factors that affect what NoSQL roles the grants of a user
 are translated into:
 
 * whether the user is a regular or admin user,
 * whether the privileges are on `*.*` or some specific `db.*`, and
 * the privileges themselves, e.g. `SELECT`, `DELETE`, etc.
 
-In NoSQL, every user resides in a specific database. Note that\
-this does **not** mean that the database would have to exist\
+In NoSQL, every user resides in a specific database. Note that
+this does **not** mean that the database would have to exist
 in MariaDB.
 
-When it comes to users, the database effectively means a scope,\
-which in the case of nosqlprotocol is handled by prefixing the\
+When it comes to users, the database effectively means a scope,
+which in the case of nosqlprotocol is handled by prefixing the
 corresponding MariaDB user name with the database/scope name.
 
-When creating a user to be used from NoSQL, there are three\
+When creating a user to be used from NoSQL, there are three
 options for the user's name:
 
 * The name can be of the format `some_db.user_name` where`some_db` can be anything (subject to the naming rules of\
-  MariaDB), except `admin` or `mariadb`. In this case, the\
-  user will be a regular user, who can access data in\
+  MariaDB), except `admin` or `mariadb`. In this case, the
+  user will be a regular user, who can access data in
   databases that she has been granted access to.
-* The name can be of the format `admin.user_name` where `admin`\
-  is exactly just that. In this case, the user will be an\
+* The name can be of the format `admin.user_name` where `admin`
+  is exactly just that. In this case, the user will be an
   admin user, who can access any database.
-* The name can be of the format `user_name`. In this case, the\
-  user will be a regular user that from the NoSQL side appears\
-  to reside in the `mariadb` database. The primary purpose of\
-  this alternative is to enable the use of existing users from\
+* The name can be of the format `user_name`. In this case, the
+  user will be a regular user that from the NoSQL side appears
+  to reside in the `mariadb` database. The primary purpose of
+  this alternative is to enable the use of existing users from
   the NoSQL side.
 
-What database the privileges can be specified `ON` depends on\
+What database the privileges can be specified `ON` depends on
 what kind of user is being created.
 
-* If it is a regular user, the privileges must be granted on a\
+* If it is a regular user, the privileges must be granted on a
   specific database, such as `\`dbA\`\`.\*\`. Note that there is no\
   dependency between this database and the (conceptual) database\
   the user resides in.
 * If it is an admin user, the privileges must be granted on\
   the `*.*` database.
 
-In NoSQL, a role can be database specific or generic. However,\
-a generic role can _only_ be assigned to a user in the _admin_\
-database. In practice this means that if the privileges are\
-on `*.*`, then the user must reside in the _admin_ database\
+In NoSQL, a role can be database specific or generic. However,
+a generic role can _only_ be assigned to a user in the _admin_
+database. In practice this means that if the privileges are
+on `*.*`, then the user must reside in the _admin_ database
 (e.g. `admin.bob`) or it is treated as an error.
 
-The following table shows what privileges are required for a\
-role to be assigned. Note that `ALL PRIVILEGES` can be used as\
+The following table shows what privileges are required for a
+role to be assigned. Note that `ALL PRIVILEGES` can be used as
 well.
 
 | ALTER | CREATE | CREATE USER | DROP | DELETE | INDEX | INSERT | SHOW DATABASES(1) | SELECT | UPDATE | WITH GRANT OPTION | Role                    |
@@ -511,19 +511,19 @@ well.
 
 1. Only required if the user is an admin user.
 
-The `AnyDatabase` version will be assigned, if the user is\
+The `AnyDatabase` version will be assigned, if the user is
 an _admin_ user.
 
-If certain roles are assigned, then other roles will be\
+If certain roles are assigned, then other roles will be
 assigned as well.
 
-* If the roles `dbAdmin`, `readWrite` and `userAdmin` are\
+* If the roles `dbAdmin`, `readWrite` and `userAdmin` are
   assigned, then `dbOwner` will be assigned as well.
-* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`\
-  and `userAdminAnyDatabase` are assigned, then `root` will\
+* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`
+  and `userAdminAnyDatabase` are assigned, then `root` will
   be assigned as well.
 
-Once the user has been created and the desired privileges have\
+Once the user has been created and the desired privileges have
 been granted, the NoSQL listener should be configured as follows:
 
 ```
@@ -542,7 +542,7 @@ At MaxScale startup, the NoSQL user will then be created.
 
 **Admin User**
 
-We want the initial NoSQL user to be an administrator, with\
+We want the initial NoSQL user to be an administrator, with
 full rights.
 
 ```
@@ -550,8 +550,8 @@ CREATE USER 'admin.nosql_admin'@'%' IDENTIFIED BY 'nosql_password';
 GRANT ALL PRIVILEGES ON *.* TO 'admin.nosql_admin'@'%' WITH GRANT OPTION;
 ```
 
-As we want an admin user, the name is prefixed with `admin`,\
-which will have that effect. And since it is an admin user, the\
+As we want an admin user, the name is prefixed with `admin`,
+which will have that effect. And since it is an admin user, the
 privileges are granted ON `*.*`.
 
 Thereafter, we specify the following in the configuration file,
@@ -569,16 +569,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'admin.nosql_admin'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -588,9 +588,9 @@ $ mongo --quiet --port 17017 -u nosql_admin -p nosql_password admin
 >
 ```
 
-Note that when connecting the user is passed as `nosql_admin` and _not_\
-as `admin.nosql_admin`. The fact that we want to authenticate against\
-the `admin` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `nosql_admin` and _not_
+as `admin.nosql_admin`. The fact that we want to authenticate against
+the `admin` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -629,13 +629,13 @@ argument.
 }
 ```
 
-As can be seen, the user has the _any_ roles on the `admin`\
-database, which means that all databases can be accessed and\
+As can be seen, the user has the _any_ roles on the `admin`
+database, which means that all databases can be accessed and
 modified, and that new users can be created.
 
 **Test User**
 
-We want the initial NoSQL user to be a user with limited rights,\
+We want the initial NoSQL user to be a user with limited rights,
 intended to be used for testing.
 
 ```
@@ -643,11 +643,11 @@ CREATE USER 'test.test_user'@'%' IDENTIFIED BY 'test_password';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX ON `test`.* TO 'test.test_user'@'%';
 ```
 
-As we want a user with limited rights, the name is _not_ prefixed\
+As we want a user with limited rights, the name is _not_ prefixed
 with `admin`. The privileges are granted specifically on database`test.*`. Indeed, if `*.*` had been used, the creation of the initial\
-NoSQL user would have failed with an error. Here, the user is created\
-in the same database that the user is given access to, but it could\
-have been another one. Further, several `GRANT` statements could have\
+NoSQL user would have failed with an error. Here, the user is created
+in the same database that the user is given access to, but it could
+have been another one. Further, several `GRANT` statements could have
 been used, had we wanted to give access to several databases.
 
 Thereafter, we specify the following in the configuration file,
@@ -665,16 +665,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'test.test_user'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -684,9 +684,9 @@ $ mongo --quiet --port 17017 -u test_user -p test_password test
 >
 ```
 
-Note that when connecting the user is passed as `test_user` and _not_\
-as `test.test_user`. The fact that we want to authenticate against\
-the `test` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `test_user` and _not_
+as `test.test_user`. The fact that we want to authenticate against
+the `test` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -713,44 +713,44 @@ argument.
 }
 ```
 
-As can be seen, the user has the `readWrite` role on the `test` database,\
+As can be seen, the user has the `readWrite` role on the `test` database,
 which means that only the `test` database can be accessed and modified.
 
 **TLS/SSL**
 
-Since `nosqlprotocol` is a regular protocol module used in a listener,\
-the TLS/SSL support of listeners is available. Please see [TLS/SSL encryption](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#tlsssl-encryption)\
+Since `nosqlprotocol` is a regular protocol module used in a listener,
+the TLS/SSL support of listeners is available. Please see [TLS/SSL encryption](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#tlsssl-encryption)
 for details.
 
 #### NoSQL Account Database
 
-So as to be able to connect to the MariaDB server on behalf of\
-clients, nosqlprotocol must know their password. As the password\
-is not transferred to nosqlprotocol during the authentication in\
-a way that could be used when logging into MariaDB, the password\
-must be stored when the user is created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser)\
+So as to be able to connect to the MariaDB server on behalf of
+clients, nosqlprotocol must know their password. As the password
+is not transferred to nosqlprotocol during the authentication in
+a way that could be used when logging into MariaDB, the password
+must be stored when the user is created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser)
 or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser).
 
-Note that the password is not stored in cleartext but as three\
-different hashes; hashed with sha1 for use with MariaDB, salted\
-and hashed with sha1 for use with the `SCRAM-SHA-1` authentication\
-mechanism (if that is enabled for the user) and salted and hashed\
-with sha256 for use with the `SCRAM-SHA-256` authentication mechanism\
+Note that the password is not stored in cleartext but as three
+different hashes; hashed with sha1 for use with MariaDB, salted
+and hashed with sha1 for use with the `SCRAM-SHA-1` authentication
+mechanism (if that is enabled for the user) and salted and hashed
+with sha256 for use with the `SCRAM-SHA-256` authentication mechanism
 (if that is enabled for the user).
 
-The account information can be stored _privately_, in which case it\
-can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can\
-share the information and a user created/added on one instance\
+The account information can be stored _privately_, in which case it
+can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can
+share the information and a user created/added on one instance
 can be used on another.
 
 **Private**
 
-In the private case, the account information of nosqlprotocol is\
-stored in an [sqlite3](https://sqlite.org/index.html) database\
-whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,\
-where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the\
-listener section in the MaxScale configuration file, and `-v1`\
-a suffix for making schema evolution easier, should there be\
+In the private case, the account information of nosqlprotocol is
+stored in an [sqlite3](https://sqlite.org/index.html) database
+whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,
+where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the
+listener section in the MaxScale configuration file, and `-v1`
+a suffix for making schema evolution easier, should there be
 a need for that.
 
 For instance, given a configuration like
@@ -765,41 +765,41 @@ protocol=nosqlprotocol
 
 the account information will be stored in the file`<libdir>/nosqlprotocol/NoSQL-Listener-v1.db`.
 
-Note that since the database name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the database name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
-To retain the accounts, the database file should also be\
+To retain the accounts, the database file should also be
 renamed.
 
-At first startup, the `nosqlprotocol` directory and\
-the file `NoSQL-Listener-v1.db` will be created. They will\
-be created with file permissions that only allow MaxScale\
-access. At subsequent startups the permissions will be checked\
-and MaxScale will refuse to start if the permissions allow\
+At first startup, the `nosqlprotocol` directory and
+the file `NoSQL-Listener-v1.db` will be created. They will
+be created with file permissions that only allow MaxScale
+access. At subsequent startups the permissions will be checked
+and MaxScale will refuse to start if the permissions allow
 access to others.
 
 **We strongly recommend that no manual modifications are made**\
 **to the database.**
 
-Note that we make **no** guarantees that the way in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the way in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 **Shared**
 
-In the shared case, the account information of nosqlprotocol\
+In the shared case, the account information of nosqlprotocol
 is stored in the cluster of the service in front of which the\
-NoSQL listener resides. The primary of the cluster will be used\
+NoSQL listener resides. The primary of the cluster will be used
 both for reading and writing data.
 
 A table whose name is the same as the listener's name in the\
-MaxScale configuration will be created in the database\
-specified with the [authentication\_db](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_db)\
-parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of\
+MaxScale configuration will be created in the database
+specified with the [authentication\_db](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_db)
+parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of
 the listener section in the MaxScale configuration file.
 
 For instance, given a configuration like
@@ -814,61 +814,61 @@ protocol=nosqlprotocol
 
 the account information will be stored in the table`nosqlprotocol.NoSQL-Listener`.
 
-Note that since the table name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the table name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
 To retain the accounts, the table should also be renamed.
 
-`nosqlprotocol` will create the table when needed, so the\
-user specified with [authentication\_user](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_user)\
+`nosqlprotocol` will create the table when needed, so the
+user specified with [authentication\_user](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_user)
 must have sufficient grants to be able to do that.
 
-`nosqlprotocol` will store in the table, data that allow\
-any MaxScale to authenticate a MongoDB® client, irrespective\
+`nosqlprotocol` will store in the table, data that allow
+any MaxScale to authenticate a MongoDB® client, irrespective
 of which MaxScale instance was used when the user was created.
 
-`nosqlprotocol` also stores in the table the SHA1 of a user's\
+`nosqlprotocol` also stores in the table the SHA1 of a user's
 password, to be able to authenticate against the MariaDB server.\
-Therefore it is **strongly** suggested to enable encryption key\
-management in MaxScale and to provide an authentication\
-key ID with [authentication\_key\_id](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_key_id) so\
+Therefore it is **strongly** suggested to enable encryption key
+management in MaxScale and to provide an authentication
+key ID with [authentication\_key\_id](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_key_id) so
 that the data will be encrypted.
 
-If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_user) and [authentication\_password](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_password) must also\
-be provided. With [authentication\_db](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_db) the\
-database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_key_id) an\
-encryption key ID, using which the sensitive data is encrypted,\
+If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_user) and [authentication\_password](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_password) must also
+be provided. With [authentication\_db](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_db) the
+database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#authentication_key_id) an
+encryption key ID, using which the sensitive data is encrypted,
 can optionally be provided.
 
-Note that we make **no** guarantees that the table in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the table in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ### Wire Protocol
 
-_Nosqlprotocol_ fully supports wire protocol version 6 and only provides\
-rudimentary support for earlier wire protocol versions, but reports at\
-startup that it would support versions 0 to 6. The reason is that some\
-client libraries are buggy and use an old wire protocol version if the\
-server claims to support only version 6. Consequently, one should use a\
+_Nosqlprotocol_ fully supports wire protocol version 6 and only provides
+rudimentary support for earlier wire protocol versions, but reports at
+startup that it would support versions 0 to 6. The reason is that some
+client libraries are buggy and use an old wire protocol version if the
+server claims to support only version 6. Consequently, one should use a
 client library version that at least supports wire protocol version 6.
 
 ### Client Library
 
-As the goal of _nosqlprotocol_ is to implement, to the extent that it\
-is feasible, the wire protocol and the database commands the way MongoDB®\
+As the goal of _nosqlprotocol_ is to implement, to the extent that it
+is feasible, the wire protocol and the database commands the way MongoDB®
 implements them, it should be possible to use any language specific driver.
 
-However, during the development of _nosqlprotocol_, the _only_ client library\
+However, during the development of _nosqlprotocol_, the _only_ client library
 that has been verified to work is version 3.6 of _MongoDB Node.JS Driver_.
 
 ### Settings
 
-Using the following parameters, the behavior of _nosqlprotocol_ can be\
+Using the following parameters, the behavior of _nosqlprotocol_ can be
 adjusted. As they are not generic listener parameters, but specific to _nosqlprotocol_ they must be qualified with the `nosqlprotocol`-prefix.
 
 For instance:
@@ -890,7 +890,7 @@ nosqlprotocol.on_unknown_command=return_error
 * Mandatory: No
 * Default: `""`
 
-Specifies the _user_ to be used when connecting to the backend, if the MongoDB®\
+Specifies the _user_ to be used when connecting to the backend, if the MongoDB®
 client is not authenticated.
 
 #### `password`
@@ -899,8 +899,8 @@ client is not authenticated.
 * Mandatory: No
 * Default: `""`
 
-Specifies the _password_ to be used when connecting to the backend, is the MongoDB®\
-client is not authenticated. Note that the same _user_/_password_ combination will be\
+Specifies the _password_ to be used when connecting to the backend, is the MongoDB®
+client is not authenticated. Note that the same _user_/_password_ combination will be
 used for all unauthenticated MongoDB® clients connecting to the same listener port.
 
 #### `authentication_required`
@@ -909,11 +909,11 @@ used for all unauthenticated MongoDB® clients connecting to the same listener p
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the client always must authenticate. If authentication is required,\
-it does not matter whether `user` and `password` have been specified, the client must\
+Specifies whether the client always must authenticate. If authentication is required,
+it does not matter whether `user` and `password` have been specified, the client must
 authenticate.
 
-Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser),\
+Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser),
 with authentication being optional and authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -925,7 +925,7 @@ MariaDB server.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the NoSQL account information should be stored in a shared\
+Specifies whether the NoSQL account information should be stored in a shared
 manner or privately.
 
 #### `authentication_db`
@@ -934,10 +934,10 @@ manner or privately.
 * Mandatory: No
 * Default: `"NoSQL"`
 
-Specifies the database of the table where the NoSQL account information\
-is stored, if `authentication_shared` is `true`. If the database does not\
-exist, nosqlprotocol will attempt to create it, so either is should be\
-manually created or the used specified with `authentication_user` should\
+Specifies the database of the table where the NoSQL account information
+is stored, if `authentication_shared` is `true`. If the database does not
+exist, nosqlprotocol will attempt to create it, so either is should be
+manually created or the used specified with `authentication_user` should
 have the grants required to do so.
 
 #### `authentication_key_id`
@@ -946,11 +946,11 @@ have the grants required to do so.
 * Mandatory: No
 * Default: `""`
 
-The encryption key ID, using which the NoSQL account information should be\
-encrypted with when stored in the MariaDB server. If an encryption key ID is\
+The encryption key ID, using which the NoSQL account information should be
+encrypted with when stored in the MariaDB server. If an encryption key ID is
 given, the encryption key manager in MaxScale must also be enabled.
 
-The encryption key must be a 256-bit key. Keys of shorter length are rejected\
+The encryption key must be a 256-bit key. Keys of shorter length are rejected
 as invalid encryption keys.
 
 #### `authentication_user`
@@ -958,7 +958,7 @@ as invalid encryption keys.
 * Type: string
 * Mandatory: Yes, if `authentication_shared` is true.
 
-Specifies the _user_ to be used when modifying and accessing the NoSQL\
+Specifies the _user_ to be used when modifying and accessing the NoSQL
 account information stored in the MariaDB server.
 
 #### `authentication_password`
@@ -975,9 +975,9 @@ Specifies the _password_ of `authentication_user`.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether nosqlprotocol itself should perform authorization in the context\
-of the commands [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsUpdateUser). Authorization should not be enabled before users\
-have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser)\
+Specifies whether nosqlprotocol itself should perform authorization in the context
+of the commands [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsUpdateUser). Authorization should not be enabled before users
+have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser)
 with authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -990,8 +990,8 @@ MariaDB server.
 * Default: `"%"`
 
 Specifies the _host_ to be used when a MariaDB user is created via nosqlprotocol.\
-By default all users are created as `...@'%'`, which means that it is possible to\
-connect to the MariaDB server from any host using the credentials of the created\
+By default all users are created as `...@'%'`, which means that it is possible to
+connect to the MariaDB server from any host using the credentials of the created
 user. For tighter security, the IP-address of the MaxScale host can be specified.
 
 NOTE: This value does **not** specify from which host it is allowed to connect to\
@@ -1017,8 +1017,8 @@ Enumeration values:
 * Mandatory: No
 * Default: `false`
 
-Specifies whether an unknown command should be logged. This is primarily\
-for debugging purposes, to find out whether a client uses a command that\
+Specifies whether an unknown command should be logged. This is primarily
+for debugging purposes, to find out whether a client uses a command that
 currently is not supported.
 
 #### `auto_create_databases`
@@ -1040,7 +1040,7 @@ Note that setting this parameter to `true`, without also setting`auto_create_tab
 Specifies whether tables should automatically be created, as needed.
 
 Note that this applies only if the relevant database already exists.\
-If a database should also be created if needed, then `auto_create_databases`\
+If a database should also be created if needed, then `auto_create_databases`
 must also be set to `true`.
 
 #### `id_length`
@@ -1061,16 +1061,16 @@ Specifies the length of the id column in tables that are automatically created.
 
 Enumeration values:
 
-* `default`: Each document is inserted using a separate `INSERT`, either in a\
-  multi-statement or in a compound statement. Whether an error causes the remaining\
-  insertions to be aborted, depends on the value of `ordered` specified in the\
+* `default`: Each document is inserted using a separate `INSERT`, either in a
+  multi-statement or in a compound statement. Whether an error causes the remaining
+  insertions to be aborted, depends on the value of `ordered` specified in the
   insert command.
-* `atomic`: If the value of `ordered` in the insert command is `true`\
-  (the default) then all documents are inserted using a single `INSERT` statement,\
-  that is, either all insertions succeed or none will. If `ordered` is false, then\
+* `atomic`: If the value of `ordered` in the insert command is `true`
+  (the default) then all documents are inserted using a single `INSERT` statement,
+  that is, either all insertions succeed or none will. If `ordered` is false, then
   the behavior is as in the `default` case.
 
-What combination of `ordered_insert_behavior` and `ordered` (in the insert command\
+What combination of `ordered_insert_behavior` and `ordered` (in the insert command
 document) is used, has an impact on the performance. Please see the discussion at [insert](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#insert).
 
 #### `cursor_timeout`
@@ -1079,7 +1079,7 @@ document) is used, has an impact on the performance. Please see the discussion a
 * Mandatory: No
 * Default: `60s`
 
-Specifies how long a cursor can be idle, that is, not accessed, before it is\
+Specifies how long a cursor can be idle, that is, not accessed, before it is
 automatically closed.
 
 #### `debug`
@@ -1104,7 +1104,7 @@ So, specify
 nosqlprotocol.debug=in,out,back
 ```
 
-to have the incoming command, the corresponding SQL sent to the backend\
+to have the incoming command, the corresponding SQL sent to the backend
 and the resulting response sent to the client logged.
 
 #### `internal_cache`
@@ -1113,7 +1113,7 @@ and the resulting response sent to the client logged.
 * Mandatory: No
 * Default: ''
 
-Specifies what internal cache to use if any. Currently, the only\
+Specifies what internal cache to use if any. Currently, the only
 permissible value is `cache`, which refers to the [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md).
 
 Please see [caching](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#caching) for more information.
@@ -1121,15 +1121,15 @@ Please see [caching](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1
 ### Databases and Tables
 
 By default, _nosqlprotocol_ automatically creates databases as needed.\
-The default behavior can be changed by setting `auto_create_databases` to\
+The default behavior can be changed by setting `auto_create_databases` to
 false. In that case, databases must manually be created.
 
 Each MongoDB® _collection_ corresponds to a MariaDB table with the same name.\
-However, it is always possible to access a collection irrespective of whether\
+However, it is always possible to access a collection irrespective of whether
 the corresponding table exists or not; it will simply appear to be empty.
 
-Inserting documents into a collection, whose corresponding table does not\
-exist, succeeds, provided `auto_create_tables` is `true`, as the table will\
+Inserting documents into a collection, whose corresponding table does not
+exist, succeeds, provided `auto_create_tables` is `true`, as the table will
 in that case be created.
 
 When _nosqlprotocol_ creates a table, it uses a statement like
@@ -1140,19 +1140,19 @@ CREATE TABLE name (id VARCHAR(35) AS (JSON_COMPACT(JSON_EXTRACT(doc, "$._id"))) 
                    CONSTRAINT id_not_null CHECK(id IS NOT NULL));
 ```
 
-where the length of the `VARCHAR` is specified by the value of `id_length`,\
+where the length of the `VARCHAR` is specified by the value of `id_length`,
 whose default and minimum is 35.
 
-_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain\
+_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain
 a similar constraint.
 
-Note that _nosqlprotocol_ does not in any way verify that the table\
-corresponding to a collection being accessed or modified does indeed\
-have the expected columns `id` and `doc` of the expected types, but it\
-simply uses the table, which will fail if the layout is not the expected\
+Note that _nosqlprotocol_ does not in any way verify that the table
+corresponding to a collection being accessed or modified does indeed
+have the expected columns `id` and `doc` of the expected types, but it
+simply uses the table, which will fail if the layout is not the expected
 one.
 
-To reduce the risk for confusion, the recommendation is to use a specific\
+To reduce the risk for confusion, the recommendation is to use a specific
 database for tables that contain documents.
 
 ### Operators
@@ -1188,7 +1188,7 @@ The following operators are currently supported.
 
 **`$type`**
 
-When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset\
+When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset
 of types can be used in `$type` queries:
 
 | Type           | Number | Alias    | MariaDB Type |
@@ -1310,10 +1310,10 @@ As arguments, only the operators `$eq` and `$ne` are supported.
 
 ### Database Commands
 
-The following commands are supported. At each command is specified\
+The following commands are supported. At each command is specified
 what fields are relevant for the command.
 
-**All** non-listed fields are ignored; their presence or absence have no\
+**All** non-listed fields are ignored; their presence or absence have no
 impact, unless otherwise explicitly specified.
 
 #### Aggregation Commands
@@ -1328,8 +1328,8 @@ The following fields are relevant.
 | pipeline  | array   | An array of [aggregation pipeline stages](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#aggregation-pipeline-stages) that process and transform the document stream. |
 | explain   | boolean | Optional. Specifies to return information on the processing of the pipeline.                                                                                                          |
 
-Depending on the stages and their parameters, the aggregation pipeline may be\
-performed entirely using SQL, by fetching documents to MaxScale where they are\
+Depending on the stages and their parameters, the aggregation pipeline may be
+performed entirely using SQL, by fetching documents to MaxScale where they are
 post-processed or by a combination of the two approaches.
 
 **count**
@@ -1398,7 +1398,7 @@ The `projection` parameter takes a document of the following form:
 { <field1>: <value>, <field2>: <value> ... }
 ```
 
-If a `projection` document is not provided or if it is empty, the entire document\
+If a `projection` document is not provided or if it is empty, the entire document
 will be returned.
 
 | Projection     | Description                             |
@@ -1413,17 +1413,17 @@ For fields in an embedded documents, the field can be specified using:
 
 * dot notation; e.g. `"field.nestedfield": <value>`
 
-In particular, specifying fields in embedded documents using nested form\
+In particular, specifying fields in embedded documents using nested form
 is not supported.
 
 **`_id` Field Projection**
 
-The `_id` field is included in the returned documents by default unless you\
+The `_id` field is included in the returned documents by default unless you
 explicitly specify `_id: 0` in the projection to suppress the field.
 
 **Inclusion or Exclusion**
 
-A `projection` cannot contain both include and exclude specifications,\
+A `projection` cannot contain both include and exclude specifications,
 with the exception of the `_id` field:
 
 * In projections that explicitly include fields, the `_id` field is the only field that can be explicitly excluded.
@@ -1455,7 +1455,7 @@ and in the latter
 ... WHERE (JSON_EXTRACT(doc, '$._id') = 4711)
 ```
 
-That is, in the former case the _indexed_ column `id` will be used, in the\
+That is, in the former case the _indexed_ column `id` will be used, in the
 latter it will not.
 
 **findAndModify**
@@ -1495,9 +1495,9 @@ The following fields are relevant.
 
 **insert**
 
-The `insert` command inserts one or more documents into the table whose\
-name is the same as that of the collection. If the option `auto_create_tables`\
-is `true`, then the table is created if it does not already exist. If the\
+The `insert` command inserts one or more documents into the table whose
+name is the same as that of the collection. If the option `auto_create_tables`
+is `true`, then the table is created if it does not already exist. If the
 value is `false`, then the insert will fail unless the table already exists.
 
 The following fields are relevant.
@@ -1514,9 +1514,9 @@ The impact of `ordered` is dependent upon the value of `ordered_insert_behavior`
 
 **`default`**
 
-In this case `ordered` has the same impact as in MongoDB®. That is, if the value\
-is `true`, then when an insert of a document fails, return without inserting any\
-remaining documents listed in the inserts array. If `false`, then when an insert\
+In this case `ordered` has the same impact as in MongoDB®. That is, if the value
+is `true`, then when an insert of a document fails, return without inserting any
+remaining documents listed in the inserts array. If `false`, then when an insert
 of a document fails, continue to insert the remaining documents.
 
 **`atomic`**
@@ -1528,7 +1528,7 @@ then the behavior is identical with that of `default`.
 
 **Performance**
 
-What combination of `ordered_insert_behavior` and `ordered` is used, has an\
+What combination of `ordered_insert_behavior` and `ordered` is used, has an
 impact on the performance.
 
 | ordered\_insert\_behavior | ordered = true                                                                                                                        | ordered = false                                                                                                                        |
@@ -1536,8 +1536,8 @@ impact on the performance.
 | default                   | All documents are inserted within a compound statement, in a transaction containing as many INSERT statements as there are documents. | All documents are inserted in a single multi-statement transaction containing as many INSERT IGNORE statements as there are documents. |
 | atomic                    | All documents are inserted using a single INSERT statement.                                                                           | Same as above                                                                                                                          |
 
-Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,\
-being roughly twice as slow. The performance of 'default + true' is halfway between\
+Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,
+being roughly twice as slow. The performance of 'default + true' is halfway between
 the two.
 
 **resetError**
@@ -1570,10 +1570,10 @@ Each document contains the following fields:
 | u     | document | The modifications to apply. See behavior below for details.                                                                                                        |
 | multi | boolean  | Optional. If true, updates all documents that meet the query criteria. If false limit the update to one document that meets the query criteria. Defaults to false. |
 
-Note that currently it is possible to set `multi` to `true` in conjunction\
+Note that currently it is possible to set `multi` to `true` in conjunction
 with a _replacement-style_ update, even though MongoDB® rejects that.
 
-All other fields are ignored, with the exception of `upsert` that if present\
+All other fields are ignored, with the exception of `upsert` that if present
 with the value of `true` will cause the command to fail.
 
 **Behavior**
@@ -1599,7 +1599,7 @@ In this case, the update command updates only the corresponding fields in the do
 
 **# Update with a Replacement Document**
 
-The update statement field `u` field can accept a _replacement document_,\
+The update statement field `u` field can accept a _replacement document_,
 i.e. the document contains only `field:value` expressions. For example:
 
 ```
@@ -1614,12 +1614,12 @@ updates: [
 ```
 
 In this case, the update command replaces the matching document with the update document.\
-The update command can only replace a single matching document; i.e. the multi field\
+The update command can only replace a single matching document; i.e. the multi field
 cannot be true.
 
-**Note** If the replacement document contains an `_id` field, it will be ignored and the\
-document id will remain non-changed while the document otherwise is replaced. This is\
-different from MongoDB® where the presence of the `_id` field in the replacement document\
+**Note** If the replacement document contains an `_id` field, it will be ignored and the
+document id will remain non-changed while the document otherwise is replaced. This is
+different from MongoDB® where the presence of the `_id` field in the replacement document
 causes an error, if the value is not the same as it is in the document being replaced.
 
 #### Authentication Commands
@@ -1634,7 +1634,7 @@ The following fields are relevant.
 
 If you are not logged in and using authentication, `logout` has no effect.
 
-Note that in order to be logged out, the logging out must be done while\
+Note that in order to be logged out, the logging out must be done while
 using the same database that was used when you logged on.
 
 Always returns
@@ -1647,7 +1647,7 @@ Always returns
 
 **createUser**
 
-Creates a new MariaDB user and adds an entry to the local nosqlprotocol\
+Creates a new MariaDB user and adds an entry to the local nosqlprotocol
 account database.
 
 The following fields are relevant.
@@ -1661,8 +1661,8 @@ The following fields are relevant.
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is\
-the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the\
+The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is
+the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the
 following command
 
 ```
@@ -1672,19 +1672,19 @@ following command
 
 the MariaDB user `'myDatabase.user1'@'%'` will be created.
 
-The elements of the `roles` array are converted into privileges\
+The elements of the `roles` array are converted into privileges
 as explained in [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#roles_and_privileges).
 
 In practice the creation is performed as follows:_First the MariaDB user is created._ Then the privileges are granted.
 
 * Finally the local nosqlprotocol account database is updated.
 
-If the granting of privileges fails, an attempt will be made to\
+If the granting of privileges fails, an attempt will be made to
 drop the user.
 
 **dropAllUsersFromDatabase**
 
-Drops all users from the local nosqlprotocol account database and\
+Drops all users from the local nosqlprotocol account database and
 the corresponding MariaDB users.
 
 The following fields are relevant.
@@ -1706,13 +1706,13 @@ The following fields are relevant.
 | -------- | ------ | ----------------------------------- |
 | dropUser | string | The name of the user to be dropped. |
 
-The user will first be dropped from the MariaDB server and if\
+The user will first be dropped from the MariaDB server and if
 that succeeds also from the local nosqlprotocol account database.
 
 **grantRolesToUser**
 
-This command _adds_ more roles to a NoSQL user, which may imply\
-that additional privileges are granted to the corresponding MariaDB\
+This command _adds_ more roles to a NoSQL user, which may imply
+that additional privileges are granted to the corresponding MariaDB
 user.
 
 | Field            | Type   | Description                                    |
@@ -1721,12 +1721,12 @@ user.
 | roles            | array  | An array of additional roles.                  |
 
 Note that roles assigned to different databases will result in separate\
-GRANT statements, which means that it is possible that some succeed and\
+GRANT statements, which means that it is possible that some succeed and
 others do not.
 
 **revokeRolesFromUser**
 
-This command _removes_ roles from an NoSQL user, which may imply\
+This command _removes_ roles from an NoSQL user, which may imply
 that privileges are revoked from the corresponding MariaDB user.
 
 | Field               | Type   | Description                                |
@@ -1734,8 +1734,8 @@ that privileges are revoked from the corresponding MariaDB user.
 | revokeRolesFromUser | string | The name of the user to remove roles from. |
 | roles               | array  | An array of roles to remove.               |
 
-Note that roles to be removed from different databases will result in\
-separate REVOKE statements, which means that it is possible that some\
+Note that roles to be removed from different databases will result in
+separate REVOKE statements, which means that it is possible that some
 succeed and others do not.
 
 **updateUser**
@@ -1750,8 +1750,8 @@ This command updates the information about a particular user.
 | roles      | array    | Optional. The roles granted to the user. Note that the existing ones are replaced and not amended with these roles.                                                                                                                                                |
 | mechanisms | array    | Optional. The specific SCRAM mechanisms for user credentials. Note that if a new pwd is provided, then the array can contain all supported SCRAM mechanisms. If a new pwd is not provided, then the array must be a subset of the existing mechanisms of the user. |
 
-Changes to `customData` or `mechanisms` are made only to the local\
-nosqlprotocol database, but changes to `pwd` or `roles` require\
+Changes to `customData` or `mechanisms` are made only to the local
+nosqlprotocol database, but changes to `pwd` or `roles` require
 the MariaDB server to be updated.
 
 **usersInfo**
@@ -1775,11 +1775,11 @@ The returned information depends the value of `usersInfo`:
 | { usersInfo: \[{ user: , db: }, ...]} | Returns information about specified users.                                          |
 | { usersInfo: \[ , ... ]}              | Returns information about specified users in the database where the command is run. |
 
-Note that users may always view their own information. Otherwise the user must\
+Note that users may always view their own information. Otherwise the user must
 have the `userAdmin` or `userAdminAnyDatabase` role.
 
 If `showCredentials` is true, the returned object(s) will contain a`mariadb: { password: "*..."}` field, where `password` is the`SHA1(SHA1())` value of the password used when logging to MariaDB.\
-That is, the same string that is found in the `password` column in\
+That is, the same string that is found in the `password` column in
 the `mysql.user` table.
 
 #### Replication Commands
@@ -1841,8 +1841,8 @@ The following fields are relevant.
 | capped | boolean | Optional. If specified, the value must be false as capped collections are not supported. |
 | viewOn | string  | Optional. If specified, the command will fail as views are not supported.                |
 
-Currently, _capped collections_ and _views_ are not supported. Consequently,\
-specifying that the collection should be capped or that it should be a\
+Currently, _capped collections_ and _views_ are not supported. Consequently,
+specifying that the collection should be capped or that it should be a
 view on another collection, will cause the command to fail.
 
 **createIndexes**
@@ -1853,9 +1853,9 @@ The following fields are relevant.
 | ------------- | ------ | ------------------------------------------- |
 | createIndexes | string | The collection for which to create indexes. |
 
-**NOTE** Currently it is not possible to create indexes, but the command\
-will nonetheless return success, provide the index specification passes\
-some rudimentary sanity checks. Note also that the collection will be\
+**NOTE** Currently it is not possible to create indexes, but the command
+will nonetheless return success, provide the index specification passes
+some rudimentary sanity checks. Note also that the collection will be
 created if it does not exist.
 
 **drop**
@@ -1882,9 +1882,9 @@ The following fields are relevant.
 | ----------- | ---- | ----------- |
 | dropIndexes | any  | Ignored.    |
 
-**NOTE** Currently it is not possible to create indexes and thus there\
-will never be any indexes that could be dropped. However, provided the\
-specified collection exists, dropping indexes will always succeed except\
+**NOTE** Currently it is not possible to create indexes and thus there
+will never be any indexes that could be dropped. However, provided the
+specified collection exists, dropping indexes will always succeed except
 for an attempt to drop the built-in `_id_` index.
 
 **fsync**
@@ -1925,7 +1925,7 @@ The following fields are relevant.
 | filter          | document | The field name is honored, other fields are not but cause warnings to be logged.                                                                 |
 | nameOnly        | boolean  | Optional. A flag to indicate whether the command should return just the collection names and type or return both the name and other information. |
 
-Up until version 24.02, the command listed every table in the current\
+Up until version 24.02, the command listed every table in the current
 database as a collection. From 24.08 onwards, only tables that contain\
 NoSQL data will be returned as NoSQL collections.
 
@@ -1946,9 +1946,9 @@ The following fields are relevant.
 | ----------- | ------ | --------------------------- |
 | listIndexes | string | The name of the collection. |
 
-**NOTE** As it currently is not possible to actually create indexes,\
-although an attempt to do so using `createIndexes` will succeed, the\
-result will always only contain information about the built-in\
+**NOTE** As it currently is not possible to actually create indexes,
+although an attempt to do so using `createIndexes` will succeed, the
+result will always only contain information about the built-in
 index `_id_`.
 
 **renameCollection**
@@ -2056,8 +2056,8 @@ The following fields are relevant.
 | -------- | ------ | --------------------------------------- |
 | validate | string | The name of the collection to validate. |
 
-The command does not actually perform any validation but for checking\
-that the collection exists. The response will contain in `nrecords`\
+The command does not actually perform any validation but for checking
+that the collection exists. The response will contain in `nrecords`
 the current number of documents/rows it contains.
 
 **whatsmyuri**
@@ -2094,11 +2094,11 @@ The following document will always be returned:
 
 **mxsAddUser**
 
-The `mxsAddUser` command adds an _existing_ MariaDB user to the local\
+The `mxsAddUser` command adds an _existing_ MariaDB user to the local
 nosqlprotocol account database. Use [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) if the\
 MariaDB user should be created as well.
 
-Note that the `mxsAddUser` command does not check that the user exists\
+Note that the `mxsAddUser` command does not check that the user exists
 or that the specified roles are compatible with the grants of the user.
 
 **Syntax**
@@ -2134,17 +2134,17 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The value of `mxsAddUser` should be the name (without the host part) of\
-an existing user in the MariaDB server and the value of `pwd` should be\
+The value of `mxsAddUser` should be the name (without the host part) of
+an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the addition of the user succeeds, the command returns a document\
+If the addition of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2170,7 +2170,7 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsCreateDatabase**
 
-The 'mxsCreateDatabase' command creates a new database and must be run\
+The 'mxsCreateDatabase' command creates a new database and must be run
 against the `admin` database.
 
 **Syntax**
@@ -2195,7 +2195,7 @@ The command takes the following fields:
 
 **Returns**
 
-If database creation succeeds, the command returns a document with the\
+If database creation succeeds, the command returns a document with the
 single field `ok` whose value is `1`.
 
 ```
@@ -2246,7 +2246,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains diagnostics of the command\
+The command returns a document that contains diagnostics of the command
 provided as argument. For example:
 
 ```
@@ -2271,19 +2271,19 @@ provided as argument. For example:
 }
 ```
 
-`kind` specifies of what kind the command is; an _immediate_ command is one for\
-which MaxScale autonomously can generate the response, a _single_ command is one\
-where the command will cause a single SQL statement to be sent to the backend, and\
-a _multi_ command is one where potentially multiple SQL statements will be sent to\
+`kind` specifies of what kind the command is; an _immediate_ command is one for
+which MaxScale autonomously can generate the response, a _single_ command is one
+where the command will cause a single SQL statement to be sent to the backend, and
+a _multi_ command is one where potentially multiple SQL statements will be sent to
 the backend.
 
-If the command is _immediate_ then there will be a field `response` containing\
-the actual response of the command, if the command is _single_ then there will be\
-a field `sql` containing the actual statement that would have been sent to the backend,\
-and if the command is _multi_ then there will be a field `sql` containing an array\
+If the command is _immediate_ then there will be a field `response` containing
+the actual response of the command, if the command is _single_ then there will be
+a field `sql` containing the actual statement that would have been sent to the backend,
+and if the command is _multi_ then there will be a field `sql` containing an array
 of statements that would have been sent to the backend.
 
-If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that\
+If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that
 the value of `ok` will always be 1.
 
 **mxsGetConfig**
@@ -2292,7 +2292,7 @@ the value of `ok` will always be 1.
 
 **mxsGetConfig**
 
-The `mxsGetConfig` command returns the current configuration of the session\
+The `mxsGetConfig` command returns the current configuration of the session
 and must be run against the 'admin' database.
 
 **Syntax**
@@ -2316,7 +2316,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the current configuration of\
+The command returns a document that contains the current configuration of
 the session. For example:
 
 ```
@@ -2361,8 +2361,8 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a cursor whose first and only batch contains\
-the names of the tables in the database and whether they are NoSQL\
+The command returns a cursor whose first and only batch contains
+the names of the tables in the database and whether they are NoSQL
 collections or not. For example:
 
 ```
@@ -2386,8 +2386,8 @@ collections or not. For example:
 
 **mxsRemoveUser**
 
-The `mxsRemoveUser` removes a user from the local nosqlprotocol account\
-database. Use [dropUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#dropUser) if the MariaDB user should be dropped\
+The `mxsRemoveUser` removes a user from the local nosqlprotocol account
+database. Use [dropUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#dropUser) if the MariaDB user should be dropped
 as well.
 
 **Syntax**
@@ -2412,7 +2412,7 @@ The command has the following fields:
 
 **Returns**
 
-If the removal of the user succeeds, the command returns a document\
+If the removal of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2438,10 +2438,10 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsSetConfig**
 
-The `mxsSetConfig` command changes the configuration of the session\
+The `mxsSetConfig` command changes the configuration of the session
 and must be run against the 'admin' database.
 
-Note that the changes only affect the current session and are **not**\
+Note that the changes only affect the current session and are **not**
 persisted.
 
 **Syntax**
@@ -2473,7 +2473,7 @@ The document takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the changed configuration of\
+The command returns a document that contains the changed configuration of
 the session. For example:
 
 ```
@@ -2505,12 +2505,12 @@ the session. For example:
 
 **mxsUpdateUser**
 
-The `mxsUpdateUser` command updates a user in the local nosqlprotocol\
-account database. Use [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#updateUser) to update MariaDB user\
+The `mxsUpdateUser` command updates a user in the local nosqlprotocol
+account database. Use [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#updateUser) to update MariaDB user
 as well.
 
-Note that the `mxsUpdateUser` command does not check that the changed\
-data is compatible e.g. with the grants of the corresponding MariaDB\
+Note that the `mxsUpdateUser` command does not check that the changed
+data is compatible e.g. with the grants of the corresponding MariaDB
 user.
 
 **Syntax**
@@ -2546,13 +2546,13 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. If a new password is not provided, the specified mechanisms must be a subset of the current mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the updating of the user succeeds, the command returns a document\
+If the updating of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2574,23 +2574,23 @@ If there is a failure of some kind, the command returns an error document
 
 ### Object Id
 
-When a document is created, an id of type `ObjectId` will be autogenerated by\
-the MongoDB® client library. If the id is provided explicitly, by assigning a\
-value to the `_id` field, the value must be an `ObjectId`, a string or an\
+When a document is created, an id of type `ObjectId` will be autogenerated by
+the MongoDB® client library. If the id is provided explicitly, by assigning a
+value to the `_id` field, the value must be an `ObjectId`, a string or an
 integer.
 
 ### Caching
 
 The conversion of the BSON used in the communication between the client and\
-MaxScale, to the SQL used in the communication between MaxScale and the server\
-carries a not insignificant cost, as does the conversion of result sets\
-returned by the server to the BSON returned by MaxScale to the client. The\
-regular [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md) provides no remedy for this, as\
-it is located after the protocol and uses SQL as the key and stores result\
+MaxScale, to the SQL used in the communication between MaxScale and the server
+carries a not insignificant cost, as does the conversion of result sets
+returned by the server to the BSON returned by MaxScale to the client. The
+regular [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md) provides no remedy for this, as
+it is located after the protocol and uses SQL as the key and stores result
 sets as values.
 
-From 23.08 onwards, the nosqlprotocol has a built-in cache that when used\
-under certain conditions diminishes the conversion cost. The cache is\
+From 23.08 onwards, the nosqlprotocol has a built-in cache that when used
+under certain conditions diminishes the conversion cost. The cache is
 enabled by adding the following line to the NoSQL listener.
 
 ```
@@ -2599,8 +2599,8 @@ enabled by adding the following line to the NoSQL listener.
 nosqlprotocol.internal_cache=cache
 ```
 
-This effectively causes the [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md) to be used\
-inside the NoSQL protocol module. The internal cache can be configured just\
+This effectively causes the [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md) to be used
+inside the NoSQL protocol module. The internal cache can be configured just
 like the cache filter is, by using the following nested configuration syntax.
 
 ```
@@ -2613,27 +2613,27 @@ nosqlprotocol.cache.hard_ttl=40s
 ...
 ```
 
-A limitation is that _only_ the default storage `storage_inmemory` is\
+A limitation is that _only_ the default storage `storage_inmemory` is
 supported; `storage_redis` and `storage_memcached` cannot be used.
 
-The cache works on both the SQL and the BSON layer. When a NoSQL request\
-that potentially is cacheable arrives, a lookup for the BSON response is\
-made. If it is found, the response is returned to the client. That is, in\
-this case neither BSON -> SQL, nor a Result Set -> BSON translation will\
+The cache works on both the SQL and the BSON layer. When a NoSQL request
+that potentially is cacheable arrives, a lookup for the BSON response is
+made. If it is found, the response is returned to the client. That is, in
+this case neither BSON -> SQL, nor a Result Set -> BSON translation will
 be made.
 
-If the request is not potentially cacheable or the response is not\
-available, the request is processed normally, which may mean that the\
-request is translated into SQL. If the SQL is a SELECT, a second lookup\
-will be made for the corresponding result set. If that is found, the\
+If the request is not potentially cacheable or the response is not
+available, the request is processed normally, which may mean that the
+request is translated into SQL. If the SQL is a SELECT, a second lookup
+will be made for the corresponding result set. If that is found, the
 result set is processed, but the roundtrip to the server will be saved.
 
-So, when a result set is received from the server, it will be cached and\
-if the generated NoSQL response is also cacheable, it will be cached as\
-well. The benefit of this approach is that two `Find` NoSQL requests\
-may effectively return the same documents, even though one but not the\
-other NoSQL response is cacheable. Both will benefit the result set being\
-in the cache. Since the used storage follows an LRU-approach when evicting\
+So, when a result set is received from the server, it will be cached and
+if the generated NoSQL response is also cacheable, it will be cached as
+well. The benefit of this approach is that two `Find` NoSQL requests
+may effectively return the same documents, even though one but not the
+other NoSQL response is cacheable. Both will benefit the result set being
+in the cache. Since the used storage follows an LRU-approach when evicting
 data from the cache, the less valuable result will be evicted first.
 
 #### Cached Commands
@@ -2642,25 +2642,25 @@ The responses of the following commands are cached.
 
 * [count](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#count)
 * [distinct](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#distinct)
-* [find](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#find), provided all found documents can be returned in one response,\
+* [find](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#find), provided all found documents can be returned in one response,
   i.e., if `singleBatch` is `true` or `batchSize` is large enough.
 
 ### Compatibility
 
-Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)\
+Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)
 test-suite pass.
 
 ### Example
 
-The following is a minimal setup for getting _nosqlprotocol_ up and\
-running. It is assumed the reader knows how to configure MaxScale for\
+The following is a minimal setup for getting _nosqlprotocol_ up and
+running. It is assumed the reader knows how to configure MaxScale for
 normal use. If not, please start with the [MaxScale tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-setting-up-mariadb-maxscale.md).\
-Note that as _nosqlprotocol_ is the first component in the MaxScale\
+Note that as _nosqlprotocol_ is the first component in the MaxScale
 routing chain, it can be used with all routers and filters.
 
 #### Configuring MaxScale
 
-In the following it is assumed that MaxScale already has been configured\
+In the following it is assumed that MaxScale already has been configured
 for normal use and that there exists a _service_ `[TheService]`.
 
 ```
@@ -2677,10 +2677,10 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-The values `the_user` and `the_password` must be replaced with the\
+The values `the_user` and `the_password` must be replaced with the
 actual credentials to be used for every MongoDB® client that connects.
 
-If MaxScale is now started, the following entry should appear in the\
+If MaxScale is now started, the following entry should appear in the
 log file.
 
 ```
@@ -2691,8 +2691,8 @@ log file.
 
 The mongo Shell is a powerful tool with which to access and manipulate a\
 MongoDB database. It is part of the MongoDB® package. Having the native\
-MongoDB database installed is convenient, as it makes it easy to ascertain\
-whether a problem is due to _nosqlprotocol_ not fully implementing something\
+MongoDB database installed is convenient, as it makes it easy to ascertain
+whether a problem is due to _nosqlprotocol_ not fully implementing something
 or due to the API not being used in the correct fashion.
 
 With the _mongo shell_, all that is needed is to invoke it with the port\_nosqlprotocol\_ is listening on:
@@ -2709,7 +2709,7 @@ MongoDB server version: 4.4.1
 >
 ```
 
-If the shell prompt appears, then a connection was successfully\
+If the shell prompt appears, then a connection was successfully
 established and the shell can be used.
 
 ```
@@ -2717,13 +2717,13 @@ established and the shell can be used.
 { "n" : 1, "ok" : 1 }
 ```
 
-The `db` variable is implicitly available, and refers by default to\
+The `db` variable is implicitly available, and refers by default to
 the `test` database.
 
 The command inserted a document into the collection called `collection`.\
-The table corresponding to that collection is created implicitly because\
-the default value of `auto_create_tables` is `true`. Here, the object id\
-is specified explicitly, but there is no need for that, as one will be\
+The table corresponding to that collection is created implicitly because
+the default value of `auto_create_tables` is `true`. Here, the object id
+is specified explicitly, but there is no need for that, as one will be
 created if needed.
 
 To check whether the documents was inserted into the collection, the`find` command can be issued:
@@ -2758,18 +2758,18 @@ MariaDB [(none)]> select * from test.collection;
 +------+------------------------------------+
 ```
 
-The collection `collection` is represented by a table `collection` with\
-the two columns `id` and `doc`. `id` is a virtual column whose content is\
+The collection `collection` is represented by a table `collection` with
+the two columns `id` and `doc`. `id` is a virtual column whose content is
 the value of the `_id` field of the document in the `doc` column.
 
-All MongoDB® commands that _mongdbprotocol_ support (but for the ones that\
-do not require database access), basically access or manipulate the\
+All MongoDB® commands that _mongdbprotocol_ support (but for the ones that
+do not require database access), basically access or manipulate the
 content in the `doc` column using the [JSON functions](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements-and-structure/sql-statements/built-in-functions/special-functions/json-functions) of MariaDB.
 
-From within the mongo shell itself it is easy to find out just what SQL\
+From within the mongo shell itself it is easy to find out just what SQL
 a particular MongoDB command is translated into.
 
-For instance, the SQL that the insert command with which the document was\
+For instance, the SQL that the insert command with which the document was
 added can be found out like:
 
 ```
@@ -2794,18 +2794,18 @@ Similarly, the SQL of the `find` command can be find out like:
 }
 ```
 
-The returned SQL can be directly pasted at the `mysql` prompt, which is\
+The returned SQL can be directly pasted at the `mysql` prompt, which is
 quite convenient in case the MongoDB® command does not behave as expected.
 
 #### MongoDB® Node.JS Driver
 
-As all client libraries implement and depend on the MongoDB® wire protocol,\
-all client libraries should work with _nosqlprotocol_. However, the\
-only client library that has been used and that has been verified to work\
+As all client libraries implement and depend on the MongoDB® wire protocol,
+all client libraries should work with _nosqlprotocol_. However, the
+only client library that has been used and that has been verified to work
 is version 3.6 of the _MongoDB Node.JS Driver_.
 
-In principle, the only thing that needs to be altered in an existing\
-program using the library is to change the uri string that typically\
+In principle, the only thing that needs to be altered in an existing
+program using the library is to change the uri string that typically
 is something like
 
 ```
@@ -2820,8 +2820,8 @@ const uri = "mongodb://<maxscale-ip>:17017";
 
 with the assumption that the default _nosqlprotocol_ port is used.
 
-In practice, additional modifications may be needed since _nosqlprotocol_\
-does not implement all commands and does not in all cases implement the\
+In practice, additional modifications may be needed since _nosqlprotocol_
+does not implement all commands and does not in all cases implement the
 full functionality of the commands that it supports.
 
 **Inserting a Document**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md
@@ -2,21 +2,21 @@
 
 ## NoSQL Protocol Module
 
-The `nosqlprotocol` module allows a MariaDB server or cluster to be\
+The `nosqlprotocol` module allows a MariaDB server or cluster to be
 used as the backend of an application using a MongoDB® client library.\
 Internally, all documents are stored in a table containing two columns;\
 an `id` column for the object id and a `doc` column for the document itself.
 
-When the MongoDB® client application issues MongoDB protocol _commands_,\
-either directly or indirectly via the client library, they are transparently\
+When the MongoDB® client application issues MongoDB protocol _commands_,
+either directly or indirectly via the client library, they are transparently
 converted into the equivalent SQL and executed against the MariaDB backend.\
-The MariaDB responses are then in turn converted into the format expected by\
+The MariaDB responses are then in turn converted into the format expected by
 the MongoDB® client library and application.
 
 ### Configuring
 
-There are a number of [parameters](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#parameters) with which the behavior\
-of _nosqlprotocol_ can be adjusted. A minimal configuration looks\
+There are a number of [parameters](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#parameters) with which the behavior
+of _nosqlprotocol_ can be adjusted. A minimal configuration looks
 like:
 
 ```
@@ -33,13 +33,13 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-`nosqlprotocol.user` and `nosqlprotocol.password` specify the\
-credentials that will be used when accessing the backend database or\
+`nosqlprotocol.user` and `nosqlprotocol.password` specify the
+credentials that will be used when accessing the backend database or
 cluster. Note that the same credentials will be used for _all_ connecting\
 MongoDB® clients.
 
-Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which\
-the client requests will be sent. _Nosqlprotocol_ places no limitations\
+Since _nosqlprotocol_ is a _listener_, there must be a _service_ to which
+the client requests will be sent. _Nosqlprotocol_ places no limitations
 on what filters, routers or backends can be used.
 
 To configure the same listener with MaxCtrl, the parameters must be passed in a\
@@ -49,7 +49,7 @@ JSON object in the following manner:
 maxctrl create listener TheService MongoDB-Listener --protocol=nosqlprotocol 'nosqlprotocol={"user":"the_user", "password": "the_password"}'
 ```
 
-All the parameters that the nosqlprotocol module takes must be passed in the\
+All the parameters that the nosqlprotocol module takes must be passed in the
 same JSON object.
 
 A complete example can be found at the [end](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#example) of this document.
@@ -59,18 +59,18 @@ A complete example can be found at the [end](mariadb-maxscale-2501-maxscale-2501
 Nosqlprotocol supports _SCRAM_ _authentication_ as implemented by MongoDB®.\
 The mechanisms `SCRAM-SHA-1` and `SCRAM-SHA-256` are both supported.
 
-If nosqlprotocol has been setup so that no authentication is required, then\
-when connecting only the host and port should be provided, but neither a\
+If nosqlprotocol has been setup so that no authentication is required, then
+when connecting only the host and port should be provided, but neither a
 username nor a password.
 
-For instance, if the _MongoDB Node.JS Driver_ is used, then the connection\
+For instance, if the _MongoDB Node.JS Driver_ is used, then the connection
 string should look like:
 
 ```
 const uri = "mongodb://127.0.0.1:17017"
 ```
 
-Similarly, if the _Mongo Shell_ is used, only the host and port should\
+Similarly, if the _Mongo Shell_ is used, only the host and port should
 be provided:
 
 ```
@@ -82,26 +82,26 @@ MongoDB shell version v4.4.1
 
 #### NoSQL and MariaDB Users
 
-A MariaDB user consists of a name and a host part. A user `'user'@'%'`\
-and a user `'user'@'127.0.0.1'` are completely different. The host part\
-specifies where a user may connect from, with `%` being a wildcard that\
-matches all hosts. What data a user is allowed to access and modify is\
+A MariaDB user consists of a name and a host part. A user `'user'@'%'`
+and a user `'user'@'127.0.0.1'` are completely different. The host part
+specifies where a user may connect from, with `%` being a wildcard that
+matches all hosts. What data a user is allowed to access and modify is
 specified by what _privileges_ are granted to the user.
 
-A NoSQL user is somewhat different. It is created in the context of a\
-particular database, so there may be a user `userx` in the database `dbA`\
-and different user with the same name `userx` in the database `dbB`. What\
-hosts a user may connect from can be restricted, but that is a property of\
-the user and not an implicit part of it. What data a user is allowed to\
-access and modify is specified by the _roles_ that have been assigned to\
+A NoSQL user is somewhat different. It is created in the context of a
+particular database, so there may be a user `userx` in the database `dbA`
+and different user with the same name `userx` in the database `dbB`. What
+hosts a user may connect from can be restricted, but that is a property of
+the user and not an implicit part of it. What data a user is allowed to
+access and modify is specified by the _roles_ that have been assigned to
 the user.
 
-From the above it should be clear that there is not a 1-to-1\
-correspondence between the concept of a user in NoSQL and the concept\
+From the above it should be clear that there is not a 1-to-1
+correspondence between the concept of a user in NoSQL and the concept
 of a user in MariaDB, but that some additional conventions are needed.
 
-To make it possible to have different NoSQL users with the same name,\
-the database in whose context the user is created is prepended to the\
+To make it possible to have different NoSQL users with the same name,
+the database in whose context the user is created is prepended to the
 user name, separated with a dot, when the MariaDB user is created.
 
 This is perhaps easiest to illustrate using an example:
@@ -117,7 +117,7 @@ MariaDB [(none)]> select user, host from mysql.user;
 2 rows in set (0.001 sec)
 ```
 
-Currently there are two user accounts defined. Even though there is\
+Currently there are two user accounts defined. Even though there is
 a user `bob`, creating a NoSQL user `bob` succeeds.
 
 ```
@@ -141,20 +141,20 @@ MariaDB [(none)]> select user, host from mysql.user;
 3 rows in set (0.001 sec)
 ```
 
-The MariaDB user corresponding to the NoSQL user `bob`, created in the\
+The MariaDB user corresponding to the NoSQL user `bob`, created in the
 context of the database `test`, has `test` as a prefix.
 
 **The `mariadb` database**
 
-The fact that NoSQL users have the database embedded in the MariaDB\
-name may be inconvenient if the same data is accessed both as NoSQL\
-via nosqlprotocol and as SQL directly from MariaDB. It also makes\
+The fact that NoSQL users have the database embedded in the MariaDB
+name may be inconvenient if the same data is accessed both as NoSQL
+via nosqlprotocol and as SQL directly from MariaDB. It also makes
 it impossible to use an existing MariaDB account from NoSQL.
 
-To provide a solution for this problem, the database `mariadb` is treated\
-in a specific fashion. A user created in the context of the `mariadb`\
+To provide a solution for this problem, the database `mariadb` is treated
+in a specific fashion. A user created in the context of the `mariadb`
 database is created in the MariaDB server without the database prefix.\
-If we now try to create a user `bob` in the `mariadb` database it will fail,\
+If we now try to create a user `bob` in the `mariadb` database it will fail,
 because the user `'bob'@'%'` exists already.
 
 ```
@@ -197,7 +197,7 @@ we will see that `alice` was created without a database prefix.
 
 When creating a user nosqlprotocol accepts all roles as predefined by\
 MongoDB®, but not all of them are translated into GRANT privileges.\
-The following table shows what privilege(s) a particular role is\
+The following table shows what privilege(s) a particular role is
 converted to.
 
 | Role      | Privileges                                    |
@@ -214,21 +214,21 @@ The following roles are shorthands for several other roles.
 | dbOwner | dbAdmin, readWrite, userAdmin |
 | root    | dbAdmin, readWrite, userAdmin |
 
-`dbOwner` differs from `root` in that the privileges of the former\
-apply only to a particular database, while the privileges of the\
-latter apply to _all_ databases. However, the role `root` can\
+`dbOwner` differs from `root` in that the privileges of the former
+apply only to a particular database, while the privileges of the
+latter apply to _all_ databases. However, the role `root` can
 only be assigned to a user in the `admin` database.
 
-In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in\
-the `admin` database. If so, then the privilege is granted on `*.*`,\
+In addition there are `AnyDatabase` versions of `dbAdmin`, `read` and`readWrite` (e.g `readAnyDatabase`) that can be assigned to a user in
+the `admin` database. If so, then the privilege is granted on `*.*`,
 otherwise on `<db>.*`.
 
-If the `root` role is assigned to a user in the `admin` database,\
+If the `root` role is assigned to a user in the `admin` database,
 then the privileges are granted on `*.*`, otherwise on `<db>.*`.
 
-Other pre-defined roles are recognized and stored in the local\
-nosqlprotocol account database, but they do not affect what privileges\
-are granted to the MariaDB user. Currently user-defined roles are\
+Other pre-defined roles are recognized and stored in the local
+nosqlprotocol account database, but they do not affect what privileges
+are granted to the MariaDB user. Currently user-defined roles are
 not supported.
 
 #### Client Authentication
@@ -241,11 +241,11 @@ Authenticationwise nosqlprotocol can be used in three different ways:
 
 **Anonymously**
 
-If there is an anonymous user on the MariaDB server and if nosqlprotocol\
-is configured without a user/password, then all nosqlprotocol clients will\
+If there is an anonymous user on the MariaDB server and if nosqlprotocol
+is configured without a user/password, then all nosqlprotocol clients will
 access the MariaDB server as anonymous users.
 
-Note that the anonymous MariaDB user is only intended for testing and\
+Note that the anonymous MariaDB user is only intended for testing and
 should in general not be used, but deleted.
 
 **Shared Credentials**
@@ -259,18 +259,18 @@ nosqlprotocol.password=thepassword
 ```
 
 then each MongoDB® client will use those credentials when accessing the\
-MariaDB server. Note that from the perspective of the MariaDB server, it\
+MariaDB server. Note that from the perspective of the MariaDB server, it
 is not possible to distinguish between different MongoDB® clients.
 
 **Unique Credentials**
 
-If nosqlprotocol authentication has been taken into use and a MongoDB®\
-client authenticates, either when connecting or later, then the credentials\
+If nosqlprotocol authentication has been taken into use and a MongoDB®
+client authenticates, either when connecting or later, then the credentials
 of MongoDB® client will be used when accessing the MariaDB server.
 
-Note that even if nosqlprotocol authentication has been enabled, authentication\
-is not required, and if the MongoDB® client has not authenticated itself, the\
-credentials specified with `nosqlprotocol.[user|password]` (or the anonymous\
+Note that even if nosqlprotocol authentication has been enabled, authentication
+is not required, and if the MongoDB® client has not authenticated itself, the
+credentials specified with `nosqlprotocol.[user|password]` (or the anonymous
 user) will be used when accessing the MariaDB server.
 
 **Enforce Authentication**
@@ -281,14 +281,14 @@ To enforce authentication, specify
 nosqlprotocol.authentication_required=true
 ```
 
-in the configuration. If authentication is required, then any command\
-that requires access to the MariaDB server will fail, unless the client\
+in the configuration. If authentication is required, then any command
+that requires access to the MariaDB server will fail, unless the client
 has authenticated.
 
 #### Authorization
 
-By default nosqlprotocol does no authorization. However, a nosqlprotocol\
-client is _always_ subject to the authorization performed by the MariaDB\
+By default nosqlprotocol does no authorization. However, a nosqlprotocol
+client is _always_ subject to the authorization performed by the MariaDB
 server.
 
 When nosqlprotocol authorization is enabled by adding
@@ -297,8 +297,8 @@ When nosqlprotocol authorization is enabled by adding
 nosqlprotocol.authorization_enabled=true
 ```
 
-to the configuration file, some commands will be subject to authorization,\
-by nosqlprotocol. The following table lists the commands and what role they\
+to the configuration file, some commands will be subject to authorization,
+by nosqlprotocol. The following table lists the commands and what role they
 require.
 
 | Command                                                                                                 | Role      |
@@ -313,27 +313,27 @@ require.
 | [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#updateUser)                   | userAdmin |
 | [usersInfo](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#usersInfo)                     | userAdmin |
 
-It is important to note that even if nosqlprotocol authorization\
-is enabled, the MariaDB server has the final word. That is, even if the\
-roles of a user would be sufficient for a particular operation, if the\
-granted privileges are not, the operation will not succeed. There may\
-be a mismatch between roles and grants, for instance, if the wrong roles\
-were specified when the user was added, or if the grants have been\
+It is important to note that even if nosqlprotocol authorization
+is enabled, the MariaDB server has the final word. That is, even if the
+roles of a user would be sufficient for a particular operation, if the
+granted privileges are not, the operation will not succeed. There may
+be a mismatch between roles and grants, for instance, if the wrong roles
+were specified when the user was added, or if the grants have been
 altered directly and not via nosqlprotocol.
 
 #### Bootstrapping the Authentication/Authorization
 
-The authentication/authorization can be bootstrapped explicitly\
-or implicitly. Bootstrapping explicitly provides more control, while\
+The authentication/authorization can be bootstrapped explicitly
+or implicitly. Bootstrapping explicitly provides more control, while
 bootstrapping implicitly is much more convenient.
 
 **Explicit bootstrapping**
 
-In order to enable authorization you need to have NoSQL users and\
-those can be created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) or added\
+In order to enable authorization you need to have NoSQL users and
+those can be created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) or added
 with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#addUser).
 
-If you want to _create_ a user, then you first need to configure\
+If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
 
 ```
@@ -341,7 +341,7 @@ nosqlprotocol.user = user_with_privileges_for_creating_a_user
 nosqlprotocol.password = the_users_password
 ```
 
-At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that\
+At this point `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` should both be `false`. Note that
 as those are their default values, they do not have to be specified.
 
 Start MaxScale and connect to it with the MongoDB® command line client
@@ -361,8 +361,8 @@ switched to db admin
 { "ok" : 1 }
 ```
 
-Alternatively you can add an existing user. Note that it should be\
-added to the `mariadb` database, unless it was created with the\
+Alternatively you can add an existing user. Note that it should be
+added to the `mariadb` database, unless it was created with the
 convention of having the database as a prefix, e.g. `db.bob`.
 
 ```
@@ -381,12 +381,12 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but\
-as they will be ignored with `nosqlprotocol.authentication_required=true`\
+The `nosqlprotocol.user` and `nosqlprotocol.password` can be removed but
+as they will be ignored with `nosqlprotocol.authentication_required=true`
 being present, it is not mandatory.
 
-If you now try to create a user when not having been authenticated or\
-when authenticated as a user without the `userAdmin` role, the result\
+If you now try to create a user when not having been authenticated or
+when authenticated as a user without the `userAdmin` role, the result
 will be:
 
 ```
@@ -401,105 +401,105 @@ switched to db test
 }
 ```
 
-**NOTE** When a client authenticates, the password will not be\
-transferred in cleartext over the network, so, even without SSL,\
-it is not possible to gain access to a password by monitoring the\
+**NOTE** When a client authenticates, the password will not be
+transferred in cleartext over the network, so, even without SSL,
+it is not possible to gain access to a password by monitoring the
 network traffic.
 
-However, when a user is created or added (or the password is changed),\
-the password will be transferred in _cleartext_. To prevent eavesdropping,\
+However, when a user is created or added (or the password is changed),
+the password will be transferred in _cleartext_. To prevent eavesdropping,
 create/add users when connecting over a domain socket, or use [TLS/SSL](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#tlsssl)
 
 **Implicit bootstrapping**
 
-With implicit bootstrapping, you should first create the MariaDB\
-user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat\
-different in MariaDB and NoSQL, which means that certain factors\
-must be taken into account when creating the MariaDB user. Then\
+With implicit bootstrapping, you should first create the MariaDB
+user that should appear as the initial NoSQL user. As explained [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#nosql-and-mariadb-users), the concept of a user is somewhat
+different in MariaDB and NoSQL, which means that certain factors
+must be taken into account when creating the MariaDB user. Then
 at first startup, nosqlprotocol will create the corresponding\
-NoSQL user, which will enable the authenticated and authorized\
+NoSQL user, which will enable the authenticated and authorized
 use of nosqlprotocol.
 
 When MaxScale is started, if the following hold
 
-* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration\
+* `nosqlprotocol.authentication_required` and`nosqlprotocol.authorization_enabled` are true in the configuration
   section of the nosqlprotocol listener,
 * `nosqlprotocol.user` and `nosqlprotocol.password` are provided, and
 * there are no NoSQL users in the NoSQL account database.
 
 then, MaxScale will
 
-* wait until the primary of the service pointed to by the listener\
+* wait until the primary of the service pointed to by the listener
   is available,
-* connect using the credentials specified in `nosqlprotocol.user`\
+* connect using the credentials specified in `nosqlprotocol.user`
   and `nosqlprotocol.password`,
 * execute `SHOW GRANTS`,
 * translate the privileges into the equivalent NoSQL roles, and
 * create a corresponding NoSQL user into the NoSQL account database.
 
-Immediately thereafter it is possible to connect to the nosqlprotocol\
+Immediately thereafter it is possible to connect to the nosqlprotocol
 port with a MongoDB® client using the specified credentials.
 
-Note that after the bootstrapping, nosqlprotocol will not use\
+Note that after the bootstrapping, nosqlprotocol will not use
 the `user` and `password` settings and they can be removed.
 
 **Grants**
 
-When a NoSQL user is created using [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser)\
-the MariaDB grants are obtained from the specified NoSQL roles\
+When a NoSQL user is created using [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser)
+the MariaDB grants are obtained from the specified NoSQL roles
 as explained [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#Roles_and_privileges).
 
 When implicitly creating a NoSQL user from an existing user in\
-MariaDB, the inverse operation must be performed. There are\
-many factors that affect what NoSQL roles the grants of a user\
+MariaDB, the inverse operation must be performed. There are
+many factors that affect what NoSQL roles the grants of a user
 are translated into:
 
 * whether the user is a regular or admin user,
 * whether the privileges are on `*.*` or some specific `db.*`, and
 * the privileges themselves, e.g. `SELECT`, `DELETE`, etc.
 
-In NoSQL, every user resides in a specific database. Note that\
-this does **not** mean that the database would have to exist\
+In NoSQL, every user resides in a specific database. Note that
+this does **not** mean that the database would have to exist
 in MariaDB.
 
-When it comes to users, the database effectively means a scope,\
-which in the case of nosqlprotocol is handled by prefixing the\
+When it comes to users, the database effectively means a scope,
+which in the case of nosqlprotocol is handled by prefixing the
 corresponding MariaDB user name with the database/scope name.
 
-When creating a user to be used from NoSQL, there are three\
+When creating a user to be used from NoSQL, there are three
 options for the user's name:
 
 * The name can be of the format `some_db.user_name` where`some_db` can be anything (subject to the naming rules of\
-  MariaDB), except `admin` or `mariadb`. In this case, the\
-  user will be a regular user, who can access data in\
+  MariaDB), except `admin` or `mariadb`. In this case, the
+  user will be a regular user, who can access data in
   databases that she has been granted access to.
-* The name can be of the format `admin.user_name` where `admin`\
-  is exactly just that. In this case, the user will be an\
+* The name can be of the format `admin.user_name` where `admin`
+  is exactly just that. In this case, the user will be an
   admin user, who can access any database.
-* The name can be of the format `user_name`. In this case, the\
-  user will be a regular user that from the NoSQL side appears\
-  to reside in the `mariadb` database. The primary purpose of\
-  this alternative is to enable the use of existing users from\
+* The name can be of the format `user_name`. In this case, the
+  user will be a regular user that from the NoSQL side appears
+  to reside in the `mariadb` database. The primary purpose of
+  this alternative is to enable the use of existing users from
   the NoSQL side.
 
-What database the privileges can be specified `ON` depends on\
+What database the privileges can be specified `ON` depends on
 what kind of user is being created.
 
-* If it is a regular user, the privileges must be granted on a\
+* If it is a regular user, the privileges must be granted on a
   specific database, such as `\`dbA\`\`.\*\`. Note that there is no\
   dependency between this database and the (conceptual) database\
   the user resides in.
 * If it is an admin user, the privileges must be granted on\
   the `*.*` database.
 
-In NoSQL, a role can be database specific or generic. However,\
-a generic role can _only_ be assigned to a user in the _admin_\
-database. In practice this means that if the privileges are\
-on `*.*`, then the user must reside in the _admin_ database\
+In NoSQL, a role can be database specific or generic. However,
+a generic role can _only_ be assigned to a user in the _admin_
+database. In practice this means that if the privileges are
+on `*.*`, then the user must reside in the _admin_ database
 (e.g. `admin.bob`) or it is treated as an error.
 
-The following table shows what privileges are required for a\
-role to be assigned. Note that `ALL PRIVILEGES` can be used as\
+The following table shows what privileges are required for a
+role to be assigned. Note that `ALL PRIVILEGES` can be used as
 well.
 
 | ALTER | CREATE | CREATE USER | DROP | DELETE | INDEX | INSERT | SHOW DATABASES(1) | SELECT | UPDATE | WITH GRANT OPTION | Role                    |
@@ -511,19 +511,19 @@ well.
 
 1. Only required if the user is an admin user.
 
-The `AnyDatabase` version will be assigned, if the user is\
+The `AnyDatabase` version will be assigned, if the user is
 an _admin_ user.
 
-If certain roles are assigned, then other roles will be\
+If certain roles are assigned, then other roles will be
 assigned as well.
 
-* If the roles `dbAdmin`, `readWrite` and `userAdmin` are\
+* If the roles `dbAdmin`, `readWrite` and `userAdmin` are
   assigned, then `dbOwner` will be assigned as well.
-* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`\
-  and `userAdminAnyDatabase` are assigned, then `root` will\
+* If the roles `dbAdminAnyDatabase`, `readWriteAnyDatabase`
+  and `userAdminAnyDatabase` are assigned, then `root` will
   be assigned as well.
 
-Once the user has been created and the desired privileges have\
+Once the user has been created and the desired privileges have
 been granted, the NoSQL listener should be configured as follows:
 
 ```
@@ -542,7 +542,7 @@ At MaxScale startup, the NoSQL user will then be created.
 
 **Admin User**
 
-We want the initial NoSQL user to be an administrator, with\
+We want the initial NoSQL user to be an administrator, with
 full rights.
 
 ```
@@ -550,8 +550,8 @@ CREATE USER 'admin.nosql_admin'@'%' IDENTIFIED BY 'nosql_password';
 GRANT ALL PRIVILEGES ON *.* TO 'admin.nosql_admin'@'%' WITH GRANT OPTION;
 ```
 
-As we want an admin user, the name is prefixed with `admin`,\
-which will have that effect. And since it is an admin user, the\
+As we want an admin user, the name is prefixed with `admin`,
+which will have that effect. And since it is an admin user, the
 privileges are granted ON `*.*`.
 
 Thereafter, we specify the following in the configuration file,
@@ -569,16 +569,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'admin.nosql_admin'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -588,9 +588,9 @@ $ mongo --quiet --port 17017 -u nosql_admin -p nosql_password admin
 >
 ```
 
-Note that when connecting the user is passed as `nosql_admin` and _not_\
-as `admin.nosql_admin`. The fact that we want to authenticate against\
-the `admin` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `nosql_admin` and _not_
+as `admin.nosql_admin`. The fact that we want to authenticate against
+the `admin` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -629,13 +629,13 @@ argument.
 }
 ```
 
-As can be seen, the user has the _any_ roles on the `admin`\
-database, which means that all databases can be accessed and\
+As can be seen, the user has the _any_ roles on the `admin`
+database, which means that all databases can be accessed and
 modified, and that new users can be created.
 
 **Test User**
 
-We want the initial NoSQL user to be a user with limited rights,\
+We want the initial NoSQL user to be a user with limited rights,
 intended to be used for testing.
 
 ```
@@ -643,11 +643,11 @@ CREATE USER 'test.test_user'@'%' IDENTIFIED BY 'test_password';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX ON `test`.* TO 'test.test_user'@'%';
 ```
 
-As we want a user with limited rights, the name is _not_ prefixed\
+As we want a user with limited rights, the name is _not_ prefixed
 with `admin`. The privileges are granted specifically on database`test.*`. Indeed, if `*.*` had been used, the creation of the initial\
-NoSQL user would have failed with an error. Here, the user is created\
-in the same database that the user is given access to, but it could\
-have been another one. Further, several `GRANT` statements could have\
+NoSQL user would have failed with an error. Here, the user is created
+in the same database that the user is given access to, but it could
+have been another one. Further, several `GRANT` statements could have
 been used, had we wanted to give access to several databases.
 
 Thereafter, we specify the following in the configuration file,
@@ -665,16 +665,16 @@ nosqlprotocol.authorization_enabled=true
 
 and start MaxScale.
 
-As the creation of the initial user can be made only after the\
-monitor for the listener's service has marked one server as primary,\
-whether the creation succeeded or not must be checked from MaxScale'\
+As the creation of the initial user can be made only after the
+monitor for the listener's service has marked one server as primary,
+whether the creation succeeded or not must be checked from MaxScale'
 log file:
 
 ```
 ... notice : [nosqlprotocol] Created initial NoSQL user 'test.test_user'.
 ```
 
-Under normal conditions, the bootstrapping will be almost\
+Under normal conditions, the bootstrapping will be almost
 instantaneous.
 
 It is now possible to connect using any MongoDB® client application.
@@ -684,9 +684,9 @@ $ mongo --quiet --port 17017 -u test_user -p test_password test
 >
 ```
 
-Note that when connecting the user is passed as `test_user` and _not_\
-as `test.test_user`. The fact that we want to authenticate against\
-the `test` database is expressed by passing the database as the last\
+Note that when connecting the user is passed as `test_user` and _not_
+as `test.test_user`. The fact that we want to authenticate against
+the `test` database is expressed by passing the database as the last
 argument.
 
 ```
@@ -713,44 +713,44 @@ argument.
 }
 ```
 
-As can be seen, the user has the `readWrite` role on the `test` database,\
+As can be seen, the user has the `readWrite` role on the `test` database,
 which means that only the `test` database can be accessed and modified.
 
 **TLS/SSL**
 
-Since `nosqlprotocol` is a regular protocol module used in a listener,\
-the TLS/SSL support of listeners is available. Please see [TLS/SSL encryption](https://github.com/mariadb-corporation/docs-server/blob/test/maxscale/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/Getting-Started/Configuration-Guide.md#tls-encryption)\
+Since `nosqlprotocol` is a regular protocol module used in a listener,
+the TLS/SSL support of listeners is available. Please see [TLS/SSL encryption](https://github.com/mariadb-corporation/docs-server/blob/test/maxscale/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/Getting-Started/Configuration-Guide.md#tls-encryption)
 for details.
 
 #### NoSQL Account Database
 
-So as to be able to connect to the MariaDB server on behalf of\
-clients, nosqlprotocol must know their password. As the password\
-is not transferred to nosqlprotocol during the authentication in\
-a way that could be used when logging into MariaDB, the password\
-must be stored when the user is created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser)\
+So as to be able to connect to the MariaDB server on behalf of
+clients, nosqlprotocol must know their password. As the password
+is not transferred to nosqlprotocol during the authentication in
+a way that could be used when logging into MariaDB, the password
+must be stored when the user is created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser)
 or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser).
 
-Note that the password is not stored in cleartext but as three\
-different hashes; hashed with sha1 for use with MariaDB, salted\
-and hashed with sha1 for use with the `SCRAM-SHA-1` authentication\
-mechanism (if that is enabled for the user) and salted and hashed\
-with sha256 for use with the `SCRAM-SHA-256` authentication mechanism\
+Note that the password is not stored in cleartext but as three
+different hashes; hashed with sha1 for use with MariaDB, salted
+and hashed with sha1 for use with the `SCRAM-SHA-1` authentication
+mechanism (if that is enabled for the user) and salted and hashed
+with sha256 for use with the `SCRAM-SHA-256` authentication mechanism
 (if that is enabled for the user).
 
-The account information can be stored _privately_, in which case it\
-can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can\
-share the information and a user created/added on one instance\
+The account information can be stored _privately_, in which case it
+can be used only by a particular MaxScale instance, or in a\_shared\_ manner, in which case multiple MaxScale instances can
+share the information and a user created/added on one instance
 can be used on another.
 
 **Private**
 
-In the private case, the account information of nosqlprotocol is\
-stored in an [sqlite3](https://sqlite.org/index.html) database\
-whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,\
-where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the\
-listener section in the MaxScale configuration file, and `-v1`\
-a suffix for making schema evolution easier, should there be\
+In the private case, the account information of nosqlprotocol is
+stored in an [sqlite3](https://sqlite.org/index.html) database
+whose name is `<libdir>/nosqlprotocol/<listener-name>-v1.db`,
+where `<libdir>` is the _libdir_ of MaxScale, typically`/var/lib/maxscale`, `<listener-name>` is the name of the
+listener section in the MaxScale configuration file, and `-v1`
+a suffix for making schema evolution easier, should there be
 a need for that.
 
 For instance, given a configuration like
@@ -765,41 +765,41 @@ protocol=nosqlprotocol
 
 the account information will be stored in the file`<libdir>/nosqlprotocol/NoSQL-Listener-v1.db`.
 
-Note that since the database name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the database name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
-To retain the accounts, the database file should also be\
+To retain the accounts, the database file should also be
 renamed.
 
-At first startup, the `nosqlprotocol` directory and\
-the file `NoSQL-Listener-v1.db` will be created. They will\
-be created with file permissions that only allow MaxScale\
-access. At subsequent startups the permissions will be checked\
-and MaxScale will refuse to start if the permissions allow\
+At first startup, the `nosqlprotocol` directory and
+the file `NoSQL-Listener-v1.db` will be created. They will
+be created with file permissions that only allow MaxScale
+access. At subsequent startups the permissions will be checked
+and MaxScale will refuse to start if the permissions allow
 access to others.
 
 **We strongly recommend that no manual modifications are made**\
 **to the database.**
 
-Note that we make **no** guarantees that the way in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the way in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 **Shared**
 
-In the shared case, the account information of nosqlprotocol\
+In the shared case, the account information of nosqlprotocol
 is stored in the cluster of the service in front of which the\
-NoSQL listener resides. The primary of the cluster will be used\
+NoSQL listener resides. The primary of the cluster will be used
 both for reading and writing data.
 
 A table whose name is the same as the listener's name in the\
-MaxScale configuration will be created in the database\
-specified with the [authentication\_db](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_db)\
-parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of\
+MaxScale configuration will be created in the database
+specified with the [authentication\_db](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_db)
+parameter. If it is not specified explicitly, the default is`nosqlprotocol`. The name of the table will be the name of
 the listener section in the MaxScale configuration file.
 
 For instance, given a configuration like
@@ -814,61 +814,61 @@ protocol=nosqlprotocol
 
 the account information will be stored in the table`nosqlprotocol.NoSQL-Listener`.
 
-Note that since the table name is derived from the listener\
-name, changing the name of the listener in the configuration\
+Note that since the table name is derived from the listener
+name, changing the name of the listener in the configuration
 file will have the effect of making all accounts disappear.\
 To retain the accounts, the table should also be renamed.
 
-`nosqlprotocol` will create the table when needed, so the\
-user specified with [authentication\_user](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_user)\
+`nosqlprotocol` will create the table when needed, so the
+user specified with [authentication\_user](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_user)
 must have sufficient grants to be able to do that.
 
-`nosqlprotocol` will store in the table, data that allow\
-any MaxScale to authenticate a MongoDB® client, irrespective\
+`nosqlprotocol` will store in the table, data that allow
+any MaxScale to authenticate a MongoDB® client, irrespective
 of which MaxScale instance was used when the user was created.
 
-`nosqlprotocol` also stores in the table the SHA1 of a user's\
+`nosqlprotocol` also stores in the table the SHA1 of a user's
 password, to be able to authenticate against the MariaDB server.\
-Therefore it is **strongly** suggested to enable encryption key\
-management in MaxScale and to provide an authentication\
-key ID with [authentication\_key\_id](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_key_id) so\
+Therefore it is **strongly** suggested to enable encryption key
+management in MaxScale and to provide an authentication
+key ID with [authentication\_key\_id](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_key_id) so
 that the data will be encrypted.
 
-If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_password) must also\
-be provided. With [authentication\_db](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_db) the\
-database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_key_id) an\
-encryption key ID, using which the sensitive data is encrypted,\
+If shared authentication has been enabled with [authentication\_shared](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_shared) then [authentication\_user](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_user) and [authentication\_password](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_password) must also
+be provided. With [authentication\_db](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_db) the
+database name can optionally be changed, and with [authentication\_key\_id](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#authentication_key_id) an
+encryption key ID, using which the sensitive data is encrypted,
 can optionally be provided.
 
-Note that we make **no** guarantees that the table in which the\
-account information is stored by `nosqlprotocol` will remain the\
-same _even_ between maintenance releases. We do guarantee,\
-however, that even if the way in which the account information is\
-stored changes, existing account information will automatically\
-be converted and no manual intervention, such as re-creation of\
+Note that we make **no** guarantees that the table in which the
+account information is stored by `nosqlprotocol` will remain the
+same _even_ between maintenance releases. We do guarantee,
+however, that even if the way in which the account information is
+stored changes, existing account information will automatically
+be converted and no manual intervention, such as re-creation of
 accounts, will be needed.
 
 ### Wire Protocol
 
-_Nosqlprotocol_ fully supports wire protocol version 6 and only provides\
-rudimentary support for earlier wire protocol versions, but reports at\
-startup that it would support versions 0 to 6. The reason is that some\
-client libraries are buggy and use an old wire protocol version if the\
-server claims to support only version 6. Consequently, one should use a\
+_Nosqlprotocol_ fully supports wire protocol version 6 and only provides
+rudimentary support for earlier wire protocol versions, but reports at
+startup that it would support versions 0 to 6. The reason is that some
+client libraries are buggy and use an old wire protocol version if the
+server claims to support only version 6. Consequently, one should use a
 client library version that at least supports wire protocol version 6.
 
 ### Client Library
 
-As the goal of _nosqlprotocol_ is to implement, to the extent that it\
-is feasible, the wire protocol and the database commands the way MongoDB®\
+As the goal of _nosqlprotocol_ is to implement, to the extent that it
+is feasible, the wire protocol and the database commands the way MongoDB®
 implements them, it should be possible to use any language specific driver.
 
-However, during the development of _nosqlprotocol_, the _only_ client library\
+However, during the development of _nosqlprotocol_, the _only_ client library
 that has been verified to work is version 3.6 of _MongoDB Node.JS Driver_.
 
 ### Settings
 
-Using the following parameters, the behavior of _nosqlprotocol_ can be\
+Using the following parameters, the behavior of _nosqlprotocol_ can be
 adjusted. As they are not generic listener parameters, but specific to _nosqlprotocol_ they must be qualified with the `nosqlprotocol`-prefix.
 
 For instance:
@@ -890,7 +890,7 @@ nosqlprotocol.on_unknown_command=return_error
 * Mandatory: No
 * Default: `""`
 
-Specifies the _user_ to be used when connecting to the backend, if the MongoDB®\
+Specifies the _user_ to be used when connecting to the backend, if the MongoDB®
 client is not authenticated.
 
 #### `password`
@@ -899,8 +899,8 @@ client is not authenticated.
 * Mandatory: No
 * Default: `""`
 
-Specifies the _password_ to be used when connecting to the backend, is the MongoDB®\
-client is not authenticated. Note that the same _user_/_password_ combination will be\
+Specifies the _password_ to be used when connecting to the backend, is the MongoDB®
+client is not authenticated. Note that the same _user_/_password_ combination will be
 used for all unauthenticated MongoDB® clients connecting to the same listener port.
 
 #### `authentication_required`
@@ -909,11 +909,11 @@ used for all unauthenticated MongoDB® clients connecting to the same listener p
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the client always must authenticate. If authentication is required,\
-it does not matter whether `user` and `password` have been specified, the client must\
+Specifies whether the client always must authenticate. If authentication is required,
+it does not matter whether `user` and `password` have been specified, the client must
 authenticate.
 
-Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser),\
+Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser),
 with authentication being optional and authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -925,7 +925,7 @@ MariaDB server.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether the NoSQL account information should be stored in a shared\
+Specifies whether the NoSQL account information should be stored in a shared
 manner or privately.
 
 #### `authentication_db`
@@ -934,10 +934,10 @@ manner or privately.
 * Mandatory: No
 * Default: `"NoSQL"`
 
-Specifies the database of the table where the NoSQL account information\
-is stored, if `authentication_shared` is `true`. If the database does not\
-exist, nosqlprotocol will attempt to create it, so either is should be\
-manually created or the used specified with `authentication_user` should\
+Specifies the database of the table where the NoSQL account information
+is stored, if `authentication_shared` is `true`. If the database does not
+exist, nosqlprotocol will attempt to create it, so either is should be
+manually created or the used specified with `authentication_user` should
 have the grants required to do so.
 
 #### `authentication_key_id`
@@ -946,11 +946,11 @@ have the grants required to do so.
 * Mandatory: No
 * Default: `""`
 
-The encryption key ID, using which the NoSQL account information should be\
-encrypted with when stored in the MariaDB server. If an encryption key ID is\
+The encryption key ID, using which the NoSQL account information should be
+encrypted with when stored in the MariaDB server. If an encryption key ID is
 given, the encryption key manager in MaxScale must also be enabled.
 
-The encryption key must be a 256-bit key. Keys of shorter length are rejected\
+The encryption key must be a 256-bit key. Keys of shorter length are rejected
 as invalid encryption keys.
 
 #### `authentication_user`
@@ -958,7 +958,7 @@ as invalid encryption keys.
 * Type: string
 * Mandatory: Yes, if `authentication_shared` is true.
 
-Specifies the _user_ to be used when modifying and accessing the NoSQL\
+Specifies the _user_ to be used when modifying and accessing the NoSQL
 account information stored in the MariaDB server.
 
 #### `authentication_password`
@@ -975,9 +975,9 @@ Specifies the _password_ of `authentication_user`.
 * Mandatory: No
 * Default: `false`
 
-Specifies whether nosqlprotocol itself should perform authorization in the context\
-of the commands [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users\
-have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser)\
+Specifies whether nosqlprotocol itself should perform authorization in the context
+of the commands [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users
+have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser)
 with authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -990,8 +990,8 @@ MariaDB server.
 * Default: `"%"`
 
 Specifies the _host_ to be used when a MariaDB user is created via nosqlprotocol.\
-By default all users are created as `...@'%'`, which means that it is possible to\
-connect to the MariaDB server from any host using the credentials of the created\
+By default all users are created as `...@'%'`, which means that it is possible to
+connect to the MariaDB server from any host using the credentials of the created
 user. For tighter security, the IP-address of the MaxScale host can be specified.
 
 NOTE: This value does **not** specify from which host it is allowed to connect to\
@@ -1017,8 +1017,8 @@ Enumeration values:
 * Mandatory: No
 * Default: `false`
 
-Specifies whether an unknown command should be logged. This is primarily\
-for debugging purposes, to find out whether a client uses a command that\
+Specifies whether an unknown command should be logged. This is primarily
+for debugging purposes, to find out whether a client uses a command that
 currently is not supported.
 
 #### `auto_create_databases`
@@ -1040,7 +1040,7 @@ Note that setting this parameter to `true`, without also setting`auto_create_tab
 Specifies whether tables should automatically be created, as needed.
 
 Note that this applies only if the relevant database already exists.\
-If a database should also be created if needed, then `auto_create_databases`\
+If a database should also be created if needed, then `auto_create_databases`
 must also be set to `true`.
 
 #### `id_length`
@@ -1061,16 +1061,16 @@ Specifies the length of the id column in tables that are automatically created.
 
 Enumeration values:
 
-* `default`: Each document is inserted using a separate `INSERT`, either in a\
-  multi-statement or in a compound statement. Whether an error causes the remaining\
-  insertions to be aborted, depends on the value of `ordered` specified in the\
+* `default`: Each document is inserted using a separate `INSERT`, either in a
+  multi-statement or in a compound statement. Whether an error causes the remaining
+  insertions to be aborted, depends on the value of `ordered` specified in the
   insert command.
-* `atomic`: If the value of `ordered` in the insert command is `true`\
-  (the default) then all documents are inserted using a single `INSERT` statement,\
-  that is, either all insertions succeed or none will. If `ordered` is false, then\
+* `atomic`: If the value of `ordered` in the insert command is `true`
+  (the default) then all documents are inserted using a single `INSERT` statement,
+  that is, either all insertions succeed or none will. If `ordered` is false, then
   the behavior is as in the `default` case.
 
-What combination of `ordered_insert_behavior` and `ordered` (in the insert command\
+What combination of `ordered_insert_behavior` and `ordered` (in the insert command
 document) is used, has an impact on the performance. Please see the discussion at [insert](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#insert).
 
 #### `cursor_timeout`
@@ -1079,7 +1079,7 @@ document) is used, has an impact on the performance. Please see the discussion a
 * Mandatory: No
 * Default: `60s`
 
-Specifies how long a cursor can be idle, that is, not accessed, before it is\
+Specifies how long a cursor can be idle, that is, not accessed, before it is
 automatically closed.
 
 #### `debug`
@@ -1104,7 +1104,7 @@ So, specify
 nosqlprotocol.debug=in,out,back
 ```
 
-to have the incoming command, the corresponding SQL sent to the backend\
+to have the incoming command, the corresponding SQL sent to the backend
 and the resulting response sent to the client logged.
 
 #### `internal_cache`
@@ -1113,7 +1113,7 @@ and the resulting response sent to the client logged.
 * Mandatory: No
 * Default: ''
 
-Specifies what internal cache to use if any. Currently, the only\
+Specifies what internal cache to use if any. Currently, the only
 permissible value is `cache`, which refers to the [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md).
 
 Please see [caching](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#caching) for more information.
@@ -1121,15 +1121,15 @@ Please see [caching](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.m
 ### Databases and Tables
 
 By default, _nosqlprotocol_ automatically creates databases as needed.\
-The default behavior can be changed by setting `auto_create_databases` to\
+The default behavior can be changed by setting `auto_create_databases` to
 false. In that case, databases must manually be created.
 
 Each MongoDB® _collection_ corresponds to a MariaDB table with the same name.\
-However, it is always possible to access a collection irrespective of whether\
+However, it is always possible to access a collection irrespective of whether
 the corresponding table exists or not; it will simply appear to be empty.
 
-Inserting documents into a collection, whose corresponding table does not\
-exist, succeeds, provided `auto_create_tables` is `true`, as the table will\
+Inserting documents into a collection, whose corresponding table does not
+exist, succeeds, provided `auto_create_tables` is `true`, as the table will
 in that case be created.
 
 When _nosqlprotocol_ creates a table, it uses a statement like
@@ -1140,19 +1140,19 @@ CREATE TABLE name (id VARCHAR(35) AS (JSON_COMPACT(JSON_EXTRACT(doc, "$._id"))) 
                    CONSTRAINT id_not_null CHECK(id IS NOT NULL));
 ```
 
-where the length of the `VARCHAR` is specified by the value of `id_length`,\
+where the length of the `VARCHAR` is specified by the value of `id_length`,
 whose default and minimum is 35.
 
-_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain\
+_NOTE_ If the tables are created manually, then the `CREATE` statement\_must\_ contain a similar `AS`-clause as the one above and _should_ contain
 a similar constraint.
 
-Note that _nosqlprotocol_ does not in any way verify that the table\
-corresponding to a collection being accessed or modified does indeed\
-have the expected columns `id` and `doc` of the expected types, but it\
-simply uses the table, which will fail if the layout is not the expected\
+Note that _nosqlprotocol_ does not in any way verify that the table
+corresponding to a collection being accessed or modified does indeed
+have the expected columns `id` and `doc` of the expected types, but it
+simply uses the table, which will fail if the layout is not the expected
 one.
 
-To reduce the risk for confusion, the recommendation is to use a specific\
+To reduce the risk for confusion, the recommendation is to use a specific
 database for tables that contain documents.
 
 ### Operators
@@ -1188,7 +1188,7 @@ The following operators are currently supported.
 
 **`$type`**
 
-When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset\
+When `$type` is used, it will be converted into a condition involving one or more [JSON\_TYPE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/special-functions/json-functions/json_type) comparisons. The following subset
 of types can be used in `$type` queries:
 
 | Type           | Number | Alias    | MariaDB Type |
@@ -1310,10 +1310,10 @@ As arguments, only the operators `$eq` and `$ne` are supported.
 
 ### Database Commands
 
-The following commands are supported. At each command is specified\
+The following commands are supported. At each command is specified
 what fields are relevant for the command.
 
-**All** non-listed fields are ignored; their presence or absence have no\
+**All** non-listed fields are ignored; their presence or absence have no
 impact, unless otherwise explicitly specified.
 
 #### Aggregation Commands
@@ -1328,8 +1328,8 @@ The following fields are relevant.
 | pipeline  | array   | An array of [aggregation pipeline stages](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#aggregation-pipeline-stages) that process and transform the document stream. |
 | explain   | boolean | Optional. Specifies to return information on the processing of the pipeline.                                                                                                        |
 
-Depending on the stages and their parameters, the aggregation pipeline may be\
-performed entirely using SQL, by fetching documents to MaxScale where they are\
+Depending on the stages and their parameters, the aggregation pipeline may be
+performed entirely using SQL, by fetching documents to MaxScale where they are
 post-processed or by a combination of the two approaches.
 
 **count**
@@ -1398,7 +1398,7 @@ The `projection` parameter takes a document of the following form:
 { <field1>: <value>, <field2>: <value> ... }
 ```
 
-If a `projection` document is not provided or if it is empty, the entire document\
+If a `projection` document is not provided or if it is empty, the entire document
 will be returned.
 
 | Projection     | Description                             |
@@ -1413,17 +1413,17 @@ For fields in an embedded documents, the field can be specified using:
 
 * dot notation; e.g. `"field.nestedfield": <value>`
 
-In particular, specifying fields in embedded documents using nested form\
+In particular, specifying fields in embedded documents using nested form
 is not supported.
 
 **`_id` Field Projection**
 
-The `_id` field is included in the returned documents by default unless you\
+The `_id` field is included in the returned documents by default unless you
 explicitly specify `_id: 0` in the projection to suppress the field.
 
 **Inclusion or Exclusion**
 
-A `projection` cannot contain both include and exclude specifications,\
+A `projection` cannot contain both include and exclude specifications,
 with the exception of the `_id` field:
 
 * In projections that explicitly include fields, the `_id` field is the only field that can be explicitly excluded.
@@ -1455,7 +1455,7 @@ and in the latter
 ... WHERE (JSON_EXTRACT(doc, '$._id') = 4711)
 ```
 
-That is, in the former case the _indexed_ column `id` will be used, in the\
+That is, in the former case the _indexed_ column `id` will be used, in the
 latter it will not.
 
 **findAndModify**
@@ -1495,9 +1495,9 @@ The following fields are relevant.
 
 **insert**
 
-The `insert` command inserts one or more documents into the table whose\
-name is the same as that of the collection. If the option `auto_create_tables`\
-is `true`, then the table is created if it does not already exist. If the\
+The `insert` command inserts one or more documents into the table whose
+name is the same as that of the collection. If the option `auto_create_tables`
+is `true`, then the table is created if it does not already exist. If the
 value is `false`, then the insert will fail unless the table already exists.
 
 The following fields are relevant.
@@ -1514,9 +1514,9 @@ The impact of `ordered` is dependent upon the value of `ordered_insert_behavior`
 
 **`default`**
 
-In this case `ordered` has the same impact as in MongoDB®. That is, if the value\
-is `true`, then when an insert of a document fails, return without inserting any\
-remaining documents listed in the inserts array. If `false`, then when an insert\
+In this case `ordered` has the same impact as in MongoDB®. That is, if the value
+is `true`, then when an insert of a document fails, return without inserting any
+remaining documents listed in the inserts array. If `false`, then when an insert
 of a document fails, continue to insert the remaining documents.
 
 **`atomic`**
@@ -1528,7 +1528,7 @@ then the behavior is identical with that of `default`.
 
 **Performance**
 
-What combination of `ordered_insert_behavior` and `ordered` is used, has an\
+What combination of `ordered_insert_behavior` and `ordered` is used, has an
 impact on the performance.
 
 | ordered\_insert\_behavior | ordered = true                                                                                                                        | ordered = false                                                                                                                        |
@@ -1536,8 +1536,8 @@ impact on the performance.
 | default                   | All documents are inserted within a compound statement, in a transaction containing as many INSERT statements as there are documents. | All documents are inserted in a single multi-statement transaction containing as many INSERT IGNORE statements as there are documents. |
 | atomic                    | All documents are inserted using a single INSERT statement.                                                                           | Same as above                                                                                                                          |
 
-Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,\
-being roughly twice as slow. The performance of 'default + true' is halfway between\
+Of these, `atomic + true` is the fastest and `atomic|default + false` the slowest,
+being roughly twice as slow. The performance of 'default + true' is halfway between
 the two.
 
 **resetError**
@@ -1570,10 +1570,10 @@ Each document contains the following fields:
 | u     | document | The modifications to apply. See behavior below for details.                                                                                                        |
 | multi | boolean  | Optional. If true, updates all documents that meet the query criteria. If false limit the update to one document that meets the query criteria. Defaults to false. |
 
-Note that currently it is possible to set `multi` to `true` in conjunction\
+Note that currently it is possible to set `multi` to `true` in conjunction
 with a _replacement-style_ update, even though MongoDB® rejects that.
 
-All other fields are ignored, with the exception of `upsert` that if present\
+All other fields are ignored, with the exception of `upsert` that if present
 with the value of `true` will cause the command to fail.
 
 **Behavior**
@@ -1599,7 +1599,7 @@ In this case, the update command updates only the corresponding fields in the do
 
 **# Update with a Replacement Document**
 
-The update statement field `u` field can accept a _replacement document_,\
+The update statement field `u` field can accept a _replacement document_,
 i.e. the document contains only `field:value` expressions. For example:
 
 ```
@@ -1614,12 +1614,12 @@ updates: [
 ```
 
 In this case, the update command replaces the matching document with the update document.\
-The update command can only replace a single matching document; i.e. the multi field\
+The update command can only replace a single matching document; i.e. the multi field
 cannot be true.
 
-**Note** If the replacement document contains an `_id` field, it will be ignored and the\
-document id will remain non-changed while the document otherwise is replaced. This is\
-different from MongoDB® where the presence of the `_id` field in the replacement document\
+**Note** If the replacement document contains an `_id` field, it will be ignored and the
+document id will remain non-changed while the document otherwise is replaced. This is
+different from MongoDB® where the presence of the `_id` field in the replacement document
 causes an error, if the value is not the same as it is in the document being replaced.
 
 #### Authentication Commands
@@ -1634,7 +1634,7 @@ The following fields are relevant.
 
 If you are not logged in and using authentication, `logout` has no effect.
 
-Note that in order to be logged out, the logging out must be done while\
+Note that in order to be logged out, the logging out must be done while
 using the same database that was used when you logged on.
 
 Always returns
@@ -1647,7 +1647,7 @@ Always returns
 
 **createUser**
 
-Creates a new MariaDB user and adds an entry to the local nosqlprotocol\
+Creates a new MariaDB user and adds an entry to the local nosqlprotocol
 account database.
 
 The following fields are relevant.
@@ -1661,8 +1661,8 @@ The following fields are relevant.
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is\
-the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the\
+The MariaDB user will be created as `'<db>.<user>'@'%'` where `<db>` is
+the name of the NoSQL database in whose context the user is created, and`<user>` the value of the `createUser` field. For instance, with the
 following command
 
 ```
@@ -1672,19 +1672,19 @@ following command
 
 the MariaDB user `'myDatabase.user1'@'%'` will be created.
 
-The elements of the `roles` array are converted into privileges\
+The elements of the `roles` array are converted into privileges
 as explained in [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#roles_and_privileges).
 
 In practice the creation is performed as follows:_First the MariaDB user is created._ Then the privileges are granted.
 
 * Finally the local nosqlprotocol account database is updated.
 
-If the granting of privileges fails, an attempt will be made to\
+If the granting of privileges fails, an attempt will be made to
 drop the user.
 
 **dropAllUsersFromDatabase**
 
-Drops all users from the local nosqlprotocol account database and\
+Drops all users from the local nosqlprotocol account database and
 the corresponding MariaDB users.
 
 The following fields are relevant.
@@ -1706,13 +1706,13 @@ The following fields are relevant.
 | -------- | ------ | ----------------------------------- |
 | dropUser | string | The name of the user to be dropped. |
 
-The user will first be dropped from the MariaDB server and if\
+The user will first be dropped from the MariaDB server and if
 that succeeds also from the local nosqlprotocol account database.
 
 **grantRolesToUser**
 
-This command _adds_ more roles to a NoSQL user, which may imply\
-that additional privileges are granted to the corresponding MariaDB\
+This command _adds_ more roles to a NoSQL user, which may imply
+that additional privileges are granted to the corresponding MariaDB
 user.
 
 | Field            | Type   | Description                                    |
@@ -1721,12 +1721,12 @@ user.
 | roles            | array  | An array of additional roles.                  |
 
 Note that roles assigned to different databases will result in separate\
-GRANT statements, which means that it is possible that some succeed and\
+GRANT statements, which means that it is possible that some succeed and
 others do not.
 
 **revokeRolesFromUser**
 
-This command _removes_ roles from an NoSQL user, which may imply\
+This command _removes_ roles from an NoSQL user, which may imply
 that privileges are revoked from the corresponding MariaDB user.
 
 | Field               | Type   | Description                                |
@@ -1734,8 +1734,8 @@ that privileges are revoked from the corresponding MariaDB user.
 | revokeRolesFromUser | string | The name of the user to remove roles from. |
 | roles               | array  | An array of roles to remove.               |
 
-Note that roles to be removed from different databases will result in\
-separate REVOKE statements, which means that it is possible that some\
+Note that roles to be removed from different databases will result in
+separate REVOKE statements, which means that it is possible that some
 succeed and others do not.
 
 **updateUser**
@@ -1750,8 +1750,8 @@ This command updates the information about a particular user.
 | roles      | array    | Optional. The roles granted to the user. Note that the existing ones are replaced and not amended with these roles.                                                                                                                                                |
 | mechanisms | array    | Optional. The specific SCRAM mechanisms for user credentials. Note that if a new pwd is provided, then the array can contain all supported SCRAM mechanisms. If a new pwd is not provided, then the array must be a subset of the existing mechanisms of the user. |
 
-Changes to `customData` or `mechanisms` are made only to the local\
-nosqlprotocol database, but changes to `pwd` or `roles` require\
+Changes to `customData` or `mechanisms` are made only to the local
+nosqlprotocol database, but changes to `pwd` or `roles` require
 the MariaDB server to be updated.
 
 **usersInfo**
@@ -1775,11 +1775,11 @@ The returned information depends the value of `usersInfo`:
 | { usersInfo: \[{ user: , db: }, ...]} | Returns information about specified users.                                          |
 | { usersInfo: \[ , ... ]}              | Returns information about specified users in the database where the command is run. |
 
-Note that users may always view their own information. Otherwise the user must\
+Note that users may always view their own information. Otherwise the user must
 have the `userAdmin` or `userAdminAnyDatabase` role.
 
 If `showCredentials` is true, the returned object(s) will contain a`mariadb: { password: "*..."}` field, where `password` is the`SHA1(SHA1())` value of the password used when logging to MariaDB.\
-That is, the same string that is found in the `password` column in\
+That is, the same string that is found in the `password` column in
 the `mysql.user` table.
 
 #### Replication Commands
@@ -1841,8 +1841,8 @@ The following fields are relevant.
 | capped | boolean | Optional. If specified, the value must be false as capped collections are not supported. |
 | viewOn | string  | Optional. If specified, the command will fail as views are not supported.                |
 
-Currently, _capped collections_ and _views_ are not supported. Consequently,\
-specifying that the collection should be capped or that it should be a\
+Currently, _capped collections_ and _views_ are not supported. Consequently,
+specifying that the collection should be capped or that it should be a
 view on another collection, will cause the command to fail.
 
 **createIndexes**
@@ -1853,9 +1853,9 @@ The following fields are relevant.
 | ------------- | ------ | ------------------------------------------- |
 | createIndexes | string | The collection for which to create indexes. |
 
-**NOTE** Currently it is not possible to create indexes, but the command\
-will nonetheless return success, provide the index specification passes\
-some rudimentary sanity checks. Note also that the collection will be\
+**NOTE** Currently it is not possible to create indexes, but the command
+will nonetheless return success, provide the index specification passes
+some rudimentary sanity checks. Note also that the collection will be
 created if it does not exist.
 
 **drop**
@@ -1882,9 +1882,9 @@ The following fields are relevant.
 | ----------- | ---- | ----------- |
 | dropIndexes | any  | Ignored.    |
 
-**NOTE** Currently it is not possible to create indexes and thus there\
-will never be any indexes that could be dropped. However, provided the\
-specified collection exists, dropping indexes will always succeed except\
+**NOTE** Currently it is not possible to create indexes and thus there
+will never be any indexes that could be dropped. However, provided the
+specified collection exists, dropping indexes will always succeed except
 for an attempt to drop the built-in `_id_` index.
 
 **fsync**
@@ -1925,7 +1925,7 @@ The following fields are relevant.
 | filter          | document | The field name is honored, other fields are not but cause warnings to be logged.                                                                 |
 | nameOnly        | boolean  | Optional. A flag to indicate whether the command should return just the collection names and type or return both the name and other information. |
 
-Up until version 24.02, the command listed every table in the current\
+Up until version 24.02, the command listed every table in the current
 database as a collection. From 24.08 onwards, only tables that contain\
 NoSQL data will be returned as NoSQL collections.
 
@@ -1946,9 +1946,9 @@ The following fields are relevant.
 | ----------- | ------ | --------------------------- |
 | listIndexes | string | The name of the collection. |
 
-**NOTE** As it currently is not possible to actually create indexes,\
-although an attempt to do so using `createIndexes` will succeed, the\
-result will always only contain information about the built-in\
+**NOTE** As it currently is not possible to actually create indexes,
+although an attempt to do so using `createIndexes` will succeed, the
+result will always only contain information about the built-in
 index `_id_`.
 
 **renameCollection**
@@ -2056,8 +2056,8 @@ The following fields are relevant.
 | -------- | ------ | --------------------------------------- |
 | validate | string | The name of the collection to validate. |
 
-The command does not actually perform any validation but for checking\
-that the collection exists. The response will contain in `nrecords`\
+The command does not actually perform any validation but for checking
+that the collection exists. The response will contain in `nrecords`
 the current number of documents/rows it contains.
 
 **whatsmyuri**
@@ -2094,11 +2094,11 @@ The following document will always be returned:
 
 **mxsAddUser**
 
-The `mxsAddUser` command adds an _existing_ MariaDB user to the local\
+The `mxsAddUser` command adds an _existing_ MariaDB user to the local
 nosqlprotocol account database. Use [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) if the\
 MariaDB user should be created as well.
 
-Note that the `mxsAddUser` command does not check that the user exists\
+Note that the `mxsAddUser` command does not check that the user exists
 or that the specified roles are compatible with the grants of the user.
 
 **Syntax**
@@ -2134,17 +2134,17 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. Must be a subset of the supported mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                          |
 
-The value of `mxsAddUser` should be the name (without the host part) of\
-an existing user in the MariaDB server and the value of `pwd` should be\
+The value of `mxsAddUser` should be the name (without the host part) of
+an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the addition of the user succeeds, the command returns a document\
+If the addition of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2170,7 +2170,7 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsCreateDatabase**
 
-The 'mxsCreateDatabase' command creates a new database and must be run\
+The 'mxsCreateDatabase' command creates a new database and must be run
 against the `admin` database.
 
 **Syntax**
@@ -2195,7 +2195,7 @@ The command takes the following fields:
 
 **Returns**
 
-If database creation succeeds, the command returns a document with the\
+If database creation succeeds, the command returns a document with the
 single field `ok` whose value is `1`.
 
 ```
@@ -2246,7 +2246,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains diagnostics of the command\
+The command returns a document that contains diagnostics of the command
 provided as argument. For example:
 
 ```
@@ -2271,19 +2271,19 @@ provided as argument. For example:
 }
 ```
 
-`kind` specifies of what kind the command is; an _immediate_ command is one for\
-which MaxScale autonomously can generate the response, a _single_ command is one\
-where the command will cause a single SQL statement to be sent to the backend, and\
-a _multi_ command is one where potentially multiple SQL statements will be sent to\
+`kind` specifies of what kind the command is; an _immediate_ command is one for
+which MaxScale autonomously can generate the response, a _single_ command is one
+where the command will cause a single SQL statement to be sent to the backend, and
+a _multi_ command is one where potentially multiple SQL statements will be sent to
 the backend.
 
-If the command is _immediate_ then there will be a field `response` containing\
-the actual response of the command, if the command is _single_ then there will be\
-a field `sql` containing the actual statement that would have been sent to the backend,\
-and if the command is _multi_ then there will be a field `sql` containing an array\
+If the command is _immediate_ then there will be a field `response` containing
+the actual response of the command, if the command is _single_ then there will be
+a field `sql` containing the actual statement that would have been sent to the backend,
+and if the command is _multi_ then there will be a field `sql` containing an array
 of statements that would have been sent to the backend.
 
-If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that\
+If an error occurs while the command is being diagnosed, then there will be no`response` field but an `error` field whose value is an error document. Note that
 the value of `ok` will always be 1.
 
 **mxsGetConfig**
@@ -2292,7 +2292,7 @@ the value of `ok` will always be 1.
 
 **mxsGetConfig**
 
-The `mxsGetConfig` command returns the current configuration of the session\
+The `mxsGetConfig` command returns the current configuration of the session
 and must be run against the 'admin' database.
 
 **Syntax**
@@ -2316,7 +2316,7 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the current configuration of\
+The command returns a document that contains the current configuration of
 the session. For example:
 
 ```
@@ -2361,8 +2361,8 @@ The command takes the following fields:
 
 **Returns**
 
-The command returns a cursor whose first and only batch contains\
-the names of the tables in the database and whether they are NoSQL\
+The command returns a cursor whose first and only batch contains
+the names of the tables in the database and whether they are NoSQL
 collections or not. For example:
 
 ```
@@ -2386,8 +2386,8 @@ collections or not. For example:
 
 **mxsRemoveUser**
 
-The `mxsRemoveUser` removes a user from the local nosqlprotocol account\
-database. Use [dropUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped\
+The `mxsRemoveUser` removes a user from the local nosqlprotocol account
+database. Use [dropUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped
 as well.
 
 **Syntax**
@@ -2412,7 +2412,7 @@ The command has the following fields:
 
 **Returns**
 
-If the removal of the user succeeds, the command returns a document\
+If the removal of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2438,10 +2438,10 @@ If there is a failure of some kind, the command returns an error document
 
 **mxsSetConfig**
 
-The `mxsSetConfig` command changes the configuration of the session\
+The `mxsSetConfig` command changes the configuration of the session
 and must be run against the 'admin' database.
 
-Note that the changes only affect the current session and are **not**\
+Note that the changes only affect the current session and are **not**
 persisted.
 
 **Syntax**
@@ -2473,7 +2473,7 @@ The document takes the following fields:
 
 **Returns**
 
-The command returns a document that contains the changed configuration of\
+The command returns a document that contains the changed configuration of
 the session. For example:
 
 ```
@@ -2505,12 +2505,12 @@ the session. For example:
 
 **mxsUpdateUser**
 
-The `mxsUpdateUser` command updates a user in the local nosqlprotocol\
-account database. Use [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#updateUser) to update MariaDB user\
+The `mxsUpdateUser` command updates a user in the local nosqlprotocol
+account database. Use [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#updateUser) to update MariaDB user
 as well.
 
-Note that the `mxsUpdateUser` command does not check that the changed\
-data is compatible e.g. with the grants of the corresponding MariaDB\
+Note that the `mxsUpdateUser` command does not check that the changed
+data is compatible e.g. with the grants of the corresponding MariaDB
 user.
 
 **Syntax**
@@ -2546,13 +2546,13 @@ The command has the following fields:
 | mechanisms     | array    | Optional. The specific supported SCRAM mechanisms for this user. If a new password is not provided, the specified mechanisms must be a subset of the current mechanisms. |
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
-The `roles` array should contain roles that a compatible with the\
-grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#roles_and_grants)\
+The `roles` array should contain roles that a compatible with the
+grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#roles_and_grants)
 for a discussion on how to map roles map to grants.
 
 **Returns**
 
-If the updating of the user succeeds, the command returns a document\
+If the updating of the user succeeds, the command returns a document
 with the single field `ok` whose value is `1`.
 
 ```
@@ -2574,23 +2574,23 @@ If there is a failure of some kind, the command returns an error document
 
 ### Object Id
 
-When a document is created, an id of type `ObjectId` will be autogenerated by\
-the MongoDB® client library. If the id is provided explicitly, by assigning a\
-value to the `_id` field, the value must be an `ObjectId`, a string or an\
+When a document is created, an id of type `ObjectId` will be autogenerated by
+the MongoDB® client library. If the id is provided explicitly, by assigning a
+value to the `_id` field, the value must be an `ObjectId`, a string or an
 integer.
 
 ### Caching
 
 The conversion of the BSON used in the communication between the client and\
-MaxScale, to the SQL used in the communication between MaxScale and the server\
-carries a not insignificant cost, as does the conversion of result sets\
-returned by the server to the BSON returned by MaxScale to the client. The\
-regular [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md) provides no remedy for this, as\
-it is located after the protocol and uses SQL as the key and stores result\
+MaxScale, to the SQL used in the communication between MaxScale and the server
+carries a not insignificant cost, as does the conversion of result sets
+returned by the server to the BSON returned by MaxScale to the client. The
+regular [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md) provides no remedy for this, as
+it is located after the protocol and uses SQL as the key and stores result
 sets as values.
 
-From 23.08 onwards, the nosqlprotocol has a built-in cache that when used\
-under certain conditions diminishes the conversion cost. The cache is\
+From 23.08 onwards, the nosqlprotocol has a built-in cache that when used
+under certain conditions diminishes the conversion cost. The cache is
 enabled by adding the following line to the NoSQL listener.
 
 ```
@@ -2599,8 +2599,8 @@ enabled by adding the following line to the NoSQL listener.
 nosqlprotocol.internal_cache=cache
 ```
 
-This effectively causes the [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md) to be used\
-inside the NoSQL protocol module. The internal cache can be configured just\
+This effectively causes the [cache filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md) to be used
+inside the NoSQL protocol module. The internal cache can be configured just
 like the cache filter is, by using the following nested configuration syntax.
 
 ```
@@ -2613,27 +2613,27 @@ nosqlprotocol.cache.hard_ttl=40s
 ...
 ```
 
-A limitation is that _only_ the default storage `storage_inmemory` is\
+A limitation is that _only_ the default storage `storage_inmemory` is
 supported; `storage_redis` and `storage_memcached` cannot be used.
 
-The cache works on both the SQL and the BSON layer. When a NoSQL request\
-that potentially is cacheable arrives, a lookup for the BSON response is\
-made. If it is found, the response is returned to the client. That is, in\
-this case neither BSON -> SQL, nor a Result Set -> BSON translation will\
+The cache works on both the SQL and the BSON layer. When a NoSQL request
+that potentially is cacheable arrives, a lookup for the BSON response is
+made. If it is found, the response is returned to the client. That is, in
+this case neither BSON -> SQL, nor a Result Set -> BSON translation will
 be made.
 
-If the request is not potentially cacheable or the response is not\
-available, the request is processed normally, which may mean that the\
-request is translated into SQL. If the SQL is a SELECT, a second lookup\
-will be made for the corresponding result set. If that is found, the\
+If the request is not potentially cacheable or the response is not
+available, the request is processed normally, which may mean that the
+request is translated into SQL. If the SQL is a SELECT, a second lookup
+will be made for the corresponding result set. If that is found, the
 result set is processed, but the roundtrip to the server will be saved.
 
-So, when a result set is received from the server, it will be cached and\
-if the generated NoSQL response is also cacheable, it will be cached as\
-well. The benefit of this approach is that two `Find` NoSQL requests\
-may effectively return the same documents, even though one but not the\
-other NoSQL response is cacheable. Both will benefit the result set being\
-in the cache. Since the used storage follows an LRU-approach when evicting\
+So, when a result set is received from the server, it will be cached and
+if the generated NoSQL response is also cacheable, it will be cached as
+well. The benefit of this approach is that two `Find` NoSQL requests
+may effectively return the same documents, even though one but not the
+other NoSQL response is cacheable. Both will benefit the result set being
+in the cache. Since the used storage follows an LRU-approach when evicting
 data from the cache, the less valuable result will be evicted first.
 
 #### Cached Commands
@@ -2642,25 +2642,25 @@ The responses of the following commands are cached.
 
 * [count](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#count)
 * [distinct](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#distinct)
-* [find](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#find), provided all found documents can be returned in one response,\
+* [find](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#find), provided all found documents can be returned in one response,
   i.e., if `singleBatch` is `true` or `batchSize` is large enough.
 
 ### Compatibility
 
-Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)\
+Currently 30% of the tests in the [MongoDB® core](https://github.com/mongodb/mongo/tree/master/jstests/core)
 test-suite pass.
 
 ### Example
 
-The following is a minimal setup for getting _nosqlprotocol_ up and\
-running. It is assumed the reader knows how to configure MaxScale for\
+The following is a minimal setup for getting _nosqlprotocol_ up and
+running. It is assumed the reader knows how to configure MaxScale for
 normal use. If not, please start with the [MaxScale tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-setting-up-mariadb-maxscale.md).\
-Note that as _nosqlprotocol_ is the first component in the MaxScale\
+Note that as _nosqlprotocol_ is the first component in the MaxScale
 routing chain, it can be used with all routers and filters.
 
 #### Configuring MaxScale
 
-In the following it is assumed that MaxScale already has been configured\
+In the following it is assumed that MaxScale already has been configured
 for normal use and that there exists a _service_ `[TheService]`.
 
 ```
@@ -2677,10 +2677,10 @@ nosqlprotocol.password=the_password
 port=17017
 ```
 
-The values `the_user` and `the_password` must be replaced with the\
+The values `the_user` and `the_password` must be replaced with the
 actual credentials to be used for every MongoDB® client that connects.
 
-If MaxScale is now started, the following entry should appear in the\
+If MaxScale is now started, the following entry should appear in the
 log file.
 
 ```
@@ -2691,8 +2691,8 @@ log file.
 
 The mongo Shell is a powerful tool with which to access and manipulate a\
 MongoDB database. It is part of the MongoDB® package. Having the native\
-MongoDB database installed is convenient, as it makes it easy to ascertain\
-whether a problem is due to _nosqlprotocol_ not fully implementing something\
+MongoDB database installed is convenient, as it makes it easy to ascertain
+whether a problem is due to _nosqlprotocol_ not fully implementing something
 or due to the API not being used in the correct fashion.
 
 With the _mongo shell_, all that is needed is to invoke it with the port\_nosqlprotocol\_ is listening on:
@@ -2709,7 +2709,7 @@ MongoDB server version: 4.4.1
 >
 ```
 
-If the shell prompt appears, then a connection was successfully\
+If the shell prompt appears, then a connection was successfully
 established and the shell can be used.
 
 ```
@@ -2717,13 +2717,13 @@ established and the shell can be used.
 { "n" : 1, "ok" : 1 }
 ```
 
-The `db` variable is implicitly available, and refers by default to\
+The `db` variable is implicitly available, and refers by default to
 the `test` database.
 
 The command inserted a document into the collection called `collection`.\
-The table corresponding to that collection is created implicitly because\
-the default value of `auto_create_tables` is `true`. Here, the object id\
-is specified explicitly, but there is no need for that, as one will be\
+The table corresponding to that collection is created implicitly because
+the default value of `auto_create_tables` is `true`. Here, the object id
+is specified explicitly, but there is no need for that, as one will be
 created if needed.
 
 To check whether the documents was inserted into the collection, the`find` command can be issued:
@@ -2758,18 +2758,18 @@ MariaDB [(none)]> select * from test.collection;
 +------+------------------------------------+
 ```
 
-The collection `collection` is represented by a table `collection` with\
-the two columns `id` and `doc`. `id` is a virtual column whose content is\
+The collection `collection` is represented by a table `collection` with
+the two columns `id` and `doc`. `id` is a virtual column whose content is
 the value of the `_id` field of the document in the `doc` column.
 
-All MongoDB® commands that _mongdbprotocol_ support (but for the ones that\
-do not require database access), basically access or manipulate the\
+All MongoDB® commands that _mongdbprotocol_ support (but for the ones that
+do not require database access), basically access or manipulate the
 content in the `doc` column using the [JSON functions](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements-and-structure/sql-statements/built-in-functions/special-functions/json-functions) of MariaDB.
 
-From within the mongo shell itself it is easy to find out just what SQL\
+From within the mongo shell itself it is easy to find out just what SQL
 a particular MongoDB command is translated into.
 
-For instance, the SQL that the insert command with which the document was\
+For instance, the SQL that the insert command with which the document was
 added can be found out like:
 
 ```
@@ -2794,18 +2794,18 @@ Similarly, the SQL of the `find` command can be find out like:
 }
 ```
 
-The returned SQL can be directly pasted at the `mysql` prompt, which is\
+The returned SQL can be directly pasted at the `mysql` prompt, which is
 quite convenient in case the MongoDB® command does not behave as expected.
 
 #### MongoDB® Node.JS Driver
 
-As all client libraries implement and depend on the MongoDB® wire protocol,\
-all client libraries should work with _nosqlprotocol_. However, the\
-only client library that has been used and that has been verified to work\
+As all client libraries implement and depend on the MongoDB® wire protocol,
+all client libraries should work with _nosqlprotocol_. However, the
+only client library that has been used and that has been verified to work
 is version 3.6 of the _MongoDB Node.JS Driver_.
 
-In principle, the only thing that needs to be altered in an existing\
-program using the library is to change the uri string that typically\
+In principle, the only thing that needs to be altered in an existing
+program using the library is to change the uri string that typically
 is something like
 
 ```
@@ -2820,8 +2820,8 @@ const uri = "mongodb://<maxscale-ip>:17017";
 
 with the assumption that the default _nosqlprotocol_ port is used.
 
-In practice, additional modifications may be needed since _nosqlprotocol_\
-does not implement all commands and does not in all cases implement the\
+In practice, additional modifications may be needed since _nosqlprotocol_
+does not implement all commands and does not in all cases implement the
 full functionality of the commands that it supports.
 
 **Inserting a Document**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-maxctrl.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-maxctrl.md
@@ -4,14 +4,14 @@
 
 ## MaxCtrl
 
-MaxCtrl is a command line administrative client for MaxScale which uses\
-the MaxScale REST API for communication. It has replaced the legacy MaxAdmin\
+MaxCtrl is a command line administrative client for MaxScale which uses
+the MaxScale REST API for communication. It has replaced the legacy MaxAdmin
 command line client that is no longer supported or included.
 
-By default, the MaxScale REST API listens on port 8989 on the local host. The\
+By default, the MaxScale REST API listens on port 8989 on the local host. The
 default credentials for the REST API are `admin:mariadb`. The users used by the\
-REST API are the same that are used by the MaxAdmin network interface. This\
-means that any users created for the MaxAdmin network interface should work with\
+REST API are the same that are used by the MaxAdmin network interface. This
+means that any users created for the MaxAdmin network interface should work with
 the MaxScale REST API and MaxCtrl.
 
 For more information about the MaxScale REST API, refer to the [REST API documentation](../mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-rest-api.md) and the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
@@ -22,10 +22,10 @@ For more information about the MaxScale REST API, refer to the [REST API documen
 
 ## .maxctrl.cnf
 
-If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the\
-section `[maxctrl]` as defaults for command line arguments. For instance,\
-to avoid having to specify the user and password on the command line,\
-create the file `.maxctrl.cnf` in your home directory, with the following\
+If the file `~/.maxctrl.cnf` exists, maxctrl will use any values in the
+section `[maxctrl]` as defaults for command line arguments. For instance,
+to avoid having to specify the user and password on the command line,
+create the file `.maxctrl.cnf` in your home directory, with the following
 content:
 
 ```
@@ -34,11 +34,11 @@ u = my-name
 p = my-password
 ```
 
-Note that all access rights to the file must be removed from everybody else\
-but the owner. MaxCtrl refuses to use the file unless the rights have been\
+Note that all access rights to the file must be removed from everybody else
+but the owner. MaxCtrl refuses to use the file unless the rights have been
 removed.
 
-Another file from which to read the defaults can be specified with the `-c`\
+Another file from which to read the defaults can be specified with the `-c`
 flag.
 
 ## Commands

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md
@@ -2,17 +2,17 @@
 
 ## Module commands
 
-Introduced in MaxScale 2.1, the module commands are special, module-specific\
+Introduced in MaxScale 2.1, the module commands are special, module-specific
 commands. They allow the modules to expand beyond the capabilities of the module\
 API. Currently, only MaxCtrl implements an interface to the module commands.
 
-All registered module commands can be shown with `maxctrl list commands` and\
+All registered module commands can be shown with `maxctrl list commands` and
 they can be executed with `maxctrl call command <module> <name> ARGS...` whereis the name of the module and is the name of the command._ARGS_ is a command specific list of arguments.
 
 ### Developer reference
 
-The module command API is defined in the _modulecmd.h_ header. It consists of\
-various functions to register and call module commands. Read the function\
+The module command API is defined in the _modulecmd.h_ header. It consists of
+various functions to register and call module commands. Read the function
 documentation in the header for more details.
 
 The following example registers the module command _my\_command_ for module _my\_module_.
@@ -52,11 +52,11 @@ int main(int argc, char **argv)
 }
 ```
 
-The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of\
-arguments the command expects. The first argument is a boolean and the second\
+The array _my\_args_ of type _modulecmd\_arg\_type\_t_ is used to tell what kinds of
+arguments the command expects. The first argument is a boolean and the second
 argument is an optional string.
 
-Arguments are passed to the parsing function as an array of void pointers. They\
+Arguments are passed to the parsing function as an array of void pointers. They
 are interpreted as the types the command expects.
 
 When the module command is executed, the _argv_ parameter for the _my\_simple\_cmd_ contains the parsed arguments received from the caller of the

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-securing-your-maxscale-deployment.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-securing-your-maxscale-deployment.md
@@ -2,7 +2,7 @@
 
 ## Securing Your MaxScale Deployment
 
-There are five main components that you need to make sure are completed\
+There are five main components that you need to make sure are completed
 before you go into production:
 
 * Encrypting Plaintext Passwords
@@ -13,8 +13,8 @@ before you go into production:
 
 ### Encrypting Plaintext Passwords
 
-Ensuring the security of your MaxScale setup involves stringent control over\
-the key file permissions. Utilizing [maxkeys](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+Ensuring the security of your MaxScale setup involves stringent control over
+the key file permissions. Utilizing [maxkeys](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 is an effective approach to generate a secure key file.
 
 This generates a keyfile in `/var/lib/maxscale`
@@ -23,22 +23,22 @@ This generates a keyfile in `/var/lib/maxscale`
 $ maxkeys
 ```
 
-See [Encrypting Passwords](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+See [Encrypting Passwords](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 for more information about `maxkeys`.
 
-Once generated, this key file can be relocated to a secure location. This\
-key file serves a dual purpose: it enables the encryption of passwords and\
+Once generated, this key file can be relocated to a secure location. This
+key file serves a dual purpose: it enables the encryption of passwords and
 facilitates MaxScale in decrypting those encrypted passwords.
 
-To maintain confidentiality, it is crucial to adjust the ownership and\
-permissions of the key file appropriately using `chown`. This step ensures\
+To maintain confidentiality, it is crucial to adjust the ownership and
+permissions of the key file appropriately using `chown`. This step ensures
 that the key file remains secure and inaccessible to unauthorized users.
 
 ```
 $ chown maxscale:maxscale /var/lib/maxscale/.secrets
 ```
 
-Following the secure setup of the key file, you can proceed to encrypt the\
+Following the secure setup of the key file, you can proceed to encrypt the
 plaintext passwords of users already created in your databases.
 
 ```
@@ -47,8 +47,8 @@ $ maxpasswd plaintextpassword
 ```
 
 These encrypted passwords can then replace the plaintext passwords in your\
-MaxScale configuration (CNF) files. This enhances the overall security\
-of your database system by reducing the risk that passwords are accidentally\
+MaxScale configuration (CNF) files. This enhances the overall security
+of your database system by reducing the risk that passwords are accidentally
 shared.
 
 ```
@@ -62,12 +62,12 @@ password=96F99AA1315BDC3604B006F427DD9484
 
 ### Securing the GUI Interface
 
-To enhance the security of your MaxScale environment, it’s crucial to\
-configure the GUI host address properly. The default setting, `0.0.0.0`,\
-allows unrestricted access from any network, which poses a significant\
-security risk. Instead, you should set the `admin_host` to a more secure\
-address. Additionally, you can change the default port (8989) to another\
-port for added security. For example, you can restrict access to the\
+To enhance the security of your MaxScale environment, it’s crucial to
+configure the GUI host address properly. The default setting, `0.0.0.0`,
+allows unrestricted access from any network, which poses a significant
+security risk. Instead, you should set the `admin_host` to a more secure
+address. Additionally, you can change the default port (8989) to another
+port for added security. For example, you can restrict access to the
 localhost by setting:
 
 ```
@@ -76,7 +76,7 @@ admin_host=127.0.0.1
 admin_port=2222
 ```
 
-Alternatively, you can specify an internal network IP address to limit\
+Alternatively, you can specify an internal network IP address to limit
 access within your internal network, such as:
 
 ```
@@ -85,14 +85,14 @@ admin_host=10.0.0.3
 admin_port=2222
 ```
 
-If you need to allow external access, ensure that the network is adequately\
-secured and that only authorized users can access the MaxScale\
-interface. Consult with your network administrator to determine the most\
+If you need to allow external access, ensure that the network is adequately
+secured and that only authorized users can access the MaxScale
+interface. Consult with your network administrator to determine the most
 appropriate and secure configuration.
 
 #### Enabling TLS Encryption
 
-To further secure your MaxScale setup, enable TLS encryption for data in\
+To further secure your MaxScale setup, enable TLS encryption for data in
 transit. Follow these steps to configure SSL:
 
 **1. Set Up SSL Keys and Certificates:**
@@ -127,17 +127,17 @@ $ maxctrl --user=my_user --password=my_password --secure --tls-ca-cert=/certs/ca
 
 ### Managing Users & Passwords
 
-MaxScale allows you to manage user access to its GUI, offering different\
-permission levels to suit various operational needs. Currently, MaxScale\
-supports two primary roles: `admin` and `basic`. This functionality is\
-particularly useful for organizations with hierarchical structures or\
-distinct departments, enabling you to grant status view access without\
+MaxScale allows you to manage user access to its GUI, offering different
+permission levels to suit various operational needs. Currently, MaxScale
+supports two primary roles: `admin` and `basic`. This functionality is
+particularly useful for organizations with hierarchical structures or
+distinct departments, enabling you to grant status view access without
 allowing execution or manipulation capabilities.
 
 #### Creating and Deleting Users
 
-To create or delete users in the MaxScale GUI, you can use the `maxctrl`\
-command. Here’s an example of creating a user with administrative\
+To create or delete users in the MaxScale GUI, you can use the `maxctrl`
+command. Here’s an example of creating a user with administrative
 privileges:
 
 ```
@@ -152,30 +152,30 @@ $ maxctrl destroy user admin
 
 #### Managing Users in the GUI
 
-The MaxScale GUI also provides functionality to manage user access and\
+The MaxScale GUI also provides functionality to manage user access and
 update the admin password. Through the GUI, you can:
 
 * Add Users: Create users with basic or admin access.
 * Modify User Permissions: Change roles as needed to adapt to evolving security requirements.
 * Update Admin Password: Enhance security by regularly updating the admin password.
 
-By leveraging these features, you can ensure that your MaxScale environment\
-remains secure and that user access is appropriately managed according to\
+By leveraging these features, you can ensure that your MaxScale environment
+remains secure and that user access is appropriately managed according to
 your organization’s needs.
 
 ### Enabling Audit Logging
 
-Turn on admin auditing to log all login, connection, and configuration\
+Turn on admin auditing to log all login, connection, and configuration
 changes. Choose an audit file location and set up log rotation.
 
 #### Enabling and Managing Admin Auditing in MaxScale
 
-Admin auditing in MaxScale provides comprehensive tracking of all\
-administrative activities, including logins, connections, and\
-modifications. These activities are recorded in an audit file for enhanced\
+Admin auditing in MaxScale provides comprehensive tracking of all
+administrative activities, including logins, connections, and
+modifications. These activities are recorded in an audit file for enhanced
 security and traceability.
 
-To enable admin auditing, add the following configuration to your MaxScale\
+To enable admin auditing, add the following configuration to your MaxScale
 configuration file:
 
 ```
@@ -184,7 +184,7 @@ admin_audit = true
 admin_audit_file = /var/log/maxscale/audit_files/audit.csv
 ```
 
-This configuration activates auditing and specifies the location of the\
+This configuration activates auditing and specifies the location of the
 audit file. Ensure that the specified directory exists before restarting\
 MaxScale.
 
@@ -197,7 +197,7 @@ MaxScale.
 
 **2. Audit File Management:**
 
-* Implement log rotation to manage the size and number of audit files. This\
+* Implement log rotation to manage the size and number of audit files. This
   can be achieved using standard Linux log rotation tools. See [Rotating Logs on Unix and Linux](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/rotating-logs-on-unix-and-linux)
 
 For manual log rotation, you can use the following MaxCtrl command:
@@ -210,9 +210,9 @@ $ maxctrl rotate logs
 
 Configuring SSL Encryption for MaxScale with an Encrypted MariaDB Server
 
-If you have already implemented encryption on your MariaDB server, it’s\
-crucial to extend this encryption configuration to MaxScale to ensure secure\
-communication. Once encryption is enabled on your MariaDB server, follow\
+If you have already implemented encryption on your MariaDB server, it’s
+crucial to extend this encryption configuration to MaxScale to ensure secure
+communication. Once encryption is enabled on your MariaDB server, follow
 these steps to configure MaxScale to utilize SSL.
 
 Steps to Configure SSL in MaxScale:
@@ -223,7 +223,7 @@ Steps to Configure SSL in MaxScale:
 
 #### 2. Verify Peer Certificates:
 
-* Add `ssl_verify_peer_certificate=true` to ensure that MaxScale verifies\
+* Add `ssl_verify_peer_certificate=true` to ensure that MaxScale verifies
   the server’s SSL certificates, providing an additional layer of security.
 
 Your MaxScale configuration file should look something like this:
@@ -235,8 +235,8 @@ ssl=true
 ssl_verify_peer_certificate=true
 ```
 
-These settings instruct MaxScale to use SSL for connections to the MariaDB\
-server and to verify peer certificates, enhancing the security of data in\
+These settings instruct MaxScale to use SSL for connections to the MariaDB
+server and to verify peer certificates, enhancing the security of data in
 transit.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-admin-user-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-admin-user-resource.md
@@ -13,7 +13,7 @@ MaxScale's configuration.
 GET /v1/users/inet/:name
 ```
 
-Get a single network user. The _:name_ in the URI must be a valid network\
+Get a single network user. The _:name_ in the URI must be a valid network
 user name.
 
 **Response**
@@ -136,7 +136,7 @@ Get all administrative users.
 POST /v1/users/inet
 ```
 
-Create a new network user. The request body must define at least the\
+Create a new network user. The request body must define at least the
 following fields.
 
 * `data.id`
@@ -148,11 +148,11 @@ following fields.
 * `data.attributes.account`
 * Set to `admin` for administrative users and `basic` to read-only users
 
-Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic\
-account performs one of the aforementioned request, the REST API will respond\
+Only admin accounts can perform POST, PUT, DELETE and PATCH requests. If a basic
+account performs one of the aforementioned request, the REST API will respond
 with a `401 Unauthorized` error.
 
-Here is an example request body defining the network user _my-user_ with the\
+Here is an example request body defining the network user _my-user_ with the
 password _my-password_ that is allowed to execute only read-only operations.
 
 ```
@@ -180,7 +180,7 @@ Status: 204 No Content
 POST /v1/users/unix
 ```
 
-This enables an existing UNIX account on the system for administrative\
+This enables an existing UNIX account on the system for administrative
 operations. The request body must define at least the following fields.
 
 * `data.id`
@@ -244,8 +244,8 @@ Status: 204 No Content
 PATCH /v1/users/inet/:name
 ```
 
-Update network user. Currently, only the password can be updated. This\
-means that the request body must define the `data.attributes.password`\
+Update network user. Currently, only the password can be updated. This
+means that the request body must define the `data.attributes.password`
 field.
 
 Here is an example request body that updates the password.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-filter-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-filter-resource.md
@@ -2,7 +2,7 @@
 
 ## Filter Resource
 
-A filter resource represents an instance of a filter inside MaxScale. Multiple\
+A filter resource represents an instance of a filter inside MaxScale. Multiple
 services can use the same filter and a single service can use multiple filters.
 
 ### Resource Operations
@@ -188,7 +188,7 @@ GET /v1/filters
 POST /v1/filters
 ```
 
-Create a new filter. The posted object must define at\
+Create a new filter. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -200,8 +200,8 @@ least the following fields.
 
 All of the filter parameters should be defined at creation time in the`data.attributes.parameters` object.
 
-As the service to filter relationship is ordered (filters are applied in the\
-order they are listed), filter to service relationships cannot be defined at\
+As the service to filter relationship is ordered (filters are applied in the
+order they are listed), filter to service relationships cannot be defined at
 creation time.
 
 The following example defines a request body which creates a new filter.
@@ -233,8 +233,8 @@ Filter is created:
 PATCH /v1/filters/:name
 ```
 
-Filter parameters can be updated at runtime if the module supports it. Refer to\
-the individual module documentation for more details on whether it supports\
+Filter parameters can be updated at runtime if the module supports it. Refer to
+the individual module documentation for more details on whether it supports
 runtime configuration and which parameters can be updated.
 
 The following example modifies a filter by changing the `match` parameter to`.*users.*`.
@@ -266,10 +266,10 @@ DELETE /v1/filters/:filter
 The _:filter_ in the URI must map to the name of the filter to be destroyed.
 
 A filter can only be destroyed if no service uses it. This means that the`data.relationships` object for the filter must be empty. Note that the service\
-→ filter relationship cannot be modified from the filters resource and must be\
+→ filter relationship cannot be modified from the filters resource and must be
 done via the services resource.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the filter by first removing it from all services that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-listener-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-listener-resource.md
@@ -2,7 +2,7 @@
 
 ## Listener Resource
 
-A listener resource represents a listener of a service in MaxScale. All\
+A listener resource represents a listener of a service in MaxScale. All
 listeners point to a service in MaxScale.
 
 ### Resource Operations
@@ -249,10 +249,10 @@ Creates a new listener. The request body must define the following fields.
 * `data.type`
 * Type of the object, must be `listeners`
 * `data.attributes.parameters.port` OR `data.attributes.parameters.socket`
-* The TCP port or UNIX Domain Socket the listener listens on. Only one of the\
+* The TCP port or UNIX Domain Socket the listener listens on. Only one of the
   fields can be defined.
 * `data.relationships.services.data`
-* The service relationships data, must define a JSON object with an `id` value\
+* The service relationships data, must define a JSON object with an `id` value
   that defines the service to use and a `type` value set to `services`.
 
 The following is the minimal required JSON object for defining a new listener.
@@ -278,7 +278,7 @@ The following is the minimal required JSON object for defining a new listener.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) for\
+Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) for
 a full list of listener parameters.
 
 **Response**
@@ -293,15 +293,15 @@ Listener is created:
 PATCH /v1/listeners/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the listener.
 
 All parameters marked as modifiable at runtime can be modified. Currently, all\
-TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters\
+TLS/SSL parameters and the `connection_init_sql_file` and `sql_mode` parameters
 can be modified at runtime.
 
-Parameters that affect the network address or the port the listener listens on\
-cannot be modified at runtime. To modify these parameters, recreate the\
+Parameters that affect the network address or the port the listener listens on
+cannot be modified at runtime. To modify these parameters, recreate the
 listener.
 
 **Response**
@@ -316,7 +316,7 @@ Listener is modified:
 DELETE /v1/listeners/:name
 ```
 
-The _:name_ must be a valid listener name. When a listener is destroyed, the\
+The _:name_ must be a valid listener name. When a listener is destroyed, the
 network port it listens on is available for reuse.
 
 **Response**
@@ -335,7 +335,7 @@ Listener cannot be deleted:
 PUT /v1/listeners/:name/stop
 ```
 
-Stops a started listener. When a listener is stopped, new connections are no\
+Stops a started listener. When a listener is stopped, new connections are no
 longer accepted and are queued until the listener is started again.
 
 **Parameters**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-maxscale-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-maxscale-resource.md
@@ -2,7 +2,7 @@
 
 ## MaxScale Resource
 
-The MaxScale resource represents a MaxScale instance and it is the core on top\
+The MaxScale resource represents a MaxScale instance and it is the core on top
 of which the modules build upon.
 
 ### Resource Operations
@@ -13,7 +13,7 @@ of which the modules build upon.
 GET /v1/maxscale
 ```
 
-Retrieve global information about a MaxScale instance. This includes various\
+Retrieve global information about a MaxScale instance. This includes various
 file locations, configuration options and version information.
 
 **Response**
@@ -152,8 +152,8 @@ file locations, configuration options and version information.
 PATCH /v1/maxscale
 ```
 
-Update MaxScale parameters. The request body must define updated values for the`data.attributes.parameters` object. The parameters that can be modified are\
-listed in the `/v1/maxscale/modules/maxscale` endpoint and have the `modifiable`\
+Update MaxScale parameters. The request body must define updated values for the`data.attributes.parameters` object. The parameters that can be modified are
+listed in the `/v1/maxscale/modules/maxscale` endpoint and have the `modifiable`
 value set to `true`.
 
 **Response**
@@ -172,8 +172,8 @@ Invalid JSON body:
 GET /v1/maxscale/threads/:id
 ```
 
-Get the information and statistics of a particular thread. The _:id_ in\
-the URI must map to a valid thread number between 0 and the configured\
+Get the information and statistics of a particular thread. The _:id_ in
+the URI must map to a valid thread number between 0 and the configured
 value of `threads`.
 
 **Response**
@@ -392,15 +392,15 @@ Get the information for all threads. Returns a collection of threads resources.
 GET /v1/maxscale/logs
 ```
 
-Get information about the current state of logging, enabled log files and the\
+Get information about the current state of logging, enabled log files and the
 location where the log files are stored.
 
-**Note:** The parameters in this endpoint are a subset of the parameters in the`/v1/maxscale` endpoint. Because of this, the parameters in this endpoint are\
+**Note:** The parameters in this endpoint are a subset of the parameters in the`/v1/maxscale` endpoint. Because of this, the parameters in this endpoint are
 deprecated as of MaxScale 6.0.
 
-**Note:** In MaxScale 2.5 the `log_throttling` and `ms_timestamp` parameters\
-were incorrectly named as `throttling` and `highprecision`. In MaxScale 6,\
-the parameter names are now correct which means the parameters declared here\
+**Note:** In MaxScale 2.5 the `log_throttling` and `ms_timestamp` parameters
+were incorrectly named as `throttling` and `highprecision`. In MaxScale 6,
+the parameter names are now correct which means the parameters declared here
 aren't fully backwards compatible.
 
 **Response**
@@ -450,11 +450,11 @@ GET /v1/maxscale/logs/data
 
 Get the contents of the MaxScale logs. This endpoint was added in MaxScale 6.
 
-To navigate the log, use the `prev` link to move backwards to older log\
+To navigate the log, use the `prev` link to move backwards to older log
 entries. The latest log entries can be read with the `last` link.
 
-The entries are sorted in ascending order by the time they were logged. This\
-means that with the default parameters, the latest logged event is the last\
+The entries are sorted in ascending order by the time they were logged. This
+means that with the default parameters, the latest logged event is the last
 element in the returned array.
 
 **Parameters**
@@ -462,19 +462,19 @@ element in the returned array.
 This endpoint supports the following parameters:
 
 * `page[size]`
-* Set number of rows of data to read. By default, 50 rows of data are read\
+* Set number of rows of data to read. By default, 50 rows of data are read
   from the log.
 * `page[cursor]`
-* Set position from where the log data is retrieved. The default position to\
+* Set position from where the log data is retrieved. The default position to
   retrieve the log data is the end of the log.\
-  This value should not be modified by the user and the values returned in the`links` object should be used instead. This way the navigation will provide\
+  This value should not be modified by the user and the values returned in the`links` object should be used instead. This way the navigation will provide
   a consistent view of the log that does not overlap.\
-  Optionally, the `id` values in the returned data can be used as the values\
+  Optionally, the `id` values in the returned data can be used as the values
   for this parameter to read data from a known point in the file.
 * `priority`
-* Include messages only from these log levels. The default is to include all\
+* Include messages only from these log levels. The default is to include all
   messages.\
-  The value given should be a comma-separated list of log priorities. The\
+  The value given should be a comma-separated list of log priorities. The
   priorities are `alert`, `error`, `warning`, `notice`, `info` and`debug`. Note that the `debug` log level is only used in debug builds of\
   MaxScale.
 
@@ -528,8 +528,8 @@ This endpoint supports the following parameters:
 GET /v1/maxscale/logs/entries
 ```
 
-Get the contents of the MaxScale logs as separate entries. This endpoint was\
-added in MaxScale 24.02. This endpoint is nearly identical to the`/v1/maxscale/logs/data` endpoint except that this is a resource collection\
+Get the contents of the MaxScale logs as separate entries. This endpoint was
+added in MaxScale 24.02. This endpoint is nearly identical to the`/v1/maxscale/logs/data` endpoint except that this is a resource collection
 where each log line is a separate resource.
 
 **Parameters**
@@ -596,10 +596,10 @@ GET /v1/maxscale/logs/stream
 
 Stream the contents of the MaxScale logs. This endpoint was added in MaxScale 6.
 
-This endpoint opens a [WebSocket](https://tools.ietf.org/html/rfc6455)\
-connection and streams the contents of the log to it. Each WebSocket message\
-will contain the JSON representation of the log message. The JSON is formatted\
-in the same way as the values in the `log` array of the `/v1/maxscale/logs/data`\
+This endpoint opens a [WebSocket](https://tools.ietf.org/html/rfc6455)
+connection and streams the contents of the log to it. Each WebSocket message
+will contain the JSON representation of the log message. The JSON is formatted
+in the same way as the values in the `log` array of the `/v1/maxscale/logs/data`
 endpoint:
 
 ```
@@ -613,12 +613,12 @@ endpoint:
 
 #### Limitations
 
-* If the client writes any data to the open socket, it will be treated as\
+* If the client writes any data to the open socket, it will be treated as
   an error and the stream is closed.
-* The WebSocket ping and close commands are not yet supported and will be\
+* The WebSocket ping and close commands are not yet supported and will be
   treated as errors.
-* When `maxlog` is used as source of log data, any log messages logged after log\
-  rotation will not be sent if the file was moved or truncated. To fetch new\
+* When `maxlog` is used as source of log data, any log messages logged after log
+  rotation will not be sent if the file was moved or truncated. To fetch new
   events after log rotation, reopen the WebSocket connection.
 
 **Parameters**
@@ -626,14 +626,14 @@ endpoint:
 This endpoint supports the following parameters:
 
 * `page[cursor]`
-* Set position from where the log data is retrieved. The default position to\
+* Set position from where the log data is retrieved. The default position to
   retrieve the log data is the end of the log.\
-  To stream data from a known point, first read the data via the`/v1/maxscale/logs/data` endpoint and then use the `id` value of the newest\
+  To stream data from a known point, first read the data via the`/v1/maxscale/logs/data` endpoint and then use the `id` value of the newest
   log message (i.e. the first value in the `log` array) to start the stream.
 * `priority`
-* Include messages only from these log levels. The default is to include all\
+* Include messages only from these log levels. The default is to include all
   messages.\
-  The value given should be a comma-separated list of log priorities. The\
+  The value given should be a comma-separated list of log priorities. The
   priorities are `alert`, `error`, `warning`, `notice`, `info` and`debug`. Note that the `debug` log level is only used in debug builds of\
   MaxScale.
 
@@ -649,7 +649,7 @@ Client didn't request a WebSocket upgrade:
 
 ### Update logging parameters
 
-**Note:** The modification of logging parameters via this endpoint has\
+**Note:** The modification of logging parameters via this endpoint has
 deprecated in MaxScale 6.0. The parameters should be modified with the`/v1/maxscale` endpoint instead.
 
 Any PATCH requests done to this endpoint will be redirected to the`/v1/maxscale` endpoint. Due to the misspelling of the `ms_timestamp` and`log_throttling` parameters, this is not fully backwards compatible.
@@ -676,7 +676,7 @@ Invalid JSON body:
 POST /v1/maxscale/logs/flush
 ```
 
-Flushes any pending messages to disk and reopens the log files. The body of the\
+Flushes any pending messages to disk and reopens the log files. The body of the
 message is ignored.
 
 **Response**
@@ -689,15 +689,15 @@ message is ignored.
 POST /v1/maxscale/tls/reload
 ```
 
-Reloads all TLS certificates for listeners and servers as well as the REST API\
-itself. If the reloading fails, the old certificates will remain in use for the\
-objects that failed to reload. This also causes the JWT signature keys to be\
-reloaded if one of the asymmetric key algorithms is being used. If JWTs are\
+Reloads all TLS certificates for listeners and servers as well as the REST API
+itself. If the reloading fails, the old certificates will remain in use for the
+objects that failed to reload. This also causes the JWT signature keys to be
+reloaded if one of the asymmetric key algorithms is being used. If JWTs are
 being signed with a random symmetric keys, a new random key is created.
 
-The reloading is not transactional: if a single listener or server fails to\
-reload its certificates, the remaining ones are not reloaded. This means that a\
-failed reload can partially reload certificates. The REST API certificates are\
+The reloading is not transactional: if a single listener or server fails to
+reload its certificates, the remaining ones are not reloaded. This means that a
+failed reload can partially reload certificates. The REST API certificates are
 only reloaded if all other certificate reloads were successful.
 
 **Response**
@@ -710,16 +710,16 @@ only reloaded if all other certificate reloads were successful.
 GET /v1/maxscale/modules/:name
 ```
 
-Retrieve information about a loaded module. The _:name_ must be the name of a\
+Retrieve information about a loaded module. The _:name_ must be the name of a
 valid loaded module or either `maxscale` or `servers`.
 
-The `maxscale` module will display the global configuration options\
+The `maxscale` module will display the global configuration options
 (i.e. everything under the `[maxscale]` section) as a module.
 
-The `servers` module displays the server object type and the configuration\
+The `servers` module displays the server object type and the configuration
 parameters it accepts as a module.
 
-Any parameter with the `modifiable` value set to `true` can be modified\
+Any parameter with the `modifiable` value set to `true` can be modified
 at runtime using a PATCH command on the corresponding object endpoint.
 
 **Response**
@@ -1293,8 +1293,8 @@ GET /v1/maxscale/modules
 
 Retrieve information about all loaded modules.
 
-This endpoint supports the `load=all` parameter. When defined, all modules\
-located in the MaxScale module directory (`libdir`) will be loaded. This allows\
+This endpoint supports the `load=all` parameter. When defined, all modules
+located in the MaxScale module directory (`libdir`) will be loaded. This allows
 one to see the parameters of a module before the object is created.
 
 **Response**
@@ -4620,16 +4620,16 @@ For commands that can modify data:
 POST /v1/maxscale/modules/:module/:command
 ```
 
-Modules can expose commands that can be called via the REST API. The module\
-resource lists all commands in the `data.attributes.commands` list. Each value\
-is a command sub-resource identified by its `id` field and the HTTP method the\
+Modules can expose commands that can be called via the REST API. The module
+resource lists all commands in the `data.attributes.commands` list. Each value
+is a command sub-resource identified by its `id` field and the HTTP method the
 command uses is defined by the `attributes.method` field.
 
-The _:module_ in the URI must be a valid name of a loaded module and _:command_\
-must be a valid command identifier that is exposed by that module. All\
+The _:module_ in the URI must be a valid name of a loaded module and _:command_
+must be a valid command identifier that is exposed by that module. All
 parameters to the module commands are passed as HTTP request parameters.
 
-Here is an example POST requests to the mariadbmon module command _reset-replication_ with\
+Here is an example POST requests to the mariadbmon module command _reset-replication_ with
 two parameters, the name of the monitor instance and the server name:
 
 ```
@@ -4655,8 +4655,8 @@ Command with output:
 }
 ```
 
-The contents of the `meta` field will contain the output of the module\
-command. This output depends on the command that is being executed. It can\
+The contents of the `meta` field will contain the output of the module
+command. This output depends on the command that is being executed. It can
 contain any valid JSON value.
 
 Command with no output:

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-monitor-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-monitor-resource.md
@@ -2,7 +2,7 @@
 
 ## Monitor Resource
 
-A monitor resource represents a monitor inside MaxScale that monitors one or\
+A monitor resource represents a monitor inside MaxScale that monitors one or
 more servers.
 
 ### Resource Operations
@@ -349,7 +349,7 @@ Get all monitors.
 POST /v1/monitors
 ```
 
-Create a new monitor. The request body must define at least the following\
+Create a new monitor. The request body must define at least the following
 fields.
 
 * `data.id`
@@ -365,8 +365,8 @@ fields.
 
 All monitor parameters can be defined at creation time.
 
-The following example defines a request body which creates a new monitor and\
-assigns two servers to be monitored by it. It also defines a custom value for\
+The following example defines a request body which creates a new monitor and
+assigns two servers to be monitored by it. It also defines a custom value for
 the _monitor\_interval_ parameter.
 
 ```
@@ -412,7 +412,7 @@ Monitor is created:
 PATCH /v1/monitors/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 monitor.
 
 #### Modifiable Fields
@@ -427,8 +427,8 @@ The following standard server parameter can be modified.
 * [backend\_read\_timeout](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md)
 * [backend\_connect\_attempts](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md)
 
-In addition to these standard parameters, the monitor specific parameters can\
-also be modified. Refer to the monitor module documentation for details on these\
+In addition to these standard parameters, the monitor specific parameters can
+also be modified. Refer to the monitor module documentation for details on these
 parameters.
 
 **Response**
@@ -447,12 +447,12 @@ Invalid request body:
 PATCH /v1/monitors/:name/relationships/servers
 ```
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the monitor.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 server relationship for a monitor.
 
 ```
@@ -491,10 +491,10 @@ Invalid JSON body:
 DELETE /v1/monitors/:name
 ```
 
-Destroy a created monitor. The monitor must not have relationships to any\
+Destroy a created monitor. The monitor must not have relationships to any
 servers in order to be destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
+This endpoint also supports the `force=yes` parameter that will unconditionally
 delete the monitor by first unlinking it from all servers that it uses.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-rest-api.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-rest-api.md
@@ -6,28 +6,28 @@ This document describes the version 1 of the MaxScale REST API.
 
 ### Note About Syntax
 
-Although JSON does not define a syntax for comments, some of the JSON examples\
-have C-style inline comments in them. These comments use `//` to mark the start\
+Although JSON does not define a syntax for comments, some of the JSON examples
+have C-style inline comments in them. These comments use `//` to mark the start
 of the comment and extend to the end of the current line.
 
 ### Configuration
 
-Read the [REST API](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+Read the [REST API](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 section of the configuration guide for more details on how to configure the REST API.
 
 ### Authentication
 
-The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)\
-authentication with the MaxScale administrative interface users. The default\
+The MaxScale REST API uses [HTTP Basic Access](https://tools.ietf.org/html/rfc2617#section-2)
+authentication with the MaxScale administrative interface users. The default
 user is `admin:mariadb`.
 
-It is highly recommended to enable HTTPS on the MaxScale REST API to make the\
-communication between the client and MaxScale secure. Without it, the passwords\
-can be intercepted from the network traffic. Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) for more\
+It is highly recommended to enable HTTPS on the MaxScale REST API to make the
+communication between the client and MaxScale secure. Without it, the passwords
+can be intercepted from the network traffic. Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) for more
 details on how to enable HTTPS for the MaxScale REST API.
 
-For more details on how administrative interface users are created and managed,\
-refer to the [MaxCtrl](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-maxctrl.md) documentation as well as the\
+For more details on how administrative interface users are created and managed,
+refer to the [MaxCtrl](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-maxctrl.md) documentation as well as the
 documentation of the [users](mariadb-maxscale-2501-maxscale-2501-admin-user-resource.md) resource.
 
 #### JSON Web Tokens
@@ -38,7 +38,7 @@ MaxScale supports authentication via [JSON Web Tokens](https://tools.ietf.org/ht
 GET /v1/auth
 ```
 
-The `/v1/auth` endpoint can be used to generate new tokens which are returned in\
+The `/v1/auth` endpoint can be used to generate new tokens which are returned in
 the following form.
 
 ```
@@ -49,41 +49,41 @@ the following form.
 }
 ```
 
-Note that by default the `/auth` endpoint requires the connection to be\
-encrypted (HTTPS) and attempts to use it without encryption will be treated as\
+Note that by default the `/auth` endpoint requires the connection to be
+encrypted (HTTPS) and attempts to use it without encryption will be treated as
 an error. To allow use of the `/auth` endpoint without encryption, use`admin_secure_gui=false`.
 
-If the token is used to authenticate users in a web browser, the token can be\
-optionally stored in cookies. This can be enabled with the `persist=yes`\
+If the token is used to authenticate users in a web browser, the token can be
+optionally stored in cookies. This can be enabled with the `persist=yes`
 parameter in the request:
 
 ```
 GET /v1/auth?persist=yes
 ```
 
-When the token is stored in the cookies, it will be stored in the `token_sig`\
+When the token is stored in the cookies, it will be stored in the `token_sig`
 cookie using the `SameSite=Strict` and `HttpOnly` cookie options. This means the\
-JavaScript context of the browser will not have access to it. This is done to\
+JavaScript context of the browser will not have access to it. This is done to
 prevent CSRF attacks.
 
-By default, the generated tokens are valid for 8 hours. The token validity\
+By default, the generated tokens are valid for 8 hours. The token validity
 period can be set with the `max-age` request parameter:
 
 ```
 GET /v1/auth?max-age=28800
 ```
 
-When `max-age` is combined with `persist`, the `Max-Age` cookie option is\
+When `max-age` is combined with `persist`, the `Max-Age` cookie option is
 also set to the same value.
 
-The maximum lifetime of the tokens is controlled by the `admin_jwt_max_age`\
-parameter. If the configured value is less than 8 hours, the default token\
-lifetime is also lowered to it. A request for a token with a lifetime longer\
-than `admin_jwt_max_age` will be accepted but the token will have its lifetime\
+The maximum lifetime of the tokens is controlled by the `admin_jwt_max_age`
+parameter. If the configured value is less than 8 hours, the default token
+lifetime is also lowered to it. A request for a token with a lifetime longer
+than `admin_jwt_max_age` will be accepted but the token will have its lifetime
 set to `admin_jwt_max_age`.
 
-To use the token for authentication, the generated token must be presented in\
-the Authorization header with the Bearer authentication scheme. For example, the\
+To use the token for authentication, the generated token must be presented in
+the Authorization header with the Bearer authentication scheme. For example, the
 token above would be used in the following manner:
 
 ```
@@ -94,24 +94,24 @@ If MaxScale is restarted, all generated tokens are invalidated.
 
 **`/auth` Request Parameters**
 
-The `/auth` endpoint supports the following request parameters that must be\
+The `/auth` endpoint supports the following request parameters that must be
 given in the HTTP query string.
 
 * `max-age`
-* Sets the token maximum age in seconds. The default is `max-age=28800`. Only\
-  positive values between 1 and 2147483646 are accepted and if a non-positive\
+* Sets the token maximum age in seconds. The default is `max-age=28800`. Only
+  positive values between 1 and 2147483646 are accepted and if a non-positive
   or a non-integer value is found, the parameter is ignored.
 * `persist`
 * Store the generated token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `token_sig` cookie and the
   response is 204 No Content instead of 200 OK.\
-  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie\
-  which prevents access to from JavaScript. This is done to mitigate any\
+  The `token_sig` cookie contains the JWT and is stored as a HttpOnly cookie
+  which prevents access to from JavaScript. This is done to mitigate any
   attacks that might leak the token.
 
 ### Resources
 
-The MaxScale REST API provides the following resources. All resources conform to\
+The MaxScale REST API provides the following resources. All resources conform to
 the [JSON API](https://jsonapi.org/format/) specification.
 
 * [maxscale](mariadb-maxscale-2501-maxscale-2501-maxscale-resource.md)
@@ -124,45 +124,45 @@ the [JSON API](https://jsonapi.org/format/) specification.
 * [users](mariadb-maxscale-2501-maxscale-2501-admin-user-resource.md)
 * [sql](mariadb-maxscale-2501-maxscale-2501-sql-resource.md)
 
-In addition to the named resources, the REST API will respond with a HTTP 200 OK\
-response to GET requests on the root resource (`/`) as well as the namespace\
-root resource (`/v1/`). These can be used for HTTP health checks to determine\
+In addition to the named resources, the REST API will respond with a HTTP 200 OK
+response to GET requests on the root resource (`/`) as well as the namespace
+root resource (`/v1/`). These can be used for HTTP health checks to determine
 whether MaxScale is running.
 
 ### API Versioning
 
 All of the current resources are in the `/v1/` namespace of the MaxScale REST\
-API. Further additions to the namespace can be added that do not break backwards\
+API. Further additions to the namespace can be added that do not break backwards
 compatibility of any existing resources. What this means in practice is that:
 
 * No resources or URLs will be removed
 * The API will be JSON API compliant
 
-Note that this means that the contents of individual resources can change. New\
-fields can be added, old ones can be removed and the meaning of existing fields\
-can change. The aim is to be as backwards compatible as reasonably possible\
+Note that this means that the contents of individual resources can change. New
+fields can be added, old ones can be removed and the meaning of existing fields
+can change. The aim is to be as backwards compatible as reasonably possible
 without sacrificing the clarity and functionality of the API.
 
-Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the\
+Since MaxScale 2.4.0, the use of the version prefix `/v1/` is optional: if the
 prefix is not used, the latest API version is used.
 
 #### Resource Relationships
 
-All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other\
+All resources return complete JSON objects. The returned objects can have a_relationships_ field that represents any relations the object has to other
 objects. This closely resembles the JSON API definition of links.
 
-In the _relationships_ objects, all resources have a _self_ link that points to\
-the resource itself. This allows easy access to the objects pointed by the\
+In the _relationships_ objects, all resources have a _self_ link that points to
+the resource itself. This allows easy access to the objects pointed by the
 relationships as the reply URL is included in the response itself.
 
-To create a relationship between two objects, define it in the initial POST\
-request. To modify the relationships of existing objects, perform a PATCH\
-request with the new definition of the relevant relationship. To completely\
-remove all relationships from an object, the `data` field of the corresponding\
+To create a relationship between two objects, define it in the initial POST
+request. To modify the relationships of existing objects, perform a PATCH
+request with the new definition of the relevant relationship. To completely
+remove all relationships from an object, the `data` field of the corresponding
 relationship object must be set to an empty array.
 
-The following lists the resources and the types of links each resource can have\
-in addition to the _self_ link. Examples of these relationships can be seen in\
+The following lists the resources and the types of links each resource can have
+in addition to the _self_ link. Examples of these relationships can be seen in
 the resource documentation.
 
 * `services` - Service resource
@@ -172,7 +172,7 @@ the resource documentation.
   List of services used by the service
 * `filters`\
   List of filters used by the service\
-  NOTE: This is an ordered relationship where the order of the filters\
+  NOTE: This is an ordered relationship where the order of the filters
   defines the order in which they process queries.
 * `listeners`\
   List of listeners used by the service
@@ -195,57 +195,57 @@ the resource documentation.
 ### Common Request Parameters
 
 All parameters that use boolean values use the same rules that are used for the [boolean values](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) in the\
-MaxScale configuration. For example, both `pretty=off` and `pretty=false`\
+MaxScale configuration. For example, both `pretty=off` and `pretty=false`
 disable the `pretty` option.
 
-All the resources that return JSON content also support the following\
+All the resources that return JSON content also support the following
 parameters. Parameters are given in the HTTP query string:`https://localhost:8989/v1/servers?pretty=true&fields[servers]=state`.
 
 * `pretty`
 * Pretty-print output.\
-  If this parameter is set to `true` then the returned objects are formatted\
-  in a more human readable format. If the parameter is set to `false` then the\
-  returned objects are formatted in a compact format. All resources support\
+  If this parameter is set to `true` then the returned objects are formatted
+  in a more human readable format. If the parameter is set to `false` then the
+  returned objects are formatted in a compact format. All resources support
   this parameter. The default value for this parameter is `true`.
 * `fields[TYPE]=field1,field2...`
 * Return a [Sparse Fieldset](https://jsonapi.org/format/#fetching-sparse-fieldsets)\
-  This parameter controls which fields are returned in the REST API\
-  response. The `TYPE` value in the `fields` parameter must be the resource\
-  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated\
-  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which\
-  fields of the object to return. Only fields in objects in the `attributes`\
-  and `relationships` objects are inspected. This means that if the path\
-  marked by the JSON Pointer contains an array in it, it will not advance past\
+  This parameter controls which fields are returned in the REST API
+  response. The `TYPE` value in the `fields` parameter must be the resource
+  type that is being retrieved (i.e. the `servers` in `/v1/servers` and`/v1/server/server1`). The value of the parameter must be a comma-separated
+  list of [JSON Pointers](https://tools.ietf.org/html/rfc6901) that mark which
+  fields of the object to return. Only fields in objects in the `attributes`
+  and `relationships` objects are inspected. This means that if the path
+  marked by the JSON Pointer contains an array in it, it will not advance past
   this array.\
-  For example, to return only the server state output from the `/servers`\
-  endpoint, the `fields[servers]=state` parameter can be used. This would\
-  return only the `data.attributes.state` part of the resource. To return the\
-  nested value `data.attributes.statistics.connections`, the corresponding\
+  For example, to return only the server state output from the `/servers`
+  endpoint, the `fields[servers]=state` parameter can be used. This would
+  return only the `data.attributes.state` part of the resource. To return the
+  nested value `data.attributes.statistics.connections`, the corresponding
   parameter would be `fields[servers]=statistics/connections`.
 * `filter=json_ptr=expr`
 * Filter the output of the result\
-  This parameter controls which rows are returned in a REST API response that\
-  returns an array in the `data` member (i.e. a request to a resource\
+  This parameter controls which rows are returned in a REST API response that
+  returns an array in the `data` member (i.e. a request to a resource
   collection). Requests to individual resources are not filtered.\
-  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a\
-  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2501-maxscale-2501-rest-api.md#filter-expressions). The comparison is done for each\
-  individual object in the `data` array of the result. If given only a JSON\
-  value, the stored value is compared for equality. If an expression is used,\
+  The argument to the filter parameter must be a key-value pair with a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) as the key and either a
+  valid JSON type as the value or a [filter-expression](mariadb-maxscale-2501-maxscale-2501-rest-api.md#filter-expressions). The comparison is done for each
+  individual object in the `data` array of the result. If given only a JSON
+  value, the stored value is compared for equality. If an expression is used,
   the expression is evaluated and only rows that match are returned.\
-  For example, if the object stored in `data[0]` has a value pointed by the\
-  given JSON pointer and that value compares equal to the given JSON value,\
-  the array row is kept in the result. Examples for filtering expression can\
+  For example, if the object stored in `data[0]` has a value pointed by the
+  given JSON pointer and that value compares equal to the given JSON value,
+  the array row is kept in the result. Examples for filtering expression can
   be found [here](mariadb-maxscale-2501-maxscale-2501-rest-api.md#filter-expression-examples).\
-  A practical use for this parameter is to return only sessions for a\
-  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can\
-  be used. Note the double quotes around the `"RW-Split-Router"`, they are\
+  A practical use for this parameter is to return only sessions for a
+  particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
+  be used. Note the double quotes around the `"RW-Split-Router"`, they are
   required to correctly convert strings into JSON values.
 * `filter[json_path]=expr`
 * Filter based on a JSONPath and a filtering expression.\
-  Similar to the `filter` parameter that takes a JSON Pointer, this version of\
-  the `filter` controls which rows are returned in a REST API response for a\
+  Similar to the `filter` parameter that takes a JSON Pointer, this version of
+  the `filter` controls which rows are returned in a REST API response for a
   resource collection. Requests to individual resources are never filtered.\
-  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)\
+  The value inside the brackets must be a valid [JSONPath](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html)
   expression that MaxScale supports. The currently supported syntax is:
   * dot notation: `$.store.book`
   * bracket notation: `$['store']['book']`
@@ -255,53 +255,53 @@ parameters. Parameters are given in the HTTP query string:`https://localhost:898
   * object wildcards: `$.store.bicycle.*`
   * optional root object: `store.book`
 
-The root object being optional is an extension to the JSONPath specification\
+The root object being optional is an extension to the JSONPath specification
 that MaxScale implements.\
-The `expr` value must be a [filter-expression](mariadb-maxscale-2501-maxscale-2501-rest-api.md#filter-expressions). Similarly to the other `filter`\
-parameter, the comparison is done for each individual object in the `data`\
+The `expr` value must be a [filter-expression](mariadb-maxscale-2501-maxscale-2501-rest-api.md#filter-expressions). Similarly to the other `filter`
+parameter, the comparison is done for each individual object in the `data`
 array of the result.\
-If the JSONPath expression returns multiple objects, the comparison is done\
-for each element and if any of them matches, the object is considered to\
+If the JSONPath expression returns multiple objects, the comparison is done
+for each element and if any of them matches, the object is considered to
 match. In other words, wildcard JSONPath expressions are ORed together.\
-If multiple `filter[json_path]=expr` parameters are found in the request,\
-all returned values must match all of them. In other words, the filter\
-parameters are all combined into an AND expression. For example, the\
-following filter will only return all values whose `id` field is `"srv1` and\
+If multiple `filter[json_path]=expr` parameters are found in the request,
+all returned values must match all of them. In other words, the filter
+parameters are all combined into an AND expression. For example, the
+following filter will only return all values whose `id` field is `"srv1` and
 the `attributes.parameters.port` field is 3306:`filter[id]=eq("srv1")&filter[attributes.parameters.port]=eq(3306)`
 
 * `page[size]`
-* The number of elements that are returned for resource collections. By\
-  default all elements in the resource collection are returned. The value must\
-  be a valid positive integer, otherwise the parameter is ignored. If\
-  pagination is used, the `links` object will have pagination links to the\
+* The number of elements that are returned for resource collections. By
+  default all elements in the resource collection are returned. The value must
+  be a valid positive integer, otherwise the parameter is ignored. If
+  pagination is used, the `links` object will have pagination links to the
   next page if more elements are available.
 * `page[number]`
-* How many pages of results to skip. The first page of results starts from 0\
-  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This\
-  should be considered pseudo-pagination as the results are not guaranteed to\
+* How many pages of results to skip. The first page of results starts from 0
+  and each page has no more than `page[size]` elements. If defined,`page[size]` must also be defined, otherwise this parameter is ignored. This
+  should be considered pseudo-pagination as the results are not guaranteed to
   be consistent between requests.
 * `sync`
 * Control configuration synchronization.\
-  If this parameter is set to `false` then the configuration synchronization\
-  is disabled for this request. This can be used to perform configuration\
-  changes when MaxScale is unable to reach the cluster used to synchronize the\
-  configuration. The modifications to the local configuration will be\
-  overwritten when the next modification to the cluster's configuration is\
+  If this parameter is set to `false` then the configuration synchronization
+  is disabled for this request. This can be used to perform configuration
+  changes when MaxScale is unable to reach the cluster used to synchronize the
+  configuration. The modifications to the local configuration will be
+  overwritten when the next modification to the cluster's configuration is
   done which means this should only be used to perform temporary fixes.
 
 #### Filter Expressions
 
-MaxScale 24.02 added support for expressions in the `filter` request\
-parameter. Each resource in a resource collection that evaluates to a true value\
-will be kept in the returned result. All rows that evaluate to false are\
+MaxScale 24.02 added support for expressions in the `filter` request
+parameter. Each resource in a resource collection that evaluates to a true value
+will be kept in the returned result. All rows that evaluate to false are
 removed.
 
-Equality and inequality is defined for all JSON types but ordering is defined\
-only for numbers and strings. The logical operators allow one or more\
+Equality and inequality is defined for all JSON types but ordering is defined
+only for numbers and strings. The logical operators allow one or more
 sub-expressions.
 
-The following table lists the supported operations in the filter expressions. In\
-it, the stored value is marked as `S` and the literal JSON value in the\
+The following table lists the supported operations in the filter expressions. In
+it, the stored value is marked as `S` and the literal JSON value in the
 expression as `V`. For the logical operators, the sub-expression is marked as`expr`.
 
 | Expression   | Logic          | Types               |
@@ -318,25 +318,25 @@ expression as `V`. For the logical operators, the sub-expression is marked as`ex
 
 **Filter Expression Examples**
 
-Ranges of values can be defined using an `and()` expression with the range\
-limits defined with the ordering operators `ge()` and `le()`. To filter the\
-sessions in MaxScale to ones that have an ID between 50 and 100, the following\
+Ranges of values can be defined using an `and()` expression with the range
+limits defined with the ordering operators `ge()` and `le()`. To filter the
+sessions in MaxScale to ones that have an ID between 50 and 100, the following
 filtering expression can be used.
 
 ```
 filter=id=and(ge(50),le(100))
 ```
 
-Limiting the result to only the given values can be done with an `or()`\
-expression that uses `eq()` expressions to select the rows to return. To only\
-return sessions with IDs 1, 5, 10 the following filtering expression can be\
+Limiting the result to only the given values can be done with an `or()`
+expression that uses `eq()` expressions to select the rows to return. To only
+return sessions with IDs 1, 5, 10 the following filtering expression can be
 used.
 
 ```
 filter=id=or(eq(1),eq(5),eq(10))
 ```
 
-Similarly, excluding certain rows from the result can be done by simply\
+Similarly, excluding certain rows from the result can be done by simply
 replacing `or()` with `not()`. This expression would exclude sessions with the\
 IDs 1, 5 and 10 from the result.
 
@@ -348,22 +348,22 @@ filter=id=not(eq(1),eq(5),eq(10))
 
 #### Request Headers
 
-REST makes use of the HTTP protocols in its aim to provide a natural way to\
-understand the workings of an API. The following request headers are understood\
+REST makes use of the HTTP protocols in its aim to provide a natural way to
+understand the workings of an API. The following request headers are understood
 by this API.
 
 **Authorization**
 
 Credentials for authentication. This header should consist of a HTTP Basic\
-Access authentication type payload which is the base64 encoded value of the\
+Access authentication type payload which is the base64 encoded value of the
 username and password joined by a colon e.g. `Base64("maxuser:maxpwd")`.
 
 **Content-Type**
 
-All PUT and POST requests must use the `Content-Type: application/json` media\
-type and the request body must be a complete and valid JSON representation of a\
-resource. All PATCH requests must use the `Content-Type: application/json` media\
-type and the request body must be a JSON document containing a partial\
+All PUT and POST requests must use the `Content-Type: application/json` media
+type and the request body must be a complete and valid JSON representation of a
+resource. All PATCH requests must use the `Content-Type: application/json` media
+type and the request body must be a JSON document containing a partial
 definition of the modified resource.
 
 **Host**
@@ -372,59 +372,59 @@ The address and port of the server.
 
 **If-Match**
 
-The request is performed only if the provided ETag value matches the one on the\
-server. This field should be used with PATCH requests to prevent concurrent\
+The request is performed only if the provided ETag value matches the one on the
+server. This field should be used with PATCH requests to prevent concurrent
 updates to the same resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Modified-Since**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **If-None-Match**
 
-If the content has not changed the server responds with a 304 status code. If\
-the content has changed the server responds with a 200 status code and the\
+If the content has not changed the server responds with a 304 status code. If
+the content has changed the server responds with a 200 status code and the
 requested resource.
 
-The value of this header must be a value from the `ETag` header retrieved from\
+The value of this header must be a value from the `ETag` header retrieved from
 the same resource at an earlier point in time.
 
 **If-Unmodified-Since**
 
-The request is performed only if the requested resource has not been modified\
+The request is performed only if the requested resource has not been modified
 since the provided date.
 
 The value of this header must be a date value in the ["HTTP-date"](https://www.ietf.org/rfc/rfc2822.txt) format.
 
 **X-HTTP-Method-Override**
 
-Some clients only support GET and PUT requests. By providing the string value of\
-the intended method in the `X-HTTP-Method-Override` header, a client can, for\
-example, perform a POST, PATCH or DELETE request with the PUT method\
+Some clients only support GET and PUT requests. By providing the string value of
+the intended method in the `X-HTTP-Method-Override` header, a client can, for
+example, perform a POST, PATCH or DELETE request with the PUT method
 (e.g. `X-HTTP-Method-Override: PATCH`).
 
-If this header is defined in the request, the current method of the request is\
-replaced with the one in the header. The HTTP method must be in uppercase and it\
+If this header is defined in the request, the current method of the request is
+replaced with the one in the header. The HTTP method must be in uppercase and it
 must be one of the methods that the requested resource supports.
 
 #### Response Headers
 
 **Allow**
 
-All resources return the Allow header with the supported HTTP methods. For\
-example the resource `/services` will always return the `Accept: GET, PATCH, PUT`\
+All resources return the Allow header with the supported HTTP methods. For
+example the resource `/services` will always return the `Accept: GET, PATCH, PUT`
 header.
 
 **Accept-Patch**
 
-All PATCH capable resources return the `Accept-Patch: application/json-patch`\
+All PATCH capable resources return the `Accept-Patch: application/json-patch`
 header.
 
 **Date**
@@ -434,12 +434,12 @@ English and it uses the server's local timezone.
 
 **ETag**
 
-An identifier for a specific version of a resource. The value of this header\
-changes whenever a resource is modified via the REST API. It will not change if\
-an internal MaxScale event (e.g. server changing state or statistics being\
+An identifier for a specific version of a resource. The value of this header
+changes whenever a resource is modified via the REST API. It will not change if
+an internal MaxScale event (e.g. server changing state or statistics being
 updated) causes a change.
 
-When the client sends the `If-Match` or `If-None-Match` header, the provided\
+When the client sends the `If-Match` or `If-None-Match` header, the provided
 value should be the value of the `ETag` header of an earlier GET.
 
 **Last-Modified**
@@ -448,29 +448,29 @@ The date when the resource was last modified in "HTTP-date" format.
 
 **Location**
 
-If an out of date resource location is requested, a HTTP return code of 3XX with\
-the `Location` header is returned. The value of the header contains the new\
+If an out of date resource location is requested, a HTTP return code of 3XX with
+the `Location` header is returned. The value of the header contains the new
 location of the requested resource as a relative URI.
 
 **WWW-Authenticate**
 
-The requested authentication method. For example, `WWW-Authenticate: Basic`\
+The requested authentication method. For example, `WWW-Authenticate: Basic`
 would require basic HTTP authentication.
 
 **Mxs-Warning**
 
-This header is used for sending generic warnings to clients about actions that\
-were successful and valid but could cause problems in the future. Currently\
-these are used to indicate when a configuration change was made to a static\
-object and an overriding configuration is created or when a static object is\
+This header is used for sending generic warnings to clients about actions that
+were successful and valid but could cause problems in the future. Currently
+these are used to indicate when a configuration change was made to a static
+object and an overriding configuration is created or when a static object is
 being deleted at runtime.
 
-The content of the header is the human-readable warning that should be displayed\
+The content of the header is the human-readable warning that should be displayed
 to a user.
 
 ### Response Codes
 
-Every HTTP response starts with a line with a return code which indicates the\
+Every HTTP response starts with a line with a return code which indicates the
 outcome of the request. The API uses some of the standard HTTP values:
 
 #### 2xx Success
@@ -480,37 +480,37 @@ outcome of the request. The API uses some of the standard HTTP values:
 * 201 Created
 * A new resource was created.
 * 202 Accepted
-* The request has been accepted for processing, but the processing has not\
+* The request has been accepted for processing, but the processing has not
   been completed.
 * 204 No Content
 * Successful HTTP requests, response has no body.
 
 #### 3xx Redirection
 
-This class of status code indicates the client must take additional action to\
+This class of status code indicates the client must take additional action to
 complete the request.
 
 * 301 Moved Permanently
 * This and all future requests should be directed to the given URI.
 * 302 Found
-* The response to the request can be found under another URI using the same\
+* The response to the request can be found under another URI using the same
   method as in the original request.
 * 303 See Other
-* The response to the request can be found under another URI using a GET\
+* The response to the request can be found under another URI using a GET
   method.
 * 304 Not Modified
-* Indicates that the resource has not been modified since the version\
+* Indicates that the resource has not been modified since the version
   specified by the request headers If-Modified-Since or If-None-Match.
 * 307 Temporary Redirect
-* The request should be repeated with another URI but future requests should\
+* The request should be repeated with another URI but future requests should
   use the original URI.
 * 308 Permanent Redirect
 * The request and all future requests should be repeated using another URI.
 
 #### 4xx Client Error
 
-The 4xx class of status code is when the client seems to have erred. Except when\
-responding to a HEAD request, the body of the response _MAY_ contains a JSON\
+The 4xx class of status code is when the client seems to have erred. Except when
+responding to a HEAD request, the body of the response _MAY_ contains a JSON
 representation of the error.
 
 ```
@@ -521,7 +521,7 @@ representation of the error.
 }
 ```
 
-The _error_ field contains a short error description and the _description_ field\
+The _error_ field contains a short error description and the _description_ field
 contains a more detailed version of the error message.
 
 * 400 Bad Request
@@ -529,41 +529,41 @@ contains a more detailed version of the error message.
 * 401 Unauthorized
 * Authentication is required. The response includes a WWW-Authenticate header.
 * 403 Forbidden
-* The request was a valid request, but the client does not have the necessary\
+* The request was a valid request, but the client does not have the necessary
   permissions for the resource.
 * 404 Not Found
 * The requested resource could not be found.
 * 405 Method Not Allowed
 * A request method is not supported for the requested resource.
 * 406 Not Acceptable
-* The requested resource is capable of generating only content not acceptable\
+* The requested resource is capable of generating only content not acceptable
   according to the Accept headers sent in the request.
 * 409 Conflict
-* Indicates that the request could not be processed because of conflict in the\
+* Indicates that the request could not be processed because of conflict in the
   request, such as an edit conflict be tween multiple simultaneous updates.
 * 411 Length Required
-* The request did not specify the length of its content, which is required by\
+* The request did not specify the length of its content, which is required by
   the requested resource.
 * 412 Precondition Failed
-* The server does not meet one of the preconditions that the requester put on\
+* The server does not meet one of the preconditions that the requester put on
   the request.
 * 413 Payload Too Large
 * The request is larger than the server is willing or able to process.
 * 414 URI Too Long
 * The URI provided was too long for the server to process.
 * 415 Unsupported Media Type
-* The request entity has a media type which the server or resource does not\
+* The request entity has a media type which the server or resource does not
   support.
 * 422 Unprocessable Entity
-* The request was well-formed but was unable to be followed due to semantic\
+* The request was well-formed but was unable to be followed due to semantic
   errors.
 * 423 Locked
 * The resource that is being accessed is locked.
 * 428 Precondition Required
-* The origin server requires the request to be conditional. This error code is\
+* The origin server requires the request to be conditional. This error code is
   returned when none of the `Modified-Since` or `Match` type headers are used.
 * 431 Request Header Fields Too Large
-* The server is unwilling to process the request because either an individual\
+* The server is unwilling to process the request because either an individual
   header field, or all the header fields collectively, are too large.
 
 #### 5xx Server Error
@@ -571,30 +571,30 @@ contains a more detailed version of the error message.
 The server failed to fulfill an apparently valid request.
 
 * 500 Internal Server Error
-* A generic error message, given when an unexpected condition was encountered\
+* A generic error message, given when an unexpected condition was encountered
   and no more specific message is suitable.
 * 501 Not Implemented
-* The server either does not recognize the request method, or it lacks the\
+* The server either does not recognize the request method, or it lacks the
   ability to fulfill the request.
 * 502 Bad Gateway
-* The server was acting as a gateway or proxy and received an invalid response\
+* The server was acting as a gateway or proxy and received an invalid response
   from the upstream server.
 * 503 Service Unavailable
-* The server is currently unavailable (because it is overloaded or down for\
+* The server is currently unavailable (because it is overloaded or down for
   maintenance). Generally, this is a temporary state.
 * 504 Gateway Timeout
-* The server was acting as a gateway or proxy and did not receive a timely\
+* The server was acting as a gateway or proxy and did not receive a timely
   response from the upstream server.
 * 505 HTTP Version Not Supported
 * The server does not support the HTTP protocol version used in the request.
 * 506 Variant Also Negotiates
-* Transparent content negotiation for the request results in a circular\
+* Transparent content negotiation for the request results in a circular
   reference.
 * 507 Insufficient Storage
-* The server is unable to store the representation needed to complete the\
+* The server is unable to store the representation needed to complete the
   request.
 * 508 Loop Detected
-* The server detected an infinite loop while processing the request (sent in\
+* The server detected an infinite loop while processing the request (sent in
   lieu of 208 Already Reported).
 * 510 Not Extended
 * Further extensions to the request are required for the server to fulfil it.
@@ -605,23 +605,23 @@ The following response headers are not currently in use. Future versions of the\
 API could return them.
 
 * 206 Partial Content
-* The server is delivering only part of the resource (byte serving) due to a\
+* The server is delivering only part of the resource (byte serving) due to a
   range header sent by the client.
 * 300 Multiple Choices
-* Indicates multiple options for the resource from which the client may choose\
+* Indicates multiple options for the resource from which the client may choose
   (via agent-driven content negotiation).
 * 407 Proxy Authentication Required
 * The client must first authenticate itself with the proxy.
 * 408 Request Timeout
-* The server timed out waiting for the request. According to HTTP\
-  specifications: "The client did not produce a request within the time that\
-  the server was prepared to wait. The client MAY repeat the request without\
+* The server timed out waiting for the request. According to HTTP
+  specifications: "The client did not produce a request within the time that
+  the server was prepared to wait. The client MAY repeat the request without
   modifications at any later time."
 * 410 Gone
-* Indicates that the resource requested is no longer available and will not be\
+* Indicates that the resource requested is no longer available and will not be
   available again.
 * 416 Range Not Satisfiable
-* The client has asked for a portion of the file (byte serving), but the\
+* The client has asked for a portion of the file (byte serving), but the
   server cannot supply that portion.
 * 417 Expectation Failed
 * The server cannot meet the requirements of the Expect request-header field.
@@ -630,10 +630,10 @@ API could return them.
 * 424 Failed Dependency
 * The request failed due to failure of a previous request.
 * 426 Upgrade Required
-* The client should switch to a different protocol such as TLS/1.0, given in\
+* The client should switch to a different protocol such as TLS/1.0, given in
   the Upgrade header field.
 * 429 Too Many Requests
-* The user has sent too many requests in a given amount of time. Intended for\
+* The user has sent too many requests in a given amount of time. Intended for
   use with rate-limiting schemes.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-server-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-server-resource.md
@@ -769,7 +769,7 @@ Response contains a resource collection with all servers.
 POST /v1/servers
 ```
 
-Create a new server by defining the resource. The posted object must define at\
+Create a new server by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -777,10 +777,10 @@ least the following fields.
 * `data.type`
 * Type of the object, must be `servers`
 * `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-* The [address](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) or [socket](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) to use. Only\
+* The [address](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) or [socket](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) to use. Only
   one of the fields can be defined.
 * `data.attributes.parameters.port`
-* The [port](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) to use. Needs\
+* The [port](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) to use. Needs
   to be defined if the `address` field is defined.
 
 The following is the minimal required JSON object for defining a new server.
@@ -800,7 +800,7 @@ The following is the minimal required JSON object for defining a new server.
 }
 ```
 
-The relationships of a server can also be defined at creation time. This allows\
+The relationships of a server can also be defined at creation time. This allows
 new servers to be created and immediately taken into use.
 
 ```
@@ -840,7 +840,7 @@ new servers to be created and immediately taken into use.
 }
 ```
 
-Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 for a full list of server parameters.
 
 **Response**
@@ -859,19 +859,19 @@ Invalid JSON body:
 PATCH /v1/servers/:name
 ```
 
-The request body must be a valid JSON document representing the modified\
+The request body must be a valid JSON document representing the modified
 server.
 
 #### Modifiable Fields
 
-In addition to the server [parameters](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md), the _services_\
-and _monitors_ fields of the _relationships_ object can be modified. Removal,\
-addition and modification of the links will change which service and monitors\
+In addition to the server [parameters](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md), the _services_
+and _monitors_ fields of the _relationships_ object can be modified. Removal,
+addition and modification of the links will change which service and monitors
 use this server.
 
 For example, removing the first value in the _services_ list in the_relationships_ object from the following JSON document will remove the_server1_ from the service _RW-Split-Router_.
 
-Removing a service from a server is analogous to removing the server from the\
+Removing a service from a server is analogous to removing the server from the
 service. Both unlink the two objects from each other.
 
 Request for `PATCH /v1/servers/server1` that modifies the address of the server:
@@ -909,9 +909,9 @@ Request for `PATCH /v1/servers/server1` that modifies the server relationships:
 }
 ```
 
-If parts of the resource are not defined (e.g. the `attributes` field in the\
-above example), those parts of the resource are not modified. All parts that are\
-defined are interpreted as the new definition of those part of the resource. In\
+If parts of the resource are not defined (e.g. the `attributes` field in the
+above example), those parts of the resource are not modified. All parts that are
+defined are interpreted as the new definition of those part of the resource. In
 the above example, the `relationships` of the resource are completely redefined.
 
 **Response**
@@ -930,15 +930,15 @@ Invalid JSON body:
 PATCH /v1/servers/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _services_, for service\
+The _:type_ in the URI must be either _services_, for service
 relationships, or _monitors_, for monitor relationships.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of the particular type from the server.
 
-The following is an example request and request body that defines a single\
+The following is an example request and request body that defines a single
 service relationship for a server.
 
 ```
@@ -977,11 +977,11 @@ Invalid JSON body:
 DELETE /v1/servers/:name
 ```
 
-A server can only be deleted if it is not used by any services or\
+A server can only be deleted if it is not used by any services or
 monitors.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the server by first unlinking it from all services and monitors that use\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the server by first unlinking it from all services and monitors that use
 it.
 
 **Response**
@@ -1000,7 +1000,7 @@ Server is in use:
 PUT /v1/servers/:name/set
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the following values.
 
 | Value       | State Description                |
@@ -1012,19 +1012,19 @@ request. The value of `state` must be one of the following values.
 | synced      | Server is a Galera node          |
 | drain       | Server is drained of connections |
 
-For example, to set the server _db-server-1_ into maintenance mode, a request to\
+For example, to set the server _db-server-1_ into maintenance mode, a request to
 the following URL must be made:
 
 ```
 PUT /v1/servers/db-server-1/set?state=maintenance
 ```
 
-This endpoint also supports the `force=yes` parameter that will cause all\
-connections to the server to be closed if `state=maintenance` is also set. By\
-default setting a server into maintenance mode will cause connections to be\
+This endpoint also supports the `force=yes` parameter that will cause all
+connections to the server to be closed if `state=maintenance` is also set. By
+default setting a server into maintenance mode will cause connections to be
 closed only after the next request is sent.
 
-The following example forcefully closes all connections to server _db-server-1_\
+The following example forcefully closes all connections to server _db-server-1_
 and sets it into maintenance mode:
 
 ```
@@ -1047,7 +1047,7 @@ Missing or invalid parameter:
 PUT /v1/servers/:name/clear
 ```
 
-This endpoint requires that the `state` parameter is passed with the\
+This endpoint requires that the `state` parameter is passed with the
 request. The value of `state` must be one of the values defined in the_set_ endpoint documentation.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-service-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-service-resource.md
@@ -2,7 +2,7 @@
 
 ## Service Resource
 
-A service resource represents a service inside MaxScale. A service is a\
+A service resource represents a service inside MaxScale. A service is a
 collection of network listeners, filters, a router and a set of backend servers.
 
 ### Resource Operations
@@ -778,7 +778,7 @@ Get all services.
 POST /v1/services
 ```
 
-Create a new service by defining the resource. The posted object must define at\
+Create a new service by defining the resource. The posted object must define at
 least the following fields.
 
 * `data.id`
@@ -792,24 +792,24 @@ least the following fields.
 * `data.attributes.parameters.password`
 * The [password](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) to use
 
-The `data.attributes.parameters` object is used to define router and service\
-parameters. All configuration parameters that can be defined in the\
-configuration file can also be added to the parameters object. The exceptions to\
-this are the `type`, `router`, `servers` and `filters` parameters which must not\
+The `data.attributes.parameters` object is used to define router and service
+parameters. All configuration parameters that can be defined in the
+configuration file can also be added to the parameters object. The exceptions to
+this are the `type`, `router`, `servers` and `filters` parameters which must not
 be defined.
 
-As with other REST API resources, the `data.relationships` field defines the\
-relationships of the service to other resources. Services can have two types of\
+As with other REST API resources, the `data.relationships` field defines the
+relationships of the service to other resources. Services can have two types of
 relationships: `servers` and `filters` relationships.
 
-If the request body defines a valid `relationships` object, the service is\
-linked to those resources. For servers, this is equivalent to adding the list of\
-server names into the [servers](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) parameter. For\
-filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) parameter in the\
-order they appear. For other services, this is equivalent to adding the list of\
+If the request body defines a valid `relationships` object, the service is
+linked to those resources. For servers, this is equivalent to adding the list of
+server names into the [servers](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) parameter. For
+filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) parameter in the
+order they appear. For other services, this is equivalent to adding the list of
 server names into the [targets](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) parameter.
 
-The following example defines a new service with both a server and a filter\
+The following example defines a new service with both a server and a filter
 relationship.
 
 ```
@@ -858,21 +858,21 @@ Service is created:
 DELETE /v1/services/:name
 ```
 
-A service can only be destroyed if the service uses no servers or filters and\
-all the listeners pointing to the service have been destroyed. This means that\
-the `data.relationships` must be an empty object and `data.attributes.listeners`\
+A service can only be destroyed if the service uses no servers or filters and
+all the listeners pointing to the service have been destroyed. This means that
+the `data.relationships` must be an empty object and `data.attributes.listeners`
 must be an empty array in order for the service to qualify for destruction.
 
-If there are open client connections that use the service when it is destroyed,\
-they are allowed to gracefully close before the service is destroyed. This means\
-that the destruction of a service can be acknowledged via the REST API before\
+If there are open client connections that use the service when it is destroyed,
+they are allowed to gracefully close before the service is destroyed. This means
+that the destruction of a service can be acknowledged via the REST API before
 the destruction process has fully completed.
 
-To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2501-maxscale-2501-session-resource.md) resource should be used. If a session for\
+To find out whether a service is still in use after it has been destroyed, the [sessions](mariadb-maxscale-2501-maxscale-2501-session-resource.md) resource should be used. If a session for
 the service is still open, it has not yet been destroyed.
 
-This endpoint also supports the `force=yes` parameter that will unconditionally\
-delete the service by first unlinking it from all servers and filters that it\
+This endpoint also supports the `force=yes` parameter that will unconditionally
+delete the service by first unlinking it from all servers and filters that it
 uses.
 
 **Response**
@@ -887,15 +887,15 @@ Service is destroyed:
 PATCH /v1/services/:name
 ```
 
-The request body must be a JSON object which represents a set of new definitions\
+The request body must be a JSON object which represents a set of new definitions
 for the service.
 
-All standard service parameters can be modified. Refer to the [service](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) documentation on\
+All standard service parameters can be modified. Refer to the [service](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) documentation on
 the details of these parameters.
 
-In addition to the standard service parameters, router parameters can be updated\
-at runtime if the router module supports it. Refer to the individual router\
-documentation for more details on whether the router supports it and which\
+In addition to the standard service parameters, router parameters can be updated
+at runtime if the router module supports it. Refer to the individual router
+documentation for more details on whether the router supports it and which
 parameters can be updated at runtime.
 
 The following example modifies a service by changing the `user` parameter to `admin`.
@@ -924,22 +924,22 @@ Service is modified:
 PATCH /v1/services/:name/relationships/:type
 ```
 
-The _:type_ in the URI must be either _servers_, _services_ or _filters_,\
+The _:type_ in the URI must be either _servers_, _services_ or _filters_,
 depending on which relationship is being modified.
 
-The request body must be a JSON object that defines only the _data_ field. The\
-value of the _data_ field must be an array of relationship objects that define\
-the _id_ and _type_ fields of the relationship. This object will replace the\
+The request body must be a JSON object that defines only the _data_ field. The
+value of the _data_ field must be an array of relationship objects that define
+the _id_ and _type_ fields of the relationship. This object will replace the
 existing relationships of this type for the service.
 
-_Note:_ The order of the values in the `filters` relationship will define the\
-order the filters are set up in. The order in which the filters appear in the\
-array will be the order in which the filters are applied to each query. Refer\
-to the [filters](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) parameter\
+_Note:_ The order of the values in the `filters` relationship will define the
+order the filters are set up in. The order in which the filters appear in the
+array will be the order in which the filters are applied to each query. Refer
+to the [filters](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) parameter
 for more details.
 
-The following is an example request and request body that defines a single\
-server relationship for a service that is equivalent to a `servers=my-server`\
+The following is an example request and request body that defines a single
+server relationship for a service that is equivalent to a `servers=my-server`
 parameter.
 
 ```
@@ -1035,7 +1035,7 @@ This endpoint is deprecated, use the [this](mariadb-maxscale-2501-maxscale-2501-
 GET /v1/services/:name/listeners/:listener
 ```
 
-This endpoint is deprecated, use the [this](mariadb-maxscale-2501-maxscale-2501-listener-resource.md)\
+This endpoint is deprecated, use the [this](mariadb-maxscale-2501-maxscale-2501-listener-resource.md)
 listeners endpoint instead.
 
 #### Create a new listener

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-session-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-session-resource.md
@@ -2,8 +2,8 @@
 
 ## Session Resource
 
-A session is an abstraction of a client connection, any number of related backend\
-connections, a router module session and possibly filter module sessions. Each\
+A session is an abstraction of a client connection, any number of related backend
+connections, a router module session and possibly filter module sessions. Each
 session is created on a service and each service can have multiple sessions.
 
 ### Resource Operations
@@ -14,11 +14,11 @@ session is created on a service and each service can have multiple sessions.
 GET /v1/sessions/:id
 ```
 
-Get a single session. _:id_ must be a valid session ID. The session ID is the\
+Get a single session. _:id_ must be a valid session ID. The session ID is the
 same that is exposed to the client as the connection ID.
 
-This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to\
-perform reverse DNS on the client IP address. As this requires communicating with\
+This endpoint also supports the `rdns=true` parameter, which instructs MaxScale to
+perform reverse DNS on the client IP address. As this requires communicating with
 an external server, the operation may be expensive.
 
 **Response**
@@ -233,10 +233,10 @@ Get all sessions.
 PATCH /v1/sessions/:id
 ```
 
-The request body must be a JSON object which represents the new configuration of\
+The request body must be a JSON object which represents the new configuration of
 the session. The `:id` must be a valid session ID that is active.
 
-The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean\
+The `log_debug`, `log_info`, `log_notice`, `log_warning` and `log_error` boolean
 parameters control whether the associated logging level is enabled:
 
 ```
@@ -251,11 +251,11 @@ parameters control whether the associated logging level is enabled:
 }
 ```
 
-The filters that a session uses can be updated by re-defining the filter\
-relationship of the session. This causes new filter sessions to be opened\
-immediately. The old filter session are closed and replaced with the new filter\
-session the next time the session is idle. The order in which the filters are\
-defined in the request body is the order in which the filters are installed,\
+The filters that a session uses can be updated by re-defining the filter
+relationship of the session. This causes new filter sessions to be opened
+immediately. The old filter session are closed and replaced with the new filter
+session the next time the session is idle. The order in which the filters are
+defined in the request body is the order in which the filters are installed,
 similar to how the filter relationship for services behaves.
 
 ```
@@ -287,14 +287,14 @@ Session is modified:
 POST /v1/sessions/:id/restart
 ```
 
-This endpoint causes the session to re-read the configuration from the\
-service. As a result of this, all backend connections will be closed and then\
-opened again. All router and filter sessions will be created again which means\
-that for modules that perform something whenever a new module session is opened,\
+This endpoint causes the session to re-read the configuration from the
+service. As a result of this, all backend connections will be closed and then
+opened again. All router and filter sessions will be created again which means
+that for modules that perform something whenever a new module session is opened,
 this behaves as if a new session was started.
 
-This endpoint can be used to apply configuration changes that were done after\
-the session was started. This can be useful for situations where the client\
+This endpoint can be used to apply configuration changes that were done after
+the session was started. This can be useful for situations where the client
 connections live for a long time and connections are not recycled often enough.
 
 **Response**
@@ -309,7 +309,7 @@ Session is was restarted:
 POST /v1/sessions/restart
 ```
 
-This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint\
+This endpoint does the same thing as the `/v1/sessions/:id/restart` endpoint
 except that it applies to all sessions.
 
 **Response**
@@ -331,8 +331,8 @@ This endpoint causes the session to be forcefully closed.
 This endpoint supports the following request parameters.
 
 * `ttl`
-* The time after which the session is killed. If this parameter is not given,\
-  the session is killed immediately. This can be used to give the session time\
+* The time after which the session is killed. If this parameter is not given,
+  the session is killed immediately. This can be used to give the session time
   to finish the work it is performing before the connection is closed.
 
 **Response**

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-sql-resource.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-sql-resource.md
@@ -9,35 +9,35 @@ The SQL resource represents a database connection.
 The following endpoints provide a simple REST API interface for executing\
 SQL queries on servers and services in MaxScale.
 
-This endpoint also supports executing SQL queries using an ODBC driver. The\
-results returned by connections that use ODBC drivers can differ from the ones\
+This endpoint also supports executing SQL queries using an ODBC driver. The
+results returned by connections that use ODBC drivers can differ from the ones
 returned by normal SQL connections to objects in MaxScale.
 
-This document uses the `:id` value in the URL to represent a connection ID and\
-the `:query_id` to represent a query ID. These values do not need to be manually\
+This document uses the `:id` value in the URL to represent a connection ID and
+the `:query_id` to represent a query ID. These values do not need to be manually
 added as the relevant links are returned in the request body of each endpoint.
 
-The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A\
-connection token can be acquired with a `POST /v1/sql` request and can be used\
-with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in\
+The endpoints use JSON Web Tokens to uniquely identify open SQL connections. A
+connection token can be acquired with a `POST /v1/sql` request and can be used
+with the `POST /v1/sql/:id/query`, `GET /v1/sql/:id/results/:query_id` and`DELETE /v1/sql` endpoints. All of these endpoints accept a connection token in
 the `token` parameter of the request:
 
 ```
 POST /v1/sql/query?token=eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhZG1pbiIsImV4cCI6MTU4MzI1NDE1MSwiaWF0IjoxNTgzMjI1MzUxLCJpc3MiOiJtYXhzY2FsZSJ9.B1BqhjjKaCWKe3gVXLszpOPfeu8cLiwSb4CMIJAoyqw
 ```
 
-In addition to request parameters, the token can be stored in cookies in which\
-case they are automatically used by the REST API. For more information about\
+In addition to request parameters, the token can be stored in cookies in which
+case they are automatically used by the REST API. For more information about
 token storage in cookies, see the documentation for `POST /v1/sql`.
 
 ### Request Parameters
 
-All of the endpoints that operate on a single connection support the following\
-request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an\
+All of the endpoints that operate on a single connection support the following
+request parameters. The `GET /v1/sql` and `GET /v1/sql/:id` endpoints are an
 exception as they ignore the current connection token.
 
 * `token`
-* The connection token to use for the request. If provided, the value is\
+* The connection token to use for the request. If provided, the value is
   unconditionally used even if a cookie with a valid token exists.
 
 #### Get one SQL connection
@@ -133,24 +133,24 @@ POST /v1/sql
 The request body must be a JSON object consisting of the following fields:
 
 * `target`
-* The object to connect to. This is a mandatory value and the\
+* The object to connect to. This is a mandatory value and the
   given value must be the name of a valid server, service or listener in\
   MaxScale or the value `odbc` if an ODBC connection is being made.
 * `user`
-* The username to use when creating the connection. This is a mandatory value\
+* The username to use when creating the connection. This is a mandatory value
   when connecting to an object in MaxScale.
 * `password`
-* The password for the user. This is a mandatory value when connecting to an\
+* The password for the user. This is a mandatory value when connecting to an
   object in MaxScale.
 * `db`
-* The default database for the connection. By default the connection will have\
+* The default database for the connection. By default the connection will have
   no default database. This is ignored by ODBC connections.
 * `timeout`
-* Connection timeout in seconds. The default connection timeout is 10\
-  seconds. This controls how long the SQL connection creation can take before\
+* Connection timeout in seconds. The default connection timeout is 10
+  seconds. This controls how long the SQL connection creation can take before
   an error is returned. This is accepted by all connection types.
 * `connection_string`
-* Connection string that defines the ODBC connection. This is a required value\
+* Connection string that defines the ODBC connection. This is a required value
   for ODBC type connections and is ignored by all other connection types.
 
 Here is an example request body:
@@ -165,7 +165,7 @@ Here is an example request body:
 }
 ```
 
-And here is an example request that uses an ODBC driver to connect to a remote\
+And here is an example request that uses an ODBC driver to connect to a remote
 server:
 
 ```
@@ -175,16 +175,16 @@ server:
 }
 ```
 
-The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token\
-is stored in cookies instead of the metadata object and the response body will\
+The response will contain the new connection with the token stored at`meta.token`. If the request uses the `persist=yes` request parameter, the token
+is stored in cookies instead of the metadata object and the response body will
 not contain the token.
 
-The location of the newly created connection will be stored at `links.self` in\
+The location of the newly created connection will be stored at `links.self` in
 the response body as well as in the `Location` header.
 
-The token must be given to all subsequent requests that use the connection. It\
-must be either given in the `token` parameter of a request or it must be stored\
-in the cookies. If both a `token` parameter and a cookie exist at the same time,\
+The token must be given to all subsequent requests that use the connection. It
+must be either given in the `token` parameter of a request or it must be stored
+in the cookies. If both a `token` parameter and a cookie exist at the same time,
 the `token` parameter will be used instead of the cookie.
 
 **Request Parameters**
@@ -193,12 +193,12 @@ This endpoint supports the following request parameters.
 
 * `persist`
 * Store the connection token in cookies instead of returning it as the response body.\
-  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie\
+  This parameter expects only one value, `yes`, as its argument. When`persist=yes` is set, the token is stored in the `conn_id_sig_<id>` cookie
   where the `<id>` part is replaced by the ID of the connection.
 * `max-age`
-* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or\
-  a non-integer value is found, the parameter is ignored. Once the token age\
-  exceeds the configured maximum value, the token can no longer be used and a\
+* Sets the connection token maximum age in seconds. The default is`max-age=28800`. Only positive values are accepted and if a non-positive or
+  a non-integer value is found, the parameter is ignored. Once the token age
+  exceeds the configured maximum value, the token can no longer be used and a
   new connection must be created.
 
 **Response**
@@ -258,12 +258,12 @@ Missing or invalid connection token:
 POST /v1/sql/:id/reconnect
 ```
 
-Reconnects an existing connection. This can also be used if the connection to\
+Reconnects an existing connection. This can also be used if the connection to
 the backend server was lost due to a network error.
 
 The connection will use the same credentials that were passed to the `POST /v1/sql` endpoint. The new connection will still have the same ID in the REST\
-API but will be treated as a new connection by the database. A reconnection\
-re-initializes the connection and resets the session state. Reconnections cannot\
+API but will be treated as a new connection by the database. A reconnection
+re-initializes the connection and resets the session state. Reconnections cannot
 take place while a transaction is open.
 
 **Response**
@@ -286,17 +286,17 @@ Missing or invalid connection token:
 POST /v1/sql/:id/clone
 ```
 
-Clones an existing connection. This is done by opening a new connection using\
+Clones an existing connection. This is done by opening a new connection using
 the credentials and configuration from the given connection.
 
 **Request Parameters**
 
-This endpoint supports the same request parameters as the `POST /v1/sql`\
+This endpoint supports the same request parameters as the `POST /v1/sql`
 endpoint.
 
 **Response**
 
-The response is identical to the one in the `POST /v1/sql` endpoint. In\
+The response is identical to the one in the `POST /v1/sql` endpoint. In
 addition, this endpoint can return the following responses.
 
 Connection is already in use:
@@ -313,7 +313,7 @@ Missing or invalid connection token:
 POST /v1/sql/:id/queries
 ```
 
-The request body must be a JSON object with the value of the `sql` field set to\
+The request body must be a JSON object with the value of the `sql` field set to
 the SQL to be executed:
 
 ```
@@ -326,23 +326,23 @@ the SQL to be executed:
 The request body must be a JSON object consisting of the following fields:
 
 * `sql`
-* The SQL to be executed. If the SQL contain multiple statements, multiple\
+* The SQL to be executed. If the SQL contain multiple statements, multiple
   results are returned in the response body.
 * `max_rows`
-* The maximum number of rows returned in the response. By default this is 1000\
-  rows. Setting the value to 0 means no limit. Any extra rows in the result\
+* The maximum number of rows returned in the response. By default this is 1000
+  rows. Setting the value to 0 means no limit. Any extra rows in the result
   will be discarded.
 
-By default, the complete result is returned in the response body. If the SQL\
-query returns more than one result, the `results` array will contain all the\
-results. If the `async=true` request option is used, the query is queued for\
+By default, the complete result is returned in the response body. If the SQL
+query returns more than one result, the `results` array will contain all the
+results. If the `async=true` request option is used, the query is queued for
 execution.
 
-The `results` array can have three types of objects: resultsets, errors, and OK\
+The `results` array can have three types of objects: resultsets, errors, and OK
 responses.
 
-* A resultset consists of the `data` field with the result data stored as a two\
-  dimensional array. The names of the fields are stored in an array in the`fields` field and the field types and other metadata are stored in the`metadata` field. These types of results will be returned for any operation\
+* A resultset consists of the `data` field with the result data stored as a two
+  dimensional array. The names of the fields are stored in an array in the`fields` field and the field types and other metadata are stored in the`metadata` field. These types of results will be returned for any operation
   that returns rows (i.e. `SELECT` statements)
 
 ```
@@ -391,7 +391,7 @@ responses.
 }
 ```
 
-* An error consists of an object with the `errno` field set to the MariaDB error\
+* An error consists of an object with the `errno` field set to the MariaDB error
   code, the `message` field set to the human-readable error message and the`sqlstate` field set to the current SQLSTATE of the connection.
 
 ```
@@ -417,9 +417,9 @@ responses.
 }
 ```
 
-* An OK response is returned for any result that completes successfully but not\
-  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`\
-  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field\
+* An OK response is returned for any result that completes successfully but not
+  return rows (e.g. an `INSERT` or `UPDATE` statement). The `affected_rows`
+  field contains the number of rows affected by the operation, the`last_insert_id` contains the auto-generated ID and the `warnings` field
   contains the number of warnings raised by the operation.
 
 ```
@@ -445,17 +445,17 @@ responses.
 }
 ```
 
-It is also possible for the fields of the error response to be present in the\
-resultset response if the result ended with an error but still generated some\
-data. Usually this happens when query execution is interrupted but a partial\
+It is also possible for the fields of the error response to be present in the
+resultset response if the result ended with an error but still generated some
+data. Usually this happens when query execution is interrupted but a partial
 result was generated by the server.
 
 **Request Parameters**
 
 * `async`
-* If set to `true`, the query is queued for asynchronous execution and the\
-  results must be retrieved later from the URL stored in `links.self` field\
-  of the response. The HTTP response code is set to HTTP 202 Accepted if the\
+* If set to `true`, the query is queued for asynchronous execution and the
+  results must be retrieved later from the URL stored in `links.self` field
+  of the response. The HTTP response code is set to HTTP 202 Accepted if the
   query was successfully queued for execution.
 
 **Response**
@@ -532,7 +532,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 #### Get Asynchronous Query Results
@@ -541,10 +541,10 @@ Fatal connection error:
 GET /v1/sql/:id/queries/:query_id
 ```
 
-The results are only available if a `POST /v1/sql/:id/queries` was executed with\
-the `async` field set to `true`. The result of any asynchronous query can be\
-read multiple times. Only the latest result is stored: executing a new query\
-will cause the latest result to be erased. Results can be explicitly erased\
+The results are only available if a `POST /v1/sql/:id/queries` was executed with
+the `async` field set to `true`. The result of any asynchronous query can be
+read multiple times. Only the latest result is stored: executing a new query
+will cause the latest result to be erased. Results can be explicitly erased
 with a `DELETE` request.
 
 **Response**
@@ -605,7 +605,7 @@ Fatal connection error:
 
 `Status: 503 Service Unavailable`
 
-* If the API returns this response, the connection to the database server was\
+* If the API returns this response, the connection to the database server was
   lost. The only valid action to take at this point is to close it with the`DELETE /v1/sql/:id` endpoint.
 
 #### Erase Asynchronous Query Results
@@ -614,7 +614,7 @@ Fatal connection error:
 DELETE /v1/sql/:id/queries/:query_id
 ```
 
-Erases the latest result of an asynchronously executed query. All asynchronous\
+Erases the latest result of an asynchronously executed query. All asynchronous
 results are erased when the connection that owns them is closed.
 
 **Response**
@@ -637,12 +637,12 @@ Missing connection token:
 POST /v1/sql/:id/cancel
 ```
 
-This endpoint cancels the current query being executed by this connection. If no\
+This endpoint cancels the current query being executed by this connection. If no
 query is being done and the connection is idle, no action is taken.
 
-If the connection is busy but it is not executing a query, an attempt to cancel\
-is still made: in this case the results of this operation are undefined for ODBC\
-connections, for MariaDB connections this will cause a `KILL QUERY` command to\
+If the connection is busy but it is not executing a query, an attempt to cancel
+is still made: in this case the results of this operation are undefined for ODBC
+connections, for MariaDB connections this will cause a `KILL QUERY` command to
 be executed.
 
 **Response**
@@ -665,9 +665,9 @@ Missing connection token:
 GET /v1/sql/odbc/drivers
 ```
 
-Get the list of configured ODBC drivers found by the driver manager. The list of\
-drivers includes all drivers known to the driver manager for which an installed\
-library was found (i.e. `Driver` or `Driver64` in `/etc/odbcinst.ini` points to\
+Get the list of configured ODBC drivers found by the driver manager. The list of
+drivers includes all drivers known to the driver manager for which an installed
+library was found (i.e. `Driver` or `Driver64` in `/etc/odbcinst.ini` points to
 a file).
 
 **Response**
@@ -702,13 +702,13 @@ The response contains a resource collection with all available drivers.
 POST /v1/sql/:id/etl/prepare
 ```
 
-The ETL operation requires two connections: an ODBC connection to a remote\
-server (source connection) and a connection to a server in MaxScale (destination\
+The ETL operation requires two connections: an ODBC connection to a remote
+server (source connection) and a connection to a server in MaxScale (destination
 connection). All ETL operations must be done on the ODBC connection.
 
 The ETL operations require that the MariaDB ODBC driver is installed on the\
-MaxScale server. This driver is often available in the package manager of your\
-operating system but it can also be downloaded from the MariaDB\
+MaxScale server. This driver is often available in the package manager of your
+operating system but it can also be downloaded from the MariaDB
 website. 
 
 The request body must be a JSON object consisting of the following fields:
@@ -716,12 +716,12 @@ The request body must be a JSON object consisting of the following fields:
 * `target`
 
 The target connection ID that defines the destination server. This must be the\
-ID of a connection (i.e. `data.attributes.id` ) to a server in MaxScale\
+ID of a connection (i.e. `data.attributes.id` ) to a server in MaxScale
 created via the `POST /v1/sql/` endpoint.
 
 * `type`
 
-The type of the ETL data source. The value must be a string with one of the\
+The type of the ETL data source. The value must be a string with one of the
 following values:
 
 ```
@@ -749,48 +749,48 @@ following values:
 
 * `tables`
 
-An array of objects, each of which must define a `table` and a `schema`\
+An array of objects, each of which must define a `table` and a `schema`
 field. The `table` field defines the name of the table to be imported and the`schema` field defines the schema it is in. If the objects contain a value for`create`, `select` or `insert`, the SQL generation for that part is skipped.
 
 * `connection_string`
 
-Extra connection string that is appended to the destination server's\
-connection string. This connection will always use the MariaDB ODBC\
+Extra connection string that is appended to the destination server's
+connection string. This connection will always use the MariaDB ODBC
 driver. The list of supported options can be found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#parameters).
 
 * `threads`
 
-The number of parallel connections used during the ETL operation. By default\
+The number of parallel connections used during the ETL operation. By default
 the ETL operation will use up to 16 connections.
 
 * `timeout`
 
-The connection and query timeout in seconds. By default a timeout of 30\
+The connection and query timeout in seconds. By default a timeout of 30
 seconds is used.
 
 * `create_mode`
 
-A string with either `normal`, `ignore` or `replace` which controls how tables\
+A string with either `normal`, `ignore` or `replace` which controls how tables
 are handled that already exist on the destination server.
 
-If left undefined or set to `normal`, the tables are created using a normal`CREATE TABLE` statement. This will cause an error to be reported if the table\
-already exist and will prevent the ETL from proceeding past the object\
+If left undefined or set to `normal`, the tables are created using a normal`CREATE TABLE` statement. This will cause an error to be reported if the table
+already exist and will prevent the ETL from proceeding past the object
 creation stage.
 
-If set to `ignore` the tables are created with `CREATE TABLE IF NOT EXISTS`\
-which will ignore any existing tables and assume that they are compatible with\
-the rest of the ETL operation. This mode can be used to continuously load data\
+If set to `ignore` the tables are created with `CREATE TABLE IF NOT EXISTS`
+which will ignore any existing tables and assume that they are compatible with
+the rest of the ETL operation. This mode can be used to continuously load data
 from an external source into MariaDB.
 
-If set to `replace`, the tables are created with `CREATE OR REPLACE TABLE`\
-which will cause existing tables to be dropped if they exist. This is not a\
+If set to `replace`, the tables are created with `CREATE OR REPLACE TABLE`
+which will cause existing tables to be dropped if they exist. This is not a
 reversible process so caution should be taken when this mode is used.
 
 * `catalog`
 
 The catalog for the tables. This is only used when `type` is set to`generic`. In all other cases this value is ignored.
 
-Here is an example payload that prepares the table `test.t1` for extraction from\
+Here is an example payload that prepares the table `test.t1` for extraction from
 a MariaDB server.
 
 ```
@@ -806,9 +806,9 @@ a MariaDB server.
 }
 ```
 
-The token for the source connection is provided the same way it is\
-provided for all other `/v1/sql` endpoints: in the `token` request\
-parameter or in the cookies. The destination connection token is\
+The token for the source connection is provided the same way it is
+provided for all other `/v1/sql` endpoints: in the `token` request
+parameter or in the cookies. The destination connection token is
 provided either in the `target_token` request parameter or as a cookie.
 
 ### Request Parameters
@@ -816,8 +816,8 @@ provided either in the `target_token` request parameter or as a cookie.
 This endpoints supports the following additional request parameters.
 
 * `target_token`
-* The connection token for the destination connection. If provided, the value\
-  is unconditionally used even if a cookie with a valid token exists for the\
+* The connection token for the destination connection. If provided, the value
+  is unconditionally used even if a cookie with a valid token exists for the
   destination connection.
 
 **Response**
@@ -826,7 +826,7 @@ ETL operation prepared:
 
 `Status: 202 Accepted`
 
-Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the\
+Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the
 following result.
 
 ```
@@ -868,32 +868,32 @@ Invalid payload or missing connection token:
 POST /v1/sql/:id/etl/start
 ```
 
-The behavior of this endpoint is identical to the preparation but instead of\
-preparing the operation, this endpoint will execute the prepared ETL and load\
+The behavior of this endpoint is identical to the preparation but instead of
+preparing the operation, this endpoint will execute the prepared ETL and load
 the data into MariaDB.
 
-The intended way of doing an ETL operation is to first prepare it using the`/v1/sql/:id/etl/prepare` endpoint to retrieve the SQL statements that define\
-the ETL operation. Then if the ETL preparation is successful, the`data.attributes.results.tables` value from the response is used as the `tables`\
+The intended way of doing an ETL operation is to first prepare it using the`/v1/sql/:id/etl/prepare` endpoint to retrieve the SQL statements that define
+the ETL operation. Then if the ETL preparation is successful, the`data.attributes.results.tables` value from the response is used as the `tables`
 value for the ETL start operation, done on the `/v1/sql/:id/etl/start` endpoint.
 
-If any of the `create`, `select` or `insert` fields for a table in the `tables`\
-list have not been defined, the SQL will be automatically generated by querying\
-the source server, similarly to how the preparation generates the SQL\
-statements. This means that the preparation step is optional if there is no need\
+If any of the `create`, `select` or `insert` fields for a table in the `tables`
+list have not been defined, the SQL will be automatically generated by querying
+the source server, similarly to how the preparation generates the SQL
+statements. This means that the preparation step is optional if there is no need
 to adjust the automatically generated SQL.
 
-The ETL operation can be canceled using the `/v1/sql/:id/cancel` endpoint which\
-will roll back the ETL operation. Any tables that were created during the ETL\
-operation are not deleted on the destination server and must be manually cleaned\
+The ETL operation can be canceled using the `/v1/sql/:id/cancel` endpoint which
+will roll back the ETL operation. Any tables that were created during the ETL
+operation are not deleted on the destination server and must be manually cleaned
 up.
 
-If the ETL fails to extract the SQL from the source server or an error was\
-encountered during table creation, the response will have the `"ok"` field set\
-to false. Both the top-level object as well as the individual tables can have\
+If the ETL fails to extract the SQL from the source server or an error was
+encountered during table creation, the response will have the `"ok"` field set
+to false. Both the top-level object as well as the individual tables can have
 the `"error"` field set to the error message. This field is filled during the\
 ETL operation which means errors are visible even if the ETL is still ongoing.
 
-During the ETL operation, tables that have been fully processed will have a`"execution_time"` field. This field has the total time in seconds it took to\
+During the ETL operation, tables that have been fully processed will have a`"execution_time"` field. This field has the total time in seconds it took to
 execute the data loading step.
 
 **Response**
@@ -902,7 +902,7 @@ ETL operation started:
 
 `Status: 202 Accepted`
 
-Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the\
+Once complete, the `/v1/sql/:id/queries/:query_id` endpoint will return the
 following result.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-avrorouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-avrorouter.md
@@ -4,17 +4,17 @@
 
 ## Avrorouter
 
-The Avrorouter was deprecated in MaxScale 25.01 and will be removed\
+The Avrorouter was deprecated in MaxScale 25.01 and will be removed
 in the next major release. [KafkaCDC](mariadb-maxscale-2501-maxscale-2501-kafkacdc.md) can be used instead.
 
-The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes\
+The avrorouter is a MariaDB 10.0 binary log to Avro file converter. It consumes
 binary logs from a local directory and transforms them into a set of Avro files.\
 These files can then be queried by clients for various purposes.
 
 This router is intended to be used in tandem with the [Binlog Server](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md).\
 The Binlog Server can connect to a primary server and request binlog records.\
-These records can then consumed by the avrorouter directly from the binlog cache\
-of the Binlog Server. This allows MariaDB MaxScale to automatically transform\
+These records can then consumed by the avrorouter directly from the binlog cache
+of the Binlog Server. This allows MariaDB MaxScale to automatically transform
 binlog events on the primary to local Avro format files.
 
 ```mermaid
@@ -71,25 +71,25 @@ flowchart LR
 ```
 _Data flow through the MariaDB MaxScale Avro router: the Primary server's binlog events are converted to Avro-formatted change data and streamed to CDC clients, Kafka, and Hadoop._
 
-The avrorouter can also consume binary logs straight from the primary. This will\
-remove the need to configure the Binlog Server but it will increase the disk space\
+The avrorouter can also consume binary logs straight from the primary. This will
+remove the need to configure the Binlog Server but it will increase the disk space
 requirement on the primary server by at least a factor of two.
 
-The converted Avro files can be requested with the CDC protocol. This protocol\
-should be used to communicate with the avrorouter and currently it is the only\
-supported protocol. The clients can request either Avro or JSON format data\
+The converted Avro files can be requested with the CDC protocol. This protocol
+should be used to communicate with the avrorouter and currently it is the only
+supported protocol. The clients can request either Avro or JSON format data
 streams from a database table.
 
 ### Direct Replication Mode
 
-MaxScale 2.4.0 added a direct replication mode that connects the avrorouter\
-directly to a MariaDB server. This mode is an improvement over the binlogrouter\
-based replication as it provides a more space-efficient and faster conversion\
-process. This is the recommended method of using the avrorouter as it is faster,\
+MaxScale 2.4.0 added a direct replication mode that connects the avrorouter
+directly to a MariaDB server. This mode is an improvement over the binlogrouter
+based replication as it provides a more space-efficient and faster conversion
+process. This is the recommended method of using the avrorouter as it is faster,
 more efficient and less prone to errors caused by missing DDL events.
 
-To enable the direct replication mode, add either the `servers` or the `cluster`\
-parameter to the avrorouter service. The avrorouter will then use one of the\
+To enable the direct replication mode, add either the `servers` or the `cluster`
+parameter to the avrorouter service. The avrorouter will then use one of the
 servers as the replication source.
 
 Here is a minimal avrorouter direct replication configuration:
@@ -117,12 +117,12 @@ protocol=CDC
 port=4001
 ```
 
-In direct replication mode, the avrorouter stores the latest replicated GTID in\
-the `current_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove\
+In direct replication mode, the avrorouter stores the latest replicated GTID in
+the `current_gtid.txt` file located in the `avrodir` (defaults to`/var/lib/maxscale`). To reset the replication process, stop MaxScale and remove
 the file.
 
-Additionally, the avrorouter will attempt to automatically create any missing\
-schema files for tables that have data events for them but the DDL for those\
+Additionally, the avrorouter will attempt to automatically create any missing
+schema files for tables that have data events for them but the DDL for those
 tables is not contained in the binlogs.
 
 ### Configuration
@@ -138,24 +138,24 @@ For information about common service parameters, refer to the [Configuration Gui
 * Dynamic: No
 * Default: `""`
 
-The GTID where avrorouter starts the replication from in direct replication\
-mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where\
-the first number is the replication domain, the second the server\_id value of\
+The GTID where avrorouter starts the replication from in direct replication
+mode. The parameter value must be in the MariaDB GTID format e.g. 0-1-123 where
+the first number is the replication domain, the second the server\_id value of
 the server and the last is the GTID sequence number.
 
-This parameter has no effect in the traditional mode. If this parameter is\
-defined, the replication will start from the implicit GTID that the primary first\
+This parameter has no effect in the traditional mode. If this parameter is
+defined, the replication will start from the implicit GTID that the primary first
 serves.
 
-Starting in MaxScale 24.02, the special values `newest` and `oldest` can be\
+Starting in MaxScale 24.02, the special values `newest` and `oldest` can be
 used:
 
-* `newest` uses the current value of `@@gtid_binlog_pos` as the GTID where the\
+* `newest` uses the current value of `@@gtid_binlog_pos` as the GTID where the
   replication is started from.
-* `oldest` uses the oldest binlog that's available in `SHOW BINARY LOGS` and\
+* `oldest` uses the oldest binlog that's available in `SHOW BINARY LOGS` and
   then extracting the oldest GTID from it with `SHOW BINLOG EVENTS`.
 
-Once the replication has started and a GTID position has been recorded, this\
+Once the replication has started and a GTID position has been recorded, this
 parameter will be ignored. To reset the recorded GTID position, delete the`current_gtid.txt` file located in `/var/lib/maxscale/<SERVICE>/` where`<SERVICE>` is the name of the Avrorouter service.
 
 #### `server_id`
@@ -165,7 +165,7 @@ parameter will be ignored. To reset the recorded GTID position, delete the`curre
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
 used when replicating from the primary in direct replication mode.
 
 #### `codec`
@@ -179,7 +179,7 @@ used when replicating from the primary in direct replication mode.
 The compression codec to use. By default, the avrorouter does not use compression.
 
 This parameter takes one of the following two values; _null_ or\_deflate\_. These are the mandatory compression algorithms required by the\
-Avro specification. For more information about the compression types,\
+Avro specification. For more information about the compression types,
 refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specification/#required-codecs).
 
 #### `match`
@@ -189,14 +189,14 @@ refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specificat
 * Dynamic: No
 * Default: `""`
 
-This and `exclude` are [regular expression settings](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
-that filter events for processing depending on table names. Avrorouter does\
+This and `exclude` are [regular expression settings](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
+that filter events for processing depending on table names. Avrorouter does
 not support the _options_-parameter for regular expressions.
 
-To prevent excessive matching of similarly named tables, surround each table\
-name with the `^` and `$` tokens. For example, to match the `test.clients` table\
-but not `test.clients_old` table use `match=^test[.]clients$`. For multiple\
-tables, surround each table in parentheses and add a pipe character between\
+To prevent excessive matching of similarly named tables, surround each table
+name with the `^` and `$` tokens. For example, to match the `test.clients` table
+but not `test.clients_old` table use `match=^test[.]clients$`. For multiple
+tables, surround each table in parentheses and add a pipe character between
 them: `match=(^test[.]t1$)|(^test[.]t2$)`.
 
 #### `exclude`
@@ -215,8 +215,8 @@ See [match](mariadb-maxscale-2501-maxscale-2501-avrorouter.md#match).
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location of the binary log files. This is the first mandatory parameter\
-and it defines where the module will read binlog files from. Read access to\
+The location of the binary log files. This is the first mandatory parameter
+and it defines where the module will read binlog files from. Read access to
 this directory is required.
 
 #### `avrodir`
@@ -226,14 +226,14 @@ this directory is required.
 * Dynamic: No
 * Default: `/var/lib/maxscale/`
 
-The location where the Avro files are stored. This is the second mandatory\
-parameter and it governs where the converted files are stored. This directory\
-will be used to store the Avro files, plain-text Avro schemas and other files\
-needed by the avrorouter. The user running MariaDB MaxScale will need both read and\
+The location where the Avro files are stored. This is the second mandatory
+parameter and it governs where the converted files are stored. This directory
+will be used to store the Avro files, plain-text Avro schemas and other files
+needed by the avrorouter. The user running MariaDB MaxScale will need both read and
 write access to this directory.
 
-The avrorouter will also use the _avrodir_ to store various internal\
-files. These files are named _avro.index_ and _avro-conversion.ini_. By default,\
+The avrorouter will also use the _avrodir_ to store various internal
+files. These files are named _avro.index_ and _avro-conversion.ini_. By default,
 the default data directory, _/var/lib/maxscale/_, is used. Before version 2.1 of\
 MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 
@@ -244,7 +244,7 @@ MaxScale, the value of _binlogdir_ was used as the default value for _avrodir_.
 * Dynamic: No
 * Default: `mysql-bin`
 
-The base name of the binlog files. The binlog files are assumed to follow the\
+The base name of the binlog files. The binlog files are assumed to follow the
 naming schema _._ where is the binlog number and is the value of this router option.
 
 For example, with the following parameters:
@@ -264,11 +264,11 @@ The first binlog file the avrorouter would look for is `/var/lib/mysql/binlogs/m
 * Default: `1`
 
 The starting index number of the binlog file. The default value is 1.\
-For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_\
+For the binlog _mysql-bin.000001_ the index would be 1, for _mysql-bin.000005_
 the index would be 5.
 
-If you need to start from a binlog file other than 1, you need to set the value\
-of this option to the correct index. The avrorouter will always start from the\
+If you need to start from a binlog file other than 1, you need to set the value
+of this option to the correct index. The avrorouter will always start from the
 beginning of the binary log file.
 
 #### `cooperative_replication`
@@ -278,39 +278,39 @@ beginning of the binary log file.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
-cluster. This is a boolean parameter and is disabled by default. It was\
+Controls whether multiple instances cooperatively replicate from the same
+cluster. This is a boolean parameter and is disabled by default. It was
 added in MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`),\
-the replication is only active if the monitor owns the cluster it is\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`),
+the replication is only active if the monitor owns the cluster it is
 monitoring.
 
-With this feature, multiple MaxScale instances can replicate from the same set\
-of servers and only one of them actively processes the replication stream. This\
-allows the avrorouter instances to be made highly-available without having to\
+With this feature, multiple MaxScale instances can replicate from the same set
+of servers and only one of them actively processes the replication stream. This
+allows the avrorouter instances to be made highly-available without having to
 have them all process the events at the same time.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID processed by that\
-instance. This means that if the instance hasn't replicated events that have\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID processed by that
+instance. This means that if the instance hasn't replicated events that have
 been purged from the binary logs, the replication cannot continue.
 
 ### Settings for Avro File
 
 These options control how large the Avro file data blocks can get.\
-Increasing or lowering the block size could have a positive effect\
-depending on your use case. For more information about the Avro file\
+Increasing or lowering the block size could have a positive effect
+depending on your use case. For more information about the Avro file
 format and how it organizes data, refer to the [Avro documentation](https://avro.apache.org/docs/current/).
 
-The avrorouter will flush a block and start a new one when either `group_trx`\
-transactions or `group_rows` row events have been processed. Changing these\
-options will also allow more frequent updates to stored data but this\
+The avrorouter will flush a block and start a new one when either `group_trx`
+transactions or `group_rows` row events have been processed. Changing these
+options will also allow more frequent updates to stored data but this
 will cause a small increase in file size and search times.
 
-It is highly recommended to keep the block sizes relatively large to allow\
-larger chunks of memory to be flushed to disk at one time. This will make\
+It is highly recommended to keep the block sizes relatively large to allow
+larger chunks of memory to be flushed to disk at one time. This will make
 the conversion process noticeably faster.
 
 #### `group_trx`
@@ -320,7 +320,7 @@ the conversion process noticeably faster.
 * Dynamic: No
 * Default: `1`
 
-Controls the number of transactions that are grouped into a single Avro\
+Controls the number of transactions that are grouped into a single Avro
 data block.
 
 #### `group_rows`
@@ -330,7 +330,7 @@ data block.
 * Dynamic: No
 * Default: `1000`
 
-Controls the number of row events that are grouped into a single Avro\
+Controls the number of row events that are grouped into a single Avro
 data block.
 
 #### `block_size`
@@ -340,10 +340,10 @@ data block.
 * Dynamic: Yes
 * Default: `16KiB`
 
-The Avro data block size in bytes. The default is 16 kilobytes. Increase this\
-value if individual events in the binary logs are very large. The value is a\
+The Avro data block size in bytes. The default is 16 kilobytes. Increase this
+value if individual events in the binary logs are very large. The value is a
 size type parameter which means that it can also be defined with an SI suffix.\
-Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 for more details about size type parameters and how to use them.
 
 #### `max_file_size`
@@ -353,17 +353,17 @@ for more details about size type parameters and how to use them.
 * Dynamic: No
 * Default: 0
 
-If the size of a single Avro data file exceeds this limit, the avrorouter will\
-rotate to a new file. This is done by closing the existing file and creating a\
-new one with the next version number. By default the avrorouter does not rotate\
-files based on their size. Setting the value to 0 disables file rotation based on\
+If the size of a single Avro data file exceeds this limit, the avrorouter will
+rotate to a new file. This is done by closing the existing file and creating a
+new one with the next version number. By default the avrorouter does not rotate
+files based on their size. Setting the value to 0 disables file rotation based on
 size.
 
-This uses the size of the file as reported by the operating system. The check\
-for the file size is done after a transaction has been processed which means\
+This uses the size of the file as reported by the operating system. The check
+for the file size is done after a transaction has been processed which means
 that large transactions can still cause the file size to exceed the given limit.
 
-File rotation only works with the direct replication mode. The legacy file based\
+File rotation only works with the direct replication mode. The legacy file based
 replication mode does not support this.
 
 #### `max_data_age`
@@ -373,17 +373,17 @@ replication mode does not support this.
 * Dynamic: No
 * Default: 0s
 
-When enabled, the avrorouter will automatically purge any files that only have\
-data that is older than the given limit. This means that all data files with at\
-least one event that is newer than the configured limit will not be removed,\
-even if the age of all the other events is above the limit. The purge operation\
-is only done when a file rotation takes place (either manual or automatic) or\
+When enabled, the avrorouter will automatically purge any files that only have
+data that is older than the given limit. This means that all data files with at
+least one event that is newer than the configured limit will not be removed,
+even if the age of all the other events is above the limit. The purge operation
+is only done when a file rotation takes place (either manual or automatic) or
 when a schema change is detected.
 
-This parameter is best combined with `max_file_size` to provide automatic\
+This parameter is best combined with `max_file_size` to provide automatic
 removal of stale data.
 
-Automatic file purging only works with the direct replication mode. The legacy\
+Automatic file purging only works with the direct replication mode. The legacy
 file based replication mode does not support this.
 
 ### Example configuration
@@ -406,94 +406,94 @@ avrodir=/var/lib/maxscale
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md) documentation for
 details about module commands.
 
 The avrorouter supports the following module commands.
 
 #### `avrorouter::convert SERVICE {start | stop}`
 
-Start or stop the binary log to Avro conversion. The first parameter is the name\
-of the service to stop and the second parameter tells whether to start the\
+Start or stop the binary log to Avro conversion. The first parameter is the name
+of the service to stop and the second parameter tells whether to start the
 conversion process or to stop it.
 
 #### `avrorouter::purge SERVICE`
 
 This command will delete all files created by the avrorouter. This includes all\
-.avsc schema files and .avro data files as well as the internal state tracking\
+.avsc schema files and .avro data files as well as the internal state tracking
 files. Use this to completely reset the conversion process.
 
-**Note:** Once the command has completed, MaxScale must be restarted to restart\
+**Note:** Once the command has completed, MaxScale must be restarted to restart
 the conversion process. Issuing a `convert start` command **will not work**.
 
-**WARNING:** You will lose any and all converted data when this command is\
+**WARNING:** You will lose any and all converted data when this command is
 executed.
 
 ### Files Created by the Avrorouter
 
-The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store\
-the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains\
-the last converted position and GTID in the binlogs. If you need to reset the\
+The avrorouter creates two files in the location pointed by _avrodir_:_avro.index_ and _avro-conversion.ini_. The _avro.index_ file is used to store
+the locations of the GTIDs in the .avro files. The _avro-conversion.ini_ contains
+the last converted position and GTID in the binlogs. If you need to reset the
 conversion process, delete these two files and restart MaxScale.
 
 ### Resetting the Conversion Process
 
-To reset the binlog conversion process, issue the `purge` module command by\
-executing it via MaxCtrl and stop MaxScale. If manually created schema files\
+To reset the binlog conversion process, issue the `purge` module command by
+executing it via MaxCtrl and stop MaxScale. If manually created schema files
 were used, they need to be recreated once MaxScale is stopped. After stopping\
-MaxScale and optionally creating the schema files, the conversion process can be\
+MaxScale and optionally creating the schema files, the conversion process can be
 started by starting MaxScale.
 
 ### Stopping the Avrorouter
 
-The safest way to stop the avrorouter when used with the binlogrouter is to\
+The safest way to stop the avrorouter when used with the binlogrouter is to
 follow the following steps:
 
 * Issue `STOP SLAVE` on the binlogrouter
 * Wait for the avrorouter to process all files
 * Stop MaxScale with `systemctl stop maxscale`
 
-This guarantees that the conversion process halts at a known good position in\
+This guarantees that the conversion process halts at a known good position in
 the latest binlog file.
 
 ### Example Client
 
 The avrorouter comes with an example client program, _cdc.py_, written in Python 3.\
-This client can connect to a MaxScale configured with the CDC protocol and the\
+This client can connect to a MaxScale configured with the CDC protocol and the
 avrorouter.
 
-Before using this client, you will need to install the Python 3 interpreter and\
-add users to the service with the _cdc\_users.py_ script. Fore more details about\
-the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-change-data-capture-cdc-protocol.md)\
+Before using this client, you will need to install the Python 3 interpreter and
+add users to the service with the _cdc\_users.py_ script. Fore more details about
+the user creation, please refer to the [CDC Protocol](../mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-change-data-capture-cdc-protocol.md)
 and [CDC Users](../mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-change-data-capture-cdc-users.md) documentation.
 
-Read the output of `cdc.py --help` for a full list of supported options\
+Read the output of `cdc.py --help` for a full list of supported options
 and a short usage description of the client program.
 
 ### Avro Schema Generator
 
-The avrorouter needs to have access to the CREATE TABLE statement for all tables\
-for which there are data events in the binary logs. If the CREATE TABLE\
-statements for the tables aren't present in the current binary logs, the schema\
+The avrorouter needs to have access to the CREATE TABLE statement for all tables
+for which there are data events in the binary logs. If the CREATE TABLE
+statements for the tables aren't present in the current binary logs, the schema
 files must be created.
 
-In the direct replication mode, avrorouter will automatically create the missing\
-schema files by connecting to the database and executing a `SHOW CREATE TABLE`\
-statement. If a connection cannot be made or the service user lacks the\
-permission, an error will be logged and the data events for that table will not\
+In the direct replication mode, avrorouter will automatically create the missing
+schema files by connecting to the database and executing a `SHOW CREATE TABLE`
+statement. If a connection cannot be made or the service user lacks the
+permission, an error will be logged and the data events for that table will not
 be processed.
 
-For the legacy binlog mode, the files must be generated with a schema file\
+For the legacy binlog mode, the files must be generated with a schema file
 generator. There are currently two methods to generate the .avsc schema files.
 
 #### Simple Schema Generator
 
-The `cdc_one_schema.py` generates a schema file for a single table by reading a\
-tab separated list of field and type names from the standard input. This is the\
-recommended schema generation tool as it does not directly communicate with the\
+The `cdc_one_schema.py` generates a schema file for a single table by reading a
+tab separated list of field and type names from the standard input. This is the
+recommended schema generation tool as it does not directly communicate with the
 database thus making it more flexible.
 
-The only requirement to run the script is that a Python interpreter is\
+The only requirement to run the script is that a Python interpreter is
 installed.
 
 To use this script, pipe the output of the `mysql` command line into the`cdc_one_schema.py` script:
@@ -502,15 +502,15 @@ To use this script, pipe the output of the `mysql` command line into the`cdc_one
 mysql -ss -u <user> -p -h <host> -P <port> -e 'DESCRIBE `<database>`.`<table>`'|./cdc_one_schema.py <database> <table>
 ```
 
-Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with\
-appropriate values and run the command. Note that the `-ss` parameter is\
-mandatory as that will generate the tab separated output instead of the default\
+Replace the `<user>`, `<host>`, `<port>`, `<database>` and `<table>` with
+appropriate values and run the command. Note that the `-ss` parameter is
+mandatory as that will generate the tab separated output instead of the default
 pretty-printed output.
 
-An .avsc file named after the database and table name will be generated in the\
+An .avsc file named after the database and table name will be generated in the
 current working directory. Copy this file to the location pointed by the`avrodir` parameter of the avrorouter.
 
-Alternatively, you can also copy the output of the `mysql` command to a file and\
+Alternatively, you can also copy the output of the `mysql` command to a file and
 feed it into the script if you cannot execute the SQL command directly:
 
 ```
@@ -533,31 +533,31 @@ usage: cdc_schema.py [--help] [-h HOST] [-P PORT] [-u USER] [-p PASSWORD] DATABA
 The _cdc\_schema.py_ executable is installed as a part of MaxScale. This is a\
 Python 3 script that generates Avro schema files from an existing database.
 
-The script will generate the .avsc schema files into the current directory. Run\
-the script for all required databases copy the generated .avsc files to the\
+The script will generate the .avsc schema files into the current directory. Run
+the script for all required databases copy the generated .avsc files to the
 directory where the avrorouter stores the .avro files (the value of `avrodir`).
 
 #### Go Schema Generator
 
-The _cdc\_schema.go_ example Go program is provided with MaxScale. This file\
-can be used to create Avro schemas for the avrorouter by connecting to a\
-database and reading the table definitions. You can find the file in MaxScale's\
+The _cdc\_schema.go_ example Go program is provided with MaxScale. This file
+can be used to create Avro schemas for the avrorouter by connecting to a
+database and reading the table definitions. You can find the file in MaxScale's
 share directory in `/usr/share/maxscale/`.
 
-You'll need to install the Go compiler and run `go get` to resolve Go\
-dependencies before you can use the _cdc\_schema_ program. After resolving the\
-dependencies you can run the program with `go run cdc_schema.go`. The program\
-will create .avsc files in the current directory. These files should be moved\
-to the location pointed by the _avrodir_ option of the avrorouter if they are\
+You'll need to install the Go compiler and run `go get` to resolve Go
+dependencies before you can use the _cdc\_schema_ program. After resolving the
+dependencies you can run the program with `go run cdc_schema.go`. The program
+will create .avsc files in the current directory. These files should be moved
+to the location pointed by the _avrodir_ option of the avrorouter if they are
 to be used by the router itself.
 
-Read the output of `go run cdc_schema.go -help` for more information on how\
+Read the output of `go run cdc_schema.go -help` for more information on how
 to run the program.
 
 ### Examples
 
-The [Avrorouter Tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-avrorouter-tutorial.md) shows you how\
-the Avrorouter works with the Binlog Server to convert binlogs from a primary server\
+The [Avrorouter Tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-avrorouter-tutorial.md) shows you how
+the Avrorouter works with the Binlog Server to convert binlogs from a primary server
 into easy to process Avro data.
 
 Here is a simple configuration example which reads binary logs locally from`/var/lib/mysql/` and stores them as Avro files in `/var/lib/maxscale/avro/`.\
@@ -587,7 +587,7 @@ Python script. It queries the table _test.mytable_ for all change records.
 cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytable
 ```
 
-You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change\
+You can then combine it with the _cdc\_kafka\_producer.py_ to publish these change
 records to a Kafka broker.
 
 ```
@@ -595,28 +595,28 @@ cdc.py --user=myuser --password=mypasswd --host=127.0.0.1 --port=4001 test.mytab
 cdc_kafka_producer.py --kafka-broker 127.0.0.1:9092 --kafka-topic test.mytable
 ```
 
-For more information on how to use these scripts, see the output of `cdc.py -h`\
+For more information on how to use these scripts, see the output of `cdc.py -h`
 and `cdc_kafka_producer.py -h`.
 
 ### Building Avrorouter
 
-To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development\
+To build the avrorouter from source, you will need the [Avro C](https://avro.apache.org/docs/1.11.1/api/c/) library, liblzma,[the Jansson library](https://www.digip.org/jansson/) and sqlite3 development
 headers. When configuring MaxScale with CMake, you will need to add`-DBUILD_CDC=Y` to build the CDC module set.
 
-The Avro C library needs to be build with position independent code enabled. You\
-can do this by adding the following flags to the CMake invocation when\
+The Avro C library needs to be build with position independent code enabled. You
+can do this by adding the following flags to the CMake invocation when
 configuring the Avro C library.
 
 ```
 -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC
 ```
 
-For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-building-mariadb-maxscale-from-source-code.md)\
+For more details about building MaxScale from source, please refer to the [Building MaxScale from Source Code](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-building-mariadb-maxscale-from-source-code.md)
 document.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for an avrorouter service contains the following\
+The `router_diagnostics` output for an avrorouter service contains the following
 fields.
 
 * `infofile`: File where the avrorouter stores the conversion process state.
@@ -636,8 +636,8 @@ The avrorouter does not support the following data types, conversions or SQL sta
 * Fields CAST from integer types to string types
 * [CREATE TABLE ... AS SELECT statements](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/tables/create-table)
 
-The avrorouter does not do any crash recovery. This means that the avro files\
-need to be removed or truncated to valid block lengths before starting the\
+The avrorouter does not do any crash recovery. This means that the avro files
+need to be removed or truncated to valid block lengths before starting the
 avrorouter.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-binlogrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-binlogrouter.md
@@ -1,37 +1,37 @@
 # MaxScale 25.01 Binlogrouter
 
-The binlogrouter is a router that acts as a replication proxy for MariaDB\
-primary-replica replication. The router connects to a primary, retrieves the binary\
-logs and stores them locally. Replica servers can connect to MaxScale like they\
-would connect to a normal primary server. If the primary server goes down,\
-replication between MaxScale and the replicas can still continue up to the latest\
-point to which the binlogrouter replicated to. The primary can be changed without\
-disconnecting the replicas and without them noticing that the primary server has\
+The binlogrouter is a router that acts as a replication proxy for MariaDB
+primary-replica replication. The router connects to a primary, retrieves the binary
+logs and stores them locally. Replica servers can connect to MaxScale like they
+would connect to a normal primary server. If the primary server goes down,
+replication between MaxScale and the replicas can still continue up to the latest
+point to which the binlogrouter replicated to. The primary can be changed without
+disconnecting the replicas and without them noticing that the primary server has
 changed. This allows for a more highly available replication setup.
 
-In addition to the high availability benefits, the binlogrouter creates only one\
-connection to the primary whereas with normal replication each individual replica\
-will create a separate connection. This reduces the amount of work the primary\
-database has to do which can be significant if there are a large number of\
+In addition to the high availability benefits, the binlogrouter creates only one
+connection to the primary whereas with normal replication each individual replica
+will create a separate connection. This reduces the amount of work the primary
+database has to do which can be significant if there are a large number of
 replicating replicas.
 
 ### Binlog purge, archive and compress
 
-File purge and archive are mutually exclusive. Archiving simply means that\
-a binlog is moved to another directory. That directory can be mounted to another\
+File purge and archive are mutually exclusive. Archiving simply means that
+a binlog is moved to another directory. That directory can be mounted to another
 file system for backups or, for example, a locally mounted S3 bucket.
 
-If archiving is started from a primary that still has all its history intact, a\
+If archiving is started from a primary that still has all its history intact, a
 full copy of the primary can be archived.
 
-File compression preserves disk space and makes archiving faster. All\
-binlogs except the very last one, which is the one being logged to, can be\
-compressed. The overhead of reading from a compressed binlog is small, and\
-is typically only needed when a replica goes down, reconnects and is far\
+File compression preserves disk space and makes archiving faster. All
+binlogs except the very last one, which is the one being logged to, can be
+compressed. The overhead of reading from a compressed binlog is small, and
+is typically only needed when a replica goes down, reconnects and is far
 enough behind the current GTID that an older file needs to be opened.
 
-There is no automated way as of yet for the binlogrouter to use archived files,\
-but should the need arise files can be copied from the archive to the binlog\
+There is no automated way as of yet for the binlogrouter to use archived files,
+but should the need arise files can be copied from the archive to the binlog
 directory. See ['Modifying binlog files manually'](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#modifying-binlog-files-manually).
 
 The related configuration options, which are explained in more detail in the configuration section are:
@@ -42,10 +42,10 @@ The related configuration options, which are explained in more detail in the con
 * [expire\_log\_minimum\_files](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#expire_log_minimum_files) The minimum number of binlogs to keep before purge or archive is allowed.
 * [expire\_log\_duration](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#expire_log_duration) Duration from the last file modification until the binlog is eligible for purge or archive.
 * [compression\_algorithm](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#compression_algorithm) Select a compression algorithm or `none` for no compression. Currently only zstandard is supported.
-* [number\_of\_noncompressed\_files](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#number_of_noncompressed_files) The minimum number of\
+* [number\_of\_noncompressed\_files](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#number_of_noncompressed_files) The minimum number of
   binlogs not to compress.
 
-Following are example settings where it is expected that a\
+Following are example settings where it is expected that a
 replica is down for no more than 24 hours.
 
 ```
@@ -60,26 +60,26 @@ number_of_noncompressed_files=2
 ### Modifying binlog files manually
 
 There is usually no reason to modify the contents of the binlog directory.\
-Changing the contents can cause **failures** if not done correctly. Never make\
+Changing the contents can cause **failures** if not done correctly. Never make
 any changes if running a version prior to 23.08, except when a [bootstrap](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#bootstrap-binlogrouter) is needed.
 
-A binlog file has the name .\<sequence\_number>. The basename is decided\
-by the primary server. The sequence number increases by one for each file and is six\
+A binlog file has the name .\<sequence\_number>. The basename is decided
+by the primary server. The sequence number increases by one for each file and is six
 digits long. The first file has the name .000001
 
-The file `binlog.index` contains the view of the current state of the binlogs\
-as a list of file names ordered by the file sequence number. `binlog.index` is\
+The file `binlog.index` contains the view of the current state of the binlogs
+as a list of file names ordered by the file sequence number. `binlog.index` is
 automatically generated any time the contents of `datadir` changes.
 
-Older files can be manually deleted and should be deleted in the order they\
+Older files can be manually deleted and should be deleted in the order they
 were created, lowest to highest sequence number. Prefer to use purge configuration.
 
-Archived files can be copied back to `datadir`, but care should be taken to copy\
+Archived files can be copied back to `datadir`, but care should be taken to copy
 them back in the reverse order they were created, highest to lowest sequence number.\
-The copied over files will be re-archived once `expire_log_duration` time has\
+The copied over files will be re-archived once `expire_log_duration` time has
 passed.
 
-Never leave a gap in the sequence numbers, and always preserve the name of a\
+Never leave a gap in the sequence numbers, and always preserve the name of a
 binlog file if copied. Do not copy binlog files on top of existing binlog files.
 
 As of version 24.02 any binlog except the latest one can be manually compressed, .e.g:
@@ -90,11 +90,11 @@ zstd --rm -z binlog.001234
 
 ### Supported SQL Commands
 
-The binlogrouter supports a subset of the SQL constructs that the MariaDB server\
+The binlogrouter supports a subset of the SQL constructs that the MariaDB server
 supports. The following commands are supported:
 
 * `CHANGE MASTER TO`
-* The binlogrouter supports the same syntax as the MariaDB server but only the\
+* The binlogrouter supports the same syntax as the MariaDB server but only the
   following values are allowed:
   * `MASTER_HOST`
   * `MASTER_PORT`
@@ -111,7 +111,7 @@ supports. The following commands are supported:
   * `MASTER_SSL_CIPHER`
   * `MASTER_SSL_VERIFY_SERVER_CERT`
 
-NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported\
+NOTE: `MASTER_LOG_FILE` and `MASTER_LOG_POS` are not supported
 as binlogrouter only supports GTID based replication.
 
 * `STOP SLAVE`
@@ -119,56 +119,56 @@ as binlogrouter only supports GTID based replication.
 * `START SLAVE`
 * Starts replication, same as MariaDB.
 * `RESET SLAVE`
-* Resets replication. Note that the `RESET SLAVE ALL` form that is supported\
+* Resets replication. Note that the `RESET SLAVE ALL` form that is supported
   by MariaDB isn't supported by the binlogrouter.
 * `SHOW BINARY LOGS`
-* Lists the current files and their sizes. These will be different from the\
-  ones listed by the original primary where the binlogrouter is replicating\
+* Lists the current files and their sizes. These will be different from the
+  ones listed by the original primary where the binlogrouter is replicating
   from.
 * `PURGE { BINARY | MASTER } LOGS TO <filename>`
-* Purges binary logs up to but not including the given file. The file name\
-  must be one of the names shown in `SHOW BINARY LOGS`. The version of this\
+* Purges binary logs up to but not including the given file. The file name
+  must be one of the names shown in `SHOW BINARY LOGS`. The version of this
   command which accepts a timestamp is not currently supported.\
-  Automatic purging is supported using the configuration\
+  Automatic purging is supported using the configuration
   parameter [expire\_log\_duration](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#expire_log_duration).\
-  The files are purged in the order they were created. If a file to be purged\
-  is detected to be in use, the purge stops. This means that the purge will\
+  The files are purged in the order they were created. If a file to be purged
+  is detected to be in use, the purge stops. This means that the purge will
   stop at the oldest file that a replica is still reading.\
-  NOTE: You should still take precaution not to purge files that a potential\
-  replica will need in the future. MaxScale can only detect that a file is\
+  NOTE: You should still take precaution not to purge files that a potential
+  replica will need in the future. MaxScale can only detect that a file is
   in active use when a replica is connected, and requesting events from it.
 * `SHOW MASTER STATUS`
-* Shows the name and position of the file to which the binlogrouter will write\
-  the next replicated data. The name and position do not correspond to the\
+* Shows the name and position of the file to which the binlogrouter will write
+  the next replicated data. The name and position do not correspond to the
   name and position in the primary.
 * `SHOW SLAVE STATUS`
-* Shows the replica status information similar to what a normal MariaDB replica\
-  server shows. Some of the values are replaced with constants values that\
+* Shows the replica status information similar to what a normal MariaDB replica
+  server shows. Some of the values are replaced with constants values that
   never change. The following values are not constant:
-  * `Slave_IO_State`: Set to `Waiting for primary to send event` when\
+  * `Slave_IO_State`: Set to `Waiting for primary to send event` when
     replication is ongoing.
   * `Master_Host`: Address of the current primary.
   * `Master_User`: The user used to replicate.
   * `Master_Port`: The port the primary is listening on.
-  * `Master_Log_File`: The name of the latest file that the binlogrouter is\
+  * `Master_Log_File`: The name of the latest file that the binlogrouter is
     writing to.
-  * `Read_Master_Log_Pos`: The current position where the last event was\
+  * `Read_Master_Log_Pos`: The current position where the last event was
     written in the latest binlog.
-  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's\
+  * `Slave_IO_Running`: Set to `Yes` if replication running and `No` if it's
     not.
-  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's\
+  * `Slave_SQL_Running` Set to `Yes` if replication running and `No` if it's
     not.
   * `Exec_Master_Log_Pos`: Same as `Read_Master_Log_Pos`.
   * `Gtid_IO_Pos`: The latest replicated GTID.
 * `SELECT { Field } ...`
-* The binlogrouter implements a small subset of the MariaDB SELECT syntax as\
-  it is mainly used by the replicating replicas to query various parameters. If\
-  a field queried by a client is not known to the binlogrouter, the value\
-  will be returned back as-is. The following list of functions and variables\
+* The binlogrouter implements a small subset of the MariaDB SELECT syntax as
+  it is mainly used by the replicating replicas to query various parameters. If
+  a field queried by a client is not known to the binlogrouter, the value
+  will be returned back as-is. The following list of functions and variables
   are understood by the binlogrouter and are replaced with actual values:
-  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of\
+  * `@@gtid_slave_pos`, `@@gtid_current_pos` or `@@gtid_binlog_pos`: All of
     these return the latest GTID replicated from the primary.
-  * `version()` or `@@version`: The version string returned by MaxScale when\
+  * `version()` or `@@version`: The version string returned by MaxScale when
     a client connects to it.
   * `UNIX_TIMESTAMP()`: The current timestamp.
   * `@@version_comment`: Always `pinloki`.
@@ -196,27 +196,27 @@ as binlogrouter only supports GTID based replication.
   * `@@tx_isolation`: Always `REPEATABLE-READ`
   * `@@wait_timeout`: Always `28800`
 * `SET`
-* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should\
+* `@@global.gtid_slave_pos`: Set the position from which binlogrouter should
   start replicating. E.g. `SET @@global.gtid_slave_pos="0-1000-1234,1-1001-5678"`
 * `SHOW VARIABLES LIKE '...'`
-* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`\
-  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`\
-  is not currently supported. In addition, the `LIKE` operator in\
+* Shows variables matching a string. The `LIKE` operator in `SHOW VARIABLES`
+  is mandatory for the binlogrouter. This means that a plain `SHOW VARIABLES`
+  is not currently supported. In addition, the `LIKE` operator in
   binlogrouter only supports exact matches.\
-  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID\
-  coordinates of the binlogrouter. In addition to these, the `server_id`\
+  Currently the only variables that are returned are `gtid_slave_pos`,`gtid_current_pos` and `gtid_binlog_pos` which return the current GTID
+  coordinates of the binlogrouter. In addition to these, the `server_id`
   variable will return the configured server ID of the binlogrouter.
 
 ### Semi-sync replication
 
-If the server from which the binlogrouter replicates from is using semi-sync\
+If the server from which the binlogrouter replicates from is using semi-sync
 replication, the binlogrouter will acknowledge the replicated events.
 
 ### Settings
 
 The binlogrouter is configured similarly to how normal routers are configured in\
-MaxScale. It requires at least one listener where clients can connect to and one\
-server from which the database user information can be retrieved. An example\
+MaxScale. It requires at least one listener where clients can connect to and one
+server from which the database user information can be retrieved. An example
 configuration can be found in the [example](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#example) section of this document.
 
 #### `datadir`
@@ -237,7 +237,7 @@ Directory where binary log files are stored.
 
 Mandatory if `expiration_mode=archive`
 
-The directory to where files are archived. This is presumably a directory\
+The directory to where files are archived. This is presumably a directory
 mounted to a remote file system or an S3 bucket. Ensure that the user running\
 MaxScale (typically "maxscale") has sufficient privileges on the archive directory.\
 S3 buckets mounted with s3fs may require setting permissions manually:
@@ -255,7 +255,7 @@ The directory must exist when MaxScale starts.
 * Dynamic: No
 * Default: `1234`
 
-The server ID that MaxScale uses when connecting to the primary and when serving\
+The server ID that MaxScale uses when connecting to the primary and when serving
 binary logs to the replicas.
 
 #### `net_timeout`
@@ -276,26 +276,26 @@ Network connection and read timeout for the connection to the primary.
 
 Automatically select the primary server to replicate from.
 
-When this feature is enabled, the primary which binlogrouter will replicate\
+When this feature is enabled, the primary which binlogrouter will replicate
 from will be selected from the servers defined by a monitor `cluster=TheMonitor`.\
-Alternatively servers can be listed in `servers`. The servers should be monitored\
-by a monitor. Only servers with the `Master` status are used. If multiple primary\
+Alternatively servers can be listed in `servers`. The servers should be monitored
+by a monitor. Only servers with the `Master` status are used. If multiple primary
 servers are available, the first available primary server will be used.
 
-If a `CHANGE MASTER TO` command is received while `select_master` is on, the\
+If a `CHANGE MASTER TO` command is received while `select_master` is on, the
 command will be honored and `select_master` turned off until the next reboot.\
 This allows the Monitor to perform failover, and more importantly, switchover.\
-It also allows the user to manually redirect the Binlogrouter. The current\
+It also allows the user to manually redirect the Binlogrouter. The current
 primary is "sticky", meaning that the same primary will be chosen on reboot.
 
-**NOTE:** Do not use the `mariadbmon` parameterauto\_rejoin if the monitor is\
-monitoring a binlogrouter. The binlogrouter does not support all the SQL\
-commands that the monitor will send and the rejoin will fail. This restriction\
+**NOTE:** Do not use the `mariadbmon` parameterauto\_rejoin if the monitor is
+monitoring a binlogrouter. The binlogrouter does not support all the SQL
+commands that the monitor will send and the rejoin will fail. This restriction
 will be lifted in a future version.
 
 The GTID the replication will start from, will be based on the latest replicated\
-GTID. If no GTID has been replicated, the router will start replication from the\
-start. Manual configuration of the GTID can be done by first configuring the\
+GTID. If no GTID has been replicated, the router will start replication from the
+start. Manual configuration of the GTID can be done by first configuring the
 replication manually with `CHANGE MASTER TO`.
 
 #### `expiration_mode`
@@ -321,9 +321,9 @@ A value of `0s` turns off purging.
 
 [expire\_log\_days](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#expire_logs_days).
 
-The duration is measured from the last modification of the log file. Files are\
-purged in the order they were created. The automatic purge works in a similar\
-manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if\
+The duration is measured from the last modification of the log file. Files are
+purged in the order they were created. The automatic purge works in a similar
+manner to `PURGE BINARY LOGS TO <filename>` in that it will stop the purge if
 an eligible file is in active use, i.e. being read by a replica.
 
 #### `expire_log_minimum_files`
@@ -333,7 +333,7 @@ an eligible file is in active use, i.e. being read by a replica.
 * Dynamic: No
 * Default: `2`
 
-The minimum number of log files the automatic purge keeps. At least one file\
+The minimum number of log files the automatic purge keeps. At least one file
 is always kept.
 
 #### `compression_algorithm`
@@ -351,7 +351,7 @@ is always kept.
 * Dynamic: No
 * Default: `2`
 
-The minimum number of log files that are not compressed. At least one file\
+The minimum number of log files that are not compressed. At least one file
 is not compressed.
 
 #### `ddl_only`
@@ -363,9 +363,9 @@ is not compressed.
 
 When enabled, only DDL events are written to the binary logs. This means that`CREATE`, `ALTER` and `DROP` events are written but `INSERT`, `UPDATE` and`DELETE` events are not.
 
-This mode can be used to keep a record of all the schema changes that occur on a\
-database. As only the DDL events are stored, it becomes very easy to set up an\
-empty server with no data in it by simply pointing it at a binlogrouter instance\
+This mode can be used to keep a record of all the schema changes that occur on a
+database. As only the DDL events are stored, it becomes very easy to set up an
+empty server with no data in it by simply pointing it at a binlogrouter instance
 that has `ddl_only` enabled.
 
 #### `encryption_key_id`
@@ -376,23 +376,23 @@ that has `ddl_only` enabled.
 * Default: `""`
 
 Encryption key ID used to encrypt the binary logs. If configured, an [Encryption\
-Key Manager](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
-must also be configured and it must contain the key with the given ID. If the\
-encryption key manager supports versioning, new binary logs will be encrypted\
-using the latest encryption key. Old binlogs will remain encrypted with older\
-key versions and remain readable as long as the key versions used to encrypt\
+Key Manager](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
+must also be configured and it must contain the key with the given ID. If the
+encryption key manager supports versioning, new binary logs will be encrypted
+using the latest encryption key. Old binlogs will remain encrypted with older
+key versions and remain readable as long as the key versions used to encrypt
 them are available.
 
-Once binary log encryption has been enabled, the encryption key ID cannot be\
-changed and the key must remain available to MaxScale in order for replication\
-to work. If an encryption key is not available or the key manager fails to\
-retrieve it, the replication from the currently selected primary server will\
-stop. If the replication is restarted manually, the encryption key retrieval is\
+Once binary log encryption has been enabled, the encryption key ID cannot be
+changed and the key must remain available to MaxScale in order for replication
+to work. If an encryption key is not available or the key manager fails to
+retrieve it, the replication from the currently selected primary server will
+stop. If the replication is restarted manually, the encryption key retrieval is
 attempted again.
 
-Re-encryption of binlogs using another encryption key is not possible. However,\
-this is possible if the data is replicated to a second MaxScale server that uses\
-a different encryption key. The same approach can also be used to decrypt\
+Re-encryption of binlogs using another encryption key is not possible. However,
+this is possible if the data is replicated to a second MaxScale server that uses
+a different encryption key. The same approach can also be used to decrypt
 binlogs.
 
 #### `encryption_cipher`
@@ -403,7 +403,7 @@ binlogs.
 * Values: `AES_CBC`, `AES_CTR`, `AES_GCM`
 * Default: `AES_GCM`
 
-The encryption cipher to use. The encryption key size also affects which mode is\
+The encryption cipher to use. The encryption key size also affects which mode is
 used: only 128, 192 and 256 bit encryption keys are currently supported.
 
 Possible values are:
@@ -422,16 +422,16 @@ Possible values are:
 * Default: false
 * Dynamic: Yes
 
-Enable [semi-synchronous](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
-replication when replicating from a MariaDB server. If enabled, the binlogrouter\
-will send acknowledgment for each received event. Note that the [rpl\_semi\_sync\_master\_enabled](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication#rpl_semi_sync_master_enabled)\
-parameter must be enabled in the MariaDB server where the replication is done\
+Enable [semi-synchronous](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
+replication when replicating from a MariaDB server. If enabled, the binlogrouter
+will send acknowledgment for each received event. Note that the [rpl\_semi\_sync\_master\_enabled](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication#rpl_semi_sync_master_enabled)
+parameter must be enabled in the MariaDB server where the replication is done
 from for the semi-synchronous replication to take place.
 
 ### New installation
 
 1. Configure and start MaxScale.
-2. If you have not configured `select_master=true` (automatic\
+2. If you have not configured `select_master=true` (automatic
    primary selection), issue a `CHANGE MASTER TO` command to binlogrouter.
 
 ```
@@ -453,34 +453,34 @@ SHOW SLAVE STATUS \G
 
 ### Upgrading from legacy versions
 
-Binlogrouter does not read any of the data that a version prior to 2.5\
-has saved. By default binlogrouter will request the replication stream\
-from the blank state (from the start of time), which is basically meant\
-for new systems. If a system is live, the entire replication data probably\
-does not exist, and if it does, it is not necessary for binlogrouter to read\
+Binlogrouter does not read any of the data that a version prior to 2.5
+has saved. By default binlogrouter will request the replication stream
+from the blank state (from the start of time), which is basically meant
+for new systems. If a system is live, the entire replication data probably
+does not exist, and if it does, it is not necessary for binlogrouter to read
 and store all the data.
 
 #### Before you start
 
 * Binlogrouter uses [inotify](https://man7.org/linux/man-pages/man7/inotify.7.html) which has three kernel limits.\
-  While Binlogrouter uses a modest number of inotify instances, the limit `max_user_instances` applies to the total\
-  number of instances for the user and has a low default value on many systems. A double or triple of the\
-  default value should suffice. The other two limits, `max_queued_events` and `max_user_watches` are usually high\
+  While Binlogrouter uses a modest number of inotify instances, the limit `max_user_instances` applies to the total
+  number of instances for the user and has a low default value on many systems. A double or triple of the
+  default value should suffice. The other two limits, `max_queued_events` and `max_user_watches` are usually high
   enough, but it is sensible to double (triple) them if `max_user_instances` was doubled (tripled).
 * Note that binlogrouter only supports GTID based replication.
-* Make sure that the configured data directory for the new binlogrouter\
+* Make sure that the configured data directory for the new binlogrouter
   is different from the old one, or move old data away.\
   See [datadir](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#datadir).
-* If the primary contains binlogs from the blank state, and there\
+* If the primary contains binlogs from the blank state, and there
   is a large amount of data, consider purging old binlogs.\
   See [Using and Maintaining the Binary Log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log).
 
 #### Deployment
 
-The method described here inflicts the least downtime. Assuming you have\
+The method described here inflicts the least downtime. Assuming you have
 configured MaxScale version 2.5 or newer, and it is ready to go:
 
-1. Redirect each replica that replicates from Binlogrouter to replicate from the\
+1. Redirect each replica that replicates from Binlogrouter to replicate from the
    primary.
 
 ```
@@ -503,7 +503,7 @@ master_user=USER,master_password="PASSWORD", master_use_gtid=slave_pos;
 ```
 
 1. Run `maxctrl list servers`. Make sure all your servers are accounted for.\
-   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and\
+   Pick the lowest gtid state (e.g. 0-1000-1234,1-1001-5678) on display and
    issue this command to Binlogrouter:
 
 ```
@@ -512,8 +512,8 @@ SET @@global.gtid_slave_pos = "0-1000-1234,1-1001-5678";
 START SLAVE
 ```
 
-**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos\
-if any binlog files have been purged on the primary. The server will only stream\
+**NOTE:** Even with `select_master=true` you have to set @@global.gtid\_slave\_pos
+if any binlog files have been purged on the primary. The server will only stream
 from the start of time if the first binlog file is present.\
 See [select\_master](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#select_master).
 
@@ -531,19 +531,19 @@ SHOW SLAVE STATUS \G
 
 #### Bootstrap binlogrouter
 
-If for any reason you need to "bootstrap" the binlogrouter you can change\
+If for any reason you need to "bootstrap" the binlogrouter you can change
 the `datadir` or delete the entire binglog directory (`datadir`) when\
-MaxScale is NOT running. This could be necessary if files are accidentally\
+MaxScale is NOT running. This could be necessary if files are accidentally
 deleted or the file system becomes corrupt.
 
 No changes are required to the attached replicas.
 
-if [select\_master](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#select_master) is set to `true` and the primary contains\
+if [select\_master](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#select_master) is set to `true` and the primary contains
 the entire binlog history, a simple restart of MaxScale sufficies.
 
-In the normal case, the primary does not have the entire history and\
-you will need to set the GTID position to a starting value, usually the\
-earliest gtid state of all replicas. Once MaxScale has been restarted\
+In the normal case, the primary does not have the entire history and
+you will need to set the GTID position to a starting value, usually the
+earliest gtid state of all replicas. Once MaxScale has been restarted
 connect to the binlogrouter from the command line.
 
 If [select\_master](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#select_master) is set to true issue:
@@ -566,7 +566,7 @@ START SLAVE;
 
 ### Galera cluster
 
-When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#select_master) must be\
+When replicating from a Galera cluster, [select\_master](mariadb-maxscale-2501-maxscale-2501-binlogrouter.md#select_master) must be
 set to true, and the servers must be monitored by the [Galera Monitor](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-galera-monitor.md).\
 Configuring binlogrouter is the same as described above.
 
@@ -635,8 +635,8 @@ port=3306
 
 ### Limitations
 
-* Old-style replication with binlog name and file offset is not supported\
-  and the replication must be started by setting up the GTID to replicate\
+* Old-style replication with binlog name and file offset is not supported
+  and the replication must be started by setting up the GTID to replicate
   from.
 * Only replication from MariaDB servers (including Galera) is supported.
 * Old encrypted binary logs are not re-encrypted with newer key versions ([MXS-4140](https://jira.mariadb.org/browse/MXS-4140))

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-cat.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-cat.md
@@ -6,8 +6,8 @@
 
 The `cat` router is a special router that concatenates result sets.
 
-_Note:_ This module is experimental and must be built from source. The\
-module is deprecated in MaxScale 23.08 and might be removed in a future\
+_Note:_ This module is experimental and must be built from source. The
+module is deprecated in MaxScale 23.08 and might be removed in a future
 release.
 
 ### Configuration
@@ -16,28 +16,28 @@ The router has no special parameters. To use it, define a service with`router=ca
 
 ### Behavior
 
-The order the servers are defined in is the order in which the servers are\
-queried. This means that the results are ordered based on the `servers`\
-parameter of the service. The result will only be completed once all servers\
+The order the servers are defined in is the order in which the servers are
+queried. This means that the results are ordered based on the `servers`
+parameter of the service. The result will only be completed once all servers
 have executed this.
 
-All commands executed via this router will be executed on all servers. This\
-means that an INSERT through the `cat` router will send it to all servers. In\
-the case of commands that do not return resultsets, the response of the last\
-server is sent to the client. This means that if one of the earlier servers\
+All commands executed via this router will be executed on all servers. This
+means that an INSERT through the `cat` router will send it to all servers. In
+the case of commands that do not return resultsets, the response of the last
+server is sent to the client. This means that if one of the earlier servers
 returns a different result, the client will not see it.
 
-As the intended use-case of the router is to mainly reduce multiple result sets\
-into one, it has no mechanisms to prevent writes from being executed on slave\
-servers (which would cause data corruption or replication failure). Take great\
+As the intended use-case of the router is to mainly reduce multiple result sets
+into one, it has no mechanisms to prevent writes from being executed on slave
+servers (which would cause data corruption or replication failure). Take great
 care when performing administrative operations though this router.
 
-If a connection to one of the servers is lost, the client connection will also\
+If a connection to one of the servers is lost, the client connection will also
 be closed.
 
 ### Example
 
-Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-configuring-servers.md) tutorial and the\
+Here is a simple example service definition that uses the servers from the [Configuring Servers](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-configuring-servers.md) tutorial and the
 credentials from the [MaxScale Tutorial](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-setting-up-mariadb-maxscale.md).
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md
@@ -4,34 +4,34 @@
 
 ### Overview
 
-The `diff`-router, hereafter referred to as _Diff_, compares the\
+The `diff`-router, hereafter referred to as _Diff_, compares the
 behaviour of one MariaDB server version to that of another.
 
-Diff will send the workload both to the server currently being used -\
-called _main_ - and to another server - called _other_ - whose\
+Diff will send the workload both to the server currently being used -
+called _main_ - and to another server - called _other_ - whose
 behaviour needs to be assessed.
 
-The responses from _main_ are returned to the client, without\
-waiting for the responses from _other_. While running, Diff collects\
-latency histogram data that later can be used for evaluating the\
+The responses from _main_ are returned to the client, without
+waiting for the responses from _other_. While running, Diff collects
+latency histogram data that later can be used for evaluating the
 behaviour of _main_ and _other_.
 
-Although Diff is a normal MaxScale router that can be configured\
-manually, typically it is created using commands provided by the\
-router itself. As its only purpose is to compare the behaviour of\
-different servers, it is only meaningful to start it provided certain\
-conditions are fulfilled and those conditions are easily ensured using\
+Although Diff is a normal MaxScale router that can be configured
+manually, typically it is created using commands provided by the
+router itself. As its only purpose is to compare the behaviour of
+different servers, it is only meaningful to start it provided certain
+conditions are fulfilled and those conditions are easily ensured using
 the router itself.
 
 #### Histogram
 
 Diff collects latency information separately for each _canonical statement_, which simply means a statement where all literals have been
 replaced with question marks. For instance, the canonical statement of `SELECT f FROM t WHERE f = 10` and `SELECT f FROM t WHERE f = 20` is
-in both cases `SELECT f FROM t WHERE f = ?`. The latency information\
-of both of those statements will be collected under the same canonical\
+in both cases `SELECT f FROM t WHERE f = ?`. The latency information
+of both of those statements will be collected under the same canonical
 statement.
 
-Before starting to register histogram data, Diff will collect [samples](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#samples) from _main_ that will be used for defining the\
+Before starting to register histogram data, Diff will collect [samples](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#samples) from _main_ that will be used for defining the
 edges and the number of bins of the histogram.
 
 #### Discrepancies
@@ -39,30 +39,30 @@ edges and the number of bins of the histogram.
 The responses from _main_ and _other_ are considered to be different
 
 * if the checksum of the response from _main_ and \*other differ, or
-* if the response time of \_other\* is outside the boundaries of the\
+* if the response time of \_other\* is outside the boundaries of the
   histogram edges calculated from the samples from _main_.
 
-A difference in the response time of individual queries is not a\
-meaningful criteria, as there for varying reasons (e.g. network\
-traffic) can be a significant amount of variance in the results. It\
+A difference in the response time of individual queries is not a
+meaningful criteria, as there for varying reasons (e.g. network
+traffic) can be a significant amount of variance in the results. It
 would only always cause a large number of false positives.
 
 #### EXPLAIN
 
-When a discrepancy is detected, an EXPLAIN statement will be executed\
-if the query was a DELETE, SELECT, INSERT or UPDATE. The EXPLAIN will\
-be executed using the same connection that was used for executing the\
-original statement. In the normal case, the EXPLAIN will be executed\
-immediately after the original statement, but if the client is\
-streaming requests, an other statement may have been executed in\
+When a discrepancy is detected, an EXPLAIN statement will be executed
+if the query was a DELETE, SELECT, INSERT or UPDATE. The EXPLAIN will
+be executed using the same connection that was used for executing the
+original statement. In the normal case, the EXPLAIN will be executed
+immediately after the original statement, but if the client is
+streaming requests, an other statement may have been executed in
 between.
 
-EXPLAINs are not always executed, but the frequency is controlled by [explain\_entries](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#explain_entries) and [explain\_period](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#explain_period). The EXPLAIN results are included in\
+EXPLAINs are not always executed, but the frequency is controlled by [explain\_entries](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#explain_entries) and [explain\_period](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#explain_period). The EXPLAIN results are included in
 the [output](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#reporting) of Diff.
 
 #### QPS
 
-While running, Diff will also collect QPS information over a sliding\
+While running, Diff will also collect QPS information over a sliding
 window whose size is defined by [qps\_period](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#qps_period).
 
 #### Reporting
@@ -70,21 +70,21 @@ window whose size is defined by [qps\_period](mariadb-maxscale-2501-maxscale-250
 Diff produces two kinds of output:
 
 * Output that is generated when Diff terminates or upon [request](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#summary). That output can be visualized as explained [here](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#visualizing).
-* [Optionally](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#report) Diff can continuously report queries whose\
+* [Optionally](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#report) Diff can continuously report queries whose
   responses from _main_ and other _differ_ as described [here](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#discrepancies).
 
-When Diff starts it will create a directory `diff` in MaxScale's\
-data directory (typically `/var/lib/maxscale`). Under that it\
-will create a directory whose name is the same as that of the\
-service specified in [service](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#service). The output files are created\
+When Diff starts it will create a directory `diff` in MaxScale's
+data directory (typically `/var/lib/maxscale`). Under that it
+will create a directory whose name is the same as that of the
+service specified in [service](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#service). The output files are created
 in that directory.
 
 ### Setup
 
-The behaviour and usage of Diff is most easily explained\
+The behaviour and usage of Diff is most easily explained
 using an example.
 
-Consider the following simple configuration that only includes\
+Consider the following simple configuration that only includes
 the very essential.
 
 ```
@@ -100,22 +100,22 @@ servers=MyServer1
 ...
 ```
 
-There is a service `MyService` that uses a single server `MyServer1`,\
+There is a service `MyService` that uses a single server `MyServer1`,
 which, for this example, is assumed to run MariaDB 10.5.
 
-Suppose that the server should be upgraded to 11.2 and we want\
+Suppose that the server should be upgraded to 11.2 and we want
 to find out whether there would be some issues with that.
 
 #### Prerequisites
 
-In order to use Diff for comparing the behaviour of MariaDB 10.5\
+In order to use Diff for comparing the behaviour of MariaDB 10.5
 and MariaDB 11.2, the following steps must be taken.
 
-* Install MariaDB 11.2 on a host that performance wise is\
+* Install MariaDB 11.2 on a host that performance wise is
   similar to the host on which MariaDB 10.5 is running.
 * Configure the MariaDB 11.2 server to replicate from the\
   MariaDB 10.5 server.
-* Create a server entry for the MariaDB 11.2 server in\
+* Create a server entry for the MariaDB 11.2 server in
   the MaxScale configuration.
 
 The created entry could be something like:
@@ -128,13 +128,13 @@ port=3306
 protocol=mariadbbackend
 ```
 
-Note that this server must **not** be added to the service that\
-uses the original server. That is, in this example, `MariaDB_112`\
+Note that this server must **not** be added to the service that
+uses the original server. That is, in this example, `MariaDB_112`
 must not be added to the service `MyService`.
 
-The new server can be added to the monitor used for monitoring\
-the servers of the service, but that is not necessary. However,\
-unless it is added, `maxctrl list servers` will show the server\
+The new server can be added to the monitor used for monitoring
+the servers of the service, but that is not necessary. However,
+unless it is added, `maxctrl list servers` will show the server
 as being down.
 
 With these steps Diff is ready to be used.
@@ -149,9 +149,9 @@ Syntax: `create new-service existing-service used-server new-server`
 
 Where:
 
-* `new-service`: The name of the service using the Diff router, to be\
+* `new-service`: The name of the service using the Diff router, to be
   created.
-* `existing-service`: The name of an existing service in whose context\
+* `existing-service`: The name of an existing service in whose context
   the new server is to be evaluated.
 * `used-server`: A server used by `existing-service`
 * `new-server`: The server that should be compared to `used-server`.
@@ -163,7 +163,7 @@ maxctrl call command diff create DiffMyService MyService MyServer1 MariaDB_112
 }
 ```
 
-With this command, preparations for comparing the server `MariaDB_112`\
+With this command, preparations for comparing the server `MariaDB_112`
 against the server `MyServer1` of the service `MyService` will be made.\
 At this point it will be checked in what kind of replication relationship`MariaDB_112` is with respect to `MyServer1`. If the steps in [prerequisites](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#prerequisites) were followed, it will be detected that`MariaDB_112` replicates from `MyServer1`.
 
@@ -209,33 +209,33 @@ maxctrl call command diff start DiffMyService
 When Diff is started, it performs the following steps:
 
 1. All sessions of `MyService` are suspended.
-2. In the `MyService` service, the server target `MyServer1`\
+2. In the `MyService` service, the server target `MyServer1`
    is replaced with `DiffMyService`.
 3. The replication from `MyServer1` to `MariaDB_112` is stopped.
-4. The sessions are restarted, which will cause existing connections\
-   to `MyServer1` to be closed and new ones to be created, via Diff,\
+4. The sessions are restarted, which will cause existing connections
+   to `MyServer1` to be closed and new ones to be created, via Diff,
    to both `MyServer1` and `MariaDB_112`.
-5. The sessions are resumed, which means that the client traffic\
+5. The sessions are resumed, which means that the client traffic
    will continue.
 
-In the first step, all sessions that are idle will immediately\
-be suspended, which simply means that nothing is read from\
-the client socket. Sessions that are waiting for a response\
-from the server and sessions that have an active transaction\
-continue to run. Immediately when a session becomes idle,\
+In the first step, all sessions that are idle will immediately
+be suspended, which simply means that nothing is read from
+the client socket. Sessions that are waiting for a response
+from the server and sessions that have an active transaction
+continue to run. Immediately when a session becomes idle,
 it is suspended.
 
 Once all sessions have been suspended, the service is rewired.\
-In the case of `MyService` above, it means that the target`MyServer1` is replaced with `DiffMyService`. That is, requests\
-that earlier were sent to `MyServer1`, will, once the sessions\
-are resumed, be sent to `DiffMyService`, which sends them forward\
+In the case of `MyService` above, it means that the target`MyServer1` is replaced with `DiffMyService`. That is, requests
+that earlier were sent to `MyServer1`, will, once the sessions
+are resumed, be sent to `DiffMyService`, which sends them forward
 to both `MyServer1` and `MariaDB_112`.
 
-Restarting the sessions means that the direct connections to`MyServer1` will be closed and equivalent ones created via the\
-service `DiffMyService`, which will also create connections\
+Restarting the sessions means that the direct connections to`MyServer1` will be closed and equivalent ones created via the
+service `DiffMyService`, which will also create connections
 to `MariaDB_112`.
 
-When the sessions are resumed, client requests will again be\
+When the sessions are resumed, client requests will again be
 processed, but they will now be routed via `DiffMyService`.
 
 With maxctrl we can check that MyServer has been rewired.
@@ -251,7 +251,7 @@ maxctrl list services
 └───────────────┴────────────────┴─────────────┴───────────────────┴────────────────────────┘
 ```
 
-The target of `MyService` is `DiffMyService` instead of `MyServer1`\
+The target of `MyService` is `DiffMyService` instead of `MyServer1`
 that it used to be.
 
 The output object returned by `create` tells the current state.
@@ -267,12 +267,12 @@ The output object returned by `create` tells the current state.
 }
 ```
 
-The `sessions` object shows how many sessions there are in total\
-and how many that currently are suspended. Since there were no\
+The `sessions` object shows how many sessions there are in total
+and how many that currently are suspended. Since there were no
 existing sessions in this example, they are both 0.
 
-The `state` shows what Diff is currently doing. `synchronizing`\
-means that it is in the process of changing `MyService` to use`DiffMyService`. `sync_state` shows that it is currently in the\
+The `state` shows what Diff is currently doing. `synchronizing`
+means that it is in the process of changing `MyService` to use`DiffMyService`. `sync_state` shows that it is currently in the
 process of suspending sessions.
 
 **Status**
@@ -283,7 +283,7 @@ Where:
 
 * `diff-service: The name of the service created in the`create\` step.
 
-When Diff has been started, its current status can be checked with the\
+When Diff has been started, its current status can be checked with the
 command `status`. The output is the same as what was returned when\
 Diff was started.
 
@@ -299,7 +299,7 @@ maxctrl call command diff status DiffMyService
 }
 ```
 
-The state is now `comparing`, which means that everything is ready\
+The state is now `comparing`, which means that everything is ready
 and clients can connect in normal fashion.
 
 **Summary**
@@ -310,7 +310,7 @@ Where:
 
 * `diff-service: The name of the service created in the`create\` step.
 
-While Diff is running, it is possible at any point to request\
+While Diff is running, it is possible at any point to request
 a summary.
 
 ```
@@ -318,15 +318,15 @@ maxctrl call command diff summary DiffMyService
 OK
 ```
 
-The summary consists of two files, one for the _main_ server and\
-one for the _other_ server. The files are written to a subdirectory\
-with the same name as the Diff service, which is created in the\
+The summary consists of two files, one for the _main_ server and
+one for the _other_ server. The files are written to a subdirectory
+with the same name as the Diff service, which is created in the
 subdirectory `diff` in the data directory of MaxScale.
 
-Assuming the data directory is the default `/var/lib/maxscale`,\
+Assuming the data directory is the default `/var/lib/maxscale`,
 the directory would in this example be`/var/lib/maxscale/diff/DiffMyService`.
 
-The names of the files will be the server name, concatenated with a\
+The names of the files will be the server name, concatenated with a
 timestamp. In this example, the names of the files could be:
 
 ```
@@ -365,8 +365,8 @@ Stopping Diff reverses the effect of starting it:
 3. The sessions are restarted.
 4. The sessions are resumed.
 
-As the sessions have to be suspended, it may take a while\
-before the operation has completed. The status can be checked with\
+As the sessions have to be suspended, it may take a while
+before the operation has completed. The status can be checked with
 the 'status' command.
 
 **Destroy**
@@ -377,7 +377,7 @@ Where:
 
 * `diff-service: The name of the service created in the`create\` step.
 
-As the final step, the command `destroy` can be called to\
+As the final step, the command `destroy` can be called to
 destroy the service.
 
 ```
@@ -387,23 +387,23 @@ OK
 
 ### Visualizing
 
-The visualization of the data is done with the `maxvisualize` program,\
-which is part of the _Capture_ functionality. The visualization will\
+The visualization of the data is done with the `maxvisualize` program,
+which is part of the _Capture_ functionality. The visualization will
 open up a browser window to show the visualization.
 
-If no browser opens up, the visualization URL is also printed into\
+If no browser opens up, the visualization URL is also printed into
 the command line which by default should be.
 
-In the case of the example above, the directory where the output files\
-are created would be `/var/lib/maxscale/diff/MyService`. And the files\
-to be used when visualizing would be called something like`MyServer1_2024-05-07_140323.json` and`MariaDB_112_2024-05-07_140323.json`. The timestamp will be different\
+In the case of the example above, the directory where the output files
+are created would be `/var/lib/maxscale/diff/MyService`. And the files
+to be used when visualizing would be called something like`MyServer1_2024-05-07_140323.json` and`MariaDB_112_2024-05-07_140323.json`. The timestamp will be different
 every time [summary](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#summary) is executed.
 
 ```
 maxvisualize MyServer1_2024-05-07_140323.json MariaDB_112_2024-05-07_140323.json
 ```
 
-The order is significant; the first argument is the baseline and the\
+The order is significant; the first argument is the baseline and the
 second argument the results compared to the baseline.
 
 ### Continuous Reporting
@@ -446,8 +446,8 @@ Each line (here expanded for readability) in the file will look like:
 
 The meaning of the fields are as follows:
 
-* id: Running number, increases for each query, but will not be in\
-  strict increasing order if a statement needed to be EXPLAINed and\
+* id: Running number, increases for each query, but will not be in
+  strict increasing order if a statement needed to be EXPLAINed and
   the following did not.
 * session: The session id.
 * command: The protocol packet type.
@@ -461,28 +461,28 @@ The meaning of the fields are as follows:
 * type: What type of result `resultset`, `ok` or `error`.
 * explain: The result of `EXPLAIN FORMAT=JSON statement`.
 
-Instead of an `explain` object, there may be an `explained_by` array,\
-containing the ids of similar statements (i.e. their canonical\
+Instead of an `explain` object, there may be an `explained_by` array,
+containing the ids of similar statements (i.e. their canonical
 statement is the same) that were EXPLAINed.
 
 ### Mode
 
-Diff can run in a read-only or read-write mode and the mode is\
+Diff can run in a read-only or read-write mode and the mode is
 deduced from the replication relationship between _main_ and _other_.
 
-If _other_ replicates from _main_, it is assumed that _main_ is\
-the primary. In this case Diff will, when started, stop the\
+If _other_ replicates from _main_, it is assumed that _main_ is
+the primary. In this case Diff will, when started, stop the
 replication from _main_ to _other_. When the comparison ends\
-Diff will, depending on the value of [reset\_replication](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#reset_replication)\
-either reset the replication from _main_ to _other_ or leave\
+Diff will, depending on the value of [reset\_replication](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#reset_replication)
+either reset the replication from _main_ to _other_ or leave
 the situation as it is.
 
-If _other_ and _main_ replicates from a third seriver, it is\
-assumed _main_ is a replica. In this case, Diff will, when\
-started, leave the replication as it is and do nothing when\
+If _other_ and _main_ replicates from a third seriver, it is
+assumed _main_ is a replica. In this case, Diff will, when
+started, leave the replication as it is and do nothing when
 the comparison ends.
 
-If the replication relationship between _main_ and _other_\
+If the replication relationship between _main_ and _other_
 is anything else, Diff will refuse to start.
 
 ### Settings
@@ -493,10 +493,10 @@ is anything else, Diff will refuse to start.
 * Mandatory: Yes
 * Dynamic: No
 
-The main target from which results are returned to the client. Must be\
+The main target from which results are returned to the client. Must be
 a server and must be one of the servers listed in [targets](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
 
-If the connection to the main target cannot be created or is lost\
+If the connection to the main target cannot be created or is lost
 mid-session, the client connection will be closed.
 
 #### `service`
@@ -515,7 +515,7 @@ Specifies the service Diff will modify.
 * Values: `none`, `other`, \`both'
 * Default: `both`
 
-Specifies whether a request should be EXPLAINed on only _other_,\
+Specifies whether a request should be EXPLAINed on only _other_,
 both _other_ and _main_ or neither.
 
 #### `explain_entries`
@@ -525,7 +525,7 @@ both _other_ and _main_ or neither.
 * Dynamic: Yes
 * Default: 2
 
-Specifies how many times at most a particular canonical statement\
+Specifies how many times at most a particular canonical statement
 is EXPLAINed during the period specified by [explain\_period](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#explain_period).
 
 #### `explain_period`
@@ -535,7 +535,7 @@ is EXPLAINed during the period specified by [explain\_period](mariadb-maxscale-2
 * Dynamic: Yes
 * Default: 15m
 
-Specifies the length of the period during which at most [explain\_entries](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#explain_entries) number of EXPLAINs are executed\
+Specifies the length of the period during which at most [explain\_entries](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#explain_entries) number of EXPLAINs are executed
 for a statement.
 
 #### `max_request_lag`
@@ -545,8 +545,8 @@ for a statement.
 * Dynamic: Yes
 * Default: 10
 
-Specifies the maximum number of requests _other_ may be lagging\
-behind _main_ before the execution of SELECTs against _other_\
+Specifies the maximum number of requests _other_ may be lagging
+behind _main_ before the execution of SELECTs against _other_
 are skipped to bring it back in line with _main_.
 
 #### `on_error`
@@ -557,7 +557,7 @@ are skipped to bring it back in line with _main_.
 * Values: `close`, `ignore`
 * Default: `ignore`
 
-Specifies whether an error from _other_, will cause the session to\
+Specifies whether an error from _other_, will cause the session to
 be closed. By default it will not.
 
 #### `percentile`
@@ -569,7 +569,7 @@ be closed. By default it will not.
 * Max: 100
 * Default: 99
 
-Specifies the percentile of samples that will be considered when\
+Specifies the percentile of samples that will be considered when
 calculating the width and number of bins of the histogram.
 
 #### `qps_window`
@@ -579,8 +579,8 @@ calculating the width and number of bins of the histogram.
 * Dynamic: No
 * Default: 15m
 
-Specifies the size of the sliding window during which QPS is calculated\
-and stored. When a [summary](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#summary) is requested, the QPS information\
+Specifies the size of the sliding window during which QPS is calculated
+and stored. When a [summary](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#summary) is requested, the QPS information
 will also be saved.
 
 #### `report`
@@ -591,7 +591,7 @@ will also be saved.
 * Values: `always`, `on_discrepancy`, `never`
 * Default: `on_discrepancy`
 
-Specifies when the results of executing a statement on _other_ and _main_\
+Specifies when the results of executing a statement on _other_ and _main_
 should be logged; _always_, when there is a significant difference or _never_.
 
 #### `reset_replication`
@@ -601,7 +601,7 @@ should be logged; _always_, when there is a significant difference or _never_.
 * Dynamic: Yes
 * Default: `true`
 
-If Diff has started in read-write mode and the value of`reset_replication` is `true`, when the comparison ends\
+If Diff has started in read-write mode and the value of`reset_replication` is `true`, when the comparison ends
 it will execute the following on _other_:
 
 ```
@@ -609,11 +609,11 @@ RESET SLAVE
 START SLAVE
 ```
 
-If Diff has started in read-only mode, the value of `reset_replication`\
+If Diff has started in read-only mode, the value of `reset_replication`
 will be ignored.
 
 Note that since Diff writes updates directly to both _main_ and _other_ there is no guarantee that it will be possible to simply
-start the replication. Especially not if `gtid_strict_mode`\
+start the replication. Especially not if `gtid_strict_mode`
 is on.
 
 #### `retain_faster_statements`
@@ -624,7 +624,7 @@ is on.
 * Default: 5
 
 Specifies the number of faster statements that are retained in memory.\
-The statements will be saved in the summary when the comparison ends,\
+The statements will be saved in the summary when the comparison ends,
 or when Diff is explicitly instructed to do so.
 
 #### `retain_slower_statements`
@@ -642,16 +642,16 @@ or when Diff is explicitly instructed to do so.
 * Min: 100
 * Default: 1000
 
-Specifies the number of samples that will be collected in order to\
+Specifies the number of samples that will be collected in order to
 define the edges and number of bins of the histograms.
 
 ### Limitations
 
-Diff is not capable of adapting to any changes made in\
-the cluster configuration. For instance, if Diff starts up in\
-read-only mode and _main_ is subsequently made _primary_, Diff\
-will not sever the replication from _main_ to _other_. The result\
-will be that _other_ receives the same writes twice; once via the\
+Diff is not capable of adapting to any changes made in
+the cluster configuration. For instance, if Diff starts up in
+read-only mode and _main_ is subsequently made _primary_, Diff
+will not sever the replication from _main_ to _other_. The result
+will be that _other_ receives the same writes twice; once via the
 replication from the server it is replicating from and once when\
 Diff executes the same writes.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-kafkacdc.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-kafkacdc.md
@@ -4,10 +4,10 @@
 
 ### Overview
 
-The KafkaCDC module reads data changes in MariaDB via replication and converts\
+The KafkaCDC module reads data changes in MariaDB via replication and converts
 them into JSON objects that are then streamed to a Kafka broker.
 
-DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the\
+DDL events (`CREATE TABLE`, `ALTER TABLE`) are streamed as JSON objects in the
 following format (example created by `CREATE TABLE test.t1(id INT)`):
 
 ```
@@ -67,10 +67,10 @@ following format (example created by `CREATE TABLE test.t1(id INT)`):
 }
 ```
 
-The `domain`, `server_id` and `sequence` fields contain the GTID that this event\
-belongs to. The `event_number` field is the sequence number of events inside the\
-transaction starting from 1. The `timestamp` field is the UNIX timestamp when\
-the event occurred. The `event_type` field contains the type of the event, one\
+The `domain`, `server_id` and `sequence` fields contain the GTID that this event
+belongs to. The `event_number` field is the sequence number of events inside the
+transaction starting from 1. The `timestamp` field is the UNIX timestamp when
+the event occurred. The `event_type` field contains the type of the event, one
 of:
 
 * `insert`: the event is the data that was added to MariaDB
@@ -78,13 +78,13 @@ of:
 * `update_before`: the event contains the data before an update statement modified it
 * `update_after`: the event contains the data after an update statement modified it
 
-All remaining fields contains data from the table. In the example event this\
+All remaining fields contains data from the table. In the example event this
 would be the fields `id` and `data`.
 
 The sending of these schema objects is optional and can be disabled using`send_schema=false`.
 
-DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that\
-follow the format specified in the DDL event. The objects are in the following\
+DML events (`INSERT`, `UPDATE`, `DELETE`) are streamed as JSON objects that
+follow the format specified in the DDL event. The objects are in the following
 format (example created by `INSERT INTO test.t1 VALUES (1)`):
 
 ```
@@ -101,28 +101,28 @@ format (example created by `INSERT INTO test.t1 VALUES (1)`):
 }
 ```
 
-The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These\
+The `table_name` and `table_schema` fields were added in MaxScale 2.5.3. These
 contain the table name and schema the event targets.
 
-The router stores table metadata in the MaxScale data directory. The\
-default value is `/var/lib/maxscale/<service name>`. If data for a table\
-is replicated before a DDL event for it is replicated, the CREATE TABLE\
+The router stores table metadata in the MaxScale data directory. The
+default value is `/var/lib/maxscale/<service name>`. If data for a table
+is replicated before a DDL event for it is replicated, the CREATE TABLE
 will be queried from the primary server.
 
-During shutdown, the Kafka event queue is flushed. This can take up to 60\
+During shutdown, the Kafka event queue is flushed. This can take up to 60
 seconds if the network is slow or there are network problems.
 
 ### Configuration
 
-* In order for `kafkacdc` to work, the binary logging on the source server must\
-  be configured to use row-based replication and the row image must be set to\
+* In order for `kafkacdc` to work, the binary logging on the source server must
+  be configured to use row-based replication and the row image must be set to
   full by configuring `binlog_format=ROW` and `binlog_row_image=FULL`.
-* The `servers` parameter defines the set of servers where the data is\
-  replicated from. The replication will be done from the first primary server\
+* The `servers` parameter defines the set of servers where the data is
+  replicated from. The replication will be done from the first primary server
   that is found.
-* The `user` and `password` of the service will be used to connect to the\
+* The `user` and `password` of the service will be used to connect to the
   primary. This user requires the `REPLICATION SLAVE` grant.
-* The KafkaCDC service must not be configured to use listeners. If a listener is\
+* The KafkaCDC service must not be configured to use listeners. If a listener is
   configured, all attempts to start a session will fail.
 
 ### Settings
@@ -133,7 +133,7 @@ seconds if the network is slow or there are network problems.
 * Mandatory: Yes
 * Dynamic: No
 
-The list of Kafka brokers to use in `host:port` format. Multiple values\
+The list of Kafka brokers to use in `host:port` format. Multiple values
 can be separated with commas. This is a mandatory parameter.
 
 #### `topic`
@@ -142,7 +142,7 @@ can be separated with commas. This is a mandatory parameter.
 * Mandatory: Yes
 * Dynamic: No
 
-The Kafka topic where the replicated events will be sent. This is a\
+The Kafka topic where the replicated events will be sent. This is a
 mandatory parameter.
 
 #### `enable_idempotence`
@@ -152,22 +152,22 @@ mandatory parameter.
 * Dynamic: No
 * Default: `false`
 
-Enable idempotent producer mode. This feature requires Kafka version 0.11 or\
+Enable idempotent producer mode. This feature requires Kafka version 0.11 or
 newer to work and is disabled by default.
 
-When enabled, the Kafka producer enters a strict mode which avoids event\
-duplication due to broker outages or other network errors. In HA scenarios where\
-there are more than two MaxScale instances, event duplication can still happen\
+When enabled, the Kafka producer enters a strict mode which avoids event
+duplication due to broker outages or other network errors. In HA scenarios where
+there are more than two MaxScale instances, event duplication can still happen
 as there is no synchronization between the MaxScale instances.
 
-The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),\
+The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md),
 describes the parameter as follows:
 
-When set to true, the producer will ensure that messages are successfully\
-produced exactly once and in the original produce order. The following\
-configuration properties are adjusted automatically (if not modified by the\
-user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must\
-be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),\
+When set to true, the producer will ensure that messages are successfully
+produced exactly once and in the original produce order. The following
+configuration properties are adjusted automatically (if not modified by the
+user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must
+be less than or equal to 5), retries=INT32\_MAX (must be greater than 0),
 acks=all, queuing.strategy=fifo.
 
 #### `timeout`
@@ -186,20 +186,20 @@ The connection and read timeout for the replication stream.
 * Dynamic: No
 * Default: `""`
 
-The initial GTID position from where the replication is started. By default the\
-replication is started from the beginning. The value of this parameter is only\
-used if no previously replicated events with GTID positions can be retrieved\
+The initial GTID position from where the replication is started. By default the
+replication is started from the beginning. The value of this parameter is only
+used if no previously replicated events with GTID positions can be retrieved
 from Kafka.
 
-Starting in MaxScale 24.02, the special values `newest` and `oldest` can be\
+Starting in MaxScale 24.02, the special values `newest` and `oldest` can be
 used:
 
-* `newest` uses the current value of `@@gtid_binlog_pos` as the GTID where the\
+* `newest` uses the current value of `@@gtid_binlog_pos` as the GTID where the
   replication is started from.
-* `oldest` uses the oldest binlog that's available in `SHOW BINARY LOGS` and\
+* `oldest` uses the oldest binlog that's available in `SHOW BINARY LOGS` and
   then extracting the oldest GTID from it with `SHOW BINLOG EVENTS`.
 
-Once the replication has started and a GTID position has been recorded, this\
+Once the replication has started and a GTID position has been recorded, this
 parameter will be ignored. To reset the recorded GTID position, delete the`current_gtid.txt` file located in `/var/lib/maxscale/<SERVICE>/` where`<SERVICE>` is the name of the KafkaCDC service.
 
 #### `server_id`
@@ -209,8 +209,8 @@ parameter will be ignored. To reset the recorded GTID position, delete the`curre
 * Dynamic: No
 * Default: `1234`
 
-The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)\
-used when replicating from the primary in direct replication mode. The default\
+The [server\_id](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id)
+used when replicating from the primary in direct replication mode. The default
 value is 1234. This parameter was added in MaxScale 2.5.7.
 
 #### `match`
@@ -224,13 +224,13 @@ Only include data from tables that match this pattern.
 
 For example, if configured with `match=accounts[.].*`, only data from the`accounts` database is sent to Kafka.
 
-The pattern is matched against the combined database and table name separated by\
-a period. This means that the event for the table `t1` in the `test` database\
-would appear as `test.t1`. The behavior is the same even if the database or the\
-table name contains a period. This means that an event for the `test.table`\
+The pattern is matched against the combined database and table name separated by
+a period. This means that the event for the table `t1` in the `test` database
+would appear as `test.t1`. The behavior is the same even if the database or the
+table name contains a period. This means that an event for the `test.table`
 table in the `my.data` database would appear as `my.data.test.table`.
 
-Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are\
+Here is an example configuration that only sends events for tables from the`db1` database. The `accounts` and `users` tables in the `db1` database are
 filtered out using the `exclude` parameter.
 
 ```
@@ -255,11 +255,11 @@ exclude=db1 [.](accounts|users)
 
 Exclude data from tables that match this pattern.
 
-For example, if configured with `exclude=mydb[.].*`, all data from the tables in\
+For example, if configured with `exclude=mydb[.].*`, all data from the tables in
 the `mydb` database is not sent to Kafka.
 
-The pattern matching works the same way for both of the `exclude` and `match`\
-parameters. See [match](mariadb-maxscale-2501-maxscale-2501-kafkacdc.md#match) for an explanation on how the patterns are\
+The pattern matching works the same way for both of the `exclude` and `match`
+parameters. See [match](mariadb-maxscale-2501-maxscale-2501-kafkacdc.md#match) for an explanation on how the patterns are
 matched against the database and table names.
 
 #### `cooperative_replication`
@@ -269,22 +269,22 @@ matched against the database and table names.
 * Dynamic: No
 * Default: `false`
 
-Controls whether multiple instances cooperatively replicate from the same\
+Controls whether multiple instances cooperatively replicate from the same
 cluster. This is a boolean parameter and is disabled by default. It was added in\
 MaxScale 6.0.
 
-When this parameter is enabled and the monitor pointed to by the `cluster`\
-parameter supports cooperative monitoring (currently only `mariadbmon`), the\
+When this parameter is enabled and the monitor pointed to by the `cluster`
+parameter supports cooperative monitoring (currently only `mariadbmon`), the
 replication is only active if the monitor owns the cluster it is monitoring.
 
-Whenever an instance that does not own the cluster gains ownership of the\
-cluster, the replication will continue from the latest GTID that was delivered\
+Whenever an instance that does not own the cluster gains ownership of the
+cluster, the replication will continue from the latest GTID that was delivered
 to Kafka.
 
-This means that multiple MaxScale instances can replicate from the same set of\
-servers and the event is only processed once. This feature does not provide\
-exactly-once semantics for the Kafka event delivery. However, it does provide\
-high-availability for the `kafkacdc` instances which allows automated failover\
+This means that multiple MaxScale instances can replicate from the same set of
+servers and the event is only processed once. This feature does not provide
+exactly-once semantics for the Kafka event delivery. However, it does provide
+high-availability for the `kafkacdc` instances which allows automated failover
 between multiple MaxScale instances.
 
 #### `send_schema`
@@ -294,12 +294,12 @@ between multiple MaxScale instances.
 * Dynamic: Yes
 * Default: true
 
-Send JSON schema object into the stream whenever the table schema changes. These\
-events, as described [here](mariadb-maxscale-2501-maxscale-2501-kafkacdc.md#overview), can be used to detect whenever the\
+Send JSON schema object into the stream whenever the table schema changes. These
+events, as described [here](mariadb-maxscale-2501-maxscale-2501-kafkacdc.md#overview), can be used to detect whenever the
 format of the data being sent changes.
 
-If this information in these schema change events is not needed or the code that\
-processes the Kafka stream can't handle them, they can be disabled with this\
+If this information in these schema change events is not needed or the code that
+processes the Kafka stream can't handle them, they can be disabled with this
 parameter.
 
 #### `read_gtid_from_kafka`
@@ -309,10 +309,10 @@ parameter.
 * Dynamic: No
 * Default: `true`
 
-On startup, the latest GTID is by default read from the Kafka cluster. This\
+On startup, the latest GTID is by default read from the Kafka cluster. This
 makes it possible to recover the replication position stored by another\
-MaxScale. Sometimes this is not desirable and the GTID should only be read from\
-the local file or started anew. Examples of these are when the GTIDs are reset\
+MaxScale. Sometimes this is not desirable and the GTID should only be read from
+the local file or started anew. Examples of these are when the GTIDs are reset
 or the replication topology has changed.
 
 #### `kafka_ssl`
@@ -322,7 +322,7 @@ or the replication topology has changed.
 * Dynamic: No
 * Default: `false`
 
-Enable SSL for Kafka connections. This is a boolean parameter and is disabled by\
+Enable SSL for Kafka connections. This is a boolean parameter and is disabled by
 default.
 
 #### `kafka_ssl_ca`
@@ -332,7 +332,7 @@ default.
 * Dynamic: No
 * Default: `""`
 
-Path to the certificate authority file in PEM format. If this is not provided,\
+Path to the certificate authority file in PEM format. If this is not provided,
 the default system certificates will be used.
 
 #### `kafka_ssl_cert`
@@ -344,8 +344,8 @@ the default system certificates will be used.
 
 Path to the public certificate in PEM format.
 
-The client must provide a certificate if the Kafka server performs authentication\
-of the client certificates. This feature is enabled by default in Kafka and is\
+The client must provide a certificate if the Kafka server performs authentication
+of the client certificates. This feature is enabled by default in Kafka and is
 controlled by [ssl.endpoint.identification.algorithm](https://kafka.apache.org/documentation/#brokerconfigs_ssl.endpoint.identification.algorithm).
 
 If `kafka_ssl_cert` is provided, `kafka_ssl_key` must also be provided.
@@ -391,8 +391,8 @@ If `kafka_sasl_password` is provided, `kafka_sasl_user` must also be provided.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-The SASL mechanism used. The default value is `PLAIN` which uses plaintext\
-authentication. It is recommended to enable SSL whenever plaintext\
+The SASL mechanism used. The default value is `PLAIN` which uses plaintext
+authentication. It is recommended to enable SSL whenever plaintext
 authentication is used.
 
 Allowed values are:
@@ -406,7 +406,7 @@ Kafka broker.
 
 ### Example Configuration
 
-The following configuration defines the minimal setup for streaming replication\
+The following configuration defines the minimal setup for streaming replication
 events from MariaDB into Kafka as JSON:
 
 ```
@@ -438,8 +438,8 @@ topic=my-cdc-topic
 
 ### Limitations
 
-* The KafkaCDC module provides at-least-once semantics for the generated\
-  events. This means that each replication event is delivered to kafka at least\
+* The KafkaCDC module provides at-least-once semantics for the generated
+  events. This means that each replication event is delivered to kafka at least
   once but there can be duplicate events in case of failures.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-kafkaimporter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-kafkaimporter.md
@@ -5,8 +5,8 @@
 ### Overview
 
 The KafkaImporter module reads messages from Kafka and streams them into a\
-MariaDB server. The messages are inserted into a table designated by either the\
-topic name or the message key (see [table\_name\_in](mariadb-maxscale-2501-maxscale-2501-kafkaimporter.md#table_name_in) for\
+MariaDB server. The messages are inserted into a table designated by either the
+topic name or the message key (see [table\_name\_in](mariadb-maxscale-2501-maxscale-2501-kafkaimporter.md#table_name_in) for
 details). By default the table will be automatically created with the following\
 SQL:
 
@@ -17,31 +17,31 @@ CREATE TABLE IF NOT EXISTS my_table (
 );
 ```
 
-The payload of the message is inserted into the `data` field from which the `id`\
-field is calculated. The payload must be a valid JSON object and it must either\
-contain a unique `_id` field or it must not exist or the value must be a JSON\
-null. This is similar to the MongoDB document format where the `_id` field is\
+The payload of the message is inserted into the `data` field from which the `id`
+field is calculated. The payload must be a valid JSON object and it must either
+contain a unique `_id` field or it must not exist or the value must be a JSON
+null. This is similar to the MongoDB document format where the `_id` field is
 the primary key of the document collection.
 
-If a message is read from Kafka and the insertion into the table fails due to a\
-violation of one of the constraints, the message is ignored. Similarly, messages\
-with duplicate `_id` value are also ignored: this is done to avoid inserting the\
-same document multiple times whenever the connection to either Kafka or MariaDB\
+If a message is read from Kafka and the insertion into the table fails due to a
+violation of one of the constraints, the message is ignored. Similarly, messages
+with duplicate `_id` value are also ignored: this is done to avoid inserting the
+same document multiple times whenever the connection to either Kafka or MariaDB
 is lost.
 
-The limitations on the data can be removed by either creating the table before\
-the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`\
-does nothing, or by altering the structure of the existing table. The minimum\
-requirement that must be met is that the table contains the `data` field to\
+The limitations on the data can be removed by either creating the table before
+the KafkaImporter is started, in which case the `CREATE TABLE IF NOT EXISTS`
+does nothing, or by altering the structure of the existing table. The minimum
+requirement that must be met is that the table contains the `data` field to
 which string values can be inserted into.
 
-The database server where the data is inserted is chosen from the set of servers\
-available to the service. The first server labeled as the `Master` with the best\
+The database server where the data is inserted is chosen from the set of servers
+available to the service. The first server labeled as the `Master` with the best
 rank will be chosen. This means that a monitor must be configured for the\
 MariaDB server where the data is to be inserted.
 
-In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 25.01.1\
-the `_id` field is not required to be present. Older versions of MaxScale used\
+In MaxScale versions 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and 25.01.1
+the `_id` field is not required to be present. Older versions of MaxScale used
 the following SQL where the `_id` field was mandatory:
 
 ```
@@ -82,9 +82,9 @@ The comma separated list of topics to subscribe to.
 * Dynamic: Yes
 * Default: `100`
 
-Maximum number of uncommitted records. The KafkaImporter will buffer records\
-into batches and commit them once either enough records are gathered (controlled\
-by this parameter) or when the KafkaImporter goes idle. Any uncommitted records\
+Maximum number of uncommitted records. The KafkaImporter will buffer records
+into batches and commit them once either enough records are gathered (controlled
+by this parameter) or when the KafkaImporter goes idle. Any uncommitted records
 will be read again if a reconnection to either Kafka or MariaDB occurs.
 
 #### `kafka_sasl_mechanism`
@@ -95,7 +95,7 @@ will be read again if a reconnection to either Kafka or MariaDB occurs.
 * Values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
 * Default: `PLAIN`
 
-SASL mechanism to use. The Kafka broker must be configured with the same\
+SASL mechanism to use. The Kafka broker must be configured with the same
 authentication scheme.
 
 #### `kafka_sasl_user`
@@ -114,7 +114,7 @@ SASL username used for authentication. If this parameter is defined,`kafka_sasl_
 * Dynamic: Yes
 * Default: `""`
 
-SASL password for the user. If this parameter is defined, `kafka_sasl_user` must\
+SASL password for the user. If this parameter is defined, `kafka_sasl_user` must
 also be provided.
 
 #### `kafka_ssl`
@@ -133,7 +133,7 @@ Enable SSL for Kafka connections.
 * Dynamic: Yes
 * Default: `""`
 
-SSL Certificate Authority file in PEM format. If this parameter is not\
+SSL Certificate Authority file in PEM format. If this parameter is not
 defined, the system default CA certificate is used.
 
 #### `kafka_ssl_cert`
@@ -167,14 +167,14 @@ The Kafka message part that is used to locate the table to insert the data into.
 Enumeration Values:
 
 * `topic`: The topic named is used as the fully qualified table name.
-* `key`: The message key is used as the fully qualified table name. If the Kafka\
+* `key`: The message key is used as the fully qualified table name. If the Kafka
   message does not have a key, the message is ignored.
 
-For example, all messages with a fully qualified table name of `my_db.my_table`\
-will be inserted into the table `my_table` located in the `my_db` database. If\
-the table or database names have special characters that must be escaped to make\
-them valid identifiers, the name must also contain those escape characters. For\
-example, to insert into a table named `my table` in the database `my database`,\
+For example, all messages with a fully qualified table name of `my_db.my_table`
+will be inserted into the table `my_table` located in the `my_db` database. If
+the table or database names have special characters that must be escaped to make
+them valid identifiers, the name must also contain those escape characters. For
+example, to insert into a table named `my table` in the database `my database`,
 the name would be:
 
 ```
@@ -199,20 +199,20 @@ Timeout for both Kafka and MariaDB network communication.
 
 The storage engine used for tables that are created by the KafkaImporter.
 
-This defines the `ENGINE` table option and must be the name of a valid storage\
-engine in MariaDB. When the storage engine is something other than `InnoDB`, the\
+This defines the `ENGINE` table option and must be the name of a valid storage
+engine in MariaDB. When the storage engine is something other than `InnoDB`, the
 table is created without the generated column and the check constraints:
 
 ```
 CREATE TABLE IF NOT EXISTS my_table (data JSON NOT NULL);
 ```
 
-This is done to avoid conflicts where the custom engine does not support all the\
+This is done to avoid conflicts where the custom engine does not support all the
 features that InnoDB supports.
 
 ### Limitations
 
-* The backend servers used by this service must be MariaDB version 10.2 or\
+* The backend servers used by this service must be MariaDB version 10.2 or
   newer.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-mirror.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-mirror.md
@@ -4,11 +4,11 @@
 
 ### Overview
 
-The `mirror` router is designed for data consistency and database behavior\
-verification during system upgrades. It allows statement duplication to multiple\
+The `mirror` router is designed for data consistency and database behavior
+verification during system upgrades. It allows statement duplication to multiple
 servers in a manner similar to that of the [Tee filter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-tee-filter.md) with exporting of collected query metrics.
 
-For each executed query the router exports a JSON object that describes the\
+For each executed query the router exports a JSON object that describes the
 query results and has the following fields:
 
 | Key       | Description                                              |
@@ -19,7 +19,7 @@ query results and has the following fields:
 | query\_id | Query sequence number, starts from 1                     |
 | results   | Array of query result objects                            |
 
-The objects in the `results` array describe an individual query result and have\
+The objects in the `results` array describe an individual query result and have
 the following fields:
 
 | Key      | Description                                |
@@ -39,12 +39,12 @@ the following fields:
 * Mandatory: Yes
 * Dynamic: Yes
 
-The main target from which results are returned to the client. This is a\
+The main target from which results are returned to the client. This is a
 mandatory parameter and must define one of the targets configured in the`targets` parameter of the service.
 
-If the connection to the main target cannot be created or is lost mid-session,\
-the client connection will be closed. Connection failures to other targets are\
-not fatal errors and any open connections to them will be closed. The router\
+If the connection to the main target cannot be created or is lost mid-session,
+the client connection will be closed. Connection failures to other targets are
+not fatal errors and any open connections to them will be closed. The router
 does not create new connections after the initial connections are created.
 
 #### `exporter`
@@ -54,7 +54,7 @@ does not create new connections after the initial connections are created.
 * Dynamic: Yes
 * Values: `log`, `file`, `kafka`
 
-The exporter where the data is exported. This is a mandatory parameter. Possible\
+The exporter where the data is exported. This is a mandatory parameter. Possible
 values are:
 
 * `log`
@@ -62,7 +62,7 @@ values are:
 * `file`
 * Exports metrics to a file. Configured with the [file](mariadb-maxscale-2501-maxscale-2501-mirror.md#file) parameter.
 * `kafka`
-* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2501-maxscale-2501-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2501-maxscale-2501-mirror.md#kafka_topic)\
+* Exports metrics to a Kafka broker. Configured with the [kafka\_broker](mariadb-maxscale-2501-maxscale-2501-mirror.md#kafka_broker) and [kafka\_topic](mariadb-maxscale-2501-maxscale-2501-mirror.md#kafka_topic)
   parameters.
 
 #### `file`
@@ -72,12 +72,12 @@ values are:
 * Mandatory: No
 * Dynamic: Yes
 
-The output file where the metrics will be written. The file must be writable by\
+The output file where the metrics will be written. The file must be writable by
 the user that is running MaxScale, usually the `maxscale` user.
 
-When the `file` parameter is altered at runtime, the old file is closed before\
-the new file is opened. This makes it a convenient way of rotating the file\
-where the metrics are exported. Note that the file name alteration must change\
+When the `file` parameter is altered at runtime, the old file is closed before
+the new file is opened. This makes it a convenient way of rotating the file
+where the metrics are exported. Note that the file name alteration must change
 the value for it to take effect.
 
 This is a mandatory parameter when configured with `exporter=file`.
@@ -89,7 +89,7 @@ This is a mandatory parameter when configured with `exporter=file`.
 * Mandatory: No
 * Dynamic: Yes
 
-The Kafka broker list. Must be given as a comma-separated list of broker hosts\
+The Kafka broker list. Must be given as a comma-separated list of broker hosts
 with optional ports in `host:port` format.
 
 This is a mandatory parameter when configured with `exporter=kafka`.
@@ -116,12 +116,12 @@ This is a mandatory parameter when configured with `exporter=kafka`.
 What to do when a backend network connection fails. Accepted values are:
 
 * `ignore`
-* Ignore the failing backend if it's not the backend that the `main` parameter\
+* Ignore the failing backend if it's not the backend that the `main` parameter
   points to.
 * `close`
 * Close the client connection when the first backend fails.
 
-This parameter was added in MaxScale 6.0. Older versions always ignored\
+This parameter was added in MaxScale 6.0. Older versions always ignored
 failing backends.
 
 #### `report`
@@ -139,7 +139,7 @@ When to report the result of the queries. Accepted values are:
 * `on_conflict`
 * Only report when one or more backends returns a conflicting result.
 
-This parameter was added in MaxScale 6.0. Older versions always reported the\
+This parameter was added in MaxScale 6.0. Older versions always reported the
 result.
 
 ### Example Configuration
@@ -184,8 +184,8 @@ port=3306
 * Broken network connections are not recreated.
 * Prepared statements are not supported.
 * Contents of non-SQL statements are not added to the exported metrics.
-* Data synchronization in dynamic environments (e.g. when replication is in use)\
-  is not guaranteed. This means that result mismatches can be reported when the\
+* Data synchronization in dynamic environments (e.g. when replication is in use)
+  is not guaranteed. This means that result mismatches can be reported when the
   data is only eventually consistent.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readconnroute.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readconnroute.md
@@ -2,30 +2,30 @@
 
 ## Readconnroute
 
-This document provides an overview of the **readconnroute** router module\
-and its intended use case scenarios. It also displays all router\
+This document provides an overview of the **readconnroute** router module
+and its intended use case scenarios. It also displays all router
 configuration parameters with their descriptions.
 
 ### Overview
 
-The readconnroute router provides simple and lightweight load balancing\
-across a set of servers. The router can also be configured to balance\
+The readconnroute router provides simple and lightweight load balancing
+across a set of servers. The router can also be configured to balance
 connections based on a weighting parameter defined in the server's section.
 
 Note that \*_readconnroute_ balances _connections_ and not _statements_.\
-When a client connects, the router selects a server based upon the router\
-configuration and current server load, but the single created connection\
-is fixed and will not be changed for the duration of the session. If the\
-connection between MaxScale and the server breaks, the connection cannot\
-be re-established and the session will be closed. The fact that the server\
+When a client connects, the router selects a server based upon the router
+configuration and current server load, but the single created connection
+is fixed and will not be changed for the duration of the session. If the
+connection between MaxScale and the server breaks, the connection cannot
+be re-established and the session will be closed. The fact that the server
 is fixed when the client connects also means that routing hints are ignored.
 
-**Warning:** `readconnroute` will not prevent writes from being done even if you\
-define `router_options=slave`. The client application is responsible for\
-making sure that it only performs read-only queries in such\
-cases. `readconnroute` is simple by design: it selects a server for each\
-client connection and routes all queries there. If something more complex is\
-required, the [readwritesplit](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md) router is usually the right\
+**Warning:** `readconnroute` will not prevent writes from being done even if you
+define `router_options=slave`. The client application is responsible for
+making sure that it only performs read-only queries in such
+cases. `readconnroute` is simple by design: it selects a server for each
+client connection and routes all queries there. If something more complex is
+required, the [readwritesplit](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md) router is usually the right
 choice.
 
 ### Settings
@@ -40,8 +40,8 @@ For more details about the standard service parameters, refer to the [Configurat
 * Values: `master`, `slave`, `synced`, `running`
 * Default: `running`
 
-**`router_options`** can contain a comma separated list of valid server\
-roles. These roles are used as the valid types of servers the router will\
+**`router_options`** can contain a comma separated list of valid server
+roles. These roles are used as the valid types of servers the router will
 form connections to when new sessions are created.
 
 Examples:
@@ -60,14 +60,14 @@ Here is a list of all possible values for the `router_options`.
 | synced  | A Galera cluster node which is in a synced state with the cluster.                                                                                                                                                           |
 | running | A server that is up and running. All servers that MariaDB MaxScale can connect to are labeled as running.                                                                                                                    |
 
-If no `router_options` parameter is configured in the service definition,\
-the router will use the default value of `running`. This means that it will\
-load balance connections across all running servers defined in the `servers`\
+If no `router_options` parameter is configured in the service definition,
+the router will use the default value of `running`. This means that it will
+load balance connections across all running servers defined in the `servers`
 parameter of the service.
 
-When a connection is being created and the candidate server is being chosen,\
-the list of servers is processed in from first entry to last. This means\
-that if two servers with equal weight and status are found, the one that's\
+When a connection is being created and the candidate server is being chosen,
+the list of servers is processed in from first entry to last. This means
+that if two servers with equal weight and status are found, the one that's
 listed first in the _servers_ parameter for the service is chosen.
 
 #### `master_accept_reads`
@@ -78,8 +78,8 @@ listed first in the _servers_ parameter for the service is chosen.
 * Default: true
 
 This option can be used to prevent queries from being sent to the current primary.\
-If `router_options` does not contain `master`, the readconnroute instance is\
-usually meant for reading. Setting `master_accept_reads=false` excludes the primary\
+If `router_options` does not contain `master`, the readconnroute instance is
+usually meant for reading. Setting `master_accept_reads=false` excludes the primary
 from server selection (and thus from receiving reads).
 
 If `router_options` contains `master`, the setting of `master_accept_reads` has no effect.
@@ -93,22 +93,22 @@ By default `master_accept_reads=true`.
 * Dynamic: Yes
 * Default: 0s
 
-The maximum acceptable replication lag. The value is in seconds and is specified\
-as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). The\
+The maximum acceptable replication lag. The value is in seconds and is specified
+as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). The
 default value is `0s`, which means that the lag is ignored.
 
-The replication lag of a server must be less than the configured value in order\
-for it to be used for routing. To configure the router to not allow any lag, use\
+The replication lag of a server must be less than the configured value in order
+for it to be used for routing. To configure the router to not allow any lag, use
 the smallest duration larger than 0, that is, `max_replication_lag=1s`.
 
 ### Examples
 
-The most common use for the readconnroute is to provide either a read or\
-write port for an application. This provides a more lightweight routing\
-solution than the more complex readwritesplit router but requires the\
+The most common use for the readconnroute is to provide either a read or
+write port for an application. This provides a more lightweight routing
+solution than the more complex readwritesplit router but requires the
 application to be able to use distinct write and read ports.
 
-To configure a read-only service that tolerates primary failures, we first\
+To configure a read-only service that tolerates primary failures, we first
 need to add a new section into the configuration file.
 
 ```
@@ -119,11 +119,11 @@ servers=replica1,replica2,replica3
 router_options=slave
 ```
 
-Here the `router_options` designates replicas as the only valid server\
-type. With this configuration, the queries are load balanced across the\
+Here the `router_options` designates replicas as the only valid server
+type. With this configuration, the queries are load balanced across the
 replica servers.
 
-For more complex examples of the readconnroute router, take a look at the\
+For more complex examples of the readconnroute router, take a look at the
 examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
 
 ### Router Diagnostics

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
@@ -2,53 +2,53 @@
 
 ## Readwritesplit
 
-This document provides a short overview of the **readwritesplit** router module\
-and its intended use case scenarios. It also displays all router configuration\
-parameters with their descriptions. A list of current limitations of the module\
+This document provides a short overview of the **readwritesplit** router module
+and its intended use case scenarios. It also displays all router configuration
+parameters with their descriptions. A list of current limitations of the module
 is included and use examples are provided.
 
 ### Overview
 
-The **readwritesplit** router is designed to increase the read-only processing\
-capability of a cluster while maintaining consistency. This is achieved by\
-splitting the query load into read and write queries. Read queries, which do not\
-modify data, are spread across multiple nodes while all write queries will be\
+The **readwritesplit** router is designed to increase the read-only processing
+capability of a cluster while maintaining consistency. This is achieved by
+splitting the query load into read and write queries. Read queries, which do not
+modify data, are spread across multiple nodes while all write queries will be
 sent to a single node.
 
-The router is designed to be used with a traditional Primary-Replica replication\
-cluster. It automatically detects changes in the primary server and will use the\
-current primary server of the cluster. With a Galera cluster, one can achieve a\
+The router is designed to be used with a traditional Primary-Replica replication
+cluster. It automatically detects changes in the primary server and will use the
+current primary server of the cluster. With a Galera cluster, one can achieve a
 resilient setup and easy primary failover by using one of the Galera nodes as a\
-Write-Primary node, where all write queries are routed, and spreading the read\
+Write-Primary node, where all write queries are routed, and spreading the read
 load over all the nodes.
 
 ### Interaction with servers in `Maintenance` and `Draining` state
 
-When a server that readwritesplit uses is put into maintenance mode, any ongoing\
-requests are allowed to finish before the connection is closed. If the server\
-that is put into maintenance mode is a primary, open transaction are allowed to\
-complete before the connection is closed. Note that this means neither idle\
-session nor long-running transactions will be closed by readwritesplit. To\
+When a server that readwritesplit uses is put into maintenance mode, any ongoing
+requests are allowed to finish before the connection is closed. If the server
+that is put into maintenance mode is a primary, open transaction are allowed to
+complete before the connection is closed. Note that this means neither idle
+session nor long-running transactions will be closed by readwritesplit. To
 forcefully close the connections, use the following command:
 
 ```
 maxctrl set server <server> maintenance --force
 ```
 
-If a server is put into the `Draining` state while a connection is open, the\
-connection will be used normally. Whenever a new connection needs to be created,\
-whether that be due to a network error or when a new session being opened, only\
+If a server is put into the `Draining` state while a connection is open, the
+connection will be used normally. Whenever a new connection needs to be created,
+whether that be due to a network error or when a new session being opened, only
 servers that are neither `Draining` nor `Drained` will be used.
 
 ### Configuration
 
-Readwritesplit router-specific settings are specified in the configuration file\
-of MariaDB MaxScale in its specific section. The section can be freely named but\
+Readwritesplit router-specific settings are specified in the configuration file
+of MariaDB MaxScale in its specific section. The section can be freely named but
 the name is used later as a reference in a listener section.
 
 For more details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
 
-Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be\
+Starting with 2.3, all router parameters can be configured at runtime. Use`maxctrl alter service` to modify them. The changed configuration will only be
 taken into use by new sessions.
 
 ### Settings
@@ -60,45 +60,45 @@ taken into use by new sessions.
 * Dynamic: Yes
 * Default: 255
 
-`max_slave_connections` sets the maximum number of replicas a router session uses\
-at any moment. The default is to use at most 255 replica connections per client\
-connection. In older versions the default was to use all available replicas with\
+`max_slave_connections` sets the maximum number of replicas a router session uses
+at any moment. The default is to use at most 255 replica connections per client
+connection. In older versions the default was to use all available replicas with
 no limit.
 
 For MaxScale 2.5.12 and newer, the minimum value is 0.
 
-For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions\
-suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that\
-causes the parameter to accept any values but only function when a value greater\
+For MaxScale versions 2.5.11 and older, the minimum value is 1. These versions
+suffer from a bug ([MXS-3536](https://jira.mariadb.org/browse/MXS-3536)) that
+causes the parameter to accept any values but only function when a value greater
 than one was given.
 
-Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be\
+Starting with MaxScale 2.5.0, the use of percentage values in`max_slave_connections` is deprecated. The support for percentages will be
 removed in a future release.
 
-For example, if you have configured MaxScale with one primary and three replicas\
-and set `max_slave_connections=2`, for each client connection a connection to\
-the primary and two replica connections would be opened. The read query load\
-balancing is then done between these two replicas and writes are sent to the\
+For example, if you have configured MaxScale with one primary and three replicas
+and set `max_slave_connections=2`, for each client connection a connection to
+the primary and two replica connections would be opened. The read query load
+balancing is then done between these two replicas and writes are sent to the
 primary.
 
-By tuning this parameter, you can control how dynamic the load balancing is at\
-the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of\
-possible replica servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more\
-resources but load balancing will almost always give the best single query\
+By tuning this parameter, you can control how dynamic the load balancing is at
+the cost of extra created connections. With a lower value of`max_slave_connections`, less connections per session are created and the set of
+possible replica servers is smaller. With a higher value in`max_slave_connections`, more connections are created which requires more
+resources but load balancing will almost always give the best single query
 response time and performance. Longer sessions are less affected by a high`max_slave_connections` as the relative cost of opening a connection is lower.
 
 **Behavior of `max_slave_connections=0`**
 
-When readwritesplit is configured with `max_slave_connections=0`, readwritesplit\
-will behave slightly differently in that it will route all reads to the current\
-master server. This is a convenient way to force all of the traffic to go to a\
-single node while still being able to leverage the replay and reconnection\
+When readwritesplit is configured with `max_slave_connections=0`, readwritesplit
+will behave slightly differently in that it will route all reads to the current
+master server. This is a convenient way to force all of the traffic to go to a
+single node while still being able to leverage the replay and reconnection
 features of readwritesplit.
 
-In this mode, the behavior of `master_failure_mode=fail_on_write` also changes\
-slightly. If the current `Master` server fails and a read is done when there's\
-no other `Master` server available, the connection will be closed. This is done\
-to prevent an extra slave connection from being opened that would not be closed\
+In this mode, the behavior of `master_failure_mode=fail_on_write` also changes
+slightly. If the current `Master` server fails and a read is done when there's
+no other `Master` server available, the connection will be closed. This is done
+to prevent an extra slave connection from being opened that would not be closed
 if a new `Master` server would arrive.
 
 #### `slave_connections`
@@ -108,17 +108,17 @@ if a new `Master` server would arrive.
 * Dynamic: Yes
 * Default: 255
 
-This parameter controls how many replica connections each new session starts\
+This parameter controls how many replica connections each new session starts
 with. The default value is 255 which is the same as the default value of`max_slave_connections`.
 
-In contrast to `max_slave_connections`, `slave_connections` serves as a\
-soft limit on how many replica connections are created. The number of replica\
-connections can exceed `slave_connections` if the load balancing algorithm\
+In contrast to `max_slave_connections`, `slave_connections` serves as a
+soft limit on how many replica connections are created. The number of replica
+connections can exceed `slave_connections` if the load balancing algorithm
 finds an unconnected replica server better than all other replicas.
 
-Setting this parameter to 1 allows faster connection creation and improved\
-resource usage due to the smaller amount of initial backend\
-connections. It is recommended to use `slave_connections=1` when the\
+Setting this parameter to 1 allows faster connection creation and improved
+resource usage due to the smaller amount of initial backend
+connections. It is recommended to use `slave_connections=1` when the
 lifetime of the client connections is short.
 
 #### `max_replication_lag`
@@ -128,38 +128,38 @@ lifetime of the client connections is short.
 * Dynamic: Yes
 * Default: 0s
 
-**NOTE** Up until 23.02, this parameter was called `max_slave_replication_lag`,\
+**NOTE** Up until 23.02, this parameter was called `max_slave_replication_lag`,
 which has been deprecated but still works as an alias for `max_replication_lag`.
 
-Specify how many seconds a replica is allowed to be behind the primary. The lag of\
-a replica must be less than the configured value in order for it to be used for\
+Specify how many seconds a replica is allowed to be behind the primary. The lag of
+a replica must be less than the configured value in order for it to be used for
 routing. If set to `0s` (the default value), the feature is disabled.
 
-The replica lag must be less than `max_replication_lag`. This means that it\
-is possible to define, with `max_replication_lag=1s`, that all replicas must\
+The replica lag must be less than `max_replication_lag`. This means that it
+is possible to define, with `max_replication_lag=1s`, that all replicas must
 be up to date in order for them to be used for routing.
 
-Note that this feature does not guarantee that writes done on the primary are\
-visible for reads done on the replica. This is mainly due to the method of\
+Note that this feature does not guarantee that writes done on the primary are
+visible for reads done on the replica. This is mainly due to the method of
 replication lag measurement. For a feature that guarantees this, refer to [causal\_reads](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#causal_reads).
 
-The lag is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). Note that since\
-the granularity of the lag is seconds, a lag specified in milliseconds will be\
+The lag is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). Note that since
+the granularity of the lag is seconds, a lag specified in milliseconds will be
 rejected, even if the duration is longer than a second.
 
-The Readwritesplit-router does not detect the replication lag itself. A monitor\
-such as the MariaDB-monitor for a Primary-Replica cluster is required. This option\
-only affects Primary-Replica clusters. Galera clusters do not have a concept of\
-replica lag even if the application of write sets might have lag. When a server is\
-disqualified from routing because of replication lag, a warning is logged. Similarly,\
-when the server has caught up enough to be a valid routing target, another warning\
-is logged. These messages are only logged when a query is being routed and the\
+The Readwritesplit-router does not detect the replication lag itself. A monitor
+such as the MariaDB-monitor for a Primary-Replica cluster is required. This option
+only affects Primary-Replica clusters. Galera clusters do not have a concept of
+replica lag even if the application of write sets might have lag. When a server is
+disqualified from routing because of replication lag, a warning is logged. Similarly,
+when the server has caught up enough to be a valid routing target, another warning
+is logged. These messages are only logged when a query is being routed and the
 replication state changes.
 
-Starting with MaxScale versions 23.08.7, 24.02.3 and 25.01.1, readwritesplit\
-will discard connections to any servers that have excessive replication lag. The\
-connection will be discarded if a server is lagging behind by more than twice\
-the amount of `max_replication_lag` and the server is behind by more than 300\
+Starting with MaxScale versions 23.08.7, 24.02.3 and 25.01.1, readwritesplit
+will discard connections to any servers that have excessive replication lag. The
+connection will be discarded if a server is lagging behind by more than twice
+the amount of `max_replication_lag` and the server is behind by more than 300
 seconds (`replication lag > MAX(300, 2 * max_replication_lag)`).
 
 #### `use_sql_variables_in`
@@ -170,8 +170,8 @@ seconds (`replication lag > MAX(300, 2 * max_replication_lag)`).
 * Values: `master`, `all`
 * Default: `all`
 
-This parameter controls how `SELECT` statements that use SQL user variables are\
-handled. Here is an example of such a query that uses it to return an increasing\
+This parameter controls how `SELECT` statements that use SQL user variables are
+handled. Here is an example of such a query that uses it to return an increasing
 row number for a resultset:
 
 ```
@@ -179,31 +179,31 @@ SET @rownum := 0;
 SELECT @rownum := @rownum + 1 AS rownum, user, host FROM mysql.user;
 ```
 
-By default MaxScale will route both the `SET` and `SELECT` statements to all\
+By default MaxScale will route both the `SET` and `SELECT` statements to all
 nodes. Any future reads of the user variables can also be performed on any node.
 
 The possible values for this parameter are:
 
 * `all` (default)
-* Modifications to user variables inside `SELECT` statements as well as reads\
+* Modifications to user variables inside `SELECT` statements as well as reads
   of user variables are routed to all servers.\
-  Versions before MaxScale 22.08 returned an error if a user variable was\
-  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was\
-  used. MaxScale 22.08 will instead route the query to all servers and discard\
+  Versions before MaxScale 22.08 returned an error if a user variable was
+  modified inside of a `SELECT` statement when `use_sql_variables_in=all` was
+  used. MaxScale 22.08 will instead route the query to all servers and discard
   the extra results.
 * `master`
-* Modifications to user variables inside `SELECT` statements as well as reads\
-  of user variables are routed to the primary server. This forces more of the\
-  traffic onto the primary server but it reduces the amount of data that is\
-  discarded for any `SELECT` statement that also modifies a user\
-  variable. With this mode, the state of user variables is not deterministic\
-  if they are modified inside of a `SELECT` statement. `SET` statements that\
+* Modifications to user variables inside `SELECT` statements as well as reads
+  of user variables are routed to the primary server. This forces more of the
+  traffic onto the primary server but it reduces the amount of data that is
+  discarded for any `SELECT` statement that also modifies a user
+  variable. With this mode, the state of user variables is not deterministic
+  if they are modified inside of a `SELECT` statement. `SET` statements that
   modify user variables are still routed to all servers.
 
-DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user\
-variables are still treated as writes and are only routed to the primary\
-server. For example, after the following query the value of `@myid` is no longer\
-the same on all servers and the `SELECT` statement can return different values\
+DML statements, such as `INSERT`, `UPDATE` or `DELETE`, that modify SQL user
+variables are still treated as writes and are only routed to the primary
+server. For example, after the following query the value of `@myid` is no longer
+the same on all servers and the `SELECT` statement can return different values
 depending where it ends up being executed:
 
 ```
@@ -223,27 +223,27 @@ Allow the primary server to change mid-session. This feature requires that`disab
 
 Starting with MaxScale 24.02, if `disable_sescmd_history` is enabled,`master_reconnection` will be automatically disabled.
 
-When a readwritesplit session starts, it will pick a primary server as the\
-current primary server of that session. When `master_reconnection` is disabled,\
-when this primary server is lost or changes to another server, the connection\
+When a readwritesplit session starts, it will pick a primary server as the
+current primary server of that session. When `master_reconnection` is disabled,
+when this primary server is lost or changes to another server, the connection
 will be closed.
 
-When `master_reconnection` is enabled, readwritesplit can sometimes recover a\
+When `master_reconnection` is enabled, readwritesplit can sometimes recover a
 lost connection to the primary server. This largely depends on the value of`master_failure_mode`.
 
-With `master_failure_mode=fail_instantly`, the primary server is only allowed to\
-change to another server. This change must happen without a loss of the primary\
+With `master_failure_mode=fail_instantly`, the primary server is only allowed to
+change to another server. This change must happen without a loss of the primary
 server.
 
-With `master_failure_mode=fail_on_write`, the loss of the primary server is no\
-longer a fatal error: if a replacement primary server appears before any write\
-queries are received, readwritesplit will transparently reconnect to the new\
+With `master_failure_mode=fail_on_write`, the loss of the primary server is no
+longer a fatal error: if a replacement primary server appears before any write
+queries are received, readwritesplit will transparently reconnect to the new
 primary server.
 
-In both cases the change in the primary server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet\
+In both cases the change in the primary server can only take place if`prune_sescmd_history` is enabled or `max_sescmd_history` has not yet
 been exceeded and the session does not have an open transaction.
 
-The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance\
+The recommended configuration is to use `master_reconnection=true` and`master_failure_mode=fail_on_write`. This provides improved fault tolerance
 without any risk to the consistency of the database.
 
 #### `slave_selection_criteria`
@@ -254,8 +254,8 @@ without any risk to the consistency of the database.
 * Values: `least_current_operations`, `adaptive_routing`, `least_behind_master`, `least_router_connections`, `least_global_connections`
 * Default: `least_current_operations`
 
-This option controls how the readwritesplit router chooses the replicas it\
-connects to and how the load balancing is done. The default behavior is to route\
+This option controls how the readwritesplit router chooses the replicas it
+connects to and how the load balancing is done. The default behavior is to route
 read queries to the replica server with the lowest amount of ongoing queries i.e.`least_current_operations`.
 
 The option syntax:
@@ -272,45 +272,45 @@ Where `<criteria>` is one of the following values.
 * `least_global_connections`, the replica with least connections from MariaDB MaxScale
 * `least_router_connections`, the replica with least connections from this service
 
-`least_current_operations` uses the current number of active operations\
-(i.e. SQL queries) as the load balancing metric and it optimizes for maximal\
-query throughput. Each query gets routed to the server with the least active\
+`least_current_operations` uses the current number of active operations
+(i.e. SQL queries) as the load balancing metric and it optimizes for maximal
+query throughput. Each query gets routed to the server with the least active
 operations which results in faster servers processing more traffic.
 
-`adaptive_routing` uses the server response time and current estimated server\
-load as the load balancing metric. The server that is estimated to finish an\
-additional query first is chosen. A modified average response time for each\
-server is continuously updated to allow slow servers at least some traffic and\
-quickly react to changes in server load conditions. This selection criteria is\
-designed for heterogeneous clusters: servers of differing hardware, differing\
-network distances, or when other loads are running on the servers (including a\
-backup). If the servers are queried by other clients than MaxScale, the load\
+`adaptive_routing` uses the server response time and current estimated server
+load as the load balancing metric. The server that is estimated to finish an
+additional query first is chosen. A modified average response time for each
+server is continuously updated to allow slow servers at least some traffic and
+quickly react to changes in server load conditions. This selection criteria is
+designed for heterogeneous clusters: servers of differing hardware, differing
+network distances, or when other loads are running on the servers (including a
+backup). If the servers are queried by other clients than MaxScale, the load
 caused by them is indirectly taken into account.
 
-`least_behind_master` uses the measured replication lag as the load balancing\
-metric. This means that servers that are more up-to-date are favored which\
-increases the likelihood of the data being read being up-to-date. However, this\
-is not as effective as `causal_reads` would be as there's no guarantee that\
-writes done by the same connection will be routed to a server that has\
+`least_behind_master` uses the measured replication lag as the load balancing
+metric. This means that servers that are more up-to-date are favored which
+increases the likelihood of the data being read being up-to-date. However, this
+is not as effective as `causal_reads` would be as there's no guarantee that
+writes done by the same connection will be routed to a server that has
 replicated those changes. The recommended approach is to use`LEAST_CURRENT_OPERATIONS` or `ADAPTIVE_ROUTING` in combination with`causal_reads`
 
-**NOTE**: `least_global_connections` and `least_router_connections` should not\
-be used, they are legacy options that exist only for backwards\
-compatibility. Using them will result in skewed load balancing as the algorithm\
-uses a metric that's too coarse (number of connections) to load balance\
+**NOTE**: `least_global_connections` and `least_router_connections` should not
+be used, they are legacy options that exist only for backwards
+compatibility. Using them will result in skewed load balancing as the algorithm
+uses a metric that's too coarse (number of connections) to load balance
 something that's finer (individual SQL queries).
 
-The `least_global_connections` and `least_router_connections` use the\
-connections from MariaDB MaxScale to the server, not the amount of connections\
+The `least_global_connections` and `least_router_connections` use the
+connections from MariaDB MaxScale to the server, not the amount of connections
 reported by the server itself.
 
-Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,\
-lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid\
+Starting with MaxScale versions 2.5.29, 6.4.11, 22.08.9, 23.02.5 and 23.08.1,
+lowercase versions of the values are also accepted. For example,`slave_selection_criteria=LEAST_CURRENT_OPERATIONS` and`slave_selection_criteria=least_current_operations` are both accepted as valid
 values.
 
-Starting with MaxScale 23.08.1, the legacy uppercase values have been\
-deprecated. All runtime modifications of the parameter will now be persisted in\
-lowercase. The uppercase values are still accepted but will be removed in a\
+Starting with MaxScale 23.08.1, the legacy uppercase values have been
+deprecated. All runtime modifications of the parameter will now be persisted in
+lowercase. The uppercase values are still accepted but will be removed in a
 future MaxScale release.
 
 #### `master_accept_reads`
@@ -320,13 +320,13 @@ future MaxScale release.
 * Dynamic: Yes
 * Default: false
 
-Enables the primary server to be used for reads. This is a useful option to\
-enable if you are using a small number of servers and wish to use the primary\
-for reads as well and the load on it does not reduce the write throughput of the\
+Enables the primary server to be used for reads. This is a useful option to
+enable if you are using a small number of servers and wish to use the primary
+for reads as well and the load on it does not reduce the write throughput of the
 cluster.
 
-By default, no reads are sent to the primary as long as there is a valid replica\
-server available. If no replicas are available, reads are sent to the primary\
+By default, no reads are sent to the primary as long as there is a valid replica
+server available. If no replicas are available, reads are sent to the primary
 regardless of the value of `master_accept_reads`.
 
 ```
@@ -341,15 +341,15 @@ master_accept_reads=true
 * Dynamic: Yes
 * Default: false
 
-When a client executes a multi-statement query, it will be treated as if it were\
-a DML statement and routed to the primary. If the option is enabled, all queries\
-after a multi-statement query will be routed to the primary to guarantee a\
+When a client executes a multi-statement query, it will be treated as if it were
+a DML statement and routed to the primary. If the option is enabled, all queries
+after a multi-statement query will be routed to the primary to guarantee a
 consistent session state.
 
-If the feature is disabled, queries are routed normally after a multi-statement\
+If the feature is disabled, queries are routed normally after a multi-statement
 query.
 
-**Warning:** Enable the strict mode only if you know that the clients will send\
+**Warning:** Enable the strict mode only if you know that the clients will send
 statements that cause inconsistencies in the session state.
 
 ```
@@ -364,7 +364,7 @@ strict_multi_stmt=true
 * Dynamic: Yes
 * Default: false
 
-Similar to `strict_multi_stmt`, this option allows all queries after a CALL\
+Similar to `strict_multi_stmt`, this option allows all queries after a CALL
 operation on a stored procedure to be routed to the primary.
 
 All warnings and restrictions that apply to `strict_multi_stmt` also apply to`strict_sp_calls`.
@@ -376,15 +376,15 @@ All warnings and restrictions that apply to `strict_multi_stmt` also apply to`st
 * Dynamic: Yes
 * Default: true (>= MaxScale 24.02), false (<= MaxScale 23.08)
 
-When `strict_tmp_tables` is disabled, all temporary tables are lost when a\
-reconnection of the primary node occurs. This means that if a reconnection to\
-the primary takes place, temporary tables might appear to disappear in the\
+When `strict_tmp_tables` is disabled, all temporary tables are lost when a
+reconnection of the primary node occurs. This means that if a reconnection to
+the primary takes place, temporary tables might appear to disappear in the
 middle of a connection.
 
-When `strict_tmp_tables` is enabled, reconnections are prevented as long as a\
-temporary tables exist. In this case if the primary node is lost and temporary\
-table exist, the session is closed. If a session creates temporary tables but\
-does not drop them, this behavior will effectively disable reconnections until\
+When `strict_tmp_tables` is enabled, reconnections are prevented as long as a
+temporary tables exist. In this case if the primary node is lost and temporary
+table exist, the session is closed. If a session creates temporary tables but
+does not drop them, this behavior will effectively disable reconnections until
 the session is closed.
 
 #### `master_failure_mode`
@@ -397,7 +397,7 @@ the session is closed.
 
 This option controls how the failure of a primary server is handled.
 
-The following table describes the values for this option and how they treat the\
+The following table describes the values for this option and how they treat the
 loss of a primary server.
 
 | Value            | Description                                                                                                                      |
@@ -406,22 +406,22 @@ loss of a primary server.
 | fail\_on\_write  | The client connection is closed if a write query is received when no primary is available.                                       |
 | error\_on\_write | If no primary is available and a write query is received, an error is returned stating that the connection is in read-only mode. |
 
-These also apply to new sessions created after the primary has failed. This means\
-that in `fail_on_write` or `error_on_write` mode, connections are accepted as\
+These also apply to new sessions created after the primary has failed. This means
+that in `fail_on_write` or `error_on_write` mode, connections are accepted as
 long as replica servers are available.
 
-When configured with `fail_on_write` or `error_on_write`, sessions that are idle\
-will not be closed even if all backend connections for that session have\
-failed. This is done in the hopes that before the next query from the idle\
-session arrives, a reconnection to one of the replicas is made. However, this can\
-leave idle connections around unless the client application actively closes\
-them. To prevent this, use the [connection\_timeout](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+When configured with `fail_on_write` or `error_on_write`, sessions that are idle
+will not be closed even if all backend connections for that session have
+failed. This is done in the hopes that before the next query from the idle
+session arrives, a reconnection to one of the replicas is made. However, this can
+leave idle connections around unless the client application actively closes
+them. To prevent this, use the [connection\_timeout](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 parameter.
 
-**Note:** If `master_failure_mode` is set to `error_on_write` and the connection\
-to the primary is lost, by default, clients will not be able to execute write\
-queries without reconnecting to MariaDB MaxScale once a new primary is\
-available. If [master\_reconnection](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#master_reconnection) is enabled, the\
+**Note:** If `master_failure_mode` is set to `error_on_write` and the connection
+to the primary is lost, by default, clients will not be able to execute write
+queries without reconnecting to MariaDB MaxScale once a new primary is
+available. If [master\_reconnection](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#master_reconnection) is enabled, the
 session can recover if one of the replicas is promoted as the primary.
 
 #### `retry_failed_reads`
@@ -433,13 +433,13 @@ session can recover if one of the replicas is promoted as the primary.
 
 This option controls whether autocommit selects are retried in case of failure.
 
-When a simple autocommit select is being executed outside of a transaction and\
-the replica server where the query is being executed fails, readwritesplit can\
-retry the read on a replacement server. This makes the failure of a replica\
+When a simple autocommit select is being executed outside of a transaction and
+the replica server where the query is being executed fails, readwritesplit can
+retry the read on a replacement server. This makes the failure of a replica
 transparent to the client.
 
-If a part of the result was already delivered to the client, the query will not\
-be retried. The retrying of queries with partially delivered results is only\
+If a part of the result was already delivered to the client, the query will not
+be retried. The retrying of queries with partially delivered results is only
 possible when `transaction_replay` is enabled.
 
 #### `delayed_retry`
@@ -451,31 +451,31 @@ possible when `transaction_replay` is enabled.
 
 Retry queries over a period of time.
 
-When this feature is enabled, a failure to route a query due to a connection\
-problem will not immediately result in an error. The routing of the query is\
-delayed until either a valid candidate server is available or the retry timeout\
-is reached. If a candidate server becomes available before the timeout is\
-reached, the query is routed normally and no connection error is returned. If no\
-candidates are found and the timeout is exceeded, the router returns to normal\
+When this feature is enabled, a failure to route a query due to a connection
+problem will not immediately result in an error. The routing of the query is
+delayed until either a valid candidate server is available or the retry timeout
+is reached. If a candidate server becomes available before the timeout is
+reached, the query is routed normally and no connection error is returned. If no
+candidates are found and the timeout is exceeded, the router returns to normal
 behavior and returns an error.
 
-When combined with the `master_reconnection` parameter, failures of writes done\
-outside of transactions can be hidden from the client connection. This allows a\
+When combined with the `master_reconnection` parameter, failures of writes done
+outside of transactions can be hidden from the client connection. This allows a
 primary to be replaced while writes are being sent.
 
 Starting with MaxScale 21.06.18, 22.08.15, 23.02.12, 23.08.8, 24.02.4 and\
-25.01.1, `delayed_retry` will no longer attempt to retry a query if it was\
-already sent to the database. If a query is received while a valid target server\
-is not available, the execution of the query is delayed until a valid target is\
-found or the delayed retry timeout is hit. If a query was already sent, it will\
+25.01.1, `delayed_retry` will no longer attempt to retry a query if it was
+already sent to the database. If a query is received while a valid target server
+is not available, the execution of the query is delayed until a valid target is
+found or the delayed retry timeout is hit. If a query was already sent, it will
 not be replayed to prevent duplicate execution of statements.
 
-In older versions of MaxScale, duplicate execution of a statement can occur if\
-the connection to the server is lost or the server crashes but the server comes\
-back up before the timeout for the retrying is exceeded. At this point, if the\
-server managed to read the client's statement, it will be executed. For this\
+In older versions of MaxScale, duplicate execution of a statement can occur if
+the connection to the server is lost or the server crashes but the server comes
+back up before the timeout for the retrying is exceeded. At this point, if the
+server managed to read the client's statement, it will be executed. For this
 reason, it is recommended to only enable `delayed_retry` for older versions of\
-MaxScale when the possibility of duplicate statement execution is an acceptable\
+MaxScale when the possibility of duplicate statement execution is an acceptable
 risk.
 
 #### `delayed_retry_timeout`
@@ -487,10 +487,10 @@ risk.
 
 The duration to wait until an error is returned to the client when`delayed_retry` is enabled.
 
-The timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `transaction_replay`
@@ -502,20 +502,20 @@ even if the duration is longer than a second.
 
 Replay interrupted transactions.
 
-Enabling this parameter enables both `delayed_retry` and `master_reconnection`\
-and sets `master_failure_mode` to `fail_on_write`, thereby overriding any\
+Enabling this parameter enables both `delayed_retry` and `master_reconnection`
+and sets `master_failure_mode` to `fail_on_write`, thereby overriding any
 configured values for these parameters.
 
-When the server where the transaction is in progress fails, readwritesplit can\
-migrate the transaction to a replacement server. This can completely hide the\
+When the server where the transaction is in progress fails, readwritesplit can
+migrate the transaction to a replacement server. This can completely hide the
 failure of a primary node without any visible effects to the client.
 
 If no replacement node becomes available, the client connection is closed.
 
 To control how long a transaction replay can take, use`transaction_replay_timeout`.
 
-Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#transaction-replay-limitations) section for\
-a more detailed explanation of what should and should not be done with\
+Please refer to the [Transaction Replay Limitations](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#transaction-replay-limitations) section for
+a more detailed explanation of what should and should not be done with
 transaction replay.
 
 #### `transaction_replay_max_size`
@@ -525,19 +525,19 @@ transaction replay.
 * Dynamic: Yes
 * Default: 1 MiB
 
-The limit on transaction size for transaction replay in bytes. Any transaction\
-that exceeds this limit will not be replayed. The default value is 1 MiB. This\
-limit applies at a session level which means that the total peak memory\
-consumption can be `transaction_replay_max_size` times the number of client\
+The limit on transaction size for transaction replay in bytes. Any transaction
+that exceeds this limit will not be replayed. The default value is 1 MiB. This
+limit applies at a session level which means that the total peak memory
+consumption can be `transaction_replay_max_size` times the number of client
 connections.
 
-The amount of memory needed to store a particular transaction will be slightly\
-larger than the length in bytes of the SQL used in the transaction. If the limit\
+The amount of memory needed to store a particular transaction will be slightly
+larger than the length in bytes of the SQL used in the transaction. If the limit
 is ever exceeded, a message will be logged at the info level.
 
 The number of times that this limit has been exceeded is shown in`maxctrl show service` as `trx_max_size_exceeded`.
 
-Read [the configuration guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+Read [the configuration guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 for more details on size type parameters in MaxScale.
 
 #### `transaction_replay_attempts`
@@ -547,13 +547,13 @@ for more details on size type parameters in MaxScale.
 * Dynamic: Yes
 * Default: 5
 
-The upper limit on how many times a transaction replay is attempted before\
+The upper limit on how many times a transaction replay is attempted before
 giving up.
 
-A transaction replay failure can happen if the server where the transaction is\
-being replayed fails while the replay is in progress. In practice this parameter\
-controls how many server and network failures a single transaction replay\
-tolerates. If a transaction is replayed successfully, the counter for failed\
+A transaction replay failure can happen if the server where the transaction is
+being replayed fails while the replay is in progress. In practice this parameter
+controls how many server and network failures a single transaction replay
+tolerates. If a transaction is replayed successfully, the counter for failed
 attempts is reset.
 
 #### `transaction_replay_timeout`
@@ -563,27 +563,27 @@ attempts is reset.
 * Dynamic: Yes
 * Default: 30s (>= MaxScale 24.02), 0s (<= MaxScale 23.08)
 
-The time how long transactions are attempted for. To explicitly disable this\
+The time how long transactions are attempted for. To explicitly disable this
 feature, set the value to 0 seconds.
 
-The timeout is [a duration type](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+The timeout is [a duration type](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 and the value must include a unit for the duration.
 
-When `transaction_replay_timeout` is enabled, the time a transaction replay can\
-take is controlled solely by this parameter. This is a more convenient and\
-predictable method of controlling how long a transaction replay can be attempted\
+When `transaction_replay_timeout` is enabled, the time a transaction replay can
+take is controlled solely by this parameter. This is a more convenient and
+predictable method of controlling how long a transaction replay can be attempted
 before the connection is closed.
 
-If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set\
+If `delayed_retry_timeout` is less than `transaction_replay_timeout`, it is set
 to the same value.
 
-Without `transaction_replay_timeout` the time how long a transaction can be\
-retried is controlled by `delayed_retry_timeout` and`transaction_replay_attempts`. This can result in a maximum replay time limit of`delayed_retry_timeout` multiplied by `transaction_replay_attempts`, by default\
-this is 50 seconds. The minimum replay time limit can be as low as`transaction_replay_attempts` seconds (5 seconds by default) in cases where the\
-connection fails after it was created. Usually this happens due to problems like\
+Without `transaction_replay_timeout` the time how long a transaction can be
+retried is controlled by `delayed_retry_timeout` and`transaction_replay_attempts`. This can result in a maximum replay time limit of`delayed_retry_timeout` multiplied by `transaction_replay_attempts`, by default
+this is 50 seconds. The minimum replay time limit can be as low as`transaction_replay_attempts` seconds (5 seconds by default) in cases where the
+connection fails after it was created. Usually this happens due to problems like
 the max\_connections limit being hit on the database server.
 
-`transaction_replay_timeout` is the recommended method of controlling the\
+`transaction_replay_timeout` is the recommended method of controlling the
 timeouts for transaction replay and is by default set to 30 seconds in MaxScale\
 24.02.
 
@@ -596,10 +596,10 @@ timeouts for transaction replay and is by default set to 30 seconds in MaxScale\
 
 Enable automatic retrying of transactions that end up in a deadlock.
 
-If this feature is enabled and a transaction returns a deadlock error\
-(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),\
-the transaction is automatically retried. If the retrying of the transaction\
-results in another deadlock error, it is retried until it either succeeds or a\
+If this feature is enabled and a transaction returns a deadlock error
+(e.g. `SQLSTATE 40001: Deadlock found when trying to get lock; try restarting transaction`),
+the transaction is automatically retried. If the retrying of the transaction
+results in another deadlock error, it is retried until it either succeeds or a
 transaction checksum error is encountered.
 
 #### `transaction_replay_safe_commit`
@@ -609,26 +609,26 @@ transaction checksum error is encountered.
 * Dynamic: Yes
 * Default: true
 
-If a transaction is ending and the `COMMIT` statement at the end of it is\
-interrupted, there is a risk of duplicating the transaction if it is\
-replayed. This parameter prevents the retrying of transactions that are about to\
+If a transaction is ending and the `COMMIT` statement at the end of it is
+interrupted, there is a risk of duplicating the transaction if it is
+replayed. This parameter prevents the retrying of transactions that are about to
 commit.
 
-This parameter was added in MaxScale 23.08.0 and is enabled by default. The\
-older version of MaxScale always attempted to replay the transaction even if\
+This parameter was added in MaxScale 23.08.0 and is enabled by default. The
+older version of MaxScale always attempted to replay the transaction even if
 there was a risk of duplicating the transaction.
 
 In MaxScale 25.01.0, this parameter also disabled the replaying of individual\
-DML statements that `delayed_retry` enabled. The result of this was that only\
-statements done inside of an explicit transactions or with autocommit disabled\
+DML statements that `delayed_retry` enabled. The result of this was that only
+statements done inside of an explicit transactions or with autocommit disabled
 were replayed and writes done with autocommit enabled were never replayed.
 
 In MaxScale 25.01.1 and newer versions, where `delayed_retry no longer attempts to retry a query if it was already sent to the database, write queries outside of transactions are delayed if no valid target is found but they are never retried. Thus`transaction\_replay\_safe\_commit`again only affects how the`COMMIT\` of a transaction is handled.
 
-If the data that is about to be modified is read before it is modified and it is\
-locked in an appropriate manner (e.g. with `SELECT ... FOR UPDATE` or with the`SERIALIZABLE` isolation level), it is safe to replay a transaction that was\
-about to commit. This is because the checksum of the transaction will mismatch\
-if the original transaction ended up committing on the server. Disabling this\
+If the data that is about to be modified is read before it is modified and it is
+locked in an appropriate manner (e.g. with `SELECT ... FOR UPDATE` or with the`SERIALIZABLE` isolation level), it is safe to replay a transaction that was
+about to commit. This is because the checksum of the transaction will mismatch
+if the original transaction ended up committing on the server. Disabling this
 feature can enable more robust delivery of transactions but it requires that the\
 SQL is correctly formed and compatible with this behavior.
 
@@ -641,8 +641,8 @@ SQL is correctly formed and compatible with this behavior.
 
 Retry transactions that end in checksum mismatch.
 
-When enabled, any replayed transactions that end with a checksum mismatch are\
-retried until they either succeeds or one of the transaction replay limits is\
+When enabled, any replayed transactions that end with a checksum mismatch are
+retried until they either succeeds or one of the transaction replay limits is
 reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_replay_attempts`).
 
 #### `transaction_replay_checksum`
@@ -653,35 +653,35 @@ reached (`delayed_retry_timeout`, `transaction_replay_timeout` or`transaction_re
 * Values: `full`, `result_only`, `no_insert_id`
 * Default: `full`
 
-Selects which transaction checksum method is used to verify the result of the\
+Selects which transaction checksum method is used to verify the result of the
 replayed transaction.
 
-Note that only `transaction_replay_checksum=full` is guaranteed to retain the\
+Note that only `transaction_replay_checksum=full` is guaranteed to retain the
 consistency of the replayed transaction.
 
 Possible values are:
 
 * `full` (default)
-* All responses from the server are included in the checksum. This retains the\
-  full consistency guarantee of the replayed transaction as it must match\
+* All responses from the server are included in the checksum. This retains the
+  full consistency guarantee of the replayed transaction as it must match
   exactly the one that was already returned to the client.
 * `result_only`
-* Only resultsets and errors are included in the checksum. OK packets\
-  (i.e. successful queries that do not return results) are ignored. This mode\
+* Only resultsets and errors are included in the checksum. OK packets
+  (i.e. successful queries that do not return results) are ignored. This mode
   is intended to be used in cases where the extra information (auto-generated\
-  ID, warnings etc.) returned in the OK packet is not used by the\
+  ID, warnings etc.) returned in the OK packet is not used by the
   application.\
-  This mode is safe to use only if the auto-generated ID is not actually used\
-  by any following queries. An example of such behavior would be a transaction\
+  This mode is safe to use only if the auto-generated ID is not actually used
+  by any following queries. An example of such behavior would be a transaction
   that ends with an `INSERT` into a table with an `AUTO_INCREMENT` field.
 * `no_insert_id`
-* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the\
-  result of the query is not used by any subsequent statement in the\
+* The same as `result_only` but results from queries that use`LAST_INSERT_ID()` are also ignored. This mode is safe to use only if the
+  result of the query is not used by any subsequent statement in the
   transaction.
 
 #### `optimistic_trx`
 
-This feature has been moved into the [OptimisticTrx](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-optimistic-transaction-execution-filter.md) filter in MaxScale 25.01 and the\
+This feature has been moved into the [OptimisticTrx](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-optimistic-transaction-execution-filter.md) filter in MaxScale 25.01 and the
 parameter has been removed from readwritesplit.
 
 #### `causal_reads`
@@ -694,12 +694,12 @@ parameter has been removed from readwritesplit.
 
 Enable causal reads. This feature requires MariaDB 10.2.16 or newer to function.
 
-If a client connection modifies the database and `causal_reads` is enabled, any\
-subsequent reads performed on replica servers will be done in a manner that\
+If a client connection modifies the database and `causal_reads` is enabled, any
+subsequent reads performed on replica servers will be done in a manner that
 prevents replication lag from affecting the results.
 
-The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#implementation-of-causal_reads) for more\
-information on what a sync consists of and why minimizing the number of them is\
+The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#implementation-of-causal_reads) for more
+information on what a sync consists of and why minimizing the number of them is
 important.
 
 | Mode            | Level of Causality | Latency                                                  |
@@ -711,16 +711,16 @@ important.
 | universal       | Cluster            | High, one sync per read plus a roundtrip to the primary. |
 | fast\_universal | Cluster            | Low, one roundtrip to the primary.                       |
 
-The `fast`, `fast_global` and `fast_universal` modes should only be used when\
-low latency is more important than proper distribution of reads. These modes\
-should only be used when the workload is mostly read-only with only occasional\
-writes. If used with a mixed or a write-heavy workload, the traffic will end up\
+The `fast`, `fast_global` and `fast_universal` modes should only be used when
+low latency is more important than proper distribution of reads. These modes
+should only be used when the workload is mostly read-only with only occasional
+writes. If used with a mixed or a write-heavy workload, the traffic will end up
 being routed almost exclusively to the primary server.
 
-**Note:** This feature also enables multi-statement execution of SQL in the\
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)\
+**Note:** This feature also enables multi-statement execution of SQL in the
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
-Connector/C. The _Implementation of causal\_reads_ section explains why this is\
+Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.
 
 The possible values for this parameter are:
@@ -728,94 +728,94 @@ The possible values for this parameter are:
 * `none` (default)
 * Read causality is disabled.
 * `local`
-* Writes are locally visible. Writes are guaranteed to be visible only to the\
-  connection that does it. Unrelated modifications done by other connections\
-  are not visible. This mode improves read scalability at the cost of latency\
-  and reduces the overall load placed on the primary server without breaking\
+* Writes are locally visible. Writes are guaranteed to be visible only to the
+  connection that does it. Unrelated modifications done by other connections
+  are not visible. This mode improves read scalability at the cost of latency
+  and reduces the overall load placed on the primary server without breaking
   causality guarantees.
 * `global`
-* Writes are globally visible. If one connection writes a value, all\
-  connections to the same service will see it. In general this mode is slower\
-  than the `local` mode due to the extra synchronization it has to do. This\
-  guarantees global happens-before ordering of reads when all transactions are\
-  inside a single GTID domain.This mode gives similar benefits as the `local`\
+* Writes are globally visible. If one connection writes a value, all
+  connections to the same service will see it. In general this mode is slower
+  than the `local` mode due to the extra synchronization it has to do. This
+  guarantees global happens-before ordering of reads when all transactions are
+  inside a single GTID domain.This mode gives similar benefits as the `local`
   mode in that it improves read scalability at the cost of latency.\
-  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads\
-  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this\
-  was fixed and all the GTID coordinates are passed alongside all requests\
+  With MaxScale versions 2.5.14 and older, multi-domain use of causal\_reads
+  could cause non-causal reads to occur. Starting with MaxScale 2.5.15, this
+  was fixed and all the GTID coordinates are passed alongside all requests
   which makes multi-domain GTIDs safe to use. However, this does mean that the\
-  GTID coordinates will never be reset: if replication is reset and GTID\
-  coordinates go "backwards", readwritesplit will not consider these as being\
-  newer than the ones already stored. To reset the stored GTID coordinates in\
+  GTID coordinates will never be reset: if replication is reset and GTID
+  coordinates go "backwards", readwritesplit will not consider these as being
+  newer than the ones already stored. To reset the stored GTID coordinates in
   readwritesplit, MaxScale must be restarted.\
-  MaxScale 6.4.11 added the new `reset-gtid` module command to\
+  MaxScale 6.4.11 added the new `reset-gtid` module command to
   readwritesplit. This allows the global GTID state used by`causal_reads=global` to be reset without having to restart MaxScale.
 * `fast`
-* This mode is similar to the `local` mode where it will only affect the\
-  connection that does the write but where the `local` mode waits for a replica\
-  server to catch up, the `fast` mode will only use servers that are known to\
-  have replicated the write. This means that if no replica has replicated the\
-  write, the primary where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication\
-  state is only updated by the mariadbmon monitor whenever the servers are\
-  monitored. This means that a smaller `monitor_interval` provides faster\
+* This mode is similar to the `local` mode where it will only affect the
+  connection that does the write but where the `local` mode waits for a replica
+  server to catch up, the `fast` mode will only use servers that are known to
+  have replicated the write. This means that if no replica has replicated the
+  write, the primary where the write was done will be used. The value of`causal_reads_timeout` is ignored in this mode. Currently the replication
+  state is only updated by the mariadbmon monitor whenever the servers are
+  monitored. This means that a smaller `monitor_interval` provides faster
   replication state updates and possibly better overall usage of servers.\
-  This mode is the inverse of the `local` mode in the sense that it improves\
-  read latency at the cost of read scalability while still retaining the\
-  causality guarantees for reads. This functionality can also be considered an\
+  This mode is the inverse of the `local` mode in the sense that it improves
+  read latency at the cost of read scalability while still retaining the
+  causality guarantees for reads. This functionality can also be considered an
   improved version of the functionality that the [CCRFilter](../mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-consistent-critical-read-filter.md) module provides.
 * `fast_global`
 * This mode is identical to the `fast` mode except that it uses the global\
-  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`\
-  is ignored in this mode. Currently the replication state is only updated by\
-  the mariadbmon monitor whenever the servers are monitored. This means that a\
-  smaller `monitor_interval` provides faster replication state updates and\
+  GTID instead of the session local one. This is similar to how `local` and`global` modes differ from each other. The value of `causal_reads_timeout`
+  is ignored in this mode. Currently the replication state is only updated by
+  the mariadbmon monitor whenever the servers are monitored. This means that a
+  smaller `monitor_interval` provides faster replication state updates and
   possibly better overall usage of servers.
 * `universal`
-* The universal mode guarantees that all SELECT statements always see the\
-  latest observable transaction state on a database cluster. The basis of this\
-  is the `@@gtid_current_pos` variable which is read from the current primary\
-  server before each read. This guarantees that if a transaction was visible\
-  at the time the read is received by readwritesplit, the transaction is\
+* The universal mode guarantees that all SELECT statements always see the
+  latest observable transaction state on a database cluster. The basis of this
+  is the `@@gtid_current_pos` variable which is read from the current primary
+  server before each read. This guarantees that if a transaction was visible
+  at the time the read is received by readwritesplit, the transaction is
   guaranteed to be complete on the replica server where the read is done.\
-  This mode is the most consistent of all the modes. It provides consistency\
-  regardless of where a write originated from but it comes at the cost of\
-  increased latency. For every read, a round trip to the current primary server\
-  is done. This means that the latency of any given SELECT statement increases\
-  by roughly twice the network latency between MaxScale and the database\
-  cluster. In addition, an extra SELECT statement is always executed on the\
+  This mode is the most consistent of all the modes. It provides consistency
+  regardless of where a write originated from but it comes at the cost of
+  increased latency. For every read, a round trip to the current primary server
+  is done. This means that the latency of any given SELECT statement increases
+  by roughly twice the network latency between MaxScale and the database
+  cluster. In addition, an extra SELECT statement is always executed on the
   primary which places some load on the server.
 * `fast_universal`
-* A mix of `fast` and `universal`. This mode that guarantees that all SELECT\
-  statements always see the latest observable transaction state but unlike the`universal` mode that waits on the server to catch up, this mode behaves\
-  like `fast` and routes the query to the current primary if no replicas are\
+* A mix of `fast` and `universal`. This mode that guarantees that all SELECT
+  statements always see the latest observable transaction state but unlike the`universal` mode that waits on the server to catch up, this mode behaves
+  like `fast` and routes the query to the current primary if no replicas are
   available that have caught up.\
-  This mode provides the same consistency guarantees of `universal` with a\
-  constant latency overhead of one extra roundtrip. However, this also puts\
-  the most load on the primary node as even a moderate write load can cause\
+  This mode provides the same consistency guarantees of `universal` with a
+  constant latency overhead of one extra roundtrip. However, this also puts
+  the most load on the primary node as even a moderate write load can cause
   the GTIDs of replicas to lag too far behind.
 
-Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean\
+Before MaxScale 2.5.0, the `causal_reads` parameter was a boolean
 parameter. False values translated to `none` and true values translated to`local`. The use of boolean parameters is deprecated but still accepted in\
 MaxScale 2.5.0.
 
 **Implementation of `causal_reads`**
 
-This feature is based on the `MASTER_GTID_WAIT` function and the tracking of\
-server-side status variables. By tracking the latest GTID that each statement\
-generates, readwritesplit can then perform a synchronization operation with the\
+This feature is based on the `MASTER_GTID_WAIT` function and the tracking of
+server-side status variables. By tracking the latest GTID that each statement
+generates, readwritesplit can then perform a synchronization operation with the
 help of the `MASTER_GTID_WAIT` function.
 
-If the replica has not caught up to the primary within the configured time, as\
-specified by [causal\_reads\_timeout](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#causal_reads_timeout), it will\
+If the replica has not caught up to the primary within the configured time, as
+specified by [causal\_reads\_timeout](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#causal_reads_timeout), it will
 be retried on the primary.
 
-The exception to this rule is the `fast` mode which does not do any\
-synchronization at all. This can be done as any reads that would go to\
+The exception to this rule is the `fast` mode which does not do any
+synchronization at all. This can be done as any reads that would go to
 out-of-date servers will be re-routed to the current primary.
 
 **Normal SQL**
 
-A practical example can be given by the following set of SQL commands executed\
+A practical example can be given by the following set of SQL commands executed
 with `autocommit=1`.
 
 ```
@@ -823,17 +823,17 @@ INSERT INTO test.t1 (id) VALUES (1);
 SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-As the statements are not executed inside a transaction, from the load balancer's\
-point of view, the latter statement can be routed to a replica server. The problem\
-with this is that if the value that was inserted on the primary has not yet\
-replicated to the server where the SELECT statement is being performed, it can\
+As the statements are not executed inside a transaction, from the load balancer's
+point of view, the latter statement can be routed to a replica server. The problem
+with this is that if the value that was inserted on the primary has not yet
+replicated to the server where the SELECT statement is being performed, it can
 appear as if the value we just inserted is not there.
 
-By prefixing these types of SELECT statements with a command that guarantees\
-consistent results for the reads, read scalability can be improved without\
+By prefixing these types of SELECT statements with a command that guarantees
+consistent results for the reads, read scalability can be improved without
 sacrificing consistency.
 
-The set of example SQL above will be translated by MaxScale into the following\
+The set of example SQL above will be translated by MaxScale into the following
 statements.
 
 ```
@@ -847,18 +847,18 @@ SET @maxscale_secret_variable=(
     END); SELECT * FROM test.t1 WHERE id = 1;
 ```
 
-The `SET` command will synchronize the replica to a certain logical point in the\
-replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more\
-details). If the synchronization fails, the query will not run and it will be\
+The `SET` command will synchronize the replica to a certain logical point in the
+replication stream (see [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait) for more
+details). If the synchronization fails, the query will not run and it will be
 retried on the server where the transaction was originally done.
 
 **Prepared Statements**
 
-Binary protocol prepared statements are handled in a different manner. Instead\
-of adding the synchronization SQL into the original SQL query, it is sent as a\
+Binary protocol prepared statements are handled in a different manner. Instead
+of adding the synchronization SQL into the original SQL query, it is sent as a
 separate packet before the prepared statement is executed.
 
-We'll use the same example SQL but use a binary protocol prepared statement for\
+We'll use the same example SQL but use a binary protocol prepared statement for
 the SELECT:
 
 ```
@@ -876,20 +876,20 @@ COM_QUERY:         IF (MASTER_GTID_WAIT('0-3000-8', 10) <> 0) THEN KILL (SELECT 
 COM_STMT_EXECUTE:  ? = 123
 ```
 
-Both the synchronization query and the execution of the prepared statement are\
-sent at the same time. This is done to remove the need to wait for the result of\
-the synchronization query before routing the execution of the prepared\
-statement. This keeps the performance of causal\_reads for prepared statements\
+Both the synchronization query and the execution of the prepared statement are
+sent at the same time. This is done to remove the need to wait for the result of
+the synchronization query before routing the execution of the prepared
+statement. This keeps the performance of causal\_reads for prepared statements
 the same as it is for normal SQL queries.
 
-As a result of this, each time the synchronization query times out, the\
-connection will be killed by the `KILL` statement and readwritesplit will retry\
-the query on the primary. This is done to prevent the execution of the prepared\
+As a result of this, each time the synchronization query times out, the
+connection will be killed by the `KILL` statement and readwritesplit will retry
+the query on the primary. This is done to prevent the execution of the prepared
 statement that follows the synchronization query from being processed by the\
 MariaDB server.
 
-It is recommend that the session command history is enabled whenever prepared\
-statements are used with `causal_reads`. This allows new connections to be\
+It is recommend that the session command history is enabled whenever prepared
+statements are used with `causal_reads`. This allows new connections to be
 created whenever a causal read times out.
 
 A failed causal read inside of a read-only transaction started with`START TRANSACTION READ ONLY` will return the following error:
@@ -900,22 +900,22 @@ SQLSTATE: 25006
 Message:  Causal read timed out while in a read-only transaction, cannot retry command.
 ```
 
-Older versions of MaxScale attempted to retry the command on the current primary\
+Older versions of MaxScale attempted to retry the command on the current primary
 server which would cause the connection to be closed and a warning to be logged.
 
 **Limitations of Causal Reads**
 
-* Starting with MaxScale 24.02.5, the fast modes `fast`, `fast_global` and`fast_universal` work with Galera clusters. In older versions, none of the`causal_reads` modes worked with Galera. The non-fast modes that rely on the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)\
-  function still do not work with Galera. This is because Galera does not\
+* Starting with MaxScale 24.02.5, the fast modes `fast`, `fast_global` and`fast_universal` work with Galera clusters. In older versions, none of the`causal_reads` modes worked with Galera. The non-fast modes that rely on the [MASTER\_GTID\_WAIT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/master_gtid_wait)
+  function still do not work with Galera. This is because Galera does not
   implement a mechanism that allows a client to wait for a particular GTID.
-* If the combination of the original SQL statement and the modifications\
-  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),\
+* If the combination of the original SQL statement and the modifications
+  added to it by readwritesplit exceed the maximum packet size (16777213 bytes),
   the causal read will not be attempted and a non-causal read is done instead.\
-  This applies only to text protocol queries as the binary protocol queries use\
+  This applies only to text protocol queries as the binary protocol queries use
   a different synchronization mechanism.
-* SQL like `INSERT ... RETURNING` that commits a transaction and returns a\
+* SQL like `INSERT ... RETURNING` that commits a transaction and returns a
   resultset will only work with causal reads if the connector supports the\
-  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB\
+  DEPRECATE\_EOF protocol feature. The following table contains a list of MariaDB
   connectors and whether they support the protocol feature.
 
 | Connector         | Supported | Version |
@@ -936,10 +936,10 @@ server which would cause the connection to be closed and a warning to be logged.
 
 The timeout for the replica synchronization done by `causal_reads`.
 
-The timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `lazy_connect`
@@ -949,24 +949,24 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: false
 
-Lazy connection creation causes connections to backend servers to be opened only\
-when they are needed. This reduces the load that is placed on the backend\
+Lazy connection creation causes connections to backend servers to be opened only
+when they are needed. This reduces the load that is placed on the backend
 servers when the client connections are short.
 
-Normally readwritesplit opens as many connections as it can when the session is\
-first opened. This makes the execution of the first query faster when all\
-available connections are already created. When `lazy_connect` is enabled, this\
-initial connection creation is skipped. If the client executes only read\
-queries, no connection to the primary is made. If only write queries are made,\
+Normally readwritesplit opens as many connections as it can when the session is
+first opened. This makes the execution of the first query faster when all
+available connections are already created. When `lazy_connect` is enabled, this
+initial connection creation is skipped. If the client executes only read
+queries, no connection to the primary is made. If only write queries are made,
 only the primary connection is used.
 
-In MaxScale 23.08.2, if a [session command](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#routing-to-every-session-backend)\
-is received as the first command, the default behavior is to execute it on a\
-replica. If [master\_accept\_reads](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#master_accept_reads) is enabled, the query is\
-executed on the primary server, if one is available. In practice this means that\
+In MaxScale 23.08.2, if a [session command](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#routing-to-every-session-backend)
+is received as the first command, the default behavior is to execute it on a
+replica. If [master\_accept\_reads](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#master_accept_reads) is enabled, the query is
+executed on the primary server, if one is available. In practice this means that
 workloads which are mostly reads with infrequent writes should disable`master_accept_reads` if they also use `lazy_connect`.
 
-Older versions of MaxScale always tried to execute all session commands on the\
+Older versions of MaxScale always tried to execute all session commands on the
 primary node if one was available.
 
 #### `reuse_prepared_statements`
@@ -976,7 +976,7 @@ MaxScale 25.01 and the parameter has been removed from readwritesplit.
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a readwritesplit service contains the\
+The `router_diagnostics` output for a readwritesplit service contains the
 following fields.
 
 * `queries`: Number of queries executed through this service.
@@ -997,48 +997,48 @@ following fields.
 
 ### Server Ranks
 
-The general rule with server ranks is that primary servers will be used before\
-secondary servers. Readwritesplit is an exception to this rule. The following\
+The general rule with server ranks is that primary servers will be used before
+secondary servers. Readwritesplit is an exception to this rule. The following
 rules govern how readwritesplit behaves with servers that have different ranks.
 
-* Sessions will use the current primary server as long as possible. This means\
-  that sessions with a secondary primary will not use the main primary as long\
+* Sessions will use the current primary server as long as possible. This means
+  that sessions with a secondary primary will not use the main primary as long
   as the secondary primary is available.
-* All replica connections will use the same rank as the primary connection. Any\
+* All replica connections will use the same rank as the primary connection. Any
   stale connections with a different rank than the primary will be discarded.
-* If no primary connection is available and `master_reconnection` is enabled, a\
-  connection to the best primary is created. If the new primary has a different\
-  priority than existing connections have, the connections with a different rank\
+* If no primary connection is available and `master_reconnection` is enabled, a
+  connection to the best primary is created. If the new primary has a different
+  priority than existing connections have, the connections with a different rank
   will be discarded.
-* If open connections exist, these will be used for routing. This means that if\
-  the primary is lost but the session still has replica servers with the same rank,\
+* If open connections exist, these will be used for routing. This means that if
+  the primary is lost but the session still has replica servers with the same rank,
   they will remain in use.
 * If no open connections exist, the servers with the best rank will used.
 
 ### Routing hints
 
-The readwritesplit router supports routing hints. For a detailed guide on hint\
-syntax and functionality, please read [this](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-hint-syntax.md)\
+The readwritesplit router supports routing hints. For a detailed guide on hint
+syntax and functionality, please read [this](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-hint-syntax.md)
 document.
 
-**Note**: Routing hints will always have the highest priority when a routing\
-decision is made. This means that it is possible to cause inconsistencies in\
-the session state and the actual data in the database by adding routing hints\
-to DDL/DML statements which are then directed to replica servers. Only use routing\
+**Note**: Routing hints will always have the highest priority when a routing
+decision is made. This means that it is possible to cause inconsistencies in
+the session state and the actual data in the database by adding routing hints
+to DDL/DML statements which are then directed to replica servers. Only use routing
 hints when you are sure that they can cause no harm.
 
-An exception to this rule is `transaction_replay`: when it is enabled, all\
-routing hints inside transaction are ignored. This is done to prevent changes\
-done inside a re-playable transaction from affecting servers outside of the\
-transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed\
+An exception to this rule is `transaction_replay`: when it is enabled, all
+routing hints inside transaction are ignored. This is done to prevent changes
+done inside a re-playable transaction from affecting servers outside of the
+transaction. This behavior was added in MaxScale 6.1.4. Older versions allowed
 routing hints to override the transaction logic.
 
 #### Known Limitations of Routing Hints
 
-* If a `SELECT` statement with a `maxscale route to slave` hint is received\
-  while autocommit is disabled, the query will be routed to a replica server. This\
-  causes some metadata locks to be acquired on the database in question which\
-  will block DDL statements on the server until either the connection is closed\
+* If a `SELECT` statement with a `maxscale route to slave` hint is received
+  while autocommit is disabled, the query will be routed to a replica server. This
+  causes some metadata locks to be acquired on the database in question which
+  will block DDL statements on the server until either the connection is closed
   or autocommit is enabled again.
 
 ### Module Commands
@@ -1047,11 +1047,11 @@ The readwritesplit router implements the following module commands.
 
 #### `reset-gtid`
 
-The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is\
-reverted to an earlier state and the GTIDs recorded in MaxScale are no longer\
+The command resets the global GTID state in the router. It can be used with`causal_reads=global` to reset the state. This can be useful when the cluster is
+reverted to an earlier state and the GTIDs recorded in MaxScale are no longer
 valid.
 
-The first and only argument to the command is the router name. For example, to\
+The first and only argument to the command is the router name. For example, to
 reset the GTID state of a readwritesplit named `My-RW-Router`, the following\
 MaxCtrl command should be used:
 
@@ -1065,12 +1065,12 @@ Examples of the readwritesplit router in use can be found in the [Tutorials](../
 
 ### Readwritesplit routing decisions
 
-Here is a small explanation which shows what kinds of queries are routed to\
+Here is a small explanation which shows what kinds of queries are routed to
 which type of server.
 
 #### Routing to Primary
 
-Routing to primary is important for data consistency and because majority of\
+Routing to primary is important for data consistency and because majority of
 writes are written to binlog and thus become replicated to replicas.
 
 The following operations are routed to primary:
@@ -1091,32 +1091,32 @@ The following operations are routed to primary:
 * `@@last_insert_id`
 * `@@identity`
 
-In addition to these, if the **readwritesplit** service is configured with the`max_replication_lag` parameter, and if all replicas suffer from too much\
-replication lag, then statements will be routed to the primary. (There might be\
-other similar configuration parameters in the future which limit the number of\
+In addition to these, if the **readwritesplit** service is configured with the`max_replication_lag` parameter, and if all replicas suffer from too much
+replication lag, then statements will be routed to the primary. (There might be
+other similar configuration parameters in the future which limit the number of
 statements that will be routed to replicas.)
 
 **Transaction Isolation Level Tracking**
 
-If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB\
-server, readwritesplit will track the transaction isolation level and lock the\
-session to the primary when the isolation level is set to serializable. This\
-retains the correctness of the isolation level which can otherwise cause\
+If either `session_track_transaction_info=CHARACTERISTICS` or`session_track_system_variables=tx_isolation` is configured for the MariaDB
+server, readwritesplit will track the transaction isolation level and lock the
+session to the primary when the isolation level is set to serializable. This
+retains the correctness of the isolation level which can otherwise cause
 problems.
 
-Starting with MaxScale 23.08, once the transaction isolation level is set to\
-something other than `SERIALIZABLE`, the session is no longer locked to the\
-primary and returns to its normal state. Older versions of MaxScale remain\
-locked to the primary even if the session goes out of the `SERIALIZABLE`\
+Starting with MaxScale 23.08, once the transaction isolation level is set to
+something other than `SERIALIZABLE`, the session is no longer locked to the
+primary and returns to its normal state. Older versions of MaxScale remain
+locked to the primary even if the session goes out of the `SERIALIZABLE`
 isolation level.
 
 #### Routing to Replicas
 
-The ability to route some statements to replicas is important because it also\
-decreases the load targeted to _primary_. Moreover, it is possible to have multiple\
+The ability to route some statements to replicas is important because it also
+decreases the load targeted to _primary_. Moreover, it is possible to have multiple
 replicas to share the load in contrast to single primary.
 
-Queries which can be routed to replicas must be auto committed and belong to one\
+Queries which can be routed to replicas must be auto committed and belong to one
 of the following group:
 
 * Read-only statements (i.e. `SELECT`) that only use read-only built-in functions
@@ -1127,10 +1127,10 @@ The list of supported built-in functions can be found [here](https://github.com/
 
 #### Routing to every session backend
 
-A third class of statements includes those which modify session data, such as\
-session system variables, user-defined variables, the default database, etc. We\
-call them session commands, and they must be replicated as they affect the\
-future results of read and write operations. They must be executed on all\
+A third class of statements includes those which modify session data, such as
+session system variables, user-defined variables, the default database, etc. We
+call them session commands, and they must be replicated as they affect the
+future results of read and write operations. They must be executed on all
 servers that could execute statements on behalf of this client.
 
 Session commands include for example:
@@ -1140,26 +1140,26 @@ Session commands include for example:
 * Binary protocol prepared statements
 * Other miscellaneous commands (COM\_QUIT, COM\_PING etc.)
 
-**NOTE**: if variable assignment is embedded in a write statement it is routed\
-to _primary_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be\
+**NOTE**: if variable assignment is embedded in a write statement it is routed
+to _primary_ only. For example, `INSERT INTO t1 values(@myvar:=5, 7)` would be
 routed to _primary_ only.
 
-The router stores all of the executed session commands so that in case of a\
-replica failure, a replacement replica can be chosen and the session command history\
-can be repeated on that new replica. This means that the router stores each\
-executed session command for the duration of the session. Applications that use\
-long-running sessions might cause MariaDB MaxScale to consume a growing amount\
-of memory unless the sessions are closed. This can be solved by adjusting the\
+The router stores all of the executed session commands so that in case of a
+replica failure, a replacement replica can be chosen and the session command history
+can be repeated on that new replica. This means that the router stores each
+executed session command for the duration of the session. Applications that use
+long-running sessions might cause MariaDB MaxScale to consume a growing amount
+of memory unless the sessions are closed. This can be solved by adjusting the
 value of `max_sescmd_history`.
 
 #### Routing to previous target
 
-In the following cases, a query is routed to the same server where the previous\
-query was executed. If no previous target is found, the query is routed to the\
+In the following cases, a query is routed to the same server where the previous
+query was executed. If no previous target is found, the query is routed to the
 current primary.
 
-* If a query uses the `FOUND_ROWS()` function, it will be routed to the server\
-  where the last query was executed. This is done with the assumption that a\
+* If a query uses the `FOUND_ROWS()` function, it will be routed to the server
+  where the last query was executed. This is done with the assumption that a
   query with `SQL_CALC_FOUND_ROWS` was previously executed.
 * COM\_STMT\_FETCH\_ROWS will always be routed to the same server where the\
   COM\_STMT\_EXECUTE was routed.
@@ -1174,90 +1174,90 @@ Read queries are routed to the primary server in the following situations:
 
 #### Prepared Statement Limitations
 
-If a prepared statement targets a temporary table on the primary, the replica\
-servers will fail to execute it. This will cause all replica connections to be\
+If a prepared statement targets a temporary table on the primary, the replica
+servers will fail to execute it. This will cause all replica connections to be
 closed (MXS-1816).
 
 #### Transaction Replay Limitations
 
-When transaction replay is enabled, readwritesplit calculates a checksum of the\
-server responses for each transaction. This is used to determine whether a\
+When transaction replay is enabled, readwritesplit calculates a checksum of the
+server responses for each transaction. This is used to determine whether a
 replayed transaction was identical to the original transaction. Starting with\
-MaxScale 23.08, a 128-bit xxHash checksum is stored for each statement that is\
-in the transaction. Older versions of MaxScale used a single 160-bit SHA1\
+MaxScale 23.08, a 128-bit xxHash checksum is stored for each statement that is
+in the transaction. Older versions of MaxScale used a single 160-bit SHA1
 checksum for the whole transaction.
 
-If the results from the replacement server are not identical when the\
-transaction is replayed, the client connection is closed. This means that any\
-transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot\
+If the results from the replacement server are not identical when the
+transaction is replayed, the client connection is closed. This means that any
+transaction with a server specific result (e.g. `NOW()`, `@@server_id`) cannot
 be replayed successfully but it will still be attempted.
 
-If a transaction reads data before updating it, the rows should be locked by\
-using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when\
+If a transaction reads data before updating it, the rows should be locked by
+using `SELECT ... FOR UPDATE`. This will prevent overlapping transactions when
 multiple transactions are being replayed that modify the same set of rows.
 
-If the connection to the server where the transaction is being executed is\
-lost when the final `COMMIT` is being executed, it is impossible to know\
-whether the transaction was successfully committed. This means that there\
-is a possibility for duplicate transaction execution which can result in\
+If the connection to the server where the transaction is being executed is
+lost when the final `COMMIT` is being executed, it is impossible to know
+whether the transaction was successfully committed. This means that there
+is a possibility for duplicate transaction execution which can result in
 data duplication in certain cases.
 
-In MaxScale 23.08, the `transaction_replay_safe_commit` variable controls\
-whether a replay is attempted or not whenever a `COMMIT` is interrupted. By\
-default the transaction will not be replayed. Older versions of MaxScale always\
+In MaxScale 23.08, the `transaction_replay_safe_commit` variable controls
+whether a replay is attempted or not whenever a `COMMIT` is interrupted. By
+default the transaction will not be replayed. Older versions of MaxScale always
 replayed the transaction.
 
-Data duplication can happen if the transaction consists of the following\
+Data duplication can happen if the transaction consists of the following
 statement types:
 
 * INSERT of rows into a table that does not have an auto-increment primary key
 * A "blind update" of one or more rows e.g. `UPDATE t SET c = c + 1 WHERE id = 123`
 * A "blind delete" e.g. `DELETE FROM t LIMIT 100`
 
-This is not an exhaustive list and any operations that do not check the row\
+This is not an exhaustive list and any operations that do not check the row
 contents before performing the operation on them might face this problem.
 
-In all cases the problem of duplicate transaction execution can be avoided by\
-including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that\
-in the case that the transaction fails when it is being committed, the row is\
+In all cases the problem of duplicate transaction execution can be avoided by
+including a `SELECT ... FOR UPDATE` in the statement. This will guarantee that
+in the case that the transaction fails when it is being committed, the row is
 only modified if it matches the expected contents.
 
-Similarly, a connection loss during `COMMIT` can also result in transaction\
-replay failure. This happens due to the same reason as duplicate transaction\
-execution but the retried transaction will not be committed. This can be\
-considered a success case as the transaction replay detected that the results of\
-the two transactions are different. In these cases readwritesplit will abort the\
+Similarly, a connection loss during `COMMIT` can also result in transaction
+replay failure. This happens due to the same reason as duplicate transaction
+execution but the retried transaction will not be committed. This can be
+considered a success case as the transaction replay detected that the results of
+the two transactions are different. In these cases readwritesplit will abort the
 transaction and close the client connection.
 
-Statements that result in an implicit commit do not reset the transaction when\
-transaction\_replay is enabled. This means that if the transaction is replayed,\
-the transaction will be committed twice due to the implicit commit being\
-present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the\
+Statements that result in an implicit commit do not reset the transaction when
+transaction\_replay is enabled. This means that if the transaction is replayed,
+the transaction will be committed twice due to the implicit commit being
+present. The exception to this are the transaction management statements such as`BEGIN` and `START TRANSACTION`: they are detected and will cause the
 transaction to be correctly reset.
 
-In older versions of MaxScale, if a connection to a server is lost while a\
-statement is being executed and the result was partially delivered to the\
-client, readwritesplit would immediately close the session without attempting to\
-replay the failing statement. Starting with MaxScale 23.08, this limitation no\
+In older versions of MaxScale, if a connection to a server is lost while a
+statement is being executed and the result was partially delivered to the
+client, readwritesplit would immediately close the session without attempting to
+replay the failing statement. Starting with MaxScale 23.08, this limitation no
 longer applies if the statement was done inside of a transaction and`transaction_replay` is enabled\
 ([MXS-4549](https://jira.mariadb.org/browse/MXS-4549)).
 
-If the connection to the server where a transaction is being executed is lost\
-while a `ROLLBACK` is being executed, readwritesplit will still attempt to\
-replay the transaction in the hopes that the real response can be delivered to\
-the client. However, this does mean that it is possible that a rolled back\
-transaction which gets replayed ends up with a conflict and is reported as a\
-replay failure when in reality a rolled back transaction could be safely\
+If the connection to the server where a transaction is being executed is lost
+while a `ROLLBACK` is being executed, readwritesplit will still attempt to
+replay the transaction in the hopes that the real response can be delivered to
+the client. However, this does mean that it is possible that a rolled back
+transaction which gets replayed ends up with a conflict and is reported as a
+replay failure when in reality a rolled back transaction could be safely
 ignored.
 
 **Limitations in Session State Modifications**
 
-Any changes to the session state (e.g. autocommit state, SQL mode) done inside a\
-transaction will remain in effect even if the connection to the server where the\
-transaction is being executed fails. When readwritesplit creates a new\
-connection to a server to replay the transaction, it will first restore the\
-session state by executing all session commands that were executed. This means\
-that if the session state is changed mid-transaction in a way that affects the\
+Any changes to the session state (e.g. autocommit state, SQL mode) done inside a
+transaction will remain in effect even if the connection to the server where the
+transaction is being executed fails. When readwritesplit creates a new
+connection to a server to replay the transaction, it will first restore the
+session state by executing all session commands that were executed. This means
+that if the session state is changed mid-transaction in a way that affects the
 results, transaction replay will fail.
 
 The following partial transaction demonstrates the problem by using [SQL\_MODE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) inside a transaction.
@@ -1270,7 +1270,7 @@ SET SQL_MODE='ANSI_QUOTES'; -- A session command
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-If this transaction has to be replayed the actual SQL that gets executed is the\
+If this transaction has to be replayed the actual SQL that gets executed is the
 following.
 
 ```
@@ -1281,38 +1281,38 @@ SELECT "hello world";       -- Returns an error
 SELECT 'hello world';       -- Returns the string "hello world"
 ```
 
-First the session state is restored by executing all commands that changed the\
+First the session state is restored by executing all commands that changed the
 state after which the actual transaction is replayed. Due to the fact that the\
-SQL\_MODE was changed mid-transaction, one of the queries will now return an\
+SQL\_MODE was changed mid-transaction, one of the queries will now return an
 error instead of the result we expected leading to a transaction replay failure.
 
 **Limitations in Service-to-Service Routing**
 
-In a service-to-service configuration (i.e. a service using another service in\
-its `targets` list ), if the topmost service starts a transaction, all\
-lower-level readwritesplit services will also behave as if a transaction is\
-open. If a connection to a backend database fails during this, it can result in\
-unnecessary transaction replays which in turn can end up with checksum\
-conflicts. The recommended approach is to not use any commands inside a\
+In a service-to-service configuration (i.e. a service using another service in
+its `targets` list ), if the topmost service starts a transaction, all
+lower-level readwritesplit services will also behave as if a transaction is
+open. If a connection to a backend database fails during this, it can result in
+unnecessary transaction replays which in turn can end up with checksum
+conflicts. The recommended approach is to not use any commands inside a
 transaction that would be routed to more than one node.
 
 **Limitations in multi-statement handling**
 
-When a multi-statement query is executed through the readwritesplit router, it\
-will always be routed to the primary. See [strict\_multi\_stmt](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md) for more\
+When a multi-statement query is executed through the readwritesplit router, it
+will always be routed to the primary. See [strict\_multi\_stmt](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md) for more
 details.
 
-If the multi-statement query creates a temporary table, it will not be\
-detected and reads to this table can be routed to replica servers. To\
-prevent this, always execute the temporary table creation as an individual\
+If the multi-statement query creates a temporary table, it will not be
+detected and reads to this table can be routed to replica servers. To
+prevent this, always execute the temporary table creation as an individual
 statement.
 
 **Limitations in client session handling**
 
-Some of the queries that a client sends are routed to all backends instead of\
-just to one. These queries include `USE <db name>` and `SET autocommit=0`, among\
-many others. Readwritesplit sends a copy of these queries to each backend server\
-and forwards the primary's reply to the client. Below is a list of MySQL commands\
+Some of the queries that a client sends are routed to all backends instead of
+just to one. These queries include `USE <db name>` and `SET autocommit=0`, among
+many others. Readwritesplit sends a copy of these queries to each backend server
+and forwards the primary's reply to the client. Below is a list of MySQL commands
 which are classified as session commands.
 
 ```
@@ -1334,19 +1334,19 @@ SELECT ..INTO variable|OUTFILE|DUMPFILE
 SET autocommit=1|0
 ```
 
-Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were\
+Prior to MaxScale 2.3.0, session commands that were 2²⁴ - 1 bytes or longer were
 not supported and caused the session to be closed.
 
-There is a possibility for misbehavior. If `USE mytable` is executed in one of\
-the replicas and fails, it may be due to replication lag rather than the database\
-not existing. Thus, the same command may produce different result in different\
-backend servers. The replicas which fail to execute a session command will be\
-dropped from the active list of replicas for this session to guarantee a\
-consistent session state across all the servers used by the session. In\
-addition, the server will not be used again for routing for the duration of the\
+There is a possibility for misbehavior. If `USE mytable` is executed in one of
+the replicas and fails, it may be due to replication lag rather than the database
+not existing. Thus, the same command may produce different result in different
+backend servers. The replicas which fail to execute a session command will be
+dropped from the active list of replicas for this session to guarantee a
+consistent session state across all the servers used by the session. In
+addition, the server will not be used again for routing for the duration of the
 session.
 
-The above-mentioned behavior for user variables can be partially controlled with\
+The above-mentioned behavior for user variables can be partially controlled with
 the configuration parameter `use_sql_variables_in`:
 
 ```
@@ -1355,10 +1355,10 @@ use_sql_variables_in=[master|all] (default: all)
 
 **WARNING**
 
-If a SELECT query modifies a user variable when the `use_sql_variables_in`\
-parameter is set to `all`, it will not be routed and the client will receive an\
-error. A log message is written into the log further explaining the reason for\
-the error. Here is an example use of a SELECT query which modifies a user\
+If a SELECT query modifies a user variable when the `use_sql_variables_in`
+parameter is set to `all`, it will not be routed and the client will receive an
+error. A log message is written into the log further explaining the reason for
+the error. Here is an example use of a SELECT query which modifies a user
 variable and how MariaDB MaxScale responds to it.
 
 ```
@@ -1369,7 +1369,7 @@ MySQL [(none)]> SELECT @id := @id + 1 FROM test.t1;
 ERROR 1064 (42000): Routing query to backend failed. See the error log for further details.
 ```
 
-Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user\
+Allow user variable modification in SELECT queries by setting`use_sql_variables_in=master`. This will route all queries that use user
 variables to the primary.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-schemarouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-schemarouter.md
@@ -2,16 +2,16 @@
 
 ## SchemaRouter
 
-The SchemaRouter provides an easy and manageable sharding solution by\
-building a single logical database server from multiple separate ones. Each\
-database is shown to the client and queries targeting unique databases are\
-routed to their respective servers. In addition to providing simple\
-database-based sharding, the schemarouter also enables cross-node\
-session variable usage by routing all queries that modify the session to all\
+The SchemaRouter provides an easy and manageable sharding solution by
+building a single logical database server from multiple separate ones. Each
+database is shown to the client and queries targeting unique databases are
+routed to their respective servers. In addition to providing simple
+database-based sharding, the schemarouter also enables cross-node
+session variable usage by routing all queries that modify the session to all
 nodes.
 
-By default the SchemaRouter assumes that each database and table is only located\
-on one server. If it finds the same database or table on multiple servers, it\
+By default the SchemaRouter assumes that each database and table is only located
+on one server. If it finds the same database or table on multiple servers, it
 will close the session with the following error:
 
 ```
@@ -20,68 +20,68 @@ ERROR 5000 (DUPDB): Error: duplicate tables found on two different shards.
 
 The exception to this rule are the system tables `mysql`, `information_schema`,`performance_schema`, `sys` that are never treated as duplicates.
 
-If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2501-maxscale-2501-schemarouter.md#ignore_tables_regex) parameter to control which\
-duplicate tables are allowed. To disable the duplicate database detection, use`ignore_tables_regex=.*`. Starting with MaxScale 25.01, the detection of\
+If duplicate tables are expected, use the [ignore\_tables\_regex](mariadb-maxscale-2501-maxscale-2501-schemarouter.md#ignore_tables_regex) parameter to control which
+duplicate tables are allowed. To disable the duplicate database detection, use`ignore_tables_regex=.*`. Starting with MaxScale 25.01, the detection of
 duplicate tables can be turned off with `allow_duplicates=true`.
 
-Schemarouter compares table and database names case-insensitively. This means\
+Schemarouter compares table and database names case-insensitively. This means
 that the tables `test.t1` and `test.T1` are assumed to refer to the same table.
 
-The main limitation of SchemaRouter is that aside from session variable writes\
-and some specific queries, a query can only target one server. This means that\
+The main limitation of SchemaRouter is that aside from session variable writes
+and some specific queries, a query can only target one server. This means that
 queries which depend on results from multiple servers give incorrect results.\
 See [Limitations](mariadb-maxscale-2501-maxscale-2501-schemarouter.md#limitations) for more information.
 
 From 2.3.0 onwards, SchemaRouter is capable of limited table family sharding.
 
-Older versions of MaxScale required that the `auth_all_servers` parameter was\
-enabled in order for the schemarouter services to load the authentication data\
-from all servers instead of just one server. Starting with MaxScale 24.02, the\
-schemarouter automatically fetches the authentication data from all servers and\
-joins it together. At the same time, the `auth_all_servers` parameter has been\
+Older versions of MaxScale required that the `auth_all_servers` parameter was
+enabled in order for the schemarouter services to load the authentication data
+from all servers instead of just one server. Starting with MaxScale 24.02, the
+schemarouter automatically fetches the authentication data from all servers and
+joins it together. At the same time, the `auth_all_servers` parameter has been
 deprecated and is ignored if present in the configuration.
 
 ### Routing Logic
 
-* If a command modifies the session state by modifying any session or user\
-  variables, the query is routed to all nodes. These statements include `SET`\
-  statements as well as any other statements that modify the behavior of the\
+* If a command modifies the session state by modifying any session or user
+  variables, the query is routed to all nodes. These statements include `SET`
+  statements as well as any other statements that modify the behavior of the
   client.
-* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers\
-  that contain the database. This same logic applies when a client connects with\
-  a default database: the default database is set only on servers that actually\
+* If a client changes the default database after connecting, either with a `USE <db>` query or a `COM_INIT_DB` command, the query is routed to all servers
+  that contain the database. This same logic applies when a client connects with
+  a default database: the default database is set only on servers that actually
   contain it.
-* If a query targets one or more tables that the schemarouter has discovered\
-  during the database mapping phase, the query is only routed if a server is\
-  found that contains all of the tables that the query uses. If no such server\
-  is found, the query is routed to the server that was previously used or to the\
-  first available backend if none have been used. If a query uses a table but\
-  doesn't define the database it is in, it is assumed to be located on the\
+* If a query targets one or more tables that the schemarouter has discovered
+  during the database mapping phase, the query is only routed if a server is
+  found that contains all of the tables that the query uses. If no such server
+  is found, the query is routed to the server that was previously used or to the
+  first available backend if none have been used. If a query uses a table but
+  doesn't define the database it is in, it is assumed to be located on the
   default database of the connection.
-* If a query targets a table or a database that is present on all nodes\
-  (e.g. `information_schema`) and the connection is using a default database,\
-  the query is routed based on the default database. This makes it possible to\
-  control where queries that do match a specific node are routed. If the\
-  connection is not using a default database, the query is routed based solely\
+* If a query targets a table or a database that is present on all nodes
+  (e.g. `information_schema`) and the connection is using a default database,
+  the query is routed based on the default database. This makes it possible to
+  control where queries that do match a specific node are routed. If the
+  connection is not using a default database, the query is routed based solely
   on the tables it contains.
-* If a query uses a table that is unknown to the schemarouter or executes a\
-  command that doesn't target a table, the query is routed to a server contains\
-  the current active default database. If the connection does not have a default\
-  database, the query is routed to the backend that was last used or to the\
-  first available backend if none have been used. If the query contains a\
+* If a query uses a table that is unknown to the schemarouter or executes a
+  command that doesn't target a table, the query is routed to a server contains
+  the current active default database. If the connection does not have a default
+  database, the query is routed to the backend that was last used or to the
+  first available backend if none have been used. If the query contains a
   routing hint that directs it to a server, the query is routed there.
 
-This means that all administrative commands, replication related command as\
-well as certain transaction control statements (XA transaction) are routed to\
-the first available server in certain cases. To avoid problems, use routing\
+This means that all administrative commands, replication related command as
+well as certain transaction control statements (XA transaction) are routed to
+the first available server in certain cases. To avoid problems, use routing
 hints to direct where these statements should go.
 
-* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`\
-  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the\
-  queries to the first available backend. This means that cross-shard\
-  transactions are technically possible but, without external synchronization,\
+* Starting with MaxScale 6.4.5, transaction control commands (`BEGIN`, `COMMIT`
+  and `ROLLBACK`) are routed to all nodes. Older versions of MaxScale routed the
+  queries to the first available backend. This means that cross-shard
+  transactions are technically possible but, without external synchronization,
   the transactions are not guaranteed to be globally consistent.
-* `LOAD DATA LOCAL INFILE` commands are routed to the first available server\
+* `LOAD DATA LOCAL INFILE` commands are routed to the first available server
   that contains the tables listed in the query.
 
 #### Custom SQL Commands
@@ -98,24 +98,24 @@ db1.t2   |MyServer1    |
 db2.t1   |MyServer2    |
 ```
 
-The schemarouter will also intercept the `SHOW DATABASES` command and generate\
-it based on its internal data. This means that newly created databases will not\
-show up immediately and will only be visible when the cached data has been\
+The schemarouter will also intercept the `SHOW DATABASES` command and generate
+it based on its internal data. This means that newly created databases will not
+show up immediately and will only be visible when the cached data has been
 updated.
 
 #### Database Mapping
 
-The schemarouter maps each of the servers to know where each database and table\
-is located. As each user has access to a different set of tables and databases,\
-the result is unique to the username and the set of servers that the service\
-uses. These results are cached by the schemarouter. The lifetime of the cached\
+The schemarouter maps each of the servers to know where each database and table
+is located. As each user has access to a different set of tables and databases,
+the result is unique to the username and the set of servers that the service
+uses. These results are cached by the schemarouter. The lifetime of the cached
 result is controlled by the `refresh_interval` parameter.
 
-When a server needs to be mapped, the schemarouter will route a query to each of\
-the servers using the client's credentials. While this query is being executed,\
-all other sessions that would otherwise share the cached result will wait for\
-the update to complete. This waiting functionality was added in MaxScale 2.4.19,\
-older versions did not wait for existing updates to finish and would perform\
+When a server needs to be mapped, the schemarouter will route a query to each of
+the servers using the client's credentials. While this query is being executed,
+all other sessions that would otherwise share the cached result will wait for
+the update to complete. This waiting functionality was added in MaxScale 2.4.19,
+older versions did not wait for existing updates to finish and would perform
 parallel database mapping queries.
 
 ### Configuration
@@ -131,24 +131,24 @@ user=myuser
 password=mypwd
 ```
 
-The module generates the list of databases based on the servers parameter\
-using the connecting client's credentials. The user and password parameters\
-define the credentials that are used to fetch the authentication data from\
-the database servers. The credentials used only require the same grants as\
+The module generates the list of databases based on the servers parameter
+using the connecting client's credentials. The user and password parameters
+define the credentials that are used to fetch the authentication data from
+the database servers. The credentials used only require the same grants as
 mentioned in the configuration documentation.
 
-The list of databases is built by sending a SHOW DATABASES query to all the\
-servers. This requires the user to have at least USAGE and SELECT grants on\
+The list of databases is built by sending a SHOW DATABASES query to all the
+servers. This requires the user to have at least USAGE and SELECT grants on
 the databases that need be sharded.
 
-If you are connecting directly to a database or have different users on some\
-of the servers, you need to get the authentication data from all the\
-servers. You can control this with the `auth_all_servers` parameter. With\
-this parameter, MariaDB MaxScale forms a union of all the users and their\
-grants from all the servers. By default, the schemarouter will fetch the\
+If you are connecting directly to a database or have different users on some
+of the servers, you need to get the authentication data from all the
+servers. You can control this with the `auth_all_servers` parameter. With
+this parameter, MariaDB MaxScale forms a union of all the users and their
+grants from all the servers. By default, the schemarouter will fetch the
 authentication data from all servers.
 
-For example, if two servers have the database `shard` and the following\
+For example, if two servers have the database `shard` and the following
 rights are granted only on one server, all queries targeting the database`shard` would be routed to the server where the grants were given.
 
 ```
@@ -159,9 +159,9 @@ CREATE USER 'john'@'%' IDENTIFIED BY 'password';
 GRANT SELECT,USAGE ON shard.* TO 'john'@'%';
 ```
 
-This would in effect allow the user 'john' to only see the database 'shard'\
+This would in effect allow the user 'john' to only see the database 'shard'
 on this server. Take notice that these grants are matched against MariaDB\
-MaxScale's hostname instead of the client's hostname. Only user\
+MaxScale's hostname instead of the client's hostname. Only user
 authentication uses the client's hostname and all other grants use MariaDB\
 MaxScale's hostname.
 
@@ -176,8 +176,8 @@ MaxScale's hostname.
 
 If enabled, the detection of duplicated tables on shards is not done.
 
-This parameter was added in MaxScale 25.01 and it is a more convenient and\
-efficient way to disable the duplicate table detection that previously was only\
+This parameter was added in MaxScale 25.01 and it is a more convenient and
+efficient way to disable the duplicate table detection that previously was only
 possible with `ignore_tables_regex=.*`.
 
 #### `ignore_tables`
@@ -187,7 +187,7 @@ possible with `ignore_tables_regex=.*`.
 * Dynamic: Yes
 * Default: `""`
 
-List of full table names (e.g. db1.t1) to ignore when checking for duplicate\
+List of full table names (e.g. db1.t1) to ignore when checking for duplicate
 tables. By default no tables are ignored.
 
 This parameter was once called `ignore_databases`.
@@ -199,11 +199,11 @@ This parameter was once called `ignore_databases`.
 * Dynamic: No
 * Default: `""`
 
-A [PCRE2 regular expression](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+A [PCRE2 regular expression](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 that is matched against database names when checking for duplicate databases.\
 By default no tables are ignored.
 
-The following configuration ignores duplicate tables in the databases `db1` and `db2`,\
+The following configuration ignores duplicate tables in the databases `db1` and `db2`,
 and all tables starting with "t" in `db3`.
 
 ```
@@ -220,12 +220,12 @@ This parameter was once called `ignore_databases_regex`.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)\
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 in MaxScale 6.0.
 
 #### `refresh_databases`
@@ -235,11 +235,11 @@ in MaxScale 6.0.
 * Dynamic: No
 * Default: `false`
 
-Enable database map refreshing mid-session. These are triggered by a failure to\
+Enable database map refreshing mid-session. These are triggered by a failure to
 change the database i.e. `USE ...` queries. This feature is disabled by default.
 
-Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0\
-release of MaxScale this parameter now works again but it is disabled by default\
+Before MaxScale 6.2.0, this parameter did nothing. Starting with the 6.2.0
+release of MaxScale this parameter now works again but it is disabled by default
 to retain the same behavior as in older releases.
 
 #### `refresh_interval`
@@ -249,13 +249,13 @@ to retain the same behavior as in older releases.
 * Dynamic: Yes
 * Default: `300s`
 
-The minimum interval between database map refreshes in seconds. The default\
+The minimum interval between database map refreshes in seconds. The default
 value is 300 seconds.
 
-The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the intervaltimeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 #### `max_staleness`
@@ -265,28 +265,28 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: 150s
 
-The time how long stale database map entries can be used while an update is in\
-progress. When a database map entry goes stale, the next connection to be\
-created will start an update of the database map. While this update is ongoing,\
-other connections can use the stale entry for up to `max_staleness` seconds. If\
-this limit is exceeded and the update still hasn't completed, new connections\
+The time how long stale database map entries can be used while an update is in
+progress. When a database map entry goes stale, the next connection to be
+created will start an update of the database map. While this update is ongoing,
+other connections can use the stale entry for up to `max_staleness` seconds. If
+this limit is exceeded and the update still hasn't completed, new connections
 will instead block and wait for the update to finish.
 
-This feature was added in MaxScale 23.08.0. Older versions of MaxScale\
-always waited for the update to complete when the database map entry\
+This feature was added in MaxScale 23.08.0. Older versions of MaxScale
+always waited for the update to complete when the database map entry
 went stale.
 
 ### Table Family Sharding
 
 This functionality was introduced in 2.3.0.
 
-If the same database exists on multiple servers, but the database contains different\
-tables in each server, SchemaRouter is capable of routing queries to the right server,\
+If the same database exists on multiple servers, but the database contains different
+tables in each server, SchemaRouter is capable of routing queries to the right server,
 depending on which table is being addressed.
 
-As an example, suppose the database `db` exists on servers _server1_ and _server2_, but\
-that the database on _server1_ contains the table `tbl1` and on _server2_ contains the\
-table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table\
+As an example, suppose the database `db` exists on servers _server1_ and _server2_, but
+that the database on _server1_ contains the table `tbl1` and on _server2_ contains the
+table `tbl2`. The query `SELECT * FROM db.tbl1` will be routed to _server1_ and the query`SELECT * FROM db.tbl2` will be routed to _server2_. As in the example queries, the table
 names must be qualified with the database names for table-level sharding to work.\
 Specifically, the query series below is not supported.
 
@@ -297,7 +297,7 @@ SELECT * FROM tbl1; // May be routed to an incorrect backend if using table shar
 
 ### Router Diagnostics
 
-The `router_diagnostics` output for a schemarouter service contains the\
+The `router_diagnostics` output for a schemarouter service contains the
 following fields.
 
 * `shard_map_hits`: Cache hits for the shard map cache.
@@ -307,72 +307,72 @@ In MaxScale 24.02, the `queries` `sescmd_percentage`, `longest_sescmd_chain`,`ti
 
 ### Module commands
 
-Read [Module Commands](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md) documentation for\
+Read [Module Commands](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-module-commands.md) documentation for
 details about module commands.
 
 The schemarouter supports the following module commands.
 
 #### `invalidate SERVICE`
 
-Invalidates the database map cache of the given service. This can be used to schedule\
-the updates to the database maps to happen at off-peak hours by configuring a\
+Invalidates the database map cache of the given service. This can be used to schedule
+the updates to the database maps to happen at off-peak hours by configuring a
 high value for `refresh_interval` and invalidating the cache externally.
 
 #### `clear SERVICE`
 
-Clears the database map cache of the given service. This forces new connections\
+Clears the database map cache of the given service. This forces new connections
 to use a freshly retrieved entry.
 
-If the set of databases and tables in each shard is very large, the update can\
-take some time. If there are stale cache entries and `max_staleness` is\
-configured to be higher than the time it takes to update the database map, the\
-invalidation will only slow down one client connection that ends up doing the\
-update. When the cache is cleared completely, all clients will have to wait for\
-the update to complete. In general, cache invalidation should be preferred over\
+If the set of databases and tables in each shard is very large, the update can
+take some time. If there are stale cache entries and `max_staleness` is
+configured to be higher than the time it takes to update the database map, the
+invalidation will only slow down one client connection that ends up doing the
+update. When the cache is cleared completely, all clients will have to wait for
+the update to complete. In general, cache invalidation should be preferred over
 cache clearing.
 
 ### Limitations
 
-* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the\
-  first explicit database in the query, the current database in use or to the first\
+* Cross-database queries (e.g. `SELECT column FROM database1.table UNION select column FROM database2.table`) are not properly supported. Such queries are routed either to the
+  first explicit database in the query, the current database in use or to the first
   available database, depending on which succeeds.
-* Without a default database, queries that do not use fully qualified table\
-  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will\
-  be routed to the first available server. This includes queries such as explicit\
-  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`\
-  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`\
-  statements that do not directly refer to a table. `CREATE` commands should be\
-  done directly on the node or the router should be equipped with the hint filter\
-  and a routing hint should be used. Queries that modify the session state\
-  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the\
-  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,\
-  otherwise routing hints are required to correctly route the transaction control\
-  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the\
-  routing of transaction control commands to route them to all servers used by the\
+* Without a default database, queries that do not use fully qualified table
+  names and which do not modify the session state (e.g. `SELECT * FROM t1`) will
+  be routed to the first available server. This includes queries such as explicit
+  transaction commands (`BEGIN`, `COMMIT`, `ROLLBACK`), all non-table `CREATE`
+  commands (`CREATE DATABASE`, `CREATE SEQUENCE`) as well as any `SELECT`
+  statements that do not directly refer to a table. `CREATE` commands should be
+  done directly on the node or the router should be equipped with the hint filter
+  and a routing hint should be used. Queries that modify the session state
+  (e.g. `SET autocommit=1`) will be routed to all servers regardless of the
+  default database. For explicit transactions, the recommended way is to use `SET autocommit=0` to start a transaction and `SET autocommit=1` to commit it,
+  otherwise routing hints are required to correctly route the transaction control
+  commands. [MXS-4467](https://jira.mariadb.org/browse/MXS-4467) changed the
+  routing of transaction control commands to route them to all servers used by the
   schemarouter.
-* SELECT queries that modify session variables are not supported because uniform results\
-  cannot be guaranteed. If such a query is executed, the behavior of the router is\
+* SELECT queries that modify session variables are not supported because uniform results
+  cannot be guaranteed. If such a query is executed, the behavior of the router is
   undefined. To work around this limitation, the query must be executed in separate parts.
-* If a query targets a database the SchemaRouter has not mapped to a server, the\
-  query will be routed to the first available server. This possibly returns an\
+* If a query targets a database the SchemaRouter has not mapped to a server, the
+  query will be routed to the first available server. This possibly returns an
   error about database rights instead of a missing database.
-* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the\
+* Prepared statement support is limited. PREPARE, EXECUTE and DEALLOCATE are routed to the
   correct backend if the statement is known and only requires one backend server. EXECUTE\
-  IMMEDIATE is not supported and is routed to the first available backend and may give\
+  IMMEDIATE is not supported and is routed to the first available backend and may give
   wrong results. Similarly, preparing a statement from a variable (e.g. `PREPARE stmt FROM @a`) is not supported and may be routed wrong.
-* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only\
-  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are\
+* `SHOW DATABASES` is handled by the router instead of routed to a server. The router only
+  answers correctly to the basic version of the query. Any modifiers such as `LIKE` are
   ignored. Starting with MaxScale 22.08, the database names will always be in lowercase.
-* `SHOW TABLES` is routed to the server with the current database. If using\
-  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table\
+* `SHOW TABLES` is routed to the server with the current database. If using
+  table-level sharding, the results will be incomplete. Similarly, `SHOW TABLES FROM db1` is routed to the server with database `db1`, ignoring table
   sharding. Use `SHOW SHARDS` to get results from the router itself. Starting with\
   MaxScale 22.08, the database names will always be in lowercase.
-* `USE db1` is routed to the server with `db1`. If the database is divided to multiple\
+* `USE db1` is routed to the server with `db1`. If the database is divided to multiple
   servers, only one server will get the command.
 
 ### Examples
 
-[Here](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-schemarouter-simple-sharding-with-two-servers.md) is a small tutorial on how\
+[Here](../mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-schemarouter-simple-sharding-with-two-servers.md) is a small tutorial on how
 to set up a sharded database.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-smartrouter.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-smartrouter.md
@@ -4,20 +4,20 @@
 
 ### Overview
 
-SmartRouter is the query router of the SmartQuery framework. Based on the type\
-of the query, each query is routed to the server or cluster that can best\
+SmartRouter is the query router of the SmartQuery framework. Based on the type
+of the query, each query is routed to the server or cluster that can best
 handle it.
 
 For workloads where both transactional and analytical queries are needed,\
-SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into\
-a single entry point in MaxScale. This allows a MaxScale client to freely mix\
-transactional and analytical queries using the same connection. This is known\
+SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into
+a single entry point in MaxScale. This allows a MaxScale client to freely mix
+transactional and analytical queries using the same connection. This is known
 as Hybrid Transactional and Analytical Processing, HTAP.
 
 ### Settings
 
-SmartRouter is configured as a service that either routes to other MaxScale\
-routers or plain servers. Although one can configure SmartRouter to use a plain\
+SmartRouter is configured as a service that either routes to other MaxScale
+routers or plain servers. Although one can configure SmartRouter to use a plain
 server directly, we refer to the configured "servers" as clusters.
 
 For details about the standard service parameters, refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
@@ -28,10 +28,10 @@ For details about the standard service parameters, refer to the [Configuration G
 * Mandatory: Yes
 * Dynamic: No
 
-One of the clusters must be designated as the **`master`**. All writes go to the\
+One of the clusters must be designated as the **`master`**. All writes go to the
 primary cluster, which for all practical purposes should be a primary-replica\
-ReadWriteSplit. This document does not go into details about setting up\
-primary-replica clusters, but suffice to say, that when setting up the ColumnStore\
+ReadWriteSplit. This document does not go into details about setting up
+primary-replica clusters, but suffice to say, that when setting up the ColumnStore
 servers they should be configured to be replicas of a MariaDB server running an\
 InnoDB engine.\
 The ReadWriteSplit [documentation](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md) has more on primary-replica setup.
@@ -87,8 +87,8 @@ service = SmartQuery
 port = <port>
 ```
 
-Note that the SmartQuery listener listens on a port, while the Row and Column\
-service listeners listen on Unix domain sockets. The reason is that there is a\
+Note that the SmartQuery listener listens on a port, while the Row and Column
+service listeners listen on Unix domain sockets. The reason is that there is a
 significant performance benefit when SmartRouter accesses the services over a\
 Unix domain socket compared to accessing them over a TCP/IP socket.
 
@@ -96,31 +96,31 @@ A complete configuration example can be found at the end of this document.
 
 ### Cluster selection - how queries are routed
 
-SmartRouter keeps track of the performance, or the execution time, of queries to\
+SmartRouter keeps track of the performance, or the execution time, of queries to
 the clusters. Measurements are stored with the canonical of a query as the key.\
-The canonical of a query is the sql with all user-defined constants replaced with\
-question marks. When SmartRouter sees a read-query whose canonical has not been\
-seen before, it will send the query to all clusters. The first response from a\
-cluster will designate that cluster as the best one for that canonical. Also,\
-when the first response is received, the other queries are cancelled. The\
-response is sent to the client once all clusters have responded to the query\
+The canonical of a query is the sql with all user-defined constants replaced with
+question marks. When SmartRouter sees a read-query whose canonical has not been
+seen before, it will send the query to all clusters. The first response from a
+cluster will designate that cluster as the best one for that canonical. Also,
+when the first response is received, the other queries are cancelled. The
+response is sent to the client once all clusters have responded to the query
 or the cancel.
 
-There is obviously overhead when a new canonical is seen. This means that\
-queries after a MaxScale start will be slightly slower than normal. The\
-execution time of a query depends on the database engine, and on the contents\
-of the tables being queried. As a result, MaxScale will periodically re-measure\
+There is obviously overhead when a new canonical is seen. This means that
+queries after a MaxScale start will be slightly slower than normal. The
+execution time of a query depends on the database engine, and on the contents
+of the tables being queried. As a result, MaxScale will periodically re-measure
 queries.
 
-The performance behavior of queries under dynamic conditions, and their effect\
-on different storage engines is being studied at MariaDB. As we learn more, we\
+The performance behavior of queries under dynamic conditions, and their effect
+on different storage engines is being studied at MariaDB. As we learn more, we
 will be able to better categorize queries and move that knowledge into\
 SmartRouter.
 
 ### Limitations
 
 * `LOAD DATA LOCAL INFILE` is not supported.
-* The performance data is not persisted. The measurements will be performed\
+* The performance data is not persisted. The measurements will be performed
   anew after each startup.
 
 ### Complete configuration example

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-avrorouter-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-avrorouter-tutorial.md
@@ -1,6 +1,6 @@
 # Avrorouter Tutorial
 
-This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-avrorouter.md), how to set it up and how it interacts\
+This tutorial is a short introduction to the [Avrorouter](../mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-avrorouter.md), how to set it up and how it interacts
 with the binlogrouter.
 
 The first part configures the services and sets them up for the binary log to Avro file conversion. The second part of this tutorial uses the client listener interface for the avrorouter and shows how to communicate with the service over the network.
@@ -109,7 +109,7 @@ protocol=CDC
 port=4001
 ```
 
-The `source` parameter in the _avro-service_ points to the _replication-service_ we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog number to start from. With these parameters, the avrorouter will start reading\
+The `source` parameter in the _avro-service_ points to the _replication-service_ we defined before. This service will be the data source for the avrorouter. The_filestem_ is the prefix in the binlog files and _start\_index_ is the binlog number to start from. With these parameters, the avrorouter will start reading
 events from binlog `binlog.000015`.
 
 Note that the _filestem_ and _start\_index_ must point to the file that is the first binlog that the binlogrouter will replicate. For example, if the first file you are replicating is `my-binlog-file.001234`, set the parameters to`filestem=my-binlog-file` and `start_index=1234`.
@@ -126,7 +126,7 @@ If the binary logs contain data modification events for tables that aren't creat
 * Use the [cdc\_schema Go utility](../mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-avrorouter.md) and copy the generated .avsc files to the avrodir
 * Use the [Python version of the schema generator](https://mariadb.com/server/modules/protocol/examples/cdc_schema.py) and copy the generated `.avsc` files to the avrodir
 
-If you used the schema generator scripts, all Avro schema files for tables that are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of\
+If you used the schema generator scripts, all Avro schema files for tables that are not created in the binary logs need to be in the location pointed to by the_avrodir_ parameter. The files use the following naming:`<database>.<table>.<schema_version>.avsc`. For example, the schema file name of
 the _test.t1_ table would be `test.t1.0000001.avsc`.
 
 ## Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-configuring-the-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-configuring-the-galera-monitor.md
@@ -16,19 +16,19 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
-This monitor module will assign one node within the Galera Cluster as the\
-current primary and other nodes as replica. Only those nodes that are active\
-members of the cluster are considered when making the choice of primary node. The\
+This monitor module will assign one node within the Galera Cluster as the
+current primary and other nodes as replica. Only those nodes that are active
+members of the cluster are considered when making the choice of primary node. The
 primary node will be the node with the lowest value of `wsrep_local_index`.
 
 ### Monitor User
 
-The monitor user does not require any special grants to monitor a Galera\
+The monitor user does not require any special grants to monitor a Galera
 cluster. To create a user for the monitor, execute the following SQL.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-configuring-the-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-configuring-the-mariadb-monitor.md
@@ -1,6 +1,6 @@
 # Configuring the MariaDB Monitor
 
-This document describes how to configure a MariaDB primary-replica cluster monitor\
+This document describes how to configure a MariaDB primary-replica cluster monitor
 to be used with MaxScale.
 
 ### Configuring the Monitor
@@ -17,14 +17,14 @@ password=my_password
 monitor_interval=2000ms
 ```
 
-The mandatory parameters are the object type, the monitor module to use, the\
-list of servers to monitor and the username and password to use when connecting\
-to the servers. The `monitor_interval` parameter controls for how long\
+The mandatory parameters are the object type, the monitor module to use, the
+list of servers to monitor and the username and password to use when connecting
+to the servers. The `monitor_interval` parameter controls for how long
 the monitor waits between each monitoring loop.
 
 ### Monitor User
 
-The monitor user requires the REPLICATION CLIENT privileges to do basic\
+The monitor user requires the REPLICATION CLIENT privileges to do basic
 monitoring. To create a user with the proper grants, execute the following SQL.
 
 ```
@@ -32,7 +32,7 @@ CREATE USER 'monitor_user'@'%' IDENTIFIED BY 'my_password';
 GRANT REPLICATION CLIENT ON *.* TO 'monitor_user'@'%';
 ```
 
-**Note:** If the automatic failover of the MariaDB Monitor will used, the user\
+**Note:** If the automatic failover of the MariaDB Monitor will used, the user
 will require additional grants. Execute the following SQL to grant them.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-connection-routing-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-connection-routing-with-mariadb-maxscale.md
@@ -1,7 +1,7 @@
 # Connection Routing with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that has two ports available, one for\
-write connections and another for read connections. The read connections are load-\
+The goal of this tutorial is to configure a system that has two ports available, one for
+write connections and another for read connections. The read connections are load-
 balanced across replica servers.
 
 ### Setting up MariaDB MaxScale
@@ -11,11 +11,11 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring services
 
-We want two services and ports to which the client application can connect. One service\
-routes client connections to the primary server, the other load balances between replica\
+We want two services and ports to which the client application can connect. One service
+routes client connections to the primary server, the other load balances between replica
 servers. To achieve this, we need to define two services in the configuration file.
 
-Create the following two sections in your configuration file. The section names are the\
+Create the following two sections in your configuration file. The section names are the
 names of the services and should be meaningful. For this tutorial, we use the names_Write-Service_ and _Read-Service_.
 
 ```
@@ -36,18 +36,18 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readconnroute_ for\
+_router_ defines the routing module used. Here we use _readconnroute_ for
 connection-level routing.
 
-A service needs a list of servers to route queries to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers to route queries to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _router\_options_-parameter tells the _readconnroute_-module which servers it should\
-route a client connection to. For the write service we use the `master`-type and for the\
+The _router\_options_-parameter tells the _readconnroute_-module which servers it should
+route a client connection to. For the write service we use the `master`-type and for the
 read service the `slave`-type.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2501-maxscale-2501-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2501-maxscale-2501-encrypting-passwords.md).
@@ -55,7 +55,7 @@ For increased security, see [password encryption](mariadb-maxscale-2501-maxscale
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one per service is enough.
 
 ```
@@ -70,13 +70,13 @@ service=Read-Service
 port=3307
 ```
 
-The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set\
+The _service_ parameter tells which service the listener connects to. For the_Write-Listener_ we set it to _Write-Service_ and for the _Read-Listener_ we set
 it to _Read-Service_.
 
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-encrypting-passwords.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-encrypting-passwords.md
@@ -4,24 +4,24 @@
 
 ## Encrypting Passwords
 
-**Note**: The password encryption format changed in MaxScale 2.5. All\
-encrypted passwords created with MaxScale 2.4 or older need to be\
+**Note**: The password encryption format changed in MaxScale 2.5. All
+encrypted passwords created with MaxScale 2.4 or older need to be
 re-encrypted.
 
-There are two options for representing the password, either plain text or\
-encrypted passwords may be used. In order to use encrypted passwords a set of\
-keys must be generated that will be used by the encryption and decryption\
+There are two options for representing the password, either plain text or
+encrypted passwords may be used. In order to use encrypted passwords a set of
+keys must be generated that will be used by the encryption and decryption
 process. To generate the keys, use the `maxkeys` command.
 
 ```
 maxkeys
 ```
 
-By default the key file will be generated in `/var/lib/maxscale`. If a different\
-directory is required, it can be given as the first argument to the program. For\
+By default the key file will be generated in `/var/lib/maxscale`. If a different
+directory is required, it can be given as the first argument to the program. For
 more information, see `maxkeys --help`.
 
-Once the keys have been created the `maxpasswd` command can be used to generate\
+Once the keys have been created the `maxpasswd` command can be used to generate
 the encrypted password.
 
 ```
@@ -29,10 +29,10 @@ maxpasswd plainpassword
 96F99AA1315BDC3604B006F427DD9484
 ```
 
-The username and password, either encrypted or plain text, are stored in the\
+The username and password, either encrypted or plain text, are stored in the
 service section using the `user` and `password` parameters.
 
-If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For\
+If a custom location was used for the key file, give it as the first argument to`maxpasswd` and pass the password to be encrypted as the second argument. For
 more information, see `maxkeys --help`.
 
 Here is an example configuration that uses an encrypted password.
@@ -47,7 +47,7 @@ user=maxscale
 password=96F99AA1315BDC3604B006F427DD9484
 ```
 
-If the key file is not in the default location, the [datadir](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) parameter must be\
+If the key file is not in the default location, the [datadir](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) parameter must be
 set to the directory that contains it.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-administration-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-administration-tutorial.md
@@ -1,46 +1,46 @@
 # MariaDB MaxScale Administration Tutorial
 
-The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator\
-to a few of the common administration tasks. This is intended to be an\
-introduction for administrators who are new to MariaDB MaxScale and not a\
+The purpose of this tutorial is to introduce the MariaDB MaxScale Administrator
+to a few of the common administration tasks. This is intended to be an
+introduction for administrators who are new to MariaDB MaxScale and not a
 reference to all the tasks that may be performed.
 
 ### Administration audit file
 
-The REST API calls that MaxCtrl and MaxGui issue to MaxScale can be logged\
+The REST API calls that MaxCtrl and MaxGui issue to MaxScale can be logged
 by enabling [admin\_audit](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
 
 The generated file is a csv file that can be opened in most spread sheet programs.
 
 \[Rotating Log Files]\(#Rotating Log Files) also applies to the audit file.\
-The admin audit file will never be overwritten as a result of a rotate, unlike the\
+The admin audit file will never be overwritten as a result of a rotate, unlike the
 regular log file (in case a rotate is issued, but the file name has not been moved).\
-There is also the option to change the audit file name, which effectively rotates it\
+There is also the option to change the audit file name, which effectively rotates it
 independently of the regular log file.
 
 For e.g. `maxctrl alter maxscale admin_audit_file=/var/log/maxscale/admin_audit.march.csv`.
 
 ### Starting and Stopping MariaDB MaxScale
 
-MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,\
+MaxScale uses systemd for managing the process. This means that normal`systemctl` commands can be used to start and stop MaxScale. To start MaxScale,
 use `systemctl start maxscale`. To stop it, use `systemctl stop maxscale`.
 
 The systemd service file for MaxScale is located in`/lib/systemd/system/maxscale.service`.
 
 #### Additional Options for MaxScale
 
-Additional command line options and other systemd configuration options\
-can be given to MariaDB MaxScale by creating a drop-in file for the\
-service unit file. You can do this with the `systemctl edit maxscale.service`\
-command. For more information about systemd drop-in\
-files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)\
+Additional command line options and other systemd configuration options
+can be given to MariaDB MaxScale by creating a drop-in file for the
+service unit file. You can do this with the `systemctl edit maxscale.service`
+command. For more information about systemd drop-in
+files, refer to [the systemctl man page](https://www.freedesktop.org/software/systemd/man/systemctl.html)
 and [the systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html).
 
 ### Checking The Status Of The MariaDB MaxScale Services
 
-It is possible to use the maxctrl command to obtain statistics about the\
-services that are running within MaxScale. The maxctrl command `list services`\
-will give very basic information regarding services. This command may be either\
+It is possible to use the maxctrl command to obtain statistics about the
+services that are running within MaxScale. The maxctrl command `list services`
+will give very basic information regarding services. This command may be either
 run in interactive mode or passed on the maxctrl command line.
 
 ```
@@ -60,16 +60,16 @@ $ maxctrl list services
 └────────────────────────┴────────────────┴─────────────┴───────────────────┴────────────────────────────────────┘
 ```
 
-Network listeners count as a user of the service, therefore there will always be\
-one user per network port in which the service listens. More details can be\
+Network listeners count as a user of the service, therefore there will always be
+one user per network port in which the service listens. More details can be
 obtained by using the "show service" command.
 
 ### What Clients Are Connected To MariaDB MaxScale
 
-To determine what client are currently connected to MariaDB MaxScale, you can\
-use the `list sessions` command within maxctrl. This will give you IP address\
-and the ID of the session for that connection. As with any maxctrl\
-command this can be passed on the command line or typed interactively in\
+To determine what client are currently connected to MariaDB MaxScale, you can
+use the `list sessions` command within maxctrl. This will give you IP address
+and the ID of the session for that connection. As with any maxctrl
+command this can be passed on the command line or typed interactively in
 maxctrl.
 
 ```
@@ -83,32 +83,32 @@ $ maxctrl list sessions
 
 ### Rotating Log Files
 
-Log rotation applies to the MaxScale log file, admin audit file and\
+Log rotation applies to the MaxScale log file, admin audit file and
 qlafilter files.
 
 MariaDB MaxScale logs messages of different priority into a single log file.\
-With the exception if error messages that are always logged, whether messages of\
-a particular priority should be logged or not can be enabled via the maxctrl\
-interface or in the configuration file. By default, MaxScale keeps on writing to\
-the same log file. To prevent the file from growing indefinitely, the\
+With the exception if error messages that are always logged, whether messages of
+a particular priority should be logged or not can be enabled via the maxctrl
+interface or in the configuration file. By default, MaxScale keeps on writing to
+the same log file. To prevent the file from growing indefinitely, the
 administrator must take action.
 
-The name of the log file is maxscale.log. When the log is rotated, MaxScale\
+The name of the log file is maxscale.log. When the log is rotated, MaxScale
 closes the current log file and opens a new one using the same name.
 
-Log file rotation is achieved by use of the `rotate logs` command\
+Log file rotation is achieved by use of the `rotate logs` command
 in maxctrl.
 
 ```
 maxctrl rotate logs
 ```
 
-As there currently is only the maxscale log, that is the only one that will be\
+As there currently is only the maxscale log, that is the only one that will be
 rotated.
 
-This may be integrated into the Linux _logrotate_ mechanism by adding a\
-configuration file to the /etc/logrotate.d directory. If we assume we want to\
-rotate the log files once per month and wish to keep 5 log files worth of\
+This may be integrated into the Linux _logrotate_ mechanism by adding a
+configuration file to the /etc/logrotate.d directory. If we assume we want to
+rotate the log files once per month and wish to keep 5 log files worth of
 history, the configuration file would look as follows.
 
 ```
@@ -127,7 +127,7 @@ endscript
 }
 ```
 
-MariaDB MaxScale will also rotate all of its log files if it receives the USR1\
+MariaDB MaxScale will also rotate all of its log files if it receives the USR1
 signal. Using this the logrotate configuration script can be rewritten as
 
 ```
@@ -143,41 +143,41 @@ endscript
 }
 ```
 
-In older versions MaxScale renamed the log file, behavior which is not fully\
-compliant with the assumptions of logrotate and may lead to issues, depending on\
-the used logrotate configuration file. From version 2.1 onward, MaxScale will\
-not itself rename the log file, but when the log is rotated, MaxScale will\
-simply close and reopen the same log file. That will make the behavior fully\
+In older versions MaxScale renamed the log file, behavior which is not fully
+compliant with the assumptions of logrotate and may lead to issues, depending on
+the used logrotate configuration file. From version 2.1 onward, MaxScale will
+not itself rename the log file, but when the log is rotated, MaxScale will
+simply close and reopen the same log file. That will make the behavior fully
 compliant with logrotate.
 
 ### Taking Objects Temporarily Out of Use
 
 #### Putting Servers into Maintenance
 
-MariaDB MaxScale supports the concept of maintenance mode for servers within a\
-cluster. This allows for planned, temporary removal of a database from the\
+MariaDB MaxScale supports the concept of maintenance mode for servers within a
+cluster. This allows for planned, temporary removal of a database from the
 cluster without the need to change the MariaDB MaxScale configuration.
 
 ```
 maxctrl set server db-server-3 maintenance
 ```
 
-To achieve this, you can use the `set server` command in maxctrl to set the\
-maintenance mode flag for the server. This may be done interactively within\
+To achieve this, you can use the `set server` command in maxctrl to set the
+maintenance mode flag for the server. This may be done interactively within
 maxctrl or by passing the command on the command line.
 
-This will cause MariaDB MaxScale to stop routing any new requests to the server,\
-however if there are currently requests executing on the server these will not\
-be interrupted. Connections to servers in maintenance mode are closed as soon as\
-the next request arrives. To close them immediately, use the `--force` option\
+This will cause MariaDB MaxScale to stop routing any new requests to the server,
+however if there are currently requests executing on the server these will not
+be interrupted. Connections to servers in maintenance mode are closed as soon as
+the next request arrives. To close them immediately, use the `--force` option
 for `maxctrl set server`.
 
 ```
 maxctrl clear server db-server-3 maintenance
 ```
 
-Clearing the maintenance mode for a server will bring it back into use. If\
-multiple MariaDB MaxScale instances are configured to use the node then\
+Clearing the maintenance mode for a server will bring it back into use. If
+multiple MariaDB MaxScale instances are configured to use the node then
 maintenance mode must be set within each MariaDB MaxScale instance.
 
 ### Stopping and Starting Services
@@ -186,16 +186,16 @@ maintenance mode must be set within each MariaDB MaxScale instance.
 maxctrl stop service db-service
 ```
 
-Services can be stopped to temporarily halt their use. Stopping a service will\
-cause it to stop accepting new connections until it is started. New connections\
-are not refused if the service is stopped and are queued instead. This means\
+Services can be stopped to temporarily halt their use. Stopping a service will
+cause it to stop accepting new connections until it is started. New connections
+are not refused if the service is stopped and are queued instead. This means
 that connecting clients will wait until the service is started again.
 
 ```
 maxctrl start service db-service
 ```
 
-Starting a service will cause it to accept all queued connections that were\
+Starting a service will cause it to accept all queued connections that were
 created while it was stopped.
 
 #### Stopping and Starting Monitors
@@ -204,35 +204,35 @@ created while it was stopped.
 maxctrl stop monitor db-monitor
 ```
 
-Stopping a monitor will cause it to stop monitoring the state of the servers\
-assigned to it. This is useful when the state of the servers is assigned\
+Stopping a monitor will cause it to stop monitoring the state of the servers
+assigned to it. This is useful when the state of the servers is assigned
 manually with `maxctrl set server`.
 
 ```
 maxctrl start monitor db-monitor
 ```
 
-Starting a monitor will make it resume monitoring of the servers. Any manually\
+Starting a monitor will make it resume monitoring of the servers. Any manually
 assigned states will be overwritten by the monitor.
 
 ### Runtime Configuration Modification
 
-The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,\
+The MaxScale configuration can be changed at runtime by using the `create`,`alter` and `destroy` commands of `maxctrl`. These commands either create,
 modify or destroy objects (servers, services, monitors etc.) inside\
-MaxScale. The exact syntax for each of the commands and any additional options\
+MaxScale. The exact syntax for each of the commands and any additional options
 that they take can be seen with `maxctrl --help <command>`.
 
-Not all parameters can be modified at runtime. Refer to the module documentation\
-for more information on which parameters can be modified at runtime. If a\
-parameter cannot be modified at runtime, the object can be destroyed and\
+Not all parameters can be modified at runtime. Refer to the module documentation
+for more information on which parameters can be modified at runtime. If a
+parameter cannot be modified at runtime, the object can be destroyed and
 recreated in order to change it.
 
-All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime\
-persist through restarts. Any changes done to objects in the main configuration\
+All runtime changes are persisted in files stored by default in`/var/lib/maxscale/maxscale.cnf.d/`. This means that any changes done at runtime
+persist through restarts. Any changes done to objects in the main configuration
 file are ignored if a persisted entry is found for it.
 
-For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete\
-configuration for the object. To remove all runtime changes for all objects,\
+For example, if the address of a server is modified with `maxctrl alter server db-server-1 address 192.168.0.100`, the file`/var/lib/maxscale/maxscale.cnf.d/db-server-1.cnf` is created with the complete
+configuration for the object. To remove all runtime changes for all objects,
 remove all files found in `/var/lib/maxscale/maxscale.cnf.d`.
 
 #### Core Parameter Configuration
@@ -243,7 +243,7 @@ Modify global MaxScale parameters:
 maxctrl alter maxscale auth_connect_timeout 5s
 ```
 
-Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) for a full list\
+Some global parameters cannot be modified at runtime. Refer to the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md) for a full list
 of parameters that can be modified at runtime.
 
 #### Managing Servers
@@ -266,8 +266,8 @@ maxctrl alter server db-server-1 port 3307
 maxctrl destroy server db-server-1
 ```
 
-A server can only be destroyed if it is not used by any services or monitors. To\
-automatically remove the server from the services and monitors that use it, use\
+A server can only be destroyed if it is not used by any services or monitors. To
+automatically remove the server from the services and monitors that use it, use
 the `--force` flag.
 
 **Drain a Server**
@@ -276,9 +276,9 @@ the `--force` flag.
 maxctrl set server db-server-1 drain
 ```
 
-When a server is set into the `drain` state, no new connections to it are\
-created. Unlike to the `maintenance` state which immediately stops all new\
-requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them\
+When a server is set into the `drain` state, no new connections to it are
+created. Unlike to the `maintenance` state which immediately stops all new
+requests and closes all connections if used with the `--force` option, the`drain` state allows existing connections to continue routing requests to them
 in order to be gracefully closed once the client disconnects.
 
 To remove the `drain` state, use `clear server` command:
@@ -287,7 +287,7 @@ To remove the `drain` state, use `clear server` command:
 maxctrl clear server db-server-1 drain
 ```
 
-Servers with the `Master` state cannot be drained. To drain them, first perform\
+Servers with the `Master` state cannot be drained. To drain them, first perform
 a switchover to another node and then drain the server.
 
 #### Managing Monitors
@@ -322,7 +322,7 @@ maxctrl unlink monitor db-monitor db-server-1
 maxctrl destroy monitor db-monitor
 ```
 
-A monitor can only be destroyed if it is not monitoring any servers. To\
+A monitor can only be destroyed if it is not monitoring any servers. To
 automatically remove the servers from the monitor, use the `--force` flag.
 
 #### Managing Services
@@ -345,7 +345,7 @@ maxctrl alter service db-service user new-db-user
 maxctrl link service db-service db-server1
 ```
 
-Any servers added to services will only be used by new sessions. Existing\
+Any servers added to services will only be used by new sessions. Existing
 sessions will use the servers that were available when they connected.
 
 **Remove Servers from a Service**
@@ -354,8 +354,8 @@ sessions will use the servers that were available when they connected.
 maxctrl unlink service db-service db-server1
 ```
 
-Similarly to adding servers, removing servers from a service will only affect\
-new sessions. Existing sessions keep using the servers even if they are removed\
+Similarly to adding servers, removing servers from a service will only affect
+new sessions. Existing sessions keep using the servers even if they are removed
 from a service.
 
 **Change the Filters of a Service**
@@ -364,9 +364,9 @@ from a service.
 maxctrl alter service-filters my-regexfilter my-qlafilter
 ```
 
-The order of the filters is significant: the first filter will be the first to\
-receive the query. The new set of filters will only be used by new\
-sessions. Existing sessions will keep using the filters that were configured\
+The order of the filters is significant: the first filter will be the first to
+receive the query. The new set of filters will only be used by new
+sessions. Existing sessions will keep using the filters that were configured
 when they connected.
 
 **Destroy a Service**
@@ -375,9 +375,9 @@ when they connected.
 maxctrl destroy service db-service
 ```
 
-The service can only be destroyed if it uses no servers or clusters and has no\
-listeners associated with it. To force destruction of a service even if it does\
-use servers or has listeners, use the `--force` flag. This will also destroy any\
+The service can only be destroyed if it uses no servers or clusters and has no
+listeners associated with it. To force destruction of a service even if it does
+use servers or has listeners, use the `--force` flag. This will also destroy any
 listeners associated with the service.
 
 #### Managing Filters
@@ -394,11 +394,11 @@ maxctrl create filter regexfilter match=ENGINE=MyISAM replace=ENGINE=InnoDB
 maxctrl destroy filter my-regexfilter
 ```
 
-A filter can only be destroyed if it is not used by any services. To\
-automatically remove the filter from all services using it, use the `--force`\
+A filter can only be destroyed if it is not used by any services. To
+automatically remove the filter from all services using it, use the `--force`
 flag.
 
-Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters\
+Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters
 of a filter, destroy it and recreate it with the modified parameters.
 
 #### Managing Listeners
@@ -415,16 +415,16 @@ maxctrl create listener db-listener db-service 4006
 maxctrl destroy listener db-listener
 ```
 
-Destroying a listener will close the network socket and stop it from accepting\
-new connections. Existing connections that were created through it will keep\
+Destroying a listener will close the network socket and stop it from accepting
+new connections. Existing connections that were created through it will keep
 displaying it as the originating listener.
 
-Listeners cannot be moved from one service to another. In order to do this, the\
+Listeners cannot be moved from one service to another. In order to do this, the
 listener must be destroyed and then recreated with the new service.
 
 ### Managing MaxCtrl and REST API Users
 
-MaxCtrl uses the same credentials as the MaxScale REST API. These users can be\
+MaxCtrl uses the same credentials as the MaxScale REST API. These users can be
 managed via MaxCtrl.
 
 #### Create a New MaxCtrl User
@@ -433,14 +433,14 @@ managed via MaxCtrl.
 maxctrl create user basic-user basic-password
 ```
 
-By default new users are only allowed to read data. To make the account an\
+By default new users are only allowed to read data. To make the account an
 administrative account, add the `--type=admin` option to the command:
 
 ```
 maxctrl create user admin-user admin-password --type=admin
 ```
 
-Administrative accounts are allowed to use all MaxCtrl commands and modify any\
+Administrative accounts are allowed to use all MaxCtrl commands and modify any
 parts of MaxScale.
 
 #### Change the Password of an Existing User

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-read-write-splitting-with-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-read-write-splitting-with-mariadb-maxscale.md
@@ -1,7 +1,7 @@
 # Read-Write Splitting with MariaDB MaxScale
 
-The goal of this tutorial is to configure a system that appears to the client as a single\
-database. MariaDB MaxScale will split the statements such that write statements are sent\
+The goal of this tutorial is to configure a system that appears to the client as a single
+database. MariaDB MaxScale will split the statements such that write statements are sent
 to the primary server and read statements are balanced across the replica servers.
 
 ### Setting up MariaDB MaxScale
@@ -11,9 +11,9 @@ Please read it and follow the instructions. Return here once basic setup is comp
 
 ### Configuring the service
 
-After configuring the servers and the monitor, we create a read-write-splitter service\
-configuration. Create the following section in your configuration file. The section name\
-is also the name of the service and should be meaningful. For this tutorial, we use the\
+After configuring the servers and the monitor, we create a read-write-splitter service
+configuration. Create the following section in your configuration file. The section name
+is also the name of the service and should be meaningful. For this tutorial, we use the
 name _Splitter-Service_.
 
 ```
@@ -25,14 +25,14 @@ user=maxscale
 password=maxscale_pw
 ```
 
-_router_ defines the routing module used. Here we use _readwritesplit_ for\
+_router_ defines the routing module used. Here we use _readwritesplit_ for
 query-level read-write-splitting.
 
-A service needs a list of servers where queries will be routed to. The server names must\
-match the names of server sections in the configuration file and not the hostnames or\
+A service needs a list of servers where queries will be routed to. The server names must
+match the names of server sections in the configuration file and not the hostnames or
 addresses of the servers.
 
-The _user_ and _password_ parameters define the credentials the service uses to populate\
+The _user_ and _password_ parameters define the credentials the service uses to populate
 user authentication data. These users were created at the start of the [MaxScale Tutorial](mariadb-maxscale-2501-maxscale-2501-setting-up-mariadb-maxscale.md).
 
 For increased security, see [password encryption](mariadb-maxscale-2501-maxscale-2501-encrypting-passwords.md).
@@ -40,7 +40,7 @@ For increased security, see [password encryption](mariadb-maxscale-2501-maxscale
 ### Configuring the Listener
 
 To allow network connections to a service, a network ports must be associated with it.\
-This is done by creating a separate listener section in the configuration file. A service\
+This is done by creating a separate listener section in the configuration file. A service
 may have multiple listeners but for this tutorial one is enough.
 
 ```
@@ -55,7 +55,7 @@ The _service_ parameter tells which service the listener connects to. For the_Sp
 A listener must define the network port to listen on.
 
 The optional _address_-parameter defines the local address the listener should bind to.\
-This may be required when the host machine has multiple network interfaces. The\
+This may be required when the host machine has multiple network interfaces. The
 default behavior is to listen on all network interfaces (the IPv6 address `::`).
 
 ### Starting MariaDB MaxScale

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-rest-api-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-rest-api-tutorial.md
@@ -1,22 +1,22 @@
 # REST API Tutorial
 
-This tutorial is a quick overview of what the MaxScale REST API offers, how it\
-can be used to inspect the state of MaxScale and how to use it to modify the\
-runtime configuration of MaxScale. The tutorial uses the `curl` command line\
+This tutorial is a quick overview of what the MaxScale REST API offers, how it
+can be used to inspect the state of MaxScale and how to use it to modify the
+runtime configuration of MaxScale. The tutorial uses the `curl` command line
 client to demonstrate how the API is used.
 
 ### Configuration and Hardening
 
-The MaxScale REST API listens on port 8989 on the local host. The `admin_port`\
-and `admin_host` parameters control which port and address the REST API listens\
-on. Note that for security reasons the API only listens for local connections\
-with the default configuration. It is critical that the default credentials are\
-changed and TLS/SSL encryption is configured before exposing the REST API to a\
+The MaxScale REST API listens on port 8989 on the local host. The `admin_port`
+and `admin_host` parameters control which port and address the REST API listens
+on. Note that for security reasons the API only listens for local connections
+with the default configuration. It is critical that the default credentials are
+changed and TLS/SSL encryption is configured before exposing the REST API to a
 network.
 
-The default user for the REST API is `admin` and the password is `mariadb`. The\
-easiest way to secure the REST API is to use the `maxctrl` command line client\
-to create a new admin user and delete the default one. To do this, run the\
+The default user for the REST API is `admin` and the password is `mariadb`. The
+easiest way to secure the REST API is to use the `maxctrl` command line client
+to create a new admin user and delete the default one. To do this, run the
 following commands:
 
 ```
@@ -24,13 +24,13 @@ maxctrl create user my_user my_password --type=admin
 maxctrl destroy user admin
 ```
 
-This will create the user `my_user` with the password `my_password` that is an\
-administrative account. After this account is created, the default `admin`\
+This will create the user `my_user` with the password `my_password` that is an
+administrative account. After this account is created, the default `admin`
 account is removed with the next command.
 
-The next step is to enable TLS encryption. To do this, you need a CA\
-certificate, a private key and a public certificate file all in PEM format. Add\
-the following three parameters under the `[maxscale]` section of the MaxScale\
+The next step is to enable TLS encryption. To do this, you need a CA
+certificate, a private key and a public certificate file all in PEM format. Add
+the following three parameters under the `[maxscale]` section of the MaxScale
 configuration file and restart MaxScale.
 
 ```
@@ -39,15 +39,15 @@ admin_ssl_cert=/certs/server-cert.pem
 admin_ssl_ca_cert=/certs/ca-cert.pem
 ```
 
-Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our\
-server certificates are self-signed so the `--tls-verify-server-cert=false`\
+Use `maxctrl` to verify that the TLS encryption is enabled. In this tutorial our
+server certificates are self-signed so the `--tls-verify-server-cert=false`
 option is required.
 
 ```
 maxctrl --user=my_user --password=my_password --secure --tls-ca-cert=/certs/ca-cert.pem --tls-verify-server-cert=false show maxscale
 ```
 
-If no errors are raised, this means that the communication via the REST API is\
+If no errors are raised, this means that the communication via the REST API is
 now secure and can be used across networks.
 
 ### Requesting Data
@@ -55,8 +55,8 @@ now secure and can be used across networks.
 **Note:** For the sake of brevity, the rest of this tutorial will omit the\
 TLS/SSL options from the `curl` command line. For more information, refer to the`curl` manpage.
 
-The most basic task to do with the REST API is to see whether MaxScale is up and\
-running. To do this, we do a HTTP request on the root resource (the `-i` option\
+The most basic task to do with the REST API is to see whether MaxScale is up and
+running. To do this, we do a HTTP request on the root resource (the `-i` option
 shows the HTTP headers).
 
 `curl -i 127.0.0.1:8989/v1/`
@@ -70,7 +70,7 @@ ETag: "0"
 Date: Mon, 04 Mar 19 08:29:41 GMT
 ```
 
-To query a resource collection endpoint, append it to the URL. The `/v1/filters/`\
+To query a resource collection endpoint, append it to the URL. The `/v1/filters/`
 endpoint shows the list of filters configured in MaxScale. This is a _resource collection_ endpoint: it contains the list of all resources of a particular type.
 
 `curl 127.0.0.1:8989/v1/filters`
@@ -145,17 +145,17 @@ endpoint shows the list of filters configured in MaxScale. This is a _resource c
 }
 ```
 
-The `data` holds the actual list of resources: the `Hint` and `Logger`\
-filters. Each object has the `id` field which is the unique name of that\
+The `data` holds the actual list of resources: the `Hint` and `Logger`
+filters. Each object has the `id` field which is the unique name of that
 object. It is the same as the section name in `maxscale.cnf`.
 
-Each resource in the list has a `relationships` object. This shows the\
-relationship links between resources. In our example, the `Hint` filter is used\
-by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in\
+Each resource in the list has a `relationships` object. This shows the
+relationship links between resources. In our example, the `Hint` filter is used
+by a service named `RW-Split-Hint-Router` and the `Logger` is not currently in
 use.
 
-To request an individual resource, we add the object name to the resource\
-collection URL. For example, if we want to get only the `Logger` filter we\
+To request an individual resource, we add the object name to the resource
+collection URL. For example, if we want to get only the `Logger` filter we
 execute the following command.
 
 `curl 127.0.0.1:8989/v1/filters/Logger`
@@ -204,18 +204,18 @@ execute the following command.
 }
 ```
 
-Note that this time the `data` member holds an object instead of an array of\
-objects. All other parts of the response are similar to what was shown in the\
+Note that this time the `data` member holds an object instead of an array of
+objects. All other parts of the response are similar to what was shown in the
 previous example.
 
 ### Creating Objects
 
-One of the uses of the REST API is to create new objects in MaxScale at\
-runtime. This allows new servers, services, filters, monitor and listeners to be\
+One of the uses of the REST API is to create new objects in MaxScale at
+runtime. This allows new servers, services, filters, monitor and listeners to be
 created without restarting MaxScale.
 
-For example, to create a new server in MaxScale the JSON definition of a server\
-must be sent to the REST API at the `/v1/servers/` endpoint. The request body\
+For example, to create a new server in MaxScale the JSON definition of a server
+must be sent to the REST API at the `/v1/servers/` endpoint. The request body
 defines the server name as well as the parameters for it.
 
 To create objects with `curl`, first write the JSON definition into a file.
@@ -241,9 +241,9 @@ To send the data, use the following command.
 curl -X POST -d @new_server.txt 127.0.0.1:8989/v1/servers
 ```
 
-The `-d` option takes a file name prefixed with a `@` as an argument. Here we\
-have `@new_server.txt` which is the name of the file where the JSON definition\
-was stored. The `-X` option defines the HTTP verb to use and to create a new\
+The `-d` option takes a file name prefixed with a `@` as an argument. Here we
+have `@new_server.txt` which is the name of the file where the JSON definition
+was stored. The `-X` option defines the HTTP verb to use and to create a new
 object we must use the POST verb.
 
 To verify the data request the newly created object.
@@ -254,18 +254,18 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Modifying Data
 
-The easiest way to modify an object is to first request it, store the result in\
+The easiest way to modify an object is to first request it, store the result in
 a file, edit it and then send the updated object back to the REST API.
 
-Let's say we want to modify the port that the server we created earlier listens\
+Let's say we want to modify the port that the server we created earlier listens
 on. First we request the current object and store the result in a file.
 
 ```
 curl 127.0.0.1:8989/v1/servers/server1 > server1.txt
 ```
 
-After that we edit the file and change the port from 3003 to 3306. Next the\
-modified JSON object is sent to the REST API as a PATCH command. To do this,\
+After that we edit the file and change the port from 3003 to 3306. Next the
+modified JSON object is sent to the REST API as a PATCH command. To do this,
 execute the following command.
 
 ```
@@ -280,12 +280,12 @@ curl 127.0.0.1:8989/v1/servers/server1
 
 ### Object Relationships
 
-To continue with our previous example, we add the updated server to a\
-service. To do this, the `relationships` object of the server must be modified\
+To continue with our previous example, we add the updated server to a
+service. To do this, the `relationships` object of the server must be modified
 to include the service we want to add the server to.
 
-To define a relationship between a server and a service, the `data` member must\
-have the `relationships` field and it must contain an object with the `services`\
+To define a relationship between a server and a service, the `data` member must
+have the `relationships` field and it must contain an object with the `services`
 field (some fields omitted for brevity).
 
 ```
@@ -308,13 +308,13 @@ field (some fields omitted for brevity).
 }
 ```
 
-The `data.relationships.services.data` field contains a list of objects that\
-define the `id` and `type` fields. The id is the name of the object (a service\
-or a monitor for servers) and the type tells which type it is. Only `services`\
+The `data.relationships.services.data` field contains a list of objects that
+define the `id` and `type` fields. The id is the name of the object (a service
+or a monitor for servers) and the type tells which type it is. Only `services`
 type objects should be present in the `services` object.
 
-In our example we are linking the `server1` server to the `RW-Split-Router`\
-service. As was seen with the previous example, the easiest way to do this is to\
+In our example we are linking the `server1` server to the `RW-Split-Router`
+service. As was seen with the previous example, the easiest way to do this is to
 store the result, edit it and then send it back with a HTTP PATCH.
 
 If we want to remove a server from _all_ services and monitors, we can set the`data` member of the `services` and `monitors` relationships to an empty array:
@@ -334,39 +334,39 @@ If we want to remove a server from _all_ services and monitors, we can set the`d
 }
 ```
 
-This is useful if you want to delete the server which can only be done if it has\
+This is useful if you want to delete the server which can only be done if it has
 no relationships to other objects.
 
 ### Deleting Objects
 
-To delete an object, simply execute a HTTP DELETE request on the resource you\
-want to delete. For example, to delete the `server1` server, execute the\
+To delete an object, simply execute a HTTP DELETE request on the resource you
+want to delete. For example, to delete the `server1` server, execute the
 following command.
 
 ```
 curl -X DELETE 127.0.0.1:8989/v1/servers/server1
 ```
 
-In order to delete an object, it must not have any relationships to other\
+In order to delete an object, it must not have any relationships to other
 objects.
 
 ### Further Reading
 
 The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-rest-api.md).
 
-The `maxctrl` command line client is self-documenting and the `maxctrl help`\
-command is a good tool for exploring the various commands that are available in\
-it. The `maxctrl api get` command can be useful way to explore the REST API as\
+The `maxctrl` command line client is self-documenting and the `maxctrl help`
+command is a good tool for exploring the various commands that are available in
+it. The `maxctrl api get` command can be useful way to explore the REST API as
 it provides a way to easily extract values out of the JSON data generated by the\
 REST API.
 
-There is a multitude of REST API clients readily available and most of them are\
-far more convenient to use than `curl`. We recommend investigating what you need\
-and how you intend to either integrate or use the MaxScale REST API. Most modern\
-languages either have a built-in HTTP library or there exists a de facto\
+There is a multitude of REST API clients readily available and most of them are
+far more convenient to use than `curl`. We recommend investigating what you need
+and how you intend to either integrate or use the MaxScale REST API. Most modern
+languages either have a built-in HTTP library or there exists a de facto
 standard library.
 
-The MaxScale REST API follows the JSON API specification and there exist\
+The MaxScale REST API follows the JSON API specification and there exist
 libraries that are built specifically for these sorts of APIs
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-schemarouter-simple-sharding-with-two-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-schemarouter-simple-sharding-with-two-servers.md
@@ -1,15 +1,15 @@
 # Schemarouter: Simple Sharding With Two Servers
 
-Sharding is the method of splitting a single logical database server into\
-separate physical databases. This tutorial describes a very simple way of\
+Sharding is the method of splitting a single logical database server into
+separate physical databases. This tutorial describes a very simple way of
 sharding. Each schema is located on a different database server and MariaDB\
-MaxScale's schemarouter module is used to combine them into a single logical\
+MaxScale's schemarouter module is used to combine them into a single logical
 database server.
 
 ### Environment
 
-This tutorial was written for Ubuntu 22.04, MaxScale 23.08 and [MariaDB 10.11](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/what-is-mariadb-1011). In addition to\
-the MaxScale server, you'll need two MariaDB servers which will be used for the\
+This tutorial was written for Ubuntu 22.04, MaxScale 23.08 and [MariaDB 10.11](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/what-is-mariadb-1011). In addition to
+the MaxScale server, you'll need two MariaDB servers which will be used for the
 sharding. The installation of MariaDB is not covered by this tutorial.
 
 ### Installing MaxScale
@@ -26,13 +26,13 @@ apt -y install maxscale
 
 ### Creating Users
 
-This tutorial uses a broader set of grants than is required for the sake of\
+This tutorial uses a broader set of grants than is required for the sake of
 brevity and backwards compatibility. For the minimal set of grants, refer to the [MaxScale Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
 
-All MaxScale configurations require at least two accounts: one for reading\
-authentication data and another for monitoring the state of the\
-database. Services will use the first one and monitors will use the second\
-one. In addition to this, we want to have a separate account that our\
+All MaxScale configurations require at least two accounts: one for reading
+authentication data and another for monitoring the state of the
+database. Services will use the first one and monitors will use the second
+one. In addition to this, we want to have a separate account that our
 application will use.
 
 ```
@@ -57,8 +57,8 @@ All of the users must be created on both of the MariaDB servers.
 
 ### Creating the Schemas and Tables
 
-Each server will hold one unique schema which contains the data of one specific\
-customer. We'll also create a shared schema that is present on all shards that\
+Each server will hold one unique schema which contains the data of one specific
+customer. We'll also create a shared schema that is present on all shards that
 the shard-local tables can be joined into.
 
 Create the tables on the first server:
@@ -91,8 +91,8 @@ INSERT INTO shared_info.account_types VALUES (1, 'admin'), (2, 'user');
 
 The MaxScale configuration is stored in `/etc/maxscale.cnf`.
 
-First, we configure two servers we will use to shard our database. The `db-01`\
-server has the `customer_01` schema and the `db-02` server has the `customer_02`\
+First, we configure two servers we will use to shard our database. The `db-01`
+server has the `customer_01` schema and the `db-02` server has the `customer_02`
 schema.
 
 ```
@@ -123,7 +123,7 @@ password=secret
 ignore_tables_regex=.*
 ```
 
-After this we configure a listener for the service. The listener is the actual\
+After this we configure a listener for the service. The listener is the actual
 port that the user connects to. We will use the port 4000.
 
 ```
@@ -133,11 +133,11 @@ service=Sharded-Service
 port=4000
 ```
 
-The final step is to configure a monitor which will monitor the state of the\
-servers. The monitor will notify MariaDB MaxScale if the servers are down. We\
-add the two servers to the monitor and use the `monitor_user` credentials. For\
-the sharding use-case, the `galeramon` module is suitable even if we're not\
-using a Galera cluster. The `schemarouter` is only interested in whether the\
+The final step is to configure a monitor which will monitor the state of the
+servers. The monitor will notify MariaDB MaxScale if the servers are down. We
+add the two servers to the monitor and use the `monitor_user` credentials. For
+the sharding use-case, the `galeramon` module is suitable even if we're not
+using a Galera cluster. The `schemarouter` is only interested in whether the
 server is in the `Running` state or in the `Down` state.
 
 ```
@@ -192,12 +192,12 @@ systemctl start maxscale.service
 
 ### Testing the Sharding
 
-MariaDB MaxScale is now ready to start accepting client connections and routing\
-them. Queries are routed to the right servers based on the database they target\
-and switching between the shards is seamless since MariaDB MaxScale keeps the\
+MariaDB MaxScale is now ready to start accepting client connections and routing
+them. Queries are routed to the right servers based on the database they target
+and switching between the shards is seamless since MariaDB MaxScale keeps the
 session state intact between servers.
 
-To test, we query the schema that's located on the local shard and join it to\
+To test, we query the schema that's located on the local shard and join it to
 the shared table.
 
 ```
@@ -270,8 +270,8 @@ MariaDB [customer_02]> SELECT * FROM customer_01.accounts UNION SELECT * FROM cu
 ERROR 1146 (42S02): Table 'customer_01.accounts' doesn't exist
 ```
 
-In most multi-tenant situations, this is an acceptable limitation. If you do\
-need cross-shard joins, the [Spider](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/spider/spider-storage-engine-overview) storage\
+In most multi-tenant situations, this is an acceptable limitation. If you do
+need cross-shard joins, the [Spider](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/spider/spider-storage-engine-overview) storage
 engine will provide you this.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-setting-up-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-setting-up-mariadb-maxscale.md
@@ -3,26 +3,26 @@
 This document is designed as a quick introduction to setting up MariaDB MaxScale.
 
 The installation and configuration of the MariaDB Server is not covered in this document.\
-See the following MariaDB documentation articles for more information on setting up a\
-primary-replica-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)\
+See the following MariaDB documentation articles for more information on setting up a
+primary-replica-cluster or a Galera-cluster:[Setting Up Replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/setting-up-replication)
 and [Getting Started With MariaDB Galera Cluster](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster)\
 .
 
-This tutorial assumes that one of the standard MaxScale binary distributions is used and\
+This tutorial assumes that one of the standard MaxScale binary distributions is used and
 that MaxScale is installed using default options.
 
 Building from source code in GitHub is covered in [Building from Source](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-building-mariadb-maxscale-from-source-code.md).
 
 ### Installing MaxScale
 
-The precise installation process varies from one distribution to another. Details on\
+The precise installation process varies from one distribution to another. Details on
 package installation can be found in the [Installation Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-installation-guide.md).
 
 ### Creating a user account for MaxScale
 
-MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve\
-user authentication information from the backend databases. Create a special user\
-account for this purpose by executing the following SQL commands on the primary server of\
+MaxScale checks that incoming clients are valid. To do this, MaxScale needs to retrieve
+user authentication information from the backend databases. Create a special user
+account for this purpose by executing the following SQL commands on the primary server of
 your database cluster. The following tutorials will use these credentials.
 
 ```
@@ -41,12 +41,12 @@ MariaDB versions 10.2.2 to 10.2.10 also require `GRANT SELECT ON mysql.* TO 'max
 
 ### Creating client user accounts
 
-Because MariaDB MaxScale sits between the clients and the backend databases, the backend\
-databases will see all clients as if they were connecting from MaxScale's address. This\
+Because MariaDB MaxScale sits between the clients and the backend databases, the backend
+databases will see all clients as if they were connecting from MaxScale's address. This
 usually means that two sets of grants for each user are required.
 
 For example, assume that the user _'jdoe'@'client-host'_ exists and MaxScale is located at _maxscale-host_. If _'jdoe'@'client-host'_ needs to be able to connect through MaxScale,
-another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the\
+another user, _'jdoe'@'maxscale-host'_, must be created. The second user must have the
 same password and similar grants as _'jdoe'@'client-host'_.
 
 The quickest way to do this is to first create the new user:
@@ -73,18 +73,18 @@ Then copy the same grants to the `'jdoe'@'maxscale-host'` user.
 GRANT SELECT, INSERT, UPDATE, DELETE ON *.* TO 'jdoe'@'maxscale-host';
 ```
 
-An alternative to generating two separate accounts is to use one account with a wildcard\
-host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than\
+An alternative to generating two separate accounts is to use one account with a wildcard
+host (_'jdoe'@'%'_) which covers both hosts. This is more convenient but less secure than
 having specific user accounts as it allows access from all hosts.
 
 ### Creating the configuration file
 
-MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is\
+MaxScale reads its configuration from _/etc/maxscale.cnf_. A template configuration is
 provided with the MaxScale installation.
 
-A global _maxscale_ section is included in every MaxScale configuration file. This section\
-sets the values of various global parameters, such as the number of threads MaxScale uses\
-to handle client requests. To set thread count to the number of available cpu cores, set\
+A global _maxscale_ section is included in every MaxScale configuration file. This section
+sets the values of various global parameters, such as the number of threads MaxScale uses
+to handle client requests. To set thread count to the number of available cpu cores, set
 the following.
 
 ```
@@ -94,7 +94,7 @@ threads=auto
 
 ### Configuring the servers
 
-Read the [Configuring Servers](mariadb-maxscale-2501-maxscale-2501-configuring-servers.md) mini-tutorial for server\
+Read the [Configuring Servers](mariadb-maxscale-2501-maxscale-2501-configuring-servers.md) mini-tutorial for server
 configuration instructions.
 
 ### Configuring the monitor
@@ -111,7 +111,7 @@ For a simple connection based setup, read the [Connection Routing Tutorial](mari
 
 ### Starting MaxScale
 
-After configuration is complete, MariaDB MaxScale is ready to start. For systems that\
+After configuration is complete, MariaDB MaxScale is ready to start. For systems that
 use systemd, use the _systemctl_ command.
 
 ```
@@ -124,13 +124,13 @@ For older SysV systems, use the _service_ command.
 sudo service maxscale start
 ```
 
-If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see\
+If MaxScale fails to start, check the error log in _/var/log/maxscale/maxscale.log_ to see
 if any errors are detected in the configuration file.
 
 ### Checking MaxScale status with MaxCtrl
 
-The _maxctrl_-command can be used to confirm that MaxScale is running and the services,\
-listeners and servers have been correctly configured. The following shows expected output\
+The _maxctrl_-command can be used to confirm that MaxScale is running and the services,
+listeners and servers have been correctly configured. The following shows expected output
 when using a read-write-splitting configuration.
 
 ```
@@ -163,7 +163,7 @@ when using a read-write-splitting configuration.
 └───────────────────┴──────┴──────┴─────────┘
 ```
 
-MariaDB MaxScale is now ready to start accepting client connections and route queries to\
+MariaDB MaxScale is now ready to start accepting client connections and route queries to
 the backend cluster.
 
 More options can be found in the [Configuration Guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md),[readwritesplit module documentation](../mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md) and [readconnroute module documentation](../mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readconnroute.md).

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-This tutorial is an overview of what the MaxGUI offers as an alternative\
+This tutorial is an overview of what the MaxGUI offers as an alternative
 solution to [MaxCtrl](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-maxctrl.md).
 
 ## Dashboard
@@ -14,11 +14,11 @@ solution to [MaxCtrl](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-
 ### Annotation
 
 1. [MaxScale object](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). i.e.\
-   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate\
+   Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate
    to its detail page)
 2. Create a new MaxScale object.
 3. Dashboard Tab Navigation.
-4. Search Input. This can be used as a quick way to search for a keyword in\
+4. Search Input. This can be used as a quick way to search for a keyword in
    tables.
 5. Dashboard graphs. Refresh interval is 10 seconds.
 
@@ -31,25 +31,25 @@ solution to [MaxCtrl](../mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-
    Visualization, Settings, Logs Archive, Query Editor
 3. Expand/Collapse the graphs
 4. Graph annotation configuration.
-5. Active Operations Bar: This bar chart represents the proportion of active\
-   operations on the server relative to the total number of connections. The\
-   value displayed is the ratio of `active_operations` to `connections`,\
+5. Active Operations Bar: This bar chart represents the proportion of active
+   operations on the server relative to the total number of connections. The
+   value displayed is the ratio of `active_operations` to `connections`,
    providing a visual gauge of server activity.
 
 ### Create a new MaxScale object
 
-Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating\
+Clicking on the _Create New_ button (Annotation 2) to open a dialog for creating
 a new object.
 
 ### View Replication Status
 
-The replication status of a server monitored by [MariaDB-Monitor](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md) can be viewed by mousing over\
+The replication status of a server monitored by [MariaDB-Monitor](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md) can be viewed by mousing over
 the server name. A tooltip will be displayed with the following information:\
 replication\_state, seconds\_behind\_master, slave\_io\_running, slave\_sql\_running.
 
 ### How to kill a session
 
-A session can be killed easily on the "Current Sessions" list which can be\
+A session can be killed easily on the "Current Sessions" list which can be
 found on the [Dashboard](mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md#dashboard), Server detail, and Service detail page.
 
 ![](../../../../.gitbook/assets/mariadb-corporation/MaxScale/25.01.2-docs/Documentation/Tutorials/images/MaxGUI-kill-session.png.png)
@@ -61,7 +61,7 @@ found on the [Dashboard](mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutori
 
 ### View sessions created by the "Workspace"
 
-Sessions created by the "Workspace", such as via the Query Editor can be found in\
+Sessions created by the "Workspace", such as via the Query Editor can be found in
 two places:
 
 #### Dashboard "Current Sessions" tab
@@ -70,12 +70,12 @@ two places:
 
 **Annotation**
 
-1. A session with an icon next to the "CLIENT" column indicates a connection created\
+1. A session with an icon next to the "CLIENT" column indicates a connection created
    by the "Workspace".
 
 #### Query Editor "Processlist"
 
-This table displays the result set from the `PROCESSLIST` table, with options to\
+This table displays the result set from the `PROCESSLIST` table, with options to
 filter processes created by the "Workspace".
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-processlist.png.png)
@@ -86,34 +86,34 @@ filter processes created by the "Workspace".
 
 ## Detail
 
-This page shows information on each MaxScale object and allow to edit its\
-parameter, relationships and perform other manipulation operations. Most of the\
+This page shows information on each MaxScale object and allow to edit its
+parameter, relationships and perform other manipulation operations. Most of the
 control buttons will be shown on the mouse hover. Below is a screenshot of a\
-Monitor Detail page, other Detail pages also have a similar layout structure so\
+Monitor Detail page, other Detail pages also have a similar layout structure so
 this is used for illustration purpose.
 
 ![](../../../../.gitbook/assets/mariadb-corporation/MaxScale/25.01.2-docs/Documentation/Tutorials/images/MaxGUI-detail.png.png)
 
 ### Annotation
 
-1. Settings option. Clicking on the gear icon will show icons allowing to do\
+1. Settings option. Clicking on the gear icon will show icons allowing to do
    different operations depending on the type of the Detail page.
 
 * Monitor Detail page, there are icons to Stop, Start, and Destroy monitor.
 * Service Detail page, there are icons to Stop, Start, and Destroy service.
-* Server Detail page, there are icons to Set maintenance mode, Clear server\
+* Server Detail page, there are icons to Set maintenance mode, Clear server
   state, Drain and Delete server.
-* Filter and Listener Detail page, there is a delete icon to delete the\
+* Filter and Listener Detail page, there is a delete icon to delete the
   object.
 
-1. Switchover button. This button is shown on the mouse hover allowing to\
+1. Switchover button. This button is shown on the mouse hover allowing to
    swap the running primary server with a designated secondary server.
-2. Edit parameters button. This button is shown on the mouse hover allowing\
-   to edit the MaxScale object's parameter. Clicking on it will enable editable\
+2. Edit parameters button. This button is shown on the mouse hover allowing
+   to edit the MaxScale object's parameter. Clicking on it will enable editable
    mode on the table. After finishing editing the parameters, simply click the\
    Done Editing button.
-3. A Detail page has tables showing "Relationship" between other MaxScale\
-   object. This "unlink" icon is shown on the mouse hover allowing to\
+3. A Detail page has tables showing "Relationship" between other MaxScale
+   object. This "unlink" icon is shown on the mouse hover allowing to
    remove the relationship between two objects.
 4. This button is used to link other MaxScale objects to the relationship.
 
@@ -129,12 +129,12 @@ This page visualizes MaxScale configuration as shown in the figure below.
 
 #### Annotation
 
-1. A MaxScale object (a node graph). The position of the node in the graph can\
+1. A MaxScale object (a node graph). The position of the node in the graph can
    be changed by dragging and dropping it.
-2. Anchor link. The detail page of each MaxScale object can be accessed by\
+2. Anchor link. The detail page of each MaxScale object can be accessed by
    clicking on the name of the node.
-3. Filter visualization button. By default, if the number of filters used by a\
-   service is larger than 3, filter nodes aren't visualized as shown in the\
+3. Filter visualization button. By default, if the number of filters used by a
+   service is larger than 3, filter nodes aren't visualized as shown in the
    figure. Clicking this button will visualize them.
 4. Hide filter visualization button.
 5. Refresh rate dropdown. The frequency with which the data is refreshed.
@@ -145,35 +145,35 @@ This page visualizes MaxScale configuration as shown in the figure below.
 ### Clusters
 
 This page shows all monitor clusters using [mariadbmon](../mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md) module in a card-like view.\
-Clicking on the card will visualize the cluster into a tree graph as shown in\
+Clicking on the card will visualize the cluster into a tree graph as shown in
 the figure below.
 
 ![](../../../../.gitbook/assets/mariadb-corporation/MaxScale/25.01.2-docs/Documentation/Tutorials/images/MaxGUI-cluster-visualization.png.png)
 
 #### Annotation
 
-1. Drag a secondary server on top of a primary server to promote the secondary\
+1. Drag a secondary server on top of a primary server to promote the secondary
    server as the new primary server.
-2. Server manipulation operations button. Showing a dropdown with the following\
+2. Server manipulation operations button. Showing a dropdown with the following
    operations:
 
 * Set maintenance mode: Setting a server to a maintenance mode.
 * Clear server state: Clear current server state.
 * Drain server: Drain the server of connections.
 
-1. Quick access to query editor button. Opening the `Query Editor` page for\
-   this server. If the connection is already created for that server, it'll use\
-   it. Otherwise, it creates a blank worksheet and shows a connection dialog to\
+1. Quick access to query editor button. Opening the `Query Editor` page for
+   this server. If the connection is already created for that server, it'll use
+   it. Otherwise, it creates a blank worksheet and shows a connection dialog to
    connect to that server.
-2. Carousel navigation button. Viewing more information about the server in the\
+2. Carousel navigation button. Viewing more information about the server in the
    next slide.
 3. Collapse the carousel.
-4. Anchor link of the server. Opening the detail page of the server in a new\
+4. Anchor link of the server. Opening the detail page of the server in a new
    tab.
 5. Collapse its children nodes.
-6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be\
+6. Rejoin node. When the `auto_rejoin` parameter is disabled, the node can be
    manually rejoined by dragging it on top of the primary server.
-7. Monitor manipulation operations button. Showing a dropdown with the\
+7. Monitor manipulation operations button. Showing a dropdown with the
    following operations:
 
 * Stop monitor.
@@ -181,7 +181,7 @@ the figure below.
 * Destroy monitor.
 * Reset Replication.
 * Release ownership
-* Master failover. Manually performing a primary failover. This option is\
+* Master failover. Manually performing a primary failover. This option is
   visible only when the `auto_failover` parameter is disabled.
 
 ColumnStore operations:
@@ -204,11 +204,11 @@ This page shows and allows editing of MaxScale parameters.
 
 ### Annotation
 
-1. Edit parameters button. This button is shown on the mouse hover allowing\
-   to edit the MaxScale parameter. Clicking on it will enable editable mode on\
+1. Edit parameters button. This button is shown on the mouse hover allowing
+   to edit the MaxScale parameter. Clicking on it will enable editable mode on
    the table..
 2. Editable parameters are visible as it's illustrated in the screenshot.
-3. After finishing editing the parameters, simply click the Done Editing\
+3. After finishing editing the parameters, simply click the Done Editing
    button.
 
 ## Logs Archive
@@ -231,7 +231,7 @@ On this page, you may add numerous worksheets, each of which can be used for\
 
 ### Run Queries
 
-Clicking on the "Run Queries" card will open a dialog, providing options\
+Clicking on the "Run Queries" card will open a dialog, providing options
 to establish a connection to different MaxScale object types, including\
 "Listener, Server, Service".
 
@@ -245,10 +245,10 @@ There are various features in the Query Editor worksheet, the most notable ones 
 
 **Create a new connection**
 
-If the connection of the Query Editor expires, or if you wish to make\
-a new connection for the active worksheet, simply clicking on the button\
-located on the right side of the query tabs navigation bar which features a\
-server icon and an active connection name as a label. This will open the\
+If the connection of the Query Editor expires, or if you wish to make
+a new connection for the active worksheet, simply clicking on the button
+located on the right side of the query tabs navigation bar which features a
+server icon and an active connection name as a label. This will open the
 connection dialog and allow you to create a new connection.
 
 **Schemas objects sidebar**
@@ -258,7 +258,7 @@ connection dialog and allow you to create a new connection.
 There are two ways to set the current database:
 
 * Double-click on the name of the database.
-* Right-click on the name of the database to show the context menu, then select\
+* Right-click on the name of the database to show the context menu, then select
   the `Use database` option.
 
 **Preview table data of the top 1000 rows**
@@ -266,7 +266,7 @@ There are two ways to set the current database:
 There are two ways to preview data of a table:
 
 * Click on the name of the table.
-* Right-click on the name of the table to show the context menu, then select\
+* Right-click on the name of the table to show the context menu, then select
   the `Preview Data (top 1000)` option.
 
 **Describe table**
@@ -275,12 +275,12 @@ Right-click on the name of the table to show the context menu, then select the`V
 
 **Alter/Drop/Truncate/Create table**
 
-Right-click on the name of the table to show the context menu, then select the\
+Right-click on the name of the table to show the context menu, then select the
 desired option.
 
 **Alter/Drop/Create schema**
 
-Right-click on the name of the schema to show the context menu, then select the\
+Right-click on the name of the schema to show the context menu, then select the
 desired option.
 
 **Alter/Create View, Function, Stored Procedure, Trigger**
@@ -293,13 +293,13 @@ Triggers) to show the context menu, then select the desired option.
 There are two ways to quickly insert an object to the editor:
 
 * Drag the object and drop it in the desire position in the editor.
-* Right-click on the object to show the context menu, then mouse\
+* Right-click on the object to show the context menu, then mouse
   hover the `Place to Editor` option and select the desired insert option.
 
 **Show object creation statement and insights info**
 
-To view the statement that creates the given object in the [Schemas objects sidebar](mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md#schemas-objects-sidebar), right-clicking on schema or table node and\
-select the `View Insights` option. For other objects such as view, stored\
+To view the statement that creates the given object in the [Schemas objects sidebar](mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md#schemas-objects-sidebar), right-clicking on schema or table node and
+select the `View Insights` option. For other objects such as view, stored
 procedure, function and trigger, select the `Show Create` option.
 
 **Editor**
@@ -309,7 +309,7 @@ Visual Studio Code.
 
 To see the command palette, press F1 while the cursor is active on the editor.
 
-The editor also comes with various options to assist your querying tasks. To see\
+The editor also comes with various options to assist your querying tasks. To see
 available options, right-click on the editor to show the context menu.
 
 The editor is powered by [Monaco editor](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/mariadb-client/delimiters), therefore, its features are similar to those of\
@@ -317,8 +317,8 @@ Visual Studio Code.
 
 **How to write compound statements**
 
-By default, all statements in the "Query Tab" are split by semicolons and\
-executed one by one on the server. To write the compound statements, use\
+By default, all statements in the "Query Tab" are split by semicolons and
+executed one by one on the server. To write the compound statements, use
 the `DELIMITER` command to change the delimiter.
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-query-editor-delimiter-change.png.png)
@@ -333,43 +333,43 @@ the `DELIMITER` command to change the delimiter.
 
 Every executed query will be saved in the browser's storage (IndexedDB).\
 Query history can be seen in the `History/Snippets` tab.\
-To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)\
+To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)
 and click the execute query button in the editor.
 
 **Create query snippet**
 
 Press CTRL/CMD + D to save the current SQL in the editor to the snippets storage.\
-A snippet is created with a prefix keyword, so when that keyword is typed in\
+A snippet is created with a prefix keyword, so when that keyword is typed in
 the editor, it will be suggested in the "code completion" menu.
 
 **Generate an ERD**
 
-To initiate the process, either right-click on the schema name and select the`Generate ERD` option, or click on the icon button that resembles a line graph,\
-located on the schemas sidebar. This will open a dialog for selecting the\
+To initiate the process, either right-click on the schema name and select the`Generate ERD` option, or click on the icon button that resembles a line graph,
+located on the schemas sidebar. This will open a dialog for selecting the
 tables for the diagram.
 
 ### Data Migration
 
-Clicking on the "Data Migration" card will open a dialog, providing an option\
-to name the task. The Data Migration worksheet will be rendered in the active\
+Clicking on the "Data Migration" card will open a dialog, providing an option
+to name the task. The Data Migration worksheet will be rendered in the active
 worksheet after clicking the `Create` button in the dialog.
 
 #### Data Migration worksheet
 
-MaxScale uses ODBC for extracting and loading from the data source to a server\
-in MaxScale. Before starting a migration, ensure that you have set up the\
-necessary configurations on the MaxScale server. Instruction can be found [here](../mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-sql-resource.md)\
+MaxScale uses ODBC for extracting and loading from the data source to a server
+in MaxScale. Before starting a migration, ensure that you have set up the
+necessary configurations on the MaxScale server. Instruction can be found [here](../mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-sql-resource.md)
 and limitations [here](../../mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md#etl-limitations).
 
 **Connections**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-data-migration-set-up-connections.png.png)
 
-Source connection shows the most common parameter inputs for creating\
-an ODBC connection. For extra parameters, enable the `Advanced` mode\
+Source connection shows the most common parameter inputs for creating
+an ODBC connection. For extra parameters, enable the `Advanced` mode
 to manually edit the `Connection String` input.
 
-After successfully connected to both source and destination servers,\
+After successfully connected to both source and destination servers,
 click on the `Select objects to migrate` to navigate to the next stage.
 
 **Objects Selection**
@@ -378,76 +378,76 @@ click on the `Select objects to migrate` to navigate to the next stage.
 
 Select the objects you wish to migrate to the MariaDB server.
 
-After selecting the desired objects, click on the `Prepare Migration Script` to\
-navigate to the next stage. The migration scripts will be generated\
-differently based on the value selected for the `Create mode` input. Hover over\
+After selecting the desired objects, click on the `Prepare Migration Script` to
+navigate to the next stage. The migration scripts will be generated
+differently based on the value selected for the `Create mode` input. Hover over
 the question icon for additional information on the modes.
 
 **Migration**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-data-migration-migration-script.png.png)
 
-As shown in the screenshot, you can quickly modify the script for each object\
-by selecting the corresponding object in the table and using the editors on the\
+As shown in the screenshot, you can quickly modify the script for each object
+by selecting the corresponding object in the table and using the editors on the
 right-hand side to make any necessary changes.
 
-After clicking the `Start Migration` button, the script for each object will be\
+After clicking the `Start Migration` button, the script for each object will be
 executed in parallel.
 
 **Migration report**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-data-migration-migration-report.png.png)
 
-If errors are reported for certain objects, review the output messages and\
+If errors are reported for certain objects, review the output messages and
 adjust the script accordingly. Then, click the `Manage` button and select `Restart`.
 
-To migrate additional objects, click the `Manage` button and select`Migrate other objects`. Doing so will replace the current migration\
+To migrate additional objects, click the `Manage` button and select`Migrate other objects`. Doing so will replace the current migration
 report for the current object with a new one.
 
 To retain the report and terminate open connections after migration, click the`Manage` button, then select `Disconnect`, and finally delete the worksheet.
 
-Deleting the worksheet will not delete the migration task. To clean-up\
+Deleting the worksheet will not delete the migration task. To clean-up
 everything after migration, click the `Manage` button, then select`Delete`.
 
 ### Create an ERD
 
-There are various features in the ERD worksheet, the most notable ones are\
+There are various features in the ERD worksheet, the most notable ones are
 listed below.
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-erd.png.png)
 
 #### ERD worksheet
 
-From an empty new worksheet, clicking on the "Create an ERD" card will open a\
-connection dialog. After connecting successfully, the ERD worksheet will be\
-rendered in the active worksheet. The connection is required to retrieve\
+From an empty new worksheet, clicking on the "Create an ERD" card will open a
+connection dialog. After connecting successfully, the ERD worksheet will be
+rendered in the active worksheet. The connection is required to retrieve
 essential metadata, such as engines, character sets, and collation.
 
 **Generate an ERD from the existing databases**
 
-Click on the icon button featured as a line graph, located on the top\
-toolbar next to the connection button. This will open a dialog for selecting\
+Click on the icon button featured as a line graph, located on the top
+toolbar next to the connection button. This will open a dialog for selecting
 the tables for the diagram.
 
 **Create a new ERD**
 
 New tables can be created by using either of the following methods:
 
-* Click on the icon button that resembles a line graph, located on the\
+* Click on the icon button that resembles a line graph, located on the
   top toolbar.
-* Right-click on the diagram board and select the `Create Table`\
+* Right-click on the diagram board and select the `Create Table`
   option.
 
 **Entity options**
 
-Two options are available: `Edit Table` and `Remove from Diagram`. These\
+Two options are available: `Edit Table` and `Remove from Diagram`. These
 options can be accessed using either of the following methods:
 
 * Right-click on the entity and choose the desired option.
-* Hover over the entity, click the gear icon button, and select the desired\
+* Hover over the entity, click the gear icon button, and select the desired
   option.
 
-For quickly editing or viewing the table definitions, double-clicking on the\
+For quickly editing or viewing the table definitions, double-clicking on the
 entity. The entity editor will be shown at the bottom of the worksheet.
 
 **Foreign keys quick common options**
@@ -456,42 +456,42 @@ entity. The entity editor will be shown at the bottom of the worksheet.
 
 * Edit Foreign Key, this opens an editor for viewing/editing foreign keys.
 * Remove Foreign Key.
-* `Change to One To One` or `Change to One To Many`. Toggling the uniqueness\
+* `Change to One To One` or `Change to One To Many`. Toggling the uniqueness
   of the foreign key column.
 * `Set FK Column Mandatory` or `Set FK Column Optional`. Toggling the`NOT NULL` option of the foreign key column.
 * `Set Referenced Column Mandatory` or `Set Referenced Column Optional`\
   Toggling the `NOT NULL` option of the referenced column.
 
-To show the above foreign key common options, perform a right-click on the link\
+To show the above foreign key common options, perform a right-click on the link
 within the diagram.
 
 **Viewing foreign key constraint SQL**
 
-Hover over the link in the diagram, the constraint SQL of that foreign key will\
+Hover over the link in the diagram, the constraint SQL of that foreign key will
 be shown in a tooltip.
 
 **Quickly draw a foreign key link**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-erd-fk-quick-option.png.png)
 
-As shown in the screenshot, a foreign key can be quickly established by\
+As shown in the screenshot, a foreign key can be quickly established by
 performing the following actions:
 
 1. Click on the entity that will have the foreign key.
-2. Click on the connecting point of the desired foreign key column and drag\
+2. Click on the connecting point of the desired foreign key column and drag
    it over the desired referenced column.
 
 **Entity editor**
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-erd-entity-editor.png.png)
 
-Table columns, foreign keys and indexes can be modified via\
-the entity editor which can be accessed quickly by double-clicking\
+Table columns, foreign keys and indexes can be modified via
+the entity editor which can be accessed quickly by double-clicking
 on the entity.
 
 **Export options**
 
-Three options are available: `Copy script to clipboard`, `Export script` and`Export as jpeg`. These options can be accessed using either of the following\
+Three options are available: `Copy script to clipboard`, `Export script` and`Export as jpeg`. These options can be accessed using either of the following
 methods:
 
 * Right-click on the diagram board and choose the desired option.
@@ -508,7 +508,7 @@ editor within the dialog.
 
 ![](../../../../.gitbook/assets/MaxGUI-workspace-erd-visual-enhancements.png.png)
 
-The first section of the top toolbar, there are options to improve the visual of\
+The first section of the top toolbar, there are options to improve the visual of
 the diagram as follows:
 
 * Change the shape of links

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md
@@ -1,6 +1,6 @@
 # Common Monitor Parameters
 
-This document settings supported by all monitors. These should be defined\
+This document settings supported by all monitors. These should be defined
 in the monitor section of the configuration file.
 
 ### Settings
@@ -19,7 +19,7 @@ The monitor module this monitor should use. Typically `mariadbmon` or`galeramon`
 * Mandatory: Yes
 * Dynamic: Yes
 
-Username used by the monitor to connect to the backend servers. If a server defines\
+Username used by the monitor to connect to the backend servers. If a server defines
 the `monitoruser` parameter, that value will be used instead.
 
 #### `password`
@@ -28,10 +28,10 @@ the `monitoruser` parameter, that value will be used instead.
 * Mandatory: Yes
 * Dynamic: Yes
 
-Password for the user defined with the `user` parameter. If a server defines\
+Password for the user defined with the `user` parameter. If a server defines
 the `monitorpw` parameter, that value will be used instead.
 
-**Note:** In older versions of MaxScale this parameter was called `passwd`. The\
+**Note:** In older versions of MaxScale this parameter was called `passwd`. The
 use of `passwd` was deprecated in MaxScale 2.3.0.
 
 #### `servers`
@@ -53,17 +53,17 @@ servers=MyServer1,MyServer2
 * Dynamic: Yes
 * Default: `2s`
 
-Defines how often the monitor updates the status of the servers. Choose a lower\
+Defines how often the monitor updates the status of the servers. Choose a lower
 value if servers should be queried more often. The smallest possible value is\
-100 milliseconds. If querying the servers takes longer than `monitor_interval`,\
+100 milliseconds. If querying the servers takes longer than `monitor_interval`,
 the effective update rate is reduced.
 
 ```
 monitor_interval=2s
 ```
 
-The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.
 
 #### `backend_connect_timeout`
@@ -74,10 +74,10 @@ versions a value without a unit may be rejected.
 * Default: `3s`
 
 This parameter controls the timeout for connecting to a monitored server.\
-The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -92,10 +92,10 @@ backend_connect_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for writing to a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 seconds.
 
 ```
@@ -110,10 +110,10 @@ backend_write_timeout=3s
 * Default: `3s`
 
 This parameter controls the timeout for reading from a monitored server.\
-The timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second. The minimum value is 1 second.
 
 ```
@@ -127,9 +127,9 @@ backend_read_timeout=3s
 * Dynamic: Yes
 * Default: `1`
 
-This parameter defines the maximum times a backend connection is attempted every\
-monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds\
-to perform. If none of the attempts are successful, the backend is considered to\
+This parameter defines the maximum times a backend connection is attempted every
+monitoring loop. Every attempt may take up to `backend_connect_timeout` seconds
+to perform. If none of the attempts are successful, the backend is considered to
 be unreachable and down.
 
 ```
@@ -147,18 +147,18 @@ This parameter duplicates the `disk_space_threshold`[server parameter](../mariad
 If the parameter has _not_ been specified for a server, then the one specified\
 for the monitor is applied.
 
-**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the\
-information will be available _only_ if the monitor user has the `FILE`\
+**NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the
+information will be available _only_ if the monitor user has the `FILE`
 privilege.
 
-That is, if the disk configuration is the same on all servers monitored by\
-the monitor, it is sufficient (and more convenient) to specify the disk\
-space threshold in the monitor section, but if the disk configuration is\
-different on all or some servers, then the disk space threshold can be\
+That is, if the disk configuration is the same on all servers monitored by
+the monitor, it is sufficient (and more convenient) to specify the disk
+space threshold in the monitor section, but if the disk configuration is
+different on all or some servers, then the disk space threshold can be
 specified individually for each server.
 
-For example, suppose `server1`, `server2` and `server3` are identical\
-in all respects. In that case we can specify `disk_space_threshold`\
+For example, suppose `server1`, `server2` and `server3` are identical
+in all respects. In that case we can specify `disk_space_threshold`
 in the monitor.
 
 ```
@@ -181,8 +181,8 @@ disk_space_threshold=/data:80
 ...
 ```
 
-However, if the servers are heterogeneous with the disk used for the\
-data directory mounted on different paths, then the disk space threshold\
+However, if the servers are heterogeneous with the disk used for the
+data directory mounted on different paths, then the disk space threshold
 must be specified separately for each server.
 
 ```
@@ -207,8 +207,8 @@ servers=server1,server2,server3
 ...
 ```
 
-If _most_ of the servers have the data directory disk mounted on\
-the same path, then the disk space threshold can be specified on\
+If _most_ of the servers have the data directory disk mounted on
+the same path, then the disk space threshold can be specified on
 the monitor and separately on the server with a different setup.
 
 ```
@@ -232,7 +232,7 @@ disk_space_threshold=/data:80
 ...
 ```
 
-Above, `server1` has the disk used for the data directory mounted\
+Above, `server1` has the disk used for the data directory mounted
 at `/DbData` while both `server2` and `server3` have it mounted on`/data` and thus the setting in the monitor covers them both.
 
 #### `disk_space_check_interval`
@@ -242,15 +242,15 @@ at `/DbData` while both `server2` and `server3` have it mounted on`/data` and th
 * Dynamic: Yes
 * Default: `0s`
 
-With this parameter it can be specified the minimum amount of time\
-between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent\
+With this parameter it can be specified the minimum amount of time
+between disk space checks. The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as milliseconds in MaxScale 2.4. In subsequent
 versions a value without a unit may be rejected.\
-The default value is 0, which means that by default the disk space\
+The default value is 0, which means that by default the disk space
 will not be checked.
 
-Note that as the checking is made as part of the regular monitor interval\
-cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,\
+Note that as the checking is made as part of the regular monitor interval
+cycle, the disk space check interval is affected by the value of`monitor_interval`. In particular, even if the value of`disk_space_check_interval` is smaller than that of `monitor_interval`,
 the checking will still take place at `monitor_interval` intervals.
 
 #### `script`
@@ -260,9 +260,9 @@ the checking will still take place at `monitor_interval` intervals.
 * Dynamic: Yes
 * Default: None
 
-This command will be executed on a server state change. The parameter should\
-be an absolute path to a command or the command should be in the executable\
-path. The user running MaxScale should have execution rights to the file itself\
+This command will be executed on a server state change. The parameter should
+be an absolute path to a command or the command should be in the executable
+path. The user running MaxScale should have execution rights to the file itself
 and the directory it resides in. The script may have placeholders which\
 MaxScale will substitute with useful information when launching the script.
 
@@ -276,15 +276,15 @@ The placeholders and their substitution results are:
 * `$MASTERLIST` -> list of IPs and ports of all primary servers
 * `$SYNCEDLIST` -> list of IPs and ports of all synced Galera nodes
 * `$PARENT` -> IP and port of the parent of the server which initiated the event.\
-  For primary-replica setups, this will be the primary if the initiating server is a\
+  For primary-replica setups, this will be the primary if the initiating server is a
   replica.
-* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who\
-  initiated the event. For primary-replica setups, this will be a list of replica\
+* `$CHILDREN` -> list of IPs and ports of the child nodes of the server who
+  initiated the event. For primary-replica setups, this will be a list of replica
   servers if the initiating server is a primary.
 
-The expanded variable value can be an empty string if no servers match the\
-variable's requirements. For example, if no primaries are available `$MASTERLIST`\
-will expand into an empty string. The list-type substitutions will only contain\
+The expanded variable value can be an empty string if no servers match the
+variable's requirements. For example, if no primaries are available `$MASTERLIST`
+will expand into an empty string. The list-type substitutions will only contain
 servers monitored by the current monitor.
 
 ```
@@ -299,17 +299,17 @@ The above script could be executed as:
 
 See section [Script example](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md#script-example) below for an example script.
 
-Any output by the executed script will be logged into the MaxScale log. Each\
+Any output by the executed script will be logged into the MaxScale log. Each
 outputted line will be logged as a separate log message.
 
-The log level on which the messages are logged depends on the format of the\
-messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the\
-corresponding level. If the message is not prefixed with one of the keywords,\
-the message will be logged on the notice level. Whitespace before, after or\
-between the keyword and the colon is ignored and the matching is\
+The log level on which the messages are logged depends on the format of the
+messages. If the first word in the output line is one of `alert:`, `error:`,`warning:`, `notice:`, `info:` or `debug:`, the message will be logged on the
+corresponding level. If the message is not prefixed with one of the keywords,
+the message will be logged on the notice level. Whitespace before, after or
+between the keyword and the colon is ignored and the matching is
 case-insensitive.
 
-Currently, the script must not execute any of the following MaxCtrl\
+Currently, the script must not execute any of the following MaxCtrl
 calls as they cause a deadlock:
 
 * `alter monitor` to the monitor executing the script
@@ -323,14 +323,14 @@ calls as they cause a deadlock:
 * Dynamic: Yes
 * Default: `90s`
 
-The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The timeout for the executed script. The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If the script execution exceeds the configured timeout, it is stopped by sending\
-a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be\
+If the script execution exceeds the configured timeout, it is stopped by sending
+a SIGTERM signal to it. If the process does not stop, a SIGKILL signal will be
 sent to it once the execution time is greater than twice the configured timeout.
 
 #### `events`
@@ -341,15 +341,15 @@ sent to it once the execution time is greater than twice the configured timeout.
 * Values: `master_down`, `master_up`, `slave_down`, `slave_up`, `server_down`, `server_up`, `lost_master`, `lost_slave`, `new_master`, `new_slave`
 * Default: All events
 
-A list of event names which cause the script to be executed. If this option is\
-not defined, all events cause the script to be executed. The list must contain a\
+A list of event names which cause the script to be executed. If this option is
+not defined, all events cause the script to be executed. The list must contain a
 comma separated list of event names.
 
 ```
 events=master_down,slave_down
 ```
 
-The following table contains all the possible event types and their\
+The following table contains all the possible event types and their
 descriptions.
 
 | Event Name   | Description                                  |
@@ -372,38 +372,38 @@ descriptions.
 * Dynamic: Yes
 * Default: `28800s`
 
-The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the max age is seconds, a max age specified in milliseconds will be rejected,\
+The maximum journal file age. The interval is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the max age is seconds, a max age specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-When the monitor starts, it reads any stored journal files. If the journal file\
-is older than the value of _journal\_max\_age_, it will be removed and the monitor\
+When the monitor starts, it reads any stored journal files. If the journal file
+is older than the value of _journal\_max\_age_, it will be removed and the monitor
 starts with no prior knowledge of the servers.
 
 ### Monitor Crash Safety
 
-Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the\
-latest server states. This change makes the monitors crash-safe when options\
-that introduce states are used. It also allows the monitors to retain stateful\
+Starting with MaxScale 2.2.0, the monitor modules keep an on-disk journal of the
+latest server states. This change makes the monitors crash-safe when options
+that introduce states are used. It also allows the monitors to retain stateful
 information when MaxScale is restarted.
 
-For MySQL monitor, options that introduce states into the monitoring process are\
-the `detect_stale_master` and `detect_stale_slave` options, both of which are\
-enabled by default. Galeramon has the `disable_master_failback` parameter which\
+For MySQL monitor, options that introduce states into the monitoring process are
+the `detect_stale_master` and `detect_stale_slave` options, both of which are
+enabled by default. Galeramon has the `disable_master_failback` parameter which
 introduces a state.
 
-The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the\
-name of the monitor section in the configuration file. If MaxScale crashes or is\
-shut down in an uncontrolled fashion, the journal will be read when MaxScale is\
-started. To skip the recovery process, manually delete the journal file before\
+The default location for the server state journal is in`/var/lib/maxscale/<monitor name>/monitor.dat` where `<monitor name>` is the
+name of the monitor section in the configuration file. If MaxScale crashes or is
+shut down in an uncontrolled fashion, the journal will be read when MaxScale is
+started. To skip the recovery process, manually delete the journal file before
 starting MaxScale.
 
 ### Script example
 
-Below is an example monitor configuration which launches a script with all\
-supported substitutions. The example script reads the results and prints it to\
+Below is an example monitor configuration which launches a script with all
+supported substitutions. The example script reads the results and prints it to
 file and sends it as email.
 
 ```

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-galera-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-galera-monitor.md
@@ -2,39 +2,39 @@
 
 ### Overview
 
-The Galera Monitor is a monitoring module for MaxScale that monitors a Galera\
-cluster. It detects whether nodes are a part of the cluster and if they are in\
-sync with the rest of the cluster. It can also assign primary and replica roles\
-inside MaxScale, allowing Galera clusters to be used with modules designed for\
+The Galera Monitor is a monitoring module for MaxScale that monitors a Galera
+cluster. It detects whether nodes are a part of the cluster and if they are in
+sync with the rest of the cluster. It can also assign primary and replica roles
+inside MaxScale, allowing Galera clusters to be used with modules designed for
 traditional primary-replica clusters.
 
-By default, the Galera Monitor will choose the node with the lowest`wsrep_local_index` value as the primary. This will mean that two MaxScales\
+By default, the Galera Monitor will choose the node with the lowest`wsrep_local_index` value as the primary. This will mean that two MaxScales
 running on different servers will choose the same server as the primary.
 
 #### WSREP Variables and Their Effects
 
-The following WSREP variables are inspected by galeramon to see whether a node is\
-usable. If the node is not usable, it loses the `Master` and `Slave` labels and\
+The following WSREP variables are inspected by galeramon to see whether a node is
+usable. If the node is not usable, it loses the `Master` and `Slave` labels and
 will be in the `Running` state.
 
-* If `wsrep_ready=0`, the WSREP system is not yet ready and the Galera node\
+* If `wsrep_ready=0`, the WSREP system is not yet ready and the Galera node
   cannot accept queries.
-* If `wsrep_desync=1` is set, the node is desynced and is not participating in\
+* If `wsrep_desync=1` is set, the node is desynced and is not participating in
   the Galera replication.
-* If `wsrep_reject_queries=[ALL|ALL_KILL]` is set, queries are refused and the\
+* If `wsrep_reject_queries=[ALL|ALL_KILL]` is set, queries are refused and the
   node is unusable.
-* With `wsrep_sst_donor_rejects_queries=1`, donor nodes reject\
-  queries. Galeramon treats this the same as if `wsrep_reject_queries=ALL` was\
+* With `wsrep_sst_donor_rejects_queries=1`, donor nodes reject
+  queries. Galeramon treats this the same as if `wsrep_reject_queries=ALL` was
   set.
-* If `wsrep_local_state` is not 4 (or 2 with `available_when_donor=true`), the\
+* If `wsrep_local_state` is not 4 (or 2 with `available_when_donor=true`), the
   node is not in the correct state and is not used.
 
 #### Galera clusters and replicas replicating from it
 
-MaxScale 2.4.0 added support for replicas replicating off of Galera nodes. If a\
-non-Galera server monitored by galeramon is replicating from a Galera node also\
-monitored by galeramon, it will be assigned the `Slave, Running` status as long\
-as the replication works. This allows read-scaleout with Galera servers without\
+MaxScale 2.4.0 added support for replicas replicating off of Galera nodes. If a
+non-Galera server monitored by galeramon is replicating from a Galera node also
+monitored by galeramon, it will be assigned the `Slave, Running` status as long
+as the replication works. This allows read-scaleout with Galera servers without
 increasing the size of the Galera cluster.
 
 ### Required Grants
@@ -60,7 +60,7 @@ GRANT SUPER ON *.* TO 'maxscale'@'maxscalehost';
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers. The user requires the\
 REPLICATION CLIENT privilege to successfully monitor the state of the servers.
 
@@ -87,10 +87,10 @@ These are optional parameters specific to the Galera Monitor.
 * Default: false
 * Dynamic: Yes
 
-If a node marked as primary inside MaxScale happens to fail and the primary\
-status is assigned to another node MaxScale will normally return the primary\
-status to the original node after it comes back up. With this option enabled, if\
-the primary status is assigned to a new node it will not be reassigned to the\
+If a node marked as primary inside MaxScale happens to fail and the primary
+status is assigned to another node MaxScale will normally return the primary
+status to the original node after it comes back up. With this option enabled, if
+the primary status is assigned to a new node it will not be reassigned to the
 original node for as long as the new primary node is running. In this case the`Master Stickiness` status bit is set which will be visible in the`maxctrl list servers` output.
 
 #### `available_when_donor`
@@ -100,16 +100,16 @@ original node for as long as the new primary node is running. In this case the`M
 * Dynamic: Yes
 
 This option allows Galera nodes to be used normally when they are donors in an\
-SST operation when the SST method is non-blocking\
+SST operation when the SST method is non-blocking
 (e.g. `wsrep_sst_method=mariadb-backup`).
 
-Normally when an SST is performed, both participating nodes lose their `Synced`,`Master` or `Slave` statuses. When this option is enabled, the donor is treated as\
-if it was a normal member of the cluster (i.e. `wsrep_local_state = 4`). This is\
-especially useful if the cluster drops down to one node and an SST is required\
+Normally when an SST is performed, both participating nodes lose their `Synced`,`Master` or `Slave` statuses. When this option is enabled, the donor is treated as
+if it was a normal member of the cluster (i.e. `wsrep_local_state = 4`). This is
+especially useful if the cluster drops down to one node and an SST is required
 to increase the cluster size.
 
-The current list of non-blocking SST\
-methods are `xtrabackup`, `xtrabackup-v2` and `mariadb-backup`. Read the [wsrep\_sst\_method](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables)\
+The current list of non-blocking SST
+methods are `xtrabackup`, `xtrabackup-v2` and `mariadb-backup`. Read the [wsrep\_sst\_method](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables)
 documentation for more details.
 
 #### `disable_master_role_setting`
@@ -118,8 +118,8 @@ documentation for more details.
 * Default: false
 * Dynamic: Yes
 
-This disables the assignment of primary and replica roles to the Galera cluster\
-nodes. If this option is enabled, Synced is the only status assigned by this\
+This disables the assignment of primary and replica roles to the Galera cluster
+nodes. If this option is enabled, Synced is the only status assigned by this
 monitor.
 
 #### `use_priority`
@@ -128,8 +128,8 @@ monitor.
 * Default: false
 * Dynamic: Yes
 
-Enable interaction with server priorities. This will allow the monitor to\
-deterministically pick the write node for the monitored Galera cluster and will\
+Enable interaction with server priorities. This will allow the monitor to
+deterministically pick the write node for the monitored Galera cluster and will
 allow for controlled node replacement.
 
 #### `root_node_as_master`
@@ -138,27 +138,27 @@ allow for controlled node replacement.
 * Default: false
 * Dynamic: Yes
 
-This option controls whether the write primary Galera node requires a_wsrep\_local\_index_ value of 0. This option was introduced in MaxScale 2.1.0 and\
-it is disabled by default in versions 2.1.5 and newer. In versions 2.1.4 and\
+This option controls whether the write primary Galera node requires a_wsrep\_local\_index_ value of 0. This option was introduced in MaxScale 2.1.0 and
+it is disabled by default in versions 2.1.5 and newer. In versions 2.1.4 and
 older, the option was enabled by default.
 
-A Galera cluster will always have a node which has a _wsrep\_local\_index_ value\
-of 0. Based on this information, multiple MaxScale instances can always pick the\
+A Galera cluster will always have a node which has a _wsrep\_local\_index_ value
+of 0. Based on this information, multiple MaxScale instances can always pick the
 same node for writes.
 
 If the `root_node_as_master` option is disabled for galeramon, the node with the\
 lowest index will always be chosen as the primary. If it is enabled, only the\
 node with a _wsrep\_local\_index_ value of 0 can be chosen as the primary.
 
-This parameter can work with `disable_master_failback` but using them together\
-is not advisable: the intention of `root_node_as_master` is to make sure that\
-all MaxScale instances that are configured to use the same Galera cluster will\
-send writes to the same node. If `disable_master_failback` is enabled, this is\
-no longer true if the Galera cluster reorganizes itself in a way that a\
-different node gets the node index 0, writes would still be going to the old\
-node that previously had the node index 0. A restart of one of the MaxScales or\
-a new MaxScale joining the cluster will cause writes to be sent to the wrong\
-node, thus resulting in an increasing the rate of deadlock errors and\
+This parameter can work with `disable_master_failback` but using them together
+is not advisable: the intention of `root_node_as_master` is to make sure that
+all MaxScale instances that are configured to use the same Galera cluster will
+send writes to the same node. If `disable_master_failback` is enabled, this is
+no longer true if the Galera cluster reorganizes itself in a way that a
+different node gets the node index 0, writes would still be going to the old
+node that previously had the node index 0. A restart of one of the MaxScales or
+a new MaxScale joining the cluster will cause writes to be sent to the wrong
+node, thus resulting in an increasing the rate of deadlock errors and
 sub-optimal performance.
 
 #### `set_donor_nodes`
@@ -167,12 +167,12 @@ sub-optimal performance.
 * Default: false
 * Dynamic: Yes
 
-This option controls whether the global variable _wsrep\_sst\_donor_ should be set\
+This option controls whether the global variable _wsrep\_sst\_donor_ should be set
 in each cluster node with _slave' status_.\
-The variable contains a list of replica servers, automatically sorted, with\
+The variable contains a list of replica servers, automatically sorted, with
 possible primary candidates at its end.
 
-The sorting is based either on _wsrep\_local\_index_ or node server _priority_\
+The sorting is based either on _wsrep\_local\_index_ or node server _priority_
 depending on the value of _use\_priority_ option.\
 If no server has _priority_ defined the sorting switches to _wsrep\_local\_index_.\
 Node names are collected by fetching the result of the variable _wsrep\_node\_name_.
@@ -184,24 +184,24 @@ SET GLOBAL wsrep_sst_donor = "galera001,galera000"
 ```
 
 **Note**:\
-in order to set the global variable _wsrep\_sst\_donor_, proper privileges are\
+in order to set the global variable _wsrep\_sst\_donor_, proper privileges are
 required for the monitor user that connects to cluster nodes.\
 This option is disabled by default and was introduced in MaxScale 2.1.0.
 
 ### Interaction with Server Priorities
 
-If the `use_priority` option is set and a server is configured with the`priority=<int>` parameter, galeramon will use that as the basis on which the\
-primary node is chosen. This requires the `disable_master_role_setting` to be\
-undefined or disabled. The server with the lowest positive value of _priority_\
-will be chosen as the primary node when a replacement Galera node is promoted to\
-a primary server inside MaxScale. If all candidate servers have the same\
-priority, the order of the servers in the `servers` parameter dictates which is\
+If the `use_priority` option is set and a server is configured with the`priority=<int>` parameter, galeramon will use that as the basis on which the
+primary node is chosen. This requires the `disable_master_role_setting` to be
+undefined or disabled. The server with the lowest positive value of _priority_
+will be chosen as the primary node when a replacement Galera node is promoted to
+a primary server inside MaxScale. If all candidate servers have the same
+priority, the order of the servers in the `servers` parameter dictates which is
 chosen as the primary.
 
-Nodes with a negative value (_priority_ < 0) will never be chosen as the\
-primary. This allows you to mark some servers as permanent replicas by assigning a\
-non-positive value into _priority_. Nodes with the default priority of 0 are\
-only selected if no nodes with higher priority are present and the normal node\
+Nodes with a negative value (_priority_ < 0) will never be chosen as the
+primary. This allows you to mark some servers as permanent replicas by assigning a
+non-positive value into _priority_. Nodes with the default priority of 0 are
+only selected if no nodes with higher priority are present and the normal node
 selection rules apply to them (i.e. selection is based on `wsrep_local_index`).
 
 Here is an example.
@@ -232,13 +232,13 @@ port=3306
 priority=-1
 ```
 
-In this example `node-1` is always used as the primary if available. If `node-1`\
-is not available, then the next node with the highest priority rank is used. In\
-this case it would be `node-3`. If both `node-1` and `node-3` were down, then`node-2` would be used. Because `node-4` has a value of -1 in _priority_, it\
-will never be the primary. Nodes without _priority_ parameter are considered as\
+In this example `node-1` is always used as the primary if available. If `node-1`
+is not available, then the next node with the highest priority rank is used. In
+this case it would be `node-3`. If both `node-1` and `node-3` were down, then`node-2` would be used. Because `node-4` has a value of -1 in _priority_, it
+will never be the primary. Nodes without _priority_ parameter are considered as
 having a priority of 0 and will be used only if all nodes with a positive_priority_ value are not available.
 
-With priority ranks you can control the order in which MaxScale chooses the\
+With priority ranks you can control the order in which MaxScale chooses the
 primary node. This will allow for a controlled failure and replacement of nodes.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md
@@ -2,11 +2,11 @@
 
 ### Overview
 
-MariaDB Monitor monitors a Primary-Replica replication cluster. It probes the\
-state of the backends and assigns server roles such as primary and replica, which\
-are used by the routers when deciding where to route a query. It can also modify\
-the replication cluster by performing failover, switchover and rejoin. Backend\
-server versions older than MariaDB/MySQL 5.5 are not supported. Failover and\
+MariaDB Monitor monitors a Primary-Replica replication cluster. It probes the
+state of the backends and assigns server roles such as primary and replica, which
+are used by the routers when deciding where to route a query. It can also modify
+the replication cluster by performing failover, switchover and rejoin. Backend
+server versions older than MariaDB/MySQL 5.5 are not supported. Failover and
 other similar operations require MariaDB 10.4 or later.
 
 Up until MariaDB MaxScale 2.2.0, this monitor was called _MySQL Monitor_.
@@ -41,7 +41,7 @@ set), then the FILE-grant is required with MariaDB Server versions 10.4.7,\
 GRANT FILE ON *.* TO 'maxscale'@'maxscalehost';
 ```
 
-MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it\
+MariaDB Server 10.5.2 introduces CONNECTION ADMIN. This is recommended since it
 allows the monitor to log in even if server connection limit has been reached.
 
 ```
@@ -50,7 +50,7 @@ GRANT CONNECTION ADMIN ON *.* TO 'maxscale'@'maxscalehost';
 
 #### Cluster Manipulation Grants
 
-If [cluster manipulation operations](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cluster-manipulation-operations) are used,\
+If [cluster manipulation operations](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cluster-manipulation-operations) are used,
 the following additional grants are required:
 
 ```
@@ -64,7 +64,7 @@ MariaDB 10.5.2 and later require read access to _mysql.global\_priv_:
 GRANT SELECT ON mysql.global_priv TO 'maxscale'@'maxscalehost';
 ```
 
-As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of\
+As of MariaDB Server 11.0.1, the SUPER-privilege no longer contains several of
 its former sub-privileges. These must be given separately.
 
 ```
@@ -83,59 +83,59 @@ GRANT REPLICATION SLAVE ON *.* TO 'replication'@'replicationhost';
 
 ### Primary selection
 
-Only one backend can be primary at any given time. A primary must be running\
-(successfully connected to by the monitor) and its _read\_only_-setting must be\
-off. A primary may not be replicating from another server in the monitored\
-cluster unless the primary is part of a multiprimary group. Primary selection\
-prefers to select the server with the most replicas, possibly in multiple\
-replication layers. Only replicas reachable by a chain of running relays or\
-directly connected to the primary count. When multiple servers are tied for\
-primary status, the server which appears earlier in the `servers`-setting of the\
+Only one backend can be primary at any given time. A primary must be running
+(successfully connected to by the monitor) and its _read\_only_-setting must be
+off. A primary may not be replicating from another server in the monitored
+cluster unless the primary is part of a multiprimary group. Primary selection
+prefers to select the server with the most replicas, possibly in multiple
+replication layers. Only replicas reachable by a chain of running relays or
+directly connected to the primary count. When multiple servers are tied for
+primary status, the server which appears earlier in the `servers`-setting of the
 monitor is selected.
 
-Servers in a cyclical replication topology (multiprimary group) are interpreted\
-as having all the servers in the group as replicas. Even from a multiprimary group\
+Servers in a cyclical replication topology (multiprimary group) are interpreted
+as having all the servers in the group as replicas. Even from a multiprimary group
 only one server is selected as the overall primary.
 
-After a primary has been selected, the monitor prefers to stick with the choice\
-even if other potential primaries with more replica servers are available. Only if\
-the current primary is clearly unsuitable does the monitor try to select another\
+After a primary has been selected, the monitor prefers to stick with the choice
+even if other potential primaries with more replica servers are available. Only if
+the current primary is clearly unsuitable does the monitor try to select another
 primary. An existing primary turns invalid if:
 
 1. It is unwritable (read\_only is on).
-2. It has been down for more than failcount monitor passes and has no running\
-   replicas. Running replicas behind a downed relay count. A replica in this\
-   context is any server with at least a partially running replication connection\
-   (either io or sql thread is running). The replicas must also be down for more\
+2. It has been down for more than failcount monitor passes and has no running
+   replicas. Running replicas behind a downed relay count. A replica in this
+   context is any server with at least a partially running replication connection
+   (either io or sql thread is running). The replicas must also be down for more
    than failcount monitor passes to allow new master selection.
-3. It did not previously replicate from another server in the cluster but it\
+3. It did not previously replicate from another server in the cluster but it
    is now replicating.
-4. It was previously part of a multiprimary group but is no longer, or the\
+4. It was previously part of a multiprimary group but is no longer, or the
    multiprimary group is replicating from a server not in the group.
 
-Cases 1 and 2 cover the situations in which the DBA, an external script or even\
-another MaxScale has modified the cluster such that the old primary can no longer\
-act as primary. Cases 3 and 4 are less severe. In these cases the topology has\
-changed significantly and the primary should be re-selected, although the old\
+Cases 1 and 2 cover the situations in which the DBA, an external script or even
+another MaxScale has modified the cluster such that the old primary can no longer
+act as primary. Cases 3 and 4 are less severe. In these cases the topology has
+changed significantly and the primary should be re-selected, although the old
 primary may still be the best choice.
 
-The primary change described above is different from failover and switchover\
+The primary change described above is different from failover and switchover
 described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
-A primary change only modifies the server roles inside MaxScale but does not\
+A primary change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a primary change on their own.
 
-As a general rule, it's best to avoid situations where the cluster has multiple\
+As a general rule, it's best to avoid situations where the cluster has multiple
 standalone servers, separate primary-replica pairs or separate multiprimary groups.\
-Due to primary invalidation rule 2, a standalone primary can easily lose the\
-primary status to another valid primary if it goes down. The new primary probably\
-does not have the same data as the previous one. Non-standalone primaries are less\
-vulnerable, as a single running replica or multiprimary group member will keep the\
+Due to primary invalidation rule 2, a standalone primary can easily lose the
+primary status to another valid primary if it goes down. The new primary probably
+does not have the same data as the previous one. Non-standalone primaries are less
+vulnerable, as a single running replica or multiprimary group member will keep the
 primary valid even when down.
 
 ### Configuration
 
-A minimal configuration for a monitor requires a set of servers for monitoring\
+A minimal configuration for a monitor requires a set of servers for monitoring
 and a username and a password to connect to these servers.
 
 ```
@@ -149,8 +149,8 @@ password=mypwd
 
 From MaxScale 2.2.1 onwards, the module name is `mariadbmon` instead of`mysqlmon`. The old name can still be used.
 
-The grants required by `user` depend on which monitor features are used. A full\
-list of the grants can be found in the [Required Grants](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#required-grants)\
+The grants required by `user` depend on which monitor features are used. A full
+list of the grants can be found in the [Required Grants](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#required-grants)
 section.
 
 ### Common Monitor Settings
@@ -159,9 +159,9 @@ For a list of optional parameters that all monitors support, read the [Monitor C
 
 ### Settings
 
-These are optional parameters specific to the MariaDB Monitor. Failover,\
-switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are\
-described in the [Rebuild server-section](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#rebuild-server). ColumnStore\
+These are optional parameters specific to the MariaDB Monitor. Failover,
+switchover and rejoin-specific parameters are listed in their own [section](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cluster-manipulation-operations). Rebuild-related parameters are
+described in the [Rebuild server-section](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#rebuild-server). ColumnStore
 parameters are described in the [ColumnStore commands-section](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#settings).
 
 #### `assume_unique_hostnames`
@@ -171,49 +171,49 @@ parameters are described in the [ColumnStore commands-section](mariadb-maxscale-
 * Dynamic: Yes
 * Default: `true`
 
-When active, the monitor assumes that server hostnames and\
-ports are consistent between the server definitions in the MaxScale\
-configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers\
-themselves. Specifically, the monitor assumes that if server A is replicating\
-from server B, then A must have a replica connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this\
-is not the case, e.g. an IP is used in the server while a hostname is given in\
-the file, the monitor may misinterpret the topology. The monitor attempts name\
-resolution on the addresses if a simple string comparison\
-does not find a match. Using exact matching addresses is, however, more\
-reliable. In MaxScale 24.02.0, an alternative IP or hostname for a server can be\
+When active, the monitor assumes that server hostnames and
+ports are consistent between the server definitions in the MaxScale
+configuration file and the "SHOW ALL SLAVES STATUS" outputs of the servers
+themselves. Specifically, the monitor assumes that if server A is replicating
+from server B, then A must have a replica connection with `Master_Host` and`Master_Port` equal to B's address and port in the configuration file. If this
+is not the case, e.g. an IP is used in the server while a hostname is given in
+the file, the monitor may misinterpret the topology. The monitor attempts name
+resolution on the addresses if a simple string comparison
+does not find a match. Using exact matching addresses is, however, more
+reliable. In MaxScale 24.02.0, an alternative IP or hostname for a server can be
 given in [private\_address](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#private_address).
 
-This setting must be ON to use any cluster operation features such as failover\
-or switchover, because MaxScale uses the addresses and ports in the\
+This setting must be ON to use any cluster operation features such as failover
+or switchover, because MaxScale uses the addresses and ports in the
 configuration file when issuing "CHANGE MASTER TO"-commands.
 
-If the network configuration is such that the addresses MaxScale uses to connect\
-to backends are different from the ones the servers use to connect to each\
-other and `private_address` is not used, `assume_unique_hostnames` should be\
-set to OFF. In this mode, MaxScale uses server id:s it queries from\
-the servers and the `Master_Server_Id` fields of the replica connections\
-to deduce which server is replicating from which. This is not perfect though,\
-since MaxScale doesn't know the id:s of servers it has\
-never connected to (e.g. server has been down since MaxScale was started). Also,\
-the `Master_Server_Id`-field may have an incorrect value if the replica connection\
-has not been established. MaxScale will only trust the value if the monitor has\
-seen the replica connection IO thread connected at least once. If this is not the\
+If the network configuration is such that the addresses MaxScale uses to connect
+to backends are different from the ones the servers use to connect to each
+other and `private_address` is not used, `assume_unique_hostnames` should be
+set to OFF. In this mode, MaxScale uses server id:s it queries from
+the servers and the `Master_Server_Id` fields of the replica connections
+to deduce which server is replicating from which. This is not perfect though,
+since MaxScale doesn't know the id:s of servers it has
+never connected to (e.g. server has been down since MaxScale was started). Also,
+the `Master_Server_Id`-field may have an incorrect value if the replica connection
+has not been established. MaxScale will only trust the value if the monitor has
+seen the replica connection IO thread connected at least once. If this is not the
 case, the replica connection is ignored.
 
 #### `private_address`
 
-String. This is an optional server setting, yet documented here since it's only\
-used by MariaDB Monitor. If not set, the normal server address setting\
+String. This is an optional server setting, yet documented here since it's only
+used by MariaDB Monitor. If not set, the normal server address setting
 is used.
 
-Defines an alternative IP-address or hostname for the server for use with\
-replication. Whenever MaxScale modifies replication (e.g. during switchover),\
+Defines an alternative IP-address or hostname for the server for use with
+replication. Whenever MaxScale modifies replication (e.g. during switchover),
 the private address is given as _Master\_Host_ to "CHANGE MASTER TO"-commands.\
 Also, when detecting replication, any _Master\_Host_-values from\
-"SHOW SLAVE STATUS"-queries are compared to the private addresses of configured\
+"SHOW SLAVE STATUS"-queries are compared to the private addresses of configured
 servers if the normal address doesn't match.
 
-This setting is useful if replication and application traffic are\
+This setting is useful if replication and application traffic are
 separated to different network interfaces.
 
 #### `master_conditions`
@@ -226,9 +226,9 @@ separated to different network interfaces.
 
 Designate additional conditions for\_Master\_-status, i.e. qualified for read and write queries.
 
-Normally, if a suitable primary candidate server is found as described in [Primary selection](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#primary-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a primary server. This\
+Normally, if a suitable primary candidate server is found as described in [Primary selection](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#primary-selection), MaxScale designates it _Master_._master\_conditions_ sets additional conditions for a primary server. This
 setting is an enum\_mask, allowing multiple conditions to be set simultaneously.\
-Conditions 2, 3 and 4 refer to replica servers. A single replica must\
+Conditions 2, 3 and 4 refer to replica servers. A single replica must
 fulfill all of the given conditions for the primary to be viable.
 
 If the primary candidate fails _master\_conditions_ but fulfills\_slave\_conditions\_, it may be designated _Slave_ instead.
@@ -236,28 +236,28 @@ If the primary candidate fails _master\_conditions_ but fulfills\_slave\_conditi
 The available conditions are:
 
 1. none : No additional conditions
-2. connecting\_slave : At least one immediate replica (not behind relay) is\
+2. connecting\_slave : At least one immediate replica (not behind relay) is
    attempting to replicate or is replicating from the primary (Slave\_IO\_Running is\
-   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A replica with incorrect\
-   replication credentials does not count. If the replica is currently down, results\
+   'Yes' or 'Connecting', Slave\_SQL\_Running is 'Yes'). A replica with incorrect
+   replication credentials does not count. If the replica is currently down, results
    from the last successful monitor tick are used.
-3. connected\_slave : Same as above, with the difference that the replication\
-   connection must be up (Slave\_IO\_Running is 'Yes'). If the replica is currently\
+3. connected\_slave : Same as above, with the difference that the replication
+   connection must be up (Slave\_IO\_Running is 'Yes'). If the replica is currently
    down, results from the last successful monitor tick are used.
-4. running\_slave : Same as connecting\_slave, with the addition that the\
+4. running\_slave : Same as connecting\_slave, with the addition that the
    replica must also be Running.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate primary is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate primary is selected also by the
    primary MaxScale.
-6. disk\_space\_ok : The candidate primary must not be low on disk space. This\
+6. disk\_space\_ok : The candidate primary must not be low on disk space. This
    option only takes effect if [disk space check](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md) is enabled. Added in\
    MaxScale 23.08.5.
 
-The default value of this setting is`master_requirements=primary_monitor_master,disk_space_ok` to ensure that both\
-monitors use the same primary server when cooperating and that the primary is\
+The default value of this setting is`master_requirements=primary_monitor_master,disk_space_ok` to ensure that both
+monitors use the same primary server when cooperating and that the primary is
 not out of disk space.
 
-For example, to require that the primary must have a replica which is both\
+For example, to require that the primary must have a replica which is both
 connected and running, set
 
 ```
@@ -272,32 +272,32 @@ master_conditions=connected_slave,running_slave
 * Values: `none`, `linked_master`, `running_master`, `writable_master`, `primary_monitor_master`
 * Default: `none`
 
-Designate additional conditions for _Slave_-status,\
+Designate additional conditions for _Slave_-status,
 i.e qualified for read queries.
 
-Normally, a server is _Slave_ if it is at least attempting to replicate from the\
+Normally, a server is _Slave_ if it is at least attempting to replicate from the
 primary candidate or a relay (Slave\_IO\_Running is 'Yes' or 'Connecting',\
-Slave\_SQL\_Running is 'Yes', valid replication credentials). The primary candidate\
-does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a replica\
-server. This setting is an enum\_mask, allowing multiple conditions to be set\
+Slave\_SQL\_Running is 'Yes', valid replication credentials). The primary candidate
+does not necessarily need to be writable, e.g. if it fails its\_master\_conditions\_. _slave\_conditions_ sets additional conditions for a replica
+server. This setting is an enum\_mask, allowing multiple conditions to be set
 simultaneously.
 
 The available conditions are:
 
 1. none : No additional conditions. This is the default value.
-2. linked\_master : The replica must be connected to the primary (Slave\_IO\_Running\
-   and Slave\_SQL\_Running are 'Yes') and the primary must be Running. The same\
+2. linked\_master : The replica must be connected to the primary (Slave\_IO\_Running
+   and Slave\_SQL\_Running are 'Yes') and the primary must be Running. The same
    applies to any relays between the replica and the primary.
 3. running\_master : The primary must be running. Relays may be down.
 4. writable\_master : The primary must be writable, i.e. labeled Master.
-5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the\
-   secondary MaxScale, require that the candidate primary is selected also by the\
+5. primary\_monitor\_master : If this MaxScale is [cooperating](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cooperative-monitoring) with another MaxScale and this is the
+   secondary MaxScale, require that the candidate primary is selected also by the
    primary MaxScale.
-6. disk\_space\_ok : The replica must not be low on disk space. This\
+6. disk\_space\_ok : The replica must not be low on disk space. This
    option only takes effect if [disk space check](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md) is enabled. Added in\
    MaxScale 23.08.5.
 
-For example, to require that the primary server of the cluster must be running\
+For example, to require that the primary server of the cluster must be running
 and writable for any servers to have _Slave_-status, set
 
 ```
@@ -311,8 +311,8 @@ slave_conditions=running_master,writable_master
 * Dynamic: Yes
 * Default: `5`
 
-Number of consecutive monitor passes a primary server must be down before it is\
-considered failed. If automatic failover is enabled (`auto_failover=true`), it\
+Number of consecutive monitor passes a primary server must be down before it is
+considered failed. If automatic failover is enabled (`auto_failover=true`), it
 may be performed at this time. A value of 0 or 1 enables immediate failover.
 
 If automatic failover is not possible, the monitor will try to\
@@ -321,8 +321,8 @@ for more details. Changing the primary may break replication as queries could be
 routed to a server without previous events. To prevent this, avoid having\
 multiple valid primary servers in the cluster.
 
-The worst-case delay between the primary failure and the start of the failover\
-can be estimated by summing up the timeout values and `monitor_interval` and\
+The worst-case delay between the primary failure and the start of the failover
+can be estimated by summing up the timeout values and `monitor_interval` and
 multiplying that by `failcount`:
 
 ```
@@ -336,19 +336,19 @@ multiplying that by `failcount`:
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-disable the _read\_only_-flag on the primary when seen. The flag is\
-checked every monitor tick. The monitor user requires the SUPER-privilege for\
+If set to ON, the monitor attempts to
+disable the _read\_only_-flag on the primary when seen. The flag is
+checked every monitor tick. The monitor user requires the SUPER-privilege for
 this feature to work.
 
-Typically, the primary server should never be in read-only-mode. Such a situation\
-may arise due to misconfiguration or accident, or perhaps if MaxScale crashed\
+Typically, the primary server should never be in read-only-mode. Such a situation
+may arise due to misconfiguration or accident, or perhaps if MaxScale crashed
 during switchover.
 
-When this feature is enabled, setting the primary manually to _read\_only_ will no\
-longer cause the monitor to search for another primary. The primary will instead\
-for a moment lose its \[Master]-status (no writes), until the monitor again\
-enables writes on the primary. When starting from scratch, the monitor still\
+When this feature is enabled, setting the primary manually to _read\_only_ will no
+longer cause the monitor to search for another primary. The primary will instead
+for a moment lose its \[Master]-status (no writes), until the monitor again
+enables writes on the primary. When starting from scratch, the monitor still
 prefers to select a writable server as primary if possible.
 
 #### `enforce_read_only_slaves`
@@ -358,18 +358,18 @@ prefers to select a writable server as primary if possible.
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, the monitor attempts to\
-enable the _read\_only_-flag on any writable replica server. The flag is checked\
-every monitor tick. The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this\
+If set to ON, the monitor attempts to
+enable the _read\_only_-flag on any writable replica server. The flag is checked
+every monitor tick. The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this
 feature to work. While the _read\_only_-flag is ON, only users with the\
-SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If\
-temporary write access is required, this feature should be disabled before\
-attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly\
+SUPER-privilege (or READ\_ONLY ADMIN) can write to the backend server. If
+temporary write access is required, this feature should be disabled before
+attempting to disable _read\_only_ manually. Otherwise, the monitor will quickly
 re-enable it.
 
-_read\_only_ won't be enabled on the master server, even if it has\
-lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#master_conditions) and is\
+_read\_only_ won't be enabled on the master server, even if it has
+lost \[Master]-status due to [master\_conditions](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#master_conditions) and is
 marked \[Slave].
 
 #### `enforce_read_only_servers`
@@ -379,12 +379,12 @@ marked \[Slave].
 * Dynamic: Yes
 * Default: `false`
 
-Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in\
+Works similar to [enforce\_read\_only\_slaves](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#enforce_read_only_slaves) except will set\_read\_only\_ on any writable server that is not the primary and not in
 maintenance (a superset of the servers altered by _enforce\_read\_only\_slaves_).
 
-The monitor user requires the SUPER-privilege\
-(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid\
-primary or primary candidate, _read\_only_ is not set on any server as it is\
+The monitor user requires the SUPER-privilege
+(or READ\_ONLY ADMIN) for this feature to work. If the cluster has no valid
+primary or primary candidate, _read\_only_ is not set on any server as it is
 unclear which servers should be altered.
 
 #### `maintenance_on_low_disk_space`
@@ -394,16 +394,16 @@ unclear which servers should be altered.
 * Dynamic: Yes
 * Default: `true`
 
-If a running server that is not the primary\
+If a running server that is not the primary
 or a relay primary is out of disk space the server is set to maintenance mode.\
-Such servers are not used for router sessions and are ignored when performing a\
-failover or other cluster modification operation. See the general monitor\
-parameters [disk\_space\_threshold](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md) and [disk\_space\_check\_interval](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md)\
+Such servers are not used for router sessions and are ignored when performing a
+failover or other cluster modification operation. See the general monitor
+parameters [disk\_space\_threshold](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md) and [disk\_space\_check\_interval](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md)
 on how to enable disk space monitoring.
 
-Once a server has been put to maintenance mode, the disk space situation\
-of that server is no longer updated. The server will not be taken out of\
-maintenance mode even if more disk space becomes available. The maintenance\
+Once a server has been put to maintenance mode, the disk space situation
+of that server is no longer updated. The server will not be taken out of
+maintenance mode even if more disk space becomes available. The maintenance
 flag must be removed manually:
 
 ```
@@ -418,22 +418,22 @@ maxctrl clear server server2 Maint
 * Values: `none`, `majority_of_all`, `majority_of_running`
 * Default: `none`
 
-Using this setting is recommended when multiple MaxScales are monitoring the\
-same backend cluster. When enabled, the monitor attempts to acquire exclusive\
-locks on the backend servers. The monitor considers itself the primary monitor\
-if it has a majority of locks. The majority can be either over all configured\
-servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cooperative-monitoring)\
+Using this setting is recommended when multiple MaxScales are monitoring the
+same backend cluster. When enabled, the monitor attempts to acquire exclusive
+locks on the backend servers. The monitor considers itself the primary monitor
+if it has a majority of locks. The majority can be either over all configured
+servers or just over running servers. See [Cooperative monitoring](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cooperative-monitoring)
 for more details on how this feature works and which value to use.
 
 Allowed values:
 
 1. `none` Default value, no locking.
-2. `majority_of_all` Primary monitor requires a majority of locks, even counting\
+2. `majority_of_all` Primary monitor requires a majority of locks, even counting
    servers which are \[Down].
 3. `majority_of_running` Primary monitor requires a majority of locks over\
    \[Running] servers.
 
-This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has\
+This setting is separate from the global MaxScale setting _passive_. If\_passive\_ is set to `true`, cluster operations are disabled even if monitor has
 acquired the locks. Generally, it's best not to mix cooperative monitoring with\_passive\_. Either set `passive=false` or do not set it at all.
 
 #### `script_max_replication_lag`
@@ -443,40 +443,40 @@ acquired the locks. Generally, it's best not to mix cooperative monitoring with\
 * Dynamic: Yes
 * Default: `-1`
 
-Defines a replication lag limit in seconds for\
-launching the monitor script configured in the _script_-parameter. If the\
+Defines a replication lag limit in seconds for
+launching the monitor script configured in the _script_-parameter. If the
 replication lag of a server goes above this limit, the script is ran with the\
-$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the\
+$EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
-Negative values disable this feature. For more information on monitor scripts,\
+Negative values disable this feature. For more information on monitor scripts,
 see [general monitor documentation](https://mariadb.com/kb/en/node:maxscale-25-01-common-monitor-parameters#script).
 
 ### Cluster manipulation operations
 
-MariaDB Monitor can perform several operations that modify the replication\
+MariaDB Monitor can perform several operations that modify the replication
 topology. The supported operations are:
 
 * [failover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failover), which replaces a failed primary with a replica
-* [failover-safe](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failover-safe), which replaces a failed primary with a replica\
+* [failover-safe](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failover-safe), which replaces a failed primary with a replica
   only if no data is clearly lost
 * [switchover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#switchover), which swaps a running primary with a replica
-* [switchover-force](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#switchover-force), which swaps a running primary with a replica, ignoring\
+* [switchover-force](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#switchover-force), which swaps a running primary with a replica, ignoring
   most errors. Can break replication.
 * [async-switchover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#queued-switchover), which schedules a switchover and returns
 * [rejoin](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#rejoin), which directs servers to replicate from the primary
-* [reset-replication](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and\
+* [reset-replication](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
-See [operation details](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#operation-details) for more information on the\
+See [operation details](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#operation-details) for more information on the
 implementation of the commands.
 
-The cluster operations require that the monitor user (`user`) has the following\
+The cluster operations require that the monitor user (`user`) has the following
 privileges:
 
-* SUPER, to modify replica connections, set globals such as read\_only and kill\
+* SUPER, to modify replica connections, set globals such as read\_only and kill
   connections from other super-users
-* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list\
+* REPLICATION CLIENT (REPLICATION SLAVE ADMIN in MariaDB Server 10.5), to list
   replica connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
@@ -484,19 +484,19 @@ privileges:
 * SELECT on mysql.user, to see which users have SUPER
 * SELECT on mysql.global\_priv so see to see which users have READ\_ONLY ADMIN
 
-A list of the grants can be found in the [Required Grants](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#required-grants)\
+A list of the grants can be found in the [Required Grants](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#required-grants)
 section.
 
-The privilege system was changed in MariaDB Server 10.5. The effects of this on\
-the MaxScale monitor user are minor, as the SUPER-privilege contains many of the\
-required privileges and is still required to kill connections from other\
+The privilege system was changed in MariaDB Server 10.5. The effects of this on
+the MaxScale monitor user are minor, as the SUPER-privilege contains many of the
+required privileges and is still required to kill connections from other
 super-users.
 
-In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required\
+In MariaDB Server 11.0.1 and later, SUPER no longer contains all the required
 grants. The monitor requires:
 
 * READ\_ONLY ADMIN, to set read\_only
-* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication\
+* REPLICA MONITOR and REPLICATION SLAVE ADMIN, to view and manage replication
   connections
 * RELOAD, to flush binary logs
 * PROCESS, to check if the event\_scheduler process is running
@@ -506,19 +506,19 @@ grants. The monitor requires:
 * SELECT on mysql.user, to see which users have SUPER
 * SELECT on mysql.global\_priv so see to see which users have READ\_ONLY ADMIN
 
-In addition, the monitor needs to know which username and password a\
+In addition, the monitor needs to know which username and password a
 replica should use when starting replication. These are given in`replication_user` and `replication_password`.
 
-The user can define files with SQL statements which are executed on any server\
+The user can define files with SQL statements which are executed on any server
 being demoted or promoted by cluster manipulation commands. See the sections on`promotion_sql_file` and `demotion_sql_file` for more information.
 
-The monitor can manipulate scheduled server events when promoting or demoting a\
+The monitor can manipulate scheduled server events when promoting or demoting a
 server. See the section on `handle_events` for more information.
 
-All cluster operations can be activated manually through MaxCtrl. See\
+All cluster operations can be activated manually through MaxCtrl. See
 section [Manual activation](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#manual-activation) for more details.
 
-See [Limitations and requirements](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#limitations-and-requirements) for\
+See [Limitations and requirements](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#limitations-and-requirements) for
 information on possible issues with failover and switchover.
 
 #### Operation details
@@ -529,22 +529,22 @@ information on possible issues with failover and switchover.
 call command mariadbmon failover MONITOR
 ```
 
-**Failover** replaces a failed primary with a running replica. It does the\
+**Failover** replaces a failed primary with a running replica. It does the
 following:
 
-1. Select the most up-to-date replica of the old primary to be the new primary. The\
+1. Select the most up-to-date replica of the old primary to be the new primary. The
    selection criteria is as follows in descending priority:
 2. gtid\_IO\_pos (latest event in relay log)
 3. gtid\_current\_pos (most processed events)
 4. log\_slave\_updates is on
 5. disk space is not low
-6. If the new primary has unprocessed relay log items, cancel and try again\
+6. If the new primary has unprocessed relay log items, cancel and try again
    later.
 7. Prepare the new primary:
-8. Remove the replica connection the new primary used to replicate from the\
+8. Remove the replica connection the new primary used to replicate from the
    old primary.
 9. Disable the read\_only-flag.
-10. Enable scheduled server events (if event handling is on). Only events\
+10. Enable scheduled server events (if event handling is on). Only events
     that were enabled on the old primary are enabled.
 11. Run the commands in `promotion_sql_file`.
 12. Start replication from external primary if one existed.
@@ -554,7 +554,7 @@ following:
 16. START SLAVE
 17. Check that all replicas are replicating.
 
-Failover is considered successful if steps 1 to 3 succeed, as the cluster then\
+Failover is considered successful if steps 1 to 3 succeed, as the cluster then
 has at least a valid primary server.
 
 **Failover-safe**
@@ -563,13 +563,13 @@ has at least a valid primary server.
 call command mariadbmon failover-safe MONITOR
 ```
 
-**Failover-safe** performs the same steps as a normal failover but refuses to\
-start if it's clear that data would be lost. Dataloss occurs if the primary\
+**Failover-safe** performs the same steps as a normal failover but refuses to
+start if it's clear that data would be lost. Dataloss occurs if the primary
 had data which was not replicated to any replica before the primary went down.\
-MaxScale detects this by looking at the GTIDs of the servers. Because the\
+MaxScale detects this by looking at the GTIDs of the servers. Because the
 monitor queries the GTIDs only every monitor interval, this check is inaccurate.\
-If the primary performs a write just before crashing and before MaxScale queries\
-the GTID, data could be lost even with "safe" failover. Thus, this feature\
+If the primary performs a write just before crashing and before MaxScale queries
+the GTID, data could be lost even with "safe" failover. Thus, this feature
 mainly protects against situations where the replicas are constantly lagging.
 
 **Switchover**
@@ -578,26 +578,26 @@ mainly protects against situations where the replicas are constantly lagging.
 call command mariadbmon switchover MONITOR [NEW_PRIMARY] [OLD_PRIMARY]
 ```
 
-**Switchover** swaps a running primary with a running replica. It does the\
+**Switchover** swaps a running primary with a running replica. It does the
 following:
 
 1. Prepare the old primary for demotion:
 2. If `backend_read_timeout` is short, extend it and reconnect.
 3. Stop any external replication.
 4. Enable the read\_only-flag to stop writes from normal users.
-5. Kill connections from super and read-only admin users since\
-   read\_only does not affect them. During this step, all writes are\
+5. Kill connections from super and read-only admin users since
+   read\_only does not affect them. During this step, all writes are
    blocked with "FLUSH TABLES WITH READ LOCK".
 6. Disable scheduled server events (if event handling is on).
 7. Run the commands in `demotion_sql_file`.
 8. Flush the binary log ("flush logs") so that all events are on disk.
 9. Wait a moment to check that gtid is stable.
 10. Wait for the new primary to catch up with the old primary.
-11. Promote new primary and redirect replicas as in failover steps 3 and 4. Also\
+11. Promote new primary and redirect replicas as in failover steps 3 and 4. Also
     redirect the demoted old primary.
 12. Check that all replicas are replicating.
 
-Similar to failover, switchover is considered successful if the new primary was\
+Similar to failover, switchover is considered successful if the new primary was
 successfully promoted.
 
 **Switchover-force**
@@ -606,11 +606,11 @@ successfully promoted.
 call command mariadbmon switchover-force MONITOR [NEW_PRIMARY] [OLD_PRIMARY]
 ```
 
-**Switchover-force** performs the same steps as a normal switchover but ignores\
-any errors on the old primary. Switchover-force also does not expect the new\
-primary to reach the gtid-position of the old, as the old primary\
-could be receiving more events constantly. Thus, switchover-force may lose\
-events and replication can break on multiple (or even all) replicas. This is\
+**Switchover-force** performs the same steps as a normal switchover but ignores
+any errors on the old primary. Switchover-force also does not expect the new
+primary to reach the gtid-position of the old, as the old primary
+could be receiving more events constantly. Thus, switchover-force may lose
+events and replication can break on multiple (or even all) replicas. This is
 an unsafe command and should only be used as a last resort.
 
 **Rejoin**
@@ -619,8 +619,8 @@ an unsafe command and should only be used as a last resort.
 call command mariadbmon rejoin MONITOR OLD_PRIMARY
 ```
 
-**Rejoin** joins a standalone server to the cluster or redirects a replica\
-replicating from a server other than the primary. A standalone server is joined\
+**Rejoin** joins a standalone server to the cluster or redirects a replica
+replicating from a server other than the primary. A standalone server is joined
 by:
 
 1. Run the commands in `demotion_sql_file`.
@@ -637,9 +637,9 @@ STOP SLAVE, RESET SLAVE, CHANGE MASTER TO and START SLAVE commands.
 maxctrl call command mariadbmon reset-replication MONITOR [NEW_PRIMARY]
 ```
 
-**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets\
-gtid:s. This destructive command is meant for situations where the gtid:s in the\
-cluster are out of sync while the actual data is known to be in sync. The\
+**Reset-replication** (added in MaxScale 2.3.0) deletes binary logs and resets
+gtid:s. This destructive command is meant for situations where the gtid:s in the
+cluster are out of sync while the actual data is known to be in sync. The
 operation proceeds as follows:
 
 1. Reset gtid:s and delete binary logs on all servers:
@@ -647,38 +647,38 @@ operation proceeds as follows:
 3. Enable the read\_only-flag.
 4. Disable scheduled server events (if event handling is on).
 5. Delete binary logs (RESET MASTER).
-6. Set the sequence number of gtid\_slave\_pos to zero. This also affects\
+6. Set the sequence number of gtid\_slave\_pos to zero. This also affects
    gtid\_current\_pos.
 7. Prepare new primary:
 8. Disable the read\_only-flag.
-9. Enable scheduled server events (if event handling is on). Events are\
-   only enabled if the cluster had a primary server when starting the\
-   reset-replication operation. Only events that were enabled on the previous\
+9. Enable scheduled server events (if event handling is on). Events are
+   only enabled if the cluster had a primary server when starting the
+   reset-replication operation. Only events that were enabled on the previous
    primary are enabled on the new.
-10. Direct other servers to replicate from the new primary as in the other\
+10. Direct other servers to replicate from the new primary as in the other
     operations.
 
 #### Manual activation
 
 Cluster operations can be activated manually through the REST API or MaxCtrl.\
-The commands are only performed when MaxScale is in active mode. The commands\
-generally match their automatic versions. The exception is _rejoin_, in which\
-the manual command allows rejoining even when the joining server has empty\
-gtid:s. This rule allows the user to force a rejoin on a server without binary\
+The commands are only performed when MaxScale is in active mode. The commands
+generally match their automatic versions. The exception is _rejoin_, in which
+the manual command allows rejoining even when the joining server has empty
+gtid:s. This rule allows the user to force a rejoin on a server without binary
 logs.
 
-All commands require the monitor instance name as the first parameter. Failover\
-selects the new primary server automatically and does not require additional\
+All commands require the monitor instance name as the first parameter. Failover
+selects the new primary server automatically and does not require additional
 parameters. Rejoin requires the name of the joining server as second parameter.\
 Replication reset accepts the name of the new primary server as second parameter.\
 If not given, the current primary is selected.
 
-Switchover takes one to three parameters. If only the monitor name is given,\
-switchover will autoselect both the replica to promote and the current primary as\
-the server to be demoted. If two parameters are given, the second parameter is\
-interpreted as the replica to promote. If three parameters are given, the third\
-parameter is interpreted as the current primary. The user-given current primary is\
-compared to the primary server currently deduced by the monitor and if the two\
+Switchover takes one to three parameters. If only the monitor name is given,
+switchover will autoselect both the replica to promote and the current primary as
+the server to be demoted. If two parameters are given, the second parameter is
+interpreted as the replica to promote. If three parameters are given, the third
+parameter is interpreted as the current primary. The user-given current primary is
+compared to the primary server currently deduced by the monitor and if the two
 are unequal, an error is given.
 
 Example commands are below:
@@ -695,28 +695,28 @@ maxctrl call command mariadbmon switchover MyMonitor NewPrimaryServ OldPrimarySe
 maxctrl call command mariadbmon switchover-force MyMonitor NewPrimaryServ
 ```
 
-The commands follow the standard module command syntax. All require the monitor\
-configuration name (MyMonitor) as the first parameter. For switchover, the\
-last two parameters define the server to promote (NewPrimaryServ) and the server\
-to demote (OldPrimaryServ). For rejoin, the server to join (OldPrimaryServ) is\
+The commands follow the standard module command syntax. All require the monitor
+configuration name (MyMonitor) as the first parameter. For switchover, the
+last two parameters define the server to promote (NewPrimaryServ) and the server
+to demote (OldPrimaryServ). For rejoin, the server to join (OldPrimaryServ) is
 required. Replication reset requires the server to promote (NewPrimaryServ).
 
-It is safe to perform manual operations even with automatic failover, switchover\
-or rejoin enabled since automatic operations cannot happen simultaneously\
+It is safe to perform manual operations even with automatic failover, switchover
+or rejoin enabled since automatic operations cannot happen simultaneously
 with manual ones.
 
-When a cluster modification is initiated via the REST-API, the URL path is of the\
+When a cluster modification is initiated via the REST-API, the URL path is of the
 form:
 
 ```
 /v1/maxscale/modules/mariadbmon/<operation>?<monitor-name>&<server-name1>&<server-name2>
 ```
 
-* `<operation>` is the name of the command e.g. failover, switchover,\
+* `<operation>` is the name of the command e.g. failover, switchover,
   rejoin or reset-replication.
 * `<monitor-name>` is the monitor name from the MaxScale configuration file.
-* `<server-name1>` and `<server-name2>` are server names as described\
-  above for MaxCtrl. Only switchover accepts both, failover doesn't need any\
+* `<server-name1>` and `<server-name2>` are server names as described
+  above for MaxCtrl. Only switchover accepts both, failover doesn't need any
   and both rejoin and reset-replication accept one.
 
 Given a MaxScale configuration file like
@@ -729,7 +729,7 @@ servers=server1, server2, server3, server 4
 ...
 ```
 
-with the assumption that `server2` is the current primary, then the URL\
+with the assumption that `server2` is the current primary, then the URL
 path for making `server4` the new primary would be:
 
 ```
@@ -746,9 +746,9 @@ Example REST-API paths for other commands are listed below.
 
 **Queued switchover**
 
-Most cluster modification commands wait until the operation either succeeds or\
-fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the\
-module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,\
+Most cluster modification commands wait until the operation either succeeds or
+fails. _async-switchover_ is an exception, as it returns immediately. Otherwise\_async-switchover\_ works identical to a normal _switchover_ command. Use the
+module command _fetch-cmd-result_ to view the result of the queued command._fetch-cmd-result_ returns the status or result of the latest manual command,
 whether queued or not.
 
 ```
@@ -765,8 +765,8 @@ maxctrl call command mariadbmon fetch-cmd-result Cluster1
 
 **Switchover with key-value arguments**
 
-As of MaxScale 24.08.0, switchover can be launched using an alternate command\
-syntax which passes arguments as key-value pairs. This allows for greater\
+As of MaxScale 24.08.0, switchover can be launched using an alternate command
+syntax which passes arguments as key-value pairs. This allows for greater
 flexibility as a variable number of arguments can be easily defined in the call.\
 This alternative form of _switchover_ accepts the following arguments:
 
@@ -785,10 +785,10 @@ The key-value syntax thus supports the same features as the old _switchover_,_as
 maxctrl call command mariadbmon switchover monitor=MyMonitor new_primary=MyServer2 async=1 force=1
 ```
 
-In addition, key-value argument passing supports `old_primary_maint`. This\
+In addition, key-value argument passing supports `old_primary_maint`. This
 feature leaves the old primary server in maintenance mode without replication.\
-This is useful when performing rolling MariaDB Server version upgrades. After\
-all replicas have been upgraded, switch out the old primary with`old_primary_maint=1` to promote one of the replicas while leaving the old\
+This is useful when performing rolling MariaDB Server version upgrades. After
+all replicas have been upgraded, switch out the old primary with`old_primary_maint=1` to promote one of the replicas while leaving the old
 primary as standalone.
 
 ```
@@ -797,123 +797,123 @@ maxctrl call command mariadbmon switchover monitor=MyMonitor old_primary_maint=1
 
 #### Automatic activation
 
-Failover can activate automatically if `auto_failover` is on. The activation\
+Failover can activate automatically if `auto_failover` is on. The activation
 begins when the primary has been down at least `failcount` monitor iterations.\
-Before modifying the cluster, the monitor checks that all prerequisites for the\
-failover are fulfilled. If the cluster does not seem ready, an error is printed\
+Before modifying the cluster, the monitor checks that all prerequisites for the
+failover are fulfilled. If the cluster does not seem ready, an error is printed
 and the cluster is rechecked during the next monitor iteration.
 
-Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the primary\
-server is low on disk space but otherwise the operating logic is quite similar\
+Switchover can also activate automatically with the`switchover_on_low_disk_space`-setting. The operation begins if the primary
+server is low on disk space but otherwise the operating logic is quite similar
 to automatic failover.
 
-Rejoin stands for starting replication on a standalone server or redirecting a\
-replica replicating from the wrong primary (any server that is not the cluster\
-primary). The rejoined servers are directed to replicate from the current cluster\
-primary server, forcing the replication topology to a 1-primary-N-replicas\
+Rejoin stands for starting replication on a standalone server or redirecting a
+replica replicating from the wrong primary (any server that is not the cluster
+primary). The rejoined servers are directed to replicate from the current cluster
+primary server, forcing the replication topology to a 1-primary-N-replicas
 configuration.
 
-A server is categorized as standalone if the server has no replica connections,\
-not even stopped ones. A server is replicating from the wrong primary if the\
-replica IO thread is connected but the primary server id seen by the replica does not\
-match the cluster primary id. Alternatively, the IO thread may be stopped or\
-connecting but the primary server host or port information differs from the\
-cluster primary info. These criteria mean that a STOP SLAVE does not yet set a\
+A server is categorized as standalone if the server has no replica connections,
+not even stopped ones. A server is replicating from the wrong primary if the
+replica IO thread is connected but the primary server id seen by the replica does not
+match the cluster primary id. Alternatively, the IO thread may be stopped or
+connecting but the primary server host or port information differs from the
+cluster primary info. These criteria mean that a STOP SLAVE does not yet set a
 replica as standalone.
 
-With `auto_rejoin` active, the monitor will try to rejoin any servers matching\
-the above requirements. Rejoin does not obey `failcount` and will attempt to\
-rejoin any valid servers immediately. When activating rejoin manually, the\
+With `auto_rejoin` active, the monitor will try to rejoin any servers matching
+the above requirements. Rejoin does not obey `failcount` and will attempt to
+rejoin any valid servers immediately. When activating rejoin manually, the
 user-designated server must fulfill the same requirements.
 
 #### Limitations and requirements
 
-Switchover and failover are meant for simple topologies (one primary and\
-several replicas). Using these commands with complicated topologies\
-(multiple primaries, relays, circular replication) may give unpredictable results\
+Switchover and failover are meant for simple topologies (one primary and
+several replicas). Using these commands with complicated topologies
+(multiple primaries, relays, circular replication) may give unpredictable results
 and should be tested before use on a production system.
 
-The server cluster is assumed to be well-behaving with no significant\
-replication lag (within `failover_timeout`/`switchover_timeout`) and all\
+The server cluster is assumed to be well-behaving with no significant
+replication lag (within `failover_timeout`/`switchover_timeout`) and all
 commands that modify the cluster (such as "STOP SLAVE", "CHANGE MASTER",\
-"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`\
+"START SLAVE") complete in a few seconds (faster than `backend_read_timeout`
 and `backend_write_timeout`).
 
-The backends must all use GTID-based replication, and the domain id should not\
-change during a switchover or failover. Replicas should not have extra\
+The backends must all use GTID-based replication, and the domain id should not
+change during a switchover or failover. Replicas should not have extra
 local events so that GTIDs are compatible across the cluster.
 
-Failover cannot be performed if MaxScale was started only after the primary\
-server went down. This is because MaxScale needs reliable information on the\
-gtid domain of the cluster and the replication topology in general to properly\
+Failover cannot be performed if MaxScale was started only after the primary
+server went down. This is because MaxScale needs reliable information on the
+gtid domain of the cluster and the replication topology in general to properly
 select the new primary. `enforce_simple_topology=1` relaxes this requirement.
 
-Failover may lose events. If a primary goes down before sending new events to at\
-least one replica, those events are lost when a new primary is chosen. If the old\
-primary comes back online, the other servers have likely moved on with a\
+Failover may lose events. If a primary goes down before sending new events to at
+least one replica, those events are lost when a new primary is chosen. If the old
+primary comes back online, the other servers have likely moved on with a
 diverging history and the old primary can no longer join the replication cluster.
 
 To reduce the chance of losing data, use [semisynchronous replication](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication).\
-In semisynchronous mode, the primary waits for a replica to receive an event before\
-returning an acknowledgement to the client. This does not yet guarantee a clean\
-failover. If the primary fails after preparing a transaction but before receiving\
-replica acknowledgement, it will still commit the prepared transaction as part of\
-its crash recovery. If the replicas never saw this transaction, the\
-old primary has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)\
+In semisynchronous mode, the primary waits for a replica to receive an event before
+returning an acknowledgement to the client. This does not yet guarantee a clean
+failover. If the primary fails after preparing a transaction but before receiving
+replica acknowledgement, it will still commit the prepared transaction as part of
+its crash recovery. If the replicas never saw this transaction, the
+old primary has diverged from the cluster. See [Configuring the Master Wait Point](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/semisynchronous-replication)
 for more information. This situation is much less likely in MariaDB Server\
-10.6.2 and later, as the improved crash recovery logic will delete such\
+10.6.2 and later, as the improved crash recovery logic will delete such
 transactions.
 
-Even a controlled shutdown of the primary may lose events. The server does not by\
-default wait for all data to be replicated to the replicas when shutting down and\
-instead simply closes all connections. Before shutting down the primary with the\
-intention of having a replica promoted, run _switchover_ first to ensure that all\
+Even a controlled shutdown of the primary may lose events. The server does not by
+default wait for all data to be replicated to the replicas when shutting down and
+instead simply closes all connections. Before shutting down the primary with the
+intention of having a replica promoted, run _switchover_ first to ensure that all
 data is replicated. For more information on server shutdown, see [Binary Log Dump Threads and the Shutdown Process](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-threads).
 
-Switchover requires that the cluster is "frozen" for the duration of the\
-operation. This means that no data modifying statements such as INSERT or UPDATE\
-are executed and the GTID position of the primary server is stable. When\
-switchover begins, the monitor sets the global _read\_only_ flag on the old\
+Switchover requires that the cluster is "frozen" for the duration of the
+operation. This means that no data modifying statements such as INSERT or UPDATE
+are executed and the GTID position of the primary server is stable. When
+switchover begins, the monitor sets the global _read\_only_ flag on the old
 primary backend to stop any updates. _read\_only_ does not affect users with the\
-SUPER-privilege so any such user can issue writes during a switchover. These\
-writes have a high chance of breaking replication, because the write may not be\
-replicated to all replicas before they switch to the new primary. To prevent this,\
-any users who commonly do updates should NOT have the SUPER-privilege. For even\
+SUPER-privilege so any such user can issue writes during a switchover. These
+writes have a high chance of breaking replication, because the write may not be
+replicated to all replicas before they switch to the new primary. To prevent this,
+any users who commonly do updates should NOT have the SUPER-privilege. For even
 more security, the only SUPER-user session during a switchover should be the\
-MaxScale monitor user. This also applies to users running scheduled server\
-events. Although the monitor by default disables events on the master, an\
-event may already be executing. If the event definer has SUPER-privilege, the\
+MaxScale monitor user. This also applies to users running scheduled server
+events. Although the monitor by default disables events on the master, an
+event may already be executing. If the event definer has SUPER-privilege, the
 event can write to the database even through _read\_only_.
 
-When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest\
-of the cluster. If the current cluster primary does not have binary logs from the\
-moment the rejoining server lost connection, the rejoining server cannot\
-continue replication. This is an issue if the primary has changed and\
+When mixing rejoin with failover/switchover, the backends should have\_log\_slave\_updates\_ on. The rejoining server is likely lagging behind the rest
+of the cluster. If the current cluster primary does not have binary logs from the
+moment the rejoining server lost connection, the rejoining server cannot
+continue replication. This is an issue if the primary has changed and
 the new primary does not have _log\_slave\_updates_ on.
 
-If an automatic cluster operation such as auto-failover or auto-rejoin fails,\
-all cluster modifying operations are disabled for `failcount` monitor iterations,\
-after which the operation may be retried. Similar logic applies if the cluster is\
+If an automatic cluster operation such as auto-failover or auto-rejoin fails,
+all cluster modifying operations are disabled for `failcount` monitor iterations,
+after which the operation may be retried. Similar logic applies if the cluster is
 unsuitable for such operations, e.g. replication is not using GTID.
 
 #### External primary support
 
-The monitor detects if a server in the cluster is replicating from an external\
-primary (a server that is not monitored by the monitor). If the replicating\
-server is the cluster primary server, then the cluster itself is considered to\
+The monitor detects if a server in the cluster is replicating from an external
+primary (a server that is not monitored by the monitor). If the replicating
+server is the cluster primary server, then the cluster itself is considered to
 have an external primary.
 
-If a failover/switchover happens, the new primary server is set to replicate from\
-the cluster external primary server. The username and password for the replication\
-are defined in `replication_user` and `replication_password`. The address and\
-port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster\
-primary server. In the case of switchover, the old primary also stops replicating\
+If a failover/switchover happens, the new primary server is set to replicate from
+the cluster external primary server. The username and password for the replication
+are defined in `replication_user` and `replication_password`. The address and
+port used are the ones shown by `SHOW ALL SLAVES STATUS` on the old cluster
+primary server. In the case of switchover, the old primary also stops replicating
 from the external server to preserve the topology.
 
-After failover the new primary is replicating from the external primary. If the\
-failed old primary comes back online, it is also replicating from the external\
-server. To normalize the situation, either have _auto\_rejoin_ on or manually\
-execute a rejoin. This will redirect the old primary to the current cluster\
+After failover the new primary is replicating from the external primary. If the
+failed old primary comes back online, it is also replicating from the external
+server. To normalize the situation, either have _auto\_rejoin_ on or manually
+execute a rejoin. This will redirect the old primary to the current cluster
 primary.
 
 #### Settings for Cluster manipulation operations
@@ -926,21 +926,21 @@ primary.
 * Values: `true`, `on`, `yes`, `1`, `false`, `off`, `no`, `0`, `safe`
 * Default: `false`
 
-Enable automatic primary failover. `true`, `on`, `yes` and `1` enable normal\
+Enable automatic primary failover. `true`, `on`, `yes` and `1` enable normal
 failover. `false`, `off`, `no` and `0` disable the feature. `safe` enables [safe failover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failover-safe).
 
-When automatic failover is enabled, MaxScale\
-will elect a new primary server for the cluster if the old primary goes down. A\
-server is assumed _Down_ if it cannot be connected to, even if this is caused by\
+When automatic failover is enabled, MaxScale
+will elect a new primary server for the cluster if the old primary goes down. A
+server is assumed _Down_ if it cannot be connected to, even if this is caused by
 incorrect credentials. Failover triggers if the primary stays down for [failcount](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failcount) monitor intervals. Failover will not take place if\
 MaxScale is set [passive](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md).
 
-As failover alters replication, it requires more privileges than normal\
+As failover alters replication, it requires more privileges than normal
 monitoring. See [here](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cluster-manipulation-grants) for a list of grants.
 
-Failover is designed to be used with simple primary-replica topologies. More\
-complicated topologies, such as multilayered or circular replication, are not\
-guaranteed to always work correctly. Test before using failover with such\
+Failover is designed to be used with simple primary-replica topologies. More
+complicated topologies, such as multilayered or circular replication, are not
+guaranteed to always work correctly. Test before using failover with such
 setups.
 
 **`auto_rejoin`**
@@ -950,20 +950,20 @@ setups.
 * Dynamic: Yes
 * Default: `false`
 
-Enable automatic joining of servers to the cluster. When enabled, MaxScale will\
-attempt to direct servers to replicate from the current cluster primary if they\
-are not currently doing so. Replication will be started on any standalone\
+Enable automatic joining of servers to the cluster. When enabled, MaxScale will
+attempt to direct servers to replicate from the current cluster primary if they
+are not currently doing so. Replication will be started on any standalone
 servers. Servers that are replicating from another server will be redirected.\
-This effectively enforces a 1-primary-N-replicas topology. The current primary\
-itself is not redirected, so it can continue to replicate from an external\
-primary. Rejoin is also not performed on any server that is replicating from\
-multiple sources, as this indicates a complicated topology (this rule is\
+This effectively enforces a 1-primary-N-replicas topology. The current primary
+itself is not redirected, so it can continue to replicate from an external
+primary. Rejoin is also not performed on any server that is replicating from
+multiple sources, as this indicates a complicated topology (this rule is
 overridden by [enforce\_simple\_topology](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#enforce_simple_topology)).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#auto_failover) to redirect\
-the former primary when it comes back online. Sometimes this kind of rejoin will\
-fail as the old primary may have transactions that were never replicated to the\
-current one. See [limitations](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#limitations-and-requirements) for more\
+This feature is often paired with [auto\_failover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#auto_failover) to redirect
+the former primary when it comes back online. Sometimes this kind of rejoin will
+fail as the old primary may have transactions that were never replicated to the
+current one. See [limitations](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#limitations-and-requirements) for more
 information.
 
 As an example, consider the following series of events:
@@ -973,9 +973,9 @@ As an example, consider the following series of events:
 3. Replica A comes back
 4. Old primary comes back
 
-Replica A is still trying to replicate from the downed primary, since it wasn't\
-online during failover. If _auto\_rejoin_ is on, Replica A will quickly be\
-redirected to Replica B, the current primary. The old primary will also rejoin the\
+Replica A is still trying to replicate from the downed primary, since it wasn't
+online during failover. If _auto\_rejoin_ is on, Replica A will quickly be
+redirected to Replica B, the current primary. The old primary will also rejoin the
 cluster if possible.
 
 **`switchover_on_low_disk_space`**
@@ -1008,18 +1008,18 @@ switchover_on_low_disk_space=true
 * Default: `false`
 
 This setting tells the monitor to assume that the servers should be arranged in a\
-1-primary-N-replicas topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual\
+1-primary-N-replicas topology and the monitor should try to keep it that way. If`enforce_simple_topology` is enabled, the settings `assume_unique_hostnames`,`auto_failover` and `auto_rejoin` are also activated regardless of their individual
 settings.
 
-By default, mariadbmon will not rejoin servers with more than one replication\
-stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the\
-cluster and any extra replication sources will be removed. This is done to make\
+By default, mariadbmon will not rejoin servers with more than one replication
+stream configured into the cluster. Starting with MaxScale 6.2.0, when`enforce_simple_topology` is enabled, all servers will be rejoined into the
+cluster and any extra replication sources will be removed. This is done to make
 automated failover with multi-source external replication possible.
 
-This setting also allows the monitor to perform a failover to a cluster where the primary\
-server has not been seen \[Running]. This is usually the case when the primary goes down\
-before MaxScale is started. When using this feature, the monitor will guess the GTID\
-domain id of the primary from the replicas. For reliable results, the GTID:s of the cluster\
+This setting also allows the monitor to perform a failover to a cluster where the primary
+server has not been seen \[Running]. This is usually the case when the primary goes down
+before MaxScale is started. When using this feature, the monitor will guess the GTID
+domain id of the primary from the replicas. For reliable results, the GTID:s of the cluster
 should be simple.
 
 ```
@@ -1033,18 +1033,18 @@ enforce_simple_topology=true
 * Dynamic: Yes
 * Default: None
 
-This and `replication_password` specify the username and password of the\
+This and `replication_password` specify the username and password of the
 replication user. These are given as the values for `MASTER_USER` and`MASTER_PASSWORD` whenever a `CHANGE MASTER TO` command is executed.
 
-Both `replication_user` and `replication_password` parameters must be defined if\
-a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication\
+Both `replication_user` and `replication_password` parameters must be defined if
+a custom replication user is used. If neither of the parameters is defined, the`CHANGE MASTER TO`-command will use the monitor credentials for the replication
 user.
 
-The credentials used for replication must have the `REPLICATION SLAVE`\
+The credentials used for replication must have the `REPLICATION SLAVE`
 privilege.
 
-`replication_password` uses the same encryption scheme as other password\
-parameters. If password encryption is in use, `replication_password` must be\
+`replication_password` uses the same encryption scheme as other password
+parameters. If password encryption is in use, `replication_password` must be
 encrypted with the same key to avoid erroneous decryption.
 
 **`replication_password`**
@@ -1063,25 +1063,25 @@ See [replication\_user](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#r
 * Dynamic: Yes
 * Default: `false`
 
-If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable\
-encryption for the replication stream. This setting should only be enabled if the backend\
-servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication\
+If set to ON, any `CHANGE MASTER TO`-command generated will set `MASTER_SSL=1` to enable
+encryption for the replication stream. This setting should only be enabled if the backend
+servers are configured for ssl. This typically means setting _ssl\_ca_, _ssl\_cert_ and\_ssl\_key\_ in the server configuration file. Additionally, credentials for the replication
 user should require an encrypted connection (`e.g. ALTER USER repl@'%' REQUIRE SSL;`).
 
-If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing\
+If the setting is left OFF, `MASTER_SSL` is not set at all, which will preserve existing
 settings when redirecting a replica connection.
 
 **`replication_custom_options`**
 
 Type: string
 
-A custom string added to "CHANGE MASTER TO"-commands sent by the monitor\
-whenever setting up replication (e.g. during switchover). Useful for defining\
-ssl certificates or other specialized replication options. MaxScale does not\
-check the contents of the string, so care should be taken to ensure that\
-only valid options are set and that the contents do not interfere with\
-the options MaxScale sets on its own (e.g. MASTER\_HOST). This setting can\
-also be configured for an individual server. If configured for both\
+A custom string added to "CHANGE MASTER TO"-commands sent by the monitor
+whenever setting up replication (e.g. during switchover). Useful for defining
+ssl certificates or other specialized replication options. MaxScale does not
+check the contents of the string, so care should be taken to ensure that
+only valid options are set and that the contents do not interfere with
+the options MaxScale sets on its own (e.g. MASTER\_HOST). This setting can
+also be configured for an individual server. If configured for both
 the monitor and a server, the server setting takes priority.
 
 ```
@@ -1098,12 +1098,12 @@ replication_custom_options=MASTER_SSL_CERT = '/tmp/certs/client-cert.pem',
 * Dynamic: Yes
 * Default: `90s`
 
-Time limit for failover operation. Note that since the granularity of the\
-timeout is seconds, a timeout specified in milliseconds will be rejected,\
+Time limit for failover operation. Note that since the granularity of the
+timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-If no successful failover takes place within the configured time period,\
-a message is logged and automatic failover is disabled. This prevents\
+If no successful failover takes place within the configured time period,
+a message is logged and automatic failover is disabled. This prevents
 further automatic modifications to the misbehaving cluster.
 
 **`switchover_timeout`**
@@ -1113,10 +1113,10 @@ further automatic modifications to the misbehaving cluster.
 * Dynamic: Yes
 * Default: `90s`
 
-Time limit for switchover operations. The timeout is also used as the time\
-limit for a rejoin operation. Rejoin should rarely time out, since it is a\
-faster operation than switchover. Note that since the granularity of the\
-timeouts is seconds, a timeout specified in milliseconds will be rejected,\
+Time limit for switchover operations. The timeout is also used as the time
+limit for a rejoin operation. Rejoin should rarely time out, since it is a
+faster operation than switchover. Note that since the granularity of the
+timeouts is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 **`verify_master_failure`**
@@ -1128,24 +1128,24 @@ even if the duration is longer than a second.
 
 Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and [master\_failure\_timeout](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#master_failure_timeout) defines the timeout.
 
-The primary failure timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+The primary failure timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
-Failure verification is performed by checking whether the replica servers are\
-still connected to the primary and receiving events. An event is either a change\
-in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat\
-event. Effectively, if a replica has received an event within`master_failure_timeout` duration, the primary is not considered down when\
-deciding whether to failover, even if MaxScale cannot connect to the primary.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of\
+Failure verification is performed by checking whether the replica servers are
+still connected to the primary and receiving events. An event is either a change
+in the _Gtid\_IO\_Pos_-field of the `SHOW SLAVE STATUS` output or a heartbeat
+event. Effectively, if a replica has received an event within`master_failure_timeout` duration, the primary is not considered down when
+deciding whether to failover, even if MaxScale cannot connect to the primary.`master_failure_timeout` should be longer than the `Slave_heartbeat_period` of
 the replica connection to be effective.
 
 If every replica loses its connection to the primary (_Slave\_IO\_Running_ is not\
-"Yes"), primary failure is considered verified regardless of timeout. This allows\
+"Yes"), primary failure is considered verified regardless of timeout. This allows
 faster failover when the primary properly disconnects.
 
-For automatic failover to activate, the `failcount` requirement must also be\
+For automatic failover to activate, the `failcount` requirement must also be
 met.
 
 **`master_failure_timeout`**
@@ -1155,10 +1155,10 @@ met.
 * Dynamic: Yes
 * Default: `10s`
 
-`master_failure_timeout` is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit\
-is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent\
-versions a value without a unit may be rejected. Note that since the granularity\
-of the timeout is seconds, a timeout specified in milliseconds will be rejected,\
+`master_failure_timeout` is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
+is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
+versions a value without a unit may be rejected. Note that since the granularity
+of the timeout is seconds, a timeout specified in milliseconds will be rejected,
 even if the duration is longer than a second.
 
 **`servers_no_promotion`**
@@ -1168,20 +1168,20 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: None
 
-This is a comma-separated list of server names that will not be chosen for\
-primary promotion during a failover or autoselected for switchover. This does not\
-affect switchover if the user selects the server to promote. Using this setting\
-can disrupt new primary selection for failover such that a non-optimal server is\
-chosen. At worst, this will cause replication to break. Alternatively, failover\
+This is a comma-separated list of server names that will not be chosen for
+primary promotion during a failover or autoselected for switchover. This does not
+affect switchover if the user selects the server to promote. Using this setting
+can disrupt new primary selection for failover such that a non-optimal server is
+chosen. At worst, this will cause replication to break. Alternatively, failover
 may fail if all valid promotion candidates are in the exclusion list.
 
 ```
 servers_no_promotion=backup_dc_server1,backup_dc_server2
 ```
 
-As of MaxScale 24.02.4 and 24.08.1, this setting also affects primary\
-server selection during MaxScale startup or due to replication topology\
-changes. A server listed in `servers_no_promotion` will thus not be\
+As of MaxScale 24.02.4 and 24.08.1, this setting also affects primary
+server selection during MaxScale startup or due to replication topology
+changes. A server listed in `servers_no_promotion` will thus not be
 selected as primary unless manually designated in a _switchover_-command.
 
 **`promotion_sql_file`**
@@ -1192,30 +1192,30 @@ selected as primary unless manually designated in a _switchover_-command.
 * Default: None
 
 This and `demotion_sql_file` are paths to text files with SQL statements in them.\
-During promotion or demotion, the contents are read line-by-line and executed on\
-the backend. Use these settings to execute custom statements on the servers to\
+During promotion or demotion, the contents are read line-by-line and executed on
+the backend. Use these settings to execute custom statements on the servers to
 complement the built-in operations.
 
-Empty lines or lines starting with '#' are ignored. Any results returned by the\
-statements are ignored. All statements must succeed for the failover, switchover\
-or rejoin to continue. The monitor user may require additional privileges and\
+Empty lines or lines starting with '#' are ignored. Any results returned by the
+statements are ignored. All statements must succeed for the failover, switchover
+or rejoin to continue. The monitor user may require additional privileges and
 grants for the custom commands to succeed.
 
-When promoting a replica to primary during switchover or failover, the`promotion_sql_file` is read and executed on the new primary server after its\
-read-only flag is disabled. The commands are ran _before_ starting replication\
+When promoting a replica to primary during switchover or failover, the`promotion_sql_file` is read and executed on the new primary server after its
+read-only flag is disabled. The commands are ran _before_ starting replication
 from an external primary if any.
 
-`demotion_sql_file` is ran on an old primary during demotion to replica, before the\
-old primary starts replicating from the new primary. The file is also ran before\
-rejoining a standalone server to the cluster, as the standalone server is\
-typically a former primary server. When redirecting a replica replicating from a\
+`demotion_sql_file` is ran on an old primary during demotion to replica, before the
+old primary starts replicating from the new primary. The file is also ran before
+rejoining a standalone server to the cluster, as the standalone server is
+typically a former primary server. When redirecting a replica replicating from a
 wrong primary, the sql-file is not executed.
 
-Since the queries in the files are ran during operations which modify\
-replication topology, care is required. If `promotion_sql_file` contains data\
-modification (DML) queries, the new primary server may not be able to\
-successfully replicate from an external primary. `demotion_sql_file` should never\
-contain DML queries, as these may not replicate to the replica servers before\
+Since the queries in the files are ran during operations which modify
+replication topology, care is required. If `promotion_sql_file` contains data
+modification (DML) queries, the new primary server may not be able to
+successfully replicate from an external primary. `demotion_sql_file` should never
+contain DML queries, as these may not replicate to the replica servers before
 replica threads are stopped, breaking replication.
 
 ```
@@ -1239,71 +1239,71 @@ See [promotion\_sql\_file](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.m
 * Dynamic: Yes
 * Default: `true`
 
-If enabled, the monitor continuously queries the\
-servers for enabled scheduled events and uses this information when performing\
+If enabled, the monitor continuously queries the
+servers for enabled scheduled events and uses this information when performing
 cluster operations, enabling and disabling events as appropriate.
 
 When a server is being demoted, any events with "ENABLED" status are set to\
 "SLAVESIDE\_DISABLED". When a server is being promoted to primary, events that are either\
-"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled\
-on the old primary server last time it was successfully queried. Events are considered\
-identical if they have the same schema and name. When a standalone server is rejoined to\
+"SLAVESIDE\_DISABLED" or "DISABLED" are set to "ENABLED" if the same event was also enabled
+on the old primary server last time it was successfully queried. Events are considered
+identical if they have the same schema and name. When a standalone server is rejoined to
 the cluster, its events are also disabled since it is now a replica.
 
-The monitor does not check whether the same events were disabled and enabled during a\
+The monitor does not check whether the same events were disabled and enabled during a
 switchover or failover/rejoin. All events that meet the criteria above are altered.
 
-The monitor does not enable or disable the event scheduler itself. For the\
-events to run on the new primary server, the scheduler should be enabled by the\
+The monitor does not enable or disable the event scheduler itself. For the
+events to run on the new primary server, the scheduler should be enabled by the
 admin. Enabling it in the server configuration file is recommended.
 
-Events running at high frequency may cause replication to break in a failover\
-scenario. If an old primary which was failed over restarts, its event scheduler\
-will be on if set in the server configuration file. Its events will also\
-remember their "ENABLED"-status and run when scheduled. This may happen before\
-the monitor rejoins the server and disables the events. This should only be an\
-issue for events running more often than the monitor interval or events that run\
+Events running at high frequency may cause replication to break in a failover
+scenario. If an old primary which was failed over restarts, its event scheduler
+will be on if set in the server configuration file. Its events will also
+remember their "ENABLED"-status and run when scheduled. This may happen before
+the monitor rejoins the server and disables the events. This should only be an
+issue for events running more often than the monitor interval or events that run
 immediately after the server has restarted.
 
 ### Cooperative monitoring
 
-As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means\
-that multiple monitors (typically in different MaxScale instances) can monitor\
-the same backend server cluster and only one will be the primary monitor. Only\
+As of MaxScale 2.5, MariaDB-Monitor supports cooperative monitoring. This means
+that multiple monitors (typically in different MaxScale instances) can monitor
+the same backend server cluster and only one will be the primary monitor. Only
 the primary monitor may perform _switchover_, _failover_ or _rejoin_ operations.\
-The primary also decides which server is the primary. Cooperative monitoring is\
+The primary also decides which server is the primary. Cooperative monitoring is
 enabled with the [cooperative\_monitoring\_locks](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#cooperative_monitoring_locks)-setting.\
 Even with this setting, only one monitor per server per MaxScale is allowed.\
-This limitation can be circumvented by defining multiple copies of a server in\
+This limitation can be circumvented by defining multiple copies of a server in
 the configuration file.
 
-Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)\
-for coordinating between monitors. When cooperating, the monitor regularly\
-checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and\
-acquires it if free. If the monitor acquires a majority of locks, it is the\
+Cooperative monitoring uses [server locks](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/miscellaneous-functions/get_lock)
+for coordinating between monitors. When cooperating, the monitor regularly
+checks the status of a lock named _maxscale\_mariadbmonitor_ on every server and
+acquires it if free. If the monitor acquires a majority of locks, it is the
 primary. If a monitor cannot claim majority locks, it is a secondary monitor.
 
 The primary monitor of a cluster also acquires the lock _maxscale\_mariadbmonitor\_master_ on the primary server. Secondary monitors check
 which server this lock is taken on and only accept that server as the primary.\
-This arrangement is required so that multiple monitors can agree on which server\
-is the primary regardless of replication topology. If a secondary monitor does\
-not see the primary-lock taken, then it won't mark any server as \[Master],\
+This arrangement is required so that multiple monitors can agree on which server
+is the primary regardless of replication topology. If a secondary monitor does
+not see the primary-lock taken, then it won't mark any server as \[Master],
 causing writes to fail.
 
-The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor\
-needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three\
-servers needs two locks for majority, a cluster of four needs three, and a\
+The lock-setting defines how many locks are required for primary status. Setting`cooperative_monitoring_locks=majority_of_all` means that the primary monitor
+needs _n\_servers/2 + 1_ (rounded down) locks. For example, a cluster of three
+servers needs two locks for majority, a cluster of four needs three, and a
 cluster of five needs three.\
-This scheme is resistant against split-brain situations in the sense\
-that multiple monitors cannot be primary simultaneously. However, a split may\
-cause both monitors to consider themselves secondary, in which case a primary\
+This scheme is resistant against split-brain situations in the sense
+that multiple monitors cannot be primary simultaneously. However, a split may
+cause both monitors to consider themselves secondary, in which case a primary
 server won't be detected.
 
-Even without a network split, `cooperative_monitoring_locks=majority_of_all`\
-will lead to neither monitor claiming lock majority once too many servers go\
-down. This scenario is depicted in the image below. Only two out of four servers\
-are running when three are needed for majority. Although both MaxScales see both\
-running servers, neither is certain they have majority and the cluster stays in\
+Even without a network split, `cooperative_monitoring_locks=majority_of_all`
+will lead to neither monitor claiming lock majority once too many servers go
+down. This scenario is depicted in the image below. Only two out of four servers
+are running when three are needed for majority. Although both MaxScales see both
+running servers, neither is certain they have majority and the cluster stays in
 read-only mode. If the primary server is down, no failover is performed either.
 
 ```mermaid
@@ -1334,17 +1334,17 @@ flowchart TD
 ```
 _No majority: both MaxScale instances see the same two reachable servers, so neither can lock a majority and both remain secondary._
 
-Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only\
-servers currently \[Running] are considered. This scheme adapts to multiple\
+Setting `cooperative_monitoring_locks=majority_of_running` changes the way\_n\_servers\_ is calculated. Instead of using the total number of servers, only
+servers currently \[Running] are considered. This scheme adapts to multiple
 servers going down, ensuring that claiming lock majority is always possible.\
-However, it can lead to multiple monitors claiming primary status in a\
-split-brain situation. As an example, consider a cluster with servers 1 to 4\
-with MaxScales A and B, as in the image below. MaxScale A can connect to\
-servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to\
-a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B\
+However, it can lead to multiple monitors claiming primary status in a
+split-brain situation. As an example, consider a cluster with servers 1 to 4
+with MaxScales A and B, as in the image below. MaxScale A can connect to
+servers 1 and 2 (and claim their locks) but not to servers 3 and 4 due to
+a network split. MaxScale A thus assumes servers 3 and 4 are down. MaxScale B
 does the opposite, claiming servers 3 and 4 and assuming 1 and 2 are down.\
-Both MaxScales claim two locks out of two available and assume that they have\
-lock majority. Both MaxScales may then promote their own primaries and route\
+Both MaxScales claim two locks out of two available and assume that they have
+lock majority. Both MaxScales may then promote their own primaries and route
 writes to different servers.
 
 ```mermaid
@@ -1377,23 +1377,23 @@ flowchart TD
 ```
 _Split brain: a broken heartbeat between datacenters lets both MaxScale A and MaxScale B act as primary at once, each locking its own read-write server._
 
-The recommended strategy depends on which failure scenario is more likely and/or\
-more destructive. If it's unlikely that multiple servers are ever down\
-simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other\
-hand, if split-brain is unlikely but multiple servers may be down\
+The recommended strategy depends on which failure scenario is more likely and/or
+more destructive. If it's unlikely that multiple servers are ever down
+simultaneously, then _majority\_of\_all_ is likely the safer choice. On the other
+hand, if split-brain is unlikely but multiple servers may be down
 simultaneously, then _majority\_of\_running_ would keep the cluster operational.
 
-To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the\
-monitor has lock majority on the cluster. If cooperative monitoring is disabled,\
-the field value is _null_. Lock information for individual servers is listed in\
-the server-specific field **lock\_held**. Again, _null_ indicates that locks are\
+To check if a monitor is primary, fetch monitor diagnostics with `maxctrl show monitors` or the REST API. The boolean field **primary** indicates whether the
+monitor has lock majority on the cluster. If cooperative monitoring is disabled,
+the field value is _null_. Lock information for individual servers is listed in
+the server-specific field **lock\_held**. Again, _null_ indicates that locks are
 not in use or the lock status is unknown.
 
-If a MaxScale instance tries to acquire the locks but fails to get majority\
-(perhaps another MaxScale was acquiring locks simultaneously) it will release\
-any acquired locks and try again after a random number of monitor ticks. This\
+If a MaxScale instance tries to acquire the locks but fails to get majority
+(perhaps another MaxScale was acquiring locks simultaneously) it will release
+any acquired locks and try again after a random number of monitor ticks. This
 prevents multiple MaxScales from fighting over the locks continuously as one\
-MaxScale will eventually wait less time than the others. Conflict probability\
+MaxScale will eventually wait less time than the others. Conflict probability
 can be further decreased by configuring each monitor with a different\_monitor\_interval\_.
 
 The flowchart below illustrates the lock handling logic.
@@ -1439,19 +1439,19 @@ _MariaDB Monitor cooperative locking: on each tick, a MaxScale that holds (or ca
 
 #### Releasing locks
 
-Monitor cooperation depends on the server locks. The locks are\
-connection-specific. The owning connection can manually release a lock, allowing\
+Monitor cooperation depends on the server locks. The locks are
+connection-specific. The owning connection can manually release a lock, allowing
 another connection to claim it. Also, if the owning connection closes, the\
-MariaDB Server process releases the lock. How quickly a lost connection is\
-detected affects how quickly the primary monitor status moves from one monitor\
+MariaDB Server process releases the lock. How quickly a lost connection is
+detected affects how quickly the primary monitor status moves from one monitor
 and MaxScale to another.
 
-If the primary MaxScale or its monitor is stopped normally, the monitor\
+If the primary MaxScale or its monitor is stopped normally, the monitor
 connections are properly closed, releasing the locks. This allows the secondary\
-MaxScale to quickly claim the locks. However, if the primary simply vanishes\
+MaxScale to quickly claim the locks. However, if the primary simply vanishes
 (broken network), the connection may just look idle. In this case, the\
-MariaDB Server may take a long time before it considers the monitor connection\
-lost. This time ultimately depends on TCP keepalive settings on the machines\
+MariaDB Server may take a long time before it considers the monitor connection
+lost. This time ultimately depends on TCP keepalive settings on the machines
 running MariaDB Server.
 
 On MariaDB Server 10.3.3 and later, the TCP keepalive settings can be configured\
@@ -1460,15 +1460,15 @@ for information on settings _tcp\_keepalive\_interval_, _tcp\_keepalive\_probes_
 level, as described [here](https://www.tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html).
 
 As of MaxScale 6.4.16, 22.08.13, 23.02.10, 23.08.6 and 24.02.2, configuring\
-TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_\
-variable when acquiring a lock. This causes the MariaDB Server to close the\
-monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout\
+TCP keepalive is no longer necessary as monitor sets the session _wait\_timeout_
+variable when acquiring a lock. This causes the MariaDB Server to close the
+monitor connection if the connection appears idle for too long. The value of\_wait\_timeout\_ used depends on the monitor interval and connection timeout
 settings, and is logged at MaxScale startup.
 
-A monitor can also be ordered to manually release its locks via the module\
-command _release-locks_. This is useful for manually changing the primary\
-monitor. After running the release-command, the monitor will not attempt to\
-reacquire the locks for one minute, even if it wasn't the primary monitor to\
+A monitor can also be ordered to manually release its locks via the module
+command _release-locks_. This is useful for manually changing the primary
+monitor. After running the release-command, the monitor will not attempt to
+reacquire the locks for one minute, even if it wasn't the primary monitor to
 begin with. This command can cause the cluster to become temporarily unusable by\
 MaxScale. Only use it when there is another monitor ready to claim the locks.
 
@@ -1478,23 +1478,23 @@ maxctrl call command mariadbmon release-locks MyMonitor1
 
 ### Primary server write test
 
-Some backend failures are not observable just by connecting to the server and\
-running standard monitor queries. A server may be connectable and respond to\
-queries sent by the monitor, but its disk could be full or malfunctioning or the\
-storage engine could be locked in some way. Normally, MariaDB Monitor would\
-consider such a server to be in good health, even if in reality the server\
+Some backend failures are not observable just by connecting to the server and
+running standard monitor queries. A server may be connectable and respond to
+queries sent by the monitor, but its disk could be full or malfunctioning or the
+storage engine could be locked in some way. Normally, MariaDB Monitor would
+consider such a server to be in good health, even if in reality the server
 could not perform any writes.
 
-To detect such errors, MariaDB Monitor can be configured to perform a regular\
-write test if the gtid\_binlog\_pos of the primary server is not advancing\
-otherwise. Testing that writes are going through and are being saved to\
-the binary log increases the chance of detecting storage failures. The monitor\
-can also be configured to perform a failover if the primary server fails the\
-write test. Even this test may miss storage issues, as the monitor write test\
-performs a small insert that may go through even when a large write done by\
+To detect such errors, MariaDB Monitor can be configured to perform a regular
+write test if the gtid\_binlog\_pos of the primary server is not advancing
+otherwise. Testing that writes are going through and are being saved to
+the binary log increases the chance of detecting storage failures. The monitor
+can also be configured to perform a failover if the primary server fails the
+write test. Even this test may miss storage issues, as the monitor write test
+performs a small insert that may go through even when a large write done by
 a real application does not.
 
-See the following configuration parameters for more information on how to\
+See the following configuration parameters for more information on how to
 configure this feature.
 
 #### Settings for Primary server write test
@@ -1505,10 +1505,10 @@ configure this feature.
 * Dynamic: Yes
 * Default: 0s
 
-If enabled (value > 0s), the monitor will perform a write test on the primary\
+If enabled (value > 0s), the monitor will perform a write test on the primary
 server if its gtid\_binlog\_pos has not changed within the configured interval.\
-This test inserts one row to the table configured in [write\_test\_table](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#write_test_table). If the insert fails or does not complete\
-within [backend\_read\_timeout](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md),\
+This test inserts one row to the table configured in [write\_test\_table](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#write_test_table). If the insert fails or does not complete
+within [backend\_read\_timeout](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md),
 the server fails the write test. What happens after that depends on [write\_test\_fail\_action](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#write_test_fail_action).
 
 ```
@@ -1521,9 +1521,9 @@ write_test_interval=20s
 * Dynamic: Yes
 * Default: `mxs.maxscale_write_test`
 
-The write test target table. The table name should be fully qualified\
-i.e. include the database name. If the table does not exist or\
-does not contain expected columns, the monitor (re)creates it. The table is\
+The write test target table. The table name should be fully qualified
+i.e. include the database name. If the table does not exist or
+does not contain expected columns, the monitor (re)creates it. The table is
 created with a query like
 
 ```
@@ -1533,7 +1533,7 @@ CREATE OR REPLACE TABLE mxs.maxscale_write_test
 `gtid` TEXT NULL);
 ```
 
-The database must be created manually. The monitor user requires privileges to\
+The database must be created manually. The monitor user requires privileges to
 create, drop, read and manipulate the table:
 
 ```
@@ -1552,51 +1552,51 @@ write_test_table=mxs.my_write_test_table
 * Dynamic: Yes
 
 Which action to take if primary server fails the write test. `log` means that\
-MaxScale will simply log the failure but perform no other action. This is mainly\
+MaxScale will simply log the failure but perform no other action. This is mainly
 useful for testing the feature.
 
-If set to `failover`, the monitor will perform a failover if the primary server\
-fails the write test [failcount](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failcount) consecutive times. That is,\
-the first write test is performed after `write_test_interval` has passed without\
-writes. If the test fails, the monitor will repeat the test during the next\
-monitor tick. After `failcount` monitor ticks with failed write tests, failover\
+If set to `failover`, the monitor will perform a failover if the primary server
+fails the write test [failcount](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failcount) consecutive times. That is,
+the first write test is performed after `write_test_interval` has passed without
+writes. If the test fails, the monitor will repeat the test during the next
+monitor tick. After `failcount` monitor ticks with failed write tests, failover
 begins. After failover, the former primary server is set into maintenance mode.\
 Manual intervention is required to take the server into use again.
 
 ### Backup operations
 
-Backup operations manipulate the contents of a MariaDB Server, saving it or\
+Backup operations manipulate the contents of a MariaDB Server, saving it or
 overwriting it. MariaDB-Monitor supports three backup operations:
 
-1. rebuild-server: Replace the contents of a database server with the\
+1. rebuild-server: Replace the contents of a database server with the
    contents of another.
-2. create-backup: Copy the contents of a database server to a storage\
+2. create-backup: Copy the contents of a database server to a storage
    location.
-3. restore-from-backup: Overwrite the contents of a database server with a\
+3. restore-from-backup: Overwrite the contents of a database server with a
    backup.
 
-These operations do not modify server config files, only files in the data\
+These operations do not modify server config files, only files in the data
 directory (typically _/var/lib/mysql_) are affected.
 
 All of these operations are monitor commands and best launched with MaxCtrl.\
-The operations are asynchronous, which means MaxCtrl won't wait for the\
-operation to complete and instead immediately returns "OK". To see the current\
-status of an operation, either check MaxScale log or use the\
-fetch-cmd-result-command\
+The operations are asynchronous, which means MaxCtrl won't wait for the
+operation to complete and instead immediately returns "OK". To see the current
+status of an operation, either check MaxScale log or use the
+fetch-cmd-result-command
 (e.g. `maxctrl call command mariadbmon fetch-cmd-result MyMonitor`).
 
-To perform backup operations, MaxScale requires ssh-access on all affected\
+To perform backup operations, MaxScale requires ssh-access on all affected
 machines. The _ssh\_user_ and _ssh\_keyfile_-settings define the SSH credentials\
-MaxScale uses to access the servers. MaxScale must be able to run commands with\_sudo\_ on both the source and target servers. See [settings](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#settings) and [sudoers.d configuration](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#sudoersd-configuration) below\
+MaxScale uses to access the servers. MaxScale must be able to run commands with\_sudo\_ on both the source and target servers. See [settings](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#settings) and [sudoers.d configuration](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#sudoersd-configuration) below
 for more information.
 
 The following tools need to be installed on the backends:
 
 1. mariadb-backup. Backs up and restores MariaDB Server contents. Installed e.g.\
-   with `yum install MariaDB-backup`. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup) for more\
+   with `yum install MariaDB-backup`. See [mariadb-backup documentation](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup) for more
    information.
 2. pigz. Compresses and decompresses the backup stream. Installed e.g. with`yum install pigz`.
-3. socat. Streams data from one machine to another. Is likely already\
+3. socat. Streams data from one machine to another. Is likely already
    installed. If not, can be installed e.g. with `yum install socat`.
 
 mariadb-backup needs server credentials to log in and authenticate to the\
@@ -1606,39 +1606,39 @@ for more details.
 
 #### Rebuild server
 
-The rebuild server-operation replaces the contents of a database server with the\
-contents of another server. The source server is effectively cloned and all data\
-on the target server is lost. This is useful when a replica server has diverged\
+The rebuild server-operation replaces the contents of a database server with the
+contents of another server. The source server is effectively cloned and all data
+on the target server is lost. This is useful when a replica server has diverged
 from the primary server, or when adding a new server to the cluster.\
-MaxScale performs this operation by running mariadb-backup on both the\
+MaxScale performs this operation by running mariadb-backup on both the
 source and target servers.
 
-When launched, the rebuild operation proceeds as below. If any step fails, the\
+When launched, the rebuild operation proceeds as below. If any step fails, the
 operation is stopped and the target server will be left in an unspecified state.
 
-1. Log in to both servers with ssh and check that the tools listed above are\
+1. Log in to both servers with ssh and check that the tools listed above are
    present (e.g. `mariadb-backup -v` should succeed).
-2. Check that the port used for transferring the backup is free on the source\
-   server. If not, kill the process holding it. This requires running lsof and\
+2. Check that the port used for transferring the backup is free on the source
+   server. If not, kill the process holding it. This requires running lsof and
    kill.
-3. Test the connection by streaming a short message from the source host to the\
+3. Test the connection by streaming a short message from the source host to the
    target.
-4. Launch mariadb-backup on the source machine, compress the stream and listen\
+4. Launch mariadb-backup on the source machine, compress the stream and listen
    for an incoming connection. This is performed with a command like`mariadb-backup --backup --safe-slave-backup --stream=xbstream --parallel=1 | pigz -c | socat - TCP-LISTEN:<port>`.
 5. Ask the target server what its data directory is (`select @@datadir;`). Stop\
-   MariaDB Server on the target machine and delete all contents of the data\
+   MariaDB Server on the target machine and delete all contents of the data
    directory.
-6. On the target machine, connect to the source machine, read the backup stream,\
-   decompress it and write to the data directory. This is performed with a command\
-   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can\
+6. On the target machine, connect to the source machine, read the backup stream,
+   decompress it and write to the data directory. This is performed with a command
+   like `socat -u TCP:<host>:<port> STDOUT | pigz -dc | mbstream -x`. This step can
    take a long time if there is much data to transfer.
-7. Check that the data directory on the target machine is not empty,\
+7. Check that the data directory on the target machine is not empty,
    i.e. that the transfer at least appears to have succeeded.
-8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if\
+8. Prepare the backup on the target server with a command like`mariadb-backup --use-memory=1G --prepare`. This step can also take some time if
    the source server performed writes during data transfer.
-9. On the target server, change ownership of datadir contents to the\
+9. On the target server, change ownership of datadir contents to the
    mysql-user and start MariaDB-server.
-10. Read gtid from the data directory. Have the target server start replicating\
+10. Read gtid from the data directory. Have the target server start replicating
     from the primary if it is not one already.
 
 The rebuild-operation is a monitor module command and takes four arguments:
@@ -1646,12 +1646,12 @@ The rebuild-operation is a monitor module command and takes four arguments:
 1. Monitor name, e.g. MyMonitor.
 2. Target server name, e.g. MyTargetServer.
 3. Source server name, e.g. MySourceServer. This parameter is optional.\
-   If not specified, the monitor prefers to autoselect an up-to-date replica\
-   server to avoid increasing load on the primary server. Due to the`--safe-slave-backup`-option, the replica will stop\
+   If not specified, the monitor prefers to autoselect an up-to-date replica
+   server to avoid increasing load on the primary server. Due to the`--safe-slave-backup`-option, the replica will stop
    replicating until the backup data has been transferred.
-4. Data directory on target server. This parameter is optional. If not\
-   specified, the monitor will ask the target server. If target server is\
-   not running, monitor will assume /var/lib/mysql. Thus, this only needs to be\
+4. Data directory on target server. This parameter is optional. If not
+   specified, the monitor will ask the target server. If target server is
+   not running, monitor will assume /var/lib/mysql. Thus, this only needs to be
    defined with non-standard directory setups.
 
 The following example rebuilds MyTargetServer with contents of MySourceServer.
@@ -1666,45 +1666,45 @@ The following example uses a custom data directory on the target.
 maxctrl call command mariadbmon async-rebuild-server MyMonitor MyTargetServer MySourceServer /my_datadir
 ```
 
-The operation does not launch if the target server is already replicating or if\
+The operation does not launch if the target server is already replicating or if
 the source server is not a primary or replica.
 
-Steps 6 and 8 can take a long time depending on the size of the database and if\
-writes are ongoing. During these steps, the monitor will continue monitoring the\
-cluster normally. After each monitor tick the monitor checks if the\
-rebuild-operation can proceed. No other monitor operations, either manual or\
+Steps 6 and 8 can take a long time depending on the size of the database and if
+writes are ongoing. During these steps, the monitor will continue monitoring the
+cluster normally. After each monitor tick the monitor checks if the
+rebuild-operation can proceed. No other monitor operations, either manual or
 automatic, can run until the rebuild completes.
 
 #### Create backup
 
-The create backup-operation copies the contents of a database server to the\
-backup storage. The source server is not modified but may slow down during\
-backup creation. MaxScale performs this operation by running\
-mariadb-backup on both the source and storage servers. The storage location is\
+The create backup-operation copies the contents of a database server to the
+backup storage. The source server is not modified but may slow down during
+backup creation. MaxScale performs this operation by running
+mariadb-backup on both the source and storage servers. The storage location is
 defined by the _backup\_storage\_address_ and _backup\_storage\_path_ settings.\
-Normal ssh-settings are used to access the storage server. The backup storage\
+Normal ssh-settings are used to access the storage server. The backup storage
 machine does not need to have a MariaDB Server installed.
 
-Backup creation runs somewhat similar to rebuild-server. The main difference\
-is that the backup data is simply saved to a directory and not prepared or\
-used to start a MariaDB Server. If any step fails, the operation is stopped\
+Backup creation runs somewhat similar to rebuild-server. The main difference
+is that the backup data is simply saved to a directory and not prepared or
+used to start a MariaDB Server. If any step fails, the operation is stopped
 and the backup storage directory will be left in an unspecified state.
 
 1. Init. See rebuild-server.
 2. Check listen port on backup storage machine. See rebuild-server.
-3. Check that the backup storage main directory exists. Check that it does not\
-   contain a backup with the same name as the one being created. Create the final\
+3. Check that the backup storage main directory exists. Check that it does not
+   contain a backup with the same name as the one being created. Create the final
    backup directory.
-4. Test the connection by streaming a short message from the source host to the\
+4. Test the connection by streaming a short message from the source host to the
    backup storage.
 5. Serve backup on source. Similar to rebuild-server step 4.
-6. Transfer backup directly to the final storage directory. Similar to\
+6. Transfer backup directly to the final storage directory. Similar to
    rebuild-server step 5.
 7. Check that the copied backup data looks ok.
 
-Backup creation is a monitor module command and takes three\
-arguments: the monitor name, source server name and backup name. Backup name\
-defines the subdirectory where the backup is saved and should be a valid\
+Backup creation is a monitor module command and takes three
+arguments: the monitor name, source server name and backup name. Backup name
+defines the subdirectory where the backup is saved and should be a valid
 directory name. The command
 
 ```
@@ -1714,37 +1714,37 @@ maxctrl call command mariadbmon async-create-backup MyMonitor MySourceServer wed
 would save the backup of MySourceServer to `<backup_storage_path>/wednesday_161122` on the host defined in _backup\_storage\_address_. _ssh\_user_ needs to have read and write access
 to the main storage directory. The source server must be a primary or replica.
 
-Similar to rebuild-server, the monitor will continue monitoring the servers\
+Similar to rebuild-server, the monitor will continue monitoring the servers
 while the backup is transferred.
 
 #### Restore from backup
 
-The restore-operation is the reverse of create-backup. It overwrites the\
+The restore-operation is the reverse of create-backup. It overwrites the
 contents of an existing MariaDB Server with a backup from the backup storage.\
-The backup is not removed and can be used again. MaxScale performs this\
-operation by transferring the backup contents as a tar archive and overwriting\
-the target server data directory. The backup storage is defined in monitor\
+The backup is not removed and can be used again. MaxScale performs this
+operation by transferring the backup contents as a tar archive and overwriting
+the target server data directory. The backup storage is defined in monitor
 settings similar to create-backup.
 
-The restore-operation runs somewhat similar to rebuild-server. The main\
+The restore-operation runs somewhat similar to rebuild-server. The main
 difference is that the backup data is copied with _tar_ instead of mariadb-backup.\
-If any step fails, the operation is stopped and the target server will be\
+If any step fails, the operation is stopped and the target server will be
 left in an unspecified state.
 
 1. Init. See rebuild-server.
 2. Check listen port on target machine. See rebuild-server.
-3. Check that the backup storage main directory exists and that it contains\
+3. Check that the backup storage main directory exists and that it contains
    a backup with the name requested.
-4. Test the connection by streaming a short message from the backup storage to\
+4. Test the connection by streaming a short message from the backup storage to
    the target machine.
-5. On the backup storage machine, compress the backup with tar and serve it\
-   with socat, listening for an incoming connection. This is performed with\
+5. On the backup storage machine, compress the backup with tar and serve it
+   with socat, listening for an incoming connection. This is performed with
    a command like `tar -zc -C <backup_dir> . | socat - TCP-LISTEN:<port>`.
 6. Ask the target server what its data directory is (`select @@datadir;`). Stop\
-   MariaDB Server on the target machine and delete all contents of the data\
+   MariaDB Server on the target machine and delete all contents of the data
    directory.
-7. On the target machine, connect to the source machine, read the backup stream,\
-   decompress it and write to the data directory. This is performed with a command\
+7. On the target machine, connect to the source machine, read the backup stream,
+   decompress it and write to the data directory. This is performed with a command
    like `socat -u TCP:<host>:<port> STDOUT | sudo tar -xz -C /var/lib/mysql/`.\
    This step can take a long time if there is much data to transfer.
 8. From here on, the operation proceeds as from rebuild-server step 7.
@@ -1753,11 +1753,11 @@ Server restoration is a monitor module command and takes four arguments.
 
 1. Monitor name, e.g. MyMonitor.
 2. Target server name, e.g. MyNewServer.
-3. Backup name. This parameter defines the subdirectory where the backup is\
+3. Backup name. This parameter defines the subdirectory where the backup is
    read from and should be an existing directory on the backup storage host.
-4. Data directory on target server. This parameter is optional. If not\
-   specified, the monitor will ask the target server. If target server is\
-   not running, monitor will assume /var/lib/mysql. Thus, this only needs to be\
+4. Data directory on target server. This parameter is optional. If not
+   specified, the monitor will ask the target server. If target server is
+   not running, monitor will assume /var/lib/mysql. Thus, this only needs to be
    defined with non-standard directory setups.
 
 The command
@@ -1766,9 +1766,9 @@ The command
 maxctrl call command mariadbmon async-restore-from-backup MyMonitor MyTargetServer wednesday_161122
 ```
 
-would erase the contents of MyTargetServer and replace them with the backup\
+would erase the contents of MyTargetServer and replace them with the backup
 contained in `<backup_storage_path>/wednesday_161122` on the host defined in _backup\_storage\_address_. _ssh\_user_ needs to have read access
-to the main storage directory and the backup. The target server must not be\
+to the main storage directory and the backup. The target server must not be
 a primary or replica.
 
 The following example uses a custom data directory on the target.
@@ -1777,7 +1777,7 @@ The following example uses a custom data directory on the target.
 maxctrl call command mariadbmon async-restore-from-backup MyMonitor MyTargetServer wednesday_161122 /my_datadir
 ```
 
-Similar to rebuild-server, the monitor will continue monitoring the servers\
+Similar to rebuild-server, the monitor will continue monitoring the servers
 while the backup is transferred and prepared.
 
 #### Settings for Backup operations
@@ -1798,7 +1798,7 @@ Ssh username. Used when logging in to backend servers to run commands.
 * Dynamic: Yes
 * Default: None
 
-Path to file with an ssh private key. Used when logging in to backend servers to\
+Path to file with an ssh private key. Used when logging in to backend servers to
 run commands.
 
 **`ssh_check_host_key`**
@@ -1808,7 +1808,7 @@ run commands.
 * Dynamic: Yes
 * Default: `true`
 
-Boolean, default: true. When logging in to backends, require that the server is\
+Boolean, default: true. When logging in to backends, require that the server is
 already listed in the known\_hosts-file of the user running MaxScale.
 
 **`ssh_timeout`**
@@ -1818,10 +1818,10 @@ already listed in the known\_hosts-file of the user running MaxScale.
 * Dynamic: Yes
 * Default: `10s`
 
-The rebuild operation consists of multiple ssh\
-commands. Most of the commands are assumed to complete quickly. If these\
-commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust\
-this setting if rebuild fails due to ssh commands timing out. This setting does\
+The rebuild operation consists of multiple ssh
+commands. Most of the commands are assumed to complete quickly. If these
+commands take more than _ssh\_timeout_ to complete, the operation fails. Adjust
+this setting if rebuild fails due to ssh commands timing out. This setting does
 not affect steps 5 and 6, as these are assumed to take significant time.
 
 **`ssh_port`**
@@ -1840,15 +1840,15 @@ SSH port. Used for running remote commands on servers.
 * Dynamic: Yes
 * Default: `4444`
 
-The port which the source server listens on for a\
-connection. The port must not be blocked by a firewall or listened on by any\
-other program. If another process is listening on the port when rebuild is\
+The port which the source server listens on for a
+connection. The port must not be blocked by a firewall or listened on by any
+other program. If another process is listening on the port when rebuild is
 starting, MaxScale will attempt to kill the process.
 
 **`mariadb-backup_use_memory`**
 
-String, default: "1G". Given as is to`mariadb-backup --prepare --use-memory=<mariadb-backup_use_memory>`. If set to empty,\
-no `--use-memory` is set and mariadb-backup will use its internal default. See [here](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-options#-use-memory) for more\
+String, default: "1G". Given as is to`mariadb-backup --prepare --use-memory=<mariadb-backup_use_memory>`. If set to empty,
+no `--use-memory` is set and mariadb-backup will use its internal default. See [here](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-options#-use-memory) for more
 information.
 
 ```
@@ -1858,7 +1858,7 @@ mariadb-backup_use_memory=2G
 **`mariadb-backup_parallel`**
 
 Numeric, default: 1. Given as is to`mariadb-backup --backup --parallel=<val>`.\
-Defines the number of threads used for parallel data file transfer. See [here](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-options#-parallel) for more\
+Defines the number of threads used for parallel data file transfer. See [here](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/backing-up-and-restoring-databases/mariadb-backup/mariadb-backup-options#-parallel) for more
 information.
 
 ```
@@ -1872,8 +1872,8 @@ mariadb-backup_parallel=2
 * Dynamic: Yes
 * Default: None
 
-Address of the backup storage. Does not need to have MariaDB Server\
-running or be monitored by the monitor. Connected to with ssh. Must have enough\
+Address of the backup storage. Does not need to have MariaDB Server
+running or be monitored by the monitor. Connected to with ssh. Must have enough
 disk space to store all backups.
 
 ```
@@ -1887,7 +1887,7 @@ backup_storage_address=192.168.1.11
 * Dynamic: Yes
 * Default: None
 
-Path to main backup storage directory on backup storage host. _ssh\_user_\
+Path to main backup storage directory on backup storage host. _ssh\_user_
 needs to have full access to this directory to save and read backups.
 
 ```
@@ -1896,10 +1896,10 @@ backup_storage_path=/home/maxscale_ssh_user/backup_storage
 
 #### sudoers.d configuration
 
-If giving MaxScale general sudo-access is out of the question, MaxScale must be\
-allowed to run the specific commands required by the backup operations. This can\
-be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the\
-power to run commands as root. The contents of the file may need to be tweaked\
+If giving MaxScale general sudo-access is out of the question, MaxScale must be
+allowed to run the specific commands required by the backup operations. This can
+be achieved by creating a file with the commands in the`/etc/sudoers.d`-directory. In the example below, the user _johnny_ is given the
+power to run commands as root. The contents of the file may need to be tweaked
 due to changes in install locations.
 
 ```
@@ -1917,31 +1917,31 @@ johnny ALL= NOPASSWD: /bin/tar -xz -C /var/lib/mysql/
 
 ### ColumnStore commands
 
-Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative\
+Since MaxScale version 22.08, MariaDB Monitor can run ColumnStore administrative
 commands against a ColumnStore cluster. The commands interact with the\
-ColumnStore REST-API present in recent ColumnStore versions and have been tested\
-with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the\
-commands affect monitor configuration or replication topology. MariaDB Monitor\
+ColumnStore REST-API present in recent ColumnStore versions and have been tested
+with MariaDB-Server 10.6 running the ColumnStore plugin version 6.2. None of the
+commands affect monitor configuration or replication topology. MariaDB Monitor
 simply relays the commands to the backend cluster.
 
-MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop\
-the cluster, and set cluster read-only or readwrite. MaxScale only communicates\
+MariaDB Monitor can fetch cluster status, add and remove nodes, start and stop
+the cluster, and set cluster read-only or readwrite. MaxScale only communicates
 with the first server in the `servers`-list.
 
-Most of the commands are asynchronous, i.e. they do not wait for the operation\
+Most of the commands are asynchronous, i.e. they do not wait for the operation
 to complete on the ColumnStore backend before returning to the command prompt.\
-MariaDB Monitor itself, however, runs the command in the background and does not\
-perform normal monitoring until the operation completes or fails. After an\
-operation has started the user should use _fetch-cmd-result_ to check its\
-status. The examples below show how to run the commands using MaxCtrl. If a\
-command takes a timeout-parameter, the timeout can be given in seconds (s),\
+MariaDB Monitor itself, however, runs the command in the background and does not
+perform normal monitoring until the operation completes or fails. After an
+operation has started the user should use _fetch-cmd-result_ to check its
+status. The examples below show how to run the commands using MaxCtrl. If a
+command takes a timeout-parameter, the timeout can be given in seconds (s),
 minutes (m) or hours (h).
 
 ColumnStore command settings are listed [here](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#settings). At least`cs_admin_api_key` must be set.
 
 #### Get status
 
-Fetch cluster status. Returns the result as is. Status fetching has an automatic\
+Fetch cluster status. Returns the result as is. Status fetching has an automatic
 timeout of ten seconds.
 
 ```
@@ -2055,7 +2055,7 @@ maxctrl call command mariadbmon fetch-cmd-result MyMonitor
 
 **`cs_admin_port`**
 
-Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes\
+Numeric, default: 8640. The REST-API port on the ColumnStore nodes. All nodes
 are assumed to listen on the same port.
 
 ```
@@ -2079,9 +2079,9 @@ String, default: _/cmapi/0.4.0_. Base path sent with the REST-API request.
 
 #### `fetch-cmd-result`
 
-Fetches the result of the last manual command. Requires monitor name as\
-parameter. Most commands only return a generic success message or an error\
-description. ColumnStore commands may return more data. Scheduling another\
+Fetches the result of the last manual command. Requires monitor name as
+parameter. Most commands only return a generic success message or an error
+description. ColumnStore commands may return more data. Scheduling another
 command clears a stored result.
 
 ```
@@ -2091,11 +2091,11 @@ maxctrl call command mariadbmon fetch-cmd-result MariaDB-Monitor
 
 #### `cancel-cmd`
 
-Cancels the latest operation, whether manual or automatic, if possible. Requires\
-monitor name as parameter. A scheduled manual command is simply canceled\
-before it can run. If a command is already running, it stops as soon as\
+Cancels the latest operation, whether manual or automatic, if possible. Requires
+monitor name as parameter. A scheduled manual command is simply canceled
+before it can run. If a command is already running, it stops as soon as
 possible. The _cancel-cmd_ itself does not wait for a running operation to stop.\
-Use _fetch-cmd-result_ or check the log to see if the operation has truly\
+Use _fetch-cmd-result_ or check the log to see if the operation has truly
 completed. Canceling is most useful for stopping a stalled rebuild operation.
 
 ```
@@ -2109,48 +2109,48 @@ OK
 
 See the [Limitations and requirements-section](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#limitations_and_requirements).
 
-Before performing failover or switchover, the monitor checks that\
-prerequisites are fulfilled, printing any errors and warnings found. This should\
+Before performing failover or switchover, the monitor checks that
+prerequisites are fulfilled, printing any errors and warnings found. This should
 catch and explain most issues with failover or switchover not working.\
-If the operations are attempted and still fail, then most likely one of\
-the commands the monitor issued to a server failed or timed out. The log should\
+If the operations are attempted and still fail, then most likely one of
+the commands the monitor issued to a server failed or timed out. The log should
 explain which query failed.
 
-A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the\
-monitor will retry most such queries if the failure was caused by a timeout. The retrying\
-continues until the total time for a failover or switchover has been spent. If the log\
-shows warnings or errors about commands timing out, increasing the backend timeout\
+A typical failure reason is that a command such as `STOP SLAVE` takes longer than the`backend_read_timeout` of the monitor, causing the connection to break. As of 2.3, the
+monitor will retry most such queries if the failure was caused by a timeout. The retrying
+continues until the total time for a failover or switchover has been spent. If the log
+shows warnings or errors about commands timing out, increasing the backend timeout
 settings of the monitor should help. Other settings to look at are `query_retries` and`query_retry_timeout`. These are general MaxScale settings described in the [Configuration guide](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). Setting`query_retries` to 2 is a reasonable first try.
 
-If switchover causes the old primary (now replica) to fail replication, then most\
-likely a user or perhaps a scheduled event performed a write while monitor\
+If switchover causes the old primary (now replica) to fail replication, then most
+likely a user or perhaps a scheduled event performed a write while monitor
 had set `read_only=1`. This is possible if the user performing the write has\
-"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick\
-out SUPER-users but this is not certain to succeed. Remove these privileges\
-from any users that regularly do writes to prevent them from interfering with\
+"SUPER" or "READ\_ONLY ADMIN" privileges. The switchover-operation tries to kick
+out SUPER-users but this is not certain to succeed. Remove these privileges
+from any users that regularly do writes to prevent them from interfering with
 switchover.
 
-The server configuration files should have `log-slave-updates=1` to ensure that\
-a newly promoted primary has binary logs of previous events. This allows the new\
+The server configuration files should have `log-slave-updates=1` to ensure that
+a newly promoted primary has binary logs of previous events. This allows the new
 primary to replicate past events to any lagging replicas.
 
-To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the\
-backends by monitors and authenticators. The printed queries may include\
+To print out all queries sent to the servers, start MaxScale with`--debug=enable-statement-logging`. This setting prints all queries sent to the
+backends by monitors and authenticators. The printed queries may include
 usernames and passwords.
 
 #### Replica detection shows external primaries
 
 If a replica is shown in _maxctrl_ as "Slave of External Server" instead of\
-"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection\
-does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default\
-assumes that the replica connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact\
-same "Master\_Host" as used the MaxScale configuration file server definitions. This is\
+"Slave", the reason is likely that the "Master\_Host"-setting of the replication connection
+does not match the MaxScale server definition. As of 2.3.2, the MariaDB Monitor by default
+assumes that the replica connections (as shown by `SHOW ALL SLAVES STATUS`) use the exact
+same "Master\_Host" as used the MaxScale configuration file server definitions. This is
 controlled by the setting [assume\_unique\_hostnames](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#assume_unique_hostnames).
 
 ### Using the MariaDB Monitor With Binlogrouter
 
-Since MaxScale 2.2 it's possible to detect a replication setup\
-which includes Binlog Server: the required action is to add the\
+Since MaxScale 2.2 it's possible to detect a replication setup
+which includes Binlog Server: the required action is to add the
 binlog server to the list of servers only if _master\_id_ identity is set.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-2501-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-2501-contents.md
@@ -52,8 +52,8 @@ Here are tutorials on monitoring and managing MariaDB MaxScale in cluster enviro
 
 ### Routers
 
-The routing module is the core of a MariaDB MaxScale service. The router documentation\
-contains all module specific configuration options and detailed explanations\
+The routing module is the core of a MariaDB MaxScale service. The router documentation
+contains all module specific configuration options and detailed explanations
 of their use.
 
 * [Avrorouter](mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-avrorouter.md)
@@ -119,7 +119,7 @@ The MaxScale CDC Connector provides a C++ API for consuming data from a CDC syst
 
 ### Authenticators
 
-A short description of the authentication module type can be found in the [Authentication Modules](broken-reference/)\
+A short description of the authentication module type can be found in the [Authentication Modules](broken-reference/)
 document.
 
 * [MariaDB/MySQL Authenticator](mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-mariadbmysql-authenticator.md)


### PR DESCRIPTION
Part 1 of [DOCS-6382](https://mariadbcorp.atlassian.net/browse/DOCS-6382), batched per space. **maxscale: 34,453 lines in 478 files.**

A trailing backslash in Markdown is a forced `<br>`. In the maxscale space these are KB→GitBook migration artifacts — the migration wrapped the source at ~80 columns and put a backslash on every line, so rendered text breaks at arbitrary mid-sentence points.

Only the backslash is removed. The source line break stays, becoming a soft break, so **nothing is reflowed**.

### Why this is safe for maxscale specifically

Upstream MaxScale Markdown (`mariadb-maxscale/Documentation/`) contains no trailing backslashes at all — it is plain 80-column wrapped prose that renders as flowing paragraphs. The backslashes exist only in the migrated copy, so removing them restores the intended rendering.

### Left untouched

The ticket lists three exceptions. Two more turned up that it does not mention, and they matter more:

- **Unfenced code.** The migration flattened some shell scripts into escaped prose with no fence, so fence-tracking cannot see them and the backslashes are the only thing keeping the lines apart. Example: `maxscale/.../mariadb-maxscale-2302-common-monitor-parameters.md:481-531` is an entire bash script held together by trailing backslashes. A paragraph-level code detector vetoes these.
- **Open inline code spans.** If a code span is still open at end of line, the trailing backslash is a literal character rather than a hard break. 30 such lines were excluded.

Also untouched, per the ticket: fenced / `{% code %}` / `<pre>` blocks, doubled backslashes, and lone-backslash spacers.

### Verification

- **Invariant asserted mechanically:** every changed file has an unchanged line count, and every differing line satisfies `old == new + "\"`. `git diff --shortstat` → `478 files changed, 34453 insertions(+), 34453 deletions(-)`.
- **No changed line was inside a fenced/`{% code %}`/`<pre>` block.**
- **codespell** (CI invocation) on the 478 changed files: 0 hits. Checked explicitly because removing a backslash can unmask a typo.
- **Links: provably unchanged.** Rather than a sampled lychee diff, all link targets were extracted from the 478 files before and after — **6,130 targets, zero differences**. Any lychee failure on this PR is pre-existing on `main` (see DOCS-6381 for the MaxScale dead-relative-link backlog).

### Note on ticket scope

The ticket's repo-wide figure of 104,554 lines is an over-broad grep. Roughly 57% of those backslashes are load-bearing — most of all in `release-notes/*/changelogs/`, where the backslash is the only separator between `Revision #x` / date / description records and stripping them would collapse ~750 records per page into one run-on paragraph. The real total is ~44,600. I'm updating the ticket description accordingly and filing a follow-up for the changelog markup itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6382]: https://mariadbcorp.atlassian.net/browse/DOCS-6382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ