### PR TITLE
DOCS-6379 Split connector skills into install and usage

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -68,18 +68,25 @@
       ]
     },
     "granular-connectors": {
-      "$comment": "Tier 1 (connectors) — one skill per client connector, focused on application-development usage (connect, query, params, transactions, pooling, error handling) rather than install/config. Consumed by the AI Plugin (DOCS-6345). baseline_version tracks the connector release line, which is independent of the MariaDB server version.",
+      "$comment": "Tier 1 (connectors) — two skills per client connector, split by task (DOCS-6379): `-install` covers installation, packaging, and configuration; `-usage` covers application-development usage (connect, query, params, transactions, pooling, error handling). Consumed by the AI Plugin (DOCS-6345). baseline_version tracks the connector release line, which is independent of the MariaDB server version.",
       "tier": 1,
       "path": "granular/connectors",
       "author": "docs-team",
       "skills": [
-        { "name": "mariadb-connector-python", "path": "granular/connectors/mariadb-connector-python/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "1.1" },
-        { "name": "mariadb-connector-j", "path": "granular/connectors/mariadb-connector-j/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "3.5" },
-        { "name": "mariadb-connector-nodejs", "path": "granular/connectors/mariadb-connector-nodejs/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "3.5" },
-        { "name": "mariadb-connector-odbc", "path": "granular/connectors/mariadb-connector-odbc/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "3.2" },
-        { "name": "mariadb-connector-r2dbc", "path": "granular/connectors/mariadb-connector-r2dbc/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "1.4" },
-        { "name": "mariadb-connector-cpp", "path": "granular/connectors/mariadb-connector-cpp/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "1.0" },
-        { "name": "mariadb-connector-c", "path": "granular/connectors/mariadb-connector-c/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "3.4" }
+        { "name": "mariadb-connector-python-install", "path": "granular/connectors/mariadb-connector-python-install/SKILL.md", "status": "draft", "last_reviewed": "2026-08-10", "baseline_version": "1.1" },
+        { "name": "mariadb-connector-python-usage", "path": "granular/connectors/mariadb-connector-python-usage/SKILL.md", "status": "pilot", "last_reviewed": "2026-08-10", "baseline_version": "1.1" },
+        { "name": "mariadb-connector-j-install", "path": "granular/connectors/mariadb-connector-j-install/SKILL.md", "status": "draft", "last_reviewed": "2026-08-10", "baseline_version": "3.5" },
+        { "name": "mariadb-connector-j-usage", "path": "granular/connectors/mariadb-connector-j-usage/SKILL.md", "status": "pilot", "last_reviewed": "2026-08-10", "baseline_version": "3.5" },
+        { "name": "mariadb-connector-nodejs-install", "path": "granular/connectors/mariadb-connector-nodejs-install/SKILL.md", "status": "draft", "last_reviewed": "2026-08-10", "baseline_version": "3.5" },
+        { "name": "mariadb-connector-nodejs-usage", "path": "granular/connectors/mariadb-connector-nodejs-usage/SKILL.md", "status": "pilot", "last_reviewed": "2026-08-10", "baseline_version": "3.5" },
+        { "name": "mariadb-connector-odbc-install", "path": "granular/connectors/mariadb-connector-odbc-install/SKILL.md", "status": "draft", "last_reviewed": "2026-08-10", "baseline_version": "3.2" },
+        { "name": "mariadb-connector-odbc-usage", "path": "granular/connectors/mariadb-connector-odbc-usage/SKILL.md", "status": "pilot", "last_reviewed": "2026-08-10", "baseline_version": "3.2" },
+        { "name": "mariadb-connector-r2dbc-install", "path": "granular/connectors/mariadb-connector-r2dbc-install/SKILL.md", "status": "draft", "last_reviewed": "2026-08-10", "baseline_version": "1.4" },
+        { "name": "mariadb-connector-r2dbc-usage", "path": "granular/connectors/mariadb-connector-r2dbc-usage/SKILL.md", "status": "pilot", "last_reviewed": "2026-08-10", "baseline_version": "1.4" },
+        { "name": "mariadb-connector-cpp-install", "path": "granular/connectors/mariadb-connector-cpp-install/SKILL.md", "status": "draft", "last_reviewed": "2026-08-10", "baseline_version": "1.0" },
+        { "name": "mariadb-connector-cpp-usage", "path": "granular/connectors/mariadb-connector-cpp-usage/SKILL.md", "status": "pilot", "last_reviewed": "2026-08-10", "baseline_version": "1.0" },
+        { "name": "mariadb-connector-c-install", "path": "granular/connectors/mariadb-connector-c-install/SKILL.md", "status": "draft", "last_reviewed": "2026-08-10", "baseline_version": "3.4" },
+        { "name": "mariadb-connector-c-usage", "path": "granular/connectors/mariadb-connector-c-usage/SKILL.md", "status": "pilot", "last_reviewed": "2026-08-10", "baseline_version": "3.4" }
       ]
     },
     "topical": {

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -22,7 +22,7 @@ nothing here depends on a submodule fetch or a separate repository.
 | `granular/statements/` | **Tier 1** — one skill per SQL statement family (`mariadb-create-table`, `mariadb-alter-table`, `mariadb-select`, …) | Docs team, hand-curated | Source of truth, here |
 | `granular/functions/` | **Tier 2** — one skill per function category (`mariadb-json-functions`, …); machine-extracted entries wrapped in a hand-written scaffold | Docs team + `extractor/` | Source of truth, here |
 | `granular/tools/` | **Tier 1 (tools)** — one skill per client utility (`mariadb-dump`, `mariadb-import`, …) | Docs team, hand-curated | Source of truth, here |
-| `granular/connectors/` | **Tier 1 (connectors)** — one skill per client connector (`mariadb-connector-python`, …), focused on application-development *usage* rather than install/config | Docs team, hand-curated | Source of truth, here |
+| `granular/connectors/` | **Tier 1 (connectors)** — two skills per client connector, split by task: `…-install` (installation, packaging, configuration) and `…-usage` (application development), e.g. `mariadb-connector-python-install` and `mariadb-connector-python-usage` | Docs team, hand-curated | Source of truth, here |
 | `topical/` | **Topical** — feature-area deep dives (`mariadb-features`, `mariadb-vector`, …) | Robert Silen / MariaDB Foundation | **Vendored** from [`MariaDB/skills`](https://github.com/MariaDB/skills) — see `topical/VENDORED.md`; do not hand-edit |
 
 Each skill is a directory containing a `SKILL.md` (Claude Code skill convention),

--- a/agent-skills/granular/connectors/mariadb-connector-c-install/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-c-install/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: mariadb-connector-c-install
+description: "Installing and configuring MariaDB Connector/C, the C client library the other MariaDB connectors build on — the runtime and development package names per distribution (`libmariadb3`/`libmariadb-dev`, `MariaDB-shared`/`MariaDB-devel`), how to get compile and link flags from `mariadb_config` or pkg-config `libmariadb` rather than hardcoding them, the build-from-source prerequisites, and the configuration side: that the library reads option files only when the application asks for them via `MYSQL_READ_DEFAULT_FILE` or `MYSQL_READ_DEFAULT_GROUP`, which option groups it reads, how `!includedir` and unknown options differ from the server, and which TLS options depend on the library it was built against. Use when installing, building, packaging, or configuring Connector/C."
+---
+
+# MariaDB Connector/C: Installation and Configuration
+
+*Last updated: 2026-08-10*
+
+MariaDB Connector/C is the C client library for MariaDB, and the layer that MariaDB Connector/Python, Connector/C++, and Connector/ODBC are built on. This skill covers installing it, getting an application to compile and link against it, and configuring it through option files and connection options. For calling the API, see **`mariadb-connector-c-usage`**.
+
+> **Default context:** Assume the **3.4** stable line unless the user states otherwise. Options introduced later than the 3.0 baseline carry the release that added them. Connector versions are independent of the MariaDB server version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Installs only the runtime package and then tries to compile | Compiling needs the **development** package as well: `libmariadb-dev` on Debian and Ubuntu, `MariaDB-devel` on RHEL, Rocky Linux, and SLES. The runtime alone (`libmariadb3` / `MariaDB-shared`) has no headers and no `mariadb_config` |
+| Hardcodes `-I/usr/include/mysql -lmysqlclient` | Ask the installed connector instead: **`mariadb_config --cflags --libs`**, or `pkg-config --cflags --libs libmariadb`. The library is **`-lmariadb`**, and the include directory differs per distribution and per build |
+| Expects the library to pick up `/etc/my.cnf` or `~/.my.cnf` automatically | It does **not**. `mysql_real_connect()` reads option files only if the application first called `mysql_optionsv()` with **`MYSQL_READ_DEFAULT_FILE`** or **`MYSQL_READ_DEFAULT_GROUP`**. This is the single most common configuration surprise — the command-line clients read option files because *they* opt in |
+| Assumes only `[client]` is read | Connector/C reads **`[client]`, `[client-server]`, and `[client-mariadb]`**, and a fourth custom group if one is named via `MYSQL_READ_DEFAULT_GROUP`. Precedence follows the order the sections appear in the file, not the order of the group names |
+| Calls `MYSQL_READ_DEFAULT_FILE` twice to read a custom file *and* the defaults | Both options are **exclusive** — a second call replaces the first. Pass the custom path in one call; reading the default files is governed separately by `MYSQL_READ_DEFAULT_GROUP` |
+| Uses `!includedir /etc/my.cnf.d/` expecting every `.cnf` in the directory | Unlike the server, Connector/C reads only **`my.cnf`** (and `my.ini` on Windows) from the named directory. See CONC-396 |
+| Writes `max-allowed-packet=1G` in an option file | Numeric suffixes are **not** parsed. The connector reads the leading digits and silently discards `K`, `M`, or `G` — write the plain byte count |
+| Guards a risky option with the `loose` prefix | Option prefixes have no meaning here. Unknown options are **silently ignored** anyway, so `loose-` is unnecessary and misleading. See CONC-415 |
+| Assumes every `ssl-*` option works everywhere | The available TLS options depend on which library the connector was **built against** — OpenSSL, GnuTLS, or Schannel. `ssl-capath` and `ssl-crlpath` need OpenSSL; `ssl-crl` needs OpenSSL or Schannel; `ssl-passphrase` needs OpenSSL or GnuTLS |
+| Sets `ssl-ca` and considers the connection authenticated | Encryption and identity are separate. Add **`ssl-verify-server-cert`** (`MYSQL_OPT_SSL_VERIFY_SERVER_CERT`) to actually verify the server certificate |
+| Uses a relative path for a certificate or key | The `ssl-ca`, `ssl-capath`, `ssl-cert`, `ssl-key`, `ssl-crl`, and `ssl-crlpath` options all require **absolute** paths |
+| Expects a dropped connection to come back by itself | **`reconnect` defaults to `false`** (`MYSQL_OPT_RECONNECT`). Nothing reconnects unless the application asks |
+| Ships client plugins and expects them to be found | The plugin directory is set with `MYSQL_PLUGIN_DIR`, the `plugin-dir` option, or the **`MARIADB_PLUGIN_DIR`** environment variable. Authentication plugins that are not on that path simply fail to load |
+| Sets `$MYSQL_HOME` on a machine that also has `$MARIADB_HOME` | **`$MARIADB_HOME` wins outright** — when it is set, `$MYSQL_HOME` is ignored entirely rather than merged |
+
+## Installing
+
+### Linux, from the MariaDB package repository
+
+Configure the repository first — `mariadb_repo_setup` for Community Server, `mariadb_es_repo_setup` (with a customer download token) for Enterprise Server. All major releases of a given server line ship the same Connector/C version.
+
+```bash
+# Debian, Ubuntu
+sudo apt install libmariadb3 libmariadb-dev
+
+# CentOS, RHEL, Rocky Linux
+sudo yum install MariaDB-shared MariaDB-devel
+
+# SLES
+sudo zypper install MariaDB-shared MariaDB-devel
+```
+
+Binary tarballs for Linux and an MSI installer for Windows are available from the MariaDB Connector/C download page when the distribution's packages are unsuitable.
+
+### Building from source
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+cmake --build build
+sudo cmake --install build
+```
+
+Prerequisites:
+
+- **Linux and macOS** — gcc 3.4.6 or newer, CMake 3.12.0 or newer, and TLS libraries: OpenSSL 1.0.1+ or GnuTLS 3.4.2+. The remote-io plugin additionally needs Curl; the GSSAPI plugin needs Kerberos V5.
+- **Windows** — Visual Studio 2013 or newer and CMake 3.12.0 or newer.
+
+## Compiling an application against it
+
+```bash
+gcc app.c $(mariadb_config --cflags --libs) -o app
+```
+
+`mariadb_config` also reports `--version`, `--cc_version`, `--socket`, `--port`, and `--plugindir`, which is the reliable way to discover how a given installation was configured. Under pkg-config the module is `libmariadb`. In code, the public header is `mysql.h` and the API is `mysql_`-prefixed — that naming is historical and is what the library actually exports.
+
+## Configuration
+
+### Turning on option files
+
+```c
+MYSQL *mysql = mysql_init(NULL);
+
+/* Read the default option files: /etc/my.cnf, /etc/mysql/my.cnf,
+   $MARIADB_HOME (or $MYSQL_HOME)/my.cnf, ~/.my.cnf */
+mysql_optionsv(mysql, MYSQL_READ_DEFAULT_FILE, NULL);
+
+/* …or one specific file */
+mysql_optionsv(mysql, MYSQL_READ_DEFAULT_FILE, (void *)"/etc/myapp/db.cnf");
+
+/* Read an application-specific group in addition to the standard ones */
+mysql_optionsv(mysql, MYSQL_READ_DEFAULT_GROUP, (void *)"myapp");
+
+mysql_real_connect(mysql, host, user, passwd, db, 0, NULL, 0);
+```
+
+Without at least one of those two calls, every setting must be passed programmatically.
+
+An option file for the above might read:
+
+```ini
+[client]
+port=3306
+socket=/var/run/mysqld/mysqld.sock
+
+[client-mariadb]
+ssl-ca=/etc/ssl/certs/ca.pem
+ssl-verify-server-cert
+
+[myapp]
+default-character-set=utf8mb4
+connect-timeout=10
+```
+
+Dashes and underscores in option names are interchangeable in Connector/C 3.1.1 and later.
+
+### Options worth setting deliberately
+
+| Option | `mysql_optionsv` name | Note |
+|---|---|---|
+| `connect-timeout` | `MYSQL_OPT_CONNECT_TIMEOUT` | Seconds; no default, so a dead host blocks until the OS gives up |
+| `default-character-set` | `MYSQL_SET_CHARSET_NAME` | Set it explicitly rather than inheriting the build default |
+| `local-infile` | `MYSQL_OPT_LOCAL_INFILE` | Defaults to `false`; `LOAD DATA LOCAL INFILE` fails until enabled on both ends |
+| `max-allowed-packet` | `MYSQL_OPT_MAX_ALLOWED_PACKET` | 16 MB default, 1 GB ceiling, plain integers only |
+| `multi-statements` | `MARIADB_OPT_MULTI_STATEMENTS` | Off by default; also implies multi-results |
+| `init-command` | `MYSQL_INIT_COMMAND` | **Multi-element** — each occurrence across option files appends rather than replaces, and all of them run on every connect and reconnect |
+| `tls_version` | `MARIADB_OPT_TLS_VERSION` | Comma-separated allow-list, `TLSv1.0` through `TLSv1.3` (3.0.4+) |
+| `ssl-fp`, `ssl-fp-list` | `MARIADB_OPT_SSL_FP` | Certificate fingerprint pinning; SHA1 only before 3.4.0, SHA256/384/512 from 3.4.0 |
+
+MySQL's obfuscated `.mylogin.cnf` credential file is not supported.
+
+### Checking what a configuration resolves to
+
+`my_print_defaults` reads the same files and groups and prints the result, which settles most "why is it still connecting to the wrong socket" questions:
+
+```bash
+my_print_defaults myapp client client-server client-mariadb
+```
+
+## See Also
+
+- **`mariadb-connector-c-usage`** — using the API once it is installed: connecting, prepared statements, transactions, result handling
+- **`mariadb-connector-python-install`**, **`mariadb-connector-cpp-install`**, **`mariadb-connector-odbc-install`** — connectors that depend on this library
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-c>

--- a/agent-skills/granular/connectors/mariadb-connector-c-usage/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-c-usage/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: mariadb-connector-c
+name: mariadb-connector-c-usage
 description: "MariaDB-specific behavior of MariaDB Connector/C (the `libmariadb` client library implementing the MariaDB client-server protocol in C) for application code — that the public API is still `mysql_`-prefixed (`mysql_init`, `mysql_real_connect`, `mysql_query`, ...) with only a few `mariadb_`-prefixed extensions; that `mysql_init()` must precede `mysql_real_connect()`, with `mysql_optionsv()` options set in between; the buffered-vs-unbuffered split between `mysql_store_result()` and `mysql_use_result()` plus the mandatory `mysql_free_result()`; that literals need `mysql_real_escape_string()` when not using prepared statements; the `?`-placeholder prepared-statement API (`MYSQL_BIND` arrays, `mysql_stmt_bind_param`/`execute`/`fetch`); and that autocommit is ON by default so transactions need `mysql_autocommit(conn,0)`. Use when writing or reviewing C code that talks to MariaDB via Connector/C (`libmariadb`)."
 ---
 
 # MariaDB Connector/C
 
-*Last updated: 2026-07-21*
+*Last updated: 2026-08-10*
 
-MariaDB Connector/C is the LGPL-licensed C client library (`libmariadb`) implementing the MariaDB/MySQL client-server protocol. It is the foundation other MariaDB connectors build on — Connector/Python's C extension, Connector/ODBC, and Connector/C++ all link against it — and it is API-compatible with the classic MySQL C client library, so `mysql.h` and the `mysql_*` function names carry over directly. This skill covers the connector-specific behavior and the traps that bite generated application code; it does not cover installing the library or configuring the server.
+MariaDB Connector/C is the LGPL-licensed C client library (`libmariadb`) implementing the MariaDB/MySQL client-server protocol. It is the foundation other MariaDB connectors build on — Connector/Python's C extension, Connector/ODBC, and Connector/C++ all link against it — and it is API-compatible with the classic MySQL C client library, so `mysql.h` and the `mysql_*` function names carry over directly. This skill covers the connector-specific behavior and the traps that bite generated application code. For installing the library, compiling against it, and configuring it through option files, see **`mariadb-connector-c-install`**.
 
 > **Default context:** Assume the **3.4** stable release series (GA February 2025; `mariadb_config --cc_version` reports the exact patch, e.g. `3.4.10`) unless the user states otherwise. Connector/C is compatible with all MariaDB and MySQL server versions — its version is independent of the server version it connects to, and behavior below applies across the 3.x line unless annotated.
 
@@ -28,6 +28,10 @@ MariaDB Connector/C is the LGPL-licensed C client library (`libmariadb`) impleme
 | Reads only the first result after `CALL`ing a stored procedure or a multi-statement query | Stored-procedure calls and multi-statement queries (`MARIADB_OPT_MULTI_STATEMENTS`) can return **multiple result sets** — loop with **`mysql_next_result()`** (or `mysql_stmt_next_result()` for prepared statements), calling `mysql_store_result()`/`mysql_use_result()` + `mysql_free_result()` each time, until no more results remain |
 | Passes `-1` as a length to `mysql_real_query()` or `mysql_real_escape_string()`, expecting auto-detection everywhere | Only **`mysql_stmt_prepare()`** treats `length == (unsigned long)-1` as "compute via `strlen()`". The binary-safe functions (`mysql_real_query()`, `mysql_real_escape_string()`) need the **actual** byte length — passing `-1` there is a bug, not a shortcut |
 | Calls `mysql_close()` while `MYSQL_STMT`/`MYSQL_RES` handles from that connection are still open | Free every result with `mysql_free_result()` and close every prepared statement with `mysql_stmt_close()` **before** `mysql_close()` on the connection |
+| Uses one `MYSQL` handle from several threads, or spawns threads without initializing them | A `MYSQL` handle is **not** thread-safe: one connection per thread. Each thread that uses the library must call **`mysql_thread_init()`** on entry and **`mysql_thread_end()`** on exit; the process should call `mysql_library_init()` before the first connection and `mysql_library_end()` at shutdown |
+| Loops `mysql_stmt_execute()` once per row for a bulk insert | Bind arrays instead: set **`STMT_ATTR_ARRAY_SIZE`** with `mysql_stmt_attr_set()` and point each `MYSQL_BIND` at an array of values, then execute **once**. This is a MariaDB extension and collapses the round trips |
+| Prepares a statement it will execute exactly once | **`mariadb_stmt_execute_direct()`** prepares and executes in a single round trip — the right call for one-shot parameterized statements |
+| Treats a `NULL` from `mysql_store_result()` as "no rows" | It means either "no result set" or "an error occurred". Distinguish with **`mysql_field_count()`**: zero means the statement genuinely returned no result set, non-zero means the fetch failed and `mysql_error()` has the reason |
 
 ## Connect, Prepared Statement, and Transaction
 
@@ -97,10 +101,61 @@ else
 mysql_close(conn);
 ```
 
+## Bulk insert with array binding
+
+`STMT_ATTR_ARRAY_SIZE` turns a single prepared statement into a multi-row insert — one execute, one round trip:
+
+```c
+enum { ROWS = 3 };
+unsigned int  ids[ROWS]  = { 1, 2, 3 };
+char         *names[ROWS] = { "widget", "gadget", "doohickey" };
+unsigned long lens[ROWS];
+size_t        i;
+
+for (i = 0; i < ROWS; i++)
+    lens[i] = strlen(names[i]);
+
+MYSQL_STMT *stmt = mysql_stmt_init(conn);
+const char *sql = "INSERT INTO t (id, name) VALUES (?, ?)";
+mysql_stmt_prepare(stmt, sql, strlen(sql));
+
+MYSQL_BIND bind[2];
+memset(bind, 0, sizeof(bind));
+bind[0].buffer_type = MYSQL_TYPE_LONG;
+bind[0].buffer      = ids;
+bind[1].buffer_type = MYSQL_TYPE_STRING;
+bind[1].buffer      = names;
+bind[1].length      = lens;
+
+size_t array_size = ROWS;
+mysql_stmt_attr_set(stmt, STMT_ATTR_ARRAY_SIZE, &array_size);
+mysql_stmt_bind_param(stmt, bind);
+mysql_stmt_execute(stmt);        /* all three rows, one execution */
+mysql_stmt_close(stmt);
+```
+
+## Threading
+
+```c
+mysql_library_init(0, NULL, NULL);      /* once, before any connection */
+
+/* …in each worker thread: */
+mysql_thread_init();
+MYSQL *conn = mysql_init(NULL);         /* one connection per thread */
+/* … */
+mysql_close(conn);
+mysql_thread_end();
+
+mysql_library_end();                    /* once, at shutdown */
+```
+
+Sharing a single `MYSQL` handle across threads corrupts the protocol state rather than merely serializing badly, so a pool of per-thread connections is the only safe arrangement.
+
 ## See Also
 
-- **`mariadb-connector-python`** — the `mariadb` module's C extension links against this library
-- **`mariadb-connector-odbc`** / **`mariadb-connector-cpp`** — also built on top of Connector/C
+- **`mariadb-connector-c-install`** — installing the library, compiling against it, and configuring it through option files and TLS options
+- **`mariadb-connector-python-usage`** — the `mariadb` module's C extension links against this library
+- **`mariadb-connector-odbc-usage`** / **`mariadb-connector-cpp-usage`** — also built on top of Connector/C
 - **`mariadb-transactions`** — the server-side semantics behind `mysql_commit()`/`mysql_rollback()`
 - **`mariadb-prepare`** — server-side prepared statements, what the `MYSQL_STMT` API drives
 - Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-c>

--- a/agent-skills/granular/connectors/mariadb-connector-cpp-install/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-cpp-install/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: mariadb-connector-cpp-install
+description: "Installing and configuring MariaDB Connector/C++ — that MariaDB Connector/C is a hard prerequisite on Linux and must be installed first (3.1.1 or later for Connector/C++ 1.0, 3.3.3 or later for 1.1), while the Windows MSI brings it along; that Connector/C++ is downloaded per platform rather than pulled from the server package repository; that the binary tarball install is manual and easy to leave half-done, with the authentication plugin directory the piece most often missed; that the library is `-lmariadbcpp` and the public header is `mariadb/conncpp.hpp`; and that the build requires C++11. Use when installing, building, packaging, linking, or troubleshooting the setup of MariaDB Connector/C++."
+---
+
+# MariaDB Connector/C++: Installation and Configuration
+
+*Last updated: 2026-08-10*
+
+MariaDB Connector/C++ is the C++ client library for MariaDB, layered on top of MariaDB Connector/C. This skill covers installing it, satisfying its dependency, and getting an application to compile, link, and find its plugins at runtime. For the API itself, see **`mariadb-connector-cpp-usage`**.
+
+> **Default context:** Assume the **1.0** stable line unless the user states otherwise. Where the 1.1 line differs, it is called out. Connector versions are independent of the MariaDB server version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Installs Connector/C++ on Linux and expects it to work | **MariaDB Connector/C is a hard prerequisite** and must be installed first. Connector/C++ **1.0** needs Connector/C **3.1.1 or later**; **1.1** needs **3.3.3 or later**. On Windows the MSI installs Connector/C for you |
+| Reaches for `apt install mariadb-connector-cpp` or `dnf install` from the MariaDB repository | Connector/C++ is **not** part of the server package repository. Download the `.deb`, `.rpm`, tarball, or MSI for the platform from the MariaDB Connector/C++ download page, then install the downloaded file — note the leading `./` on Debian: `sudo apt install ./mariadb-connector-cpp-*.deb` |
+| Installs from the binary tarball by copying `libmariadbcpp.so` and stopping | The tarball install is manual and has more parts than the library: the **headers** (`include/mariadb/`, including the `conncpp/` and `conncpp/compat/` subdirectories) and, most easily forgotten, the **plugin directory** (`lib/mariadb/plugin/`). Skip the plugins and the library builds and links fine, then fails at run time on authentication |
+| Uses `/usr/lib` on an RPM distribution | Path layout differs: **`/usr/lib64`** and `/usr/lib64/mariadb/plugin` on CentOS, RHEL, and Rocky Linux; **`/usr/lib`** and `/usr/lib/mariadb/plugin` on Debian and Ubuntu |
+| Links `-lmariadbcpp` but includes a Connector/C header | The public C++ header is **`mariadb/conncpp.hpp`**; the library is **`mariadbcpp`**. Including `mysql.h` pulls in the C API instead, and mixing the two in one translation unit is not the intended usage |
+| Compiles with a pre-C++11 standard, or with `-std=c++98` inherited from an old project | The connector is built as **C++11** and its headers require it. Compile the application with `-std=c++11` or later |
+| Installs on Windows and expects the loader to find the DLL | Add the directory containing the `mariadbcpp` library (for example `C:\Program Files\MariaDB\MariaDB C++ Connector 64-bit`) to the **`PATH`** environment variable |
+| Assumes the connector reads `my.cnf` on its own | Configuration reaches the connector through **connection properties** and through Connector/C underneath it — nothing is read from an option file unless that is arranged at the Connector/C level |
+| Treats the plugin directory as optional when packaging a container image | It is part of the deployable. Ship `mariadb/plugin/` alongside the library, or point the connector at it, or authentication plugins the server asks for will not load |
+| Pins Connector/C++ to the MariaDB server version | There is no such correspondence. Pin Connector/C++ and Connector/C to each other using the compatibility rule above, independently of the server |
+
+## Installing
+
+### Linux, from RPM or DEB packages
+
+Install Connector/C first, then the downloaded Connector/C++ package:
+
+```bash
+# Prerequisite (from the MariaDB package repository)
+sudo apt install libmariadb3 libmariadb-dev      # Debian, Ubuntu
+sudo dnf install MariaDB-shared MariaDB-devel    # RHEL, Rocky Linux
+
+# Connector/C++, from the file downloaded for this distribution
+sudo dnf install mariadb-connector-cpp-*.rpm     # RPM-based
+sudo apt install ./mariadb-connector-cpp-*.deb   # Debian-based
+```
+
+### Linux, from the binary tarball
+
+All four groups of files matter — headers, the compatibility headers, the library, and the plugins:
+
+```bash
+tar -xvzf mariadb-connector-cpp-*.tar.gz
+cd mariadb-connector-cpp-*/
+
+sudo install -d /usr/include/mariadb/conncpp /usr/include/mariadb/conncpp/compat
+sudo install include/mariadb/*                /usr/include/mariadb/
+sudo install include/mariadb/conncpp/*        /usr/include/mariadb/conncpp
+sudo install include/mariadb/conncpp/compat/* /usr/include/mariadb/conncpp/compat
+
+# RPM-based distributions use lib64; Debian-based use lib
+sudo install -d /usr/lib64/mariadb/plugin
+sudo install lib/mariadb/libmariadbcpp.so /usr/lib64
+sudo install lib/mariadb/plugin/*         /usr/lib64/mariadb/plugin
+```
+
+### Windows, from the MSI
+
+The MSI installs Connector/C as part of the same run. Afterwards, add the installation directory to `PATH` so the loader can resolve `mariadbcpp` at run time.
+
+### Building from source
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+cmake --build build
+sudo cmake --install build
+```
+
+CMake 3.10 or newer is required, and the build targets C++11. If a `libmariadb` subdirectory is present the build uses it and installs that Connector/C alongside; otherwise it links against the Connector/C already installed on the system.
+
+## Compiling an application against it
+
+```bash
+g++ -std=c++11 app.cpp -lmariadbcpp -o app
+```
+
+```cpp
+#include <mariadb/conncpp.hpp>
+```
+
+If the headers landed somewhere other than `/usr/include`, add the corresponding `-I`; if the library did, add `-L` and make sure the runtime linker can find it (`ldconfig`, `LD_LIBRARY_PATH`, or an rpath).
+
+## Configuration
+
+Connection settings are supplied as properties when the driver creates a connection, rather than through a configuration file the library discovers on its own:
+
+```cpp
+sql::Driver* driver = sql::mariadb::get_driver_instance();
+
+// Properties is taken by non-const reference, so it needs to be a named object
+sql::Properties properties({
+    {"user", "app"},
+    {"password", "secret"},
+    {"useTls", "true"},
+    {"tlsCA", "/etc/ssl/certs/ca.pem"},
+});
+
+std::unique_ptr<sql::Connection> conn(
+    driver->connect("jdbc:mariadb://localhost:3306/appdb", properties));
+```
+
+Because the transport underneath is Connector/C, the TLS behavior — and which TLS options are honored — follows whatever TLS library that Connector/C was built against. See **`mariadb-connector-c-install`** for that side of the configuration, including option files and certificate handling.
+
+## Verifying the install
+
+```cpp
+std::unique_ptr<sql::Statement> stmt(conn->createStatement());
+std::unique_ptr<sql::ResultSet> res(stmt->executeQuery("SELECT VERSION()"));
+res->next();
+std::cout << res->getString(1) << std::endl;   // columns are 1-based
+```
+
+A link error points at `-lmariadbcpp` or the library path; a load error at run time points at `PATH` (Windows) or the runtime linker path (Linux); an authentication failure right after connecting usually points at the missing plugin directory.
+
+## See Also
+
+- **`mariadb-connector-cpp-usage`** — using the API once it is installed: statements, result sets, transactions, batches
+- **`mariadb-connector-c-install`** — installing and configuring the required underlying C client library
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-cpp>

--- a/agent-skills/granular/connectors/mariadb-connector-cpp-usage/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-cpp-usage/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: mariadb-connector-cpp
+name: mariadb-connector-cpp-usage
 description: "MariaDB-specific behavior of MariaDB Connector/C++ (the `sql::` namespace API, modeled on JDBC 4.0) for application code — that a driver comes from `sql::mariadb::get_driver_instance()` and connections from `driver->connect(url, props)`, returning a raw `Connection*` you must own; that the URL is `jdbc:mariadb://host:port/database[?opt=val]`; that `PreparedStatement` parameter indexes and `ResultSet` column indexes are 1-based, not 0-based; that `?` is the only placeholder; that `ResultSet::next()` must be called before the first read; that the API returns raw pointers with no automatic cleanup — wrap them in `std::unique_ptr` or `close()` explicitly, child before parent; that `sql::SQLString` is the parameter/return type throughout; that autocommit defaults to true; that errors surface as `sql::SQLException`; and that it is built on Connector/C. Use when writing or reviewing C++ code that talks to MariaDB via Connector/C++ (the `sql::` API)."
 ---
 
 # MariaDB Connector/C++
 
-*Last updated: 2026-07-21*
+*Last updated: 2026-08-10*
 
-MariaDB Connector/C++ is the official C++ driver for MariaDB, exposing an API modeled on the **JDBC 4.0** object model (`sql::Driver`, `sql::Connection`, `sql::Statement`, `sql::PreparedStatement`, `sql::ResultSet` — the same shapes as MariaDB Connector/J) rather than a procedural C-style API. This skill covers the connector-specific behavior and the traps that bite generated application code; it does not cover installing the library or configuring the server. It is **built on top of MariaDB Connector/C** (`libmariadb`) for the wire protocol, but application code talks only to the `sql::` classes, never to `mysql_*` calls directly.
+MariaDB Connector/C++ is the official C++ driver for MariaDB, exposing an API modeled on the **JDBC 4.0** object model (`sql::Driver`, `sql::Connection`, `sql::Statement`, `sql::PreparedStatement`, `sql::ResultSet` — the same shapes as MariaDB Connector/J) rather than a procedural C-style API. This skill covers the connector-specific behavior and the traps that bite generated application code. For installing the library, linking against it, and configuring the connection, see **`mariadb-connector-cpp-install`**. It is **built on top of MariaDB Connector/C** (`libmariadb`) for the wire protocol, but application code talks only to the `sql::` classes, never to `mysql_*` calls directly.
 
 > **Default context:** Assume the **cpp-1.0** line (`CMakeLists.txt` reports `MACPP_VERSION "1.00.0008"`, i.e. 1.0.8) unless the user states otherwise. Connector/C++ is compatible with current MariaDB and MySQL servers — its version is independent of the server version it connects to.
 
@@ -27,6 +27,10 @@ MariaDB Connector/C++ is the official C++ driver for MariaDB, exposing an API mo
 | Expects server-side prepared statements or a statement cache by default | **Client-side prepared statements are the default** (`useServerPrepStmts=false`); set it `true` to use server-side `PREPARE`/`EXECUTE`. Don't set `cachePrepStmts=true` — on this connector line it throws `sql::SQLFeatureNotImplementedException("Callable/Prepared statement caches are not supported yet")` at connect time |
 | Loops `executeUpdate()` for bulk insert | Use `PreparedStatement::addBatch()` + `executeBatch()`/`executeLargeBatch()`; the `rewriteBatchedStatements` and `useBulkStmts` connection options further optimize batched `INSERT`s (the two are mutually exclusive — `rewriteBatchedStatements` wins if both are set) |
 | Wants the last auto-increment value or a `ResultSetMetaData`/schema introspection call | `Statement::getGeneratedKeys()` returns a `ResultSet` of generated keys after an insert; `ResultSet::getMetaData()` gives column info (`ResultSetMetaData`); `Connection::getMetaData()` gives database/schema info (`DatabaseMetaData`) |
+| Treats a `0` from `getInt()` or an empty string from `getString()` as the stored value | A SQL `NULL` reads back as the type's zero value. Call **`ResultSet::wasNull()`** immediately after the `getXxx()` to tell a real `0` from a `NULL` |
+| Calls a stored procedure by building `CALL …` text | Use **`Connection::prepareCall()`**, which returns a `sql::CallableStatement`. It binds `IN` parameters like a `PreparedStatement` and additionally registers and reads `OUT` parameters |
+| Sets an isolation level by executing `SET TRANSACTION …` | **`Connection::setTransactionIsolation()`** takes the level directly, and `getTransactionIsolation()` reads it back |
+| Rolls back a whole transaction to undo one step | `Connection::setSavepoint()` returns a `sql::Savepoint`; `rollback(savepoint)` unwinds to that point and leaves the rest of the transaction intact |
 | Shares one `Connection`/`Statement`/`ResultSet` across threads without synchronization | `get_driver_instance()` returns a **process-wide singleton** and is safe to call from multiple threads to obtain independent connections, but individual `Connection`/`Statement`/`ResultSet` objects are not documented as safe for concurrent multi-threaded use — give each thread (or task) its own connection |
 
 ## Connect, prepare, iterate, and transact
@@ -92,9 +96,36 @@ int main() {
 }
 ```
 
+## Batching
+
+```c++
+std::unique_ptr<sql::PreparedStatement> stmt(
+    conn->prepareStatement("INSERT INTO t (name, qty) VALUES (?, ?)"));
+
+for (const auto& row : rows) {
+  stmt->setString(1, row.name);
+  stmt->setInt(2, row.qty);
+  stmt->addBatch();                 // no argument on a PreparedStatement
+}
+
+const sql::Ints& counts = stmt->executeBatch();
+```
+
+`Statement::addBatch(sql)` takes a statement string instead, for batching unrelated statements. A failure part-way through surfaces as `sql::BatchUpdateException`, which carries the per-statement counts recorded before the failure.
+
+## Reading NULLs
+
+```c++
+int32_t qty = res->getInt("qty");
+if (res->wasNull()) {
+  // the column was SQL NULL, not the integer 0
+}
+```
+
 ## See Also
 
-- **`mariadb-connector-c`** — the underlying C client library (`libmariadb`) this driver is built on
+- **`mariadb-connector-cpp-install`** — installing the library, its Connector/C prerequisite, linking, and connection properties
+- **`mariadb-connector-c-usage`** — the underlying C client library (`libmariadb`) this driver is built on
 - **`mariadb-transactions`** — the server-side semantics behind `commit()`/`rollback()` and isolation levels set via `setTransactionIsolation()`
 - **`mariadb-prepare`** — server-side prepared statements, what `useServerPrepStmts=true` uses under the hood
 - Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-cpp>

--- a/agent-skills/granular/connectors/mariadb-connector-j-install/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-j-install/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: mariadb-connector-j-install
+description: "Installing and configuring MariaDB Connector/J, the JDBC driver for MariaDB — the Maven and Gradle coordinates `org.mariadb.jdbc:mariadb-java-client`, the driver class `org.mariadb.jdbc.Driver`, and the Java version each release series supports; that the 3.x lines accept only the `jdbc:mariadb:` URL scheme unless `permitMysqlScheme` is set; that JNA is not a transitive dependency and must be added by the application before Unix domain sockets or Windows named pipes will work; and the TLS configuration, where `sslMode` defaults to disabled so encryption has to be requested explicitly, then tuned with `serverSslCert`, truststores, and keystores. Use when adding the driver to a build, wiring a datasource, or configuring TLS."
+---
+
+# MariaDB Connector/J: Installation and Configuration
+
+*Last updated: 2026-08-10*
+
+MariaDB Connector/J is the Type 4 JDBC driver for MariaDB, written in pure Java with no dependency on MariaDB Connector/C. This skill covers adding it to a build, configuring the connection URL and datasource, and setting up TLS. For writing JDBC code against it, see **`mariadb-connector-j-usage`**.
+
+> **Default context:** Assume the **3.5** stable line unless the user states otherwise. Connector versions are independent of the MariaDB server version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Guesses the coordinates from the product name (`mariadb-connector-j`, `mariadb-jdbc`) | The artifact is **`org.mariadb.jdbc:mariadb-java-client`** and the driver class is **`org.mariadb.jdbc.Driver`**. Nothing else registers the `jdbc:mariadb:` scheme |
+| Writes a `jdbc:mysql://` URL | From **3.0** onward only **`jdbc:mariadb:`** is accepted by default. `jdbc:mysql:` works only when the **`permitMysqlScheme`** option is present in the URL — and using `jdbc:mariadb:` is what guarantees this driver is chosen when several drivers are on the classpath |
+| Configures a Unix domain socket or a Windows named pipe and gets a `ClassNotFoundException` | **JNA is not pulled in transitively.** Those transports use `com.sun.jna`, so the application must add **`net.java.dev.jna:jna`** and **`net.java.dev.jna:jna-platform`** (4.2.1 or later) itself. TCP connections need neither |
+| Sets `serverSslCert` and assumes the connection is now encrypted | It is not. **`sslMode` defaults to `disable`** — the certificate option alone changes nothing. TLS starts only when `sslMode` is set to `trust`, `verify-ca`, or `verify-full` (the exception: a credential plugin that requires TLS forces `verify-full`) |
+| Reaches for `useSsl=true` / `trustServerCertificate=true` on a 3.x driver | Those are the 2.x spellings. Since 3.0 the single option is **`sslMode`**, with values `disable`, `trust`, `verify-ca`, `verify-full`; `sslMode=true` and `sslMode=1` are aliases for `verify-full` |
+| Uses `sslMode=trust` in production because it "makes TLS work" | `trust` encrypts but verifies nothing, so it defends against passive eavesdropping only. Use it to prove the server has TLS enabled, then move to **`verify-full`** |
+| Assumes a certificate must be a file on disk | `serverSslCert` accepts three forms: a **full file path**, a **`classpath:`-relative path**, or the **certificate text inline**. The last is what makes a certificate deployable through configuration alone |
+| Ships a custom truststore and expects the public CAs to stop working | The connector falls back to the JVM's default truststore when `serverSslCert` does not resolve. Set **`fallbackToSystemTrustStore=false`** to make trust exclusive |
+| Targets a Java version the chosen release series does not cover | **3.5, 3.4, and 3.3 run on Java 8, 11, 17, 21, and 25.** Pick the release series from the Java version, not the other way round |
+| Recommends the 2.7 line for a Java 8 project | Unnecessary — the current 3.x lines still support Java 8, and 2.7 is a legacy series. Start new work on **3.5** |
+| Registers the driver with `Class.forName(...)` because that is the JDBC habit | Service loading handles it: `DriverManager.getConnection("jdbc:mariadb://…")` is enough. `Class.forName("org.mariadb.jdbc.Driver")` still works but is redundant |
+| Reaches for an external pool without setting the driver class | With HikariCP or similar, set `driverClassName` to **`org.mariadb.jdbc.Driver`**. The driver also ships its own pool, `MariaDbPoolDataSource`, whereas `MariaDbDataSource` opens a fresh connection on every `getConnection()` |
+
+## Installing
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>org.mariadb.jdbc</groupId>
+    <artifactId>mariadb-java-client</artifactId>
+    <version>3.5.9</version>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+implementation 'org.mariadb.jdbc:mariadb-java-client:3.5.9'
+```
+
+### Optional dependencies
+
+Add these only for the features that need them:
+
+```xml
+<!-- Unix domain sockets and Windows named pipes: JNA 4.2.1 or later -->
+<dependency>
+    <groupId>net.java.dev.jna</groupId>
+    <artifactId>jna</artifactId>
+    <version>$JNA_VERSION</version>
+</dependency>
+<dependency>
+    <groupId>net.java.dev.jna</groupId>
+    <artifactId>jna-platform</artifactId>
+    <version>$JNA_VERSION</version>
+</dependency>
+```
+
+### Manual JAR, and building from source
+
+The `.jar` can be placed on the `CLASSPATH` directly, though a build tool is the better option. To build:
+
+```bash
+git clone https://github.com/MariaDB/mariadb-connector-j.git
+cd mariadb-connector-j
+mvn -Dmaven.test.skip=true package     # result: target/mariadb-java-client-x.y.z.jar
+```
+
+Building with the tests enabled (`mvn package`) needs a MariaDB or MySQL server listening on `localhost:3306`, a database named `testj`, and a `root` account with an empty password.
+
+## Configuration
+
+### Connection URL
+
+```
+jdbc:mariadb://host:port/database?option1=value1&option2=value2
+```
+
+```java
+Connection conn = DriverManager.getConnection(
+    "jdbc:mariadb://localhost:3306/appdb?user=app&password=secret&sslMode=verify-full");
+```
+
+Options can equally be passed as a `Properties` object, which keeps credentials out of a URL that might end up in a log.
+
+### TLS
+
+```java
+// Step 1 — confirm the server offers TLS at all (encrypts, verifies nothing)
+"jdbc:mariadb://localhost/appdb?user=app&password=secret&sslMode=trust"
+
+// Step 2 — the production setting
+"jdbc:mariadb://localhost/appdb?user=app&password=secret"
+  + "&sslMode=verify-full&serverSslCert=/etc/ssl/certs/ca.pem"
+```
+
+| Option | Effect |
+|---|---|
+| `sslMode` | `disable` (default), `trust`, `verify-ca`, `verify-full` |
+| `serverSslCert` | Server or CA certificate: file path, `classpath:…`, or the certificate text inline |
+| `trustStore`, `trustStorePassword`, `trustStoreType` | Use a Java truststore instead of a single certificate |
+| `keyStore`, `keyStorePassword`, `keyPassword`, `keyStoreType` | Client certificate for mutual TLS |
+| `fallbackToSystemTrustStore` | `false` stops the fallback to the JVM's default CA set |
+| `disableSslHostnameVerification` | Legacy spelling; prefer `sslMode=verify-ca` |
+
+If the server's certificate chains to a well-known public CA already in the JVM truststore, `sslMode=verify-full` on its own is enough — no certificate option required.
+
+### Pooling
+
+```java
+MariaDbPoolDataSource ds = new MariaDbPoolDataSource(
+    "jdbc:mariadb://localhost:3306/appdb?user=app&password=secret&maxPoolSize=20");
+```
+
+The built-in pool cleans connection state on release and drops connections that have gone idle, which avoids the classic failure of handing out a connection the server has already closed at `wait_timeout`. With an external pool, configure `org.mariadb.jdbc.Driver` as the driver class and let that pool own the lifecycle.
+
+## See Also
+
+- **`mariadb-connector-j-usage`** — using the driver once it is on the classpath: statements, batches, generated keys, streaming, transactions
+- **`mariadb-connector-r2dbc-install`** — the reactive alternative for non-blocking applications
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-j>

--- a/agent-skills/granular/connectors/mariadb-connector-j-usage/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-j-usage/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: mariadb-connector-j
+name: mariadb-connector-j-usage
 description: "MariaDB-specific behavior of MariaDB Connector/J (the `org.mariadb.jdbc:mariadb-java-client` JDBC driver) for application code — that JDBC 4 auto-registers the driver so `Class.forName` is unneeded; that the URL scheme is `jdbc:mariadb://host:port/db?opts` (`jdbc:mysql:` needs `permitMysqlScheme`); that `useServerPrepStmts` defaults to false, so `PreparedStatement` substitutes parameters client-side; that batched INSERTs use the `COM_STMT_BULK` protocol by default and `getGeneratedKeys()` then returns all generated ids, one per row, not a single id; that `autocommit` defaults to true so transactions need `setAutoCommit(false)`; that `setFetchSize(Integer.MIN_VALUE)` throws (fetch size must be >= 0); that pooling should use `MariaDbPoolDataSource` or an external pool; and that failover uses multi-host URLs, not driver code. Use when writing or reviewing Java code that talks to MariaDB with the `mariadb-java-client` JDBC driver."
 ---
 
 # MariaDB Connector/J
 
-*Last updated: 2026-07-21*
+*Last updated: 2026-08-10*
 
-MariaDB Connector/J is the official JDBC driver for MariaDB and MySQL — Maven coordinates `org.mariadb.jdbc:mariadb-java-client`, LGPL-licensed. This skill covers the connector-specific behavior and the traps that bite generated application code. It is **pure Java** — it implements the client/server protocol itself and does **not** depend on MariaDB Connector/C (unlike Connector/Python or Connector/ODBC).
+MariaDB Connector/J is the official JDBC driver for MariaDB and MySQL — Maven coordinates `org.mariadb.jdbc:mariadb-java-client`, LGPL-licensed. This skill covers the connector-specific behavior and the traps that bite generated application code. For adding the driver to a build and configuring the URL, TLS, and pooling, see **`mariadb-connector-j-install`**. It is **pure Java** — it implements the client/server protocol itself and does **not** depend on MariaDB Connector/C (unlike Connector/Python or Connector/ODBC).
 
 > **Default context:** Assume the **3.5.x** line (current release `3.5.10`) unless the user states otherwise. Connector versions are independent of the MariaDB server version — a 3.x connector routinely talks to a 10.6/10.11/11.x server.
 
@@ -25,7 +25,10 @@ MariaDB Connector/J is the official JDBC driver for MariaDB and MySQL — Maven 
 | Streams a huge `ResultSet` with `setFetchSize(Integer.MIN_VALUE)` | **Throws `SQLException`** — MariaDB Connector/J requires `rows >= 0`. Use a **positive** value, e.g. `stmt.setFetchSize(1000)`, on a `TYPE_FORWARD_ONLY` statement to stream row-by-row. Even then, the fetch size is capped internally (16384) and **the server still sends all rows** to the client socket — running another statement on the same connection before the stream is fully read pulls the remainder into memory (OOM risk); use a separate connection for concurrent work |
 | Hand-rolls a pool, or opens a new `Connection` per request | Use **`MariaDbPoolDataSource`** (internal pool: `maxPoolSize` default **8**, `minPoolSize` defaults to `maxPoolSize`, `maxIdleTime` default **600s**) or wrap the plain `MariaDbDataSource`/driver URL with an external pool (HikariCP). `connection.close()` on a pooled connection returns it to the pool — it doesn't disconnect — and resets autocommit, isolation level, and any active transaction (rolled back) |
 | Builds a custom failover/round-robin loop over multiple hosts | Multi-host URLs are native: **`jdbc:mariadb:sequential://host1,host2,host3/db`** (also `replication:`, `loadbalance:`, `load-balance-read:` prefixes) — comma-separate hosts in one URL instead of driver-side retry code |
-| Enables TLS with `useSSL=true&verifyServerCertificate=true` (other-driver naming) | Use **`sslMode`**: `disable` (default) / `trust` / `verify-ca` / `verify-full`. Certificate/key material via `serverSslCert`, `trustStore`/`trustStorePassword`, `keyStore`/`keyStorePassword` — not `verifyServerCertificate` |
+| Enables TLS with `useSSL=true&verifyServerCertificate=true` (other-driver naming) | Since 3.0 the option is **`sslMode`**: `disable` (the default) / `trust` / `verify-ca` / `verify-full`. Certificate and key material is configuration — see **`mariadb-connector-j-install`** |
+| Calls a stored procedure with `prepareStatement("CALL …")` and reads `OUT` parameters from a result set | Use **`CallableStatement`** from `conn.prepareCall("{call proc(?, ?)}")`, register `OUT` parameters with `registerOutParameter()`, and read them from the statement after `execute()` |
+| Assumes `executeUpdate()` returns a `long` for very large row counts | It returns `int`. For counts beyond `Integer.MAX_VALUE` use **`executeLargeUpdate()`** / **`executeLargeBatch()`** |
+| Leaves an isolation level to a `SET TRANSACTION` statement | `conn.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ)` applies it through the driver, and a pooled connection resets it on release |
 | Catches a generic `Exception` or expects a MariaDB-specific exception class | The driver throws the **standard `java.sql.SQLException` hierarchy** mapped from the server's SQLSTATE: `SQLIntegrityConstraintViolationException`, `SQLSyntaxErrorException`, `SQLTransactionRollbackException`, `SQLTransientConnectionException`, `SQLNonTransientConnectionException`. Read `.getErrorCode()` / `.getSQLState()` for the MariaDB-specific code, don't string-match `.getMessage()` |
 | Sets `Statement.executeUpdate(sql, Statement.RETURN_GENERATED_KEYS)` and assumes it "just works" for any statement | `getGeneratedKeys()` only returns rows when `RETURN_GENERATED_KEYS` was explicitly requested on that statement/`prepareStatement()` call — it's not implicit for a plain `INSERT` |
 
@@ -80,9 +83,32 @@ try (MariaDbPoolDataSource pool = new MariaDbPoolDataSource(
 }
 ```
 
+## Batch insert and generated keys
+
+```java
+try (PreparedStatement ps = conn.prepareStatement(
+        "INSERT INTO t (name, qty) VALUES (?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+    for (Row row : rows) {
+        ps.setString(1, row.name());
+        ps.setInt(2, row.qty());
+        ps.addBatch();
+    }
+    ps.executeBatch();
+
+    try (ResultSet keys = ps.getGeneratedKeys()) {
+        while (keys.next()) {
+            System.out.println(keys.getLong(1));   // one id per inserted row
+        }
+    }
+}
+```
+
+`RETURN_GENERATED_KEYS` has to be requested when the statement is prepared; adding it later has no effect.
+
 ## See Also
 
-- **`mariadb-connector-r2dbc`** — the reactive, non-blocking sibling driver for Java (also pure Java, no Connector/C dependency)
+- **`mariadb-connector-j-install`** — adding the driver to a Maven or Gradle build, the URL and datasource wiring, and TLS configuration
+- **`mariadb-connector-r2dbc-usage`** — the reactive, non-blocking sibling driver for Java (also pure Java, no Connector/C dependency)
 - **`mariadb-transactions`** / **`mariadb-set-transaction`** — the server-side semantics behind `conn.commit()` / `conn.rollback()` and isolation levels
 - **`mariadb-prepare`** — server-side prepared statements, what `useServerPrepStmts=true` uses under the hood
 - Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-j>

--- a/agent-skills/granular/connectors/mariadb-connector-nodejs-install/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-nodejs-install/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: mariadb-connector-nodejs-install
+description: "Installing and configuring MariaDB Connector/Node.js (the `mariadb` npm package) — that it is pure JavaScript with no native build step, so no compiler or `node-gyp` is involved; that the 3.5 line requires Node.js 20 or later; that the default export is the promise API and the callback API lives behind the `mariadb/callback` subpath, with both ESM and CommonJS resolved through the package's exports map and TypeScript typings already bundled; that `ssl: true` verifies the server certificate by default and a private CA needs an object form; and the pool defaults, `connectionLimit` 10 and `acquireTimeout` 10 seconds. Use when adding the connector to a project, containerizing it, or configuring TLS and pooling."
+---
+
+# MariaDB Connector/Node.js: Installation and Configuration
+
+*Last updated: 2026-08-10*
+
+MariaDB Connector/Node.js is the official non-blocking client for Node.js, published on npm as **`mariadb`**. It is written entirely in JavaScript and does not use MariaDB Connector/C. This skill covers installing it, picking the right API entry point, and configuring TLS and pooling. For writing queries, see **`mariadb-connector-nodejs-usage`**.
+
+> **Default context:** Assume the **3.5** stable line unless the user states otherwise. Connector versions are independent of the MariaDB server version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Adds build tools, `node-gyp`, or `python3` to a Dockerfile for this package | Not needed. The connector is **pure JavaScript** — no native addon, no compile step, so a plain `npm install mariadb` works on Alpine and in slim images |
+| Targets an older Node.js runtime | The **3.5** line declares **`node >= 20.0.0`**. Installing on an older runtime is a supported-engine violation, not merely untested |
+| Installs `@types/mariadb` for TypeScript | **Typings ship with the package.** There is no separate types package to add, and both the ESM and CommonJS entry points carry their own declarations |
+| Writes `const mariadb = require('mariadb/promise')` | The **promise API is the default export**: `require('mariadb')` or `import mariadb from 'mariadb'`. Only the callback API has a subpath — **`mariadb/callback`** |
+| Requires an internal file, for example `require('mariadb/lib/connection')` | The package publishes an **exports map** with exactly two entry points, `.` and `./callback`. Deep paths into `lib/` are not part of the public surface and will not resolve |
+| Uses the callback API by default because that is the familiar Node.js shape | The callback API exists for compatibility with older client APIs. New code should use the **promise API** — it is the default for a reason |
+| Sets `ssl: true` and then adds `rejectUnauthorized: false` to make it work | Backwards. `ssl: true` already **verifies** the server certificate against the Node.js trust store; against MariaDB **11.4 and later** with zero-configuration TLS, `ssl: true` alone is usually the whole configuration. Disabling verification should be a deliberate, temporary diagnostic |
+| Passes a private CA as a top-level option | Certificates go **inside** the `ssl` object: `ssl: { ca: fs.readFileSync('ca.pem') }`. In the object form, `rejectUnauthorized` defaults to `true` unless explicitly set to `false` |
+| Creates a connection per request in a server process | Use **`mariadb.createPool()`**. Defaults: `connectionLimit` **10**, `acquireTimeout` **10000 ms**, `idleTimeout` **1800 s**, and `minimumIdle` equal to `connectionLimit` |
+| Sets `acquireTimeout` lower than `connectTimeout` and gets confusing timeouts | The pool clamps for you — `connectTimeout` is reduced when it exceeds `acquireTimeout` — but set the two coherently rather than relying on the adjustment |
+| Connects over TCP to `localhost` when the server is on the same machine | **`socketPath`** takes a Unix socket path directly; no extra dependency is required for it |
+
+## Installing
+
+```bash
+npm install mariadb
+```
+
+That is the whole installation on every platform. To pin:
+
+```bash
+npm install mariadb@3.5.4
+```
+
+## Choosing an entry point
+
+```js
+// Promise API (default), ESM
+import mariadb from 'mariadb';
+
+// Promise API (default), CommonJS
+const mariadb = require('mariadb');
+
+// Callback API, for compatibility with older client APIs
+const mariadb = require('mariadb/callback');
+```
+
+TypeScript resolves the bundled declarations automatically through the same exports map, so `import mariadb from 'mariadb'` is typed out of the box.
+
+## Configuration
+
+### Connection options
+
+```js
+const conn = await mariadb.createConnection({
+  host: 'db.example.com',
+  port: 3306,
+  user: 'app',
+  password: 'secret',
+  database: 'appdb',
+  connectTimeout: 10000,
+  socketTimeout: 0,
+  timezone: 'local',          // the default
+});
+```
+
+A connection string is accepted too, which keeps configuration in one environment variable:
+
+```js
+const conn = await mariadb.createConnection(
+  'mariadb://app:secret@db.example.com:3306/appdb?ssl=true');
+```
+
+For a local server, replace `host`/`port` with `socketPath: '/var/run/mysqld/mysqld.sock'`.
+
+### TLS
+
+```js
+// Public CA, or MariaDB 11.4+ zero-configuration TLS
+const conn = await mariadb.createConnection({ host, user, password, ssl: true });
+
+// Private CA
+const conn = await mariadb.createConnection({
+  host, user, password,
+  ssl: { ca: fs.readFileSync('/etc/ssl/certs/ca.pem') },
+});
+
+// Mutual TLS
+const conn = await mariadb.createConnection({
+  host, user, password,
+  ssl: {
+    ca:   fs.readFileSync('/etc/ssl/certs/ca.pem'),
+    cert: fs.readFileSync('/etc/ssl/certs/client-cert.pem'),
+    key:  fs.readFileSync('/etc/ssl/private/client-key.pem'),
+  },
+});
+```
+
+The `ssl` object is passed through to Node.js's own TLS layer, so any option that layer accepts is available here.
+
+### Pooling
+
+```js
+const pool = mariadb.createPool({
+  host: 'db.example.com', user: 'app', password: 'secret', database: 'appdb',
+  connectionLimit: 10,      // the default
+  acquireTimeout: 10000,    // ms to wait for a free connection
+  idleTimeout: 1800,        // seconds before an idle connection is dropped
+  minimumIdle: 10,          // defaults to connectionLimit
+});
+
+const conn = await pool.getConnection();
+try {
+  await conn.query('SELECT 1');
+} finally {
+  conn.release();           // returns it to the pool
+}
+```
+
+Call `pool.end()` on shutdown, or the process will not exit cleanly.
+
+## See Also
+
+- **`mariadb-connector-nodejs-usage`** — using the connector once installed: queries, parameters, batches, streaming, transactions, error handling
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-nodejs>

--- a/agent-skills/granular/connectors/mariadb-connector-nodejs-usage/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-nodejs-usage/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: mariadb-connector-nodejs
+name: mariadb-connector-nodejs-usage
 description: "MariaDB-specific behavior of MariaDB Connector/Node.js (the `mariadb` npm package, a non-blocking driver) for application code — that the Promise API is default, with the Callback API under `require('mariadb/callback')`; that `?` positional placeholders are default and `:name` style needs `namedPlaceholders`; that BIGINT and `insertId` return native BigInt unless `bigIntAsNumber`/`insertIdAsNumber` are set; that `batch()` uses the bulk protocol instead of looping `query()`; that `queryStream()` is needed for large results since `query()` buffers everything in memory; that `pool.getConnection()` needs a `release()` in a `finally`; that autocommit follows the server default (ON) so transactions need explicit `beginTransaction()`/`commit()`/`rollback()`; and that `execute()` uses server-side prepared statements while `query()` uses the text protocol. Use when writing or reviewing Node.js code that talks to MariaDB with the `mariadb` package."
 ---
 
 # MariaDB Connector/Node.js
 
-*Last updated: 2026-07-21*
+*Last updated: 2026-08-10*
 
-MariaDB Connector/Node.js is the official Node.js driver for MariaDB — the `mariadb` package on npm (`npm install mariadb`), LGPL-licensed and non-blocking. This skill covers the connector-specific behavior and the traps that bite generated application code. It is **pure JavaScript** and does **not** depend on MariaDB Connector/C — no native build step, no C toolchain required.
+MariaDB Connector/Node.js is the official Node.js driver for MariaDB — the `mariadb` package on npm, LGPL-licensed and non-blocking. This skill covers the connector-specific behavior and the traps that bite generated application code. For installing it, choosing an entry point, and configuring TLS and pool sizing, see **`mariadb-connector-nodejs-install`**. It is **pure JavaScript** and does **not** depend on MariaDB Connector/C — no native build step, no C toolchain required.
 
 > **Default context:** Assume the **3.5.x** line (current: 3.5.4) unless the user states otherwise; it requires **Node.js >= 20**. Connector versions are independent of the MariaDB server version — a 3.5.x connector talks to any currently supported MariaDB server release.
 
@@ -29,6 +29,11 @@ MariaDB Connector/Node.js is the official Node.js driver for MariaDB — the `ma
 | Catches `Exception`/generic `Error`, or reads `.sqlstate` (lowercase, a DB-API habit) | Thrown errors are `SqlError` instances with **`.code`** (e.g. `ER_PARSE_ERROR`), **`.errno`** (numeric), and **`.sqlState`** (camelCase, capital S) — not `.sqlstate` |
 | Assumes client and server share a timezone, or hand-converts dates | `timezone` defaults to `'local'` (no conversion — fine only if client and server timezones match). Set `timezone: 'auto'` to have the connector detect and align to the server's timezone, or pass an explicit IANA zone/offset |
 | Expects the driver to auto-reconnect after a dropped connection | No automatic reconnection on a plain `Connection`. Use a pool (which validates/replaces connections) rather than assuming a long-lived single connection survives indefinitely |
+| Calls `execute()` in a loop with the same SQL and assumes the prepare is free every time | It is cached, but the explicit form is cheaper and clearer: **`const prep = await conn.prepare(sql)`**, then `prep.execute(values)` per call and **`prep.close()`** when finished. Skipping `close()` leaks a server-side prepared statement |
+| Reads only the first array after `CALL`ing a stored procedure | A `CALL` that returns result sets resolves to an **array of result sets**, with the final element the `OK` packet. Index into it rather than treating the whole value as rows |
+| Shells out to a client binary to load a `.sql` file | **`conn.importFile({ file: '/path/to/dump.sql' })`** runs it through the same connection |
+| Interpolates a value the placeholder syntax cannot take, such as a `LIMIT` built at run time | **`conn.escape(value)`** escapes a literal and `conn.escapeId(name)` an identifier. Both are a fallback for the positions `?` cannot occupy — not a substitute for placeholders |
+| Reuses a connection after an aborted transaction and inherits its session state | **`conn.reset()`** returns the session to its initial state — variables, temporary tables, prepared statements — without reconnecting |
 
 ## Connection essentials
 
@@ -78,8 +83,43 @@ async function insertItems(basketId, itemIds) {
 }
 ```
 
+```javascript
+// Explicit prepared statement, reused across calls
+async function lookupMany(ids) {
+  const conn = await pool.getConnection();
+  try {
+    const prep = await conn.prepare('SELECT id, name FROM users WHERE id = ?');
+    try {
+      const results = [];
+      for (const id of ids) {
+        results.push(await prep.execute([id]));
+      }
+      return results;
+    } finally {
+      prep.close();          // releases the server-side prepared statement
+    }
+  } finally {
+    conn.release();
+  }
+}
+```
+
+```javascript
+// Streaming a large result set
+const stream = conn.queryStream('SELECT id, payload FROM big_table');
+try {
+  for await (const row of stream) {
+    await handle(row);
+  }
+} catch (err) {
+  stream.close();            // otherwise the connection can hang
+  throw err;
+}
+```
+
 ## See Also
 
+- **`mariadb-connector-nodejs-install`** — installing the package, entry points and typings, TLS, and pool configuration
 - **`mariadb-transactions`** — the server-side semantics behind `beginTransaction()`/`commit()`/`rollback()` and isolation levels
 - **`mariadb-prepare`** — server-side prepared statements, what `execute()` uses under the hood
 - Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-nodejs>

--- a/agent-skills/granular/connectors/mariadb-connector-odbc-install/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-odbc-install/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: mariadb-connector-odbc-install
+description: "Installing and configuring MariaDB Connector/ODBC — that a driver manager (unixODBC on Linux, iODBC on macOS, the built-in manager on Windows) is a prerequisite and the driver has to be registered with it in `odbcinst.ini` before any DSN or `DRIVER=` connection string resolves; that the driver's own bitness must match the driver manager's; where `odbcinst`, `ODBCSYSINI`, `ODBCINI`, and `ODBCINSTINI` put the configuration; that the canonical DSN keywords are `UID` and `PWD` with `USER` and `PASSWORD` as synonyms; and the TLS keywords `SSLCA`, `SSLVERIFY`, `FORCETLS`, and `TLSVERSION`. Use when installing the driver, writing an `odbcinst.ini` or `odbc.ini` entry, building a connection string, or diagnosing a data source that will not connect."
+---
+
+# MariaDB Connector/ODBC: Installation and Configuration
+
+*Last updated: 2026-08-10*
+
+MariaDB Connector/ODBC is an ODBC 3.8-compliant driver built on MariaDB Connector/C. Almost everything that goes wrong with it goes wrong before the first query: the driver manager cannot find the driver, the bitness does not match, or the DSN is in a file nothing reads. This skill covers that layer. For the ODBC API itself, see **`mariadb-connector-odbc-usage`**.
+
+> **Default context:** Assume the **3.2** stable line unless the user states otherwise. The 3.1 line is the previous series and is still supported. Connector versions are independent of the MariaDB server version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Installs the driver and connects straight away | ODBC always goes through a **driver manager**: unixODBC on Linux, iODBC on macOS, the built-in manager on Windows. The driver must be **registered** with it before either a DSN or a `DRIVER=` connection string can resolve |
+| Installs MariaDB Connector/C first, as Connector/C++ requires | Not necessary here. The **binary packages carry Connector/C with them**. A source build can use the bundled `libmariadb` submodule or link the system one, but an installed driver package is self-contained |
+| Edits `/etc/odbcinst.ini` by hand and hopes the path is right | Use **`odbcinst`**, which writes to whatever paths the local unixODBC was actually built with: `sudo odbcinst -i -d -f driver-template.ini` for the driver, `-i -s -l -f` for a system DSN, `-i -s -h -f` for a user DSN |
+| Mixes a 64-bit driver with a 32-bit driver manager | Bitness must match end to end — driver, driver manager, and application. On Windows this means opening the **matching** version of the ODBC Data Source Administrator; the 64-bit and 32-bit tools show different lists |
+| Adds a DSN through the unixODBC GUI | The driver **does not support the unixODBC GUI for adding DSNs**. Write the `.ini` entry or use `odbcinst` |
+| Cannot find the configuration and assumes it is missing | Three environment variables move it: **`ODBCSYSINI`** (directory of the system files, default `/etc`), **`ODBCINSTINI`** (driver file name, relative to `ODBCSYSINI`, default `odbcinst.ini`), and **`ODBCINI`** (user DSN file, default `~/.odbc.ini`) |
+| Writes `SERVER=…;USER=…;PASSWORD=…` and assumes those are the real keywords | They work — but as **synonyms**. The canonical ODBC keywords are **`UID`** and **`PWD`**, alongside `SERVER`, `PORT`, `DATABASE`, and `DRIVER` or `DSN` |
+| Sets `SSLCA` and treats the connection as verified | Setting any of the `SSL*` keywords turns TLS on, but **`SSLVERIFY=1`** is what makes the server prove its identity against that CA. **`FORCETLS=1`** requires TLS without supplying certificate material at all |
+| Assumes the driver reads `my.cnf` like the command-line clients | Only when asked: the **`USE_MYCNF`** option turns option-file reading on. Otherwise every setting comes from the DSN or the connection string |
+| Expects `SQLExecDirect` to use server-side prepared statements | Only `SQLPrepare` uses the binary protocol by default. One-shot `SQLExecDirect` calls default to the client-side text protocol unless **`EDSERVER=1`** (or the `SQL_ATTR_EXECDIRECT_ON_SERVER` attribute) is set |
+| Installs on macOS and dutifully registers the driver | The **PKG package registers itself** in `/Library/ODBC/odbcinst.ini`, so that step is usually already done |
+| Declares the setup working without testing it | Test the DSN outside the application: **`isql <dsn>`** with unixODBC, **`iodbctest "DSN=<dsn>"`** with iODBC. That separates a driver-manager problem from an application problem |
+
+## Installing
+
+### Linux
+
+Install unixODBC and its tools, then the driver package downloaded for the distribution:
+
+```bash
+sudo apt install unixodbc odbcinst          # Debian, Ubuntu
+sudo yum install unixODBC                   # RHEL, Rocky Linux
+```
+
+### Registering the driver
+
+```ini
+# MariaDB_odbc_driver_template.ini
+[MariaDB ODBC 3.2 Driver]
+Description = MariaDB Connector/ODBC v.3.2
+Driver = /usr/lib64/libmaodbc.so
+```
+
+```bash
+sudo odbcinst -i -d -f MariaDB_odbc_driver_template.ini
+```
+
+At this point `SQLDriverConnect` works with `Driver={MariaDB ODBC 3.2 Driver};…`, with no DSN involved.
+
+### Defining a DSN
+
+```ini
+# MariaDB_odbc_data_source_template.ini
+[MariaDB-server]
+Description = MariaDB server
+Driver      = MariaDB ODBC 3.2 Driver
+SERVER      = db.example.com
+PORT        = 3306
+UID         = app
+PWD         = secret
+DATABASE    = appdb
+```
+
+```bash
+sudo odbcinst -i -s -l -f MariaDB_odbc_data_source_template.ini   # system-wide, /etc/odbc.ini
+odbcinst -i -s -h -f MariaDB_odbc_data_source_template.ini        # this user, ~/.odbc.ini
+```
+
+### macOS
+
+macOS uses iODBC. The PKG package registers the driver in `/Library/ODBC/odbcinst.ini` automatically; the driver library lives at `/Library/MariaDB/MariaDB-Connector-ODBC/libmaodbc.dylib`. DSNs go in `~/Library/ODBC/odbc.ini` or `/Library/ODBC/odbc.ini`.
+
+### Windows
+
+Install the MSI, then define the DSN in the ODBC Data Source Administrator — taking care to open the version matching the driver's bitness.
+
+### Building from source
+
+```bash
+sudo apt install git cmake make gcc libssl-dev unixodbc odbcinst unixodbc-dev
+# or: sudo yum install git cmake make gcc openssl openssl-devel unixODBC unixODBC-devel
+
+git clone https://github.com/MariaDB/mariadb-connector-odbc.git
+cd mariadb-connector-odbc
+git submodule update --init --recursive      # brings in the bundled libmariadb
+cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+cmake --build build
+sudo cmake --install build
+```
+
+OpenSSL development headers are what make the resulting driver TLS-capable on Unix-like platforms; on Windows there are no dependencies beyond CMake, git, and Visual Studio.
+
+## Configuration
+
+### Connection-string keywords
+
+The same keywords work in a DSN file and in a `SQLDriverConnect` string:
+
+| Keyword | Purpose |
+|---|---|
+| `DRIVER`, `DSN` | Which driver, or which predefined data source |
+| `SERVER`, `PORT`, `SOCKET`, `NamedPipe` | Where the server is |
+| `UID`, `PWD` | Credentials (`USER`, `PASSWORD` are synonyms) |
+| `DATABASE` | Default schema |
+| `CHARSET` | Connection character set |
+| `INITSTMT` | Statement executed on connect |
+| `CONN_TIMEOUT` | Connect timeout, in seconds |
+| `AUTO_RECONNECT` | Reconnect after a dropped connection |
+| `USE_MYCNF` | Read settings from MariaDB option files as well |
+| `EDSERVER` | Send `SQLExecDirect` statements as server-side prepared statements |
+| `FORWARDONLY` | Force forward-only cursors |
+| `PLUGIN_DIR` | Where the Connector/C authentication plugins live |
+| `OPTION` | Legacy numeric flag word; prefer the named options above |
+
+### TLS keywords
+
+| Keyword | Purpose |
+|---|---|
+| `SSLCA`, `SSLCAPATH` | Trusted CA certificate, or a directory of them |
+| `SSLCERT`, `SSLKEY`, `TLSKEYPWD` | Client certificate for mutual TLS, and the key passphrase |
+| `SSLVERIFY` | Verify the server certificate — off unless set |
+| `FORCETLS` | Refuse to connect unencrypted |
+| `SSLCIPHER`, `TLSVERSION` | Restrict cipher suites and protocol versions |
+| `SSLCRL`, `SSLCRLPATH` | Certificate revocation list |
+| `TLSPEERFP`, `TLSPEERFPLIST` | Pin the server certificate by fingerprint |
+
+```
+Driver={MariaDB ODBC 3.2 Driver};SERVER=db.example.com;PORT=3306;
+UID=app;PWD=secret;DATABASE=appdb;
+SSLCA=/etc/ssl/certs/ca.pem;SSLVERIFY=1;FORCETLS=1
+```
+
+Which of the certificate options are honored depends on the TLS library the bundled Connector/C was built against — see **`mariadb-connector-c-install`**.
+
+## Verifying the install
+
+```bash
+isql MariaDB-server                     # unixODBC
+iodbctest "DSN=MariaDB-server"          # iODBC
+```
+
+A "data source name not found" error is a driver-manager registration problem; an authentication or TLS error means the registration worked and the problem has moved to the connection settings.
+
+## See Also
+
+- **`mariadb-connector-odbc-usage`** — using the driver once it is registered: handles, binding, prepared statements, cursors, diagnostics
+- **`mariadb-connector-c-install`** — the underlying client library, and the TLS behavior it determines
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-odbc>

--- a/agent-skills/granular/connectors/mariadb-connector-odbc-usage/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-odbc-usage/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: mariadb-connector-odbc
+name: mariadb-connector-odbc-usage
 description: "MariaDB-specific behavior of MariaDB Connector/ODBC (the ODBC 3.8-compliant driver built on MariaDB Connector/C) for application code — that the DSN-less keyword is `DRIVER={MariaDB ODBC 3.2 Driver}` on Windows, or a registered driver name / `.so` path on Linux and macOS; that parameter markers are always the positional `?` via `SQLBindParameter`, never named; that one Unicode (`SQLWCHAR`) driver binary serves both ANSI and Unicode apps via `SQL_ATTR_ANSI_APP`; that `SQLPrepare`+`SQLExecute` uses server-side prepared statements (binary protocol) while `SQLExecDirect` defaults to client-side text unless `EDSERVER` is set; that autocommit is ON by default so transactional code must switch `SQL_ATTR_AUTOCOMMIT` off; and that TLS turns on implicitly when any of `SSLCA`/`SSLCERT`/`SSLKEY` is set. Use when writing or reviewing application code (C/C++, or via a wrapper like pyodbc) that talks to MariaDB through the ODBC API."
 ---
 
 # MariaDB Connector/ODBC
 
-*Last updated: 2026-07-21*
+*Last updated: 2026-08-10*
 
-MariaDB Connector/ODBC is an ODBC 3.8-compliant driver for MariaDB and MySQL, built on top of **MariaDB Connector/C** (`libmariadb`) for the actual client-server protocol work. Applications never link against it directly — they go through the standard **ODBC API** (`SQLConnect`/`SQLDriverConnect`, `SQLExecDirect`, `SQLBindParameter`, ...) mediated by a **Driver Manager** (unixODBC on Linux, iODBC on macOS, the built-in ODBC Driver Manager on Windows), or through a language wrapper on top of that API — most commonly **pyodbc** from Python. This skill covers the connector-specific behavior and the traps that bite generated application code; it does not cover installing the driver or configuring the server.
+MariaDB Connector/ODBC is an ODBC 3.8-compliant driver for MariaDB and MySQL, built on top of **MariaDB Connector/C** (`libmariadb`) for the actual client-server protocol work. Applications never link against it directly — they go through the standard **ODBC API** (`SQLConnect`/`SQLDriverConnect`, `SQLExecDirect`, `SQLBindParameter`, ...) mediated by a **Driver Manager** (unixODBC on Linux, iODBC on macOS, the built-in ODBC Driver Manager on Windows), or through a language wrapper on top of that API — most commonly **pyodbc** from Python. This skill covers the connector-specific behavior and the traps that bite generated application code. For installing the driver, registering it with the driver manager, and defining a DSN, see **`mariadb-connector-odbc-install`**.
 
 > **Default context:** Assume the **3.2** stable release series (currently 3.2.10 GA) unless the user states otherwise. Connector/ODBC's version is independent of the MariaDB server version it connects to — behavior below applies across the 3.x line unless annotated with a specific version.
 
@@ -27,6 +27,10 @@ MariaDB Connector/ODBC is an ODBC 3.8-compliant driver for MariaDB and MySQL, bu
 | Treats `SQLGetDiagRec`'s native-error field as an ODBC-defined code | It is the raw **MariaDB server error number** (`mysql_errno()`), e.g. `1146` for "table doesn't exist" — cross-reference it against server error codes, not an ODBC error table. `SQLSTATE` is the server's mapped 5-character state |
 | Runs several statements at once on one connection without buffering results first | The MariaDB protocol allows only one command in flight per connection; fetch or discard a statement's result set before issuing another on the **same connection** (no MARS-style interleaving). Use separate statement handles sequentially, a connection pool, or `OPTION` bit 67108864 only for literal multi-statement *batches* (`stmt1; stmt2;`) in a single `SQLExecDirect` call, which has its own limitations for cross-statement dependencies |
 | Connects with `mariadb.connect(...)` (the Python `mariadb` module) when the app is ODBC-based | From Python via ODBC, use **pyodbc**: `pyodbc.connect("DRIVER={MariaDB ODBC 3.2 Driver};SERVER=...;...")`. pyodbc is a generic ODBC wrapper — it is not MariaDB-specific, but it inherits every behavior above (autocommit-on default, `?` markers, native error = server error number) |
+| Loops `SQLExecute` once per row for a bulk insert | Bind arrays instead: set **`SQL_ATTR_PARAMSET_SIZE`** to the row count, point each `SQLBindParameter` at an array, and add **`SQL_ATTR_PARAM_STATUS_PTR`** to see which rows succeeded. One execution covers the whole set |
+| Stops after the first result set from a `CALL` | Loop **`SQLMoreResults(stmt)`** until it returns `SQL_NO_DATA`. A stored procedure returns one result set per `SELECT` plus a final status result |
+| Reads a long `TEXT` or `BLOB` column with a fixed-size bound buffer | Either bind a buffer large enough, or leave the column unbound and pull it in chunks with **`SQLGetData`**, which returns `SQL_SUCCESS_WITH_INFO` and SQLSTATE `01004` while data remains |
+| Trusts `SQLRowCount` after a `SELECT` | It is defined for `INSERT`, `UPDATE`, and `DELETE`. After a `SELECT` it may report `-1`; count rows by fetching them |
 | Assumes pyodbc commits automatically after `execute()` | pyodbc's `Connection.autocommit` defaults to **`False`** at the *pyodbc* layer (distinct from the ODBC/server-level default above) — call `conn.commit()` explicitly, or construct with `pyodbc.connect(..., autocommit=True)` |
 
 ## Connection essentials
@@ -39,18 +43,7 @@ SQLWCHAR *ConnStr = L"DRIVER={MariaDB ODBC 3.2 Driver};"
                      L"SSLCA=/etc/mysql/certs/ca.pem;SSLVERIFY=1";
 ```
 
-```
-# Equivalent unixODBC/iODBC odbc.ini DSN entry
-[MariaDB-appdb]
-Driver   = MariaDB ODBC 3.2 Driver
-SERVER   = 127.0.0.1
-PORT     = 3306
-DATABASE = appdb
-UID      = app
-PASSWORD = secret
-SSLCA    = /etc/mysql/certs/ca.pem
-SSLVERIFY = 1
-```
+The same keywords work in a DSN — see **`mariadb-connector-odbc-install`** for the `odbc.ini` form and for registering the driver in the first place.
 
 ```python
 import pyodbc
@@ -75,9 +68,31 @@ cur.close()
 conn.close()
 ```
 
+## Bulk insert with array-bound parameters
+
+```c
+#define ROWS 3
+SQLINTEGER  ids[ROWS]        = { 1, 2, 3 };
+SQLCHAR     names[ROWS][64]  = { "widget", "gadget", "doohickey" };
+SQLLEN      name_len[ROWS]   = { SQL_NTS, SQL_NTS, SQL_NTS };
+SQLUSMALLINT status[ROWS];
+
+SQLSetStmtAttr(stmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)ROWS, 0);
+SQLSetStmtAttr(stmt, SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+
+SQLPrepare(stmt, (SQLCHAR *)"INSERT INTO t (id, name) VALUES (?, ?)", SQL_NTS);
+SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER,
+                 0, 0, ids, 0, NULL);
+SQLBindParameter(stmt, 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
+                 64, 0, names, sizeof(names[0]), name_len);
+
+SQLExecute(stmt);        /* all three rows in one execution */
+```
+
 ## See Also
 
-- **`mariadb-connector-c`** — the underlying `libmariadb` client library that does the actual protocol work
+- **`mariadb-connector-odbc-install`** — installing the driver, registering it with the driver manager, DSNs, and the TLS keywords
+- **`mariadb-connector-c-usage`** — the underlying `libmariadb` client library that does the actual protocol work
 - **`mariadb-transactions`** — server-side semantics behind `SQLEndTran`/`conn.commit()` and isolation levels (`SQL_ATTR_TXN_ISOLATION` maps directly to `SET SESSION TRANSACTION ISOLATION LEVEL`)
 - **`mariadb-prepare`** — server-side prepared statements, what `SQLPrepare`'s default (and `EDSERVER`) use under the hood
 - Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-odbc>

--- a/agent-skills/granular/connectors/mariadb-connector-python-install/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-python-install/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mariadb-connector-python-install
+description: "Installing and configuring MariaDB Connector/Python (the `mariadb` PyPI module) — that a plain `pip install mariadb` gets the 1.1 GA line, which always builds the C extension and so needs MariaDB Connector/C 3.3.1 or later with `mariadb_config` on the `PATH`; that the pure-Python, binary-wheel and pooling variants exist only on the 2.0 line and need `pip install --pre mariadb[...]`; that pooling is built in on 1.1 but a separate `[pool]` extra on 2.0; the Python floor (3.8 on 1.1, 3.10 on 2.0); that option files are read only when `default_file` or `default_group` is passed; and that `ssl_verify_cert` defaults to off on 1.1. Use when installing, packaging, containerizing, or configuring the `mariadb` module, or when diagnosing a failed build or connection setup."
+---
+
+# MariaDB Connector/Python: Installation and Configuration
+
+*Last updated: 2026-08-10*
+
+MariaDB Connector/Python is published on PyPI as **`mariadb`**. This skill covers getting it installed and configured — the install variants, their prerequisites, the build failures that follow from picking the wrong one, and the connection settings that belong in configuration rather than in code. For writing queries against an established connection, see **`mariadb-connector-python-usage`**.
+
+> **Default context:** Assume the **1.1** stable (GA) line unless the user states otherwise. Behavior that applies only to the newer **2.0** line — which is still a release candidate — is marked *since 2.0*. Connector versions are independent of the MariaDB server version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `pip install mariadb` yields a pure-Python package with no system dependencies | On the current GA line (**1.1**) it does not. 1.1 **always** builds the C extension, so the machine needs **MariaDB Connector/C 3.3.1 or later** and a C compiler. A pure-Python install exists only *since 2.0* |
+| Reaches for `pip install --pre` only when told to | The reverse: plain `pip install mariadb` deliberately resolves to **1.1**, because 2.0 is still a release candidate and pip skips pre-releases. `--pre` is **required** to get 2.0: `pip install --pre mariadb` |
+| Writes `mariadb[binary]`, `mariadb[c]`, or `mariadb[pool]` against 1.1 | Those extras are **2.0-only**. On 1.1 there is one install and it includes pooling. Combine them *since 2.0*: `pip install --pre mariadb[binary,pool]` |
+| Assumes connection pooling always ships in the box | True on 1.1. *Since 2.0* pooling is a separate optional package — without the **`[pool]`** extra, `ConnectionPool` is unavailable |
+| Build fails with `mariadb_config not found` and the agent installs a compiler | The compiler is not the missing piece. **`mariadb_config` ships with the Connector/C development package** and must be on the `PATH`: `libmariadb-dev` (Debian, Ubuntu) or `MariaDB-devel` (RHEL, Rocky, SLES). Alternatively, point at it explicitly in `site.cfg` |
+| Targets any Python 3 | The floor differs by line: **1.1 requires Python 3.8+**, **2.0 requires Python 3.10+** |
+| Installs `mysql-connector-python`, `mysqlclient`, or `PyMySQL` and imports `mariadb` | The distribution and the module are both **`mariadb`** — `pip install mariadb`, then `import mariadb`. No other PyPI package provides this API |
+| Builds a slim container image, then wonders why `import mariadb` fails at runtime | A source install needs the Connector/C **development** files at build time and the **runtime** library afterwards. In a multi-stage image, install `libmariadb3` (or `MariaDB-shared`) in the final stage, or *since 2.0* use `mariadb[binary]`, whose wheels bundle Connector/C |
+| Puts host, user, and password in code and expects `~/.my.cnf` to be picked up anyway | Option files are **not** read by default. Pass **`default_file`** (a path, or `""` for the standard locations) or **`default_group`**; explicit `connect()` arguments still win over option-file values |
+| Assumes TLS verifies the server certificate as soon as `ssl_ca` is set | On **1.1**, **`ssl_verify_cert` defaults to `False`** — the connection is encrypted but the server is unauthenticated until you pass `ssl_verify_cert=True`. *Since 2.0* the default flips to `True` |
+| Pins nothing, or pins the connector to the server version | Pin the connector line explicitly (`mariadb==1.1.14`). Connector releases are **independent of the server release**; there is no matching 11.8 or 12.x connector |
+
+## Installing
+
+### Version 1.1 (stable, GA)
+
+Install the Connector/C development files first, then the module:
+
+```bash
+# Debian, Ubuntu
+sudo apt install libmariadb3 libmariadb-dev
+
+# RHEL, Rocky Linux, SLES
+sudo dnf install MariaDB-shared MariaDB-devel
+
+pip install mariadb            # latest 1.1
+pip install mariadb==1.1.14    # pinned
+```
+
+Connector/C itself comes from the MariaDB package repository; configure it with `mariadb_repo_setup` (Community Server) or `mariadb_es_repo_setup` (Enterprise Server) if the distribution's own packages are too old. On POSIX systems the build reads `mariadb_config` from the `PATH`; if it lives somewhere unusual, set the path in `site.cfg`:
+
+```ini
+[cc_options]
+mariadb_config=/usr/local/bin/mariadb_config
+```
+
+### Version 2.0 (release candidate)
+
+Three variants, all requiring `--pre`:
+
+```bash
+pip install --pre mariadb                # pure Python — no compiler, no Connector/C
+pip install --pre mariadb[c]             # C extension — needs Connector/C 3.3.1+
+pip install --pre mariadb[binary]        # prebuilt wheel — Connector/C bundled
+pip install --pre mariadb[binary,pool]   # …and connection pooling
+```
+
+The pure-Python implementation runs on any interpreter and needs no system libraries; the C extension is the faster option on data-heavy workloads. The API is the same either way, so the choice is a deployment decision, not a code one.
+
+### Microsoft Windows
+
+Binary wheels are the path of least resistance, because they carry Connector/C with them:
+
+```bash
+pip install --pre mariadb[binary,pool]
+```
+
+To build the C extension instead, install MariaDB Connector/C from its MSI package first, then `pip install --pre mariadb[c,pool]`.
+
+## Configuration
+
+### Where connection settings can live
+
+`connect()` keyword arguments are the primary mechanism, but host, port, user, socket, and the TLS settings can equally come from a MariaDB option file — useful for keeping credentials out of source:
+
+```python
+import mariadb
+
+# Read ~/.my.cnf and the other standard locations, plus a custom group
+conn = mariadb.connect(
+    default_file="",             # "" = standard locations; or an explicit path
+    default_group="myapp",       # read in addition to [client], [client-server], [client-mariadb]
+    database="appdb",
+)
+```
+
+Setting either `default_file` or `default_group` is what switches option-file reading on. On Windows the file must be an `.ini` file. Explicit keyword arguments override anything the option file supplies.
+
+### TLS
+
+```python
+conn = mariadb.connect(
+    host="db.example.com", user="app", password="secret", database="appdb",
+    ssl_ca="/etc/ssl/certs/ca.pem",
+    ssl_cert="/etc/ssl/certs/client-cert.pem",
+    ssl_key="/etc/ssl/private/client-key.pem",
+    ssl_verify_cert=True,        # on 1.1 this is NOT the default — set it explicitly
+)
+```
+
+`ssl_capath`, `ssl_cipher`, `ssl_crl`, and `ssl_crlpath` are also accepted; which of them the underlying Connector/C honors depends on the TLS library it was built against.
+
+### Pooling configuration
+
+On 1.1, `ConnectionPool` is available immediately; *since 2.0* it requires the `[pool]` extra. Pool sizing belongs with the rest of the deployment configuration:
+
+```python
+pool = mariadb.ConnectionPool(
+    pool_name="app", pool_size=8,   # maximum 64
+    pool_reset_connection=True,     # the default
+    host="localhost", user="app", password="secret", database="appdb",
+)
+```
+
+## Verifying the install
+
+```python
+import mariadb
+print(mariadb.__version__)                 # module version
+conn = mariadb.connect(host="localhost", user="app", password="secret")
+print(conn.get_server_version())           # proves the round trip works
+```
+
+A failure at `import mariadb` points at the runtime library or the wheel; a failure at `connect()` points at credentials, networking, or TLS.
+
+## See Also
+
+- **`mariadb-connector-python-usage`** — using the module once it is installed: parameters, transactions, cursors, pooling, error handling
+- **`mariadb-connector-c-install`** — installing and configuring the underlying C client library this module builds against
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-python>

--- a/agent-skills/granular/connectors/mariadb-connector-python-usage/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-python-usage/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: mariadb-connector-python
-description: "MariaDB-specific behavior of MariaDB Connector/Python (the `mariadb` PyPI module, a PEP-249 / DB API 2.0 driver) for application code — that the default paramstyle is qmark (`?`), not format (`%s`), and styles must not be mixed; that string formatting must never build SQL; that autocommit is off by default so DML needs `conn.commit()`; that a single parameter needs a one-tuple `(v,)`; that the text protocol is default and `binary=True` switches to server-side prepared statements; that cursors are buffered by default; connection pooling via `ConnectionPool` (default size 5, max 64); `callproc()` for stored procedures; the DB API exception hierarchy under `mariadb.Error`; and that the module is a C extension built on Connector/C. Use when writing or reviewing Python code that talks to MariaDB with the `mariadb` module."
+name: mariadb-connector-python-usage
+description: "MariaDB-specific behavior of MariaDB Connector/Python (the `mariadb` PyPI module, a PEP-249 / DB API 2.0 driver) for application code — that the default paramstyle is qmark (`?`), not format (`%s`), and styles must not be mixed; that string formatting must never build SQL; that autocommit is off by default so DML needs `conn.commit()`; that a single parameter needs a one-tuple `(v,)`; that the text protocol is default and `binary=True` switches to server-side prepared statements; that cursors are buffered by default; connection pooling via `ConnectionPool` (default size 5, max 64); `callproc()` for stored procedures; and the DB API exception hierarchy under `mariadb.Error`. Use when writing or reviewing Python code that talks to MariaDB with the `mariadb` module."
 ---
 
 # MariaDB Connector/Python
 
-*Last updated: 2026-07-21*
+*Last updated: 2026-08-10*
 
-MariaDB Connector/Python is the official Python driver for MariaDB — the `mariadb` module on PyPI (`pip install mariadb`), implementing the Python DB API 2.0 ([PEP-249](https://peps.python.org/pep-249)). This skill covers the connector-specific behavior and the traps that bite generated application code. It is a **C extension built on MariaDB Connector/C**, so a build needs the C connector's development files (`mariadb_config` on the `PATH`) — it is not pure Python on the 1.1 line.
+MariaDB Connector/Python is the official Python driver for MariaDB — the `mariadb` module on PyPI, implementing the Python DB API 2.0 ([PEP-249](https://peps.python.org/pep-249)). This skill covers the connector-specific behavior and the traps that bite generated application code. For getting the module installed and configured in the first place — install variants, prerequisites, option files, TLS setup — see **`mariadb-connector-python-install`**.
 
 > **Default context:** Assume the **1.1** stable line unless the user states otherwise. Behavior shared with older 1.x releases is shown without annotation; features added in the newer **2.0** line (`mariadb://` URI connection strings, async `asyncConnect`/`create_async_pool`, a pure-Python implementation) are marked *since 2.0*. Connector versions are independent of the MariaDB server version.
 
@@ -28,6 +28,9 @@ MariaDB Connector/Python is the official Python driver for MariaDB — the `mari
 | Hand-rolls a pool, or opens a new connection per request | Use **`mariadb.ConnectionPool(pool_name="app", pool_size=5)`**; borrow with `pool.get_connection()` and return it by `conn.close()`. `pool_size` defaults to 5, **max 64**; `pool_reset_connection=True` (default) resets each connection before reuse |
 | Calls a stored procedure by string-building `CALL ...` with OUT params | Use **`cursor.callproc("proc_name", (in1, in2))`**; read OUT/INOUT results from the returned sequence / a following result set |
 | Catches `Exception` or a MySQL driver's error class | Catch **`mariadb.Error`** (the DB API base). Subclasses: `OperationalError`, `IntegrityError`, `ProgrammingError`, `DataError`, `InterfaceError`, `InternalError`, `NotSupportedError`, `PoolError`. `.errno` / `.sqlstate` are on the exception |
+| Wraps work in `with mariadb.connect(...) as conn:` and expects a commit on exit | The connection's `__exit__` **closes** the connection — it does not commit. Closing without committing **rolls back**, so uncommitted DML is silently lost. Commit explicitly inside the block |
+| Calls `cursor.scroll()` to reposition in a streamed result | `scroll()` raises `ProgrammingError` on an **unbuffered** cursor, and on any cursor with no result set. Repositioning only works on the buffered default |
+| Reads `cursor.rowcount` before fetching, or on a statement that produced nothing | `rowcount` is **`-1`** when no `execute*()` has run or the count cannot be determined. Treat `-1` as "unknown", not as zero |
 
 ## Connection essentials
 
@@ -56,6 +59,48 @@ with conn.cursor() as cur:
 
 Common `connect()` keywords: `host` (default `localhost`; a comma-separated list gives simple failover), `port` (default `3306`), `user`/`username`, `password`/`passwd`, `database`/`db`, `unix_socket`, `autocommit`, and the SSL/TLS options. Result-shape options include `dictionary=True` (rows as dicts) and `named_tuple=True`. Some options apply only to the C extension — see the connection-class reference.
 
+## Transactions
+
+Autocommit is off, so every statement runs inside a transaction whether or not one was opened explicitly:
+
+```python
+try:
+    with conn.cursor() as cur:
+        cur.execute("UPDATE accounts SET balance = balance - ? WHERE id = ?", (100, 1))
+        cur.execute("UPDATE accounts SET balance = balance + ? WHERE id = ?", (100, 2))
+    conn.commit()
+except mariadb.Error:
+    conn.rollback()
+    raise
+```
+
+`conn.begin()` starts a transaction explicitly, which matters when `autocommit=True` was set at connect time and one particular unit of work needs to be atomic. Isolation level is a server-side setting — issue `SET TRANSACTION ISOLATION LEVEL …` or set it on the server; there is no connector-level parameter for it.
+
+## Bulk operations
+
+```python
+rows = [("widget", 5), ("gadget", 3), ("doohickey", 8)]
+with conn.cursor() as cur:
+    cur.executemany("INSERT INTO t (name, qty) VALUES (?, ?)", rows)
+conn.commit()
+```
+
+Every tuple must have the same shape and the same types — the connector binds the batch once and reuses that binding. To mean "use the column default" or "NULL" for one element of one row, use the values in `mariadb.constants.INDICATOR` rather than `None`, which binds a literal NULL.
+
+## Error handling
+
+```python
+try:
+    cur.execute("INSERT INTO t (id, name) VALUES (?, ?)", (1, "widget"))
+except mariadb.IntegrityError as e:
+    print(e.errno, e.sqlstate, e)      # 1062, '23000', "Duplicate entry ..."
+except mariadb.OperationalError:
+    # connection-level problem: server gone, timeout, authentication
+    raise
+```
+
+`errno` carries the MariaDB error number and `sqlstate` the SQLSTATE, which is what to branch on — the message text is not stable.
+
 ## Pooling
 
 ```python
@@ -77,7 +122,8 @@ finally:
 
 ## See Also
 
-- **`mariadb-connector-c`** — the underlying C client library this module wraps (build-time dependency)
+- **`mariadb-connector-python-install`** — installing and configuring the module: install variants, prerequisites, option files, TLS
+- **`mariadb-connector-c-usage`** — the underlying C client library this module wraps on the C-extension build
 - **`mariadb-transactions`** / **`mariadb-set-transaction`** — the server-side semantics behind `conn.commit()` / `conn.rollback()` and isolation levels
 - **`mariadb-prepare`** — server-side prepared statements, what `binary=True` uses under the hood
 - Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-python>

--- a/agent-skills/granular/connectors/mariadb-connector-r2dbc-install/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-r2dbc-install/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: mariadb-connector-r2dbc-install
+description: "Installing and configuring MariaDB Connector/R2DBC, the reactive non-blocking driver for MariaDB — the Maven coordinates `org.mariadb:r2dbc-mariadb`, the fact that it implements R2DBC rather than JDBC so connections come from `ConnectionFactories.get()` with an `r2dbc:mariadb://` URL and never from `DriverManager`; that connection pooling is a separate `io.r2dbc:r2dbc-pool` dependency rather than a built-in; that `sslMode` defaults to disabled so TLS must be requested explicitly and then tuned with `serverSslCert` or a truststore; and the parameter names that differ from the JDBC driver, notably `username` and `socket`. Use when adding the driver to a build, wiring a `ConnectionFactory`, or configuring pooling and TLS."
+---
+
+# MariaDB Connector/R2DBC: Installation and Configuration
+
+*Last updated: 2026-08-10*
+
+MariaDB Connector/R2DBC is the reactive driver for MariaDB: pure Java, built on Reactor and Netty, implementing the R2DBC SPI rather than JDBC. This skill covers adding it to a build and configuring it. For writing reactive code against it, see **`mariadb-connector-r2dbc-usage`**.
+
+> **Default context:** Assume the **1.4** stable line unless the user states otherwise. Connector versions are independent of the MariaDB server version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Adds `org.mariadb.jdbc:mariadb-java-client` for a reactive application | Different artifact, different SPI. R2DBC is **`org.mariadb:r2dbc-mariadb`** — note the shorter group ID. The JDBC driver cannot serve an R2DBC `ConnectionFactory` |
+| Calls `DriverManager.getConnection("r2dbc:mariadb://…")` | R2DBC has no `DriverManager`. Obtain a factory with **`ConnectionFactories.get("r2dbc:mariadb://…")`** or build a `MariadbConnectionConfiguration` and pass it to `MariadbConnectionFactory` |
+| Writes a `jdbc:mariadb://` URL | The R2DBC scheme is **`r2dbc:mariadb://`**; the registered driver identifier is `mariadb` |
+| Expects a built-in pool, or reaches for the JDBC driver's `MariaDbPoolDataSource` | Pooling in R2DBC is a **separate dependency**, `io.r2dbc:r2dbc-pool`, which wraps any `ConnectionFactory`. Nothing pools by default |
+| Uses `user=` in the URL or configuration | The parameter is **`username`**. Similarly the Unix socket parameter is **`socket`**, not `socketPath` or `localSocket` |
+| Sets `serverSslCert` and assumes TLS is on | **`sslMode` defaults to `DISABLE`.** Nothing is encrypted until `sslMode` is set to `trust`, `verify-ca`, or `verify-full` |
+| Ships a private CA and expects the JVM's public CAs to stop applying | The driver falls back to the system truststore. Set **`fallbackToSystemTrustStore=false`** (and `fallbackToSystemKeyStore=false` for client certificates) to make trust exclusive |
+| Blocks on the returned `Publisher` — `.block()` in request-handling code | The whole point is non-blocking. A `Mono`/`Flux` must be composed and returned, not resolved; blocking on a Reactor thread can deadlock the event loop |
+| Targets a recent Java baseline and drops Java 8 support from the build | The connector is compiled for **Java 8**, so it does not force the application's baseline upward |
+| Mixes an arbitrary `r2dbc-spi` version into the build | The driver is built against a specific R2DBC SPI release (**1.0.0.RELEASE** on the 1.4 line). Let Maven resolve it transitively rather than pinning a different one |
+| Assumes prepared statements behave as they do in the JDBC driver | Server-side prepared statements are governed by **`useServerPrepStmts`** and cached according to **`prepareCacheSize`** — set them deliberately for a reactive workload |
+
+## Installing
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>org.mariadb</groupId>
+    <artifactId>r2dbc-mariadb</artifactId>
+    <version>1.4.1</version>
+</dependency>
+
+<!-- Only if the application pools connections -->
+<dependency>
+    <groupId>io.r2dbc</groupId>
+    <artifactId>r2dbc-pool</artifactId>
+    <version>1.0.2.RELEASE</version>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+implementation 'org.mariadb:r2dbc-mariadb:1.4.1'
+implementation 'io.r2dbc:r2dbc-pool:1.0.2.RELEASE'
+```
+
+Reactor and Netty arrive transitively. A manual JAR install is possible — the driver and `r2dbc-pool` both need to be on the `CLASSPATH` — but a build tool is far less error-prone given the transitive graph.
+
+## Configuration
+
+### From a URL
+
+```java
+ConnectionFactory factory = ConnectionFactories.get(
+    "r2dbc:mariadb://app:secret@db.example.com:3306/appdb?sslMode=verify-full");
+```
+
+### Programmatically
+
+The builder makes the options discoverable and keeps credentials out of a URL string:
+
+```java
+MariadbConnectionConfiguration conf = MariadbConnectionConfiguration.builder()
+    .host("db.example.com")
+    .port(3306)
+    .username("app")               // username, not user
+    .password("secret")
+    .database("appdb")
+    .connectTimeout(Duration.ofSeconds(10))
+    .useServerPrepStmts(true)
+    .build();
+
+MariadbConnectionFactory factory = new MariadbConnectionFactory(conf);
+```
+
+For a local server, replace host and port with `.socket("/var/run/mysqld/mysqld.sock")`.
+
+### TLS
+
+```java
+MariadbConnectionConfiguration.builder()
+    .host("db.example.com").username("app").password("secret")
+    .sslMode(SslMode.VERIFY_FULL)
+    .serverSslCert("/etc/ssl/certs/ca.pem")
+    .build();
+```
+
+| Parameter | Purpose |
+|---|---|
+| `sslMode` | `DISABLE` (default), `TRUST`, `VERIFY_CA`, `VERIFY_FULL`, `TUNNEL` |
+| `serverSslCert` | CA or server certificate to trust |
+| `clientSslCert`, `clientSslKey`, `clientSslPassword` | Client certificate for mutual TLS |
+| `tlsProtocol` | Allowed protocol versions |
+| `fallbackToSystemTrustStore`, `fallbackToSystemKeyStore` | `false` disables the JVM-default fallback |
+| `sslContextBuilderCustomizer` | Escape hatch for anything the named options do not cover |
+
+### Pooling
+
+```java
+ConnectionPoolConfiguration poolConf = ConnectionPoolConfiguration.builder(factory)
+    .maxSize(20)
+    .maxIdleTime(Duration.ofMinutes(30))
+    .build();
+
+ConnectionPool pool = new ConnectionPool(poolConf);
+```
+
+`ConnectionPool` is itself a `ConnectionFactory`, so the rest of the application is unaffected by whether pooling is present.
+
+### Spring Data R2DBC
+
+With Spring Boot, the same driver is configured through `spring.r2dbc.url` and friends, and Spring builds the `ConnectionFactory`. The driver dependency and the URL scheme are unchanged; only the wiring moves into configuration properties.
+
+## See Also
+
+- **`mariadb-connector-r2dbc-usage`** — using the driver once installed: statements, parameter binding, result mapping, transactions, batches
+- **`mariadb-connector-j-install`** — the blocking JDBC alternative, when a reactive stack is not in play
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-r2dbc>

--- a/agent-skills/granular/connectors/mariadb-connector-r2dbc-usage/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-r2dbc-usage/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: mariadb-connector-r2dbc
+name: mariadb-connector-r2dbc-usage
 description: "MariaDB-specific behavior of MariaDB Connector/R2DBC (the `org.mariadb:r2dbc-mariadb` reactive driver implementing the R2DBC SPI) for application code — that the URL scheme is `r2dbc:mariadb://user:pw@host:port/db` and factories come from `ConnectionFactories.get(url)` or a `MariadbConnectionConfiguration` builder; that placeholders are positional `?` bound 0-indexed or named `:name`; that NOTHING runs until the `Publisher` returned by `Statement.execute()` is subscribed, and a `Result` can be consumed exactly once; that `bindNull(index, Class)` needs an explicit type; that autocommit defaults to true and `useServerPrepStmts` to false; that transactions return `Mono<Void>` that must itself be subscribed; that pooling is not built in and needs `r2dbc-pool`; and that errors arrive as `onError` signals (`R2dbcException`), not thrown exceptions. Use when writing or reviewing Java code that talks to MariaDB reactively via R2DBC."
 ---
 
 # MariaDB Connector/R2DBC
 
-*Last updated: 2026-07-21*
+*Last updated: 2026-08-10*
 
-MariaDB Connector/R2DBC is the official reactive, non-blocking driver for MariaDB implementing the [R2DBC](https://r2dbc.io) SPI — Maven coordinates `org.mariadb:r2dbc-mariadb`. It is **100% pure Java** (Java 8+), built on Reactor and Netty, and does **not** depend on Connector/C. This skill covers the connector-specific behavior and the traps that bite generated application code. It is a separate, independently-versioned sibling of **MariaDB Connector/J** (the blocking JDBC driver, also pure Java) — same vendor, different API paradigm; do not assume JDBC idioms (blocking calls, `try`-with-resources returning a live `ResultSet`) carry over.
+MariaDB Connector/R2DBC is the official reactive, non-blocking driver for MariaDB implementing the [R2DBC](https://r2dbc.io) SPI — Maven coordinates `org.mariadb:r2dbc-mariadb`. It is **100% pure Java** (Java 8+), built on Reactor and Netty, and does **not** depend on Connector/C. This skill covers the connector-specific behavior and the traps that bite generated application code. For adding the driver to a build and configuring the factory, pooling, and TLS, see **`mariadb-connector-r2dbc-install`**. It is a separate, independently-versioned sibling of **MariaDB Connector/J** (the blocking JDBC driver, also pure Java) — same vendor, different API paradigm; do not assume JDBC idioms (blocking calls, `try`-with-resources returning a live `ResultSet`) carry over.
 
 > **Default context:** Assume the **1.4** line (`r2dbc-mariadb` 1.4.1) unless the user states otherwise; 1.0 and 1.1 have reached end of life. The connector follows the [R2DBC 1.0.0 spec](https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/) (a legacy `r2dbc-mariadb-0.9.1-spec` artifact exists for the older spec). Connector versions are independent of the MariaDB server version.
 
@@ -28,7 +28,11 @@ MariaDB Connector/R2DBC is the official reactive, non-blocking driver for MariaD
 | Hand-rolls a pool or opens a new connection per request | No pooling is built in — add **`r2dbc-pool`** and wrap the `MariadbConnectionFactory` in `ConnectionPoolConfiguration.builder(factory).maxSize(...).build()` → `new ConnectionPool(poolConfig)`; borrow with `pool.create()`, return by `.close()` |
 | Loops single-row `execute()` calls for a bulk insert | Call **`Statement.add()`** between `.bind()` calls on the *same* parameterized statement to queue another parameter set, then `execute()` once — one round trip covers all bound rows |
 | Uses `io.r2dbc.spi.Batch` expecting parameter binding | `Batch` (`conn.createBatch().add(sql1).add(sql2)...`) groups **distinct, already-literal SQL strings with no parameter binding** — for parameterized bulk operations use `Statement.add()` instead (see above) |
-| Assumes TLS is on by default | `sslMode` defaults to **`DISABLE`** (no TLS) — set it explicitly (`TRUST`/`VERIFY_CA`/`VERIFY_FULL`) for anything beyond local development |
+| Assumes TLS is on by default | `sslMode` defaults to **`DISABLE`** (no TLS) — set it explicitly (`TRUST`/`VERIFY_CA`/`VERIFY_FULL`) for anything beyond local development. Certificate configuration lives in **`mariadb-connector-r2dbc-install`** |
+| Runs a second `SELECT` to read back an auto-generated id | **`Statement.returnGeneratedValues(columns…)`** makes the insert itself yield them. Note the server-version constraint: **more than one column requires MariaDB 10.5.1 or later**, and asking for several against an older server throws `IllegalArgumentException` |
+| Pulls a large result set through the default flow control | **`Statement.fetchSize(rows)`** switches the statement to cursor-based fetching, so rows arrive in bounded chunks instead of one large burst |
+| Rolls back the whole transaction to undo one step | Savepoints are reactive too: **`createSavepoint(name)`**, **`rollbackTransactionToSavepoint(name)`**, **`releaseSavepoint(name)`**, each returning `Mono<Void>` that must be subscribed |
+| Sets an isolation level or a lock timeout with a raw `SET` statement | The connection exposes them directly: **`setTransactionIsolationLevel()`**, **`setLockWaitTimeout(Duration)`**, **`setStatementTimeout(Duration)`** |
 
 ## Connection, query, and result mapping
 
@@ -71,9 +75,31 @@ Mono<Void> work = Mono.from(factory.create())
 work.block();   // only block at the outermost boundary
 ```
 
+## Bulk insert and generated values
+
+```java
+Mono.from(factory.create())
+    .flatMapMany(conn -> {
+      Statement stmt = conn.createStatement(
+          "INSERT INTO t (name, qty) VALUES (?, ?)")
+          .returnGeneratedValues("id");
+
+      stmt.bind(0, "widget").bind(1, 5).add();      // queue this parameter set
+      stmt.bind(0, "gadget").bind(1, 3);            // no trailing add() on the last one
+
+      return Flux.from(stmt.execute())
+          .flatMap(result -> result.map((row, meta) -> row.get("id", Long.class)))
+          .concatWith(Mono.from(conn.close()).then(Mono.empty()));
+    })
+    .subscribe(System.out::println);
+```
+
+`add()` separates parameter sets on one statement; a trailing `add()` after the final bind queues an empty set and is a common source of a spurious extra execution.
+
 ## See Also
 
-- **`mariadb-connector-j`** — the blocking JDBC sibling (also pure Java, no Connector/C); use it when the application isn't reactive
+- **`mariadb-connector-r2dbc-install`** — adding the driver to a build, the `ConnectionFactory`, `r2dbc-pool`, and TLS configuration
+- **`mariadb-connector-j-usage`** — the blocking JDBC sibling (also pure Java, no Connector/C); use it when the application isn't reactive
 - **`mariadb-transactions`** / **`mariadb-set-transaction`** — server-side semantics behind `beginTransaction()`/`commitTransaction()`/isolation levels
 - **`mariadb-prepare`** — server-side prepared statements, what `useServerPrepStmts=true` uses under the hood
 - Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-r2dbc>


### PR DESCRIPTION
Closes [DOCS-6379](https://mariadbcorp.atlassian.net/browse/DOCS-6379).

Splits each of the seven connector skills under `agent-skills/granular/connectors/` into two, by task:

| Install (new) | Usage (renamed) |
|---|---|
| `mariadb-connector-c-install` | `mariadb-connector-c-usage` |
| `mariadb-connector-cpp-install` | `mariadb-connector-cpp-usage` |
| `mariadb-connector-j-install` | `mariadb-connector-j-usage` |
| `mariadb-connector-nodejs-install` | `mariadb-connector-nodejs-usage` |
| `mariadb-connector-odbc-install` | `mariadb-connector-odbc-usage` |
| `mariadb-connector-python-install` | `mariadb-connector-python-usage` |
| `mariadb-connector-r2dbc-install` | `mariadb-connector-r2dbc-usage` |

## Scope note

The seven existing skills were **usage-only by design** — DOCS-6345 deliberately excluded install and config, and both the manifest `$comment` and the README row said so. There was therefore almost nothing to split off: the seven `-install` skills are **new content**, written from the `connectors/` docs space and verified against the connector clones in the workspace.

## What the install skills cover

Each is a full peer of its usage sibling — a **What LLMs Often Miss** table, per-platform install, build-from-source, and the configuration surface (option files, DSNs, TLS, pooling knobs). Load-bearing claims were checked in source rather than taken from the docs, for example:

- **Connector/C** reads option files *only* when the application sets `MYSQL_READ_DEFAULT_FILE` or `MYSQL_READ_DEFAULT_GROUP` (`libmariadb/mariadb_lib.c:1733`) — the command-line clients read `my.cnf` because *they* opt in.
- **Connector/J** `sslMode` defaults to `DISABLE` (`Configuration.java:308-314`), so `serverSslCert` alone encrypts nothing; and JNA is not a transitive dependency although `UnixDomainSocket`/`NamedPipeSocket` need it.
- **Connector/R2DBC** `sslMode` likewise defaults to `DISABLE` (`MariadbConnectionConfiguration.java:919`).
- **Connector/Python** requires Connector/C 3.3.1+ even on the 1.1 line (`mariadb_posix.py:49`), and `ssl_verify_cert` defaults to off there (`mariadb_connection.c:328`).
- **Connector/ODBC** bundles `libmariadb` as a submodule, so unlike Connector/C++ it needs no separate Connector/C install; DSN keywords taken from `driver/ma_dsn.c`.
- **Connector/Node.js** declares `node >= 20.0.0` and publishes exactly two entry points via its exports map (`package.json`).

## Usage expansions

Threading and `STMT_ATTR_ARRAY_SIZE` bulk insert (C); batching, `wasNull()`, savepoints, `CallableStatement` (C++); batch insert with generated keys, `executeLargeUpdate()` (J); `prepare()`/`close()`, `importFile()`, `reset()`, streaming (Node.js); `SQL_ATTR_PARAMSET_SIZE`, `SQLMoreResults`, `SQLGetData` (ODBC); transactions, `executemany()`, error handling (Python); `returnGeneratedValues()`, `fetchSize()`, savepoints (R2DBC).

## Description-length compliance

The pi.dev harness caps the frontmatter `description:` at 1024 characters, and the split doubles the exposure to 14. All 14 are compliant, verified mechanically against the exact `^description: "(.*)"$` form:

| | range |
|---|---|
| install halves (new) | 704-777 |
| usage halves | 773-956 |

## Also updated

- `agent-skills/.skills-manifest.json` — 14 entries, install halves at `status: draft`, usage halves keep `pilot`.
- `agent-skills/README.md` — the `granular/connectors/` layer row.
- Cross-references in every skill's *See Also* now point at the split names.

No `SUMMARY.md` changes — agent skills stay out of the rendered navigation.

## Checks

codespell clean; lychee 21 links / 21 OK / 0 errors on the changed set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6379]: https://mariadbcorp.atlassian.net/browse/DOCS-6379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ