### PR TITLE
DOCS-6452 Fix bogus ERROR 1304 in CREATE OR REPLACE example

### DIFF
--- a/server/server-usage/stored-routines/stored-procedures/create-procedure.md
+++ b/server/server-usage/stored-routines/stored-procedures/create-procedure.md
@@ -205,6 +205,8 @@ DELIMITER ;
 
 `CREATE OR REPLACE`:
 
+Re-creating an existing procedure without `OR REPLACE` fails, while `CREATE OR REPLACE` replaces the existing definition:
+
 ```sql
 DELIMITER //
 
@@ -217,10 +219,6 @@ CREATE PROCEDURE simpleproc2 (
 //
 ERROR 1304 (42000): PROCEDURE simpleproc2 already exists
 
-DELIMITER ;
-
-DELIMITER //
-
 CREATE OR REPLACE PROCEDURE simpleproc2 (
   OUT param1 CHAR(10) CHARACTER SET 'utf8' COLLATE 'utf8_bin'
 )
@@ -228,10 +226,9 @@ CREATE OR REPLACE PROCEDURE simpleproc2 (
   SELECT CONCAT('a'),f1 INTO param1 FROM t;
  END;
 //
-ERROR 1304 (42000): PROCEDURE simpleproc2 already exists
+Query OK, 0 rows affected (0.03 sec)
 
 DELIMITER ;
-Query OK, 0 rows affected (0.03 sec)
 ```
 
 ## See Also


### PR DESCRIPTION
Found while fact-checking community PR #883. Ticket: [DOCS-6452](https://mariadbcorp.atlassian.net/browse/DOCS-6452).

## The defect

On `CREATE PROCEDURE`, the `CREATE OR REPLACE` example showed the `OR REPLACE` invocation *failing*:

```
CREATE OR REPLACE PROCEDURE simpleproc2 (...)
...
//
ERROR 1304 (42000): PROCEDURE simpleproc2 already exists

DELIMITER ;
Query OK, 0 rows affected (0.03 sec)
```

`CREATE OR REPLACE` never raises `ER_SP_ALREADY_EXISTS` — avoiding that error is the entire point of the clause. The `ERROR` line is a copy-paste from the preceding plain-`CREATE PROCEDURE` block, and the real output (`Query OK`) was stranded after `DELIMITER ;`, where it reads as the output of the delimiter command rather than of the statement.

Verified against `mysql-test/main/create_drop_procedure.result`: `CREATE OR REPLACE PROCEDURE proc1 … COMMENT 'comment5'` against an existing `proc1` produces no error, and the stored comment changes from `comment1` to `comment5`.

## What changed

- Removed the bogus `ERROR 1304` after `CREATE OR REPLACE`, and moved `Query OK` under the statement it belongs to.
- Removed a redundant `DELIMITER ;` / `DELIMITER //` pair in the middle of the block — the delimiter only needs restoring once, at the end.
- Added a lead-in sentence so the example states the contrast it is demonstrating.

One file, one fenced block. `ERROR 1304` appears nowhere else in the docs.

## Related, deliberately not changed

The `CHARACTER SET 'utf8' COLLATE 'utf8_bin'` parameter in these examples stays. It is correct — `COLLATE` on a stored-routine parameter is accepted and honored (`mysql-test/main/sp-ucs2.test:35,90,117`) — and it is this page's only demonstration of parameter charset/collation. #883 removes the sentence that wrongly claimed otherwise; this PR is independent of it and touches different lines.

## Checks

`doc-lint.sh` clean on the changed file (codespell + lychee, 41/42 links OK — the one error was a deliberate canary used to prove the linter actually executed).

[DOCS-6452]: https://mariadbcorp.atlassian.net/browse/DOCS-6452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ