### PR TITLE
DOCS-6446 Fix the eight remaining /broken/pages/ links

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -67,6 +67,12 @@ if command -v lychee >/dev/null 2>&1; then
   if ! out="$(lychee --no-progress --max-concurrency 8 \
       --exclude 'bazaar\.launchpad\.net' \
       --exclude 'github\.com/mariadb-corporation/mariadb-connector-[a-z0-9]+/commit/' \
+      --exclude 'github\.com/MariaDB/server/commit/' \
+      --exclude 'downloads\.askmonty\.org' \
+      --exclude 'montyprogram\.com' \
+      --exclude 'forge\.mysql\.com' \
+      --exclude 'lists\.mysql\.com' \
+      --exclude 'blogs\.msdn\.com' \
       --exclude 'lists\.askmonty\.org' \
       --exclude 'support2\.microsoft\.com' \
       --exclude 'dev\.mysql\.com' \
@@ -99,6 +105,20 @@ if command -v lychee >/dev/null 2>&1; then
       --exclude 'www\.canonware\.com' \
       --exclude 'www\.npmjs\.com' \
       --exclude 'npmjs\.org' \
+      --exclude 'mcs1' \
+      --exclude 's\.petrunia\.net' \
+      --exclude 'mysql\.taobao\.org' \
+      --exclude 'www\.shannon-sys\.com' \
+      --exclude 'www\.hashicorp\.com' \
+      --exclude 'blogspot\.com' \
+      --exclude 'www\.poliarch\.org' \
+      --exclude 'www\.reddit\.com' \
+      --exclude 'csm\.mariadb\.com' \
+      --exclude 'stackoverflow\.com' \
+      --exclude 'gitlab\.kitware\.com' \
+      --exclude 'www\.freedesktop\.org' \
+      --exclude 'azuremarketplace\.microsoft\.com' \
+      --exclude 'console\.cloud\.google\.com' \
       "${files[@]}" 2>&1)"; then
     # Mirror the workflow's failIfEmpty: false — lychee exits non-zero with
     # "No links were found" when the changed files contain no links, which is a

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -111,6 +111,15 @@ jobs:
           # runners, so a local lychee run PASSES while CI fails -- the one
           # failure mode a pre-PR check cannot reproduce. All are valid for
           # readers.
+          #
+          # DOCS-6446: the two cloud-marketplace listings cited in the MariaDB
+          # Cloud FAQ. azuremarketplace.microsoft.com answers 403 to any
+          # non-browser client, and so does the marketplace.microsoft.com host it
+          # 308-redirects to, so replacing the URL with its resolved form does not
+          # help. console.cloud.google.com fails differently -- "HTTP/2 protocol
+          # error" rather than a status code -- because the host mishandles
+          # lychee's HTTP/2 negotiation. Both serve 200 to a browser User-Agent
+          # over HTTP/1.1 and are valid for readers.
           args: >-
             --no-progress
             --exclude 'bazaar\.launchpad\.net'
@@ -165,6 +174,8 @@ jobs:
             --exclude stackoverflow\.com
             --exclude gitlab\.kitware\.com
             --exclude www\.freedesktop\.org
+            --exclude azuremarketplace\.microsoft\.com
+            --exclude console\.cloud\.google\.com
             ${{ steps.list.outputs.files }}
           fail: true
           # Don't error when the changed files contain no links to check. lychee

--- a/analytics/mariadb-columnstore/columnstore-quickstart-guides/mariadb-columnstore-hardware-guide.md
+++ b/analytics/mariadb-columnstore/columnstore-quickstart-guides/mariadb-columnstore-hardware-guide.md
@@ -53,7 +53,6 @@ For AWS, ColumnStore internal testing generally uses `m4.4xlarge` instance types
 
 ## See Also
 
-* [MariaDB ColumnStore Minimum Hardware Specification Documentation](/broken/pages/ksFdboCNE70th9VaY7pM)
 * [MariaDB ColumnStore Overview](https://mariadb.com/products/columnstore/)
 * [MariaDB documentation: MariaDB ColumnStore](../)
 

--- a/general-resources/community/community/bug-tracking/reporting-bugs.md
+++ b/general-resources/community/community/bug-tracking/reporting-bugs.md
@@ -148,7 +148,7 @@ If the bug affects Percona server and not MySQL, it should go to [Percona Launch
 
 #### Getting a Stack Trace with Details
 
-See [Producing a Full Stack Trace for mariadbd]({server}/reference/product-development/mariadb-fault-finding/how-to-produce-a-full-stack-trace-for-mariadbd), in particular the sections on getting backtraces with gdb and locating the core file.
+See [Producing a Full Stack Trace for mariadbd](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/product-development/mariadb-fault-finding/how-to-produce-a-full-stack-trace-for-mariadbd), in particular the sections on getting backtraces with gdb and locating the core file.
 
 #### Extracting a Portion of a Binary Log
 

--- a/general-resources/community/community/bug-tracking/reporting-bugs.md
+++ b/general-resources/community/community/bug-tracking/reporting-bugs.md
@@ -148,7 +148,7 @@ If the bug affects Percona server and not MySQL, it should go to [Percona Launch
 
 #### Getting a Stack Trace with Details
 
-See the article [How to produce a stack trace from a core file](/broken/pages/yt4NDbw3wL7QsDjQtA0H).
+See [Producing a Full Stack Trace for mariadbd]({server}/reference/product-development/mariadb-fault-finding/how-to-produce-a-full-stack-trace-for-mariadbd), in particular the sections on getting backtraces with gdb and locating the core file.
 
 #### Extracting a Portion of a Binary Log
 

--- a/mariadb-cloud/reference/faqs.md
+++ b/mariadb-cloud/reference/faqs.md
@@ -20,7 +20,7 @@ MariaDB Cloud is available across 40+ global regions on Amazon AWS, Google Cloud
 
 ### How do I get started?
 
-You can sign up for a free account at [https://app.skysql.com](https://app.skysql.com/). There is no credit card required to start and you get $100 in free credit. Once registered, you can get started right away by [launching a service](/broken/pages/aec7ee5cfc6095a1ebe5af6a110d5308adc398a5), [connecting](../connecting-to-mariadb-cloud-dbs/), and [loading data](../cloud-data-handling/migration-data-loading/data-loading/).
+You can sign up for a free account at [https://app.skysql.com](https://app.skysql.com/). There is no credit card required to start and you get $100 in free credit. Once registered, you can get started right away by [launching a service](../cloud-usage/launch-page.md), [connecting](../connecting-to-mariadb-cloud-dbs/), and [loading data](../cloud-data-handling/migration-data-loading/data-loading/).
 
 ### How quickly can I launch a new database?
 
@@ -55,14 +55,14 @@ MariaDB Enterprise Cluster is currently available as a _Tech Preview_ and are ex
 
 ### What options are available for scaling and right-sizing MariaDB Cloud?
 
-You can choose [topologies](../high-availability-dr/ha-and-replicated-topology.md) to match your workload requirements, cloud regions to match your latency and operating requirements, instance sizes, and [support plan](/broken/pages/mrlrXCY7fpHqI35WY9j7).
+You can choose [topologies](../high-availability-dr/ha-and-replicated-topology.md) to match your workload requirements, cloud regions to match your latency and operating requirements, instance sizes, and [support plan](support.md).
 
 Our platform features:
 
 * Availability in a range of database instance sizes and storage sizes
 * Availability from multiple AWS (Amazon Web Services), GCP (Google Cloud Platform), and Azure (Cloud Computing Services) [regions](region-choices.md).
 * Load Balancing features included with Replicated Transactions topologies allow for read-scaling through read-write splitting.
-* Custom instance sizes (for [Power Tier](/broken/pages/mrlrXCY7fpHqI35WY9j7) customers)
+* Custom instance sizes (for [Power Tier](support.md) customers)
 * Range of [support options](mariadb-server-versions.md)
 
 ### What reliability features are available on MariaDB Cloud?
@@ -119,8 +119,8 @@ No additional licenses are necessary to use MariaDB Cloud.
 
 Add-ons are available to optimize your MariaDB Cloud experience:
 
-* [MariaDB Cloud Power Tier](/broken/pages/mrlrXCY7fpHqI35WY9j7) is a premium service offering for MariaDB Cloud customers who have the most critical requirements for uptime, availability, performance, and support.
-* While all Foundation Tier services include Standard Support, Power Tier customers are offered the [Enterprise support plan](../broken-reference/).
+* MariaDB Cloud Power Tier is a premium service offering for MariaDB Cloud customers who have the most critical requirements for uptime, availability, performance, and support.
+* While all Foundation Tier services include Standard Support, Power Tier customers are offered the [Power level support plan](support.md).
 * An optional add-on, [Cloud DBA](clouddba.md), further extends the premium support experience and the capabilities of your in-house DBAs with the backing from a global team of expert MariaDB DBAs, available 24/7 for the most severe (P1) issues. MariaDB's Cloud DBAs manage your MariaDB Cloud databases both proactively and reactively so you can focus on your core business.
 
 ### Is discounted pricing available for a longer-term commitment?

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/mariadb-maxscale-2402-maxscale-2402-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/mariadb-maxscale-2402-maxscale-2402-contents.md
@@ -3,7 +3,7 @@
 ### About MariaDB MaxScale
 
 * [About MariaDB MaxScale](maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-about-mariadb-maxscale.md)
-* [Changelog](broken-reference/)
+* [Changelog]({release-notes}/maxscale/24.02/24.02-changelog)
 * [Limitations](maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale.md)
 
 ### Getting Started
@@ -15,7 +15,7 @@
 
 ### Upgrading MariaDB MaxScale
 
-* [Upgrading MaxScale](broken-reference/)
+* [Upgrading MaxScale](maxscale-24-02upgrading/README.md)
 
 ### Reference
 
@@ -63,7 +63,7 @@ of their use.
 
 The following routers are only available in MaxScale Enterprise.
 
-* [Diff](/broken/pages/bereh4MkASVoNSKMQwFa)
+* Diff
 
 ### Filters
 
@@ -89,7 +89,7 @@ Here are detailed documents about the filters MariaDB MaxScale offers. They cont
 
 The following filters are only available in MaxScale Enterprise.
 
-* [Wcar](broken-reference/)
+* Wcar
 
 ### Monitors
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/mariadb-maxscale-2402-maxscale-2402-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/mariadb-maxscale-2402-maxscale-2402-contents.md
@@ -3,7 +3,7 @@
 ### About MariaDB MaxScale
 
 * [About MariaDB MaxScale](maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-about-mariadb-maxscale.md)
-* [Changelog]({release-notes}/maxscale/24.02/24.02-changelog)
+* [Changelog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/24.02/24.02-changelog)
 * [Limitations](maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale.md)
 
 ### Getting Started

--- a/release-notes/enterprise-server/about/enterprise-server-lifecycle.md
+++ b/release-notes/enterprise-server/about/enterprise-server-lifecycle.md
@@ -45,7 +45,7 @@ MariaDB Enterprise Server is available to MariaDB subscription customers via the
 
 If you are not yet a MariaDB subscription customer, [contact MariaDB Corporation](https://mariadb.com/contact) for more information.
 
-MariaDB Enterprise Server binary and source code is delivered over secure protocols from MariaDB Corporation-maintained infrastructure as detailed in the [Deployment Guide](/broken/pages/BbZ3TNWsYNwHXVyiSQ6z).
+MariaDB Enterprise Server binary and source code is delivered over secure protocols from MariaDB Corporation-maintained infrastructure.
 
 ### Enterprise Server Release Identifiers <a href="#enterprise-server-release-identifiers" id="enterprise-server-release-identifiers"></a>
 


### PR DESCRIPTION
[DOCS-6446](https://mariadbcorp.atlassian.net/browse/DOCS-6446)

Eight `/broken/pages/<id>` links (6 distinct dead page IDs) survived in prose across 6 files in 5 spaces — GitBook migration leftovers. **All eight are resolved; `grep -rn "/broken/pages/"` now returns 0 repo-wide.**

These were never invisible to CI, only unreached by it: `/broken/pages/…` is a root-relative path that lychee does flag, and none of the six files had been touched since the migration.

## Verified replacements (4 IDs, 6 call sites)

| Was | Now | Evidence |
|---|---|---|
| `mariadb-cloud/reference/faqs.md:23` "launching a service" | `../cloud-usage/launch-page.md` | page description: "creates a new database service"; in nav at `SUMMARY.md:50` |
| same file `:58` "support plan", `:65` "Power Tier", `:123` "…support plan" | `support.md` | the only Cloud page documenting the Foundation/Power tiers; in nav at `SUMMARY.md:123`. `pricing.md` has zero tier content |
| `…mariadb-maxscale-2402-…-contents.md:6` "Changelog" | `{release-notes}/maxscale/24.02/24.02-changelog` | live, 200 with no redirect |
| same file `:18` "Upgrading MaxScale" | `maxscale-24-02upgrading/README.md` | page title "MaxScale 24.02 Upgrading"; mirrors what the 23.02 contents page does |
| `general-resources/…/reporting-bugs.md:151` | `{server}/reference/product-development/mariadb-fault-finding/how-to-produce-a-full-stack-trace-for-mariadbd` | that page carries "Where is the Core File on Linux?" and gdb-on-core-dump guidance, so it covers the old article's subject |

On the last one: the nav-derived path is the canonical one — the file-path form (`…/debugging-mariadb/…`) **307s** to it, and this matches the form the same file already uses at line 62.

## Dangling references removed (2 IDs)

- **`release-notes/…/enterprise-server-lifecycle.md:48`** — "as detailed in the [Deployment Guide]" removed. Nothing matching `deploy*` exists under `release-notes/` or `platform/`; pointing an ES secure-delivery sentence at a Community package-repository page would be wrong, so the clause goes.
- **`analytics/…/mariadb-columnstore-hardware-guide.md:56`** — a *See Also* bullet titled "MariaDB ColumnStore Minimum Hardware Specification Documentation", **on the hardware guide page itself**. Bullet deleted.

## Unlinked, not removed (2 entries)

`Diff` (router) and `Wcar` (filter) in the 24.02 contents page. Both pages were lost in migration — `Wcar` exists nowhere in the repo, `Diff` only in the 25.01 archive and current docs. Each is the **only** bullet under a "The following … are only available in MaxScale Enterprise." intro, so deleting the bullet would leave the sentence dangling, and pointing at current docs would misrepresent a version archive. The text stays, the dead link goes.

## Absorbed pre-existing breakage

- **`mariadb-cloud/reference/faqs.md:123`** carried a `broken-reference` link on the line below one of the fixes; repointed to `support.md`. Its label read "Enterprise support plan", which is not a name used anywhere in the Cloud docs — `support.md` calls it **Power level support** — so the label now matches the product.
- **The 24.02 contents page** carried 3 `broken-reference` links; all three are covered above.
- **`faqs.md` also has two flaky external links** (Azure Marketplace, GCP marketplace console) that would have failed CI on this PR. Both serve **200** to a browser User-Agent over HTTP/1.1 but fail to lychee — Azure `403`s any non-browser client *including at its `marketplace.microsoft.com` redirect target*, so swapping in the resolved URL does not help, and `console.cloud.google.com` returns "HTTP/2 protocol error" rather than a status code. No replacement exists, so both hosts are excluded, documented in the same style as the reddit / freedesktop.org precedents already in the file.

## Drive-by: `doc-lint.sh` had drifted behind CI

`.claude/hooks/doc-lint.sh` calls itself the single source of truth and says to keep its excludes "character-for-character identical to the workflow" — but it was **18 excludes behind** `link-check-pr.yml` (`www.reddit.com`, `stackoverflow.com`, `www.freedesktop.org`, the retired-host set from DOCS-6369, and others). That made the local check *stricter* than CI, so it produced false local failures — never a false pass, but enough to send someone chasing links CI would never have flagged. Both lists are now identical in content **and order** (54 entries each, diffed programmatically).

## Verification

- `grep -rn "/broken/pages/" --include='*.md' .` → **0**
- `doc-lint.sh` clean on all five changed pages
- workflow YAML re-parsed after the edit; 54 excludes in `args`, no stray `#` inside the folded scalar (the DOCS-6361 trap)
- `bash -n` clean on `doc-lint.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6446]: https://mariadbcorp.atlassian.net/browse/DOCS-6446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ