### PR TITLE
DOCS-6450 Add missing page descriptions in Clients and Utilities

### DIFF
--- a/server/clients-and-utilities/administrative-tools/dbdeployer.md
+++ b/server/clients-and-utilities/administrative-tools/dbdeployer.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  dbdeployer installs multiple versions of MariaDB or MySQL in isolation from
+  each other, which makes it useful for testing different server versions.
+---
+
 # dbdeployer
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/administrative-tools/innochecksum.md
+++ b/server/clients-and-utilities/administrative-tools/innochecksum.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  innochecksum prints checksums for InnoDB tablespace files and reports
+  mismatches, which identify damaged pages after a power outage or a file
+  copy.
+---
+
 # innochecksum
 
 innochecksum is a tool for printing checksums for InnoDB files.

--- a/server/clients-and-utilities/administrative-tools/mariadb-access.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-access.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  mariadb-access checks the access privileges of MariaDB users. It was
+  formerly called mysqlaccess.
+---
+
 # mariadb-access
 
 `mariadb-access` is a tool for checking access privileges, developed by Yves Carlier.

--- a/server/clients-and-utilities/administrative-tools/mariadb-admin.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-admin.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  mariadb-admin administers a running MariaDB server: monitor client activity,
+  read status variables, create and drop databases, flush logs, and kill
+  queries.
+---
+
 # mariadb-admin
 
 ## Overview

--- a/server/clients-and-utilities/administrative-tools/mariadb-conv.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-conv.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  mariadb-conv is a character set conversion utility for MariaDB, available
+  from MariaDB 10.5.
+---
+
 # mariadb-conv
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/administrative-tools/mariadb-embedded.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-embedded.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  mariadb-embedded is a MariaDB client statically linked to libmariadbd, the
+  embedded server, so it instantiates its own server on startup.
+---
+
 # mariadb-embedded
 
 `mariadb-embedded` is a [mariadb client](../mariadb-client/mariadb-command line-client.md), statically linked to `libmariadbd`, the embedded server.

--- a/server/clients-and-utilities/administrative-tools/mariadb-find-rows.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-find-rows.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  mariadb-find-rows reads files of SQL statements and extracts those that
+  match a regular expression or that contain USE or SET statements.
+---
+
 # mariadb-find-rows
 
 `mariadb-find-rows` reads files containing SQL statements and extracts statements that match a given regular expression or that contain [USE db\_name](../../reference/sql-statements/administrative-sql-statements/use-database.md) or [SET](../../reference/sql-statements/administrative-sql-statements/set-commands/set.md) statements.

--- a/server/clients-and-utilities/administrative-tools/mariadb-plugin.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-plugin.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  mariadb-plugin enables or disables MariaDB plugins from the command line
+  while the server is offline, as an alternative to INSTALL PLUGIN and
+  UNINSTALL PLUGIN.
+---
+
 # mariadb-plugin
 
 `mariadb-plugin` is a tool for enabling or disabling [plugins](../../reference/plugins/).

--- a/server/clients-and-utilities/administrative-tools/mariadb-report.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-report.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  mariadb-report interprets and formats the values from SHOW STATUS into a
+  readable report, adding inferred values such as the index read ratio.
+---
+
 # mariadb-report
 
 `mariadb-report` makes a friendly report of important MariaDB status values.

--- a/server/clients-and-utilities/administrative-tools/mariadb-setpermission.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-setpermission.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  mariadb-setpermission is a Perl script that helps add users and databases or
+  change passwords in MariaDB. It requires the DBI and DBD::mysql Perl
+  modules.
+---
+
 # mariadb-setpermission
 
 ## Syntax

--- a/server/clients-and-utilities/administrative-tools/mariadb-show.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-show.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  mariadb-show shows the structure of a MariaDB database: its databases,
+  tables, columns, and indexes.
+---
+
 # mariadb-show
 
 Shows the structure of a MariaDB database (databases, tables, columns and indexes).

--- a/server/clients-and-utilities/administrative-tools/mariadb-tzinfo-to-sql.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-tzinfo-to-sql.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  mariadb-tzinfo-to-sql loads time zone data from a system zoneinfo database
+  into the time zone tables in the mysql database.
+---
+
 # mariadb-tzinfo-to-sql
 
 `mariadb-tzinfo-to-sql` is a tool used to load [time zones](../../reference/data-types/string-data-types/character-sets/internationalization-and-localization/time-zones.md) on systems that have a zoneinfo database to load the time zone tables ([time\_zone](../../reference/system-tables/the-mysql-database-tables/mysql-time_zone-table.md), [time\_zone\_leap\_second](../../reference/system-tables/the-mysql-database-tables/mysql-time_zone_leap_second-table.md), [time\_zone\_name](../../reference/system-tables/the-mysql-database-tables/mysql-time_zone_name-table.md), [time\_zone\_transition](../../reference/system-tables/the-mysql-database-tables/mysql-time_zone_transition-table.md) and [time\_zone\_transition\_type](../../reference/system-tables/the-mysql-database-tables/mysql-time_zone_transition_type-table.md)) into the mysql database.

--- a/server/clients-and-utilities/administrative-tools/mariadb-waitpid.md
+++ b/server/clients-and-utilities/administrative-tools/mariadb-waitpid.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  mariadb-waitpid terminates a process by its ID on Unix-like systems, using
+  the kill() system call.
+---
+
 # mariadb-waitpid
 
 `mariadb_waitpid` is a utility for terminating processes. 

--- a/server/clients-and-utilities/administrative-tools/my_print_defaults.md
+++ b/server/clients-and-utilities/administrative-tools/my_print_defaults.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  my_print_defaults displays the options a tool will read from the option
+  groups of option files, one option per line in command-line form.
+---
+
 # my\_print\_defaults
 
 `my_print_defaults` displays the options from option groups of option files. It is useful to see which options a particular tool will use.

--- a/server/clients-and-utilities/administrative-tools/perror.md
+++ b/server/clients-and-utilities/administrative-tools/perror.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  perror displays the description for a system or storage engine error code.
+---
+
 # perror
 
 _perror_ is a utility that displays descriptions for system or storage engine error codes.

--- a/server/clients-and-utilities/administrative-tools/replace-utility.md
+++ b/server/clients-and-utilities/administrative-tools/replace-utility.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The replace utility changes strings in place in files or on standard input.
+---
+
 # replace
 
 ## Description

--- a/server/clients-and-utilities/administrative-tools/resolve_stack_dump.md
+++ b/server/clients-and-utilities/administrative-tools/resolve_stack_dump.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  resolve_stack_dump resolves the numeric stack trace from a mariadbd crash
+  into symbol names, using a symbols file produced by nm.
+---
+
 # resolve\_stack\_dump
 
 `resolve_stack_dump` is a tool that resolves numeric stack strace dumps into symbols.

--- a/server/clients-and-utilities/analyzing-tools/README.md
+++ b/server/clients-and-utilities/analyzing-tools/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Explore tools for analyzing how MariaDB executes queries, including the
+  EXPLAIN Analyzer and its API.
+---
+
 # Analyzing Tools
 
 {% columns %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/adminer.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/adminer.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Adminer is a database administration web interface written in PHP. It mainly
+  supports MySQL but also works with MariaDB, and has a wide range of plugins.
+---
+
 # Adminer
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/beekeeper-studio.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/beekeeper-studio.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Beekeeper Studio is an open-source database GUI for Linux, macOS, and
+  Windows that works with MariaDB and other databases.
+---
+
 # Beekeeper Studio
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/cost-effective-agentless-mariadb-database-performance-management.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/cost-effective-agentless-mariadb-database-performance-management.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  SQL Diagnostic Manager offers agentless, real-time performance monitoring
+  for MariaDB servers, and SQLyog is a GUI tool for managing them.
+---
+
 # SQL Diagnostic Manager & SQLyog
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-data-compare.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-data-compare.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  dbForge Data Compare compares and synchronizes data in MariaDB, MySQL, and
+  Percona databases, generating and applying synchronization scripts.
+---
+
 # dbForge Data Compare
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-data-generator.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-data-generator.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  dbForge Data Generator for MariaDB and MySQL creates large volumes of
+  realistic test data using predefined generators with customizable options.
+---
+
 # dbForge Data Generator
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-documenter-for-mariadb-and-mysql.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-documenter-for-mariadb-and-mysql.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  dbForge Documenter automatically generates MariaDB database documentation in
+  HTML, PDF, and Markdown, with a range of options for adjusting the output.
+---
+
 # dbForge Documenter
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-edge.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-edge.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  dbForge Edge is a multi-database IDE for full-stack database specialists,
+  covering MySQL and MariaDB development and management alongside SQL Server,
+  Oracle, and PostgreSQL.
+---
+
 # dbForge Edge
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-fusion-mysql-mariadb-plugin-for-vs.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-fusion-mysql-mariadb-plugin-for-vs.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  dbForge Fusion was an add-in that brought MariaDB database development and
+  administration into Visual Studio. It is now discontinued.
+---
+
 # dbForge Fusion
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-query-builder-for-mysql-mariadb.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-query-builder-for-mysql-mariadb.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  dbForge Query Builder is a visual tool for creating MariaDB queries by
+  drawing them on a diagram.
+---
+
 # dbForge Query Builder
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-schema-compare-for-mariadb-mysql.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-schema-compare-for-mariadb-mysql.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  dbForge Schema Compare finds the differences between MariaDB database
+  schemas and generates synchronization scripts to update them.
+---
+
 # dbForge Schema Compare
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-studio-for-mariadb-universal-gui-tool-for-management-administration.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-studio-for-mariadb-universal-gui-tool-for-management-administration.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  dbForge Studio for MariaDB is a universal IDE with GUI tools for developing,
+  managing, and administering MariaDB and MySQL databases.
+---
+
 # dbForge Studio
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-studio-for-mysqlmariadb.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbforge-studio-for-mysqlmariadb.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  dbForge Studio for MySQL is a GUI toolset for MySQL and MariaDB database
+  development, management, and administration, with code completion and source
+  control.
+---
+
 # dbForge Studio for MySQL/MariaDB
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbschema.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbschema.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  DbSchema designs, documents, and manages MariaDB databases: create tables,
+  generate HTML5 documentation, edit data, compare schemas, and run SQL.
+---
+
 # DbSchema
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dbvisualizer.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dbvisualizer.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  DbVisualizer is a cross-platform database tool for developers, DBAs, and
+  analysts, available in Free and Pro versions and supporting MariaDB, MySQL,
+  and PostgreSQL.
+---
+
 # DbVisualizer
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/dezign-for-databases.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/dezign-for-databases.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  DeZign for Databases is a Windows data modeling tool for modeling, creating,
+  and maintaining MariaDB databases with entity relationship diagrams.
+---
+
 # DeZign for Databases
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/erbuilder-data-modeler.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/erbuilder-data-modeler.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  ERBuilder Data Modeler visualizes, designs, and models MariaDB databases
+  with entity relationship diagrams, and generates SQL and data model
+  documentation.
+---
+
 # ERBuilder Data Modeler
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-dbeaver.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-dbeaver.md
@@ -1,10 +1,17 @@
+---
+description: >-
+  DBeaver is a free, multi-platform database tool for developers, DBAs, and
+  analysts that supports MariaDB, MySQL, PostgreSQL, and other relational
+  databases.
+---
+
 # DBeaver
 
 {% hint style="info" %}
 DBeaver is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
 {% endhint %}
 
-[DBeaver](https://dbeaver.jkiss.org/) is a free multi-platform database tool for developers, SQL programmers, database administrators and analysts. It supports many popular relational databases like MySQL, MariaDB, and PostgreSQL.
+[DBeaver](https://dbeaver.io/) is a free multi-platform database tool for developers, SQL programmers, database administrators and analysts. It supports many popular relational databases like MySQL, MariaDB, and PostgreSQL.
 
 A list of basic features:
 
@@ -16,7 +23,7 @@ A list of basic features:
 * Data and metadata search: full-text data search using against all chosen tables/views.
 * Database structure comparing: possibility to perform objects structure compare.
 
-Usability is the main goal of this project, so the program UI is carefully designed and implemented. Users can send bug report and feature request on the [GitHub page](https://github.com/serge-rider/dbeaver).
+Usability is the main goal of this project, so the program UI is carefully designed and implemented. Users can send bug report and feature request on the [GitHub page](https://github.com/dbeaver/dbeaver).
 
 ![](../../.gitbook/assets/screen1.png)
 

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-omnidb.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-omnidb.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  OmniDB is a lightweight, browser-based tool for managing MariaDB databases,
+  with all of its functions on a single responsive page.
+---
+
 # OmniDB
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-sequel-pro.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/graphical-and-enhanced-clients-sequel-pro.md
@@ -1,19 +1,24 @@
+---
+description: >-
+  Sequel Pro is an open-source macOS application for working with MySQL and
+  MariaDB databases.
+---
+
 # Sequel Pro
 
 {% hint style="info" %}
 Sequel Pro is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
 {% endhint %}
 
-[Sequel Pro](https://www.sequelpro.com) is a fast, database management application for working with MySQL and MariaDB databases. It runs on macOS only.
+[Sequel Pro](https://github.com/sequelpro/sequelpro) is a fast, database management application for working with MySQL and MariaDB databases. It runs on macOS only.
 
-[Sequel Pro](https://www.sequelpro.com) is open source, so it's easy to be involved and enhance it for MariaDB.
+Sequel Pro is open source, so it's easy to be involved and enhance it for MariaDB.
 
 If you have any issues with Sequel Pro on MariaDB, please use the [issue tracking](https://github.com/sequelpro/sequelpro/issues) for that!
 
 ## See Also
 
-* [Sequal Pro home site](https://www.sequelpro.com)
-* [Source code](https://github.com/sequelpro)
+* [Source code](https://github.com/sequelpro/sequelpro)
 * [Issue tracking](https://github.com/sequelpro/sequelpro/issues)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/heidisql.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/heidisql.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  HeidiSQL is a Windows client for MariaDB and MySQL, and is bundled with the
+  Windows version of MariaDB Server.
+---
+
 # HeidiSQL
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/ks-db-merge-tools-for-mysql-and-mariadb.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/ks-db-merge-tools-for-mysql-and-mariadb.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  KS DB Merge Tools is a diff and merge tool for MySQL and MariaDB that
+  compares and synchronizes both schema and data, in free and paid versions.
+---
+
 # KS DB Merge Tools
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/libreoffice-base.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/libreoffice-base.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Connect LibreOffice Base to MariaDB over MariaDB Connector/ODBC to create
+  and manage databases from an open-source RDBMS frontend.
+---
+
 # LibreOffice Base
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/luna-modeler.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/luna-modeler.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Luna Modeler is a database design tool for MariaDB that draws diagrams,
+  reverse engineers existing database structures, and generates SQL code.
+---
+
 # Luna Modeler
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/mariadb-direct-query-adapter-for-microsoft-power-bi.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/mariadb-direct-query-adapter-for-microsoft-power-bi.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  The MariaDB Direct Query Adapter is a Microsoft-certified connector that
+  lets Power BI Desktop query a MariaDB database remotely without downloading
+  the data set.
+---
+
 # MariaDB Direct Query Adapter For Microsoft Power BI
 
 MariaDB Direct Query Adapter for Power BI enables Microsoft Power BI Desktop users to remotely connect to and query their MariaDB database including on MariaDB Cloud without downloading the entire data set to their local machine.

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/mycli.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/mycli.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  mycli is a command-line client for MariaDB, MySQL, and Percona with auto-
+  completion and syntax highlighting. Written in Python, it runs on Linux,
+  macOS, and Windows.
+---
+
 # mycli
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/navicat.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/navicat.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Navicat is a commercial graphical frontend for MariaDB, available for
+  Windows, macOS, and Linux in several versions and editions.
+---
+
 # Navicat
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/ocelotgui.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/ocelotgui.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  The Ocelot GUI (ocelotgui) is a database client for MariaDB and MySQL with
+  syntax highlighting, configurable colors and fonts, multiline result rows,
+  and a debugger.
+---
+
 # ocelotgui
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/pgmanage.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/pgmanage.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  PgManage is a SQL editor and database management toolkit that supports
+  MariaDB alongside many other databases.
+---
+
 # PgManage
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/querious.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/querious.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Querious is a database administration tool for macOS, available for purchase
+  from Araelium.
+---
+
 # Querious
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/sb-data-generator.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/sb-data-generator.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  SB Data Generator is a GUI tool that populates MariaDB tables or entire
+  databases with large volumes of realistic test data from built-in
+  generators.
+---
+
 # SB Data Generator
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/sqlpro-studio.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/sqlpro-studio.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  SQLPro Studio is a native database client for macOS and iOS that supports
+  MariaDB, MySQL, and Postgres, with syntax highlighting and autocomplete.
+---
+
 # SQLPro Studio
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/sqlyog-community-edition.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/sqlyog-community-edition.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  SQLyog is a GUI tool for managing MySQL and MariaDB servers and databases in
+  physical, virtual, and cloud environments, and for comparing and documenting
+  schemas.
+---
+
 # SQLyog
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/tableplus.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/tableplus.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  TablePlus is a database management application for macOS, Windows, iOS, and
+  Linux that supports MariaDB, MySQL, Postgres, and other popular systems.
+---
+
 # TablePlus
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/toad-edge.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/toad-edge.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Toad Edge is a database management application for performing administration
+  tasks, exploring and editing database structure, and managing database
+  objects.
+---
+
 # TOAD Edge
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/valentina-studio.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/valentina-studio.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Valentina Studio is a graphical frontend for MariaDB, available natively on
+  macOS, Windows, and Linux in a free version and a Pro version with advanced
+  features.
+---
+
 # Valentina Studio
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/server-client-software/download/getting-the-mariadb-source-code.md
+++ b/server/clients-and-utilities/server-client-software/download/getting-the-mariadb-source-code.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Check out the MariaDB Server source code from GitHub, find source tarballs
+  for released versions, and see which branches development happens on.
+---
+
 # MariaDB Source Code
 
 ## Checking out the Source with Git

--- a/server/clients-and-utilities/server-client-software/download/mariadb-rpm-packages.md
+++ b/server/clients-and-utilities/server-client-software/download/mariadb-rpm-packages.md
@@ -1,4 +1,3 @@
-
 ---
 description: >-
   Where to find MariaDB RPM packages for Fedora and other distributions, plus

--- a/server/clients-and-utilities/server-client-software/download/where-to-download-mariadb.md
+++ b/server/clients-and-utilities/server-client-software/download/where-to-download-mariadb.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Where to download MariaDB Server: tarballs and binaries for Linux, Solaris,
+  and Windows, distribution packages, and pre-release Buildbot binaries.
+---
+
 # Where to Download MariaDB
 
 ## The Latest Packages


### PR DESCRIPTION
Closes DOCS-6450.

## What

All **56** pages under `server/clients-and-utilities/` that had no frontmatter now carry a `description:`. After this PR all **122** pages in the tree have one.

| Folder | Pages fixed |
| --- | --- |
| `graphical-and-enhanced-clients/` | 35 |
| `administrative-tools/` | 17 |
| `server-client-software/download/` | 3 |
| `analyzing-tools/README.md` | 1 |

Each description is one sentence, derived from the page's **own opening paragraph** — deliberately, so that a page about a third-party product gains no new claim about what that vendor's tool does. All are under GitBook's ~200-character truncation limit (the longest added is 172; the longest in the tree, 199, is pre-existing).

## A defect the inventory turned up

`server-client-software/download/mariadb-rpm-packages.md` already *had* a `description:` block — but a **blank line before the opening `---`** meant it was never frontmatter. Verified against the live page: it returns 200 with **zero** `<meta name="description">`, and the `---` renders as a horizontal rule. Deleting that one blank line is the whole fix.

## Scope note

A missing `description:` costs the published page its `<meta name="description">`, which affects search-engine snippets and GitBook's in-site search preview. It does **not** affect the section landing page's cards — those render titles only. This is a metadata fix, not a visible-navigation one.

## Drive-by fixes

Touching these files brings them into CI's changed-file link scan, so the pre-existing rot catalogued in DOCS-6449 is repaired here rather than left to turn this PR red. Both hosts were confirmed genuinely dead (`000`, not merely bot-blocked — no response even to a browser user-agent), and both replacements were confirmed live:

- `graphical-and-enhanced-clients-dbeaver.md` — `dbeaver.jkiss.org` (TLS hostname mismatch) → `dbeaver.io`. Also repointed the old `serge-rider/dbeaver` repo, which now redirects, at `dbeaver/dbeaver`.
- `graphical-and-enhanced-clients-sequel-pro.md` — `www.sequelpro.com`, dead at all three occurrences → the live project repo. The "Sequal Pro home site" bullet (typo in the original) is **dropped** rather than redirected, since no home site exists to redirect to.

This clears 2 of DOCS-6449's 5 files. The remaining three — `applications-supporting-mariadb.md` (17 failures, and an editorial retirement question), `mariadb-foundation.md`, and `valentina-studio.md` (bot-blocked, alive) — are untouched and stay with that ticket.

## Checks

`.claude/hooks/doc-lint.sh` on all 56 changed files: **codespell PASS, lychee PASS (411 links, 336 unique, 0 errors), includes PASS**. Frontmatter parsing verified programmatically across all 122 pages in the tree — 122 usable descriptions, 0 malformed blocks, 0 over 200 characters.

No fact-check report: this adds page metadata restating each page's existing lead paragraph and makes no new technical claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)