### PR TITLE
DOCS-6394 Replace licence includes with literal notices (batch 1/6)

### DIFF
--- a/analytics/README.md
+++ b/analytics/README.md
@@ -35,6 +35,6 @@ MariaDB Exa erases the barrier between live operational data and high-speed anal
 [mariadb-exa](mariadb-exa/)
 {% endcontent-ref %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/README.md
+++ b/analytics/mariadb-columnstore/README.md
@@ -44,6 +44,6 @@ icon: table-columns
 [reference](reference/)
 {% endcontent-ref %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/columnstore-architectural-overview.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-architectural-overview.md
@@ -509,6 +509,6 @@ It does not contain:
 
 * ColumnStore data
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/columnstore-performance-module.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-performance-module.md
@@ -57,6 +57,6 @@ In cases of failover where the underlying storage data is externally mounted, (s
 
 When the failed Performance Module is brought back online, ColumnStore auto-adopts it back into the configuration and begins using it for work.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/columnstore-query-processing.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-query-processing.md
@@ -38,6 +38,6 @@ The completed result set is returned to the MariaDB Server, which performs any r
 \
 Finally, the MariaDB Server returns the result set to the client.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/columnstore-read-replicas.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-read-replicas.md
@@ -177,6 +177,6 @@ See [this page](../management/deployment/install-guide/multnode-localstorage/ste
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/columnstore-storage-architecture.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-storage-architecture.md
@@ -529,6 +529,6 @@ This behavior is automatic and well suited for series, ordered, patterned and ti
 * [Adding a Node to a ColumnStore Cluster](../management/node-maintenance-for-mariadb-enterprise-columnstore/add-a-node.md)
 * [Topologies Overview](topologies-overview.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/columnstore-storage-engine-overview.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-storage-engine-overview.md
@@ -77,6 +77,6 @@ sudo mcsSetConfig CrossEngineSupport User cross_engine
 sudo mcsSetConfig CrossEngineSupport Password cross_engine_passwd
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/columnstore-system-databases.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-system-databases.md
@@ -15,6 +15,6 @@ When using ColumnStore, MariaDB Server creates a series of system databases used
 | infinidb\_querystats | Database maintains information about query performance. For more information, see [Query Analysis](../high-availability/analyzing-queries-in-columnstore.md).                                                             |
 | columnstore\_info    | The database for stored procedures is used to retrieve information about ColumnStore usage. For more information, see the [ColumnStore Information Schema](../reference/columnstore-information-schema-tables.md) tables. |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/columnstore-system-paths-and-logs.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-system-paths-and-logs.md
@@ -267,6 +267,6 @@ Attach the resulting `.tar.gz` file to your support ticket. On a multi-node clus
 
 `mcs review` without options runs a read-only health check (version, topology, storage, extent map, locks, open ports, and more) and writes its report to `/tmp/columnstore_review/<hostname>_cs_review.txt`; see `mcs review --help` for the full list of diagnostic options.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/columnstore-user-module.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-user-module.md
@@ -52,6 +52,6 @@ In addition to these, the User Module also runs processes for DMLProc, DDLPrc an
 
 DMLProc and DDLProc distribute DML and DDL statements to the appropriate Performance Modules. When cpimport runs on the User Module, it distributes source files to the Performance Modules.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/mariadb-enterprise-columnstore-locking.md
+++ b/analytics/mariadb-columnstore/architecture/mariadb-enterprise-columnstore-locking.md
@@ -35,6 +35,6 @@ For additional information, see "[MariaDB ColumnStore Data Loading](../clients-a
 
 MariaDB ColumnStore supports online schema changes, so that supported DDL operations can be performed without blocking reads. The supported DDL operations only require a write metadata lock (MDL) on the target table.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/mariadb-enterprise-columnstore-query-evaluation.md
+++ b/analytics/mariadb-columnstore/architecture/mariadb-enterprise-columnstore-query-evaluation.md
@@ -204,6 +204,6 @@ When Enterprise ColumnStore executes a query, it goes through the following proc
 8. ES returns the results to MaxScale.
 9. MaxScale returns the results to the client or application.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/architecture/topologies-overview.md
+++ b/analytics/mariadb-columnstore/architecture/topologies-overview.md
@@ -172,6 +172,6 @@ _MaxScale routes HTAP traffic to one server that replicates from InnoDB to S3-ba
 
 <ul><li>Single-stack hybrid transactional/analytical workloads</li><li>ColumnStore for analytics with scalable S3-compatible object storage</li><li>InnoDB for transactions• Cross-engine JOINs</li><li>Enterprise Server, ColumnStore, MaxScale</li></ul>
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/data-import/README.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/data-import/README.md
@@ -63,6 +63,6 @@ When a bulk data load is running:
 | Fast        | [LOAD DATA \[ LOCAL \] INFILE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) | SQL       | • Text file.                                        | • Server file system • Client file system | • Translates operation to cpimport command. • Non-blocking                              |
 | Slow        | [INSERT .. SELECT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/inserting-loading-data/insert)                                                      | SQL       | • Other table(s).                                   | • Same MariaDB server                     | • Translates operation to cpimport command. • Non-blocking                              |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-cpimport.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-cpimport.md
@@ -290,6 +290,6 @@ When this problem occurs, some solutions are:
 
 Additional information is available [here](../data-ingestion/columnstore-bulk-data-loading.md#cpimport-modes).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-insert-select.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-insert-select.md
@@ -150,6 +150,6 @@ SELECT *
 FROM innodb_inventory.products;
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-load-data-infile.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-load-data-infile.md
@@ -219,6 +219,6 @@ MariaDB Enterprise ColumnStore ignores the `ON DUPLICATE KEY` clause.
 
 Ensure that duplicate data is removed prior to performing a bulk data load.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-load_from_s3.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-load_from_s3.md
@@ -94,6 +94,6 @@ For example, the AWS user can use a user policy like the following:
 }
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/data-ingestion/README.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/data-ingestion/README.md
@@ -21,6 +21,6 @@ ColumnStore provides several mechanisms to ingest data:
     * Bulk update operations based on a join with a small staging table can be relatively fast, especially if updating a single column.
 * Using ColumnStore Bulk Write SDK or [ColumnStore Streaming Data Adapters](columnstore-streaming-data-adapters.md).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/data-ingestion/columnstore-bulk-data-loading.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/data-ingestion/columnstore-bulk-data-loading.md
@@ -572,6 +572,6 @@ A typical log might look like this:
 
 _Prior to version 1.4, this folder was located at_ `/usr/local/mariadb/columnstore/bulk`_._
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/data-ingestion/columnstore-streaming-data-adapters.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/data-ingestion/columnstore-streaming-data-adapters.md
@@ -301,7 +301,7 @@ This plugin is a beta release.
 
 In addition, it can't handle blob data types and only supports multiple inputs to one block if the input field names are equal for all input sources.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}
 

--- a/analytics/mariadb-columnstore/clients-and-tools/storagemanager/certified-s3-object-storage-providers.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/storagemanager/certified-s3-object-storage-providers.md
@@ -24,6 +24,6 @@ description: >-
 Due to the frequent code changes and deviation from the AWS standards, none are approved at this time.
 {% endhint %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/storagemanager/storagemanager-sample-storagemanagercnf.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/storagemanager/storagemanager-sample-storagemanagercnf.md
@@ -40,6 +40,6 @@ path = /var/lib/columnstore/storagemanager/cache
 Note: A region is required even when using an on-premises solution like [ActiveScale](https://qsupport.quantum.com/kb/flare/Content/ActiveScale/PDFs/ActiveScale_OS_S3_API_Reference.pdf) due to header expectations within the API.
 {% endhint %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/clients-and-tools/storagemanager/using-storagemanager-with-iam-role.md
+++ b/analytics/mariadb-columnstore/clients-and-tools/storagemanager/using-storagemanager-with-iam-role.md
@@ -51,6 +51,6 @@ path = /var/lib/columnstore/storagemanager/cache
 _Note: This is an AWS only feature. For other deployment methods, see the example_ [_here_](storagemanager-sample-storagemanagercnf.md)_._
 {% endhint %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/columnstore-quickstart-guides/mariadb-columnstore-guide.md
+++ b/analytics/mariadb-columnstore/columnstore-quickstart-guides/mariadb-columnstore-guide.md
@@ -95,6 +95,6 @@ SELECT COUNT(DISTINCT product_name) FROM sales_data;
 * [MariaDB ColumnStore Overview](https://mariadb.com/products/columnstore/)
 * [DigitalOcean: How to Install MariaDB ColumnStore on Ubuntu 20.04](https://www.google.com/search?q=https://www.digitalocean.com/community/tutorials/how-to-install-mariadb-columnstore-on-ubuntu-20-04\&authuser=1)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/columnstore-quickstart-guides/mariadb-columnstore-hardware-guide.md
+++ b/analytics/mariadb-columnstore/columnstore-quickstart-guides/mariadb-columnstore-hardware-guide.md
@@ -57,7 +57,7 @@ For AWS, ColumnStore internal testing generally uses `m4.4xlarge` instance types
 * [MariaDB ColumnStore Overview](https://mariadb.com/products/columnstore/)
 * [MariaDB documentation: MariaDB ColumnStore](../)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}
 

--- a/analytics/mariadb-columnstore/high-availability/analyzing-queries-in-columnstore.md
+++ b/analytics/mariadb-columnstore/high-availability/analyzing-queries-in-columnstore.md
@@ -359,7 +359,7 @@ Run your queries against the newly ordered table. You should observe:
 
 * [Query Statistics for MariaDB ColumnStore](columnstore-query-tuning/query-statistics-for-mariadb-enterprise-columnstore.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}
 

--- a/analytics/mariadb-columnstore/high-availability/columnstore-query-tuning/collect-statistics-with-analyze-table-for-mariadb-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/high-availability/columnstore-query-tuning/collect-statistics-with-analyze-table-for-mariadb-enterprise-columnstore.md
@@ -31,6 +31,6 @@ ColumnStore's optimizer statistics are not updated automatically. To update the 
 
 ColumnStore does not implement an interface to show optimizer statistics.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/high-availability/columnstore-query-tuning/query-plans-and-optimizer-trace/columnstore-execution-plan-csep-for-mariadb-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/high-availability/columnstore-query-tuning/query-plans-and-optimizer-trace/columnstore-execution-plan-csep-for-mariadb-enterprise-columnstore.md
@@ -38,6 +38,6 @@ AND column1 < '2020-11-01';
 SELECT calGetTrace();
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/high-availability/columnstore-query-tuning/query-plans-and-optimizer-trace/job-steps-for-mariadb-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/high-availability/columnstore-query-tuning/query-plans-and-optimizer-trace/job-steps-for-mariadb-enterprise-columnstore.md
@@ -130,6 +130,6 @@ In `calGetTrace()` output, a window function step is abbreviated WFS.
 
 Window function steps are evaluated locally by the [ExeMgr process](../../../architecture/mariadb-enterprise-columnstore-query-evaluation.md#exemgr-processfacility) on the initiator/aggregator node.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/high-availability/columnstore-query-tuning/query-tuning-recommendations-for-mariadb-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/high-availability/columnstore-query-tuning/query-tuning-recommendations-for-mariadb-enterprise-columnstore.md
@@ -114,6 +114,6 @@ To support distributed execution of custom SQL, MariaDB ColumnStore supports a D
 * The Distributed User Defined Aggregate Functions (UDAF) C++ API allows anyone to create aggregate functions of arbitrary complexity for distributed execution in the ColumnStore storage engine.
 * These functions can also be used as Analytic (Window) functions just like any built-in aggregate function.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/high-availability/mariadb-columnstore-performance-concepts.md
+++ b/analytics/mariadb-columnstore/high-availability/mariadb-columnstore-performance-concepts.md
@@ -86,7 +86,7 @@ Window functions are executed as part of final aggregation in PrimProc[^1] due t
 
 Automated system partitioning of columns is provided by ColumnStore. As data is loaded into extent maps, the system will capture and maintain min/max values of column data in that extent map. New rows are appended to each extent map until full at which point a new extent map is created. For column values that are ordered or semi-ordered this allows for very effective data partitioning. By using the min and max values, entire extent maps can be eliminated and not read to filter data. This generally works particularly well for time dimension / series data or similar values that increase over time.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}
 

--- a/analytics/mariadb-columnstore/high-availability/mariadb-columnstore-performance-related-configuration-settings.md
+++ b/analytics/mariadb-columnstore/high-availability/mariadb-columnstore-performance-related-configuration-settings.md
@@ -121,6 +121,6 @@ A MariaDB global or session variable is available to specify a memory limit at w
 
 * `infinidb_um_mem_limit` - Memory limit in MB per user (i.e., switch to disk-based join if this limit is exceeded). By default, this limit is not set (value of 0).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/column-store-backup-and-restore/backup-and-restore-with-mariadb-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/column-store-backup-and-restore/backup-and-restore-with-mariadb-enterprise-columnstore.md
@@ -92,6 +92,6 @@ flowchart TD
 
 _MaxScale routes read/write traffic to three ES + ColumnStore nodes backed by NFS shared storage._
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/column-store-backup-and-restore/mariadb-enterprise-columnstore-backup-and-restore-with-object-storage.md
+++ b/analytics/mariadb-columnstore/management/column-store-backup-and-restore/mariadb-enterprise-columnstore-backup-and-restore-with-object-storage.md
@@ -208,6 +208,6 @@ $ sudo systemctl start mariadb
 $ sudo systemctl start mariadb-columnstore-cmapi
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/column-store-backup-and-restore/mariadb-enterprise-columnstore-backup-and-restore-with-shared-local-storage.md
+++ b/analytics/mariadb-columnstore/management/column-store-backup-and-restore/mariadb-enterprise-columnstore-backup-and-restore-with-shared-local-storage.md
@@ -198,6 +198,6 @@ $ sudo systemctl start mariadb
 $ sudo systemctl start mariadb-columnstore-cmapi
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/columnstore-and-recursive-cte-limitations.md
+++ b/analytics/mariadb-columnstore/management/columnstore-and-recursive-cte-limitations.md
@@ -214,6 +214,6 @@ WITH RECURSIVE org_chart AS (
 SELECT * FROM org_chart;
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/columnstore-system-variables.md
+++ b/analytics/mariadb-columnstore/management/columnstore-system-variables.md
@@ -427,6 +427,6 @@ where n is:
 2. (the default) query syntax is evaluated by ColumnStore for compatibility with distributed execution and incompatible queries are rejected. Queries executed in this mode take advantage of distributed execution and typically result in higher performance.
 3. auto-switch mode: ColumnStore will attempt to process the query internally, if it cannot, it will automatically switch the query to run in row-by-row mode.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/README.md
@@ -673,6 +673,6 @@ $ mariadb --quick \
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
@@ -159,6 +159,6 @@ This page was step 1 of 5.
 
 [Next: Step 2: Install MariaDB ColumnStore](step-3-start-and-configure-enterprise-columnstore.md).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-2-install-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-2-install-enterprise-columnstore.md
@@ -123,6 +123,6 @@ This page was step 2 of 5.
 
 [Next: Step 3: Start and Configure MariaDB ColumnStore.](step-4-test-enterprise-columnstore.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-3-start-and-configure-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-3-start-and-configure-enterprise-columnstore.md
@@ -207,6 +207,6 @@ This page was step 3 of 5.
 
 [Next: Step 4: Test MariaDB ColumnStore.](step-4-test-enterprise-columnstore.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-4-test-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-4-test-enterprise-columnstore.md
@@ -172,6 +172,6 @@ This page was step 4 of 5.
 
 [Next: Step 5: Bulk Import of Data.](step-5-bulk-import-of-data.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-5-bulk-import-of-data.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-5-bulk-import-of-data.md
@@ -84,6 +84,6 @@ This page was step 5 of 5.
 
 This procedure is complete.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/README.md
@@ -2802,6 +2802,6 @@ $ mariadb --quick \
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-1-prepare-columnstore-nodes.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-1-prepare-columnstore-nodes.md
@@ -216,6 +216,6 @@ Navigation in the procedure "Deploy ColumnStore Shared Local Storage Topology".
 
 This page was step 1 of 9.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-2-configure-shared-local-storage.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-2-configure-shared-local-storage.md
@@ -244,6 +244,6 @@ This page was step 2 of 9.
 
 [Next: Step 3: Install MariaDB Enterprise Server.](step-3-install-mariadb-enterprise-server.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-3-install-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-3-install-mariadb-enterprise-server.md
@@ -122,6 +122,6 @@ This page was step 3 of 9.
 
 [Next: Step 4: Start and Configure MariaDB Enterprise Server.](step-4-start-and-configure-mariadb-enterprise-server.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-4-start-and-configure-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-4-start-and-configure-mariadb-enterprise-server.md
@@ -685,6 +685,6 @@ This page was step 4 of 9.
 
 [Next: Step 5: Test MariaDB Enterprise Server](step-5-test-mariadb-enterprise-server.md).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-5-test-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-5-test-mariadb-enterprise-server.md
@@ -296,6 +296,6 @@ This page was step 5 of 9.
 
 [Next: Step 6: Install MariaDB MaxScale](step-6-install-mariadb-maxscale.md).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-6-install-mariadb-maxscale.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-6-install-mariadb-maxscale.md
@@ -86,6 +86,6 @@ This page was step 6 of 9.
 
 [Next: Step 7: Start and Configure MariaDB MaxScale.](step-7-start-and-configure-mariadb-maxscale.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-7-start-and-configure-mariadb-maxscale.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-7-start-and-configure-mariadb-maxscale.md
@@ -191,6 +191,6 @@ This page was step 7 of 9.
 
 [Next: Next: Step 8: Test MariaDB MaxScale.](step-8-test-mariadb-maxscale.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-8-test-mariadb-maxscale.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-8-test-mariadb-maxscale.md
@@ -645,6 +645,6 @@ This page was step 8 of 9.
 
 [Next: Step 9: Import Data.](step-9-import-data.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-9-import-data.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-9-import-data.md
@@ -86,6 +86,6 @@ This page was step 9 of 9.
 
 This procedure is complete.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/README.md
@@ -2931,6 +2931,6 @@ $ mariadb --quick \
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-1-prepare-columnstore-nodes.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-1-prepare-columnstore-nodes.md
@@ -226,6 +226,6 @@ This page was step 1 of 9.
 
 [Next: Step 2: Configure Shared Local Storage](step-2-configure-shared-local-storage.md).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-2-configure-shared-local-storage.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-2-configure-shared-local-storage.md
@@ -237,6 +237,6 @@ This page was **step 2 of 9**.
 
 [Next: Step 3: Install MariaDB Enterprise Server.](step-3-install-mariadb-enterprise-server.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-3-install-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-3-install-mariadb-enterprise-server.md
@@ -122,6 +122,6 @@ This page was **step 3 of 9**.
 
 [Next: Step 4: Start and Configure MariaDB Enterprise Server.](step-4-start-and-configure-mariadb-enterprise-server.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-4-start-and-configure-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-4-start-and-configure-mariadb-enterprise-server.md
@@ -721,6 +721,6 @@ This page was **step 4 of 9**.
 
 [Next: Step 5: Test MariaDB Enterprise Server.](step-5-test-mariadb-enterprise-server.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-5-test-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-5-test-mariadb-enterprise-server.md
@@ -318,6 +318,6 @@ This page was **step 5 of 9**.
 
 [Next: Step 6: Install MariaDB MaxScale.](step-6-install-mariadb-maxscale.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-6-install-mariadb-maxscale.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-6-install-mariadb-maxscale.md
@@ -88,6 +88,6 @@ This page was **step 6 of 9**.
 
 [Next: Step 7: Start and Configure MariaDB MaxScale](step-7-start-and-configure-mariadb-maxscale.md).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-7-start-and-configure-mariadb-maxscale.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-7-start-and-configure-mariadb-maxscale.md
@@ -188,6 +188,6 @@ This page was **step 7 of 9**.
 
 [Next: Step 8: Test MariaDB MaxScale](step-8-test-mariadb-maxscale.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-8-test-mariadb-maxscale.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-8-test-mariadb-maxscale.md
@@ -644,6 +644,6 @@ This page was **step 8 of 9**.
 
 [Next: Step 9: Import Data](step-9-import-data.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-9-import-data.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-9-import-data.md
@@ -86,6 +86,6 @@ This page was **step 9 of 9**.
 
 This procedure is complete.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/README.md
@@ -771,6 +771,6 @@ $ mariadb --quick \
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
@@ -153,6 +153,6 @@ This page was step 1 of 5.
 
 [Next: Step 2: Install MariaDB ColumnStore.](step-2-install-enterprise-columnstore.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-2-install-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-2-install-enterprise-columnstore.md
@@ -123,6 +123,6 @@ This page was step 2 of 5.
 
 [Next: Step 3: Start and Configure MariaDB ColumnStore.](step-3-start-and-configure-enterprise-columnstore.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-3-start-and-configure-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-3-start-and-configure-enterprise-columnstore.md
@@ -168,6 +168,6 @@ This page was step 3 of 5.
 
 [Next: Step 4: Test MariaDB ColumnStore.](step-4-test-enterprise-columnstore.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-4-test-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-4-test-enterprise-columnstore.md
@@ -159,6 +159,6 @@ This page was step 4 of 5.
 
 [Next: Step 5: Bulk Import of Data.](step-5-bulk-import-of-data.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-5-bulk-import-of-data.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-5-bulk-import-of-data.md
@@ -84,6 +84,6 @@ This page was step 5 of 5.
 
 This procedure is complete.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/upgrades/major-release-upgrades-for-mariadb-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/upgrades/major-release-upgrades-for-mariadb-enterprise-columnstore.md
@@ -96,6 +96,6 @@ On the **new ColumnStore cluster**, verify that the table schemas and data have 
     SELECT * FROM DATABASE_NAME.TABLE_NAME LIMIT 100;
     ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/deployment/upgrades/upgrade-multi-node-mariadb-enterprise-columnstore-from-6-to-23.10.md
+++ b/analytics/mariadb-columnstore/management/deployment/upgrades/upgrade-multi-node-mariadb-enterprise-columnstore-from-6-to-23.10.md
@@ -331,6 +331,6 @@ maxctrl list servers
 
 If the node is no longer in maintenance mode, then the `State` column will no longer show `Maintenance` as one of the states.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/extent-map-backup-recovery.md
+++ b/analytics/mariadb-columnstore/management/extent-map-backup-recovery.md
@@ -143,6 +143,6 @@ Incorporate the `save_brm` command into your data import scripts (e.g., those us
 
 Refer to the MariaDB ColumnStore Backup Script for an example implementation.​
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/managing-columnstore-database-environment/columnstore-partition-management.md
+++ b/analytics/mariadb-columnstore/management/managing-columnstore-database-environment/columnstore-partition-management.md
@@ -259,6 +259,6 @@ A bulk-delete statement can be used to delete the remaining rows that do not fal
 DELETE FROM orders WHERE orderdate <= '1998-12-31';
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/add-a-node.md
+++ b/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/add-a-node.md
@@ -385,6 +385,6 @@ maxctrl list servers
 
 If the new node is properly replicating, then the `State` column will show `Slave, Running`.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/rejoin-a-node.md
+++ b/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/rejoin-a-node.md
@@ -42,6 +42,6 @@ maxctrl list servers
 
 If the node properly rejoined, the `State` column of the node shows `Slave, Running`.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/remove-a-node.md
+++ b/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/remove-a-node.md
@@ -236,6 +236,6 @@ Example output:
 }
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/set-a-node-to-maintenance-mode.md
+++ b/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/set-a-node-to-maintenance-mode.md
@@ -89,6 +89,6 @@ maxctrl list servers
 
 If the node is no longer in maintenance mode, the `State` column no longer shows `Maintenance` as one of the states.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/switchover-primary-node.md
+++ b/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/switchover-primary-node.md
@@ -52,6 +52,6 @@ maxctrl list servers
 
 If switchover was properly performed, the `State` column of the new primary shows `Master, Running`.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/view-clear-table-locks.md
+++ b/analytics/mariadb-columnstore/management/node-maintenance-for-mariadb-enterprise-columnstore/view-clear-table-locks.md
@@ -86,6 +86,6 @@ Clearing table lock 54303 for table edf_colstore.pl_cs_tracking_summary_t
 Table lock 54303 for table edf_colstore.pl_cs_tracking_summary_t is cleared.
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/optimizing-linux-kernel-parameters-for-mariadb-columnstore.md
+++ b/analytics/mariadb-columnstore/management/optimizing-linux-kernel-parameters-for-mariadb-columnstore.md
@@ -80,6 +80,6 @@ These optimized parameters are recommended for all MariaDB ColumnStore deploymen
 
 By optimizing the Linux kernel parameters, you can significantly improve the performance of your MariaDB ColumnStore deployments. These recommendations provide a starting point for optimizing your system, and you may need to adjust the values based on your specific hardware and workload.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/management/upgrades.md
+++ b/analytics/mariadb-columnstore/management/upgrades.md
@@ -265,6 +265,6 @@ Contact MariaDB Support if you encounter unexpected failures, data issues, or pe
 * Backups: `mcs backup` and Extent Map backup guidance.
 * Cluster management: `mcs cluster start|stop|status` .
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/5568.md
+++ b/analytics/mariadb-columnstore/reference/5568.md
@@ -11,6 +11,6 @@ The `COMMIT` statement makes changes to a table permanent. You should only commi
 
 images here
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/5571.md
+++ b/analytics/mariadb-columnstore/reference/5571.md
@@ -14,6 +14,6 @@ The following statement drops the _`sp_complex_variable`_ procedure:
 DROP PROCEDURE sp_complex_variable;
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/5573.md
+++ b/analytics/mariadb-columnstore/reference/5573.md
@@ -30,6 +30,6 @@ does not already exist):
 RENAME TABLE customer TO temp_table, vendor TO customer,temp_table to vendor;
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/5574.md
+++ b/analytics/mariadb-columnstore/reference/5574.md
@@ -9,6 +9,6 @@ description: >-
 
 The `ROLLBACK` statement undoes transactions that have not been permanently saved to the database with the `COMMIT` statement. You cannot rollback changes to table properties including `ALTER`, `CREATE`, or `DROP TABLE` statements.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/cmapi/README.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/README.md
@@ -195,6 +195,6 @@ The final part of the standard HTTP response message is the body.
 | Success     | JSON Data                             |
 | Failure     | Undefined Depends on specific failure |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/cmapi/mode-set.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/mode-set.md
@@ -64,6 +64,6 @@ mcsReadWrite
 
 These aliases use `jq` produces human-readable output from the returned JSON response.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/cmapi/node-delete.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/node-delete.md
@@ -48,6 +48,6 @@ In this example, `jq` produces human-readable output from the returned JSON resp
 }
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/cmapi/node-put.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/node-put.md
@@ -49,6 +49,6 @@ In this example, `jq` produces human-readable output from the returned JSON resp
 }
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/cmapi/shutdown.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/shutdown.md
@@ -54,6 +54,6 @@ mcsShutdown
 
 These aliases use `jq` produces human-readable output from the returned JSON response.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/cmapi/start.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/start.md
@@ -55,6 +55,6 @@ mcsStart
 
 These aliases use `jq` produces human-readable output from the returned JSON response.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/cmapi/status.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/status.md
@@ -151,6 +151,6 @@ mcsStatus
 
 In this example, `jq` produces human-readable output from the returned JSON response.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-compression-mode.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-compression-mode.md
@@ -20,6 +20,6 @@ where n is:
 1. 0 = Compression is turned off. Any subsequent table create statements run will have compression turned off for that table unless any statement overrides have been performed. Any `ALTER` statements run to add a column will have compression turned off for that column unless any statement override has been performed.
 2. 1 = Compression is turned on. Any subsequent table create statements run will have compression turned on for that table unless any statement overrides have been performed. Any `ALTER` statements run to add a column will have compression turned on for that column unless any statement override has been performed. ColumnStore uses snappy compression in this mode.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-conditions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-conditions.md
@@ -75,6 +75,6 @@ Notes:
 * Circular joins are not supported in ColumnStore. See the Troubleshooting section
 * When the join memory limit is exceeded, a disk-based join will be used for processing if this option has been enabled.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-data-types.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-data-types.md
@@ -58,6 +58,6 @@ ColumnStore supports the following data types:
   * Unlike other MariaDB storage engines, the actual storage limit for `LONGBLOB/LONGTEXT` is 2,100,000,000 bytes instead of 4 GB per entry. MariaDB's client API is limited to a row length of 1 GB.
 * Timestamp and current\_timestamp are still not supported. ([MCOL-3694](https://jira.mariadb.org/browse/MCOL-3694) / [MCOL-1039](https://jira.mariadb.org/browse/MCOL-1039))
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-decimal-math-and-scale.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-decimal-math-and-scale.md
@@ -58,6 +58,6 @@ SET columnstore_use_decimal_scale
 
 where _n_ is the amount of precision desired for calculations.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-distributed-aggregate-functions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-distributed-aggregate-functions.md
@@ -53,6 +53,6 @@ GROUP BY order_year
 ORDER BY order_year;
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-distributed-functions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-distributed-functions.md
@@ -146,6 +146,6 @@ ColumnStore supports the following functions. These functions can be specified i
 
 * [ColumnStore Non-Distributed Post-Processed Functions](columnstore-non-distributed-post-processed-functions.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-information-functions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-information-functions.md
@@ -25,6 +25,6 @@ MariaDB ColumnStore information functions are selectable pseudo functions that r
 | idbSegmentDir(column)        | The lowest level directory id for the column file containing the physical row                     |
 | idbSegment(column)           | The number of the segment file containing the physical row                                        |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-information-schema-tables.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-information-schema-tables.md
@@ -132,6 +132,6 @@ The `compression_ratio()` procedure calculates the average compression ratio acr
 > call columnstore_info.compression_ratio();
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-naming-conventions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-naming-conventions.md
@@ -100,6 +100,6 @@ In addition to MariaDB Server [reserved words](https://app.gitbook.com/s/SsmexDF
 | WITH            |
 | ZONE            |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-non-distributed-post-processed-functions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-non-distributed-post-processed-functions.md
@@ -15,6 +15,6 @@ ColumnStore supports all MariaDB functions that can be used in a post-processing
 
 * [ColumnStore Distributed Functions](columnstore-distributed-functions.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-operating-mode.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-operating-mode.md
@@ -19,6 +19,6 @@ where n is:
 2. (the default) query syntax is evaluated by ColumnStore for compatibility with distributed execution and incompatible queries are rejected. Queries executed in this mode take advantage of distributed execution and typically result in higher performance.
 3. auto-switch mode: ColumnStore will attempt to process the query internally, if it cannot, it will automatically switch the query to run in row-by-row mode.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-user-defined-aggregate-and-window-functions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-user-defined-aggregate-and-window-functions.md
@@ -50,7 +50,7 @@ This requires a MariaDB ColumnStore source tree and the necessary tools to compi
 
 * The implementation of the median and `avg_mode` functions will scale in memory consumption to the size of the set of unique values in the aggregation.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}
 

--- a/analytics/mariadb-columnstore/reference/columnstore-user-defined-functions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-user-defined-functions.md
@@ -132,7 +132,7 @@ MariaDB [test]> select i1, i2 from t1 where mcs_add(i1,i2) = 4;
 1 row in set (0.02 sec)
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}
 

--- a/analytics/mariadb-columnstore/reference/columnstore-utility-functions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-utility-functions.md
@@ -14,6 +14,6 @@ MariaDB ColumnStore utility functions are a set of simple functions that return 
 | mcsSystemReady()    | Returns 1 if the system can accept queries, 0 if it's not ready yet.                                                                                                                                                                                                                                                                                                                 |
 | mcsSystemReadOnly() | <p>Returns 1 if ColumnStore is in a write-suspended mode. That is, a user executed the <code>SuspendDatabaseWrites</code>. <br>It returns 2 if in a read-only state. ColumnStore puts itself into a read-only state if it detects a logic error that may have corrupted data. Generally, it means a <code>ROLLBACK</code> operation failed. Returns 0 if the system is writable.</p> |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/columnstore-window-functions.md
+++ b/analytics/mariadb-columnstore/reference/columnstore-window-functions.md
@@ -364,6 +364,6 @@ With example results:
 | Olivier | Devpulse     | 2016-10-05 | 834235.93 | 667519.1100000000 | 500802.29 |
 | Olivier | Trupe        | 2016-10-07 | 500802.29 | 667519.1100000000 | 500802.29 |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-alter-table.md
+++ b/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-alter-table.md
@@ -94,6 +94,6 @@ The `RENAME` clause allows to rename a table. The following example renames the 
 ALTER TABLE orders RENAME TO customer_orders;
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-alter-view.md
+++ b/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-alter-view.md
@@ -17,6 +17,6 @@ CREATE
     AS select_statement
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-create-procedure.md
+++ b/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-create-procedure.md
@@ -48,6 +48,6 @@ CREATE PROCEDURE sp_complex_variable(IN arg_key INT, IN arg_date DATE)
 CALL sp_complex_variable(1000, '1998-10-10');
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-create-table.md
+++ b/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-create-table.md
@@ -53,6 +53,6 @@ CREATE TABLE orders (
 ) ENGINE=ColumnStore
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-create-view.md
+++ b/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-create-view.md
@@ -30,6 +30,6 @@ SELECT c.cust_name, o.ordernum, o.status FROM customer c, orders o
 WHERE c.custnum = o.custnum;
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-drop-table.md
+++ b/analytics/mariadb-columnstore/reference/data-definition-statements/columnstore-drop-table.md
@@ -29,6 +29,6 @@ DROP TABLE orders RESTRICT;
 
 * [DROP TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-definition/drop/drop-table)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-definition-statements/ddl-statements-that-differ-for-columnstore.md
+++ b/analytics/mariadb-columnstore/reference/data-definition-statements/ddl-statements-that-differ-for-columnstore.md
@@ -18,6 +18,6 @@ The following table lists the data definition statements (DDL) that differ from 
 | [CREATE TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-definition/create/create-table) | ColumnStore doesn't need indexes, partitions and many other table and column options. See here for [ColumnStore Specific Syntax](columnstore-create-table.md) |
 | [CREATE INDEX](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-definition/create/create-index) | ColumnStore doesn't need indexes. Hence an index many not be created on a table that is defined with engine=columnstore                                       |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-delete.md
+++ b/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-delete.md
@@ -30,6 +30,6 @@ DELETE FROM customer
   WHERE custkey > 1000 AND custkey <2000
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-disk-based-joins.md
+++ b/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-disk-based-joins.md
@@ -53,6 +53,6 @@ For modification at the session level, before issuing your join query from the S
 SET columnstore_um_mem_limit = value
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-insert.md
+++ b/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-insert.md
@@ -53,6 +53,6 @@ INSERT INTO autoinc_test (name) VALUES ('John');
 INSERT INTO autoinc_test (name) VALUES ('Doe');
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-load-data-infile.md
+++ b/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-load-data-infile.md
@@ -51,6 +51,6 @@ If the default mode is set to use cpimport internally, any output error files wi
 
 [LOAD DATA INFILE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-select.md
+++ b/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-select.md
@@ -116,6 +116,6 @@ SELECT custkey FROM customer LIMIT 1000,5;
 When `LIMIT` is used in a nested query, and the inner query contains an `ORDER BY` clause, `LIMIT` is applied before   `ORDER BY` is applied.
 {% endhint %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-update.md
+++ b/analytics/mariadb-columnstore/reference/data-manipulation-statements/columnstore-update.md
@@ -34,6 +34,6 @@ Only **one** table can be updated from the table list in `table_reference`.\
 However, multiple columns can be updated.
 {% endhint %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/security/columnstore-security-vulnerabilities.md
+++ b/analytics/mariadb-columnstore/security/columnstore-security-vulnerabilities.md
@@ -28,6 +28,6 @@ The appropriate release notes listed [here](https://app.gitbook.com/s/aEnK0ZXmUb
 
 There are no known CVEs on ColumnStore-specific infrastructure outside of the MariaDB server at this time.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/security/enterprise-columnstore-credentials-management.md
+++ b/analytics/mariadb-columnstore/security/enterprise-columnstore-credentials-management.md
@@ -64,6 +64,6 @@ To decrypt a password, execute the cspasswd utility and specify the --decrypt co
 $ cspasswd --decrypt util_user_encrypted_passwd
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/use-cases/mariadb-columnstore-guide.md
+++ b/analytics/mariadb-columnstore/use-cases/mariadb-columnstore-guide.md
@@ -32,6 +32,6 @@ Links:
 
 MariaDB ColumnStore is released under the GPL license.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-columnstore/use-cases/query-accelerator.md
+++ b/analytics/mariadb-columnstore/use-cases/query-accelerator.md
@@ -274,7 +274,7 @@ SELECT mcs_get_plan('optimized');
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}
 

--- a/analytics/mariadb-columnstore/use-cases/r-statistical-programming-using-mariadb-as-the-background-database.md
+++ b/analytics/mariadb-columnstore/use-cases/r-statistical-programming-using-mariadb-as-the-background-database.md
@@ -230,6 +230,6 @@ Some of the most advanced R resources for fully understanding the internals and 
 
 * [Chapman & Hall/CRC The R Series: Subject-specific Books](https://www.crcpress.com/Chapman--HallCRC-The-R-Series/book-series/crctherser)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-exa/README.md
+++ b/analytics/mariadb-exa/README.md
@@ -29,6 +29,6 @@ Exasol offers:
 
 When paired with MariaDB Enterprise Server and MaxScale, MariaDB Exa can act as a real-time analytical sink for data replicated or streamed from operational systems.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-exa/architecture.md
+++ b/analytics/mariadb-exa/architecture.md
@@ -141,6 +141,6 @@ flowchart LR
 
 For the full configuration procedure, see the [MariaDB MaxScale Exasolrouter Tutorial](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/mariadb-maxscale-tutorials/mariadb-maxscale-exasolrouter). Pipeline tuning parameters are covered in [Performance & Benchmarking](performance-and-benchmarking.md).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-exa/deployment.md
+++ b/analytics/mariadb-exa/deployment.md
@@ -471,6 +471,6 @@ MariaDB MaxScale uses the ExasolRouter to stream changes from MariaDB Server int
 
 * [MariaDB MaxScale ExasolRouter Tutorial](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/mariadb-maxscale-tutorials/mariadb-maxscale-exasolrouter)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-exa/limitations.md
+++ b/analytics/mariadb-exa/limitations.md
@@ -330,6 +330,6 @@ MariaDB represents `NULL` values as `\N` in export files. Exasol `TIMESTAMP` col
 * Case Sensitivity: The SQLglot preprocessor typically uppercases identifiers to match standard Exasol behavior.
 * Load Data: `LOAD DATA LOCAL INFILE` is not supported in the analytical pathway.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-exa/monitoring-and-observability.md
+++ b/analytics/mariadb-exa/monitoring-and-observability.md
@@ -17,6 +17,6 @@ Explore essential tools and techniques for monitoring and optimizing data system
 * **Grafana / Prometheus Integration:** Collect metrics across MaxScale, MariaDB, and Exasol.
 * **MariaDB Enterprise Manager:** Review operational statistics and metrics covering all MariaDB products except MariaDB Exa.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/analytics/mariadb-exa/performance-and-benchmarking.md
+++ b/analytics/mariadb-exa/performance-and-benchmarking.md
@@ -30,7 +30,7 @@ These parameters are set on the `binlogrouter` CDC service. For the full CDC set
 
 MariaDB Exa CDC has been tested and is expected to work in near real-time up to 600 TPS[^1] from the source MariaDB server side. MariaDB Exa has leading benchmark results for TPC-H[^2].
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}
 

--- a/connectors/mariadb-connector-c/connect-with-mariadb-connector-c.md
+++ b/connectors/mariadb-connector-c/connect-with-mariadb-connector-c.md
@@ -57,6 +57,6 @@ int main (int argc, char* argv[])
 }
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-c/development.md
+++ b/connectors/mariadb-connector-c/development.md
@@ -29,6 +29,6 @@ The header files:
 
 C applications developed using MariaDB Connector/C must include the `mysql.h` header file.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-c/install-mariadb-connector-c.md
+++ b/connectors/mariadb-connector-c/install-mariadb-connector-c.md
@@ -185,6 +185,6 @@ MariaDB Connector/C can be installed on Microsoft Windows via an MSI package:
 5. Click on the "Download" button to download the MSI package.
 6. When the MSI package finishes downloading, run it and follow the on-screen instructions.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-c/setup-for-examples.md
+++ b/connectors/mariadb-connector-c/setup-for-examples.md
@@ -47,6 +47,6 @@ By default, MariaDB Enterprise Server installs the [simple\_password\_check](htt
 * [simple\_password\_check\_minimal\_length](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/password-validation-plugins/simple-password-check-plugin#simple_password_check_minimal_length)
 * [simple\_password\_check\_other\_characters](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/password-validation-plugins/simple-password-check-plugin#simple_password_check_other_characters) system variables.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-cpp/mariadb-connector-c++-guide.md
+++ b/connectors/mariadb-connector-cpp/mariadb-connector-c++-guide.md
@@ -19,6 +19,6 @@ Using MariaDB Connector/C++ in C++ applications enables design with an object-or
 | Smart Pointers      | Yes           | No                                     |
 | Implements JDBC API | Yes           | No                                     |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/setup-for-examples.md
+++ b/connectors/mariadb-connector-python/setup-for-examples.md
@@ -55,6 +55,6 @@ The examples in this MariaDB Connector/Python documentation depend on a database
        TO 'db_user'@'192.0.2.1';
     ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/transactions-with-mariadb-connector-python.md
+++ b/connectors/mariadb-connector-python/transactions-with-mariadb-connector-python.md
@@ -244,6 +244,6 @@ async def main():
 asyncio.run(main())
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/galera-cluster/README.md
+++ b/galera-cluster/README.md
@@ -39,6 +39,6 @@ icon: circle-nodes
 [reference](reference/)
 {% endcontent-ref %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/galera-cluster/galera-management/general-operations/managing-sequences-in-galera-cluster.md
+++ b/galera-cluster/galera-management/general-operations/managing-sequences-in-galera-cluster.md
@@ -112,4 +112,4 @@ COMMIT;
 | `ERROR 1235 ... doesn't yet support SEQUENCEs`       | The server version is older than 10.11.16 and Streaming Replication is enabled.                               | Upgrade to a supported version or disable Streaming Replication (`SET SESSION wsrep_trx_fragment_size=0`). |
 | `ERROR 1213: Deadlock found when trying to get lock` | The sequence was likely defined with `INCREMENT BY 1` (default), causing nodes to contend for the same value. | Alter the sequence to use the Galera offset logic: `ALTER SEQUENCE my_seq INCREMENT BY 0;`                 |
 
-_This page is licensed: CC BY-SA / Gnu FDL_
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/galera-cluster/high-availability/state-snapshot-transfers-ssts-in-galera-cluster/mariadb-backup-sst-method.md
+++ b/galera-cluster/high-availability/state-snapshot-transfers-ssts-in-galera-cluster/mariadb-backup-sst-method.md
@@ -430,6 +430,6 @@ If Galera Cluster's automatic SSTs repeatedly fail, it can be helpful to perform
 * [XTRABACKUP PARAMETERS](https://galeracluster.com/library/documentation/xtrabackup-options.html)
 * [SSL FOR STATE SNAPSHOT TRANSFERS: ENABLING SSL FOR XTRABACKUP](https://galeracluster.com/library/documentation/ssl-sst.html#ssl-xtrabackup)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/7hzG0V6AUK8DqF4oiVaW/" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/galera-cluster/readme/about-galera-replication.md
+++ b/galera-cluster/readme/about-galera-replication.md
@@ -93,6 +93,6 @@ For more information on Group Commit, see the [Galera](https://galeracluster.com
 * [Galera Use Cases](../galera-use-cases.md)
 * [Getting Started with MariaDB/Galera Cluster](../galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/7hzG0V6AUK8DqF4oiVaW/" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/galera-cluster/readme/mariadb-galera-cluster-guide.md
+++ b/galera-cluster/readme/mariadb-galera-cluster-guide.md
@@ -183,6 +183,6 @@ Never execute the bootstrap command on both sides of a partition. This will crea
 * [Getting Started with MariaDB Galera Cluster](../galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster.md)
 * [MariaDB Galera Cluster - Known Limitations](../reference/mariadb-galera-cluster-known-limitations.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/7hzG0V6AUK8DqF4oiVaW/" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/galera-cluster/readme/mariadb-galera-cluster-usage-guide.md
+++ b/galera-cluster/readme/mariadb-galera-cluster-usage-guide.md
@@ -409,6 +409,6 @@ To stop using encryption on the GCache file, stop the server, set `encrypt_binlo
 encrypt_binlog=OFF
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/maxscale/maxscale-security/fixed-security-vulnerabilities.md
+++ b/maxscale/maxscale-security/fixed-security-vulnerabilities.md
@@ -14,6 +14,6 @@ The list is updated continuously. CVEs may be added retroactively to already-rel
 | ----------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------- |
 | [CVE-2023-40354](https://nvd.nist.gov/vuln/detail/CVE-2023-40354) | [MXS-4681](https://jira.mariadb.org/browse/MXS-4681) | 2.5.28, 6.4.9, 22.08.8, 23.02.3 |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/README.md
+++ b/tools/mariadb-ai-rag/README.md
@@ -21,6 +21,6 @@ MariaDB AI RAG is an all-in-one, enterprise-ready solution that handles the enti
 
 For detailed information on each component, please refer to the specific documentation sections.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/api-reference/README.md
+++ b/tools/mariadb-ai-rag/api-reference/README.md
@@ -77,6 +77,6 @@ http://localhost:8000
 
 For production deployments, replace with your configured host and port.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/api-reference/access-control.md
+++ b/tools/mariadb-ai-rag/api-reference/access-control.md
@@ -380,6 +380,6 @@ curl -X DELETE "http://localhost:8000/users/ingest-directory" \
 
 **Note**: Deleting the ingest directory configuration will cause the user to fall back to the default ingest directory (`./`).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/api-reference/api-reference.md
+++ b/tools/mariadb-ai-rag/api-reference/api-reference.md
@@ -353,6 +353,6 @@ curl -X POST "http://localhost:8000/chunks/filter" \
   -d '{"document_ids": [42, 43]}'
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/api-reference/database-integration.md
+++ b/tools/mariadb-ai-rag/api-reference/database-integration.md
@@ -145,6 +145,6 @@ curl "http://localhost:8000/documents/ingest-status/db_ingest_xyz123" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/api-reference/orchestration.md
+++ b/tools/mariadb-ai-rag/api-reference/orchestration.md
@@ -304,6 +304,6 @@ curl -X POST "http://localhost:8000/orchestrate/full-pipeline" \
   -F 'config={"chunking_method":"recursive","llm_model":"gpt-4"}'
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/deployment/deployment-checklist.md
+++ b/tools/mariadb-ai-rag/deployment/deployment-checklist.md
@@ -852,6 +852,6 @@ docker-compose down -v && docker-compose up -d
 
 **✅ Deployment Complete!**
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/deployment/docker-deployment.md
+++ b/tools/mariadb-ai-rag/deployment/docker-deployment.md
@@ -646,6 +646,6 @@ docker exec ai-nexus curl -s http://mysql-db:3306
 
 **🎉 Deployment Complete! Your MariaDB AI RAG is ready to use.**
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/deployment/technical-architecture.md
+++ b/tools/mariadb-ai-rag/deployment/technical-architecture.md
@@ -737,6 +737,6 @@ mysql-db:
 
 **End of Technical Architecture Document**
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/deployment/ubuntu-deployment.md
+++ b/tools/mariadb-ai-rag/deployment/ubuntu-deployment.md
@@ -787,6 +787,6 @@ Your MariaDB AI RAG is now running natively on Ubuntu.
 * Verify config: `nano /path/to/config.env`
 * Test health: `curl http://localhost:8000/health`
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/getting-started/configuration.md
+++ b/tools/mariadb-ai-rag/getting-started/configuration.md
@@ -71,6 +71,6 @@ For production environments, it is strongly recommended to use a properly genera
 
 External service API keys should be securely stored in the `.env` file. In production environments, consider using a secure vault solution or environment variable management system.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/getting-started/installation.md
+++ b/tools/mariadb-ai-rag/getting-started/installation.md
@@ -60,6 +60,6 @@ noIndex: true
 {% endtab %}
 {% endtabs %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/getting-started/overview.md
+++ b/tools/mariadb-ai-rag/getting-started/overview.md
@@ -116,6 +116,6 @@ flowchart TB
 
 For detailed installation instructions, see the [Installation Guide](installation.md).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/getting-started/service-management.md
+++ b/tools/mariadb-ai-rag/getting-started/service-management.md
@@ -30,6 +30,6 @@ cat logs/api.log
 cat logs/ingestion.log
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/reference/README.md
+++ b/tools/mariadb-ai-rag/reference/README.md
@@ -59,6 +59,6 @@ When configuring your MariaDB AI RAG deployment:
 * [API Reference](../api-reference/) - Complete API endpoint documentation
 * [Configuration Guide](../getting-started/configuration.md) - Detailed configuration instructions
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/reference/integration.md
+++ b/tools/mariadb-ai-rag/reference/integration.md
@@ -59,6 +59,6 @@ SECRET_KEY=your_secure_random_string
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-ai-rag/reference/supported-formats.md
+++ b/tools/mariadb-ai-rag/reference/supported-formats.md
@@ -19,6 +19,6 @@ MariaDB AI RAG supports the following file formats for document ingestion:
 
 Additional formats can be supported by installing the appropriate text extraction libraries.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/README.md
+++ b/tools/mariadb-enterprise-manager/README.md
@@ -35,6 +35,6 @@ The Workspace provides a powerful suite of tools for developers and DBAs. It fea
 
 Secure your management layer with robust security features. Authenticate users with your corporate [**identity provider (OIDC)**](administration/user-management/configure-openid-connect-identity-provider.md), enforce granular permissions with [**role-based access control (RBAC)**](administration/user-management/), and maintain compliance with a comprehensive **audit log** for all administrative actions.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/backup-and-restore-of-enterprise-manager.md
+++ b/tools/mariadb-enterprise-manager/administration/backup-and-restore-of-enterprise-manager.md
@@ -88,6 +88,6 @@ docker run --rm --volumes-from enterprise-manager-supermax -v $(pwd)/backups/:/b
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/change-hostname-or-ip-address.md
+++ b/tools/mariadb-enterprise-manager/administration/change-hostname-or-ip-address.md
@@ -64,6 +64,6 @@ After the restart, your Enterprise Manager will be accessible at the new hostnam
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/deployment/README.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/README.md
@@ -33,6 +33,6 @@ You can quickly set up and launch MariaDB Enterprise Manager with a single-line 
 Enterprise Manager includes a helper tool, integrated in the UI, for adding agents. The helper prompts you to download a small (< 50M) binary and then provides command-line instructions to install and register agents, enabling quick and seamless addition of new MariaDB databases to Enterprise Manager.
 {% endhint %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/README.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/README.md
@@ -166,6 +166,6 @@ Repeat this process for every server in the topology. Once all agents are linked
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/add-multiple-maxscale-monitors.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/add-multiple-maxscale-monitors.md
@@ -64,6 +64,6 @@ If you need to change which MaxScale monitor an existing logical database is tra
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/agent-installation-t-copy.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/agent-installation-t-copy.md
@@ -98,6 +98,6 @@ After the agent is installed, it is running but not yet configured or linked to 
 
 The final step is to link the agent, which is done from the Enterprise Manager UI. Please refer to the ["Adding Databases to MariaDB Enterprise Manager" guide](./#adding-databases-to-mariadb-enterprise-manager) for the specific steps to generate the linking command.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/sso-to-maxscale-single-sign-on.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/sso-to-maxscale-single-sign-on.md
@@ -41,6 +41,6 @@ admin_oidc_client_secret=mariadb
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/deployment/hardware-and-system-requirements.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/hardware-and-system-requirements.md
@@ -47,6 +47,6 @@ The agent must be installed on each [MariaDB Server](https://app.gitbook.com/s/S
 
 \* Monitoring and Single Sign-On(SSO) are only supported for MaxScale versions 25.10 and Above
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/deployment/installing-mariadb-enterprise-manager/README.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/installing-mariadb-enterprise-manager/README.md
@@ -329,6 +329,6 @@ At the login screen, use the default username `admin` and the generated password
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/deployment/installing-mariadb-enterprise-manager/metrics-retention-configuration.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/installing-mariadb-enterprise-manager/metrics-retention-configuration.md
@@ -93,6 +93,6 @@ When setting `PROMETHEUS_RETENTION_TIME`, you can use the following units:
 * `m` - minutes
 * `s` - seconds
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/deployment/network-and-firewall-requirements.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/network-and-firewall-requirements.md
@@ -32,6 +32,6 @@ For the current version of MariaDB Enterprise Manager, ensure the following rule
 * From user workstations, allow traffic to the Enterprise Manager Server on TCP port `8090`.
 * From agent hosts, allow traffic to the Enterprise Manager Server on TCP port `4318`.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/security-in-enterprise-manager.md
+++ b/tools/mariadb-enterprise-manager/administration/security-in-enterprise-manager.md
@@ -126,6 +126,6 @@ In the "Add Database" page:
 All certificate and key files referenced for server validation or client authentication must be placed in the `enterprise-manager/certs/` directory on the host and referenced with a path beginning with `/certs/`.
 {% endhint %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/user-management/README.md
+++ b/tools/mariadb-enterprise-manager/administration/user-management/README.md
@@ -235,6 +235,6 @@ You cannot delete the user account that you are currently logged in with. To del
 
 Upon installation of MariaDB Enterprise Manager, a default `admin` user is created with an automatically generated password.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/administration/user-management/configure-openid-connect-identity-provider.md
+++ b/tools/mariadb-enterprise-manager/administration/user-management/configure-openid-connect-identity-provider.md
@@ -131,6 +131,6 @@ A success message will confirm the reset.
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/architecture-overview.md
+++ b/tools/mariadb-enterprise-manager/architecture-overview.md
@@ -49,6 +49,6 @@ For the system to function correctly, the following firewall ports must be open 
 * `8090` (_HTTP/S_): The main entry point for the web UI. Nginx listens on this port and proxies requests to Supermax and Grafana.
 * `4318` (_HTTP/S_): Agents on monitored nodes push telemetry data to this port.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/quickstart-guide.md
+++ b/tools/mariadb-enterprise-manager/quickstart-guide.md
@@ -238,6 +238,6 @@ Wait 1–2 minutes for metrics to start populating in Enterprise Manager from th
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/troubleshooting-enterprise-manager.md
+++ b/tools/mariadb-enterprise-manager/troubleshooting-enterprise-manager.md
@@ -192,6 +192,6 @@ Ensure clocks are synchronized (for example using NTP/chrony) to avoid these iss
 
 </details>
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/alerts-and-notifications/README.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/alerts-and-notifications/README.md
@@ -54,6 +54,6 @@ To configure alerting effectively, it's helpful to understand these core concept
 For a deep dive into advanced topics like custom message templating, alert grouping, and more complex routing, see the [official Grafana documentation](https://grafana.com/docs/grafana/latest/alerting/fundamentals/).
 {% endhint %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/alerts-and-notifications/built-in-alert-rules.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/alerts-and-notifications/built-in-alert-rules.md
@@ -52,6 +52,6 @@ A key feature of these rules is the use of a **"sustained for"** duration. This 
 | **NodeFileDescriptorLimit**        | Kernel is predicted to exhaust file descriptors soon (sustained for 15m). Triggers when allocated file descriptors exceed **70%** of the kernel limit.                                                                                  |
 | **NodeFileDescriptorLimit**        | Kernel is close to exhausting file descriptors (sustained for 15m). Triggers when allocated file descriptors exceed **90%** of the kernel limit.                                                                                        |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/alerts-and-notifications/smtp-server-configuration.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/alerts-and-notifications/smtp-server-configuration.md
@@ -85,6 +85,6 @@ If the test email fails on an internal relay, common causes are the relay advert
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/database-fleet-overview-t-copy.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/database-fleet-overview-t-copy.md
@@ -86,6 +86,6 @@ admin_oidc_ssl_insecure=true
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/mariadb-galera-cluster.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/mariadb-galera-cluster.md
@@ -40,6 +40,6 @@ Per-node status summary with short state logic
 | **Cluster Status**    | Is the node in the **Primary** component? (Based on `wsrep_cluster_status`)                               |
 | **Connected**         | Is the node linked to the group? (Based on `wsrep_connected`)                                             |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/mariadb-maxscale.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/mariadb-maxscale.md
@@ -61,6 +61,6 @@ Evaluate query routing efficiency by tracking and optimizing cache metrics like 
 | **Cache Hits vs Misses** | Per-second hits and misses in the Query Classifier cache. Analyze the relationship to assess effectiveness. |
 | **Cache Size**           | Current size of the Query Classifier cache (bytes). Monitor growth with Hits/Misses for tuning insights.    |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/mariadb-server.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/mariadb-server.md
@@ -131,6 +131,6 @@ Shows information about active sessions and thread states collected from `inform
   * Client: Client host connected.
   * Value: Number of processes/threads from that client.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/node-and-operating-system.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/dashboards/node-and-operating-system.md
@@ -52,6 +52,6 @@ Monitors disk performance and utilization for the node’s storage devices.
 | Disk IOPS        | Number of input/output operations per second for reads and writes.   |
 | Disk Utilisation | Percentage of time that disk devices are busy handling I/O requests. |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/metrics/README.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/metrics/README.md
@@ -44,6 +44,6 @@ Key metrics collected by default include:
 
 For a complete and detailed list of all metrics gathered by the default collectors, please refer to the official [Prometheus Node Exporter documentation](https://prometheus.io/docs/guides/node-exporter/).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/monitoring/metrics/export-metrics.md
+++ b/tools/mariadb-enterprise-manager/usage/monitoring/metrics/export-metrics.md
@@ -105,6 +105,6 @@ For a full list of all available flags and their descriptions, run `mema-agent h
 {% endstep %}
 {% endstepper %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/workspace/README.md
+++ b/tools/mariadb-enterprise-manager/usage/workspace/README.md
@@ -47,6 +47,6 @@ Workspace enhances MariaDB Enterprise Manager by adding query editing, visual sc
 | User Management     | View, edit, create, delete database users and privileges.                                                              |
 | Process List Viewer | View and manage live sessions/commands.                                                                                |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/workspace/database-administration.md
+++ b/tools/mariadb-enterprise-manager/usage/workspace/database-administration.md
@@ -47,6 +47,6 @@ Using the Processlist Viewer, you can:
 * **Identify** long-running or problematic queries that may be impacting server performance.
 * **Manage** live sessions, which may include the ability to terminate (kill) a specific process.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/workspace/erd-designer.md
+++ b/tools/mariadb-enterprise-manager/usage/workspace/erd-designer.md
@@ -113,6 +113,6 @@ Once your design is complete, you can export it for documentation or deployment.
 
 Click the **"Apply Script"** button (▶) in the toolbar to execute the generated SQL against your connected database. This allows you to deploy your new or modified schema directly from the designer.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-manager/usage/workspace/query-editor.md
+++ b/tools/mariadb-enterprise-manager/usage/workspace/query-editor.md
@@ -133,6 +133,6 @@ Interact directly with the data displayed in the Results grid. Perform actions l
 
 <figure><img src="../../../.gitbook/assets/image (9).png" alt=""><figcaption></figcaption></figure>
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-mcp-server/architecture.md
+++ b/tools/mariadb-enterprise-mcp-server/architecture.md
@@ -134,6 +134,6 @@ The database is the foundation of the entire architecture, providing a single, c
 
 This architecture ensures a clear separation of concerns, enhances security with multiple checkpoints, and provides a highly extensible platform for building advanced AI tools.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-mcp-server/authentication/README.md
+++ b/tools/mariadb-enterprise-mcp-server/authentication/README.md
@@ -222,6 +222,6 @@ mcp-server.exe
 
 ***
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-mcp-server/authentication/token-management.md
+++ b/tools/mariadb-enterprise-mcp-server/authentication/token-management.md
@@ -67,6 +67,6 @@ sequenceDiagram
 * **Issuer/Audience Validation**: Prevents a token from one system from being used on another.
 * **Not-Before Check**: Prevents a token from being used before it is valid
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-mcp-server/example/usage-examples.md
+++ b/tools/mariadb-enterprise-mcp-server/example/usage-examples.md
@@ -51,6 +51,6 @@ description: >-
 ```
 {% endcode %}
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-mcp-server/features/README.md
+++ b/tools/mariadb-enterprise-mcp-server/features/README.md
@@ -60,6 +60,6 @@ The server exposes powerful orchestration endpoints that allow an AI agent to ex
 | `rag_ingestion`            | Triggers the full document ingestion pipeline.                                                       | Workflow Orchestration       |
 | `rag_generation`           | Synthesizes retrieved information with the user's query to generate a final, context-aware response. | Workflow Orchestration       |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-mcp-server/frequently-asked-questions.md
+++ b/tools/mariadb-enterprise-mcp-server/frequently-asked-questions.md
@@ -88,6 +88,6 @@ The JSON snippets shown in the documentation are examples of the "behind-the-sce
 
 </details>
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-mcp-server/introduction/README.md
+++ b/tools/mariadb-enterprise-mcp-server/introduction/README.md
@@ -40,6 +40,6 @@ Key objectives include:
 * **Improve Manageability**: Offer a robust, configurable, and observable server that can be reliably deployed and managed by platform engineering and DBA teams.
 * **Accelerate AI Application Development**: Provide a standardized protocol that simplifies how developers connect AI agents to MariaDB data.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/backup-and-restore/csi-specific-configuration.md
+++ b/tools/mariadb-enterprise-operator/backup-and-restore/csi-specific-configuration.md
@@ -64,6 +64,6 @@ Storage documentation or an Azure representative for guidance.
 
 ---
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/backup-and-restore/logical_backup.md
+++ b/tools/mariadb-enterprise-operator/backup-and-restore/logical_backup.md
@@ -675,6 +675,6 @@ Please make sure you understand the [Galera backup limitations](#galera-backup-l
 
 After doing so, ensure that your backup does not contain a `DROP TABLE mysql.global_priv;` statement, as it will make your liveness and readiness probes to fail after the backup restoration.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/backup-and-restore/physical_backup.md
+++ b/tools/mariadb-enterprise-operator/backup-and-restore/physical_backup.md
@@ -698,6 +698,6 @@ Without explicitly enabled [shared option](https://github.com/openebs/lvm-localp
 
 Refer to [openebs/lvm-localpv#281](https://github.com/openebs/lvm-localpv/issues/281) for further details on this issue.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/configuration.md
+++ b/tools/mariadb-enterprise-operator/configuration.md
@@ -246,6 +246,6 @@ spec:
 
 There isn't an universally correct default value for these thresholds, so we recommend determining your own based on factors like the compute resources, network, storage, and other aspects of the environment where your `MariaDB` and `MaxScale` instances are running.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/connections.md
+++ b/tools/mariadb-enterprise-operator/connections.md
@@ -326,6 +326,6 @@ spec:
 
 The `Connection` status reflects the health check results, allowing you to monitor connectivity issues through Kubernetes.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/customer-access-to-docker-mariadb-com.md
+++ b/tools/mariadb-enterprise-operator/customer-access-to-docker-mariadb-com.md
@@ -133,6 +133,6 @@ spec:
 
 When the resources from the previous examples are created, a `Job` with both `mariadb-enterprise` and `backup-registry` `imagePullSecrets` will be reconciled.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/docker-images.md
+++ b/tools/mariadb-enterprise-operator/docker-images.md
@@ -320,6 +320,6 @@ The examples above use the `mariadb-enterprise-operator:25.8.0` image. You must 
 
 ## Additional Resources
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/examples-catalog.md
+++ b/tools/mariadb-enterprise-operator/examples-catalog.md
@@ -41,6 +41,6 @@ If you are looking for production-grade examples, you can check the following ma
 * `mariadb_replication_production.yaml` and `maxscale_replication_production.yaml` for [asynchronous replication](topologies/replication.md)
 * `mariadb_galera_production.yaml` and `maxscale_galera_production.yaml` for [Galera](topologies/galera.md)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/external-mariadb.md
+++ b/tools/mariadb-enterprise-operator/external-mariadb.md
@@ -122,6 +122,6 @@ spec:
 
 When the previous example gets reconciled, an user will be created in the referred external MariaDB instance.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/installation/helm.md
+++ b/tools/mariadb-enterprise-operator/installation/helm.md
@@ -347,6 +347,6 @@ helm uninstall mariadb-enterprise-operator-crds
 | webhook.tolerations | list | `[]` | Tolerations to add to webhook Pod |
 | webhook.topologySpreadConstraints | list | `[]` | topologySpreadConstraints to add to webhook Pod |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/installation/openshift.md
+++ b/tools/mariadb-enterprise-operator/installation/openshift.md
@@ -165,6 +165,6 @@ As you can see in the previous screenshot, the form view that the OpenShift cons
 
 ![](../../.gitbook/assets/openshift-console-yaml.png)
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/introduction.md
+++ b/tools/mariadb-enterprise-operator/introduction.md
@@ -88,6 +88,6 @@ Operational expertise is baked into the `MariaDB` and `MaxScale` APIs and seamle
 * Secure, immutable and lightweight images based on Red Hat UBI, available for multiple architectires (amd64, arm64 and ppc64le).
 * [Operator certified ](https://catalog.redhat.com/en/software/container-stacks/detail/65789bcbe17f1b31944acb1d#overview)by Red Hat.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/maintenance.md
+++ b/tools/mariadb-enterprise-operator/maintenance.md
@@ -284,6 +284,6 @@ LAST SEEN   TYPE      REASON        OBJECT                           MESSAGE
 8s          Normal    Maintenance   MariaDB/mariadb-eu-south         Disabling readonly in Pod mariadb-eu-south-0
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/metadata.md
+++ b/tools/mariadb-enterprise-operator/metadata.md
@@ -179,6 +179,6 @@ spec:
 
 For instance, you probably don't want to inject the Istio sidecar to `Backup` `Pods`, as it will prevent the `Jobs` from finishing and therefore your backup process will hang.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/metrics.md
+++ b/tools/mariadb-enterprise-operator/metrics.md
@@ -196,6 +196,6 @@ The following metrics are available for `MaxScale` instances:
 | maxscale\_uptime\_seconds                                     | Maxscale uptime in seconds                                                                         | GAUGE   |
 | maxscale\_version                                             | Maxscale Version                                                                                   | GAUGE   |
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/migrations/enabling-tls-in-existing-instances.md
+++ b/tools/mariadb-enterprise-operator/migrations/enabling-tls-in-existing-instances.md
@@ -92,6 +92,6 @@ spec:
 
 **8.** `MaxScale` is now accepting TLS connections. Next, you need to [migrate your applications to use TLS](../security/tls.md) by pointing them back to `MaxScale` securely. You have done this previously for `MariaDB`, you just need to update your application configuration to use the [MaxScale Service](../topologies/maxscale.md#kubernetes-services) and its CA bundle.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/migrations/migrate-community-operator-to-enterprise-operator.md
+++ b/tools/mariadb-enterprise-operator/migrations/migrate-community-operator-to-enterprise-operator.md
@@ -70,7 +70,7 @@ done
 kubectl rollout restart deployment mariadb-enterprise-operator
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/migrations/migrate-embedded-maxscale-to-maxscale-resource.md
+++ b/tools/mariadb-enterprise-operator/migrations/migrate-embedded-maxscale-to-maxscale-resource.md
@@ -41,6 +41,6 @@ This will have created new `<migrated.mariadb_manifest.yaml>` manifests.
 
 **3.** Inspect the newly created manifests and overwrite the source manifests if satisfied with the changes.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/migrations/migrate-external-mariadb-into-kubernetes.md
+++ b/tools/mariadb-enterprise-operator/migrations/migrate-external-mariadb-into-kubernetes.md
@@ -60,7 +60,7 @@ spec:
 **5.** If you are using Galera in your new instance, migrate your previous users and grants to use the `User` and `Grant` CRs. Refer to the [SQL resource documentation](../sql-resources.md) for further detail.
 
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/plugins/pam.md
+++ b/tools/mariadb-enterprise-operator/plugins/pam.md
@@ -410,6 +410,6 @@ At this point, the problem should be fixed.
 
 For more information, check [this comment](https://github.com/kubernetes-sigs/kind/issues/4001#issuecomment-3279083954).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/plugins/supported-docker-images.md
+++ b/tools/mariadb-enterprise-operator/plugins/supported-docker-images.md
@@ -27,6 +27,6 @@ Each supported plugin will have a section on how to install it.
 | MariaDB Enterprise Server (tiered) | docker.mariadb.com/enterprise-server |  11.8.6-3.2-standard <br>  11.8.6-3.1-standard <br>  11.8-standard <br>  11.4.10-7.2-standard <br>  11.4.10-7.1-standard <br>  11.4-standard <br>  10.6.25-21.5-standard <br>  10.6.25-21.1-standard <br>  10.6-standard <br>  |  amd64 <br>  arm64 <br>  ppc64le <br>  |
 
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/quickstart.md
+++ b/tools/mariadb-enterprise-operator/quickstart.md
@@ -146,6 +146,6 @@ You have successfully deployed a MariaDB Enterprise Cluster with MaxScale in Kub
 
 Refer to the [documentation](./), the [API reference](api-reference.md) and the [examples catalog](examples-catalog.md) for further detail.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/security/tls.md
+++ b/tools/mariadb-enterprise-operator/security/tls.md
@@ -1171,6 +1171,6 @@ This doesn't affect `MaxScale`, as it is able to establish trust with intermedia
 
 Refer to the [MaxScale documentation](tls.md#maxscale-configuration) for further details.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/sql-resources.md
+++ b/tools/mariadb-enterprise-operator/sql-resources.md
@@ -234,6 +234,6 @@ spec:
 
 You can opt-out from this cleanup process using `cleanupPolicy=Skip`. Note that this resources will remain in the database.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/storage.md
+++ b/tools/mariadb-enterprise-operator/storage.md
@@ -92,6 +92,6 @@ spec:
 
 This may be useful for multiple use cases, like provisioning ephemeral `MariaDBs` for the integration tests of your CI.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/suspend-reconciliation.md
+++ b/tools/mariadb-enterprise-operator/suspend-reconciliation.md
@@ -42,6 +42,6 @@ mariadb-galera   True    Suspended   mariadb-galera-0  ReplicasFirstPrimaryLast 
 
 To re-enable it, simply remove the `suspend` setting or set it to `suspend=false`.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/topologies/data-plane.md
+++ b/tools/mariadb-enterprise-operator/topologies/data-plane.md
@@ -64,6 +64,6 @@ Unlike the [`ServiceAccount` based authentication](#serviceaccount-based-authent
 
 Please refer to the updates documentation for more information about [how to update the data-plane](../updates.md#data-plane-updates).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/topologies/galera.md
+++ b/tools/mariadb-enterprise-operator/topologies/galera.md
@@ -647,6 +647,6 @@ This is error is returned by the `mariadb-enterprise-operator` after exceeding t
 
 Increase this timeout if you consider that your Galera cluster may take longer to recover.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/topologies/high-availability.md
+++ b/tools/mariadb-enterprise-operator/topologies/high-availability.md
@@ -212,6 +212,6 @@ spec:
   # [...]
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/topologies/maxscale.md
+++ b/tools/mariadb-enterprise-operator/topologies/maxscale.md
@@ -658,6 +658,6 @@ spec:
 
 This enables the `CSIDriver` and the kubelet to recursively set the ownership ofr the `/var/lib/maxscale` folder to the group `999`, which is the one expected by MaxScale. It is important to note that not all the `CSIDrivers` implementations support this feature, see the [CSIDriver documentation](https://kubernetes-csi.github.io/docs/support-fsgroup.html) for further information.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/topologies/multi-cluster.md
+++ b/tools/mariadb-enterprise-operator/topologies/multi-cluster.md
@@ -1078,6 +1078,6 @@ kubectl get mariadb mariadb-eu-south -o jsonpath="{.status}" | jq '{conditions: 
 kubectl get mariadb mariadb-eu-central -o jsonpath="{.status}" | jq '{conditions: .conditions, currentPrimary: .currentPrimary, currentMultiClusterPrimary: .currentMultiClusterPrimary, replication: .replication}'
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/topologies/replication.md
+++ b/tools/mariadb-enterprise-operator/topologies/replication.md
@@ -783,6 +783,6 @@ must be no more than 63 characters
 
 This error happens when the name of the physical backup `Job` created for the scaling out or replica recovery operation exceeds the Kubernetes hard limit of 63 characters. We have truncated the job names already to significantly mitigate this problem, but the problem might still happen if your `MariaDB` resource name is too long.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/topologies/standalone.md
+++ b/tools/mariadb-enterprise-operator/topologies/standalone.md
@@ -54,6 +54,6 @@ Whilst this can be useful for development and testing, it is not recommended for
 
 For achieving high availability, we recommend deploying a highly available topology as described in the [high availability guide](high-availability.md).
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/updates.md
+++ b/tools/mariadb-enterprise-operator/updates.md
@@ -144,6 +144,6 @@ By default, `updateStrategy.autoUpdateDataPlane` is `false`, which means that no
 
 It is important to note that this feature is fully compatible with the [Never](updates.md#never) strategy: no upgrades will happen when `updateStrategy.autoUpdateDataPlane=true` and `updateStrategy.type=Never`.
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/updates/update-25.08.md
+++ b/tools/mariadb-enterprise-operator/updates/update-25.08.md
@@ -77,7 +77,7 @@ spec:
 -   autoUpdateDataPlane: true
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/updates/update-25.10.md
+++ b/tools/mariadb-enterprise-operator/updates/update-25.10.md
@@ -72,7 +72,7 @@ spec:
 -   autoUpdateDataPlane: true
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/updates/update-26.03.md
+++ b/tools/mariadb-enterprise-operator/updates/update-26.03.md
@@ -56,7 +56,7 @@ spec:
 -   autoUpdateDataPlane: true
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/updates/update-26.06.1.md
+++ b/tools/mariadb-enterprise-operator/updates/update-26.06.1.md
@@ -114,6 +114,6 @@ notice : (rw-router-listener); Listening for connections at [::]:3306
 notice : (ConfigManager); Added 'mariadb-repl-0', 'mariadb-repl-1' to 'rw-router'
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/tools/mariadb-enterprise-operator/updates/update-26.06.md
+++ b/tools/mariadb-enterprise-operator/updates/update-26.06.md
@@ -75,6 +75,6 @@ spec:
 -   autoUpdateDataPlane: true
 ```
 
-{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}


### PR DESCRIPTION
Implements [Daniel's decision on DOCS-6394](https://mariadbcorp.atlassian.net/browse/DOCS-6394): licence notices go **literally** into the `.md` source, with no include dependency, so the licence a page claims is readable from the file itself.

This is **batch 1 of 6**. Batches are split by space, as Daniel suggested.

## What Changed

242 pages across five spaces. Every diff is one line — the reusable-content include is replaced by the notice text it already resolved to:

```diff
-{% include "https://app.gitbook.com/s/.../~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
```

| Space | Pages |
|---|--:|
| analytics | 133 |
| tools | 95 |
| connectors | 7 |
| galera-cluster | 6 |
| maxscale | 1 |
| **Total** | **242** |

238 resolved to the MariaDB copyright notice, 3 to CC BY-SA / Gnu FDL. One galera-cluster page (`galera-management/general-operations/managing-sequences-in-galera-cluster.md`) carried the notice text without its `<sub>` wrapper and is normalized to the canonical form.

## No Page Changes Its Licence

The conversion is mechanical and licence-preserving. All 9,882 content pages were reclassified before and after; the notice each page claims is identical, and the conversion is idempotent (re-running it produces no diff). `242 files changed, 242 insertions(+), 242 deletions(-)` — one line per page, no whitespace churn.

## CI: the 22 Link Errors Are Pre-existing

The link-check gate scans changed files, so touching 242 pages surfaces existing rot. **This diff adds no links at all** — it only removes them.

Verified rather than asserted, using the CI-exact lychee invocation over the same 242 files in a clean worktree at unmodified `origin/main`:

|  | Links checked | Errors | Unique failing targets |
|---|--:|--:|--:|
| this branch | 2,128 | 22 | 20 |
| clean worktree at `origin/main` | 2,369 | 22 | 20 |

The failing-target lists are **identical**. The 241-link difference in the totals is exactly the `app.gitbook.com` include URLs this PR removes — so it slightly *reduces* what CI has to check.

The 20 targets are 5 `broken-reference` migration placeholders and 15 pieces of external rot (retired `shop.oreilly.com` product pages, `db.rstudio.com`, `mran.microsoft.com`, and similar).

codespell passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)