### PR TITLE
DOCS-6394 Replace licence includes with literal notices (batch 3/6)

### DIFF
--- a/server/architecture/server-constraints/auto_increment-constraints.md
+++ b/server/architecture/server-constraints/auto_increment-constraints.md
@@ -394,6 +394,6 @@ The offset and increment values can be configured by setting the [auto\_incremen
 
 When Galera Cluster is used, the offset and increment values are managed automatically by default. They can be managed manually by disabling the [wsrep\_auto\_increment\_control](https://app.gitbook.com/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables#wsrep_auto_increment_control) system variable.
 
-{% include "../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/server-constraints/foreign-key-constraints.md
+++ b/server/architecture/server-constraints/foreign-key-constraints.md
@@ -411,6 +411,6 @@ A foreign key constraint requires an index on the column. If a foreign key const
 
 When the [foreign\_key\_checks](../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#foreign_key_checks) system variable is disabled, it is possible to drop the index used by a foreign key constraint. When the [foreign\_key\_checks](../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#foreign_key_checks) system variable is re-enabled, InnoDB will have no way to enforce the foreign key constraint, so all operations that could potentially violate the foreign key constraint will fail.
 
-{% include "../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/server-constraints/not-null-constraints.md
+++ b/server/architecture/server-constraints/not-null-constraints.md
@@ -45,6 +45,6 @@ ALTER TABLE hq_sales.invoices
    MODIFY COLUMN customer_id INT NULL;
 ```
 
-{% include "../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/server-constraints/primary-key-constraints.md
+++ b/server/architecture/server-constraints/primary-key-constraints.md
@@ -307,6 +307,6 @@ To easily generate unique values for a primary key, consider using one of the fo
 * [InnoDB AUTO\_INCREMENT Columns](auto_increment-constraints.md#creating-an-innodb-table-with-an-auto_increment-column)
 * [InnoDB Sequences](../../reference/sql-structure/sequences/)
 
-{% include "../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/server-constraints/server-constraints-overview.md
+++ b/server/architecture/server-constraints/server-constraints-overview.md
@@ -4,6 +4,6 @@ MariaDB Enterprise Server provides DDL (Data Definition Language) syntax to `cre
 
 In the context of `ISO 9075-2:2016`, this page uses "DDL (Data Definition Language)" to refer to SQL statements in the standard's "SQL-schema statements" group.
 
-{% include "../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/server-constraints/unique-constraints-with-mariadb-enterprise-server.md
+++ b/server/architecture/server-constraints/unique-constraints-with-mariadb-enterprise-server.md
@@ -287,6 +287,6 @@ ALTER TABLE hq_sales.customers DROP INDEX customer_email;
 ALTER TABLE hq_sales.customers ADD UNIQUE INDEX (customer_email);
 ```
 
-{% include "../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-object-storage/step-1-prepare-columnstore-nodes.md
+++ b/server/architecture/topologies/columnstore-object-storage/step-1-prepare-columnstore-nodes.md
@@ -225,6 +225,6 @@ This page was step 1 of 9.
 
 Next: Step 2: Configure Shared Local Storage.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-object-storage/step-3-install-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/columnstore-object-storage/step-3-install-mariadb-enterprise-server.md
@@ -115,6 +115,6 @@ This page was **step 3 of 9**.
 
 Next: Step 4: Start and Configure MariaDB Enterprise Server.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-object-storage/step-6-install-mariadb-maxscale.md
+++ b/server/architecture/topologies/columnstore-object-storage/step-6-install-mariadb-maxscale.md
@@ -81,6 +81,6 @@ This page was **step 6 of 9**.
 
 Next: Step 7: Start and Configure MariaDB MaxScale.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-shared-local-storage/step-1-prepare-columnstore-nodes.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/step-1-prepare-columnstore-nodes.md
@@ -215,6 +215,6 @@ Navigation in the procedure "Deploy ColumnStore Shared Local Storage Topology".
 
 This page was step 1 of 9.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-shared-local-storage/step-2-configure-shared-local-storage.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/step-2-configure-shared-local-storage.md
@@ -237,6 +237,6 @@ This page was step 2 of 9.
 
 Next: Step 3: Install MariaDB Enterprise Server.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-shared-local-storage/step-3-install-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/step-3-install-mariadb-enterprise-server.md
@@ -115,6 +115,6 @@ This page was step 3 of 9.
 
 Next: Step 4: Start and Configure MariaDB Enterprise Server.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-shared-local-storage/step-4-start-and-configure-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/step-4-start-and-configure-mariadb-enterprise-server.md
@@ -686,6 +686,6 @@ This page was step 4 of 9.
 
 Next: Step 5: Test MariaDB Enterprise Server.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-shared-local-storage/step-5-test-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/step-5-test-mariadb-enterprise-server.md
@@ -293,6 +293,6 @@ This page was step 5 of 9.
 
 Next: Step 6: Install MariaDB MaxScale.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-shared-local-storage/step-6-install-mariadb-maxscale.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/step-6-install-mariadb-maxscale.md
@@ -81,6 +81,6 @@ This page was step 6 of 9.
 
 Next: Step 7: Start and Configure MariaDB MaxScale.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-shared-local-storage/step-7-start-and-configure-mariadb-maxscale.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/step-7-start-and-configure-mariadb-maxscale.md
@@ -184,6 +184,6 @@ This page was step 7 of 9.
 
 Next: Next: Step 8: Test MariaDB MaxScale.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-shared-local-storage/step-8-test-mariadb-maxscale.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/step-8-test-mariadb-maxscale.md
@@ -638,6 +638,6 @@ This page was step 8 of 9.
 
 Next: Step 9: Import Data.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/columnstore-shared-local-storage/step-9-import-data.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/step-9-import-data.md
@@ -83,6 +83,6 @@ This page was step 9 of 9.
 
 This procedure is complete.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/galera-cluster/step-1-install-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/galera-cluster/step-1-install-mariadb-enterprise-server.md
@@ -97,6 +97,6 @@ This page was step 1 of 6.
 
 Next: Step 2: Start and Configure MariaDB Enterprise Server
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/galera-cluster/step-2-start-and-configure-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/galera-cluster/step-2-start-and-configure-mariadb-enterprise-server.md
@@ -187,6 +187,6 @@ This page was step 2 of 6.
 
 Next: Step 3: Test MariaDB Enterprise Server
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/galera-cluster/step-3-test-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/galera-cluster/step-3-test-mariadb-enterprise-server.md
@@ -181,6 +181,6 @@ This page was step 3 of 6.
 
 Next: Step 4: Install MariaDB MaxScale
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/galera-cluster/step-4-install-mariadb-maxscale.md
+++ b/server/architecture/topologies/galera-cluster/step-4-install-mariadb-maxscale.md
@@ -94,6 +94,6 @@ This page was step 4 of 6.
 
 Next: Step 5: Start and Configure MariaDB MaxScale
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/galera-cluster/step-5-start-and-configure-mariadb-maxscale.md
+++ b/server/architecture/topologies/galera-cluster/step-5-start-and-configure-mariadb-maxscale.md
@@ -203,6 +203,6 @@ This page was step 5 of 6.
 
 Next: Step 6: Test MariaDB MaxScale
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/galera-cluster/step-6-test-mariadb-maxscale.md
+++ b/server/architecture/topologies/galera-cluster/step-6-test-mariadb-maxscale.md
@@ -669,6 +669,6 @@ This page was step 6 of 6.
 
 This procedure is complete.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/htap/step-1-prepare-columnstore-node.md
+++ b/server/architecture/topologies/htap/step-1-prepare-columnstore-node.md
@@ -152,6 +152,6 @@ This page was step 1 of 4.
 
 Next: Step 2: Install MariaDB Enterprise Server.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/htap/step-2-install-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/htap/step-2-install-mariadb-enterprise-server.md
@@ -114,6 +114,6 @@ This page was step 2 of 4.
 
 Next: Step 3: Start and Configure MariaDB Enterprise Server.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/htap/step-3-start-and-configure-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/htap/step-3-start-and-configure-mariadb-enterprise-server.md
@@ -299,6 +299,6 @@ This page was step 3 of 4.
 
 Next: Step 4: Test MariaDB Enterprise Server.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/htap/step-4-test-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/htap/step-4-test-mariadb-enterprise-server.md
@@ -360,6 +360,6 @@ This page was step 4 of 4.
 
 This procedure is complete.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/mariadb-enterprise-spider-topologies/README.md
+++ b/server/architecture/topologies/mariadb-enterprise-spider-topologies/README.md
@@ -49,6 +49,6 @@ Partition a large table across multiple MariaDB Enterprise Server Data Nodes usi
 [mariadb-enterprise-spider-operations](../../../server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/)
 {% endcontent-ref %}
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/mariadb-enterprise-spider-topologies/federated-mariadb-enterprise-spider-topology.md
+++ b/server/architecture/topologies/mariadb-enterprise-spider-topologies/federated-mariadb-enterprise-spider-topology.md
@@ -166,6 +166,6 @@ COMMENT='server "hq_server", table "invoices"';
 
 * [Enterprise Spider Storage Engine](../../../server-usage/storage-engines/spider/)
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/mariadb-enterprise-spider-topologies/odbc-mariadb-enterprise-spider-topology.md
+++ b/server/architecture/topologies/mariadb-enterprise-spider-topologies/odbc-mariadb-enterprise-spider-topology.md
@@ -172,6 +172,6 @@ CREATE OR REPLACE TABLE contacts (
 
 * [Enterprise Spider Storage Engine](../../../server-usage/storage-engines/spider/)
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/mariadb-enterprise-spider-topologies/sharded-mariadb-enterprise-spider-topology.md
+++ b/server/architecture/topologies/mariadb-enterprise-spider-topologies/sharded-mariadb-enterprise-spider-topology.md
@@ -194,6 +194,6 @@ PARTITION BY LIST(branch_id) (
 
 * [Enterprise Spider Storage Engine](../../../server-usage/storage-engines/spider/)
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/primary-replica/step-1-install-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/primary-replica/step-1-install-mariadb-enterprise-server.md
@@ -95,6 +95,6 @@ This page was step 1 of 7.
 
 Next: Step 2: Start and Configure MariaDB Enterprise Server on Primary Server
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/primary-replica/step-2-start-and-configure-mariadb-enterprise-server-on-primary-server.md
+++ b/server/architecture/topologies/primary-replica/step-2-start-and-configure-mariadb-enterprise-server-on-primary-server.md
@@ -150,6 +150,6 @@ This page was step 2 of 7.
 
 Next: Step 3: Start and Configure MariaDB Enterprise Server on Replica Servers
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/primary-replica/step-3-start-and-configure-mariadb-enterprise-server-on-replica-servers.md
+++ b/server/architecture/topologies/primary-replica/step-3-start-and-configure-mariadb-enterprise-server-on-replica-servers.md
@@ -224,6 +224,6 @@ This page was step 3 of 7.
 
 Next: Step 4: Test MariaDB Enterprise Server
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/primary-replica/step-4-test-mariadb-enterprise-server.md
+++ b/server/architecture/topologies/primary-replica/step-4-test-mariadb-enterprise-server.md
@@ -217,6 +217,6 @@ This page was step 4 of 7.
 
 Next: Step 5: Install MariaDB MaxScale
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/primary-replica/step-5-install-mariadb-maxscale.md
+++ b/server/architecture/topologies/primary-replica/step-5-install-mariadb-maxscale.md
@@ -94,6 +94,6 @@ This page was step 5 of 7.
 
 Next: Step 6: Start and Configure MariaDB MaxScale
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/primary-replica/step-6-start-and-configure-mariadb-maxscale.md
+++ b/server/architecture/topologies/primary-replica/step-6-start-and-configure-mariadb-maxscale.md
@@ -177,6 +177,6 @@ This page was step 6 of 7.
 
 Next: Step 7: Test MariaDB MaxScale
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/primary-replica/step-7-test-mariadb-maxscale.md
+++ b/server/architecture/topologies/primary-replica/step-7-test-mariadb-maxscale.md
@@ -667,6 +667,6 @@ This page was step 7 of 7.
 
 This procedure is complete.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/community-server-with-columnstore.md
+++ b/server/architecture/topologies/single-node-topologies/community-server-with-columnstore.md
@@ -669,6 +669,6 @@ When you have MariaDB ColumnStore up and running, you should test it to ensure t
     MariaDB [(none)]>
     ```
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/community-server.md
+++ b/server/architecture/topologies/single-node-topologies/community-server.md
@@ -254,6 +254,6 @@ When MariaDB Community Server is up and running on your system, you should test 
     MariaDB [(none)]>
     ```
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/README.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/README.md
@@ -143,6 +143,6 @@ Navigation in the Single-Node Enterprise ColumnStore topology with Local storage
 
 * Next: Step 1: Install MariaDB Enterprise ColumnStore 23.10.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
@@ -148,6 +148,6 @@ This page was step 1 of 5.
 
 Next: Step 2: Install MariaDB Enterprise ColumnStore.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-2-install-enterprise-columnstore.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-2-install-enterprise-columnstore.md
@@ -116,6 +116,6 @@ This page was step 2 of 5.
 
 Next: Step 3: Start and Configure MariaDB Enterprise ColumnStore.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-3-start-and-configure-enterprise-columnstore.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-3-start-and-configure-enterprise-columnstore.md
@@ -161,6 +161,6 @@ This page was step 3 of 5.
 
 Next: Step 4: Test MariaDB Enterprise ColumnStore.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-4-test-enterprise-columnstore.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-4-test-enterprise-columnstore.md
@@ -149,6 +149,6 @@ This page was step 4 of 5.
 
 Next: Step 5: Bulk Import of Data.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-5-bulk-import-of-data.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/step-5-bulk-import-of-data.md
@@ -77,6 +77,6 @@ This page was step 5 of 5.
 
 This procedure is complete.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/README.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/README.md
@@ -180,6 +180,6 @@ Navigation in the Single-Node Enterprise ColumnStore topology with Object storag
 
 Next: Step 1: Install MariaDB Enterprise ColumnStore.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
@@ -154,6 +154,6 @@ This page was step 1 of 5.
 
 Next: Step 2: Install MariaDB Enterprise ColumnStore.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-2-install-enterprise-columnstore.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-2-install-enterprise-columnstore.md
@@ -116,6 +116,6 @@ This page was step 2 of 5.
 
 Next: Step 3: Start and Configure MariaDB Enterprise ColumnStore.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-3-start-and-configure-enterprise-columnstore.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-3-start-and-configure-enterprise-columnstore.md
@@ -200,6 +200,6 @@ This page was step 3 of 5.
 
 Next: Step 4: Test MariaDB Enterprise ColumnStore.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-4-test-enterprise-columnstore.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-4-test-enterprise-columnstore.md
@@ -165,6 +165,6 @@ This page was step 4 of 5.
 
 Next: Step 5: Bulk Import of Data.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-5-bulk-import-of-data.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/step-5-bulk-import-of-data.md
@@ -77,6 +77,6 @@ This page was step 5 of 5.
 
 This procedure is complete.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/single-node-topologies/enterprise-server.md
+++ b/server/architecture/topologies/single-node-topologies/enterprise-server.md
@@ -230,6 +230,6 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 MariaDB [(none)]>
 ```
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/spider-federated/README.md
+++ b/server/architecture/topologies/spider-federated/README.md
@@ -126,6 +126,6 @@ Navigation in the procedure "Deploy Spider Federated Topology":
 
 Next: Step 1: Install Enterprise Spider
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/spider-federated/step-1-install-enterprise-spider.md
+++ b/server/architecture/topologies/spider-federated/step-1-install-enterprise-spider.md
@@ -126,6 +126,6 @@ This page was step 1 of 3.
 
 Next: Step 2: Configure Spider Node and Data Node
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/spider-federated/step-2-configure-spider-node-and-data-node.md
+++ b/server/architecture/topologies/spider-federated/step-2-configure-spider-node-and-data-node.md
@@ -156,6 +156,6 @@ This page was step 2 of 3.
 
 Next: Step 3: Test Spider Federated Topology.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/spider-federated/step-3-test-spider-federated-topology.md
+++ b/server/architecture/topologies/spider-federated/step-3-test-spider-federated-topology.md
@@ -144,6 +144,6 @@ This page was step 3 of 3.
 
 This procedure is complete.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/spider-sharded/README.md
+++ b/server/architecture/topologies/spider-sharded/README.md
@@ -130,6 +130,6 @@ Navigation in the procedure "Deploy Spider Sharded Topology":
 
 Next: Step 1: Install Enterprise Spider
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/spider-sharded/step-1-install-enterprise-spider.md
+++ b/server/architecture/topologies/spider-sharded/step-1-install-enterprise-spider.md
@@ -125,6 +125,6 @@ This page was step 1 of 3.
 
 Next: Step 2: Configure Spider Node and Data Nodes.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/spider-sharded/step-2-configure-spider-node-and-data-nodes.md
+++ b/server/architecture/topologies/spider-sharded/step-2-configure-spider-node-and-data-nodes.md
@@ -245,6 +245,6 @@ This page was **step 2 of 3**.
 
 Next: Step 3: Test Spider Sharded Topology.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/spider-sharded/step-3-test-spider-sharded-topology.md
+++ b/server/architecture/topologies/spider-sharded/step-3-test-spider-sharded-topology.md
@@ -176,6 +176,6 @@ This page was step 3 of 3.
 
 This procedure is complete.
 
-{% include "../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/architecture/topologies/spider-storage-engine.md
+++ b/server/architecture/topologies/spider-storage-engine.md
@@ -70,6 +70,6 @@ _Spider Sharded: a Spider Node distributes the partitions of a virtual sharded t
 
 <ul><li><strong>Shard tables for horizontal scalability</strong></li><li>Spider Node uses Spider storage engine for Sharded Spider Tables</li><li>Sharded Spider Table is a partitioned "virtual" table</li><li>Spider uses MariaDB foreign data wrapper to query Data Tables on Data Nodes for each partition</li><li>Data Node uses non-Spider storage engine for Data Tables</li><li>Supports transactions</li><li>Enterprise Server 10.3+, Enterprise Spider</li></ul>
 
-{% include "../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-fusion-mysql-mariadb-plugin-for-vs.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-fusion-mysql-mariadb-plugin-for-vs.md
@@ -6,6 +6,6 @@
 Note: dbForge Fusion is officially discontinued. However, you can access the features available in dbForge Fusion for MySQL/MariaDB through [dbForge Studio for MySQL](https://www.devart.com/dbforge/mysql/studio/), which is actively supported and regularly updated.
 {% endhint %}
 
-{% include "../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/clients-and-utilities/logging-tools/mariadb-binlog/using-mariadb-binlog.md
+++ b/server/clients-and-utilities/logging-tools/mariadb-binlog/using-mariadb-binlog.md
@@ -78,6 +78,6 @@ mariadb -u root -p -e "source /tmp/mariadb-bin.sql"
 * [mariadb-binlog](./)
 * [mariadb-binlog Options](mariadb-binlog-options.md)
 
-{% include "../../../.gitbook/includes/license-gplv2-fill-help-tables.md" %}
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-code-reference.md
+++ b/server/reference/error-codes/mariadb-error-code-reference.md
@@ -1307,6 +1307,6 @@ New error codes are being continually being added as new features are added. For
 | [4225](mariadb-error-codes-4200-to-4299/e4225.md) |          | ER\_WARN\_HINTS\_ON\_INSERT\_PART\_OF\_INSERT\_SELECT | Optimizer hints at the INSERT part of a INSERT..SELECT statement are not supported                                                     |
 | [4226](mariadb-error-codes-4200-to-4299/e4226.md) |          | ER\_INIT\_SLAVE\_ERROR                                | Slave SQL thread aborted. Can't execute init\_slave query due to error code                                                            |
 
-{% include "../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1000.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1000.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1001.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1001.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1002.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1002.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1003.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1003.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1004.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1004.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1005.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1005.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1006.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1006.md
@@ -20,6 +20,6 @@ The server has insufficient free disk space to create the database. Free up spac
 
 There may be a file permission issue on the data directories. Check both the user and group permissions and set accordingly.
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1007.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1007.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1008.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1008.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1009.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1009.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1010.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1010.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1011.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1011.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1012.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1012.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1013.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1013.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1014.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1014.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1015.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1015.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1016.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1016.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1017.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1017.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1018.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1018.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1019.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1019.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1020.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1020.md
@@ -12,6 +12,6 @@ When InnoDB returns this error, it results in a **full transaction rollback**, n
 
 Try restarting the transaction.
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1021.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1021.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1022.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1022.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1023.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1023.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1024.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1024.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1025.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1025.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1026.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1026.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1027.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1027.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1028.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1028.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1029.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1029.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1030.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1030.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1031.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1031.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1032.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1032.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1033.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1033.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1034.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1034.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1035.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1035.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1036.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1036.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1037.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1037.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1038.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1038.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1039.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1039.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1040.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1040.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1041.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1041.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1042.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1042.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1043.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1043.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1044.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1044.md
@@ -12,8 +12,6 @@ The user is trying to access a database/schema they do not have access to. See [
 
 * [When access\_denied\_errors status variable is incremented](../../../security/user-account-management/incrementing-of-the-access_denied_errors-status-variable.md)
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1045.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1045.md
@@ -12,8 +12,6 @@ The user/password combination does not exist or the user does not have privilege
 
 * [When access\_denied\_errors status variable is incremented](../../../security/user-account-management/incrementing-of-the-access_denied_errors-status-variable.md)
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1046.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1046.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1047.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1047.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1048.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1048.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1049.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1049.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1050.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1050.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1051.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1051.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1052.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1052.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1053.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1053.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1054.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1054.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1055.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1055.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1056.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1056.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1057.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1057.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1058.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1058.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1059.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1059.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1060.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1060.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1061.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1061.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1062.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1062.md
@@ -47,8 +47,6 @@ SELECT * FROM t1;
 +----+------+
 ```
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1063.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1063.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1064.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1064.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1065.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1065.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1066.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1066.md
@@ -56,8 +56,6 @@ HANDLER db_new_t1 READ NEXT LIMIT 3;
 +------+
 ```
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1067.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1067.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1068.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1068.md
@@ -34,8 +34,6 @@ CREATE TABLE t1(
 );
 ```
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1069.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1069.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1070.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1070.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1071.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1071.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1072.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1072.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1073.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1073.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1074.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1074.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1075.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1075.md
@@ -34,8 +34,6 @@ CREATE OR REPLACE TABLE animals (
 Query OK, 0 rows affected (0.017 sec)
 ```
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1076.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1076.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1077.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1077.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1078.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1078.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1079.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1079.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1080.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1080.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1081.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1081.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1082.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1082.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1083.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1083.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1084.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1084.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1085.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1085.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1086.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1086.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1087.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1087.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1088.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1088.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1089.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1089.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1090.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1090.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1091.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1091.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1092.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1092.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1093.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1093.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1094.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1094.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1095.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1095.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1096.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1096.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1097.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1097.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1098.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1098.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1099.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1099.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1100.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1100.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1101.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1101.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1102.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1102.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1103.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1103.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1104.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1104.md
@@ -9,6 +9,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1105.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1105.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1106.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1106.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1107.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1107.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1108.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1108.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1109.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1109.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1110.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1110.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1111.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1111.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1112.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1112.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1113.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1113.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1114.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1114.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1115.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1115.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1116.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1116.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1117.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1117.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1118.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1118.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1119.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1119.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1120.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1120.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1121.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1121.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1122.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1122.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1123.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1123.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1124.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1124.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1125.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1125.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1126.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1126.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1127.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1127.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1128.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1128.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1129.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1129.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1130.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1130.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1131.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1131.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1132.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1132.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1133.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1133.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1134.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1134.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1135.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1135.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1136.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1136.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1137.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1137.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1138.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1138.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1139.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1139.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1140.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1140.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1141.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1141.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1142.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1142.md
@@ -12,8 +12,6 @@ The user is trying to access a table or a column from a table they do not have a
 
 * [When access\_denied\_errors status variable is incremented](../../../security/user-account-management/incrementing-of-the-access_denied_errors-status-variable.md)
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1143.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1143.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1144.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1144.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1145.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1145.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1146.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1146.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1147.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1147.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1148.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1148.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1149.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1149.md
@@ -153,6 +153,6 @@ CREATE TABLE t (id VARCHAR2(10));
 
 See [Oracle mode](e1149.md#oracle-mode) for a full list of syntax differences.
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1150.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1150.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1151.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1151.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1152.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1152.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1153.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1153.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1154.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1154.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1155.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1155.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1156.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1156.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1157.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1157.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1158.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1158.md
@@ -54,6 +54,6 @@ This means the connection was aborted by the application/user.
 
 * [perror](../../../clients-and-utilities/administrative-tools/perror.md) Getting a description for an error number.
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1159.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1159.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1160.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1160.md
@@ -47,8 +47,6 @@ This means the connection was aborted by the application/user.
 
 * [perror](../../../clients-and-utilities/administrative-tools/perror.md) Getting a description for an error number.
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1161.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1161.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1162.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1162.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1163.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1163.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1164.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1164.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1165.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1165.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1166.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1166.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1167.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1167.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1168.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1168.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1169.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1169.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1170.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1170.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1171.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1171.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1172.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1172.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1173.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1173.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1174.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1174.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1175.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1175.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1176.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1176.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1177.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1177.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1178.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1178.md
@@ -19,8 +19,6 @@ ANALYZE TABLE s;
 +--------+---------+----------+----------------------------------------------------------+
 ```
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1179.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1179.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1180.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1180.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1181.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1181.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1182.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1182.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1183.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1183.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1184.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1184.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1185.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1185.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1186.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1186.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1187.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1187.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1188.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1188.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1189.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1189.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1190.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1190.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1191.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1191.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1192.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1192.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1193.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1193.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1194.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1194.md
@@ -13,8 +13,6 @@ This error occurs, in particular to [MyISAM](../../../server-usage/storage-engin
 
 Fixing the problem can usually be done by running a [REPAIR TABLE](../../sql-statements/table-statements/repair-table.md) statement, or one of the similar scripts, [aria\_chk](../../../clients-and-utilities/aria-clients-and-utilities/aria_chk.md), [myisamchk](../../../clients-and-utilities/myisam-clients-and-utilities/myisamchk.md) or [mariadb-check](../../../clients-and-utilities/table-tools/mariadb-check.md).
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1195.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1195.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1196.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1196.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1197.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1197.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1198.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1198.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1199.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1199.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1200.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1200.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1201.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1201.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1202.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1202.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1203.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1203.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1204.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1204.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1205.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1205.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1206.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1206.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1207.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1207.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1208.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1208.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1209.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1209.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1210.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1210.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1211.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1211.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1212.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1212.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1213.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1213.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1214.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1214.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1215.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1215.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1216.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1216.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1217.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1217.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1218.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1218.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1219.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1219.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1220.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1220.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1221.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1221.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1222.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1222.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1223.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1223.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1224.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1224.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1225.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1225.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1226.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1226.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1227.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1227.md
@@ -12,8 +12,6 @@ The user is trying to access a database/schema/object they do not have access to
 
 * [When access\_denied\_errors status variable is incremented](../../../security/user-account-management/incrementing-of-the-access_denied_errors-status-variable.md)
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1228.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1228.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1229.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1229.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1230.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1230.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1231.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1231.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1232.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1232.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1233.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1233.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1234.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1234.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1235.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1235.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1236.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1236.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1237.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1237.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1238.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1238.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1239.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1239.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1240.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1240.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1241.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1241.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1242.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1242.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1243.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1243.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1244.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1244.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1245.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1245.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1246.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1246.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1247.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1247.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1248.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1248.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1249.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1249.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1250.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1250.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1251.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1251.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1252.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1252.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1253.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1253.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1254.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1254.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1255.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1255.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1256.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1256.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1257.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1257.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1258.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1258.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1259.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1259.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1260.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1260.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1261.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1261.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1262.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1262.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1263.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1263.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1264.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1264.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1265.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1265.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1266.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1266.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1267.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1267.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1268.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1268.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1269.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1269.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1270.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1270.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1271.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1271.md
@@ -32,8 +32,6 @@ SELECT COLUMN COLLATE utf8mb3_unicode_ci
 
 This command temporarily adjusts the collation for `column` during the SELECT operation to `utf8mb3_unicode_ci`, ensuring consistent collation for the operation.
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1272.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1272.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1273.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1273.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1274.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1274.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1275.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1275.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1276.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1276.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1277.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1277.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1278.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1278.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1279.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1279.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1280.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1280.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1281.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1281.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1282.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1282.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1283.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1283.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1284.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1284.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1285.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1285.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1286.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1286.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1287.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1287.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1288.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1288.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1289.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1289.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1290.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1290.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1291.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1291.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1292.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1292.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1293.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1293.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1294.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1294.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1295.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1295.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1296.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1296.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1297.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1297.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1298.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1298.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1299.md
+++ b/server/reference/error-codes/mariadb-error-codes-1200-to-1299/e1299.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1300.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1300.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1301.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1301.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1302.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1302.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1303.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1303.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1304.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1304.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1305.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1305.md
@@ -77,8 +77,6 @@ CALL Reset_animal_count();
 Query OK, 0 rows affected (0.001 sec)
 ```
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1306.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1306.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1307.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1307.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1308.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1308.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1309.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1309.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1310.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1310.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1311.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1311.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1312.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1312.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1313.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1313.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1314.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1314.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1315.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1315.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1316.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1316.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1317.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1317.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1318.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1318.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1319.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1319.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1320.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1320.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1321.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1321.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1322.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1322.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1323.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1323.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1324.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1324.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1325.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1325.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1326.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1326.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1327.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1327.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1328.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1328.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1329.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1329.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1330.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1330.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1331.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1331.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1332.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1332.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1333.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1333.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1334.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1334.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1335.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1335.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1336.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1336.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1337.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1337.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1338.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1338.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1339.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1339.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1340.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1340.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1341.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1341.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1342.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1342.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1343.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1343.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1344.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1344.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1345.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1345.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1346.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1346.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1347.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1347.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1348.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1348.md
@@ -8,8 +8,6 @@
 
 The usual cause is that an [UPDATE](../../sql-statements/data-manipulation/changing-deleting-data/update.md), [LOAD DATA](../../sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile.md) or [LOAD XML](../../sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-xml.md), is being performed on the column of a [view](../../../server-usage/views/README.md) where the view column is an expression.
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1349.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1349.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1350.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1350.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1351.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1351.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1352.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1352.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1353.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1353.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1354.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1354.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1355.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1355.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1356.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1356.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1357.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1357.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1358.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1358.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1359.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1359.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1360.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1360.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1361.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1361.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1362.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1362.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1363.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1363.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1364.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1364.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1365.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1365.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1366.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1366.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1367.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1367.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1368.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1368.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1369.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1369.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1370.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1370.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1371.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1371.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1372.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1372.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1373.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1373.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1374.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1374.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1375.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1375.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1376.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1376.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1377.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1377.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1378.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1378.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1379.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1379.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1380.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1380.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1381.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1381.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1382.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1382.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1383.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1383.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1384.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1384.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1385.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1385.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1386.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1386.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1387.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1387.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1388.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1388.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1389.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1389.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1390.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1390.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1391.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1391.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1392.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1392.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1393.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1393.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1394.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1394.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1395.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1395.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1396.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1396.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1397.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1397.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1398.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1398.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1399.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1399.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1400.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1400.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1401.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1401.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1402.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1402.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1403.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1403.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1404.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1404.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1405.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1405.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1406.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1406.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1407.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1407.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1408.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1408.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1409.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1409.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1410.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1410.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1411.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1411.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1412.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1412.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1413.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1413.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1414.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1414.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1415.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1415.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1416.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1416.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1417.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1417.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1418.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1418.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1419.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1419.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1420.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1420.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1421.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1421.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1422.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1422.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1423.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1423.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1424.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1424.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1425.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1425.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1426.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1426.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1427.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1427.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1428.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1428.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1429.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1429.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1430.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1430.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1431.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1431.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1432.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1432.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1433.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1433.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1434.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1434.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1435.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1435.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1436.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1436.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1437.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1437.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1438.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1438.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1439.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1439.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1440.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1440.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1441.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1441.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1442.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1442.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1443.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1443.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1444.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1444.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1445.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1445.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1446.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1446.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1447.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1447.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1448.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1448.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1449.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1449.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1450.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1450.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1451.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1451.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1452.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1452.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1453.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1453.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1454.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1454.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1455.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1455.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1456.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1456.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1457.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1457.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1458.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1458.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1459.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1459.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1460.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1460.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1461.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1461.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1462.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1462.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1463.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1463.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1464.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1464.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1465.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1465.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1466.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1466.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1467.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1467.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1468.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1468.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1469.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1469.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1470.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1470.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1471.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1471.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1472.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1472.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1473.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1473.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1474.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1474.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1475.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1475.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1476.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1476.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1477.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1477.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1478.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1478.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1479.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1479.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1480.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1480.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1481.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1481.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1482.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1482.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1483.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1483.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1484.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1484.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1485.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1485.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1486.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1486.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1487.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1487.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1488.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1488.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1489.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1489.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1490.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1490.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1491.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1491.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1492.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1492.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1493.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1493.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1494.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1494.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1495.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1495.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1496.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1496.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1497.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1497.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1498.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1498.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1499.md
+++ b/server/reference/error-codes/mariadb-error-codes-1400-to-1499/e1499.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1500.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1500.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1501.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1501.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1502.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1502.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1503.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1503.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1504.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1504.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1505.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1505.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1506.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1506.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1507.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1507.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1508.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1508.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1509.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1509.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1510.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1510.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1511.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1511.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1512.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1512.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1513.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1513.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1514.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1514.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1515.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1515.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1516.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1516.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1517.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1517.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1518.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1518.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1519.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1519.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1520.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1520.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1521.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1521.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1522.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1522.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1523.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1523.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1524.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1524.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1525.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1525.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1526.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1526.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1527.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1527.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1528.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1528.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1529.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1529.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1530.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1530.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1531.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1531.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1532.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1532.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1533.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1533.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1534.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1534.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1535.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1535.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1536.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1536.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1537.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1537.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1538.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1538.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1539.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1539.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1540.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1540.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1541.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1541.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1542.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1542.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1543.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1543.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1544.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1544.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1545.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1545.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1546.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1546.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1547.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1547.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1548.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1548.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1549.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1549.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1550.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1550.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1551.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1551.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1552.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1552.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1553.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1553.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1554.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1554.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1555.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1555.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1556.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1556.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1557.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1557.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1558.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1558.md
@@ -10,8 +10,6 @@
 
 This error likely means an upgrade hasn't been performed properly, as one of the system tables does not match the expected size for the running release. [mariadb-upgrade](../../../clients-and-utilities/deployment-tools/mariadb-upgrade.md) usually takes care of this. See [Upgrading Between Major MariaDB Versions](../../../server-management/install-and-upgrade-mariadb/upgrading/upgrading-between-major-mariadb-versions.md).
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1559.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1559.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1560.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1560.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1561.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1561.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1562.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1562.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1563.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1563.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1564.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1564.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1565.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1565.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1566.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1566.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1567.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1567.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1568.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1568.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1569.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1569.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1570.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1570.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1571.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1571.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1572.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1572.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1573.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1573.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1574.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1574.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1575.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1575.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1576.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1576.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1577.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1577.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1578.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1578.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1579.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1579.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1580.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1580.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1581.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1581.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1582.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1582.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1583.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1583.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1584.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1584.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1585.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1585.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1586.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1586.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1587.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1587.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1588.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1588.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1589.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1589.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1590.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1590.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1591.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1591.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1592.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1592.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1593.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1593.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1594.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1594.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1595.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1595.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1596.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1596.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1597.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1597.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1598.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1598.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1599.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1599.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1600.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1600.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1601.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1601.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1602.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1602.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1603.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1603.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1604.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1604.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1605.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1605.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1606.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1606.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1607.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1607.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1608.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1608.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1609.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1609.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1610.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1610.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1611.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1611.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1612.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1612.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1613.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1613.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1614.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1614.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1615.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1615.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1616.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1616.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1617.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1617.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1618.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1618.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1619.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1619.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1620.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1620.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1621.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1621.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1622.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1622.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1623.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1623.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1624.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1624.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1625.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1625.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1626.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1626.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1627.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1627.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1628.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1628.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1629.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1629.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1630.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1630.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1631.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1631.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1632.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1632.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1633.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1633.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1634.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1634.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1635.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1635.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1636.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1636.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1637.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1637.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1638.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1638.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1639.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1639.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1640.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1640.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1641.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1641.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1642.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1642.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1643.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1643.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1644.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1644.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1645.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1645.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1646.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1646.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1647.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1647.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1648.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1648.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1649.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1649.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1650.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1650.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1651.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1651.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1652.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1652.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1653.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1653.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1654.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1654.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1655.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1655.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1656.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1656.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1657.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1657.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1658.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1658.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1659.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1659.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1660.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1660.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1661.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1661.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1662.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1662.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1663.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1663.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1664.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1664.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1665.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1665.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1666.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1666.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1667.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1667.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1668.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1668.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1669.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1669.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1670.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1670.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1671.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1671.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1672.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1672.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1673.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1673.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1674.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1674.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1675.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1675.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1676.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1676.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1677.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1677.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1678.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1678.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1679.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1679.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1680.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1680.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1681.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1681.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1682.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1682.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1683.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1683.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1684.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1684.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1685.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1685.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1686.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1686.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1687.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1687.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1688.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1688.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1689.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1689.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1690.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1690.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1691.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1691.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1692.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1692.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1693.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1693.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1694.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1694.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1695.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1695.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1696.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1696.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1697.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1697.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1698.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1698.md
@@ -14,8 +14,6 @@ There are a number of common problems that can occur when connecting to MariaDB.
 
 * [When access\_denied\_errors status variable is incremented](../../../security/user-account-management/incrementing-of-the-access_denied_errors-status-variable.md)
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1699.md
+++ b/server/reference/error-codes/mariadb-error-codes-1600-to-1699/e1699.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1700.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1700.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1701.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1701.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1702.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1702.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1703.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1703.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1704.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1704.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1705.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1705.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1706.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1706.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1707.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1707.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1708.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1708.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1709.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1709.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1710.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1710.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1711.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1711.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1712.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1712.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1713.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1713.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1714.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1714.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1715.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1715.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1716.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1716.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1717.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1717.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1718.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1718.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1719.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1719.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1720.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1720.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1721.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1721.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1722.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1722.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1723.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1723.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1724.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1724.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1725.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1725.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1726.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1726.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1727.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1727.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1728.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1728.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1729.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1729.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1730.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1730.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1731.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1731.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1732.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1732.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1733.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1733.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1734.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1734.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1735.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1735.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1736.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1736.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1737.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1737.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1738.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1738.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1739.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1739.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1740.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1740.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1741.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1741.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1742.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1742.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1743.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1743.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1744.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1744.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1745.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1745.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1746.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1746.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1747.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1747.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1748.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1748.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1749.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1749.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1750.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1750.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1751.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1751.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1752.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1752.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1753.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1753.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1754.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1754.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1755.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1755.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1756.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1756.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1757.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1757.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1758.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1758.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1759.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1759.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1760.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1760.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1761.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1761.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1762.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1762.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1763.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1763.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1764.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1764.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1765.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1765.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1766.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1766.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1767.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1767.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1768.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1768.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1769.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1769.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1770.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1770.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1771.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1771.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1772.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1772.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1773.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1773.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1774.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1774.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1775.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1775.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1776.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1776.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1777.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1777.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1778.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1778.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1779.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1779.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1780.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1780.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1781.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1781.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1782.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1782.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1783.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1783.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1784.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1784.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1785.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1785.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1786.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1786.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1787.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1787.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1788.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1788.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1789.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1789.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1790.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1790.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1791.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1791.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1792.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1792.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1793.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1793.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1794.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1794.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1795.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1795.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1796.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1796.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1797.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1797.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1798.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1798.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1799.md
+++ b/server/reference/error-codes/mariadb-error-codes-1700-to-1799/e1799.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1800.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1800.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1801.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1801.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1802.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1802.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1803.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1803.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1804.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1804.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1805.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1805.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1806.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1806.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1807.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1807.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1808.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1808.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1809.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1809.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1810.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1810.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1811.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1811.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1812.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1812.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1813.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1813.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1814.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1814.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1815.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1815.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1816.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1816.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1817.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1817.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1818.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1818.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1819.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1819.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1820.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1820.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1821.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1821.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1822.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1822.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1823.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1823.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1824.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1824.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1825.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1825.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1826.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1826.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1827.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1827.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1828.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1828.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1829.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1829.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1830.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1830.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1831.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1831.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1832.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1832.md
@@ -16,8 +16,6 @@ If the referenced table is the one being altered, the server reports [error 1833
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1833.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1833.md
@@ -16,8 +16,6 @@ If the table being altered is the one holding the constraint, the server reports
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1834.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1834.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1835.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1835.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1836.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1836.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1837.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1837.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1838.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1838.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1839.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1839.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1840.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1840.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1841.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1841.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1842.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1842.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1843.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1843.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1844.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1844.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1845.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1845.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1846.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1846.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1847.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1847.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1848.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1848.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1849.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1849.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1850.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1850.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1851.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1851.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1852.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1852.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1853.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1853.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1854.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1854.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1855.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1855.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1856.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1856.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1857.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1857.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1858.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1858.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1859.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1859.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1860.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1860.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1861.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1861.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1862.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1862.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1863.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1863.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1864.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1864.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1865.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1865.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1866.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1866.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1867.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1867.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1868.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1868.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1869.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1869.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1870.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1870.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1871.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1871.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1872.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1872.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1873.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1873.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1874.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1874.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1875.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1875.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1876.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1876.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1877.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1877.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1878.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1878.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1879.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1879.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1880.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1880.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1900.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1900.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1901.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1901.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1902.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1902.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1903.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1903.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1904.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1904.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1905.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1905.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1906.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1906.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1907.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1907.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1908.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1908.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1909.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1909.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1910.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1910.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1911.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1911.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1912.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1912.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1913.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1913.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1914.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1914.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1915.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1915.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1916.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1916.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1917.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1917.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1918.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1918.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1919.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1919.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1920.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1920.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1921.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1921.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1922.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1922.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1923.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1923.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1924.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1924.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1925.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1925.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1926.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1926.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1927.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1927.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1928.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1928.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1929.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1929.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1930.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1930.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1931.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1931.md
@@ -20,6 +20,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1932.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1932.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1933.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1933.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1934.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1934.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1935.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1935.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1936.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1936.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1937.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1937.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1938.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1938.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1939.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1939.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1940.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1940.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1941.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1941.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1942.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1942.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1943.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1943.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1944.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1944.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1945.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1945.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1946.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1946.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1947.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1947.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1948.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1948.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1949.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1949.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1950.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1950.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1951.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1951.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1952.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1952.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1953.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1953.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1954.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1954.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1955.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1955.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1956.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1956.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1957.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1957.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1958.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1958.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1959.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1959.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1960.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1960.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1961.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1961.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1962.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1962.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1963.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1963.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1964.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1964.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1965.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1965.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1966.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1966.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1967.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1967.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1968.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1968.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1969.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1969.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1970.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1970.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1971.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1971.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1972.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1972.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1973.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1973.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1974.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1974.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1975.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1975.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1976.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1976.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1977.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1977.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1978.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1978.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1979.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1979.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1980.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1980.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1981.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1981.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1982.md
+++ b/server/reference/error-codes/mariadb-error-codes-1900-to-1999/e1982.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3000.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3000.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3001.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3001.md
@@ -10,8 +10,6 @@ Error 3001: Query partially completed on the master (error on master: %d) and wa
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3002.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3002.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3003.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3003.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3004.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3004.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3005.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3005.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3006.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3006.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3007.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3007.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3008.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3008.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3009.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3009.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3010.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3010.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3011.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3011.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3012.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3012.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3013.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3013.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3014.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3014.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3015.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3015.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3016.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3016.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3017.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3017.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3018.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3018.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3019.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3019.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3020.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3020.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3021.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3021.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3022.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3022.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3023.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3023.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3024.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3024.md
@@ -16,6 +16,6 @@ To fix this, you have to either increase the value of [max\_statement\_time](../
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3025.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3025.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3026.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3026.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3027.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3027.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3028.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3028.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3029.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3029.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3030.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3030.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3031.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3031.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3032.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3032.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3033.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3033.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3034.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3034.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3035.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3035.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3036.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3036.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3037.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3037.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3038.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3038.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3039.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3039.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3040.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3040.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3041.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3041.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3042.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3042.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3043.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3043.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3044.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3044.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3045.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3045.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3046.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3046.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3047.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3047.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3048.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3048.md
@@ -26,8 +26,6 @@ SELECT ST_GeoHash(180,30,15);
 +-----------------------+
 ```
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3049.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3049.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3050.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3050.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3051.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3051.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3052.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3052.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3053.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3053.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3054.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3054.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3055.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3055.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3056.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3056.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3057.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3057.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3058.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3058.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3059.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3059.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3060.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3060.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3061.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3061.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3062.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3062.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3063.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3063.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3064.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3064.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3065.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3065.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3066.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3066.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3067.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3067.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3068.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3068.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3069.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3069.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3070.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3070.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3071.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3071.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3072.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3072.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3073.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3073.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3074.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3074.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3075.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3075.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3076.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3076.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3077.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3077.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3078.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3078.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3079.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3079.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3080.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3080.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3081.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3081.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3082.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3082.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3083.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3083.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3084.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3084.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3085.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3085.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3086.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3086.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3087.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3087.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3088.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3088.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3089.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3089.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3090.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3090.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3091.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3091.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3092.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3092.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3093.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3093.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3094.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3094.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3095.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3095.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3096.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3096.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3097.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3097.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3098.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3098.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3099.md
+++ b/server/reference/error-codes/mariadb-error-codes-3000-to-3099/e3099.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3100.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3100.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3101.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3101.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3102.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3102.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3103.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3103.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3104.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3104.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3105.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3105.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3106.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3106.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3107.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3107.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3108.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3108.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3109.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3109.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3110.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3110.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3111.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3111.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3112.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3112.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3113.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3113.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3114.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3114.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3115.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3115.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3116.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3116.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3117.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3117.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3118.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3118.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3119.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3119.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3120.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3120.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3121.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3121.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3122.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3122.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3123.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3123.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3124.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3124.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3125.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3125.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3126.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3126.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3127.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3127.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3128.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3128.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3129.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3129.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3130.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3130.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3131.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3131.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3132.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3132.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3133.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3133.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3134.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3134.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3135.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3135.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3136.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3136.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3137.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3137.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3138.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3138.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3139.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3139.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3140.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3140.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3141.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3141.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3142.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3142.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3143.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3143.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3144.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3144.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3145.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3145.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3146.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3146.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3147.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3147.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3148.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3148.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3149.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3149.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3150.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3150.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3151.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3151.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3152.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3152.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3153.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3153.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3154.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3154.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3155.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3155.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3156.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3156.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3157.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3157.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3158.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3158.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3159.md
+++ b/server/reference/error-codes/mariadb-error-codes-3100-to-3199/e3159.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4000.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4000.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4001.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4001.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4002.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4002.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4003.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4003.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4004.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4004.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4005.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4005.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4006.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4006.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4007.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4007.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4008.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4008.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4009.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4009.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4010.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4010.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4011.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4011.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4012.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4012.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4013.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4013.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4014.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4014.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4015.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4015.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4016.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4016.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4017.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4017.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4018.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4018.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4019.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4019.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4020.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4020.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4021.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4021.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4022.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4022.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4023.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4023.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4024.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4024.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4025.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4025.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4026.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4026.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4027.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4027.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4028.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4028.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4029.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4029.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4030.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4030.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4031.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4031.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4032.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4032.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4033.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4033.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4034.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4034.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4035.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4035.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4036.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4036.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4037.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4037.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4038.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4038.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4039.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4039.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4040.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4040.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4041.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4041.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4042.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4042.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4043.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4043.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4044.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4044.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4045.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4045.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4046.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4046.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4047.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4047.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4048.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4048.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4049.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4049.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4050.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4050.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4051.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4051.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4052.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4052.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4053.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4053.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4054.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4054.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4055.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4055.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4056.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4056.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4057.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4057.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4058.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4058.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4059.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4059.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4060.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4060.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4061.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4061.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4062.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4062.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4063.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4063.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4064.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4064.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4065.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4065.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4066.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4066.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4067.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4067.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4068.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4068.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4069.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4069.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4070.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4070.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4071.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4071.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4072.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4072.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4073.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4073.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4074.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4074.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4075.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4075.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4076.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4076.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4077.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4077.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4078.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4078.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4079.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4079.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4080.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4080.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4081.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4081.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4082.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4082.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4083.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4083.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4084.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4084.md
@@ -153,6 +153,6 @@ SELECT NEXTVAL(s);
 * [SHOW CREATE SEQUENCE](../../sql-statements/administrative-sql-statements/show/show-create-sequence.md)
 * [Information Schema SEQUENCES Table](../../system-tables/information-schema/information-schema-tables/information-schema-sequences-table.md)
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4085.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4085.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4086.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4086.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4087.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4087.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4088.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4088.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4089.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4089.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4090.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4090.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4091.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4091.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4092.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4092.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4093.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4093.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4094.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4094.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4095.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4095.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4096.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4096.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4097.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4097.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4098.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4098.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4099.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4099.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4100.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4100.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4101.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4101.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4102.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4102.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4103.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4103.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4104.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4104.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4105.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4105.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4106.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4106.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4107.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4107.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4108.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4108.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4109.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4109.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4110.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4110.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4111.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4111.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4112.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4112.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4113.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4113.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4114.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4114.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4115.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4115.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4116.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4116.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4117.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4117.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4118.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4118.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4119.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4119.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4120.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4120.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4121.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4121.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4122.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4122.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4123.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4123.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4124.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4124.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4125.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4125.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4126.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4126.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4127.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4127.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4128.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4128.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4129.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4129.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4130.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4130.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4131.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4131.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4132.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4132.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4133.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4133.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4134.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4134.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4135.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4135.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4136.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4136.md
@@ -10,6 +10,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4137.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4137.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4138.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4138.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4139.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4139.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4140.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4140.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4141.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4141.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4142.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4142.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4143.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4143.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4144.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4144.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4145.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4145.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4146.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4146.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4147.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4147.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4148.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4148.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4149.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4149.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4150.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4150.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4151.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4151.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4152.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4152.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4153.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4153.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4154.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4154.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4155.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4155.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4156.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4156.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4157.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4157.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4158.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4158.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4159.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4159.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4160.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4160.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4161.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4161.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4162.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4162.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4163.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4163.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4164.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4164.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4165.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4165.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4166.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4166.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4167.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4167.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4168.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4168.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4169.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4169.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4170.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4170.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4171.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4171.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4172.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4172.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4173.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4173.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4174.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4174.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4175.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4175.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4176.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4176.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4177.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4177.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4178.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4178.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4179.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4179.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4180.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4180.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4181.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4181.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4182.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4182.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4183.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4183.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4184.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4184.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4185.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4185.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4186.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4186.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4187.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4187.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4188.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4188.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4189.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4189.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4190.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4190.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4191.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4191.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4192.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4192.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4193.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4193.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4194.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4194.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4195.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4195.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4196.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4196.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4197.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4197.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4198.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4198.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4199.md
+++ b/server/reference/error-codes/mariadb-error-codes-4100-to-4199/e4199.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4200.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4200.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4201.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4201.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4202.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4202.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4203.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4203.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4204.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4204.md
@@ -34,6 +34,6 @@ SELECT VEC_ToText(x'e360d63ebe554f3fcdbc523f4522193f5236083d');
 +---------------------------------------------------------+
 ```
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4205.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4205.md
@@ -8,8 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4206.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4206.md
@@ -49,8 +49,6 @@ SELECT id FROM v ORDER BY VEC_DISTANCE(v, x'6ca1d43e9df91b3fe580da3e1c247d3f147c
 +----+
 ```
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4207.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4207.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4208.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4208.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4209.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4209.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4210.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4210.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4211.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4211.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4212.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4212.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4213.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4213.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4214.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4214.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4215.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4215.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4216.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4216.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4217.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4217.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4218.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4218.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4219.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4219.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4220.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4220.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4226.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4226.md
@@ -10,6 +10,6 @@ Prior to the introduction of this error, there were multiple error codes reporte
 
 This error code, ER\_INIT\_SLAVE\_ERROR, unifies all the errors related to the init\_slave query. The ER\_INIT\_SLAVE\_ERROR error is raised for any issue related to the init\_slave query, and the underlying error code and message are included in the Last\_SQL\_Error field. See those specific errors for more details.
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4227.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4227.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4228.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4228.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4229.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4229.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4230.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4230.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4231.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4231.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4232.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4232.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4233.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4233.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4234.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4234.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4235.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4235.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4236.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4236.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4237.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4237.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4238.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4238.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4239.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4239.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4240.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4240.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4241.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4241.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4242.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4242.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4243.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4243.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4244.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4244.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4245.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4245.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4246.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4246.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4247.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4247.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4248.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4248.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4249.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4249.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4250.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4250.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4251.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4251.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4252.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4252.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4253.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4253.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4254.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4254.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4255.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4255.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4256.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4256.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4257.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4257.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4258.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4258.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4259.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4259.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4260.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4260.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4261.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4261.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4262.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4262.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4263.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4263.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4264.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4264.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4265.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4265.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4266.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4266.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4267.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4267.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4268.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4268.md
@@ -8,6 +8,6 @@
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/error-codes/operating-system-error-codes.md
+++ b/server/reference/error-codes/operating-system-error-codes.md
@@ -188,6 +188,6 @@ For a complete list, see [ms681381.aspx](https://msdn.microsoft.com/en-us/librar
 | 123    | ERROR\_INVALID\_NAME             | The file name, directory name, or volume label syntax is incorrect.                          |
 | 1450   | ERROR\_NO\_SYSTEM\_RESOURCES     | Insufficient system resources exist to complete the requested service.                       |
 
-{% include "../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/performance-of-memory-tables.md
+++ b/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/performance-of-memory-tables.md
@@ -184,6 +184,6 @@ select operation, instance, avg(opsize/(unix_timestamp(ended)-unix_timestamp(sta
 from results group by operation, instance;                                      
 ```
 
-{% include "../../../../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-functions/string-functions/substr.md
+++ b/server/reference/sql-functions/string-functions/substr.md
@@ -12,7 +12,7 @@ description: >-
 `SUBSTR()` is a synonym for [SUBSTRING](substring.md)().
 
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-statements/account-management-sql-statements/grant.md
+++ b/server/reference/sql-statements/account-management-sql-statements/grant.md
@@ -1039,6 +1039,6 @@ GRANT ALL PRIVILEGES ON  *.* TO 'alexander'@'localhost' WITH GRANT OPTION;
 * [Password Validation Plugins](../../plugins/password-validation-plugins/) - permits the setting of basic criteria for passwords
 * [Authentication Plugins](../../plugins/authentication-plugins/) - allow various authentication methods to be used, and new ones to be developed.
 
-{% include "../../../.gitbook/includes/license-gplv2-fill-help-tables.md" %}
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-statements/administrative-sql-statements/replication-statements/README.md
+++ b/server/reference/sql-statements/administrative-sql-statements/replication-statements/README.md
@@ -38,6 +38,6 @@ The terms _master_ and _slave_ have historically been used in replication, and M
 [legacy-replication-statements](legacy-replication-statements/)
 {% endcontent-ref %}
 
-{% include "../../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-statements/data-definition/rename-table.md
+++ b/server/reference/sql-statements/data-definition/rename-table.md
@@ -106,6 +106,6 @@ There is a small chance that, during a server crash happening in the middle of `
 {% endtab %}
 {% endtabs %}
 
-{% include "../../../.gitbook/includes/license-gplv2-fill-help-tables.md" %}
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-properties/st_boundary.md
+++ b/server/reference/sql-structure/geometry/geometry-properties/st_boundary.md
@@ -31,6 +31,6 @@ SELECT ST_AsText(ST_Boundary(ST_GeomFromText('POLYGON((3 3,0 0, -3 3, 3 3))')));
 +--------------------------------------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-properties/st_dimension.md
+++ b/server/reference/sql-structure/geometry/geometry-properties/st_dimension.md
@@ -32,6 +32,6 @@ SELECT Dimension(GeomFromText('LineString(1 1,2 2)'));
 +------------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-properties/st_envelope.md
+++ b/server/reference/sql-structure/geometry/geometry-properties/st_envelope.md
@@ -30,6 +30,6 @@ SELECT AsText(ST_ENVELOPE(GeomFromText('LineString(1 1,4 4)')));
 +----------------------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-properties/st_geometrytype.md
+++ b/server/reference/sql-structure/geometry/geometry-properties/st_geometrytype.md
@@ -26,6 +26,6 @@ SELECT GeometryType(GeomFromText('POINT(1 1)'));
 +------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-properties/st_isempty.md
+++ b/server/reference/sql-structure/geometry/geometry-properties/st_isempty.md
@@ -15,6 +15,6 @@ Since MariaDB and MySQL do not support GIS EMPTY values such as POINT EMPTY, as 
 
 `ST_IsEmpty()` and `IsEmpty()` are synonyms.
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-properties/st_srid.md
+++ b/server/reference/sql-structure/geometry/geometry-properties/st_srid.md
@@ -29,6 +29,6 @@ SELECT SRID(GeomFromText('LineString(1 1,2 2)',101));
 +-----------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-relations/contains.md
+++ b/server/reference/sql-structure/geometry/geometry-relations/contains.md
@@ -12,6 +12,6 @@ Returns `1` or `0` to indicate whether a geometry `g1` completely contains geome
 
 This tests the opposite relationship to [Within()](within.md).
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-relations/crosses.md
+++ b/server/reference/sql-structure/geometry/geometry-relations/crosses.md
@@ -21,6 +21,6 @@ given geometries that has the following properties:
 
 CROSSES() is based on the original MySQL implementation, and uses object bounding rectangles, while [ST\_CROSSES()](st-crosses.md) uses object shapes.
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-relations/disjoint.md
+++ b/server/reference/sql-structure/geometry/geometry-relations/disjoint.md
@@ -15,6 +15,6 @@ DISJOINT() tests the opposite relationship to [INTERSECTS()](intersects.md).
 
 DISJOINT() is based on the original MySQL implementation and uses object bounding rectangles, while [ST\_DISJOINT()](st_disjoint.md) uses object shapes.
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-relations/equals.md
+++ b/server/reference/sql-structure/geometry/geometry-relations/equals.md
@@ -20,6 +20,6 @@ EQUALS() is based on the original MySQL implementation and uses object bounding 
 
 From [MariaDB 10.2.3](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.2/10.2.3), `MBREQUALS` is a synonym for `Equals`.
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-relations/intersects.md
+++ b/server/reference/sql-structure/geometry/geometry-relations/intersects.md
@@ -14,6 +14,6 @@ INTERSECTS() is based on the original MySQL implementation and uses object bound
 
 INTERSECTS() tests the opposite relationship to [DISJOINT()](disjoint.md).
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-relations/overlaps.md
+++ b/server/reference/sql-structure/geometry/geometry-relations/overlaps.md
@@ -15,6 +15,6 @@ either of the given geometries.
 
 OVERLAPS() is based on the original MySQL implementation and uses object bounding rectangles, while [ST\_OVERLAPS()](st-overlaps.md) uses object shapes.
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-relations/touches.md
+++ b/server/reference/sql-structure/geometry/geometry-relations/touches.md
@@ -15,6 +15,6 @@ interior of the other.
 
 TOUCHES() is based on the original MySQL implementation and uses object bounding rectangles, while [ST\_TOUCHES()](st-touches.md) uses object shapes.
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/geometry-relations/within.md
+++ b/server/reference/sql-structure/geometry/geometry-relations/within.md
@@ -35,6 +35,6 @@ SELECT within(@g2,@g3);
 +-----------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/linestring-properties/glength.md
+++ b/server/reference/sql-structure/geometry/linestring-properties/glength.md
@@ -27,6 +27,6 @@ SELECT GLength(GeomFromText(@ls));
 
 * [ST\_LENGTH()](../geometry-relations/st_length.md) is the OpenGIS equivalent.
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/linestring-properties/st_endpoint.md
+++ b/server/reference/sql-structure/geometry/linestring-properties/st_endpoint.md
@@ -26,6 +26,6 @@ SELECT AsText(EndPoint(GeomFromText(@ls)));
 +-------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/linestring-properties/st_numpoints.md
+++ b/server/reference/sql-structure/geometry/linestring-properties/st_numpoints.md
@@ -27,6 +27,6 @@ SELECT NumPoints(GeomFromText(@ls));
 +------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/linestring-properties/st_pointn.md
+++ b/server/reference/sql-structure/geometry/linestring-properties/st_pointn.md
@@ -27,6 +27,6 @@ SELECT AsText(PointN(GeomFromText(@ls),2));
 +-------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/linestring-properties/st_startpoint.md
+++ b/server/reference/sql-structure/geometry/linestring-properties/st_startpoint.md
@@ -26,6 +26,6 @@ SELECT AsText(StartPoint(GeomFromText(@ls)));
 +---------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbr-definition.md
+++ b/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbr-definition.md
@@ -11,6 +11,6 @@ geometry, formed by the minimum and maximum (X,Y) coordinates:
 ((MINX MINY, MAXX MINY, MAXX MAXY, MINX MAXY, MINX MINY))
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrcontains.md
+++ b/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrcontains.md
@@ -29,6 +29,6 @@ SELECT MBRContains(@g1,@g2), MBRContains(@g2,@g1);
 
 * [MBRWithin](mbrwithin.md)
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrdisjoint.md
+++ b/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrdisjoint.md
@@ -32,6 +32,6 @@ SELECT mbrdisjoint(@g1,@g2);
 +----------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrequal.md
+++ b/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrequal.md
@@ -35,6 +35,6 @@ SELECT MbrEqual(@g1,@g2);
 +-------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrintersects.md
+++ b/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrintersects.md
@@ -32,6 +32,6 @@ SELECT mbrintersects(@g1,@g2);
 +------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbroverlaps.md
+++ b/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbroverlaps.md
@@ -41,6 +41,6 @@ SELECT mbroverlaps(@g1,@g2);
 +----------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrtouches.md
+++ b/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrtouches.md
@@ -41,6 +41,6 @@ SELECT mbrtouches(@g1,@g2);
 +---------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrwithin.md
+++ b/server/reference/sql-structure/geometry/mbr-minimum-bounding-rectangle/mbrwithin.md
@@ -23,6 +23,6 @@ SELECT MBRWithin(@g1,@g2), MBRWithin(@g2,@g1);
 +--------------------+--------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/point-properties/st_x.md
+++ b/server/reference/sql-structure/geometry/point-properties/st_x.md
@@ -26,6 +26,6 @@ SELECT X(GeomFromText(@pt));
 +----------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/point-properties/st_y.md
+++ b/server/reference/sql-structure/geometry/point-properties/st_y.md
@@ -26,6 +26,6 @@ SELECT Y(GeomFromText(@pt));
 +----------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/polygon-properties/st_area.md
+++ b/server/reference/sql-structure/geometry/polygon-properties/st_area.md
@@ -26,6 +26,6 @@ SELECT Area(GeomFromText(@poly));
 +---------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/polygon-properties/st_exteriorring.md
+++ b/server/reference/sql-structure/geometry/polygon-properties/st_exteriorring.md
@@ -26,6 +26,6 @@ SELECT AsText(ExteriorRing(GeomFromText(@poly)));
 +-------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/polygon-properties/st_interiorringn.md
+++ b/server/reference/sql-structure/geometry/polygon-properties/st_interiorringn.md
@@ -26,6 +26,6 @@ SELECT AsText(InteriorRingN(GeomFromText(@poly),1));
 +----------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/polygon-properties/st_numinteriorrings.md
+++ b/server/reference/sql-structure/geometry/polygon-properties/st_numinteriorrings.md
@@ -40,6 +40,6 @@ SELECT ST_NumInteriorRings(ST_PolyFromText('POLYGON((0 0,10 0,10 10,0 10,0 0),
 +------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkb/mlinefromwkb.md
+++ b/server/reference/sql-structure/geometry/wkb/mlinefromwkb.md
@@ -26,6 +26,6 @@ SELECT ST_AsText(MLineFromWKB(@g));
 +--------------------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkb/mpointfromwkb.md
+++ b/server/reference/sql-structure/geometry/wkb/mpointfromwkb.md
@@ -26,6 +26,6 @@ SELECT ST_AsText(MPointFromWKB(@g));
 +-----------------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkb/mpolyfromwkb.md
+++ b/server/reference/sql-structure/geometry/wkb/mpolyfromwkb.md
@@ -23,6 +23,6 @@ SELECT ST_AsText(MPolyFromWKB(@g))\G
 ST_AsText(MPolyFromWKB(@g)): MULTIPOLYGON(((28 26,28 0,84 0,84 42,28 26),(52 18,66 23,73 9,48 6,52 18)),((59 18,67 18,67 13,59 13,59 18)))
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkb/st_asbinary.md
+++ b/server/reference/sql-structure/geometry/wkb/st_asbinary.md
@@ -29,6 +29,6 @@ SELECT ST_AsText(ST_GeomFromWKB(ST_AsWKB(@poly)));
 +--------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkb/st_geomcollfromwkb.md
+++ b/server/reference/sql-structure/geometry/wkb/st_geomcollfromwkb.md
@@ -29,6 +29,6 @@ SELECT ST_AsText(ST_GeomCollFromWKB(@g));
 +----------------------------------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkb/st_geomfromwkb.md
+++ b/server/reference/sql-structure/geometry/wkb/st_geomfromwkb.md
@@ -28,6 +28,6 @@ SELECT ST_AsText(ST_GeomFromWKB(@g));
 +-------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkb/st_linefromwkb.md
+++ b/server/reference/sql-structure/geometry/wkb/st_linefromwkb.md
@@ -28,6 +28,6 @@ SELECT ST_AsText(ST_LineFromWKB(@g)) AS l;
 +---------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkb/st_pointfromwkb.md
+++ b/server/reference/sql-structure/geometry/wkb/st_pointfromwkb.md
@@ -26,6 +26,6 @@ SELECT ST_AsText(ST_PointFromWKB(@g)) AS p;
 +------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkb/st_polyfromwkb.md
+++ b/server/reference/sql-structure/geometry/wkb/st_polyfromwkb.md
@@ -28,6 +28,6 @@ SELECT ST_AsText(ST_PolyFromWKB(@g)) AS p;
 +----------------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/mlinefromtext.md
+++ b/server/reference/sql-structure/geometry/wkt/mlinefromtext.md
@@ -26,6 +26,6 @@ INSERT INTO gis_multi_line VALUES
       LineString(Point(2, 5), Point(5, 8), Point(21, 7))))));
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/mpointfromtext.md
+++ b/server/reference/sql-structure/geometry/wkt/mpointfromtext.md
@@ -24,6 +24,6 @@ INSERT INTO gis_multi_point VALUES
     (MPointFromWKB(AsWKB(MultiPoint(Point(3, 6), Point(4, 10)))));
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/mpolyfromtext.md
+++ b/server/reference/sql-structure/geometry/wkt/mpolyfromtext.md
@@ -29,6 +29,6 @@ INSERT INTO gis_multi_polygon VALUES
        LineString(Point(0, 3), Point(3, 3), Point(3, 0), Point(0, 3)))))));
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/st_astext.md
+++ b/server/reference/sql-structure/geometry/wkt/st_astext.md
@@ -28,6 +28,6 @@ SELECT ST_AsText(ST_GeomFromText(@g));
 +--------------------------------+
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/st_geomcollfromtext.md
+++ b/server/reference/sql-structure/geometry/wkt/st_geomcollfromtext.md
@@ -28,6 +28,6 @@ INSERT INTO gis_geometrycollection VALUES
     (GeomFromText('GeometryCollection EMPTY'));
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/st_geomfromtext.md
+++ b/server/reference/sql-structure/geometry/wkt/st_geomfromtext.md
@@ -26,6 +26,6 @@ Constructs a geometry value of any type using its [WKT](wkt-definition.md) repre
 SET @g = ST_GEOMFROMTEXT('POLYGON((1 1,1 5,4 9,6 9,9 3,7 2,1 1))');
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/st_linefromtext.md
+++ b/server/reference/sql-structure/geometry/wkt/st_linefromtext.md
@@ -26,6 +26,6 @@ INSERT INTO gis_line VALUES
     (LineStringFromWKB(AsWKB(LineString(Point(10, 10), Point(40, 10)))));
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/st_pointfromtext.md
+++ b/server/reference/sql-structure/geometry/wkt/st_pointfromtext.md
@@ -25,6 +25,6 @@ INSERT INTO gis_point VALUES
     (PointFromWKB(AsWKB(PointFromText('POINT(10 20)'))));
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/st_polyfromtext.md
+++ b/server/reference/sql-structure/geometry/wkt/st_polyfromtext.md
@@ -24,6 +24,6 @@ INSERT INTO gis_polygon VALUES
     (PolyFromText('POLYGON((0 0,50 0,50 50,0 50,0 0), (10 10,20 10,20 20,10 20,10 10))'));
 ```
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/reference/sql-structure/geometry/wkt/wkt-definition.md
+++ b/server/reference/sql-structure/geometry/wkt/wkt-definition.md
@@ -19,6 +19,6 @@ The Well-Known Text (WKT) representation of Geometry is designed to exchange geo
 
 * [Geometry Types](../geometry-types.md)
 
-<sub>_This page is licensed: GPLv2, originally from [fill\_help\_tables.sql](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)_</sub>
+<sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)
 
 {% @marketo/form formId="4316" %}

--- a/server/security/cve/enterprise-server.md
+++ b/server/security/cve/enterprise-server.md
@@ -141,6 +141,6 @@ MariaDB Enterprise Server is an enhanced, hardened, and secured product with:
 * Premium features to meet enterprise scaling and operations requirements
 * Documentation maintained by MariaDB Corporation
 
-{% include "../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/repo-mirror.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/repo-mirror.md
@@ -72,6 +72,6 @@ Creating a local mirror of the MariaDB Enterprise Repository or the MariaDB Comm
    * APT: `debmirror`, available at: [Setup#Debian\_Repository\_Mirroring\_Tools](https://wiki.debian.org/DebianRepository/Setup#Debian_Repository_Mirroring_Tools)
 3. Secure the repository mirror to prevent outside access.
 
-{% include "../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/rpm/mariadb-installation-version-10121-via-rpms-on-centos-7.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/rpm/mariadb-installation-version-10121-via-rpms-on-centos-7.md
@@ -141,4 +141,4 @@ mysql_secure_installation
 
 ***
 
-_This page is licensed: CC BY-SA / Gnu FDL_
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage.md
+++ b/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage.md
@@ -703,6 +703,6 @@ For the list of changes made in each version, see the changelogs:
 {% endtab %}
 {% endtabs %}
 
-{% include "../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-oracle/oracle-xe-112-and-mariadb-101-integration-on-ubuntu-1404-and-debian-systems.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-oracle/oracle-xe-112-and-mariadb-101-integration-on-ubuntu-1404-and-debian-systems.md
@@ -465,4 +465,4 @@ sudo cp -p mysql-connector-java-5.0.8-bin.jar /usr/lib/jvm/java-8-oracle/lib/mar
 
 ***
 
-_This page is licensed: CC BY-SA / Gnu FDL_
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.3/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.3.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.3/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.3.md
@@ -443,6 +443,6 @@ When MariaDB Enterprise Server is up and running on your system, you should test
 
 ***
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.3/upgrade-mariadb-enterprise-server-from-10.3.x-to-10.3.y.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.3/upgrade-mariadb-enterprise-server-from-10.3.x-to-10.3.y.md
@@ -315,6 +315,6 @@ When MariaDB Enterprise Server is up and running on your system, you should test
 
 ***
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.3/upgrade-to-mariadb-enterprise-server-10.3.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.3/upgrade-to-mariadb-enterprise-server-10.3.md
@@ -384,6 +384,6 @@ SELECT VERSION();
 +-----------------------------+
 ```
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.4/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.4.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.4/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.4.md
@@ -443,6 +443,6 @@ When MariaDB Enterprise Server is up and running on your system, you should test
 
 ***
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.4/upgrade-mariadb-enterprise-server-from-10.4.x-to-10.4.y.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.4/upgrade-mariadb-enterprise-server-from-10.4.x-to-10.4.y.md
@@ -335,6 +335,6 @@ When MariaDB Enterprise Server is up and running on your system, you should test
 
 ***
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.4/upgrade-to-mariadb-enterprise-server-10.4.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.4/upgrade-to-mariadb-enterprise-server-10.4.md
@@ -388,6 +388,6 @@ SELECT VERSION();
 +-----------------------------+
 ```
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.5/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.5.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.5/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.5.md
@@ -443,6 +443,6 @@ When MariaDB Enterprise Server is up and running on your system, you should test
 
 ***
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.5/upgrade-mariadb-enterprise-server-from-10.5.x-to-10.5.y.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.5/upgrade-mariadb-enterprise-server-from-10.5.x-to-10.5.y.md
@@ -315,6 +315,6 @@ When MariaDB Enterprise Server is up and running on your system, you should test
 
 ***
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.5/upgrade-to-mariadb-enterprise-server-10.5.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.5/upgrade-to-mariadb-enterprise-server-10.5.md
@@ -394,4 +394,4 @@ SELECT VERSION();
 
 {% @marketo/form formId="4316" %}
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.6.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.6.md
@@ -464,6 +464,6 @@ When MariaDB Enterprise Server is up and running on your system, you should test
 
 ***
 
-{% include "../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/upgrade-mariadb-enterprise-server-from-10.6.x-to-10.6.y.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/upgrade-mariadb-enterprise-server-from-10.6.x-to-10.6.y.md
@@ -316,6 +316,6 @@ When MariaDB Enterprise Server is up and running on your system, you should test
 
 ***
 
-{% include "../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/upgrade-to-mariadb-enterprise-server-10.6.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/upgrade-to-mariadb-enterprise-server-10.6.md
@@ -393,6 +393,6 @@ SELECT VERSION();
 +-----------------------------+
 ```
 
-{% include "../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-11.4.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-11.4.md
@@ -464,6 +464,6 @@ When MariaDB Enterprise Server is up and running on your system, you should test
 
 ***
 
-{% include "../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-to-mariadb-enterprise-server-11.4.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-to-mariadb-enterprise-server-11.4.md
@@ -392,6 +392,6 @@ SELECT VERSION();
 +-----------------------------+
 ```
 
-{% include "../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrade-from-mariadb-community-server-10.6-to-mariadb-enterprise-server-11.8.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrade-from-mariadb-community-server-10.6-to-mariadb-enterprise-server-11.8.md
@@ -568,6 +568,6 @@ After the data upgrade is complete, verify the functionality of 11.8 features.
 
 ***
 
-{% include "../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrade-mariadb-enterprise-server-from-11.8.x-to-11.8.y.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrade-mariadb-enterprise-server-from-11.8.x-to-11.8.y.md
@@ -286,6 +286,6 @@ SELECT VERSION();
 +-----------------------------+
 ```
 
-{% include "../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrade-to-mariadb-enterprise-server-11.8.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrade-to-mariadb-enterprise-server-11.8.md
@@ -374,6 +374,6 @@ SELECT VERSION();
 +-----------------------------+
 ```
 
-{% include "../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-usage/storage-engines/connect/introduction-to-the-connect-engine.md
+++ b/server/server-usage/storage-engines/connect/introduction-to-the-connect-engine.md
@@ -45,6 +45,6 @@ With version 1.07 of CONNECT, retrieving data from REST queries is available in 
 
 1. [↑](introduction-to-the-connect-engine.md#_ref-0) Robin Schumacher is Vice President Products at DataStax and former Director of Product Management at MySQL. He has over 13 years of database experience in DB2, MySQL, Oracle, SQL Server and other database engines.
 
-{% include "../../../.gitbook/includes/license-gplv2.md" %}
+<sub>_This page is licensed: GPLv2_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/README.md
+++ b/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/README.md
@@ -25,6 +25,6 @@ description: >-
 [mariadb-enterprise-spider-topologies](../../../../../architecture/topologies/mariadb-enterprise-spider-topologies/)
 {% endcontent-ref %}
 
-{% include "../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/federated-mariadb-enterprise-spider-topology-operations/spider-federated-overview.md
+++ b/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/federated-mariadb-enterprise-spider-topology-operations/spider-federated-overview.md
@@ -43,6 +43,6 @@ ALTER TABLE spider_hq_sales.invoices
    COMMENT = 'server "new_hq_server", table "invoices"'
 ```
 
-{% include "../../../../../../.gitbook/includes/license-copyright-mariadb.md" %}
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}


### PR DESCRIPTION
Implements [Daniel's decision on DOCS-6394](https://mariadbcorp.atlassian.net/browse/DOCS-6394): licence notices go **literally** into the `.md` source, with no include dependency, so the licence a page claims is readable from the file itself.

This is **batch 3 of 6** — the whole `server` space. See #861 (batch 1) and #862 (batch 2).

## What Changed

1,537 pages. This is the one batch that does more than swap a line, because `server` is where the *path*-include form and the marker comments live.

**1. 1,482 path includes become the literal notice** they already resolved to:

```diff
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
```

1,394 CC BY-SA / Gnu FDL, 84 copyright, 3 GPLv2-help, 1 GPLv2.

**2. 1,195 marker comments are dropped.** Nearly all the error-code pages carried both an include and a `<!-- This page is licensed: CC BY-SA / Gnu FDL -->` comment. That comment existed *because* the include form is opaque — it was how a reader or a grep could tell what the page claimed. The literal notice now says it directly, so the comment is redundant:

```diff
-{% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}
-
-<!-- This page is licensed: CC BY-SA / Gnu FDL -->
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
```

**3. 55 pre-existing literal variants are normalized.** Flagging this explicitly since it's adjacent cleanup rather than pure conversion: 53 pages wrote the GPLv2-help notice with the `fill_help_tables.sql` link *inside* the italics rather than beside it, and 2 pages had the notice text with no `<sub>` wrapper. Both now match the canonical form the other 491 pages use. Happy to drop these 55 from the PR if you'd rather keep it strictly mechanical.

`1,537 files changed, 1,537 insertions(+), 3,927 deletions(-)` — the extra deletions are the 1,195 marker lines plus the 1,195 blank lines that padded them.

## No Page Changes Its Licence

All 9,882 content pages were reclassified before and after; the notice each page claims is identical, and the conversion is idempotent. Unrelated includes on the same pages (e.g. `contributing-content.md`) are left untouched.

## CI

|  | Links checked | Errors | Unique failing targets |
|---|--:|--:|--:|
| this branch | 3,660 | 2 | 1 |
| clean worktree at `origin/main` | 3,657 | 2 | 1 |

The single failing target — `server/architecture/server-constraints/broken-reference`, a migration placeholder — is identical on both sides, so it is pre-existing.

**This PR does add 3 links,** and they're accounted for: three pages converted to the GPLv2-help notice, which carries a `fill_help_tables.sql` link. All three resolve OK, which is why the error count is unchanged. codespell passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)