### PR TITLE
DOCS-6256 Document package-wide TYPE declarations

### DIFF
--- a/server/reference/sql-statements/data-definition/create/create-package.md
+++ b/server/reference/sql-statements/data-definition/create/create-package.md
@@ -40,6 +40,7 @@ package_characteristic:
 package_specification_element:
     FUNCTION_SYM package_specification_function ;
   | PROCEDURE_SYM package_specification_procedure ;
+  | type_declaration ;
 
 
 package_specification_function:
@@ -139,6 +140,26 @@ The function parameter quantifiers for `IN`, `OUT`, `INOUT`, and `IN OUT` are su
 
 `OUT`, `INOUT` and its equivalent `IN OUT`, are only valid if called from `SET` and not `SELECT`. These quantifiers are especially useful for creating functions and procedures with more than one return value. This allows functions and procedures to be more complex and nested.
 
+## Package-Wide Type Declarations
+
+{% hint style="info" %}
+This feature is available from MariaDB 13.1, in `sql_mode=ORACLE` only.
+{% endhint %}
+
+A package specification can declare data types with `TYPE`, alongside its public routines. Such a type is public: routines outside the package can declare variables of it, using the qualified name `package_name.type_name` or `schema_name.package_name.type_name`.
+
+```sql
+SET sql_mode=ORACLE;
+DELIMITER $$
+CREATE OR REPLACE PACKAGE pkg AS
+  TYPE varchar_array IS TABLE OF VARCHAR(2000) INDEX BY INTEGER;
+END;
+$$
+DELIMITER ;
+```
+
+Using the type requires the `EXECUTE` privilege on the package. For the contexts where a package type is accepted, name resolution, and the restrictions that apply, see [DECLARE TYPE](../../programmatic-compound-statements/declare-type.md).
+
 ## Examples
 
 ```sql
@@ -157,6 +178,7 @@ DELIMITER ;
 ## See Also
 
 * [CREATE PACKAGE BODY](create-package-body.md)
+* [DECLARE TYPE](../../programmatic-compound-statements/declare-type.md)
 * [SHOW CREATE PACKAGE](../../administrative-sql-statements/show/show-create-package.md)
 * [DROP PACKAGE](../drop/drop-package.md)
 * [Oracle SQL\_MODE](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/about/compatibility-and-differences/sql_modeoracle)

--- a/server/reference/sql-statements/data-definition/create/create-package.md
+++ b/server/reference/sql-statements/data-definition/create/create-package.md
@@ -158,7 +158,7 @@ $$
 DELIMITER ;
 ```
 
-Using the type requires the `EXECUTE` privilege on the package. For the contexts where a package type is accepted, name resolution, and the restrictions that apply, see [DECLARE TYPE](../../programmatic-compound-statements/declare-type.md).
+Using the type requires the `EXECUTE` privilege on the `PACKAGE`. No privileges on the `PACKAGE BODY` are required. For the contexts where a package type is accepted, name resolution, and the restrictions that apply, see [DECLARE TYPE](../../programmatic-compound-statements/declare-type.md).
 
 ## Examples
 

--- a/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
@@ -419,8 +419,192 @@ BEGIN
 END;
 ```
 
+## Package-Wide Types
+
+{% hint style="info" %}
+This feature is available from MariaDB 13.1, in `sql_mode=ORACLE` only.
+{% endhint %}
+
+A `TYPE` declaration can appear in a package specification. Such a type is public: routines outside the package can declare variables of it by qualifying the type name with the name of the package that declares it. Earlier, a `TYPE` declaration was confined to the block that declared it, so a record, associative array, or `REF CURSOR` type could not be shared between routines.
+
+### Syntax
+
+Declare the type in the package specification:
+
+```sql
+CREATE [OR REPLACE] PACKAGE [db_name.]package_name {AS | IS}
+  TYPE type_name IS record_definition;
+  TYPE type_name IS TABLE OF element_type INDEX BY key_type;
+  TYPE type_name IS REF CURSOR [RETURN return_type];
+  ...
+END [package_name]
+```
+
+Refer to it from elsewhere with a qualified name, in either of two forms:
+
+```sql
+package_name.type_name              -- two-step
+schema_name.package_name.type_name  -- three-step
+```
+
+### Example
+
+```sql
+SET sql_mode=ORACLE;
+DELIMITER $$
+CREATE OR REPLACE PACKAGE pkg1 AS
+  TYPE varchar_array IS TABLE OF VARCHAR(2000) INDEX BY INTEGER;
+  TYPE rec0_t IS RECORD (a INT, b VARCHAR(30));
+  TYPE array0_t IS TABLE OF rec0_t INDEX BY INTEGER;
+END;
+$$
+DELIMITER ;
+```
+
+A stored procedure in any schema can now declare variables of these types:
+
+```sql
+DELIMITER $$
+CREATE OR REPLACE PROCEDURE p1 AS
+  v0 pkg1.varchar_array;       -- two-step
+  v1 test.pkg1.rec0_t;         -- three-step
+  v2 pkg1.array0_t;
+BEGIN
+  v0(0):= 'test';
+  v1.a:= 1;
+  v1.b:= 'b';
+  v2(0):= v1;
+  SELECT v0(0), v2(0).a, v2(0).b;
+END;
+$$
+DELIMITER ;
+CALL p1();
+```
+
+### Where Package Types Can Be Used
+
+A qualified package type is accepted as:
+
+* The type of a local variable, in a stored procedure, a stored function, a package routine, or an anonymous block:
+
+    ```sql
+    v1 pkg1.rec0_t;
+    ```
+* The type of a parameter of a package routine, declared either in the package specification or in the package body:
+
+    ```sql
+    PROCEDURE p1(param1 pkg1.rec0_t);
+    ```
+* The `RETURN` type of a package function:
+
+    ```sql
+    FUNCTION f1 RETURN pkg1.rec0_t;
+    ```
+* The element type of an associative array:
+
+    ```sql
+    TYPE assoc1_t IS TABLE OF pkg1.rec0_t INDEX BY INTEGER;
+    ```
+* The `RETURN` type of a `REF CURSOR` type declaration:
+
+    ```sql
+    TYPE cur1_t IS REF CURSOR RETURN pkg1.rec0_t;
+    ```
+
+A package specification can also use its own types by qualified name, provided the type is declared earlier in the same specification:
+
+```sql
+SET sql_mode=ORACLE;
+DELIMITER $$
+CREATE OR REPLACE PACKAGE pkg1 AS
+  TYPE r IS RECORD (x INT);
+  PROCEDURE q(v pkg1.r);   -- self-reference to a type declared above
+END;
+$$
+DELIMITER ;
+```
+
+Referring to a type that is not yet declared, or that does not exist, fails when the package is created:
+
+```
+ERROR 4161 (HY000): Unknown data type: '`pkg1`.`no_such_type`'
+```
+
+### Where Package Types Cannot Be Used
+
+| Context | Result |
+| --- | --- |
+| Parameter of a schema-level (standalone) procedure or function | `ERROR HY000: Incorrect usage of parameter_declaration and package_name.type_name` |
+| `RETURN` type of a schema-level (standalone) function | `ERROR HY000: Incorrect usage of RETURN and package_name.type_name` |
+| Inside a trigger | `ERROR HY000: Incorrect usage of TRIGGER and` `` `pkg1`.`rec0_t` `` |
+| Inside an event | `ERROR HY000: Incorrect usage of EVENT and` `` `pkg1`.`rec0_t` `` |
+
+Parameters and `RETURN` types of schema-level routines are exposed through [INFORMATION\_SCHEMA.PARAMETERS](../../system-tables/information-schema/information-schema-tables/information-schema-parameters-table.md), which cannot yet represent a package type.
+
+Two further restrictions apply to the qualified form itself:
+
+* Data type attributes cannot be applied to a qualified type. A length, `CHARACTER SET`, or `COLLATE` clause after `pkg1.rec0_t` is a syntax error.
+* A qualified name has at most three parts. A longer chain, such as `cat1.db1.pkg1.type1`, raises `ERROR 4161 (HY000): Unknown data type`.
+
+### Name Resolution
+
+A two-step name `pkg1.rec0_t` names a package rather than a schema, so the schema that holds the package is resolved through [SET PATH](../administrative-sql-statements/set-commands/set-path.md) — the same mechanism that resolves package routine calls. The default path is `CURRENT_SCHEMA`, so an unqualified package is looked up in the current schema. With a wider path, the same type name can resolve to different packages:
+
+```sql
+SET PATH 'CURRENT_SCHEMA,test1,test2';
+```
+
+The three-step form `schema_name.package_name.type_name` names the schema explicitly and does not depend on the path.
+
+Because a routine stores the resolved type, dropping the package that declares it leaves the routine unusable. The failure appears when the routine is called, not when the package is dropped:
+
+```sql
+DROP PACKAGE pkg1;
+CALL p1();
+```
+
+```
+ERROR HY000: Failed to load routine test.p1 (internal code -6). For more details, run SHOW WARNINGS
+```
+
+```sql
+SHOW WARNINGS;
+```
+
+```
++-------+------+-------------------------------------------------------------+
+| Level | Code | Message                                                     |
++-------+------+-------------------------------------------------------------+
+| Error | 4161 | Unknown data type: '`pkg1`.`rec0_t`'                        |
+| Error | 1457 | Failed to load routine test.p1 (internal code -6). ...      |
++-------+------+-------------------------------------------------------------+
+```
+
+Cyclic type dependencies between two packages are rejected: if `b_pkg` already refers to a type in `a_pkg`, then redefining `a_pkg` to refer back to a type in `b_pkg` fails with `Unknown data type`.
+
+### Privileges
+
+Using a type declared in a package requires the `EXECUTE` privilege on that package:
+
+```sql
+GRANT EXECUTE ON PACKAGE db1.pkg1 TO user1@localhost;
+```
+
+Without it, creating the routine that declares the variable is refused:
+
+```
+ERROR 42000: execute command denied to user 'user2'@'localhost' for routine 'db1.pkg1'
+```
+
+The check applies to any user other than the one that created the package, including users that hold `CREATE ROUTINE` in the same schema. `EXECUTE` on a package does not imply `EXECUTE` on its [package body](../data-definition/create/create-package-body.md), so calling the package's routines needs a separate grant.
+
+### Limitation on Dumps
+
+[mariadb-dump](../../../clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md) writes packages in name order. If two packages depend on each other's types, the file can define the dependent package first, and the restore then fails with `Unknown data type`. Dump and restore the `mysql.proc` table instead when packages have inter-package type dependencies.
+
 ## See Also
 
+* [CREATE PACKAGE](../data-definition/create/create-package.md)
 * [DECLARE CURSOR](programmatic-compound-statements-cursors/declare-cursor.md)
 * [DECLARE Variable](declare-variable.md)
 * [Oracle Mode](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/about/compatibility-and-differences/sql_modeoracle)

--- a/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
@@ -425,7 +425,7 @@ END;
 This feature is available from MariaDB 13.1, in `sql_mode=ORACLE` only.
 {% endhint %}
 
-A `TYPE` declaration can appear in a package specification. Such a type is public: routines outside the package can declare variables of it by qualifying the type name with the name of the package that declares it. Earlier, a `TYPE` declaration was confined to the block that declared it, so a record, associative array, or `REF CURSOR` type could not be shared between routines.
+A `TYPE` declaration can appear in a package specification. Such a type is public: routines outside the package can declare variables of it by qualifying the type name with the name of the package that declares it. A `TYPE` declaring a record, associative array, or `REF CURSOR` can therefore be shared between schema-level (standalone) and package routines.
 
 ### Syntax
 
@@ -541,11 +541,6 @@ ERROR 4161 (HY000): Unknown data type: '`pkg1`.`no_such_type`'
 
 Parameters and `RETURN` types of schema-level routines are exposed through [INFORMATION\_SCHEMA.PARAMETERS](../../system-tables/information-schema/information-schema-tables/information-schema-parameters-table.md), which cannot yet represent a package type.
 
-Two further restrictions apply to the qualified form itself:
-
-* Data type attributes cannot be applied to a qualified type. A length, `CHARACTER SET`, or `COLLATE` clause after `pkg1.rec0_t` is a syntax error.
-* A qualified name has at most three parts. A longer chain, such as `cat1.db1.pkg1.type1`, raises `ERROR 4161 (HY000): Unknown data type`.
-
 ### Name Resolution
 
 A two-step name `pkg1.rec0_t` names a package rather than a schema, so the schema that holds the package is resolved through [SET PATH](../administrative-sql-statements/set-commands/set-path.md) — the same mechanism that resolves package routine calls. The default path is `CURRENT_SCHEMA`, so an unqualified package is looked up in the current schema. With a wider path, the same type name can resolve to different packages:
@@ -600,7 +595,19 @@ The check applies to any user other than the one that created the package, inclu
 
 ### Limitation on Dumps
 
-[mariadb-dump](../../../clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md) writes packages in name order. If two packages depend on each other's types, the file can define the dependent package first, and the restore then fails with `Unknown data type`. Dump and restore the `mysql.proc` table instead when packages have inter-package type dependencies.
+[mariadb-dump](../../../clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md) writes packages in name order. If two packages depend on each other's types, the file can define the dependent package first, and the restore then fails with `Unknown data type`.
+
+When the packages are in different databases, dump each database separately and restore them in dependency order:
+
+```bash
+mariadb-dump --routines dependency_db > dependency_db.sql
+mariadb-dump --routines dependent_db > dependent_db.sql
+
+mariadb < dependency_db.sql
+mariadb < dependent_db.sql
+```
+
+When the dependency is between packages in the same database, dump and restore the `mysql.proc` table instead.
 
 ## See Also
 


### PR DESCRIPTION
## Why this is a draft

**MDEV-39587 is not merged to `main`.** Remote `main` is `f4a85225ea1` (2026-08-05) and contains no MDEV-39587 or MDEV-13139 commit. The patch lives only on `bb-13.0-bar-MDEV-39587`, `bb-13.1-bar-MDEV-39587`, `bb-13.1-bar-MDEV-13139`, and (in an older form) `preview-13.1-preview`.

MDEV-39587 is **Stalled**: QA signed off on 2026-07-28, 15 regressions were filed against it and closed, but **MDEV-40721 (SIGSEGV) is still Open**, and the MDEV-40430 test (cross-schema package type in a trigger) is commented out in the branch. The ticket was closed as Fixed on 2026-08-11 and reopened on 2026-08-12 ("Closed in a mistake"); the branch was force-pushed on 2026-08-12.

So the content is source-verified but the **version annotation is forward-looking**. Please don't merge until the patch is in `main`, at which point the "from MariaDB 13.1" hints need re-checking — the parent task MDEV-13139 currently carries fix version 13.2.

Note also that the DOCS ticket says "Release Series: 13.0". That is stale: Sergei Golubchik moved the fix version from 13.0 to 13.1 on 2026-06-16.

## What the feature is

`MDEV-39587` allows a `TYPE` declaration in a **package specification**. Such a type is public, and routines outside the package can declare variables of it by qualified name — `pkg1.rec0_t` (two-step) or `test.pkg1.rec0_t` (three-step). Only in `sql_mode=ORACLE`: the new grammar alternative sits inside `%ifdef ORACLE`.

Verified against `bb-13.1-bar-MDEV-39587` @ `a63ab98e319` (the newest patch version), primarily against the 16 new `mysql-test/suite/compat/oracle/*sp-package-spec-type*` test/result pairs.

## Changes

**`declare-type.md`** — a new `## Package-Wide Types` section covering:

- syntax of the declaration and the two qualified reference forms
- where a package type is accepted: local variables, package routine parameters (specification *and* body), package function `RETURN`, associative-array element type, `REF CURSOR RETURN`, plus same-specification self-references to a type declared earlier
- where it is rejected, with the exact errors
- name resolution through `@@path` / `SET PATH`, and the call-time failure after the package is dropped
- cyclic package type dependencies
- the `EXECUTE ON PACKAGE` privilege requirement, and that it does not extend to the package body
- the `mariadb-dump` ordering limitation for inter-package type dependencies

**`create-package.md`** — the Oracle-mode grammar gains the `type_declaration` element (confirmed against `sql/sql_yacc.yy` on the branch vs `main`), plus a short `## Package-Wide Type Declarations` section pointing at `DECLARE TYPE`, and a See Also entry.

## Two things the ticket got wrong

The Jira description lists only one restriction — schema-level routine parameters and function `RETURN` types. The tests show two more, both documented here:

| Context | Error |
| --- | --- |
| Inside a trigger | `Incorrect usage of TRIGGER and` `` `pkg`.`rec` `` |
| Inside an event | `Incorrect usage of EVENT and` `` `pkg`.`rec` `` |

Two apparent restrictions in the tests turned out not to be restrictions, and are deliberately *not* documented: the `ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION` case is an `OPEN..FOR` row-count mismatch (2-field record vs 3-column `SELECT`), and the `ER_NOT_ALLOWED_IN_THIS_CONTEXT` case is the pre-existing ban on `REF CURSOR` package-level variables (`'sys_refcursor' is not allowed in this context`).

## Checks

- `codespell --check-filenames --skip ./.git --ignore-words .codespellignore` — clean
- `lychee` on both changed files — 20 total, 14 unique, **20 OK, 0 errors**
- All five new relative link targets confirmed to exist on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
