### PR TITLE
DOCS-6445 Fix Binary Log Formats nav link and landing entries

### DIFF
--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -1079,7 +1079,7 @@
   * [Replication](ha-and-performance/standard-replication/README.md)
     * [Replication Overview](ha-and-performance/standard-replication/replication-overview.md)
     * [Choosing a Replication Strategy](ha-and-performance/standard-replication/choosing-a-replication-strategy.md)
-    * [Binary Log Formats](ha-and-performance/standard-replication/innodb-based-binary-log.md)
+    * [Binary Log Formats](server-management/server-monitoring-logs/binary-log/binary-log-formats.md)
     * [InnoDB-Based Binary Log](ha-and-performance/standard-replication/innodb-based-binary-log.md)
     * [Replication Statements](ha-and-performance/standard-replication/replication-statements.md)
     * [Setting Up Replication](ha-and-performance/standard-replication/setting-up-replication.md)

--- a/server/ha-and-performance/standard-replication/README.md
+++ b/server/ha-and-performance/standard-replication/README.md
@@ -49,13 +49,13 @@ Choose a MariaDB replication strategy by matching the replication method and for
 
 {% columns %}
 {% column %}
-{% content-ref url="innodb-based-binary-log.md" %}
-[innodb-based-binary-log.md](innodb-based-binary-log.md)
+{% content-ref url="../../server-management/server-monitoring-logs/binary-log/binary-log-formats.md" %}
+[binary-log-formats.md](../../server-management/server-monitoring-logs/binary-log/binary-log-formats.md)
 {% endcontent-ref %}
 {% endcolumn %}
 
 {% column %}
-From MariaDB 12.3, the binary log can be stored in InnoDB-managed, page-structured files integrated with InnoDB crash recovery, instead of traditional flat binary log files.
+Compare the three binary logging formats — statement-based, row-based, and mixed — including their trade-offs and how to select one with `binlog_format`.
 {% endcolumn %}
 {% endcolumns %}
 

--- a/server/server-management/server-monitoring-logs/binary-log/README.md
+++ b/server/server-management/server-monitoring-logs/binary-log/README.md
@@ -75,6 +75,18 @@ Complete binary log maintenance: `PURGE BINARY LOGS`/`RESET MASTER`, `expire_log
 
 {% columns %}
 {% column %}
+{% content-ref url="row-binlog-events.md" %}
+[row-binlog-events.md](row-binlog-events.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The `Row_log_event` structure that row-based logging writes to the binary log, and the event types it uses to record inserts, updates, and deletes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../../ha-and-performance/standard-replication/innodb-based-binary-log.md" %}
 [innodb-based-binary-log.md](../../../ha-and-performance/standard-replication/innodb-based-binary-log.md)
 {% endcontent-ref %}


### PR DESCRIPTION
[DOCS-6445](https://mariadbcorp.atlassian.net/browse/DOCS-6445)

## What was wrong

`server/SUMMARY.md` listed two differently-labeled Replication entries pointing at the **same** page:

```
* [Binary Log Formats](ha-and-performance/standard-replication/innodb-based-binary-log.md)
* [InnoDB-Based Binary Log](ha-and-performance/standard-replication/innodb-based-binary-log.md)
```

The first is a regression from `fb407224a2` **"GITBOOK-2276: Fix page links." (2026-04-22)**, which was resolving two `/broken/pages/...` entries and, as collateral, repointed a valid cross-section entry at an unrelated page in the same folder. *Binary Log Formats* was therefore unreachable from the Replication section, and the nav showed a confusing pair of labels leading to one page.

No CI gate can see this: both the old and the new target exist, so it is a *wrong-target* bug, not a dead link, and lychee only checks resolvability.

## Changes

1. **`server/SUMMARY.md`** — restored the target to `server-management/server-monitoring-logs/binary-log/binary-log-formats.md`, matching the correct entry at line 568. Cross-section nav entries are the established pattern here; the Binary Log section reciprocally lists two pages that live under `ha-and-performance/standard-replication/`.
2. **`ha-and-performance/standard-replication/README.md`** — the landing page carried the *same* defect: the Binary Log Formats slot held a **verbatim duplicate** of the InnoDB-Based Binary Log block. That duplicate is exactly why the gap was invisible — a path-resolved coverage check saw 28 refs for 29 nav children and blamed the one deliberately hidden page. Replaced the duplicate with a Binary Log Formats entry, matching the cross-section `content-ref` style the Binary Log landing page already uses.

### Drive-by fixes

3. **`server-management/server-monitoring-logs/binary-log/README.md`** — added the missing landing entry for its *Row Binlog Events* child (11 nav children, 10 entries).

## Verification

- Swept every space's `SUMMARY.md` (9,319 nav entries) for the signature of this bug class — one target reached by two *differently-labeled* entries. Before: 2 hits (this one, plus one in the MaxScale archive). After: 0 in `server`.
- Both touched landing pages now cover every nav child; Replication's only omission is the deliberately `hidden: true` CDR Triggers page (DOCS-6444).
- `codespell` and `lychee` clean on all three files.

## Out of scope, noted for follow-up

- `maxscale/SUMMARY.md:356` labels a child *MaxScale 23.08 MaxScale CDC Connector* but points at the parent `README.md`. 23.08 is the only archived version whose CDC Connector page is missing from disk — every other version (21.06, 22.08, 23.02, 24.02, 25.01) has one. That is a lost page, not a mis-target, and it sits inside the archive tree that DOCS-6435 may retire.
- Eight `/broken/pages/<id>` links survive in prose across 6 files in 5 spaces, invisible because CI scans only changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6445]: https://mariadbcorp.atlassian.net/browse/DOCS-6445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ