### PR TITLE
DOCS-6353: Update Advanced Cluster docs for 12.3 ES Beta

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -163,7 +163,7 @@ space_of() {
 
 # `grep | while` puts the loop body in a subshell, so it cannot set `rc` directly — failures are
 # tallied in a temp file instead.
-inc_fail="$(mktemp -t doclint-inc)" || { echo "doc-lint: mktemp failed" >&2; exit 2; }
+inc_fail="$(mktemp -t doclint-inc.XXXXXX)" || { echo "doc-lint: mktemp failed" >&2; exit 2; }
 trap 'rm -f "$inc_fail"' EXIT
 
 for f in "${files[@]}"; do

--- a/release-notes/SUMMARY.md
+++ b/release-notes/SUMMARY.md
@@ -1867,7 +1867,7 @@
   * [All Releases](galera-cluster/all-releases.md)
 * [Advanced Cluster Release Notes](advanced-cluster/README.md)
   * [MariaDB Advanced Cluster Quickstart Guide](advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md)
-  * [RAFT System Variables](advanced-cluster/raft-system-variables.md)
+  * [Raft System Variables](advanced-cluster/raft-system-variables.md)
 * [Connectors Release Notes](connectors/README.md)
   * [Connector/C](connectors/c/README.md)
     * [All Releases](connectors/c/all-releases.md)

--- a/release-notes/SUMMARY.md
+++ b/release-notes/SUMMARY.md
@@ -1888,7 +1888,7 @@
   * [All Releases](galera-cluster/all-releases.md)
 * [Advanced Cluster Release Notes](advanced-cluster/README.md)
   * [MariaDB Advanced Cluster Quickstart Guide](advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md)
-  * [RAFT System Variables](advanced-cluster/raft-system-variables.md)
+  * [Raft System Variables](advanced-cluster/raft-system-variables.md)
 * [Connectors Release Notes](connectors/README.md)
   * [Connector/C](connectors/c/README.md)
     * [All Releases](connectors/c/all-releases.md)

--- a/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
+++ b/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
@@ -267,7 +267,7 @@ SET SESSION wsrep_OSU_method = 'NBO';
 Non-Blocking Operations is exclusive to MariaDB Enterprise Server.
 {% endhint %}
 
-For the full procedure, including the advantages and limitations of each schema upgrade method, see [Performing Schema Upgrades in Galera Cluster]({galera}/galera-management/general-operations/performing-schema-upgrades-in-galera-cluster#non-blocking-operations-nbo).
+For the full procedure, including the advantages and limitations of each schema upgrade method, see [Performing Schema Upgrades in Galera Cluster](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/galera-management/general-operations/performing-schema-upgrades-in-galera-cluster#non-blocking-operations-nbo).
 
 ## Monitoring Cluster Connections
 

--- a/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
+++ b/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
@@ -1,10 +1,12 @@
 # MariaDB Advanced Cluster Quickstart Guide
 
-MariaDB Advanced Cluster (built on RAFT) provides a highly available, strongly consistent, and fault-tolerant solution for database deployment. It utilizes the **RAFT consensus protocol** to ensure that data is safely and synchronously replicated across all nodes, guaranteeing no lost transactions and providing a single, authoritative source of data through a **single active Leader** architecture.
+MariaDB Advanced Cluster (built on Raft) provides a highly available, strongly consistent, and fault-tolerant solution for database deployment. It utilizes the **Raft consensus protocol** to ensure that data is safely and synchronously replicated across all nodes, guaranteeing no lost transactions and providing a single, authoritative source of data through a **single active Leader** architecture.
 
-## RAFT Protocol Overview
+Advanced Cluster ships with MariaDB Enterprise Server 12.3.
 
-The RAFT Protocol is a consensus algorithm designed for managing replicated logs and ensuring data consistency across a distributed cluster. It simplifies the complexity of consensus by defining three key mechanisms: Leader Election, Log Replication, and Commit/Consensus via a Majority Quorum.
+## Raft Protocol Overview
+
+The Raft protocol is a consensus algorithm designed for managing replicated logs and ensuring data consistency across a distributed cluster. It simplifies the complexity of consensus by defining three key mechanisms: Leader Election, Log Replication, and Commit/Consensus via a Majority Quorum.
 
 ### Leader Election
 
@@ -40,11 +42,13 @@ Before setting up your MariaDB Advanced Cluster, ensure the following prerequisi
 
 ## Installation (on Each Node)
 
-Install MariaDB Enterprise Server and the associated RAFT consensus provider on all nodes of your cluster.
+Install MariaDB Enterprise Server and the associated Raft consensus provider on all nodes of your cluster.
 
 {% stepper %}
 {% step %}
-#### Download the Advanced Cluster Technical Preview tar archive
+<a id="download-the-advanced-cluster-technical-preview-tar-archive"></a>
+
+#### Download the Advanced Cluster tar archive
 
 [https://mariadb.com/downloads/enterprise/advanced-cluster/](https://mariadb.com/downloads/enterprise/advanced-cluster/)
 
@@ -54,11 +58,11 @@ Download the correct version for your Linux Distribution
 {% step %}
 #### Uninstall MariaDB Enterprise
 
-If you already have MariaDB Enterprise Server Installed you will need to uninstall it prior to installing the MariaDB Advanced Cluster technical preview packages
+If you already have MariaDB Enterprise Server Installed you will need to uninstall it prior to installing the MariaDB Advanced Cluster packages
 {% endstep %}
 
 {% step %}
-#### Install Advanced Cluster technical preview
+#### Install Advanced Cluster
 
 {% tabs %}
 {% tab title="RHEL 9 & 10" %}
@@ -96,13 +100,13 @@ There are other packages included in the package tarball that you can optionally
 
 ## Firewall Configuration (on Each Node)
 
-Open the necessary ports on the firewall of each node to allow for both client connections and inter-node RAFT communication.
+Open the necessary ports on the firewall of each node to allow for both client connections and inter-node Raft communication.
 
 | Port  | Protocol | Purpose                             |
 | ----- | -------- | ----------------------------------- |
 | 3306  | TCP      | Client connections to the database. |
 | 50001 | TCP      | SST request listener                |
-| 50002 | TCP      | RAFT server internal communication  |
+| 50002 | TCP      | Raft server internal communication  |
 
 Example using UFW (Ubuntu/Debian):
 
@@ -115,7 +119,7 @@ sudo ufw allow 50002/tcp
 sudo ufw reload
 ```
 
-## Configure RAFT Cluster (mariadb-raft.cnf on Each Node)
+## Configure Raft Cluster (mariadb-raft.cnf on Each Node)
 
 If MariaDB is already running, stop it before proceeding with configuration
 
@@ -187,7 +191,7 @@ After all nodes are started, verify that they have joined the cluster and consen
 
 ### Check Cluster Status (on any node):
 
-Connect to MariaDB Enterprise Server on any node and check the RAFT status variables.
+Connect to MariaDB Enterprise Server on any node and check the Raft status variables.
 
 ```bash
 sudo mariadb -u root -p
@@ -229,13 +233,59 @@ SELECT * FROM messages;
 
 This confirms the strong synchronous replication and consistency provided by the MariaDB Advanced Cluster.
 
+## Leadership Priority
+
+Leadership priority lets you influence which node the cluster elects as leader. Each node has a [raft-leadership-priority](raft-system-variables.md#raft-leadership-priority) value, which defaults to `0`. Nodes with a higher priority are preferred at election time.
+
+A leader that detects a follower with a higher priority steps down immediately, rather than waiting for the heartbeat timeout to expire. Failover to the preferred node therefore happens as soon as that node is visible to the leader.
+
+### Changing the Priority at Runtime
+
+The priority can be changed while the cluster is running, using the `ChangeLeaderPriority` administrative command issued through `AdminCommandCall`. The new priority is broadcast to the cluster in the node's `ServerInfo`, so the change takes effect without restarting the session.
+
+{% hint style="warning" %}
+Leadership priority changes the cluster protocol, and is **not** backwards compatible with the 0.9.0 technical preview release. Upgrade all nodes to the same release.
+{% endhint %}
+
+## XA Transactions
+
+`XA COMMIT` and `XA ROLLBACK` are fully supported. Standard Galera Cluster XA syntax and semantics apply — there are no Raft-specific differences in behavior.
+
+{% hint style="info" %}
+A small number of XA test scenarios are not run against Advanced Cluster, because they depend on `wsrep_provider_options`, which Advanced Cluster does not support. See [WSREP System Variables](#wsrep-system-variables).
+{% endhint %}
+
+## Non-Blocking Operations (NBO)
+
+Non-Blocking Operations is an online schema upgrade method that replicates DDL to all nodes in total order, while only locking the specific table being altered. It is configured for Advanced Cluster exactly as it is for Galera Cluster, through the `wsrep_OSU_method` session variable:
+
+```sql
+SET SESSION wsrep_OSU_method = 'NBO';
+```
+
+{% hint style="info" %}
+Non-Blocking Operations is exclusive to MariaDB Enterprise Server.
+{% endhint %}
+
+For the full procedure, including the advantages and limitations of each schema upgrade method, see [Performing Schema Upgrades in Galera Cluster]({galera}/galera-management/general-operations/performing-schema-upgrades-in-galera-cluster#non-blocking-operations-nbo).
+
+## Monitoring Cluster Connections
+
+The `INFORMATION_SCHEMA.wsrep_connections` table reports the connections between cluster nodes and processes. This table was not available in earlier Advanced Cluster releases.
+
+```sql
+SELECT * FROM INFORMATION_SCHEMA.wsrep_connections;
+```
+
+The SSL settings that apply to these connections are described in [Raft System Variables: SSL](#raft-system-variables-ssl).
+
 ## Configuration Options
 
-### RAFT System Variables
+### Raft System Variables
 
-| RAFT System Variable                                                                                | Default | Description                                                                                                                                                                                                                |
+| Raft System Variable                                                                                | Default | Description                                                                                                                                                                                                                |
 | --------------------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [raft-candidate-timeout](raft-system-variables.md#raft-candidate-timeout)                           | 200     | IInitial timeout for candidate waiting for votes during election (milliseconds). Uses exponential backoff up to raft\_max\_candidate\_timeout.                                                                             |
+| [raft-candidate-timeout](raft-system-variables.md#raft-candidate-timeout)                           | 200     | Initial timeout for candidate waiting for votes during election (milliseconds). Uses exponential backoff up to raft\_max\_candidate\_timeout.                                                                             |
 | [raft-data-dir](raft-system-variables.md#raft-data-dir)                                             | ./      | Data directory where to store replication logs and other node persistent state.                                                                                                                                            |
 | [raft-event-store-file-size](raft-system-variables.md#raft-event-store-file-size)                   | 128MB   | Maximum size of single log file in bytes. When a log file reaches this size, a new file is created.                                                                                                                        |
 | [raft-event-store-max-memory](raft-system-variables.md#raft-event-store-max-memory)                 | 32MB    | Maximum size of the in-memory event store buffer in bytes. Events are cached in memory for faster access before being written to disk.                                                                                     |
@@ -244,6 +294,7 @@ This confirms the strong synchronous replication and consistency provided by the
 | [raft-flow-control-max-throttle-rate](raft-system-variables.md#raft-flow-control-max-throttle-rate) | 100     | Maximum request rate (requests per second) to sustain when flow control throttling is active. Lower values provide more aggressive throttling.                                                                             |
 | [raft-follower-timeout](raft-system-variables.md#raft-follower-timeout)                             | 5000    | Time follower waits without leader messages before starting election (milliseconds).                                                                                                                                       |
 | [raft-heartbeat-timeout](raft-system-variables.md#raft-heartbeat-timeout)                           | 1000    | Interval at which leader sends heartbeat messages (milliseconds)                                                                                                                                                           |
+| [raft-leadership-priority](raft-system-variables.md#raft-leadership-priority)                       | 0       | Priority for the current node to become leader. Nodes with a higher priority are preferred at election time, and can be changed at runtime.                                                                                |
 | [raft-listen-port](raft-system-variables.md#raft-listen-port)                                       | 50002   | Port to listen for incoming cluster connections                                                                                                                                                                            |
 | [raft-log-filter](raft-system-variables.md#raft-log-filter)                                         |         | In order to reduce amount of logging on DEBUG level, this filter can be used to select output from specific operations.                                                                                                    |
 | [raft-log-level](raft-system-variables.md#raft-log-level)                                           | INFO    | Verbosity level for logging. Supported values are ERROR, WARN, INFO and DEBUG.                                                                                                                                             |
@@ -254,13 +305,13 @@ This confirms the strong synchronous replication and consistency provided by the
 | [raft-session-timeout](raft-system-variables.md#raft-session-timeout)                               | 15      | Timeout after which session to replication system is considered expired if there is no activity. If the node cannot communicate with the leader within this time period, it will be evicted from the cluster (seconds).    |
 | [raft-sst-listen-port](raft-system-variables.md#raft-sst-listen-port)                               | 50001   | Port to listen for SST requests.                                                                                                                                                                                           |
 
-#### RAFT System Variables: SSL
+#### Raft System Variables: SSL
 
-SSL is enabled by default for all Raft Cluster connections. If the certificate information is not provided, a self-signed certificate is created at startup. Notice that `VERIFY_PEER` cannot be used with self-signed certificates.
+SSL is enabled by default for all Raft cluster connections. If the certificate information is not provided, a self-signed certificate is created at startup. Peer certificate verification is controlled separately by [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert), which is disabled by default and cannot be used with the self-signed certificate generated at startup. Note that it verifies the server certificate only: it provides neither mutual TLS nor hostname verification.
 
-| RAFT System Variable                                                    | Default         | Description                                                                                                                                                                                                   |
+| Raft System Variable                                                    | Default         | Description                                                                                                                                                                                                   |
 | ----------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [raft-have-ssl](raft-system-variables.md#raft-have-ssl)                 | YES             | Indicates whether SSL/TLS is enabled for cluster communication. Possible values are YES, NO, DISABLED, or VERIFY\_PEER. This is a read-only variable that reflects the current SSL state                      |
+| [raft-have-ssl](raft-system-variables.md#raft-have-ssl)                 | YES             | Indicates whether SSL/TLS is enabled for cluster communication. Possible values are YES, NO, or DISABLED. This is a read-only variable that reflects the current SSL state                                    |
 | [raft-ssl-key](raft-system-variables.md#raft-ssl-key)                   |                 | Path to the SSL private key file in PEM format. This variable is read-only and must be set at server startup.                                                                                                 |
 | [raft-ssl-cert](raft-system-variables.md#raft-ssl-cert)                 |                 | Path to the SSL certificate file in PEM format. This variable is read-only and must be set at server startup.                                                                                                 |
 | [raft-ssl-ca](raft-system-variables.md#raft-ssl-ca)                     |                 | Path to the CA certificate file in PEM format used to verify peer certificates. This variable is read-only and must be set at server startup.                                                                 |
@@ -270,11 +321,12 @@ SSL is enabled by default for all Raft Cluster connections. If the certificate i
 | [raft-ssl-crl](raft-system-variables.md#raft-ssl-crl)                   |                 | Path to the Certificate Revocation List (CRL) file. This variable is read-only and must be set at server startup.                                                                                             |
 | [raft-ssl-crlpath](raft-system-variables.md#raft-ssl-crlpath)           |                 | Path to a directory containing Certificate Revocation List files. This variable is read-only and must be set at server startup.                                                                               |
 | [raft-ssl-verify-depth](raft-system-variables.md#raft-ssl-verify-depth) | 9               | Maximum depth for certificate chain verification. This variable is read-only and must be set at server startup.                                                                                               |
+| [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert) | NO  | Enables verification of the peer's server certificate against the configured CA certificate or certificates. Replaces the removed `VERIFY_PEER` value of `raft-have-ssl`. Verifies the server certificate only — this is not mutual TLS, and it does not perform hostname verification. |
 | [raft-tls-version](raft-system-variables.md#raft-tls-version)           | TLSv1.2,TLSv1.3 | Comma-separated list of allowed TLS protocol versions. Supported values include TLSv1.2 and TLSv1.3. Default includes both TLSv1.2 and TLSv1.3. This variable is read-only and must be set at server startup. |
 
-### RAFT Status Variables
+### Raft Status Variables
 
-| RAFT Status Variable                     | Description                                                                                                                     |
+| Raft Status Variable                     | Description                                                                                                                     |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `raft_current_log_index`                 | Index of the last processed replication event from the replication log.                                                         |
 | `raft_current_leader_node_id`            | The node ID corresponding to current leader as reported by local Leader Tracker.                                                |
@@ -289,9 +341,9 @@ SSL is enabled by default for all Raft Cluster connections. If the certificate i
 | `raft_event_store_first_index`           | Log index of the oldest entry that is still retained in the event store.                                                        |
 | `raft_event_store_last_index`            | Log index of the most recent entry persisted in the event store.                                                                |
 
-### RAFT Information Schema Tables
+### Raft Information Schema Tables
 
-| RAFT Information Schema Table | Description                                                              |
+| Raft Information Schema Table | Description                                                              |
 | ----------------------------- | ------------------------------------------------------------------------ |
 | `RAFT_CERT_FAILURES`          | Displays meta data from limited set of write set certification failures. |
 | `RAFT_CLUSTER_CONNECTIONS`    | Displays connections between cluster nodes and processes.                |
@@ -300,7 +352,22 @@ SSL is enabled by default for all Raft Cluster connections. If the certificate i
 
 ### WSREP System Variables
 
-MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Variables](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables). However, the `wsrep_provider_options` and `wsrep_ssl_mode` variables are an exception, as they are superseded by the RAFT System Variables for configuring the cluster.
+MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Variables](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables). However, the `wsrep_provider_options` and `wsrep_ssl_mode` variables are an exception, as they are superseded by the Raft System Variables for configuring the cluster.
+
+#### wsrep\_cluster\_name
+
+Names the cluster, and safeguards against a node accidentally joining the wrong one. The value must match on every node in the cluster: if a joining node's `wsrep_cluster_name` does not match, all of its connections are declined.
+
+| Property  | Value              |
+| --------- | ------------------ |
+| Scope     | Global             |
+| Dynamic   | Yes                |
+| Data Type | String             |
+| Default   | `my_wsrep_cluster` |
+
+{% hint style="info" %}
+Exposed endpoints must contain the `wsrep_cluster_name` as the last path component, or as a query parameter.
+{% endhint %}
 
 ### WSREP Status Variables
 
@@ -310,6 +377,7 @@ MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Var
 | `wsrep_apply_waits`             | Number of times a prior transaction had to be waited before applying a write set.                                                                                                                                     |
 | `wsrep_cert_deps_distance`      | Average distance between the highest and the lowest sequence numbers that can possibly be applied in parallel, or the potential degree of parallelization.                                                            |
 | `wsrep_cert_interval`           | Average number of transactions received while a transaction replicates.                                                                                                                                               |
+| `wsrep_checkpoint_position`     | The replication checkpoint position recorded by the node.                                                                                                                                                             |
 | `wsrep_cluster_capabilities`    |                                                                                                                                                                                                                       |
 | `wsrep_cluster_conf_id`         | Total number of cluster membership changes that have taken place.                                                                                                                                                     |
 | `wsrep_cluster_size`            | Number of nodes currently in the cluster.                                                                                                                                                                             |
@@ -338,6 +406,7 @@ MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Var
 | `wsrep_repl_keys_bytes`         | Total size of keys replicated.                                                                                                                                                                                        |
 | `wsrep_replicated`              | Total size in bytes of all write sets replicated to other nodes.                                                                                                                                                      |
 | `wsrep_rollbacker_thread_count` | Stores the current number of rollbacker threads to make clear how many slave threads of this type there are.                                                                                                          |
+| `wsrep_se_checkpoint`           | The storage engine checkpoint recorded by the node, shown as the recovered XID.                                                                                                                                       |
 | `wsrep_thread_count`            | Total number of wsrep (applier/rollbacker) threads.                                                                                                                                                                   |
 
 {% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}

--- a/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
+++ b/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
@@ -44,6 +44,12 @@ Before setting up your MariaDB Advanced Cluster, ensure the following prerequisi
 
 Install MariaDB Enterprise Server and the associated Raft consensus provider on all nodes of your cluster.
 
+{% hint style="info" %}
+For the Beta, MariaDB Advanced Cluster can also be installed through a package manager (`dnf` on RHEL, `apt` on Debian and Ubuntu) from the MariaDB Enterprise repositories, as an alternative to the tar-archive method shown below.
+
+_Draft: the exact repository configuration and package names for the package-manager install path are still to be confirmed before publishing._
+{% endhint %}
+
 {% stepper %}
 {% step %}
 <a id="download-the-advanced-cluster-technical-preview-tar-archive"></a>
@@ -53,12 +59,6 @@ Install MariaDB Enterprise Server and the associated Raft consensus provider on 
 [https://mariadb.com/downloads/enterprise/advanced-cluster/](https://mariadb.com/downloads/enterprise/advanced-cluster/)
 
 Download the correct version for your Linux Distribution
-{% endstep %}
-
-{% step %}
-#### Uninstall MariaDB Enterprise
-
-If you already have MariaDB Enterprise Server Installed you will need to uninstall it prior to installing the MariaDB Advanced Cluster packages
 {% endstep %}
 
 {% step %}
@@ -251,10 +251,6 @@ Leadership priority changes the cluster protocol, and is **not** backwards compa
 
 `XA COMMIT` and `XA ROLLBACK` are fully supported. Standard Galera Cluster XA syntax and semantics apply — there are no Raft-specific differences in behavior.
 
-{% hint style="info" %}
-A small number of XA test scenarios are not run against Advanced Cluster, because they depend on `wsrep_provider_options`, which Advanced Cluster does not support. See [WSREP System Variables](#wsrep-system-variables).
-{% endhint %}
-
 ## Non-Blocking Operations (NBO)
 
 Non-Blocking Operations is an online schema upgrade method that replicates DDL to all nodes in total order, while only locking the specific table being altered. It is configured for Advanced Cluster exactly as it is for Galera Cluster, through the `wsrep_OSU_method` session variable:
@@ -285,29 +281,29 @@ The SSL settings that apply to these connections are described in [Raft System V
 
 | Raft System Variable                                                                                | Default | Description                                                                                                                                                                                                                |
 | --------------------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [raft-candidate-timeout](raft-system-variables.md#raft-candidate-timeout)                           | 200     | Initial timeout for candidate waiting for votes during election (milliseconds). Uses exponential backoff up to raft\_max\_candidate\_timeout.                                                                             |
+| [raft-vote-timeout](raft-system-variables.md#raft-vote-timeout)                                     | 200     | Time candidate waits for a majority of granted votes during election. Uses exponential backoff up to raft\_max\_vote\_timeout.                                                                                          |
 | [raft-data-dir](raft-system-variables.md#raft-data-dir)                                             | ./      | Data directory where to store replication logs and other node persistent state.                                                                                                                                            |
 | [raft-event-store-file-size](raft-system-variables.md#raft-event-store-file-size)                   | 128MB   | Maximum size of single log file in bytes. When a log file reaches this size, a new file is created.                                                                                                                        |
 | [raft-event-store-max-memory](raft-system-variables.md#raft-event-store-max-memory)                 | 32MB    | Maximum size of the in-memory event store buffer in bytes. Events are cached in memory for faster access before being written to disk.                                                                                     |
 | [raft-event-store-max-size](raft-system-variables.md#raft-event-store-max-size)                     | 512MB   | Maximum total size of the event store on disk in bytes. Older log files are purged when this limit is exceeded.                                                                                                            |
 | [raft-flow-control-drift-limit](raft-system-variables.md#raft-flow-control-drift-limit)             | 100     | Maximum index drift allowed between nodes before flow control throttling activates. When the difference between the slowest and fastest node commit positions exceeds this limit, the leader begins throttling requests.   |
 | [raft-flow-control-max-throttle-rate](raft-system-variables.md#raft-flow-control-max-throttle-rate) | 100     | Maximum request rate (requests per second) to sustain when flow control throttling is active. Lower values provide more aggressive throttling.                                                                             |
-| [raft-follower-timeout](raft-system-variables.md#raft-follower-timeout)                             | 5000    | Time follower waits without leader messages before starting election (milliseconds).                                                                                                                                       |
+| [raft-election-timeout](raft-system-variables.md#raft-election-timeout)                             | 5000    | Time follower waits without leader messages before starting election. Should be significantly larger than raft\_heartbeat\_timeout to avoid unnecessary elections.                                                       |
 | [raft-heartbeat-timeout](raft-system-variables.md#raft-heartbeat-timeout)                           | 1000    | Interval at which leader sends heartbeat messages (milliseconds)                                                                                                                                                           |
 | [raft-leadership-priority](raft-system-variables.md#raft-leadership-priority)                       | 0       | Priority for the current node to become leader. Nodes with a higher priority are preferred at election time, and can be changed at runtime.                                                                                |
 | [raft-listen-port](raft-system-variables.md#raft-listen-port)                                       | 50002   | Port to listen for incoming cluster connections                                                                                                                                                                            |
 | [raft-log-filter](raft-system-variables.md#raft-log-filter)                                         |         | In order to reduce amount of logging on DEBUG level, this filter can be used to select output from specific operations.                                                                                                    |
 | [raft-log-level](raft-system-variables.md#raft-log-level)                                           | INFO    | Verbosity level for logging. Supported values are ERROR, WARN, INFO and DEBUG.                                                                                                                                             |
-| [raft-max-candidate-timeout](raft-system-variables.md#raft-max-candidate-timeout)                   | 1500    | Maximum candidate timeout after exponential backoff (milliseconds).                                                                                                                                                        |
+| [raft-max-vote-timeout](raft-system-variables.md#raft-max-vote-timeout)                             | 1500    | Upper bound for raft\_vote\_timeout after exponential backoff. Limits how long a candidate will wait between election attempts.                                                                                          |
 | [raft-max-reconnect-attempts](raft-system-variables.md#raft-max-reconnect-attempts)                 | 5       | Number of attempts to reconnect to the cluster after ending up in non-primary state                                                                                                                                        |
 | [raft-node-id](raft-system-variables.md#raft-node-id)                                               | auto    | Unique node identifier. The identifier can be either a human-readable string up to 15 characters long or a UUID. The special value 'auto' is reserved for generating a UUID whenever the server starts from a clean state. |
-| [raft-non-primary-timeout](raft-system-variables.md#raft-non-primary-timeout)                       | 20      | Timeout after which the node is considered to be in non-primary state. If no replication events appear in the log within this time period, the node will be considered to be in non-primary state (seconds).               |
-| [raft-session-timeout](raft-system-variables.md#raft-session-timeout)                               | 15      | Timeout after which session to replication system is considered expired if there is no activity. If the node cannot communicate with the leader within this time period, it will be evicted from the cluster (seconds).    |
+| [raft-liveness-timeout](raft-system-variables.md#raft-liveness-timeout)                             | 20000   | Timeout after which the node is considered unresponsive. If no replication events appear in the log within this period, the node moves to non-primary state.                                                               |
+| [raft-eviction-timeout](raft-system-variables.md#raft-eviction-timeout)                             | 15000   | Timeout after which session to replication system is considered expired if there is no activity. If the node cannot communicate with the leader within this time period, it will be evicted from the cluster.              |
 | [raft-sst-listen-port](raft-system-variables.md#raft-sst-listen-port)                               | 50001   | Port to listen for SST requests.                                                                                                                                                                                           |
 
 #### Raft System Variables: SSL
 
-SSL is enabled by default for all Raft cluster connections. If the certificate information is not provided, a self-signed certificate is created at startup. Peer certificate verification is controlled separately by [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert), which is disabled by default and cannot be used with the self-signed certificate generated at startup. Note that it verifies the server certificate only: it provides neither mutual TLS nor hostname verification.
+SSL is enabled by default for all Raft cluster connections. If the certificate information is not provided, a self-signed certificate is created at startup. Peer certificate verification is controlled separately by [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert), which is disabled by default and cannot be used with the self-signed certificate generated at startup. When it is enabled and both `raft_ssl_cert` and `raft_ssl_ca` are configured, the cluster performs mutual TLS; it does not perform hostname verification.
 
 | Raft System Variable                                                    | Default         | Description                                                                                                                                                                                                   |
 | ----------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -321,7 +317,7 @@ SSL is enabled by default for all Raft cluster connections. If the certificate i
 | [raft-ssl-crl](raft-system-variables.md#raft-ssl-crl)                   |                 | Path to the Certificate Revocation List (CRL) file. This variable is read-only and must be set at server startup.                                                                                             |
 | [raft-ssl-crlpath](raft-system-variables.md#raft-ssl-crlpath)           |                 | Path to a directory containing Certificate Revocation List files. This variable is read-only and must be set at server startup.                                                                               |
 | [raft-ssl-verify-depth](raft-system-variables.md#raft-ssl-verify-depth) | 9               | Maximum depth for certificate chain verification. This variable is read-only and must be set at server startup.                                                                                               |
-| [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert) | NO  | Enables verification of the peer's server certificate against the configured CA certificate or certificates. Replaces the removed `VERIFY_PEER` value of `raft-have-ssl`. Verifies the server certificate only — this is not mutual TLS, and it does not perform hostname verification. |
+| [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert) | NO  | Enables verification of the peer's server certificate against the configured CA certificate or certificates. Replaces the removed `VERIFY_PEER` value of `raft-have-ssl`. When enabled with `raft_ssl_cert` and `raft_ssl_ca` configured, the cluster performs mutual TLS; it does not perform hostname verification. |
 | [raft-tls-version](raft-system-variables.md#raft-tls-version)           | TLSv1.2,TLSv1.3 | Comma-separated list of allowed TLS protocol versions. Supported values include TLSv1.2 and TLSv1.3. Default includes both TLSv1.2 and TLSv1.3. This variable is read-only and must be set at server startup. |
 
 ### Raft Status Variables

--- a/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
+++ b/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
@@ -59,7 +59,7 @@ Advanced Cluster needs no installation procedure or package repository of its ow
 {% step %}
 #### Install MariaDB Enterprise Server
 
-Follow [Installing Enterprise Server]({server}/architecture/topologies/single-node-topologies/enterprise-server#installation) for your operating system: YUM on RHEL, CentOS, and Rocky; APT on Debian and Ubuntu; ZYpp on SLES.
+Follow [Installing Enterprise Server](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/architecture/topologies/single-node-topologies/enterprise-server#installation) for your operating system: YUM on RHEL, CentOS, and Rocky; APT on Debian and Ubuntu; ZYpp on SLES.
 {% endstep %}
 
 {% step %}

--- a/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
+++ b/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
@@ -348,7 +348,7 @@ SSL is enabled by default for all Raft cluster connections. If the certificate i
 
 ### WSREP System Variables
 
-MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Variables]({galera}/reference/galera-cluster-system-variables). However, the `wsrep_provider_options` and `wsrep_ssl_mode` variables are an exception, as they are superseded by the Raft System Variables for configuring the cluster.
+MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Variables](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables). However, the `wsrep_provider_options` and `wsrep_ssl_mode` variables are an exception, as they are superseded by the Raft System Variables for configuring the cluster.
 
 #### wsrep\_cluster\_name
 

--- a/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
+++ b/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
@@ -348,7 +348,7 @@ SSL is enabled by default for all Raft cluster connections. If the certificate i
 
 ### WSREP System Variables
 
-MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Variables](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables). However, the `wsrep_provider_options` and `wsrep_ssl_mode` variables are an exception, as they are superseded by the Raft System Variables for configuring the cluster.
+MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Variables]({galera}/reference/galera-cluster-system-variables). However, the `wsrep_provider_options` and `wsrep_ssl_mode` variables are an exception, as they are superseded by the Raft System Variables for configuring the cluster.
 
 #### wsrep\_cluster\_name
 

--- a/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
+++ b/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  A step-by-step guide to deploying MariaDB Advanced Cluster, covering
+  installation, firewall and Raft configuration, cluster bootstrapping, and
+  verifying replication across nodes
+---
+
 # MariaDB Advanced Cluster Quickstart Guide
 
 MariaDB Advanced Cluster (built on Raft) provides a highly available, strongly consistent, and fault-tolerant solution for database deployment. It utilizes the **Raft consensus protocol** to ensure that data is safely and synchronously replicated across all nodes, guaranteeing no lost transactions and providing a single, authoritative source of data through a **single active Leader** architecture.
@@ -44,59 +51,45 @@ Before setting up your MariaDB Advanced Cluster, ensure the following prerequisi
 
 Install MariaDB Enterprise Server and the associated Raft consensus provider on all nodes of your cluster.
 
-{% hint style="info" %}
-For the Beta, MariaDB Advanced Cluster can also be installed through a package manager (`dnf` on RHEL, `apt` on Debian and Ubuntu) from the MariaDB Enterprise repositories, as an alternative to the tar-archive method shown below.
+<a id="download-the-advanced-cluster-technical-preview-tar-archive"></a>
 
-_Draft: the exact repository configuration and package names for the package-manager install path are still to be confirmed before publishing._
-{% endhint %}
+Advanced Cluster needs no installation procedure or package repository of its own. The Raft server ships as a separate `mariadb-raft` package in the same MariaDB Enterprise repository as Enterprise Server, so installing it means following the standard Enterprise Server instructions and adding one package.
 
 {% stepper %}
 {% step %}
-<a id="download-the-advanced-cluster-technical-preview-tar-archive"></a>
+#### Install MariaDB Enterprise Server
 
-#### Download the Advanced Cluster tar archive
-
-[https://mariadb.com/downloads/enterprise/advanced-cluster/](https://mariadb.com/downloads/enterprise/advanced-cluster/)
-
-Download the correct version for your Linux Distribution
+Follow [Installing Enterprise Server]({server}/architecture/topologies/single-node-topologies/enterprise-server#installation) for your operating system: YUM on RHEL, CentOS, and Rocky; APT on Debian and Ubuntu; ZYpp on SLES.
 {% endstep %}
 
 {% step %}
-#### Install Advanced Cluster
+#### Add the Raft package
+
+Include `mariadb-raft` in the install command alongside the Enterprise Server packages:
 
 {% tabs %}
-{% tab title="RHEL 9 & 10" %}
+{% tab title="RHEL, CentOS & Rocky" %}
 ```bash
-tar -xvf mariadb-advanced-cluster*.tar
-cd mariadb-advanced-cluster*/
-sudo dnf install ./MariaDB-common* ./MariaDB-client* ./MariaDB-shared*
-sudo dnf install ./MariaDB-server* ./galera-enterprise-4* ./mariadb-raft*
+sudo yum install MariaDB-server MariaDB-backup galera-enterprise-4 mariadb-raft
 ```
-
-{% hint style="info" %}
-The `galera-enterprise-4` package needs to be installed because of a dependency in the `MariaDB-server` package.
-{% endhint %}
-
-There are other packages included in the package tarball that you can optionally install, such as `MariaDB-backup`.
 {% endtab %}
 
 {% tab title="Debian & Ubuntu" %}
 ```bash
-tar -xvf mariadb-advanced-cluster*.tar
-cd mariadb-advanced-cluster*/
-sudo apt install ./mariadb-common_* ./mariadb-client* ./libmysqlclient18_* ./libmariadb3* ./libmariadbclient18_*
-sudo apt install ./mariadb-server* ./galera-enterprise-4_* ./mariadb-raft_*
+sudo apt install mariadb-server mariadb-backup galera-enterprise-4 mariadb-raft
 ```
-
-{% hint style="info" %}
-The `galera-enterprise-4` package needs to be installed because of a dependency in the `mariadb-server` package.
-{% endhint %}
-
-There are other packages included in the package tarball that you can optionally install, such as `mariadb-backup`.
 {% endtab %}
 {% endtabs %}
+
+{% hint style="info" %}
+The `galera-enterprise-4` package is required because of a dependency in the MariaDB Enterprise Server package.
+{% endhint %}
 {% endstep %}
 {% endstepper %}
+
+{% hint style="info" %}
+If you install from a tar archive downloaded from the MariaDB download page rather than from a package repository, the Raft packages are bundled in the MariaDB Enterprise RPM/DEB tar file. Extract the archive and install the Raft package from it alongside the server packages.
+{% endhint %}
 
 ## Firewall Configuration (on Each Node)
 
@@ -339,12 +332,64 @@ SSL is enabled by default for all Raft cluster connections. If the certificate i
 
 ### Raft Information Schema Tables
 
-| Raft Information Schema Table | Description                                                              |
-| ----------------------------- | ------------------------------------------------------------------------ |
-| `RAFT_CERT_FAILURES`          | Displays meta data from limited set of write set certification failures. |
-| `RAFT_CLUSTER_CONNECTIONS`    | Displays connections between cluster nodes and processes.                |
-| `RAFT_TIMERS`                 | Displays active timers on the node.                                      |
-| `RAFT_RPC_SENT`               | Displays counts of sent RPC messages by type.                            |
+| Raft Information Schema Table | Description                                                                    |
+| ----------------------------- | ------------------------------------------------------------------------------ |
+| `RAFT_CERT_FAILURES`          | Displays meta data from limited set of write set certification failures.       |
+| `RAFT_CLUSTER_CONNECTIONS`    | Displays connections between cluster nodes and processes.                      |
+| `RAFT_TIMERS`                 | Displays active timers on the node.                                            |
+| `RAFT_RPC_SENT`               | Displays counts of sent RPC messages by type.                                  |
+| `RAFT_STATUS`                 | Displays the Raft server and plugin status as JSON documents.                  |
+| `RAFT_LATENCY_STATS`          | Displays latency percentiles for internal operations on the write-commit path. |
+
+#### RAFT_STATUS
+
+The `INFORMATION_SCHEMA.RAFT_STATUS` table exposes the Raft server's internal status as two JSON documents — one from the server process, one from the plugin — for diagnostics and monitoring tools that need structured detail beyond the dedicated `RAFT_*` status variables and tables.
+
+| Column               | Type     | Description                                                                                                                                                                             |
+| -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SERVER_STATUS_JSON` | LONGTEXT | JSON document describing the Raft server process's current status, including active network connections (peer endpoints and the local Unix socket used for plugin↔server communication) |
+| `PLUGIN_STATUS_JSON` | LONGTEXT | JSON document describing the plugin's status                                                                                                                                            |
+
+The table always has exactly one row.
+
+```sql
+SELECT JSON_PRETTY(SERVER_STATUS_JSON) FROM information_schema.RAFT_STATUS;
+```
+
+Example `SERVER_STATUS_JSON` content (abbreviated):
+
+```
+{"connections":[{"id":"0x...","local_endpoint":"127.0.0.1:51210","remote_endpoint":"127.0.0.1:46645"}, ...]}
+```
+
+#### RAFT_LATENCY_STATS
+
+The `INFORMATION_SCHEMA.RAFT_LATENCY_STATS` table reports latency percentiles for internal operations on the write-commit path, one row per operation.
+
+| Column    | Type            | Description                                |
+| --------- | --------------- | ------------------------------------------ |
+| `NAME`    | VARCHAR(64)     | The operation being measured               |
+| `P50_US`  | BIGINT UNSIGNED | 50th-percentile latency, in microseconds   |
+| `P99_US`  | BIGINT UNSIGNED | 99th-percentile latency, in microseconds   |
+| `P999_US` | BIGINT UNSIGNED | 99.9th-percentile latency, in microseconds |
+| `MAX_US`  | BIGINT UNSIGNED | Maximum observed latency, in microseconds  |
+
+Operations observed on a live node include `local_write_set`, `apply`, `certification`, `log_write`, and `log_flush`.
+
+```sql
+SELECT * FROM information_schema.RAFT_LATENCY_STATS;
+```
+
+```
+NAME             P50_US  P99_US  P999_US  MAX_US
+local_write_set       0       0        0       0
+apply                 0       0        0       0
+certification         52      52       52      52
+log_write              7       7        7      17
+log_flush             47      47       47      95
+```
+
+A row's values are all 0 until that operation has occurred at least once on the node.
 
 ### WSREP System Variables
 

--- a/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
+++ b/release-notes/advanced-cluster/mariadb-advanced-cluster-quickstart-guide.md
@@ -1,10 +1,12 @@
 # MariaDB Advanced Cluster Quickstart Guide
 
-MariaDB Advanced Cluster (built on RAFT) provides a highly available, strongly consistent, and fault-tolerant solution for database deployment. It utilizes the **RAFT consensus protocol** to ensure that data is safely and synchronously replicated across all nodes, guaranteeing no lost transactions and providing a single, authoritative source of data through a **single active Leader** architecture.
+MariaDB Advanced Cluster (built on Raft) provides a highly available, strongly consistent, and fault-tolerant solution for database deployment. It utilizes the **Raft consensus protocol** to ensure that data is safely and synchronously replicated across all nodes, guaranteeing no lost transactions and providing a single, authoritative source of data through a **single active Leader** architecture.
 
-## RAFT Protocol Overview
+Advanced Cluster ships with MariaDB Enterprise Server 12.3.
 
-The RAFT Protocol is a consensus algorithm designed for managing replicated logs and ensuring data consistency across a distributed cluster. It simplifies the complexity of consensus by defining three key mechanisms: Leader Election, Log Replication, and Commit/Consensus via a Majority Quorum.
+## Raft Protocol Overview
+
+The Raft protocol is a consensus algorithm designed for managing replicated logs and ensuring data consistency across a distributed cluster. It simplifies the complexity of consensus by defining three key mechanisms: Leader Election, Log Replication, and Commit/Consensus via a Majority Quorum.
 
 ### Leader Election
 
@@ -40,11 +42,13 @@ Before setting up your MariaDB Advanced Cluster, ensure the following prerequisi
 
 ## Installation (on Each Node)
 
-Install MariaDB Enterprise Server and the associated RAFT consensus provider on all nodes of your cluster.
+Install MariaDB Enterprise Server and the associated Raft consensus provider on all nodes of your cluster.
 
 {% stepper %}
 {% step %}
-#### Download the Advanced Cluster Technical Preview tar archive
+<a id="download-the-advanced-cluster-technical-preview-tar-archive"></a>
+
+#### Download the Advanced Cluster tar archive
 
 [https://mariadb.com/downloads/enterprise/advanced-cluster/](https://mariadb.com/downloads/enterprise/advanced-cluster/)
 
@@ -54,11 +58,11 @@ Download the correct version for your Linux Distribution
 {% step %}
 #### Uninstall MariaDB Enterprise
 
-If you already have MariaDB Enterprise Server Installed you will need to uninstall it prior to installing the MariaDB Advanced Cluster technical preview packages
+If you already have MariaDB Enterprise Server Installed you will need to uninstall it prior to installing the MariaDB Advanced Cluster packages
 {% endstep %}
 
 {% step %}
-#### Install Advanced Cluster technical preview
+#### Install Advanced Cluster
 
 {% tabs %}
 {% tab title="RHEL 9 & 10" %}
@@ -96,13 +100,13 @@ There are other packages included in the package tarball that you can optionally
 
 ## Firewall Configuration (on Each Node)
 
-Open the necessary ports on the firewall of each node to allow for both client connections and inter-node RAFT communication.
+Open the necessary ports on the firewall of each node to allow for both client connections and inter-node Raft communication.
 
 | Port  | Protocol | Purpose                             |
 | ----- | -------- | ----------------------------------- |
 | 3306  | TCP      | Client connections to the database. |
 | 50001 | TCP      | SST request listener                |
-| 50002 | TCP      | RAFT server internal communication  |
+| 50002 | TCP      | Raft server internal communication  |
 
 Example using UFW (Ubuntu/Debian):
 
@@ -115,7 +119,7 @@ sudo ufw allow 50002/tcp
 sudo ufw reload
 ```
 
-## Configure RAFT Cluster (mariadb-raft.cnf on Each Node)
+## Configure Raft Cluster (mariadb-raft.cnf on Each Node)
 
 If MariaDB is already running, stop it before proceeding with configuration
 
@@ -187,7 +191,7 @@ After all nodes are started, verify that they have joined the cluster and consen
 
 ### Check Cluster Status (on any node):
 
-Connect to MariaDB Enterprise Server on any node and check the RAFT status variables.
+Connect to MariaDB Enterprise Server on any node and check the Raft status variables.
 
 ```bash
 sudo mariadb -u root -p
@@ -229,13 +233,59 @@ SELECT * FROM messages;
 
 This confirms the strong synchronous replication and consistency provided by the MariaDB Advanced Cluster.
 
+## Leadership Priority
+
+Leadership priority lets you influence which node the cluster elects as leader. Each node has a [raft-leadership-priority](raft-system-variables.md#raft-leadership-priority) value, which defaults to `0`. Nodes with a higher priority are preferred at election time.
+
+A leader that detects a follower with a higher priority steps down immediately, rather than waiting for the heartbeat timeout to expire. Failover to the preferred node therefore happens as soon as that node is visible to the leader.
+
+### Changing the Priority at Runtime
+
+The priority can be changed while the cluster is running, using the `ChangeLeaderPriority` administrative command issued through `AdminCommandCall`. The new priority is broadcast to the cluster in the node's `ServerInfo`, so the change takes effect without restarting the session.
+
+{% hint style="warning" %}
+Leadership priority changes the cluster protocol, and is **not** backwards compatible with the 0.9.0 technical preview release. Upgrade all nodes to the same release.
+{% endhint %}
+
+## XA Transactions
+
+`XA COMMIT` and `XA ROLLBACK` are fully supported. Standard Galera Cluster XA syntax and semantics apply — there are no Raft-specific differences in behavior.
+
+{% hint style="info" %}
+A small number of XA test scenarios are not run against Advanced Cluster, because they depend on `wsrep_provider_options`, which Advanced Cluster does not support. See [WSREP System Variables](#wsrep-system-variables).
+{% endhint %}
+
+## Non-Blocking Operations (NBO)
+
+Non-Blocking Operations is an online schema upgrade method that replicates DDL to all nodes in total order, while only locking the specific table being altered. It is configured for Advanced Cluster exactly as it is for Galera Cluster, through the `wsrep_OSU_method` session variable:
+
+```sql
+SET SESSION wsrep_OSU_method = 'NBO';
+```
+
+{% hint style="info" %}
+Non-Blocking Operations is exclusive to MariaDB Enterprise Server.
+{% endhint %}
+
+For the full procedure, including the advantages and limitations of each schema upgrade method, see [Performing Schema Upgrades in Galera Cluster]({galera}/galera-management/general-operations/performing-schema-upgrades-in-galera-cluster#non-blocking-operations-nbo).
+
+## Monitoring Cluster Connections
+
+The `INFORMATION_SCHEMA.wsrep_connections` table reports the connections between cluster nodes and processes. This table was not available in earlier Advanced Cluster releases.
+
+```sql
+SELECT * FROM INFORMATION_SCHEMA.wsrep_connections;
+```
+
+The SSL settings that apply to these connections are described in [Raft System Variables: SSL](#raft-system-variables-ssl).
+
 ## Configuration Options
 
-### RAFT System Variables
+### Raft System Variables
 
-| RAFT System Variable                                                                                | Default | Description                                                                                                                                                                                                                |
+| Raft System Variable                                                                                | Default | Description                                                                                                                                                                                                                |
 | --------------------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [raft-candidate-timeout](raft-system-variables.md#raft-candidate-timeout)                           | 200     | IInitial timeout for candidate waiting for votes during election (milliseconds). Uses exponential backoff up to raft\_max\_candidate\_timeout.                                                                             |
+| [raft-candidate-timeout](raft-system-variables.md#raft-candidate-timeout)                           | 200     | Initial timeout for candidate waiting for votes during election (milliseconds). Uses exponential backoff up to raft\_max\_candidate\_timeout.                                                                             |
 | [raft-data-dir](raft-system-variables.md#raft-data-dir)                                             | ./      | Data directory where to store replication logs and other node persistent state.                                                                                                                                            |
 | [raft-event-store-file-size](raft-system-variables.md#raft-event-store-file-size)                   | 128MB   | Maximum size of single log file in bytes. When a log file reaches this size, a new file is created.                                                                                                                        |
 | [raft-event-store-max-memory](raft-system-variables.md#raft-event-store-max-memory)                 | 32MB    | Maximum size of the in-memory event store buffer in bytes. Events are cached in memory for faster access before being written to disk.                                                                                     |
@@ -244,6 +294,7 @@ This confirms the strong synchronous replication and consistency provided by the
 | [raft-flow-control-max-throttle-rate](raft-system-variables.md#raft-flow-control-max-throttle-rate) | 100     | Maximum request rate (requests per second) to sustain when flow control throttling is active. Lower values provide more aggressive throttling.                                                                             |
 | [raft-follower-timeout](raft-system-variables.md#raft-follower-timeout)                             | 5000    | Time follower waits without leader messages before starting election (milliseconds).                                                                                                                                       |
 | [raft-heartbeat-timeout](raft-system-variables.md#raft-heartbeat-timeout)                           | 1000    | Interval at which leader sends heartbeat messages (milliseconds)                                                                                                                                                           |
+| [raft-leadership-priority](raft-system-variables.md#raft-leadership-priority)                       | 0       | Priority for the current node to become leader. Nodes with a higher priority are preferred at election time, and can be changed at runtime.                                                                                |
 | [raft-listen-port](raft-system-variables.md#raft-listen-port)                                       | 50002   | Port to listen for incoming cluster connections                                                                                                                                                                            |
 | [raft-log-filter](raft-system-variables.md#raft-log-filter)                                         |         | In order to reduce amount of logging on DEBUG level, this filter can be used to select output from specific operations.                                                                                                    |
 | [raft-log-level](raft-system-variables.md#raft-log-level)                                           | INFO    | Verbosity level for logging. Supported values are ERROR, WARN, INFO and DEBUG.                                                                                                                                             |
@@ -254,13 +305,13 @@ This confirms the strong synchronous replication and consistency provided by the
 | [raft-session-timeout](raft-system-variables.md#raft-session-timeout)                               | 15      | Timeout after which session to replication system is considered expired if there is no activity. If the node cannot communicate with the leader within this time period, it will be evicted from the cluster (seconds).    |
 | [raft-sst-listen-port](raft-system-variables.md#raft-sst-listen-port)                               | 50001   | Port to listen for SST requests.                                                                                                                                                                                           |
 
-#### RAFT System Variables: SSL
+#### Raft System Variables: SSL
 
-SSL is enabled by default for all Raft Cluster connections. If the certificate information is not provided, a self-signed certificate is created at startup. Notice that `VERIFY_PEER` cannot be used with self-signed certificates.
+SSL is enabled by default for all Raft cluster connections. If the certificate information is not provided, a self-signed certificate is created at startup. Peer certificate verification is controlled separately by [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert), which is disabled by default and cannot be used with the self-signed certificate generated at startup. Note that it verifies the server certificate only: it provides neither mutual TLS nor hostname verification.
 
-| RAFT System Variable                                                    | Default         | Description                                                                                                                                                                                                   |
+| Raft System Variable                                                    | Default         | Description                                                                                                                                                                                                   |
 | ----------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [raft-have-ssl](raft-system-variables.md#raft-have-ssl)                 | YES             | Indicates whether SSL/TLS is enabled for cluster communication. Possible values are YES, NO, DISABLED, or VERIFY\_PEER. This is a read-only variable that reflects the current SSL state                      |
+| [raft-have-ssl](raft-system-variables.md#raft-have-ssl)                 | YES             | Indicates whether SSL/TLS is enabled for cluster communication. Possible values are YES, NO, or DISABLED. This is a read-only variable that reflects the current SSL state                                    |
 | [raft-ssl-key](raft-system-variables.md#raft-ssl-key)                   |                 | Path to the SSL private key file in PEM format. This variable is read-only and must be set at server startup.                                                                                                 |
 | [raft-ssl-cert](raft-system-variables.md#raft-ssl-cert)                 |                 | Path to the SSL certificate file in PEM format. This variable is read-only and must be set at server startup.                                                                                                 |
 | [raft-ssl-ca](raft-system-variables.md#raft-ssl-ca)                     |                 | Path to the CA certificate file in PEM format used to verify peer certificates. This variable is read-only and must be set at server startup.                                                                 |
@@ -270,11 +321,12 @@ SSL is enabled by default for all Raft Cluster connections. If the certificate i
 | [raft-ssl-crl](raft-system-variables.md#raft-ssl-crl)                   |                 | Path to the Certificate Revocation List (CRL) file. This variable is read-only and must be set at server startup.                                                                                             |
 | [raft-ssl-crlpath](raft-system-variables.md#raft-ssl-crlpath)           |                 | Path to a directory containing Certificate Revocation List files. This variable is read-only and must be set at server startup.                                                                               |
 | [raft-ssl-verify-depth](raft-system-variables.md#raft-ssl-verify-depth) | 9               | Maximum depth for certificate chain verification. This variable is read-only and must be set at server startup.                                                                                               |
+| [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert) | NO  | Enables verification of the peer's server certificate against the configured CA certificate or certificates. Replaces the removed `VERIFY_PEER` value of `raft-have-ssl`. Verifies the server certificate only — this is not mutual TLS, and it does not perform hostname verification. |
 | [raft-tls-version](raft-system-variables.md#raft-tls-version)           | TLSv1.2,TLSv1.3 | Comma-separated list of allowed TLS protocol versions. Supported values include TLSv1.2 and TLSv1.3. Default includes both TLSv1.2 and TLSv1.3. This variable is read-only and must be set at server startup. |
 
-### RAFT Status Variables
+### Raft Status Variables
 
-| RAFT Status Variable                     | Description                                                                                                                     |
+| Raft Status Variable                     | Description                                                                                                                     |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `raft_current_log_index`                 | Index of the last processed replication event from the replication log.                                                         |
 | `raft_current_leader_node_id`            | The node ID corresponding to current leader as reported by local Leader Tracker.                                                |
@@ -289,9 +341,9 @@ SSL is enabled by default for all Raft Cluster connections. If the certificate i
 | `raft_event_store_first_index`           | Log index of the oldest entry that is still retained in the event store.                                                        |
 | `raft_event_store_last_index`            | Log index of the most recent entry persisted in the event store.                                                                |
 
-### RAFT Information Schema Tables
+### Raft Information Schema Tables
 
-| RAFT Information Schema Table | Description                                                              |
+| Raft Information Schema Table | Description                                                              |
 | ----------------------------- | ------------------------------------------------------------------------ |
 | `RAFT_CERT_FAILURES`          | Displays meta data from limited set of write set certification failures. |
 | `RAFT_CLUSTER_CONNECTIONS`    | Displays connections between cluster nodes and processes.                |
@@ -300,7 +352,22 @@ SSL is enabled by default for all Raft Cluster connections. If the certificate i
 
 ### WSREP System Variables
 
-MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Variables](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables). However, the `wsrep_provider_options` and `wsrep_ssl_mode` variables are an exception, as they are superseded by the RAFT System Variables for configuring the cluster.
+MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Variables](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables). However, the `wsrep_provider_options` and `wsrep_ssl_mode` variables are an exception, as they are superseded by the Raft System Variables for configuring the cluster.
+
+#### wsrep\_cluster\_name
+
+Names the cluster, and safeguards against a node accidentally joining the wrong one. The value must match on every node in the cluster: if a joining node's `wsrep_cluster_name` does not match, all of its connections are declined.
+
+| Property  | Value              |
+| --------- | ------------------ |
+| Scope     | Global             |
+| Dynamic   | Yes                |
+| Data Type | String             |
+| Default   | `my_wsrep_cluster` |
+
+{% hint style="info" %}
+Exposed endpoints must contain the `wsrep_cluster_name` as the last path component, or as a query parameter.
+{% endhint %}
 
 ### WSREP Status Variables
 
@@ -310,6 +377,7 @@ MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Var
 | `wsrep_apply_waits`             | Number of times a prior transaction had to be waited before applying a write set.                                                                                                                                     |
 | `wsrep_cert_deps_distance`      | Average distance between the highest and the lowest sequence numbers that can possibly be applied in parallel, or the potential degree of parallelization.                                                            |
 | `wsrep_cert_interval`           | Average number of transactions received while a transaction replicates.                                                                                                                                               |
+| `wsrep_checkpoint_position`     | The replication checkpoint position recorded by the node.                                                                                                                                                             |
 | `wsrep_cluster_capabilities`    |                                                                                                                                                                                                                       |
 | `wsrep_cluster_conf_id`         | Total number of cluster membership changes that have taken place.                                                                                                                                                     |
 | `wsrep_cluster_size`            | Number of nodes currently in the cluster.                                                                                                                                                                             |
@@ -338,6 +406,7 @@ MariaDB Advanced Cluster configuration primarily relies on the [WSREP System Var
 | `wsrep_repl_keys_bytes`         | Total size of keys replicated.                                                                                                                                                                                        |
 | `wsrep_replicated`              | Total size in bytes of all write sets replicated to other nodes.                                                                                                                                                      |
 | `wsrep_rollbacker_thread_count` | Stores the current number of rollbacker threads to make clear how many slave threads of this type there are.                                                                                                          |
+| `wsrep_se_checkpoint`           | The storage engine checkpoint recorded by the node, shown as the recovered XID.                                                                                                                                       |
 | `wsrep_thread_count`            | Total number of wsrep (applier/rollbacker) threads.                                                                                                                                                                   |
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>

--- a/release-notes/advanced-cluster/raft-system-variables.md
+++ b/release-notes/advanced-cluster/raft-system-variables.md
@@ -1,13 +1,13 @@
 ---
 description: >-
-  A detailed reference for the system variables used by the RAFT consensus
+  A detailed reference for the system variables used by the Raft consensus
   implementation. These variables configure cluster heartbeat behavior, election
   timeouts, log management, and flow control
 ---
 
-# RAFT System Variables
+# Raft System Variables
 
-## List of RAFT System Variables
+## List of Raft System Variables
 
 ### raft-candidate-timeout
 
@@ -125,6 +125,25 @@ Interval at which leader sends heartbeat messages (milliseconds). Shorter interv
 | Data Type    | Numeric (ms)      |
 | Range        | 100 to 4294967295 |
 | Default      | 1000              |
+
+### raft-leadership-priority
+
+Priority for the current node to become leader. Nodes with a higher priority are preferred when a leader is elected. A leader that detects a follower with a higher priority steps down immediately, rather than waiting for the heartbeat timeout to expire.
+
+The priority can also be changed at runtime, without restarting the session — see [Leadership Priority](mariadb-advanced-cluster-quickstart-guide.md#leadership-priority) in the quickstart guide.
+
+| Property     | Value                        |
+| ------------ | ---------------------------- |
+| Command Line |                              |
+| Scope        | Global                       |
+| Dynamic      | Yes                          |
+| Data Type    | Numeric                      |
+| Range        | -2147483647 to 2147483647    |
+| Default      | 0                            |
+
+{% hint style="warning" %}
+Leadership priority changes the cluster protocol, and is **not** backwards compatible with the 0.9.0 technical preview release. All nodes must run the same release.
+{% endhint %}
 
 ### raft-listen-port
 
@@ -262,16 +281,20 @@ Port to listen for SST requests.
 
 ### raft-have-ssl
 
-Indicates whether SSL/TLS is enabled for cluster communication. Possible values are YES, NO, DISABLED, or VERIFY\_PEER. This is a read-only variable that reflects the current SSL state.
+Indicates whether SSL/TLS is enabled for cluster communication. Possible values are YES, NO, or DISABLED. This is a read-only variable that reflects the current SSL state.
 
-| Property     | Value                           |
-| ------------ | ------------------------------- |
-| Command Line |                                 |
-| Scope        | Global                          |
-| Dynamic      | No                              |
-| Data Type    | Enumeration                     |
-| Range        | YES, NO, DISABLED, VERIFY\_PEER |
-| Default      | NO                              |
+| Property     | Value              |
+| ------------ | ------------------ |
+| Command Line |                    |
+| Scope        | Global             |
+| Dynamic      | No                 |
+| Data Type    | Enumeration        |
+| Range        | YES, NO, DISABLED  |
+| Default      | YES                |
+
+{% hint style="info" %}
+The `VERIFY_PEER` value was removed. Peer certificate verification is now controlled by the separate [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert) variable.
+{% endhint %}
 
 ### raft-ssl-key
 
@@ -405,7 +428,11 @@ Maximum depth for certificate chain verification. This variable is read-only and
 
 ### raft-ssl-verify-server-cert
 
-Enables verification of the peer's TLS certificate to prevent man-in-the-middle attacks. This variable is read-only and must be set at server startup.
+Enables verification of the peer's server certificate against the configured CA certificate or certificates. This variable is read-only and must be set at server startup.
+
+This variable replaces the removed `VERIFY_PEER` value of [raft-have-ssl](raft-system-variables.md#raft-have-ssl).
+
+As with other MariaDB system variables, the underscore and dash forms are interchangeable. By convention, use `raft_ssl_verify_server_cert` in configuration files and `raft-ssl-verify-server-cert` on the command line — see [Setting Server System Variables]({server}/server-management/variables-and-modes/server-system-variables#setting-server-system-variables).
 
 | Property     | Value   |
 | ------------ | ------- |
@@ -414,8 +441,13 @@ Enables verification of the peer's TLS certificate to prevent man-in-the-middle 
 | Dynamic      | No      |
 | Data Type    | Boolean |
 | Range        |         |
-| Default      | OFF     |
+| Default      | NO      |
 
 {% hint style="warning" %}
-The default is `OFF`, so by default Raft inter-node TLS encrypts traffic but does **not** verify the peer's certificate — encryption without peer authentication. Set `raft_ssl_verify_server_cert=ON` (and configure `raft_ssl_ca`) to require certificate verification.
+This variable verifies the **server certificate only**. Two limitations follow from that, and both matter when you are planning cluster security:
+
+* It does **not** provide mutual TLS. The peer accepting a connection does not verify the certificate of the peer initiating it.
+* It does **not** perform hostname verification. All communication in the cluster is bi-directional and there are no fixed client and server roles, so the accepting side has no independent way to verify the other peer's hostname.
+
+The default is `NO`, so unless you set `raft_ssl_verify_server_cert=YES` (and configure `raft_ssl_ca`), Raft inter-node TLS encrypts traffic without authenticating the peer at all. Certificate verification cannot be used with the self-signed certificate generated at startup when no certificate information is provided, because that certificate is not signed by the configured CA.
 {% endhint %}

--- a/release-notes/advanced-cluster/raft-system-variables.md
+++ b/release-notes/advanced-cluster/raft-system-variables.md
@@ -432,7 +432,7 @@ Enables verification of the peer's server certificate against the configured CA 
 
 This variable replaces the removed `VERIFY_PEER` value of [raft-have-ssl](raft-system-variables.md#raft-have-ssl).
 
-As with other MariaDB system variables, the underscore and dash forms are interchangeable. By convention, use `raft_ssl_verify_server_cert` in configuration files and `raft-ssl-verify-server-cert` on the command line — see [Setting Server System Variables]({server}/server-management/variables-and-modes/server-system-variables#setting-server-system-variables).
+As with other MariaDB system variables, the underscore and dash forms are interchangeable. By convention, use `raft_ssl_verify_server_cert` in configuration files and `raft-ssl-verify-server-cert` on the command line — see [Setting Server System Variables](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#setting-server-system-variables).
 
 | Property     | Value   |
 | ------------ | ------- |

--- a/release-notes/advanced-cluster/raft-system-variables.md
+++ b/release-notes/advanced-cluster/raft-system-variables.md
@@ -39,14 +39,14 @@ Data directory where to store replication logs and other node persistent state.
 
 Maximum size, in bytes, of received but not-yet-applied write set payloads before event delivery pauses. Set to `0` to disable the limit.
 
-| Property     | Value              |
-| ------------ | ------------------ |
-| Command Line |                    |
-| Scope        | Global             |
-| Dynamic      | Not yet confirmed  |
-| Data Type    | Numeric (Bytes)    |
-| Range        | Not yet confirmed  |
-| Default      | 134217728 (128 MB) |
+| Property     | Value                               |
+| ------------ | ----------------------------------- |
+| Command Line | --raft-applied-event-memory-limit=# |
+| Scope        | Global                              |
+| Dynamic      | Yes                                 |
+| Data Type    | Numeric (Bytes)                     |
+| Range        | 0 to 18446744073709551615           |
+| Default      | 134217728 (128 MB)                  |
 
 ### raft-event-store-file-size
 
@@ -162,14 +162,14 @@ Leadership priority changes the cluster protocol, and is **not** backwards compa
 
 The local network address the node uses for its Raft cluster communication. The node binds its listening sockets to this address — both the acceptor for incoming cluster connections and the acceptor for incoming SST connections — and uses it as the source address when connecting out to the other nodes. On a host with several network interfaces, this confines all Raft traffic to one chosen interface, for example a dedicated internal or replication network, instead of the node listening on every interface. The value must be a local IPv4 or IPv6 address, without a port and without hostnames. By default the value is empty, so the node listens on all interfaces and the operating system selects the source address.
 
-| Property     | Value             |
-| ------------ | ----------------- |
-| Command Line |                   |
-| Scope        | Global            |
-| Dynamic      | Not yet confirmed |
-| Data Type    | String            |
-| Range        |                   |
-| Default      | (empty)           |
+| Property     | Value                    |
+| ------------ | ------------------------ |
+| Command Line | --raft-bind-address=name |
+| Scope        | Global                   |
+| Dynamic      | No                       |
+| Data Type    | String                   |
+| Range        |                          |
+| Default      | (empty)                  |
 
 ### raft-listen-port
 
@@ -188,14 +188,14 @@ Port to listen for incoming cluster connections.
 
 Durability level of Raft log writes.
 
-| Property     | Value             |
-| ------------ | ----------------- |
-| Command Line |                   |
-| Scope        | Global            |
-| Dynamic      | Not yet confirmed |
-| Data Type    | Enumeration       |
-| Range        | FLUSH, SYNC       |
-| Default      | FLUSH             |
+| Property     | Value                      |
+| ------------ | -------------------------- |
+| Command Line | --raft-log-durability=name |
+| Scope        | Global                     |
+| Dynamic      | No                         |
+| Data Type    | Enumeration                |
+| Range        | FLUSH, SYNC                |
+| Default      | FLUSH                      |
 
 ### raft-log-filter
 
@@ -469,14 +469,14 @@ List of permitted TLS 1.3 ciphersuites. This is separate from raft\_ssl\_cipher 
 
 Verbose logging level for SSL context initialization.
 
-| Property     | Value             |
-| ------------ | ----------------- |
-| Command Line |                   |
-| Scope        | Global            |
-| Dynamic      | Not yet confirmed |
-| Data Type    | Numeric           |
-| Range        | Not yet confirmed |
-| Default      | 1                 |
+| Property     | Value                |
+| ------------ | -------------------- |
+| Command Line | --raft-ssl-verbose=# |
+| Scope        | Global               |
+| Dynamic      | No                   |
+| Data Type    | Numeric              |
+| Range        | 0 to 2               |
+| Default      | 1                    |
 
 ### raft-ssl-verify-depth
 

--- a/release-notes/advanced-cluster/raft-system-variables.md
+++ b/release-notes/advanced-cluster/raft-system-variables.md
@@ -1,13 +1,13 @@
 ---
 description: >-
-  A detailed reference for the system variables used by the RAFT consensus
+  A detailed reference for the system variables used by the Raft consensus
   implementation. These variables configure cluster heartbeat behavior, election
   timeouts, log management, and flow control
 ---
 
-# RAFT System Variables
+# Raft System Variables
 
-## List of RAFT System Variables
+## List of Raft System Variables
 
 ### raft-candidate-timeout
 
@@ -125,6 +125,25 @@ Interval at which leader sends heartbeat messages (milliseconds). Shorter interv
 | Data Type    | Numeric (ms)      |
 | Range        | 100 to 4294967295 |
 | Default      | 1000              |
+
+### raft-leadership-priority
+
+Priority for the current node to become leader. Nodes with a higher priority are preferred when a leader is elected. A leader that detects a follower with a higher priority steps down immediately, rather than waiting for the heartbeat timeout to expire.
+
+The priority can also be changed at runtime, without restarting the session — see [Leadership Priority](mariadb-advanced-cluster-quickstart-guide.md#leadership-priority) in the quickstart guide.
+
+| Property     | Value                        |
+| ------------ | ---------------------------- |
+| Command Line |                              |
+| Scope        | Global                       |
+| Dynamic      | Yes                          |
+| Data Type    | Numeric                      |
+| Range        | -2147483647 to 2147483647    |
+| Default      | 0                            |
+
+{% hint style="warning" %}
+Leadership priority changes the cluster protocol, and is **not** backwards compatible with the 0.9.0 technical preview release. All nodes must run the same release.
+{% endhint %}
 
 ### raft-listen-port
 
@@ -262,16 +281,20 @@ Port to listen for SST requests.
 
 ### raft-have-ssl
 
-Indicates whether SSL/TLS is enabled for cluster communication. Possible values are YES, NO, DISABLED, or VERIFY\_PEER. This is a read-only variable that reflects the current SSL state.
+Indicates whether SSL/TLS is enabled for cluster communication. Possible values are YES, NO, or DISABLED. This is a read-only variable that reflects the current SSL state.
 
-| Property     | Value                           |
-| ------------ | ------------------------------- |
-| Command Line |                                 |
-| Scope        | Global                          |
-| Dynamic      | No                              |
-| Data Type    | Enumeration                     |
-| Range        | YES, NO, DISABLED, VERIFY\_PEER |
-| Default      | NO                              |
+| Property     | Value              |
+| ------------ | ------------------ |
+| Command Line |                    |
+| Scope        | Global             |
+| Dynamic      | No                 |
+| Data Type    | Enumeration        |
+| Range        | YES, NO, DISABLED  |
+| Default      | YES                |
+
+{% hint style="info" %}
+The `VERIFY_PEER` value was removed. Peer certificate verification is now controlled by the separate [raft-ssl-verify-server-cert](raft-system-variables.md#raft-ssl-verify-server-cert) variable.
+{% endhint %}
 
 ### raft-ssl-key
 
@@ -405,7 +428,11 @@ Maximum depth for certificate chain verification. This variable is read-only and
 
 ### raft-ssl-verify-server-cert
 
-Enables verification of the peer's TLS certificate to prevent man-in-the-middle attacks. This variable is read-only and must be set at server startup.
+Enables verification of the peer's server certificate against the configured CA certificate or certificates. This variable is read-only and must be set at server startup.
+
+This variable replaces the removed `VERIFY_PEER` value of [raft-have-ssl](raft-system-variables.md#raft-have-ssl).
+
+As with other MariaDB system variables, the underscore and dash forms are interchangeable. By convention, use `raft_ssl_verify_server_cert` in configuration files and `raft-ssl-verify-server-cert` on the command line — see [Setting Server System Variables]({server}/server-management/variables-and-modes/server-system-variables#setting-server-system-variables).
 
 | Property     | Value   |
 | ------------ | ------- |
@@ -414,10 +441,15 @@ Enables verification of the peer's TLS certificate to prevent man-in-the-middle 
 | Dynamic      | No      |
 | Data Type    | Boolean |
 | Range        |         |
-| Default      | OFF     |
+| Default      | NO      |
 
 {% hint style="warning" %}
-The default is `OFF`, so by default Raft inter-node TLS encrypts traffic but does **not** verify the peer's certificate — encryption without peer authentication. Set `raft_ssl_verify_server_cert=ON` (and configure `raft_ssl_ca`) to require certificate verification.
+This variable verifies the **server certificate only**. Two limitations follow from that, and both matter when you are planning cluster security:
+
+* It does **not** provide mutual TLS. The peer accepting a connection does not verify the certificate of the peer initiating it.
+* It does **not** perform hostname verification. All communication in the cluster is bi-directional and there are no fixed client and server roles, so the accepting side has no independent way to verify the other peer's hostname.
+
+The default is `NO`, so unless you set `raft_ssl_verify_server_cert=YES` (and configure `raft_ssl_ca`), Raft inter-node TLS encrypts traffic without authenticating the peer at all. Certificate verification cannot be used with the self-signed certificate generated at startup when no certificate information is provided, because that certificate is not signed by the configured CA.
 {% endhint %}
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>

--- a/release-notes/advanced-cluster/raft-system-variables.md
+++ b/release-notes/advanced-cluster/raft-system-variables.md
@@ -9,9 +9,9 @@ description: >-
 
 ## List of Raft System Variables
 
-### raft-candidate-timeout
+### raft-vote-timeout
 
-Initial timeout for candidate waiting for votes during election (milliseconds). Uses exponential backoff up to raft\_max\_candidate\_timeout.
+Time candidate waits for a majority of granted votes during election. Uses exponential backoff up to raft\_max\_vote\_timeout.
 
 | Property     | Value             |
 | ------------ | ----------------- |
@@ -34,6 +34,19 @@ Data directory where to store replication logs and other node persistent state.
 | Data Type    | String |
 | Range        |        |
 | Default      | ./     |
+
+### raft-applied-event-memory-limit
+
+Maximum size, in bytes, of received but not-yet-applied write set payloads before event delivery pauses. Set to `0` to disable the limit.
+
+| Property     | Value              |
+| ------------ | ------------------ |
+| Command Line |                    |
+| Scope        | Global             |
+| Dynamic      | Not yet confirmed  |
+| Data Type    | Numeric (Bytes)    |
+| Range        | Not yet confirmed  |
+| Default      | 134217728 (128 MB) |
 
 ### raft-event-store-file-size
 
@@ -100,9 +113,9 @@ Maximum request rate (requests per second) to sustain when flow control throttli
 | Range        | 0 to 4294967295 |
 | Default      | 100             |
 
-### raft-follower-timeout
+### raft-election-timeout
 
-Time follower waits without leader messages before starting election (milliseconds). Should be significantly larger than raft\_heartbeat\_timeout to avoid unnecessary elections.
+Time follower waits without leader messages before starting election. Should be significantly larger than raft\_heartbeat\_timeout to avoid unnecessary elections.
 
 | Property     | Value             |
 | ------------ | ----------------- |
@@ -145,6 +158,19 @@ The priority can also be changed at runtime, without restarting the session — 
 Leadership priority changes the cluster protocol, and is **not** backwards compatible with the 0.9.0 technical preview release. All nodes must run the same release.
 {% endhint %}
 
+### raft-bind-address
+
+The local network address the node uses for its Raft cluster communication. The node binds its listening sockets to this address — both the acceptor for incoming cluster connections and the acceptor for incoming SST connections — and uses it as the source address when connecting out to the other nodes. On a host with several network interfaces, this confines all Raft traffic to one chosen interface, for example a dedicated internal or replication network, instead of the node listening on every interface. The value must be a local IPv4 or IPv6 address, without a port and without hostnames. By default the value is empty, so the node listens on all interfaces and the operating system selects the source address.
+
+| Property     | Value             |
+| ------------ | ----------------- |
+| Command Line |                   |
+| Scope        | Global            |
+| Dynamic      | Not yet confirmed |
+| Data Type    | String            |
+| Range        |                   |
+| Default      | (empty)           |
+
 ### raft-listen-port
 
 Port to listen for incoming cluster connections.
@@ -157,6 +183,19 @@ Port to listen for incoming cluster connections.
 | Data Type    | Numeric (Port) |
 | Range        | 0 to 65535     |
 | Default      | 50002          |
+
+### raft-log-durability
+
+Durability level of Raft log writes.
+
+| Property     | Value             |
+| ------------ | ----------------- |
+| Command Line |                   |
+| Scope        | Global            |
+| Dynamic      | Not yet confirmed |
+| Data Type    | Enumeration       |
+| Range        | FLUSH, SYNC       |
+| Default      | FLUSH             |
 
 ### raft-log-filter
 
@@ -184,9 +223,9 @@ Verbosity level for logging. Supported values are ERROR, WARN, INFO and DEBUG. T
 | Range        | ERROR, WARN, INFO, DEBUG |
 | Default      | INFO                     |
 
-### raft-max-candidate-timeout
+### raft-max-vote-timeout
 
-Maximum candidate timeout after exponential backoff (milliseconds). Limits how long a candidate will wait between election attempts.
+Upper bound for raft\_vote\_timeout after exponential backoff. Limits how long a candidate will wait between election attempts.
 
 | Property     | Value             |
 | ------------ | ----------------- |
@@ -240,31 +279,31 @@ Node weight for replication and voting quorum. The default weight is 1, all node
 | Range        | 1 to 256 |
 | Default      | 1        |
 
-### raft-non-primary-timeout
+### raft-liveness-timeout
 
-Timeout after which the node is considered to be in non-primary state. If no replication events appear in the log within this time period, the node will be considered to be in non-primary state (seconds).
+Timeout after which the node is considered unresponsive. If no replication events appear in the log within this period, the node moves to non-primary state.
 
-| Property     | Value             |
-| ------------ | ----------------- |
-| Command Line |                   |
-| Scope        | Global            |
-| Dynamic      | No                |
-| Data Type    | Numeric (seconds) |
-| Range        | 1 to 4294967295   |
-| Default      | 20                |
+| Property     | Value              |
+| ------------ | ------------------ |
+| Command Line |                    |
+| Scope        | Global             |
+| Dynamic      | No                 |
+| Data Type    | Numeric (ms)       |
+| Range        | 1000 to 4294967295 |
+| Default      | 20000              |
 
-### raft-session-timeout
+### raft-eviction-timeout
 
-Timeout after which session to replication system is considered expired if there is no activity. If the node cannot communicate with the leader within this time period, it will be evicted from the cluster (seconds).
+Timeout after which session to replication system is considered expired if there is no activity. If the node cannot communicate with the leader within this time period, it will be evicted from the cluster.
 
-| Property     | Value             |
-| ------------ | ----------------- |
-| Command Line |                   |
-| Scope        | Global            |
-| Dynamic      | No                |
-| Data Type    | Numeric (seconds) |
-| Range        | 1 to 4294967295   |
-| Default      | 15                |
+| Property     | Value              |
+| ------------ | ------------------ |
+| Command Line |                    |
+| Scope        | Global             |
+| Dynamic      | No                 |
+| Data Type    | Numeric (ms)       |
+| Range        | 1000 to 4294967295 |
+| Default      | 15000              |
 
 ### raft-sst-listen-port
 
@@ -278,6 +317,19 @@ Port to listen for SST requests.
 | Data Type    | Numeric (Port) |
 | Range        | 0 to 65535     |
 | Default      | 50001          |
+
+### raft-segment-id
+
+Read-only datacenter segment identifier. The identifier can be either a human-readable string up to 15 characters long or a UUID. By default it is unset, meaning no segmentation is applied.
+
+| Property     | Value                                        |
+| ------------ | -------------------------------------------- |
+| Command Line |                                              |
+| Scope        | Global                                       |
+| Dynamic      | No                                           |
+| Data Type    | String                                       |
+| Range        | Human-readable string (max 15 chars) or UUID |
+| Default      | (unset)                                      |
 
 ### raft-have-ssl
 
@@ -413,6 +465,19 @@ List of permitted TLS 1.3 ciphersuites. This is separate from raft\_ssl\_cipher 
 | Range        |         |
 | Default      | (empty) |
 
+### raft-ssl-verbose
+
+Verbose logging level for SSL context initialization.
+
+| Property     | Value             |
+| ------------ | ----------------- |
+| Command Line |                   |
+| Scope        | Global            |
+| Dynamic      | Not yet confirmed |
+| Data Type    | Numeric           |
+| Range        | Not yet confirmed |
+| Default      | 1                 |
+
 ### raft-ssl-verify-depth
 
 Maximum depth for certificate chain verification. This variable is read-only and must be set at server startup.
@@ -444,12 +509,11 @@ As with other MariaDB system variables, the underscore and dash forms are interc
 | Default      | NO      |
 
 {% hint style="warning" %}
-This variable verifies the **server certificate only**. Two limitations follow from that, and both matter when you are planning cluster security:
+When this variable is set to `YES` and both `raft_ssl_cert` and `raft_ssl_ca` are configured, the cluster performs mutual TLS: each peer verifies the other peer's server certificate against the configured CA. One limitation remains, and it matters when you are planning cluster security:
 
-* It does **not** provide mutual TLS. The peer accepting a connection does not verify the certificate of the peer initiating it.
 * It does **not** perform hostname verification. All communication in the cluster is bi-directional and there are no fixed client and server roles, so the accepting side has no independent way to verify the other peer's hostname.
 
-The default is `NO`, so unless you set `raft_ssl_verify_server_cert=YES` (and configure `raft_ssl_ca`), Raft inter-node TLS encrypts traffic without authenticating the peer at all. Certificate verification cannot be used with the self-signed certificate generated at startup when no certificate information is provided, because that certificate is not signed by the configured CA.
+The default is `NO`, so unless you set `raft_ssl_verify_server_cert=YES` (and configure `raft_ssl_cert` and `raft_ssl_ca`), Raft inter-node TLS encrypts traffic without authenticating the peer at all. Certificate verification cannot be used with the self-signed certificate generated at startup when no certificate information is provided, because that certificate is not signed by the configured CA.
 {% endhint %}
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>


### PR DESCRIPTION
## Summary
Documents Advanced Cluster features shipping in MariaDB Enterprise Server 12.3 Beta: NBO, XA, wsrep_cluster_name, wsrep_connections, and dynamic leadership priority. Also corrects several pre-existing inaccuracies in the SSL configuration documentation found during fact-checking.

## Resolved during review
Item 12 (raft_ssl_verify_server_cert naming/scope) was flagged as an open question and resolved by Teemu (comment on DOCS-6353, 2026-08-07):
- `raft_ssl_verify_server_cert` (underscore, config file) and `raft-ssl-verify-server-cert` (hyphen, command line) are the same variable — standard MariaDB convention, not a duplicate.
- `ssl_verify_server_cert` (no raft prefix) is an internal implementation detail and is intentionally not documented.
- **Behavioral correction**: this variable does server-certificate verification only. It is not mutual TLS and does not perform hostname verification — hostname verification is not architecturally possible in this cluster's peer-to-peer topology (no fixed client/server roles). The previous draft implied hostname verification was covered; this has been corrected.

## Known caveats (non-blocking, tracked in report.md)
- **MGL-220**: an open ticket tracking TLS deficiency in this variable, which Teemu believes should be addressed before GA. This description may need a follow-up update if MGL-220 ships before 12.3 GA.
- The self-signed-certificate caveat on the SSL reference page is a carried-over inference from the old `VERIFY_PEER` note — plausible given the confirmed mechanism but not directly confirmed by Teemu.
- The `Boolean` data type with `NO`/`YES` rendering (vs. the more common `ON`/`OFF`) was not explicitly confirmed by Teemu, though he reviewed the entry without correcting it.

## Manual pre-merge checklist
- [ ] Verify the `<a id="download-the-advanced-cluster-technical-preview-tar-archive">` anchor at quickstart:49 survives GitBook rendering (can't be checked locally — GitBook sometimes strips raw HTML)
- [ ] Confirm codespell/lychee pass in CI (not installed locally, so spelling and link validity are unverified pre-push)

## Notes
- doc-lint.sh fix is a separate commit — repo-wide tooling bug unrelated to this content, was blocking all commits via pre-commit hook
- Pre-existing missing frontmatter in the quickstart guide was found but deliberately left out of scope — flagged in report.md as a follow-up item
- This PR standardizes "RAFT" -> "Raft" casing within the two files it touches, per a team decision (Raft is not an acronym; matches the algorithm's original naming convention and usage in etcd/Consul/TiKV/CockroachDB docs). A separate follow-up ticket is planned to standardize remaining "RAFT" → "Raft" casing instances across the rest of the doc's repo (outside the files touched here)