### PR TITLE
Create routine: Remove bogus note about unsupported COLLATE

### DIFF
--- a/server/reference/sql-statements/data-definition/create/create-function.md
+++ b/server/reference/sql-statements/data-definition/create/create-function.md
@@ -54,8 +54,6 @@ By default, a function is associated with the current database. To associate the
 
 The parameter list enclosed within parentheses must always be present. If there are no parameters, an empty parameter list of `()` should be used. Parameter names are not case-sensitive.
 
-Each parameter can be declared to use any valid data type, except that the `COLLATE` attribute cannot be used.
-
 For valid identifiers to use as function names, see [Identifier Names](../../../sql-structure/sql-language-structure/identifier-names.md).
 
 ### RETURN

--- a/server/server-usage/stored-routines/stored-procedures/create-procedure.md
+++ b/server/server-usage/stored-routines/stored-procedures/create-procedure.md
@@ -89,8 +89,6 @@ The `IGNORE_SPACE` SQL mode applies to built-in functions, not to stored routine
 
 The parameter list enclosed within parentheses must always be present. If there are no parameters, an empty parameter list of `()` should be used. Parameter names are not case sensitive.
 
-Each parameter can be declared to use any valid data type, except that the `COLLATE` attribute cannot be used.
-
 For valid identifiers to use as procedure names, see [Identifier Names](../../../reference/sql-structure/sql-language-structure/identifier-names.md).
 
 ### Things to be Aware of With CREATE OR REPLACE


### PR DESCRIPTION
Current MariaDB works with it just fine. I just don't know since what version.