### PR TITLE
DOCS-6443 Add third-party notices to third-party software pages

### DIFF
--- a/server/clients-and-utilities/administrative-tools/dbdeployer.md
+++ b/server/clients-and-utilities/administrative-tools/dbdeployer.md
@@ -1,5 +1,9 @@
 # dbdeployer
 
+{% hint style="info" %}
+dbdeployer is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 dbdeployer is a tool for installing multiple versions of MariaDB or MySQL in isolation from each other. It is primarily used for easily testing different server versions. It is written in Go, and is a replacement for [MySQL Sandbox](dbdeployer.md). 
 
 Visit [www.dbdeployer.com](https://www.dbdeployer.com) for details on how to install and use it.

--- a/server/clients-and-utilities/backup-restore-and-import-clients/backup-restore-and-import-clients-backuprestore-data-exportimport-via-dbfor.md
+++ b/server/clients-and-utilities/backup-restore-and-import-clients/backup-restore-and-import-clients-backuprestore-data-exportimport-via-dbfor.md
@@ -7,7 +7,7 @@ description: >-
 # dbForge Studio
 
 {% hint style="info" %}
-dbForge Studio is a proprietary third-party tool, not included with MariaDB Server. Content contributed by devart.
+dbForge Studio is proprietary third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Content contributed by Devart; refer to its own documentation and license terms.
 {% endhint %}
 
 Without a doubt, you want your backup/restore and export/import operations to be fast, easy, and automated wherever possible. You can have it all that way with [dbForge Studio for MySQL](https://www.devart.com/dbforge/mysql/studio/). As the name implies, it is an IDE for MySQL development, management, and administration, yet it works just as perfectly as a [MariaDB GUI client](https://www.devart.com/dbforge/mysql/studio/mariadb-gui-client.html). Now, let's see how it tackles routine database backups.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/README.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/README.md
@@ -7,6 +7,10 @@ description: >-
 
 # Graphical and Enhanced Clients
 
+{% hint style="info" %}
+The third-party tools described in this section are not developed or maintained by MariaDB and are not included with MariaDB Server. MariaDB doesn't test, validate, or support them. Refer to each tool's own documentation and license terms.
+{% endhint %}
+
 {% content-ref url="adminer.md" %}
 [adminer.md](adminer.md)
 {% endcontent-ref %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/adminer.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/adminer.md
@@ -1,5 +1,9 @@
 # Adminer
 
+{% hint style="info" %}
+Adminer is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [Adminer](https://www.adminer.org/) is a database administration web interface. It is usable via a web browser. It is written in PHP and requires a web server.
 
 Adminer mainly supports MySQL, but it also supports MariaDB and other database management systems. Adminer has a wide range of plugins, some of which have been developed by the community.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/adminneo.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/adminneo.md
@@ -7,6 +7,10 @@ description: >-
 
 # AdminNeo
 
+{% hint style="info" %}
+AdminNeo is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [AdminNeo](https://www.adminneo.org/) is a database management tool written in PHP and used through a web browser. It consists of a single file that you deploy to a web server with PHP.
 
 AdminNeo is based on the [Adminer](adminer.md) project, with a redesigned user interface and a refactored code base.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/beekeeper-studio.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/beekeeper-studio.md
@@ -1,5 +1,9 @@
 # Beekeeper Studio
 
+{% hint style="info" %}
+Beekeeper Studio is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [Beekeeper Studio](https://www.beekeeperstudio.io) is an open-source database GUI available for Linux, MacOS, and Windows.
 
 ![SQL Gui Screenshot](../../.gitbook/assets/main-dark.png)

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/cost-effective-agentless-mariadb-database-performance-management.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/cost-effective-agentless-mariadb-database-performance-management.md
@@ -1,5 +1,9 @@
 # SQL Diagnostic Manager & SQLyog
 
+{% hint style="info" %}
+SQL Diagnostic Manager and SQLyog are third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support them. Refer to their own documentation and license terms.
+{% endhint %}
+
 [SQL Diagnostic Manager](https://www.idera.com/productssolutions/sql-diagnostic-manager-for-mysql) is a monitoring tool that gives database administrators real-time insights for optimizing the performance of MariaDB servers.
 
 Key Features:

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/database-workbench.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/database-workbench.md
@@ -7,6 +7,10 @@ description: >-
 
 # Database Workbench
 
+{% hint style="info" %}
+Database Workbench is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [Database Workbench](https://www.upscene.com/database_workbench/) is a Windows application (_which works fine under Wine on Linux_) for database design, development, maintenance and testing for several database systems, including MySQL and MariaDB.
 
 With Database Workbench you can:

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-data-compare.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-data-compare.md
@@ -1,5 +1,9 @@
 # dbForge Data Compare
 
+{% hint style="info" %}
+dbForge Data Compare is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [dbForge Data Compare](https://www.devart.com/dbforge/mysql/datacompare/) helps compare and synchronize data in MariaDB, MySQL, and Percona databases and scripts folders. You can find differences between your data, as it helps analyze comparison results, creates a synchronization script, and applies changes. Additionally, MariaDB data can be compared with command-line support.
 
 Features are described in the following.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-data-generator.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-data-generator.md
@@ -1,5 +1,9 @@
 # dbForge Data Generator
 
+{% hint style="info" %}
+dbForge Data Generator is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [dbForge Data Generator for MariaDB and MySQL](https://www.devart.com/dbforge/mysql/data-generator/) is a powerful solution that helps create massive volumes of meaningful and realistic data. This tool performs various predefined data generators with customizable options.
 
 ## Data Generator Key Features:

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-documenter-for-mariadb-and-mysql.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-documenter-for-mariadb-and-mysql.md
@@ -1,5 +1,9 @@
 # dbForge Documenter
 
+{% hint style="info" %}
+dbForge Documenter is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [**dbForge Documenter**](https://www.devart.com/dbforge/mysql/documenter/) is a useful tool for the MariaDB database that allows for the automatic generation of database documentation in such formats as HTML, PDF, and Markdown. Users can adjust the created documentation with a great variety of options.
 
 Features are described in the following.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-edge.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-edge.md
@@ -1,5 +1,9 @@
 # dbForge Edge
 
+{% hint style="info" %}
+dbForge Edge is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [**dbForge Edge**](https://www.devart.com/dbforge/edge/) is a versatile software solution designed to meet the needs of full-stack database specialists. It offers a wide range of features to address database challenges across major providers: MySQL/MariaDB, SQL Server, Oracle, and PostgreSQL. When it comes to MySQL and MariaDB, dbForge Edge provides a highly functional IDE that covers almost all aspects of database development and management.
 
 Features are described in the following.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-fusion-mysql-mariadb-plugin-for-vs.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-fusion-mysql-mariadb-plugin-for-vs.md
@@ -1,5 +1,9 @@
 # dbForge Fusion
 
+{% hint style="info" %}
+dbForge Fusion is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [dbForge Fusion](https://www.devart.com/dbforge/mysql/fusion/) is an add-in for Visual Studio. It provides automatic and simple MariaDB database development, and boosts data management capacity. With this tool integrated, it is easy to work with database development and administration tasks from Visual Studio.
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-query-builder-for-mysql-mariadb.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-query-builder-for-mysql-mariadb.md
@@ -1,5 +1,9 @@
 # dbForge Query Builder
 
+{% hint style="info" %}
+dbForge Query Builder is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [dbForge Query Builder](https://www.devart.com/dbforge/mysql/querybuilder/) is a visual tool that helps create any sort of MariaDB queries. Queries can be drawn on a diagram.
 
 Features are described in the following.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-schema-compare-for-mariadb-mysql.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-schema-compare-for-mariadb-mysql.md
@@ -1,5 +1,9 @@
 # dbForge Schema Compare
 
+{% hint style="info" %}
+dbForge Schema Compare is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [dbForge Schema Compare](https://www.devart.com/dbforge/mysql/schemacompare/) is a solution that allows for the comparison of the MariaDB database structure. With this tool, you can find the differences in MariaDB database schemas.
 
 Features are described in the following.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-studio-for-mariadb-universal-gui-tool-for-management-administration.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-studio-for-mariadb-universal-gui-tool-for-management-administration.md
@@ -1,5 +1,9 @@
 # dbForge Studio
 
+{% hint style="info" %}
+dbForge Studio is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [dbForge Studio for MariaDB](https://www.devart.com/dbforge/mysql/studio/mariadb-gui-client.html) is a universal IDE with GUI tools that has all the necessary built-in capabilities to work with MariaDB and MySQL databases for their development, management, and administration. It allows for creating, managing, and editing the data without the need to store them locally.
 
 This GUI tool offers a rich visual design that is perfect for working with large scripts, preparing data reports, and database projects. At any time, you can back up or restore your data, export or import them to and from the most commonly used formats, and compare or synchronize the MariaDB databases.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-studio-for-mysqlmariadb.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-studio-for-mysqlmariadb.md
@@ -1,7 +1,7 @@
 # dbForge Studio for MySQL/MariaDB
 
 {% hint style="info" %}
-dbForge Studio is a proprietary third-party tool, not included with MariaDB Server. Content contributed by devart.
+dbForge Studio for MySQL/MariaDB is proprietary third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Content contributed by Devart; refer to its own documentation and license terms.
 {% endhint %}
 
 **dbForge Studio for MySQL** is an advanced and powerful GUI toolset designed specifically for specialists who deal with databases on MySQL and MariaDB. The purpose is to equip you with all tools needed to set up and perform the database-related routines on MariaDB. It saves time and costs, allowing you to work much more productively overall.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbschema.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbschema.md
@@ -1,5 +1,9 @@
 # DbSchema
 
+{% hint style="info" %}
+DbSchema is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 DbSchema helps you design, document and manage databases. Design new tables, generate HTML5 documentation, explore and edit the database data, compare and synchronize the schema over multiple databases, edit and execute SQL, and generate random data.
 
 DbSchema is compatible with all relational and some No-SQL databases. It works on all major operating systems, including Windows, Linux and macOS.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbvisualizer.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbvisualizer.md
@@ -1,5 +1,9 @@
 # DbVisualizer
 
+{% hint style="info" %}
+DbVisualizer is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [DbVisualizer](https://dbvis.com/) is a cross-platform database tool for developers, DBAs, analysts and SQL programmers. Both Free and paid Pro versions are available. Supported databases include MySQL, MariaDB, and PostgreSQL.
 
 DbVisualizer has been carefully developed by a small and dedicated team. Development decisions are based on user feedback.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dezign-for-databases.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dezign-for-databases.md
@@ -1,5 +1,9 @@
 # DeZign for Databases
 
+{% hint style="info" %}
+DeZign for Databases is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [DeZign for Databases](https://www.datanamic.com/dezign/) is a data modeling tool for developers and DBA's that helps model, create, and maintain MariaDB databases. It runs on Windows only.
 
 Supported database management systems include MariaDB, MySQL, and SQL Server.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/erbuilder-data-modeler.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/erbuilder-data-modeler.md
@@ -1,5 +1,9 @@
 # ERBuilder Data Modeler
 
+{% hint style="info" %}
+ERBuilder Data Modeler is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [ERBuilder Data Modeler](https://soft-builder.com/erbuilder-data-modeler/) is a GUI data modeling tool that allows developers to visualize, design, and model databases by using entity relationship diagrams and automatically generate the most popular SQL databases, and to generate and share the data model documentation. Optimize your data model by using advanced features such as test data generation, schema compare, and schema synchronization.
 
 Supported DBMS include MariaDB, MySQL, and Microsoft SQL Server.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-dbeaver.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-dbeaver.md
@@ -1,5 +1,9 @@
 # DBeaver
 
+{% hint style="info" %}
+DBeaver is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [DBeaver](https://dbeaver.jkiss.org/) is a free multi-platform database tool for developers, SQL programmers, database administrators and analysts. It supports many popular relational databases like MySQL, MariaDB, and PostgreSQL.
 
 A list of basic features:

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-omnidb.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-omnidb.md
@@ -1,5 +1,9 @@
 # OmniDB
 
+{% hint style="info" %}
+OmniDB is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 OmniDB is a browser-based tool that simplifies MariaDB database management focusing on interactivity. It is designed to be powerful and lightweight.
 
 Characteristics:

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-sequel-pro.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-sequel-pro.md
@@ -1,5 +1,9 @@
 # Sequel Pro
 
+{% hint style="info" %}
+Sequel Pro is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [Sequel Pro](https://www.sequelpro.com) is a fast, database management application for working with MySQL and MariaDB databases. It runs on macOS only.
 
 [Sequel Pro](https://www.sequelpro.com) is open source, so it's easy to be involved and enhance it for MariaDB.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/heidisql.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/heidisql.md
@@ -1,5 +1,9 @@
 # HeidiSQL
 
+{% hint style="info" %}
+HeidiSQL is third-party software, not developed or maintained by MariaDB. It ships as an optional component of the MariaDB Windows installer, but MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [HeidiSQL](https://www.heidisql.com/) is a Windows client for MariaDB and MySQL, and is bundled with the Windows version of MariaDB.
 
 | HeidiSQL Version | Introduced                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/ks-db-merge-tools-for-mysql-and-mariadb.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/ks-db-merge-tools-for-mysql-and-mariadb.md
@@ -1,5 +1,9 @@
 # KS DB Merge Tools
 
+{% hint style="info" %}
+KS DB Merge Tools is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 ## Overview
 
 KS DB Merge Tools for MySQL and MariaDB is a diff & merge tool for MySQL and MariaDB, allowing to compare and sync both schema and data. It is a Freemium application - many features are exposed in the Free version (available for commercial use), some extended features are available only in the paid Standard version (in many cases can be provided at no cost for open source developers).

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/libreoffice-base.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/libreoffice-base.md
@@ -1,5 +1,9 @@
 # LibreOffice Base
 
+{% hint style="info" %}
+LibreOffice Base is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [LibreOffice Base](https://www.libreoffice.org/discover/base/) is an open source RDBMS (relational database management system) frontend tool to create and manage various databases.
 
 ## Preparing the ODBC Connection

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/luna-modeler.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/luna-modeler.md
@@ -1,5 +1,9 @@
 # Luna Modeler
 
+{% hint style="info" %}
+Luna Modeler is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [Luna Modeler](https://www.datensen.com/) is a database design tool for MariaDB and other relational databases.
 
 Draw diagrams, reverse engineer existing database structures and generate SQL code.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/mycli.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/mycli.md
@@ -1,5 +1,9 @@
 # mycli
 
+{% hint style="info" %}
+mycli is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 **mycli** is a command-line interface for MariaDB, MySQL, and Percona, with auto-completion and syntax highlighting. It is written in Python, and runs on Linux, Mac and Windows.
 
 ![](../../.gitbook/assets/mycli_screenshot.png)

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/navicat.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/navicat.md
@@ -1,5 +1,9 @@
 # Navicat
 
+{% hint style="info" %}
+Navicat is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [Navicat](https://www.navicat.com/products/navicat-for-mariadb) is a graphical frontend for MariaDB. It is a commercial product with several different versions (Navicat Premium, Navicat for MySQL, etc...) and different "editions" within those versions (Non-commercial, Standard, and Enterprise). Certain features are only available in certain editions/versions.
 
 Navicat is available for Windows, MacOS, and Linux.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/ocelotgui.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/ocelotgui.md
@@ -1,5 +1,9 @@
 # ocelotgui
 
+{% hint style="info" %}
+ocelotgui is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 The Ocelot GUI (ocelotgui), a database client, allows to connect to a MySQL or MariaDB server, enter SQL statements, and receive results. Features include syntax highlighting, user-settable colors and fonts for each part of the screen, resultset displays with multiline rows and resizable columns, and a debugger.
 
 Visit [ocelot.ca](https://ocelot.ca/) for more information and to download.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/pgmanage.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/pgmanage.md
@@ -1,5 +1,9 @@
 # PgManage
 
+{% hint style="info" %}
+PgManage is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [PgManage](https://www.commandprompt.com/products/pgmanage/) is a modern SQL editor database management toolkit.
 
 ![App Screenshot](../../.gitbook/assets/pgmanage-mariadb.png)

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/phpmyadmin.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/phpmyadmin.md
@@ -6,6 +6,10 @@ description: >-
 
 # phpMyAdmin
 
+{% hint style="info" %}
+phpMyAdmin is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 phpMyAdmin is a web-based tool for administering MariaDB and MySQL.
 
 It requires a web server, PHP, and a browser.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/querious.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/querious.md
@@ -1,5 +1,9 @@
 # Querious
 
+{% hint style="info" %}
+Querious is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 Querious is a database administration tool for macOS.
 
 It can be purchased and downloaded at [querious](https://www.araelium.com/querious).

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/sb-data-generator.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/sb-data-generator.md
@@ -1,5 +1,9 @@
 # SB Data Generator
 
+{% hint style="info" %}
+SB Data Generator is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 Generate and populate databases with large volumes of realistic test data.
 
 [SB Data Generator](https://soft-builder.com/sb-data-generator/) is a simple and powerful GUI tool for creating large volumes of realistic test data to populate selected tables or entire databases. The tool reverses your database and displays tables and columns, so you can assign to them multiple data generator templates. It includes multiple built-in generators that allow populating MariaDB database tables with realistic data of various types.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/sqlpro-studio.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/sqlpro-studio.md
@@ -1,5 +1,9 @@
 # SQLPro Studio
 
+{% hint style="info" %}
+SQLPro Studio is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [SQLPro Studio](https://sqlprostudio.com/) is a fully native database client for macOS [macOS](https://sqlprostudio.com/) and [iOS](https://apps.apple.com/app/sqlpro-studio-database-client/id1273366668). It supports database management systems such as MariaDB, MySQL, and Postgres.
 
 ![SQLPro UI](../../.gitbook/assets/SQLProUI.png)

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/sqlyog-community-edition.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/sqlyog-community-edition.md
@@ -1,5 +1,9 @@
 # SQLyog
 
+{% hint style="info" %}
+SQLyog is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 SQLyog is a GUI tool to manage MySQL and MariaDB servers and databases in physical, virtual, and cloud environments. DBAs, developers, and database architects alike, use SQLyog to visually compare, optimize, and document schemas.
 
 Key Features:

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/tableplus.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/tableplus.md
@@ -1,5 +1,9 @@
 # TablePlus
 
+{% hint style="info" %}
+TablePlus is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [TablePlus](https://tableplus.com/) is an application with a clean user interface that allows developers to simultaneously manage databases in a very fast and secure way. It supports many popular database management systems like MariaDB, MySQL, and Postgres.
 
 ![](../../.gitbook/assets/table.png)

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/toad-edge.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/toad-edge.md
@@ -1,5 +1,9 @@
 # TOAD Edge
 
+{% hint style="info" %}
+Toad Edge is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 Toad Edge is a database management application that allows you to perform database administration tasks with ease.
 
 Toad Edge allows you to:

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/valentina-studio.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/valentina-studio.md
@@ -1,5 +1,9 @@
 # Valentina Studio
 
+{% hint style="info" %}
+Valentina Studio is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 [Valentina Studio](https://valentina-db.com/en/valentina-studio-overview) is a graphical front end for MariaDB with a free version, and a Pro version that adds advanced features.
 
 Free Valentina Studio offers the following features:

--- a/server/clients-and-utilities/server-client-software/applications-supporting-mariadb.md
+++ b/server/clients-and-utilities/server-client-software/applications-supporting-mariadb.md
@@ -6,6 +6,10 @@ description: >-
 
 # Applications Supporting MariaDB
 
+{% hint style="info" %}
+The projects listed on this page are third-party software, not developed or maintained by MariaDB. MariaDB doesn't test, validate, or support them. Refer to each project's own documentation and license terms.
+{% endhint %}
+
 This page lists projects which officially implement MariaDB's enhanced features, or state that they work with MariaDB. If you know of a project which officially supports MariaDB and it isn't listed here, please let us know in the comments.
 
 {% hint style="info" %}

--- a/server/server-usage/backup-and-restore/backup-and-restore-via-dbforge-studio.md
+++ b/server/server-usage/backup-and-restore/backup-and-restore-via-dbforge-studio.md
@@ -7,7 +7,7 @@ description: >-
 # Backup and Restore via dbForge Studio
 
 {% hint style="info" %}
-dbForge Studio is a proprietary third-party tool, not included with MariaDB Server. Content contributed by devart.
+dbForge Studio is proprietary third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Content contributed by Devart; refer to its own documentation and license terms.
 {% endhint %}
 
 In the modern world, data importance is non-negotiable, and keeping data integrity and consistency is the top priority. Data stored in databases is vulnerable to system crashes, hardware problems, security breaches, and other failures causing data loss or corruption. To prevent database damage, it is important to back the data up regularly and implement the data restore policies.\


### PR DESCRIPTION
Closes DOCS-6443.

Adds a top-of-page `{% hint %}` third-party notice to every page in the docs that documents software MariaDB does not produce, starting with the folder the ticket names.

## Scope — 42 files

| Where | Pages |
|---|---|
| `server/clients-and-utilities/graphical-and-enhanced-clients/` | 37 product pages + the section `README.md` |
| `server/clients-and-utilities/administrative-tools/` | `dbdeployer.md` |
| `server/clients-and-utilities/server-client-software/` | `applications-supporting-mariadb.md` |
| `server/clients-and-utilities/backup-restore-and-import-clients/` | the dbForge backup/restore page |
| `server/server-usage/backup-and-restore/` | `backup-and-restore-via-dbforge-studio.md` |

The standard wording, product-named:

> `<Product>` is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.

It extends the wording already present on `dbforge-studio-for-mysqlmariadb.md`, so this makes an existing house precedent uniform rather than inventing a new one.

## Three pages that could not take the standard wording

**`heidisql.md` — "not included with MariaDB Server" would be false.** HeidiSQL ships as an optional feature of the MariaDB Windows installer (`win/packaging/heidisql_feature.wxi.in` in the server tree), which the page itself states. Its notice says MariaDB doesn't develop or support it while acknowledging that it ships:

> HeidiSQL is third-party software, not developed or maintained by MariaDB. It ships as an optional component of the MariaDB Windows installer, but MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.

**`README.md` — the section is not uniformly third-party.** It also lists MariaDB Direct Query Adapter for Microsoft Power BI, a MariaDB product, so the notice is scoped to "The third-party tools described in this section" rather than claiming all of them are. That page is the one file in the folder left untouched.

**`cost-effective-agentless-mariadb-database-performance-management.md`** covers two products (SQL Diagnostic Manager and SQLyog), so its notice is plural.

## Notes for review

- **Vendor entity names are deliberately not asserted.** Most of these pages never name the company behind the product, and a wrong corporate name in a support disclaimer is worse than no name. The notice names the product — which is certain — and points the reader at the product's own documentation. `Devart` is named on the three dbForge pages that already carried that provenance, with the existing "Content contributed by devart" sentence preserved (capitalized).
- **Storage engines are deliberately out of scope**, and DOCS-6448 covers them. The same falsity applies more widely there: `videx/` and `duckdb/` are both in-tree in `mariadb-server/storage/`, and VIDEX is documented as available from MariaDB 12.3, so engines need wording that does not deny inclusion. Labelling long-shipped plugins (MyRocks, Mroonga, OQGraph, SphinxSE) as unsupported would also need a Support sign-off.
- **Not implemented as GitBook reusable content**, which the ticket floated as the ideal. The GitBook API exposes reusable content read-only — there are no create or update operations, so a block can only be authored in the web UI. Per-page hints also let each notice name its product, and stay visible to CI; a reusable include renders as nothing if the block is ever removed, and lychee cannot see includes at all.

## CI

`codespell` and both GitBook checks pass. `link-check` **fails on pre-existing external rot** on these vendor pages — dead or bot-blocked URLs such as `sequelpro.com`, `dbeaver.jkiss.org`, `valentina-db.com` (403), plus a cluster of dead links on `applications-supporting-mariadb.md`.

The failure is not introduced here, verified by running the CI-mirroring linter over the same 42 files twice — once on this branch, once on `main` in a clean worktree:

| | Total | Unique | Errors | Timeouts |
|---|---|---|---|---|
| `main` | 391 | 351 | 22 | 2 |
| this branch | 391 | 351 | 22 | 2 |

Identical, and the two sets of failing URLs are identical too — diffed in both directions, with no member unique to either side. This PR adds no links at all. CI's own list agrees, differing only by `virtuozzo.com`, which is the redirect target of the already-failing `jelastic.com` link. The rot deserves its own cleanup ticket; it is not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)