### PR TITLE
DOCS-6412 Fix TDE fundamentals instruction steps

### DIFF
--- a/server/security/encryption/data-at-rest-encryption/data-at-rest-encryption-tde-fundamentals.md
+++ b/server/security/encryption/data-at-rest-encryption/data-at-rest-encryption-tde-fundamentals.md
@@ -71,6 +71,7 @@ Enabling data-at-rest encryption encompasses these steps:
 2. Installing and enabling a [key management plugin](key-management-and-encryption-plugins/).
 3. Enabling encryption for Aria tables, InnoDB tables, or both.
 4. Verifying encryption is turned on.
+5. Monitoring encryption progress.
 
 {% hint style="info" %}
 The path used in these instructions (`/etc/mysql/encryption/`) is common for most Linux systems. Adjust if your operating system uses a different path.
@@ -94,19 +95,12 @@ sudo journalctl -u mariadb -n 1000 --no-pager | grep ERROR
 
 In this step, we create a key file that fulfills basic requirements. It contains only one unencrypted key, which is good enough to perform the rest of the steps. It is highly recommended, though, to use multiple keys, and to encrypt the key files. See [Creating the Key File](key-management-and-encryption-plugins/file-key-management-encryption-plugin.md#creating-the-key-file).
 
+{% hint style="warning" %}
+The key file format differs by product and version, so pick the tab that matches the server you're configuring. The optional key version field is only supported as of Enterprise Server 11.8. Using the wrong format makes the server fail to start with `Invalid key` in the [error log](../../../server-management/server-monitoring-logs/error-log.md).
+{% endhint %}
+
 {% tabs %}
-{% tab title="Current Enterprise Server" %}
-Run these commands to create an `encryption` folder, and a 32 byte (256 bit) long key file within that folder.
-
-{% code overflow="wrap" %}
-```bash
-mkdir -p /etc/mysql/encryption 
-echo $(echo -n "1;1;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryption/keyfile.txt
-```
-{% endcode %}
-{% endtab %}
-
-{% tab title="Enterprise Server < 11.8 & Community Server" %}
+{% tab title="Community Server (all versions) & Enterprise Server before 11.8" %}
 Run these commands to create an `encryption` folder, and a 32 byte (256 bit) long key file within that folder.
 
 {% code overflow="wrap" %}
@@ -116,7 +110,20 @@ echo $(echo -n "1;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryption/
 ```
 {% endcode %}
 {% endtab %}
+
+{% tab title="Enterprise Server 11.8 and later" %}
+Run these commands to create an `encryption` folder, and a 32 byte (256 bit) long key file within that folder. The second field is the key version.
+
+{% code overflow="wrap" %}
+```bash
+mkdir -p /etc/mysql/encryption 
+echo $(echo -n "1;1;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryption/keyfile.txt
+```
+{% endcode %}
+{% endtab %}
 {% endtabs %}
+
+To keep the keys out of reach of other users on the system, it is highly recommended to encrypt the key file as well. That requires an encryption password, which is a separate file from the key file. See [Encrypting the Key File](key-management-and-encryption-plugins/file-key-management-encryption-plugin.md#encrypting-the-key-file), and use the resulting file names in the next step.
 {% endstep %}
 
 {% step %}
@@ -130,11 +137,23 @@ Add the following to your configuration file (for instance, `my.cnf`), then rest
 plugin_load_add = file_key_management
 file_key_management_filename = /etc/mysql/encryption/keyfile.txt
 # The following line is optional but highly recommended.
-# Uncomment it to enable usage of an encrypted key file.
+# If you encrypted the key file in the previous step, point
+# file_key_management_filename at the encrypted key file instead, and
+# uncomment the next line to point at the encryption password file.
 # file_key_management_filekey = FILE:/etc/mysql/encryption/keyfile.key
-file_key_management_encryption_algorithm = AES_CTR
 ```
 {% endcode %}
+
+This configuration uses the default encryption algorithm, `AES_CBC`.
+
+{% hint style="warning" %}
+Do not set [file\_key\_management\_encryption\_algorithm](key-management-and-encryption-plugins/file-key-management-encryption-plugin.md#file_key_management_encryption_algorithm) to `AES_CTR` unless you have a reason to. The algorithm is effectively permanent for data already encrypted with it:
+
+* Changing it later makes the server fail to start, reporting the data files as corrupted rather than naming the algorithm as the cause.
+* The HashiCorp Key Management and AWS Key Management plugins only support `AES_CBC`, so data encrypted with `AES_CTR` locks you into the File Key Management plugin.
+
+See [Choosing an Encryption Algorithm](key-management-and-encryption-plugins/file-key-management-encryption-plugin.md#choosing-an-encryption-algorithm).
+{% endhint %}
 
 For details about file name, file key, and encryption algorithm, see [File Key Management Encryption Plugin](key-management-and-encryption-plugins/file-key-management-encryption-plugin.md).
 {% endstep %}
@@ -161,21 +180,35 @@ innodb_encrypt_log = ON
 innodb_encrypt_temporary_tables = ON
 aria_encrypt_tables = ON
 encrypt_tmp_disk_tables = ON
+# Required to encrypt InnoDB tables that already exist. The default is 0,
+# which means existing tables are left as they are.
+innodb_encryption_threads = 4
 ```
 {% endcode %}
+
+{% hint style="info" %}
+[innodb\_encryption\_threads](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_encryption_threads) deserves attention on an existing database. The settings above encrypt InnoDB tables that are *created* from now on, but converting tables that already exist is the job of the background encryption threads. The variable defaults to `0`, meaning no threads run, so without it your existing tables stay unencrypted and the next step has no progress to report.
+
+The same applies in reverse when you disable encryption: the threads are what decrypt existing tables. For details, see [InnoDB Background Encryption Threads](innodb-encryption/innodb-background-encryption-threads.md).
+{% endhint %}
 
 Alternatively, set it by running the following statements. Remember, though, that the settings do not persist across server restarts. Also note that some of the variables cannot be set at runtime – they have to be set in a configuration file:
 
 {% code overflow="wrap" %}
 ```sql
-SET GLOBAL innodb_encrypt_tables = ON;   -- for InnoDB tables
-SET GLOBAL aria_encrypt_tables = ON;     -- for Aria tables
-SET GLOBAL encrypt_tmp_disk_tables = ON; -- for Aria temporary tables
+SET GLOBAL innodb_encrypt_tables = ON;    -- for InnoDB tables
+SET GLOBAL innodb_encryption_threads = 4; -- to convert existing InnoDB tables
+SET GLOBAL aria_encrypt_tables = ON;      -- for Aria tables
+SET GLOBAL encrypt_tmp_disk_tables = ON;  -- for Aria temporary tables
 ```
 {% endcode %}
 
 {% hint style="info" %}
 Particularly InnoDB has more encryption options. You can fine-tune the encryption, for instance, configure encryption threads. Those details are covered [on this page](innodb-encryption/innodb-enabling-encryption.md).
+{% endhint %}
+
+{% hint style="info" %}
+Setting `innodb_encrypt_tables` to `FORCE` instead of `ON` additionally rejects any attempt to exempt an individual table with `ENCRYPTED=NO`. Use it when you need encryption to be mandatory across the whole instance. It does not change how existing tables are converted — that is the job of the encryption threads described above. Note that it also makes the [per-table exemptions](data-at-rest-encryption-tde-fundamentals.md#manual-control-disabling-encryption) shown later on this page fail.
 {% endhint %}
 {% endstep %}
 
@@ -211,6 +244,26 @@ If encryption of all database objects is successfully enabled, this is the outpu
 ```
 {% endcode %}
 {% endstep %}
+
+{% step %}
+**Monitor encryption progress.**
+
+The previous step confirms that encryption is configured, not that your data is encrypted yet. If the database already contained tables, the background encryption threads work through them after the restart. Monitor how many InnoDB tablespaces are still unencrypted:
+
+{% code overflow="wrap" %}
+```sql
+SELECT NAME, ENCRYPTION_SCHEME, ROTATING_OR_FLUSHING 
+FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION 
+WHERE ENCRYPTION_SCHEME = 0;
+```
+{% endcode %}
+
+Encryption is complete once the query returns an empty set. There's no built-in way to monitor the progress for Aria tables.
+
+{% hint style="info" %}
+If the result doesn't change, check that [innodb\_encryption\_threads](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_encryption_threads) is greater than `0`. With the default of `0`, existing tables are never converted.
+{% endhint %}
+{% endstep %}
 {% endstepper %}
 
 ## Disabling Data-at-Rest Encryption
@@ -219,7 +272,7 @@ If you determine that encryption is no longer necessary, you can revert the syst
 
 ### Prerequisites
 
-* Encryption Status: MariaDB Enterprise Server must currently have data-at-rest encryption enabled and active.
+* Encryption Status: MariaDB Server must currently have data-at-rest encryption enabled and active.
 * Key Management Access: You must have the original key management plugin active and the correct keys loaded to facilitate the decryption of the data.
 * Sufficient Disk Space: Ensure adequate free space is available to accommodate the rewritten, unencrypted data files.
 
@@ -236,6 +289,14 @@ SET GLOBAL aria_encrypt_tables = OFF;     -- Aria tables
 SET GLOBAL encrypt_tmp_disk_tables = OFF; -- Aria temporary tables
 ```
 {% endcode %}
+
+{% hint style="warning" %}
+Decrypting tables that already exist is done by the background encryption threads, so [innodb\_encryption\_threads](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_encryption_threads) must be greater than `0` for this to have any effect. With the default of `0`, turning encryption off only stops new data from being encrypted, and the monitoring step below never reports progress:
+
+```sql
+SET GLOBAL innodb_encryption_threads = 4;
+```
+{% endhint %}
 
 {% hint style="info" %}
 Any per-table encryption for InnoDB tables explicitly created with `ENCRYPTED=YES` must be manually decrypted using `ALTER TABLE table_name ENCRYPTED=NO`.
@@ -268,6 +329,8 @@ FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION
 WHERE ENCRYPTION_SCHEME != 0;
 ```
 
+Decryption is complete once the query returns an empty set.
+
 {% hint style="warning" %}
 A restore from an encrypted backup isn't possible after removing the keys.
 {% endhint %}
@@ -283,6 +346,22 @@ Only after all tables and logs are confirmed as unencrypted should you uninstall
 UNINSTALL SONAME 'file_key_management';
 ```
 {% endcode %}
+
+The statement succeeds with a warning:
+
+{% code overflow="wrap" %}
+```
++---------+------+----------------------------------------------------+
+| Level   | Code | Message                                            |
++---------+------+----------------------------------------------------+
+| Warning | 1620 | Plugin is busy and will be uninstalled on shutdown |
++---------+------+----------------------------------------------------+
+```
+{% endcode %}
+
+{% hint style="info" %}
+This warning is expected, and it doesn't indicate that something is still encrypted. While an encryption plugin is installed, the server holds a reference to it, so the plugin can never be unloaded at runtime. It's removed at the next shutdown instead. Because of this, the following step isn't optional: unless you also remove the configuration, the server loads the plugin again on restart.
+{% endhint %}
 
 Remove its configuration, then restart the server:
 

--- a/server/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin.md
+++ b/server/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/file-key-management-encryption-plugin.md
@@ -63,20 +63,24 @@ For each encryption key, the file contains these options, separated by a semicol
 Entries look like this:
 
 {% tabs %}
-{% tab title="Current Enterprise Server" %}
+{% tab title="Community Server (all versions) & Enterprise Server before 11.8" %}
+```ini
+<encryption_key_id>;<hex-encoded_encryption_key>
+```
+{% endtab %}
+
+{% tab title="Enterprise Server 11.8 and later" %}
 {% code overflow="wrap" %}
 ```
 <encryption_key_id>;<encryption_key_version>;<hex-encoded_encryption_key>
 ```
 {% endcode %}
 {% endtab %}
-
-{% tab title="Community Server & Enterprise Server < 11.8" %}
-```ini
-<encryption_key_id>;<hex-encoded_encryption_key>
-```
-{% endtab %}
 {% endtabs %}
+
+{% hint style="warning" %}
+Use the format that matches the server you're configuring. On a server that doesn't support the key version field, a key file that includes one makes the server fail to start, reporting `Invalid key` in the [error log](../../../../server-management/server-monitoring-logs/error-log.md).
+{% endhint %}
 
 You can also optionally encrypt the key file to make it less accessible from the file system. That is explained further in the section below.
 
@@ -92,18 +96,7 @@ a7addd9adea9978fda19f21e6be987880e68ac92632ca052e5bb42b1a506939a
 The key file needs to have a key identifier for each encryption key added to the beginning of each line. Key identifiers do not have to be contiguous. For example, to append three new encryption keys to a new key file, issue these commands:
 
 {% tabs %}
-{% tab title="Current Enterprise Server" %}
-{% code overflow="wrap" %}
-```bash
-mkdir -p /etc/mysql/encryption 
-echo $(echo -n "1;1;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryption/keyfile.txt 
-echo $(echo -n "2;1;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryption/keyfile.txt 
-echo $(echo -n "100;2;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryption/keyfile.txt
-```
-{% endcode %}
-{% endtab %}
-
-{% tab title="Community Server(All) & Enterprise Server < 11.8" %}
+{% tab title="Community Server (all versions) & Enterprise Server before 11.8" %}
 {% code overflow="wrap" %}
 ```bash
 mkdir -p /etc/mysql/encryption
@@ -113,24 +106,35 @@ echo $(echo -n "100;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryptio
 ```
 {% endcode %}
 {% endtab %}
+
+{% tab title="Enterprise Server 11.8 and later" %}
+{% code overflow="wrap" %}
+```bash
+mkdir -p /etc/mysql/encryption 
+echo $(echo -n "1;1;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryption/keyfile.txt 
+echo $(echo -n "2;1;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryption/keyfile.txt 
+echo $(echo -n "100;2;" ; openssl rand -hex 32) | sudo tee -a /etc/mysql/encryption/keyfile.txt
+```
+{% endcode %}
+{% endtab %}
 {% endtabs %}
 
 The resulting key file looks like this:
 
 {% tabs %}
-{% tab title="Current Enterprise Server" %}
+{% tab title="Community Server (all versions) & Enterprise Server before 11.8" %}
+```
+1;a7addd9adea9978fda19f21e6be987880e68ac92632ca052e5bb42b1a506939a
+2;49c16acc2dffe616710c9ba9a10b94944a737de1beccb52dc1560abfdd67388b
+100;8db1ee74580e7e93ab8cf157f02656d356c2f437d548d5bf16bf2a56932954a3
+```
+{% endtab %}
+
+{% tab title="Enterprise Server 11.8 and later" %}
 ```
 1;1;a7addd9adea9978fda19f21e6be987880e68ac92632ca052e5bb42b1a506939a
 2;1;49c16acc2dffe616710c9ba9a10b94944a737de1beccb52dc1560abfdd67388b
 100;2;8db1ee74580e7e93ab8cf157f02656d356c2f437d548d5bf16bf2a56932954a3
-```
-{% endtab %}
-
-{% tab title="Community Server & Enterprise Server < 11.8" %}
-```sql
-1;a7addd9adea9978fda19f21e6be987880e68ac92632ca052e5bb42b1a506939a
-2;49c16acc2dffe616710c9ba9a10b94944a737de1beccb52dc1560abfdd67388b
-100;8db1ee74580e7e93ab8cf157f02656d356c2f437d548d5bf16bf2a56932954a3
 ```
 {% endtab %}
 {% endtabs %}
@@ -250,7 +254,16 @@ The File Key Management plugin currently supports two encryption algorithms for 
 * The `AES_CBC` mode uses AES in the [Cipher Block Chaining (CBC)](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Block_Chaining_.28CBC.29) mode.
 * The `AES_CTR` mode uses AES in two slightly different modes in different contexts. When encrypting tablespace pages (such as pages in InnoDB, XtraDB, and Aria tables), it uses AES in the [Counter (CTR)](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_.28CTR.29) mode. When encrypting temporary files (where the cipher text is allowed to be larger than the plain text), it uses AES in the authenticated [Galois/Counter Mode (GCM)](https://en.wikipedia.org/wiki/Galois/Counter_Mode).
 
-The recommended algorithm is `AES_CTR`, but this algorithm is only available when MariaDB is built with [OpenSSL](https://www.openssl.org/). If the server is built with [wolfSSL](https://www.wolfssl.com/products/wolfssl/) then this algorithm is not available. See [TLS and Cryptography Libraries Used by MariaDB](../../tls-and-cryptography-libraries-used-by-mariadb.md) for more information about which libraries are used on which platforms.
+{% hint style="warning" %}
+Choose the algorithm before you encrypt any data, and treat the choice as permanent:
+
+* You cannot change the algorithm afterwards. A server started with a different algorithm than its data was encrypted with fails to start, reporting the data files as corrupted or the redo log scan as aborted, without naming the algorithm as the cause. See [MDEV-40657](https://jira.mariadb.org/browse/MDEV-40657).
+* `AES_CTR` is specific to the File Key Management plugin. The [HashiCorp Key Management](hashicorp-key-management-plugin.md) and [AWS Key Management](aws-key-management-encryption-plugin.md) plugins only support `AES_CBC`, so data encrypted with `AES_CTR` can't be read after switching to either of them, even with the same keys.
+
+If you may want to move to a key management service later, use the default `AES_CBC`.
+{% endhint %}
+
+`AES_CTR` requires a server built with [OpenSSL](https://www.openssl.org/). Before MariaDB 11.2, builds using [wolfSSL](https://www.wolfssl.com/products/wolfssl/) offer `AES_CBC` only; as of MariaDB 11.2, wolfSSL builds support `AES_CTR` as well. Where the algorithm isn't available, `AES_CTR` isn't a valid value for the system variable, and the server doesn't start if you configure it. See [TLS and Cryptography Libraries Used by MariaDB](../../tls-and-cryptography-libraries-used-by-mariadb.md) for more information about which libraries are used on which platforms.
 
 ### Configuring the Encryption Algorithm
 
@@ -332,7 +345,8 @@ The File Key Management plugin does not support [key rotation](encryption-key-ma
 ### `file_key_management_encryption_algorithm`
 
 * This system variable is used to determine which algorithm the plugin will use to encrypt data.
-  * The recommended algorithm is `AES_CTR`, but this algorithm is only available when MariaDB is built with [OpenSSL](https://www.openssl.org/). If the server is built with [wolfSSL](https://www.wolfssl.com/products/wolfssl/) then this algorithm is not available. See [TLS and Cryptography Libraries Used by MariaDB](../../tls-and-cryptography-libraries-used-by-mariadb.md) for more information about which libraries are used on which platforms.
+  * The choice is permanent for data already encrypted, and `AES_CTR` can't be read by the other key management plugins. See [Choosing an Encryption Algorithm](file-key-management-encryption-plugin.md#choosing-an-encryption-algorithm).
+  * `AES_CTR` requires a build using [OpenSSL](https://www.openssl.org/). Before MariaDB 11.2, builds using [wolfSSL](https://www.wolfssl.com/products/wolfssl/) accept `AES_CBC` only.
 * Command line: `--file-key-management-encryption-algorithm=`_`value`_
 * Scope: Global
 * Dynamic: No


### PR DESCRIPTION
Fixes [DOCS-6412](https://mariadbcorp.atlassian.net/browse/DOCS-6412), reported by Hartmut Holzgraefe after a customer failed to enable TDE by following the page.

## What was wrong

| # | Issue | Fix |
|---|---|---|
| 1 | The key file tabs led with the Enterprise Server format, so a 10.6 customer used `1;1;` and the server refused to start | Label tabs by version, put the widely applicable one first, warn that the wrong format is a hard startup failure. Same labels applied on the plugin page, which used three different spellings |
| 2 | The config snippet referenced `keyfile.key` (an encrypted key file) that step 1 never created | Link *Encrypting the Key File*, and clarify that `keyfile.key` holds the encryption *password* |
| 3 | `innodb_encryption_threads` was never set, so existing tables were never converted and the monitoring steps had nothing to show | Set it in the enable step, note it in the disable step, add the missing **Monitor encryption progress** step |
| 4 | `UNINSTALL SONAME` returns `Plugin is busy and will be uninstalled on shutdown`, undocumented | Show the warning and explain it's expected |
| 5 | The walkthrough set `file_key_management_encryption_algorithm = AES_CTR` | Removed; replaced with a warning about what that choice costs |

## Fact-check notes

Each claim was verified against `mariadb-server` @ `a217e1000f3` (13.0.1). Two places where I diverged from the ticket:

**`innodb_encrypt_tables=FORCE` — not adopted.** The ticket suggests `FORCE` instead of `ON` "so that existing tables get encrypted in the background already". That isn't what `FORCE` does. `should_encrypt()` treats both as truthy for default-mode tablespaces, so background conversion depends on the *threads*, not on `ON` vs `FORCE`. What `FORCE` actually adds is rejecting `ENCRYPTED=NO` (`ha_innodb.cc:11490`) — which would break this page's own *Manual Control: Disabling Encryption* section further down. So I fixed the real cause (threads) and documented `FORCE` as the policy control it is.

**The wolfSSL restriction is version-specific.** Both pages stated unconditionally that `AES_CTR` requires OpenSSL. That flipped in commit `f94d467d326` ("enable AES-CTR with wolfssl"), first released in **11.2.1** — `cmake/ssl.cmake` sets `HAVE_EncryptAes128Ctr ON` for bundled wolfSSL on `main`, versus `OFF` on `10.6-enterprise`. So the ticket's version of this claim is right for ES 10.6 but wrong for every current Community Server release. Qualified by version rather than deleted.

The **plugin lock-in** half of the AES_CTR concern is confirmed and was undocumented: HashiCorp and AWS KMS pass `0` for all five crypt entry points, so the server falls back to a hard-coded `MY_AES_CBC` path (`sql/encryption.cc:46`). Data written under `AES_CTR` is unreadable after switching. That's the same trap as [MDEV-40657](https://jira.mariadb.org/browse/MDEV-40657).

## Checks

`doc-lint.sh` (codespell + lychee + includes) passes. New heading anchors and relative link targets verified by hand, since lychee doesn't check fragments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6412]: https://mariadbcorp.atlassian.net/browse/DOCS-6412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ