### PR TITLE
DOCS-6031 Document RECORD types in routine parameters and RETURN

### DIFF
--- a/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
@@ -8,7 +8,12 @@ description: >-
 # DECLARE TYPE
 
 {% hint style="info" %}
-This feature is available from MariaDB 12.1.
+The type declarations on this page were introduced in different releases:
+
+* `TYPE ... IS RECORD` — from MariaDB 11.8.1
+* `TYPE ... IS TABLE OF ... INDEX BY` (associative arrays) — from MariaDB 12.0.1
+* `TYPE ... IS REF CURSOR` — from MariaDB 13.0.1
+* `TYPE` in a package specification (public, referenced by qualified name) — from MariaDB 13.1
 {% endhint %}
 
 ## Overview
@@ -21,12 +26,12 @@ The general syntax for defining associative array types is as follows:
 
 ```sql
 DECLARE
-   TYPE type_name TABLE OF rec_type_name INDEX BY idx_type_name
+   TYPE type_name IS TABLE OF element_type INDEX BY key_type
 ```
 
-* `type_name` supports explicit and anchored data types (for instance, `t1.col1%TYPE`).
-* `rec_type_name` supports scalar and record data types.
-* The `INDEX BY` clause defines the key type using `idx_type_name`, which supports integer and string data types.
+* `type_name` is the name of the new associative array type.
+* `element_type` is the type of each value. It supports scalar and record types, explicit or anchored (for example, `t1.col1%TYPE` or `t1%ROWTYPE`).
+* `key_type` defines the key type. It must be a plain integer or string type — anchored types such as `t1.col1%TYPE` are not accepted here.
 
 ## Associative Arrays
 
@@ -72,6 +77,8 @@ These differences are largely rooted in architectural constraints — MariaDB is
 **Explicit type\_name**
 
 ```sql
+SET sql_mode=ORACLE;
+DELIMITER /
 DECLARE
   TYPE salary IS TABLE OF NUMBER INDEX BY VARCHAR2(20);
   salary_list salary;
@@ -82,17 +89,21 @@ BEGIN
   name:= salary_list.FIRST;
   WHILE name IS NOT NULL
   LOOP
-    dbms_output.put_line(name || ' ' || TO_CHAR(salary_list(name)));
+    SELECT name || ' ' || salary_list(name);
     name:= salary_list.NEXT(name);
   END LOOP;
 END;
 /
+DELIMITER ;
 ```
 
 **Anchored type\_name**
 
 ```sql
+DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (a INT);
+SET sql_mode=ORACLE;
+DELIMITER /
 DECLARE
   TYPE salary IS TABLE OF t1.a%TYPE INDEX BY VARCHAR2(20);
   salary_list salary;
@@ -103,11 +114,12 @@ BEGIN
   name:= salary_list.FIRST;
   WHILE name IS NOT NULL
   LOOP
-    dbms_output.put_line(name || ' ' || TO_CHAR(salary_list(name)));
+    SELECT name || ' ' || salary_list(name);
     name:= salary_list.NEXT(name);
   END LOOP;
 END;
 /
+DELIMITER ;
 ```
 
 #### Associative Array of Records
@@ -115,6 +127,8 @@ END;
 **Using Explicit Data Types**
 
 ```sql
+SET sql_mode=ORACLE;
+DELIMITER /
 DECLARE
   TYPE person_t IS RECORD
   (
@@ -122,88 +136,97 @@ DECLARE
     last_name VARCHAR(64)
   );
   person person_t;
-  TYPE table_of_peson_t IS TABLE OF person_t INDEX BY VARCHAR(20);
-  person_by_nickname table_of_peson_t;
+  TYPE table_of_person_t IS TABLE OF person_t INDEX BY VARCHAR(20);
+  person_by_nickname table_of_person_t;
   nick VARCHAR(20);
 BEGIN
   person_by_nickname('Monty') := person_t('Michael', 'Widenius');
-  person_by_nickname('Serg') := person_t('Sergei ', 'Golubchik');
+  person_by_nickname('Serg') := person_t('Sergei', 'Golubchik');
   nick:= person_by_nickname.FIRST;
   WHILE nick IS NOT NULL
   LOOP
     person:= person_by_nickname(nick);
-    dbms_output.put_line(nick || ' ' || person.first_name || ' '|| person.last_name);
+    SELECT nick || ' ' || person.first_name || ' ' || person.last_name;
     nick:= person_by_nickname.NEXT(nick);
   END LOOP;
-  /
+END;
+/
+DELIMITER ;
 ```
 
 **Using Anchored Data Types**
 
 ```sql
-DROP TABLE persons;
+DROP TABLE IF EXISTS persons;
 CREATE TABLE persons (nickname VARCHAR(64), first_name VARCHAR(64), last_name VARCHAR(64));
-INSERT INTO persons VALUES ('Serg','Sergei ', 'Golubchik');
+INSERT INTO persons VALUES ('Serg','Sergei', 'Golubchik');
 INSERT INTO persons VALUES ('Monty','Michael', 'Widenius');
+SET sql_mode=ORACLE;
+DELIMITER /
 DECLARE
-  TYPE table_of_person_t IS TABLE OF persons%ROWTYPE INDEX BY persons.nickname%TYPE;
+  TYPE table_of_person_t IS TABLE OF persons%ROWTYPE INDEX BY VARCHAR(64);
   person_by_nickname table_of_person_t;
-  nickname persons.nickname%TYPE;
+  nickname VARCHAR(64);
   person persons%ROWTYPE;
 BEGIN
   FOR rec IN (SELECT * FROM persons)
   LOOP
     person_by_nickname(rec.nickname):= rec;
   END LOOP;
- 
+
   nickname:= person_by_nickname.FIRST;
   WHILE nickname IS NOT NULL
   LOOP
     person:= person_by_nickname(nickname);
-    dbms_output.put_line(person.nickname || ' ' || person.first_name || ' '|| person.last_name);
+    SELECT person.nickname || ' ' || person.first_name || ' ' || person.last_name;
     nickname:= person_by_nickname.NEXT(nickname);
   END LOOP;
 END;
 /
+DELIMITER ;
 ```
 
 ## RECORD Types
 
 In `sql_mode=ORACLE`, the `TYPE ... IS RECORD` statement allows you to define a user-defined data structure consisting of one or more fields.
 
-Previously, TYPE-defined `RECORD` types could only be used in local program blocks and not in routine parameters or function `RETURN` clauses.
+Before MariaDB 13.0.1, TYPE-defined `RECORD` types could only be used in local program blocks. Starting from MariaDB 13.0.1, `RECORD` can additionally be used in package routine parameters and package function `RETURN` clauses.
 
 ### **Syntax**
 
 ```sql
 TYPE record_type_name IS RECORD (
-    field_name data_type [NOT NULL] [DEFAULT expr],
+    field_name data_type,
     ...
 );
 ```
 
 * `record_type_name` is the name of the new record type.
 * Each `field_name` is a named attribute of the record.
-* Each `field_type` is a valid MariaDB data type or anchored type (`%TYPE`, `%ROWTYPE`).
+* Each `data_type` is a valid MariaDB data type, or an anchored type using `%TYPE` (for example, `t1.a%TYPE`). Record fields support only scalar types, so `%ROWTYPE` cannot be used here.
 
-### RECORD Types in Routine Parameters and Function RETURN
+### RECORD Types in Package Routine Parameters and Function RETURN
 
 Starting with MariaDB 13.0.1, custom types defined with `DECLARE TYPE` (including `RECORD` and `REF CURSOR`) can be used as:
 
-* Parameters of stored procedures and functions
-* `RETURN` types of stored functions
+* Parameters of procedures and functions declared in a package
+* `RETURN` types of functions declared in a package
 
-Earlier, the use of a `RECORD` type in these contexts was prohibited by the MariaDB grammar and resulted in:
+This applies to package routines only. Standalone procedures and functions cannot use a TYPE-defined type as a parameter or as a `RETURN` type. From MariaDB 13.1, a type declared in a package specification can be referenced by qualified name from routines outside the package — including standalone routines — subject to its own restrictions. See [Package-Wide Types](#package-wide-types).
+
+{% hint style="warning" %}
+Associative array types (`TYPE ... IS TABLE OF ... INDEX BY`) cannot be used as a routine parameter or as a function `RETURN` type, even inside a package. Attempting it fails with `ERROR 4079 (HY000): Illegal parameter data type associative_array for operation '<routine parameter>'` (or `... for operation 'RETURN'` when it is a function's return type).
+{% endhint %}
+
+Before that release, such use was prohibited by the MariaDB grammar and resulted in:
 
 ```
-ERROR 4161 (HY000): Unknown data type
+ERROR 4161 (HY000): Unknown data type: 'rec0_t'
 ```
-
-This change improves compatibility with Oracle PL/SQL, especially for private helper routines inside packages and for `REF CURSOR` usage.
 
 ### Using RECORDs in Routine Parameters
 
-Starting with MariaDB 13.0.1, stored procedures within the same package can use a `RECORD` type declared inside the package body as a parameter.
+Starting with MariaDB 13.0.1, stored routines within the same package can use a `RECORD` type declared inside the package body as a parameter.
 
 ```sql
 SET sql_mode=ORACLE;
@@ -211,19 +234,22 @@ DELIMITER $$
 CREATE OR REPLACE PACKAGE pkg1 AS
   PROCEDURE p1();
 END;
+$$
 CREATE OR REPLACE PACKAGE BODY pkg1 AS
   TYPE rec0_t IS RECORD (a INT, b VARCHAR(2), c INT);
-  PROCEDURE private_p1(p0 rec0_t) AS
+  PROCEDURE private_p1(pr0 rec0_t) AS
   BEGIN
-    NULL;
+    SELECT pr0.a || pr0.b || pr0.c;
   END;
   PROCEDURE p1 AS
+    r0 rec0_t := (1,'ab',2);
   BEGIN
-    CALL private_p1(a0);
+    private_p1(r0);
   END;
 END;
 $$
 DELIMITER ;
+CALL pkg1.p1;
 ```
 
 ### Using RECORDs as a Function Return Type
@@ -236,19 +262,23 @@ DELIMITER $$
 CREATE OR REPLACE PACKAGE pkg1 AS
   PROCEDURE p1();
 END;
+$$
 CREATE OR REPLACE PACKAGE BODY pkg1 AS
   TYPE rec0_t IS RECORD (a INT, b VARCHAR(2), c INT);
   FUNCTION private_f1() RETURN rec0_t AS
   BEGIN
-    RETURN NULL;
+    RETURN rec0_t(1,'ab',2);
   END;
-  PROCEDURE p1() AS
+  PROCEDURE p1 AS
+    r0 rec0_t;
   BEGIN
-    DO private_f1();
+    r0:= private_f1();
+    SELECT r0.a || r0.b || r0.c;
   END;
 END;
 $$
 DELIMITER ;
+CALL pkg1.p1;
 ```
 
 ### Requirement
@@ -257,7 +287,7 @@ This feature requires Oracle SQL mode at package creation time. The SQL mode is 
 
 ## REF CURSOR Types
 
-MariaDB supports Oracle-compatible `REF CURSOR` type declarations as a part of the `DECLARE TYPE` statement. A `REF CURSOR` is a cursor variable that can refer to a query result set and be passed across program blocks, such as stored procedures or functions.
+MariaDB supports Oracle-compatible [`REF CURSOR`](#overview) type declarations as part of the `DECLARE TYPE` statement. Like any other `DECLARE TYPE` declaration, a `REF CURSOR` type can be declared in a `DECLARE ... BEGIN ... END` block, in a stored routine, in a package body, or — from MariaDB 13.1 — in a package specification (see [Package-Wide Types](#package-wide-types)). The complete examples below use anonymous blocks and standalone procedures.
 
 `REF CURSOR` types must be specified with a `TYPE` declaration before any variables of that type can be declared. It can be defined as weak or strong based on whether a return type is specified.
 
@@ -284,7 +314,7 @@ TYPE weak_cursor IS REF CURSOR; -- weak type: no RETURN clause
 A strong `REF CURSOR` type is defined by a `RETURN` clause that defines the row structure the cursor must return.
 
 ```sql
-TYPE storong_cursor IS REF CURSOR RETURN employees%ROWTYPE;  -- strong type
+TYPE strong_cursor IS REF CURSOR RETURN employees%ROWTYPE;  -- strong type
 ```
 
 ### Supported RETURN Types
@@ -426,6 +456,8 @@ This feature is available from MariaDB 13.1, in `sql_mode=ORACLE` only.
 {% endhint %}
 
 A `TYPE` declaration can appear in a package specification. Such a type is public: routines outside the package can declare variables of it by qualifying the type name with the name of the package that declares it. A `TYPE` declaring a record, associative array, or `REF CURSOR` can therefore be shared between schema-level (standalone) and package routines.
+
+For using a `RECORD` type as a parameter or `RETURN` type inside its declaring package — available from MariaDB 13.0.1, without qualified names — see [RECORD Types in Package Routine Parameters and Function RETURN](#record-types-in-package-routine-parameters-and-function-return).
 
 ### Syntax
 

--- a/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
@@ -189,7 +189,7 @@ DELIMITER ;
 
 In `sql_mode=ORACLE`, the `TYPE ... IS RECORD` statement allows you to define a user-defined data structure consisting of one or more fields.
 
-Before MariaDB 13.0.1, TYPE-defined `RECORD` types could only be used in local program blocks, and not in routine parameters or function `RETURN` clauses.
+Before MariaDB 13.0.1, TYPE-defined `RECORD` types could only be used in local program blocks. Starting from MariaDB 13.0.1, `RECORD` can additionally be used in package routine parameters and package function `RETURN` clauses.
 
 ### **Syntax**
 
@@ -204,18 +204,20 @@ TYPE record_type_name IS RECORD (
 * Each `field_name` is a named attribute of the record.
 * Each `data_type` is a valid MariaDB data type, or an anchored type using `%TYPE` (for example, `t1.a%TYPE`). Record fields support only scalar types, so `%ROWTYPE` cannot be used here.
 
-### RECORD Types in Routine Parameters and Function RETURN
+### RECORD Types in Package Routine Parameters and Function RETURN
 
 Starting with MariaDB 13.0.1, custom types defined with `DECLARE TYPE` (including `RECORD` and `REF CURSOR`) can be used as:
 
-* Parameters of stored procedures and functions
-* `RETURN` types of stored functions
+* Parameters of procedures and functions declared in a package
+* `RETURN` types of functions declared in a package
+
+This applies to package routines only. Standalone procedures and functions cannot use a TYPE-defined type as a parameter or as a `RETURN` type.
 
 {% hint style="warning" %}
 Two limitations apply:
 
 * Associative array types (`TYPE ... IS TABLE OF ... INDEX BY`) cannot be used as routine parameters or as a function `RETURN` type. Attempting it fails with `ERROR 4079 (HY000): Illegal parameter data type associative_array for operation '<routine parameter>'`.
-* A type declared in a package body is visible only inside that package. A standalone routine cannot reference it, and fails with `ERROR 1221 (HY000): Incorrect usage of parameter_declaration and package_name.type_name`.
+* A type declared in a package body is visible only inside that package. A standalone routine that references it fails with `ERROR 1221 (HY000): Incorrect usage of parameter_declaration and package_name.type_name`.
 {% endhint %}
 
 Before that release, such use was prohibited by the MariaDB grammar and resulted in:
@@ -287,13 +289,9 @@ This feature requires Oracle SQL mode at package creation time. The SQL mode is 
 
 ## REF CURSOR Types
 
-MariaDB supports Oracle-compatible [`REF CURSOR`](#overview) type declarations as a part of the `DECLARE TYPE` statement. The examples in this section declare `REF CURSOR` types inside a `CREATE PACKAGE BODY`.
+MariaDB supports Oracle-compatible [`REF CURSOR`](#overview) type declarations as part of the `DECLARE TYPE` statement. Like any other `DECLARE TYPE` declaration, a `REF CURSOR` type can be declared in a `DECLARE ... BEGIN ... END` block, in a stored routine, or in a package body. The complete examples below use anonymous blocks and standalone procedures.
 
 `REF CURSOR` types must be specified with a `TYPE` declaration before any variables of that type can be declared. It can be defined as weak or strong based on whether a return type is specified.
-
-{% hint style="info" %}
-Support for `TYPE` declarations in the package specification (`CREATE PACKAGE`), in addition to the package body (`CREATE PACKAGE BODY`), is planned for MariaDB 13.1 and may change before release. The two are expected to behave slightly differently; this section describes declarations in the package body.
-{% endhint %}
 
 ### Syntax
 

--- a/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/declare-type.md
@@ -8,7 +8,11 @@ description: >-
 # DECLARE TYPE
 
 {% hint style="info" %}
-This feature is available from MariaDB 12.1.
+The type declarations on this page were introduced in different releases:
+
+* `TYPE ... IS RECORD` — from MariaDB 11.8.1
+* `TYPE ... IS TABLE OF ... INDEX BY` (associative arrays) — from MariaDB 12.0.1
+* `TYPE ... IS REF CURSOR` — from MariaDB 13.0.1
 {% endhint %}
 
 ## Overview
@@ -21,12 +25,12 @@ The general syntax for defining associative array types is as follows:
 
 ```sql
 DECLARE
-   TYPE type_name TABLE OF rec_type_name INDEX BY idx_type_name
+   TYPE type_name IS TABLE OF element_type INDEX BY key_type
 ```
 
-* `type_name` supports explicit and anchored data types (for instance, `t1.col1%TYPE`).
-* `rec_type_name` supports scalar and record data types.
-* The `INDEX BY` clause defines the key type using `idx_type_name`, which supports integer and string data types.
+* `type_name` is the name of the new associative array type.
+* `element_type` is the type of each value. It supports scalar and record types, explicit or anchored (for example, `t1.col1%TYPE` or `t1%ROWTYPE`).
+* `key_type` defines the key type. It must be a plain integer or string type — anchored types such as `t1.col1%TYPE` are not accepted here.
 
 ## Associative Arrays
 
@@ -72,6 +76,8 @@ These differences are largely rooted in architectural constraints — MariaDB is
 **Explicit type\_name**
 
 ```sql
+SET sql_mode=ORACLE;
+DELIMITER /
 DECLARE
   TYPE salary IS TABLE OF NUMBER INDEX BY VARCHAR2(20);
   salary_list salary;
@@ -82,17 +88,21 @@ BEGIN
   name:= salary_list.FIRST;
   WHILE name IS NOT NULL
   LOOP
-    dbms_output.put_line(name || ' ' || TO_CHAR(salary_list(name)));
+    SELECT name || ' ' || salary_list(name);
     name:= salary_list.NEXT(name);
   END LOOP;
 END;
 /
+DELIMITER ;
 ```
 
 **Anchored type\_name**
 
 ```sql
+DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (a INT);
+SET sql_mode=ORACLE;
+DELIMITER /
 DECLARE
   TYPE salary IS TABLE OF t1.a%TYPE INDEX BY VARCHAR2(20);
   salary_list salary;
@@ -103,11 +113,12 @@ BEGIN
   name:= salary_list.FIRST;
   WHILE name IS NOT NULL
   LOOP
-    dbms_output.put_line(name || ' ' || TO_CHAR(salary_list(name)));
+    SELECT name || ' ' || salary_list(name);
     name:= salary_list.NEXT(name);
   END LOOP;
 END;
 /
+DELIMITER ;
 ```
 
 #### Associative Array of Records
@@ -115,6 +126,8 @@ END;
 **Using Explicit Data Types**
 
 ```sql
+SET sql_mode=ORACLE;
+DELIMITER /
 DECLARE
   TYPE person_t IS RECORD
   (
@@ -122,69 +135,74 @@ DECLARE
     last_name VARCHAR(64)
   );
   person person_t;
-  TYPE table_of_peson_t IS TABLE OF person_t INDEX BY VARCHAR(20);
-  person_by_nickname table_of_peson_t;
+  TYPE table_of_person_t IS TABLE OF person_t INDEX BY VARCHAR(20);
+  person_by_nickname table_of_person_t;
   nick VARCHAR(20);
 BEGIN
   person_by_nickname('Monty') := person_t('Michael', 'Widenius');
-  person_by_nickname('Serg') := person_t('Sergei ', 'Golubchik');
+  person_by_nickname('Serg') := person_t('Sergei', 'Golubchik');
   nick:= person_by_nickname.FIRST;
   WHILE nick IS NOT NULL
   LOOP
     person:= person_by_nickname(nick);
-    dbms_output.put_line(nick || ' ' || person.first_name || ' '|| person.last_name);
+    SELECT nick || ' ' || person.first_name || ' ' || person.last_name;
     nick:= person_by_nickname.NEXT(nick);
   END LOOP;
-  /
+END;
+/
+DELIMITER ;
 ```
 
 **Using Anchored Data Types**
 
 ```sql
-DROP TABLE persons;
+DROP TABLE IF EXISTS persons;
 CREATE TABLE persons (nickname VARCHAR(64), first_name VARCHAR(64), last_name VARCHAR(64));
-INSERT INTO persons VALUES ('Serg','Sergei ', 'Golubchik');
+INSERT INTO persons VALUES ('Serg','Sergei', 'Golubchik');
 INSERT INTO persons VALUES ('Monty','Michael', 'Widenius');
+SET sql_mode=ORACLE;
+DELIMITER /
 DECLARE
-  TYPE table_of_person_t IS TABLE OF persons%ROWTYPE INDEX BY persons.nickname%TYPE;
+  TYPE table_of_person_t IS TABLE OF persons%ROWTYPE INDEX BY VARCHAR(64);
   person_by_nickname table_of_person_t;
-  nickname persons.nickname%TYPE;
+  nickname VARCHAR(64);
   person persons%ROWTYPE;
 BEGIN
   FOR rec IN (SELECT * FROM persons)
   LOOP
     person_by_nickname(rec.nickname):= rec;
   END LOOP;
- 
+
   nickname:= person_by_nickname.FIRST;
   WHILE nickname IS NOT NULL
   LOOP
     person:= person_by_nickname(nickname);
-    dbms_output.put_line(person.nickname || ' ' || person.first_name || ' '|| person.last_name);
+    SELECT person.nickname || ' ' || person.first_name || ' ' || person.last_name;
     nickname:= person_by_nickname.NEXT(nickname);
   END LOOP;
 END;
 /
+DELIMITER ;
 ```
 
 ## RECORD Types
 
 In `sql_mode=ORACLE`, the `TYPE ... IS RECORD` statement allows you to define a user-defined data structure consisting of one or more fields.
 
-Previously, TYPE-defined `RECORD` types could only be used in local program blocks and not in routine parameters or function `RETURN` clauses.
+Before MariaDB 13.0.1, TYPE-defined `RECORD` types could only be used in local program blocks, and not in routine parameters or function `RETURN` clauses.
 
 ### **Syntax**
 
 ```sql
 TYPE record_type_name IS RECORD (
-    field_name data_type [NOT NULL] [DEFAULT expr],
+    field_name data_type,
     ...
 );
 ```
 
 * `record_type_name` is the name of the new record type.
 * Each `field_name` is a named attribute of the record.
-* Each `field_type` is a valid MariaDB data type or anchored type (`%TYPE`, `%ROWTYPE`).
+* Each `data_type` is a valid MariaDB data type, or an anchored type using `%TYPE` (for example, `t1.a%TYPE`). Record fields support only scalar types, so `%ROWTYPE` cannot be used here.
 
 ### RECORD Types in Routine Parameters and Function RETURN
 
@@ -193,17 +211,22 @@ Starting with MariaDB 13.0.1, custom types defined with `DECLARE TYPE` (includin
 * Parameters of stored procedures and functions
 * `RETURN` types of stored functions
 
-Earlier, the use of a `RECORD` type in these contexts was prohibited by the MariaDB grammar and resulted in:
+{% hint style="warning" %}
+Two limitations apply:
+
+* Associative array types (`TYPE ... IS TABLE OF ... INDEX BY`) cannot be used as routine parameters or as a function `RETURN` type. Attempting it fails with `ERROR 4079 (HY000): Illegal parameter data type associative_array for operation '<routine parameter>'`.
+* A type declared in a package body is visible only inside that package. A standalone routine cannot reference it, and fails with `ERROR 1221 (HY000): Incorrect usage of parameter_declaration and package_name.type_name`.
+{% endhint %}
+
+Before that release, such use was prohibited by the MariaDB grammar and resulted in:
 
 ```
-ERROR 4161 (HY000): Unknown data type
+ERROR 4161 (HY000): Unknown data type: 'rec0_t'
 ```
-
-This change improves compatibility with Oracle PL/SQL, especially for private helper routines inside packages and for `REF CURSOR` usage.
 
 ### Using RECORDs in Routine Parameters
 
-Starting with MariaDB 13.0.1, stored procedures within the same package can use a `RECORD` type declared inside the package body as a parameter.
+Starting with MariaDB 13.0.1, stored routines within the same package can use a `RECORD` type declared inside the package body as a parameter.
 
 ```sql
 SET sql_mode=ORACLE;
@@ -211,19 +234,22 @@ DELIMITER $$
 CREATE OR REPLACE PACKAGE pkg1 AS
   PROCEDURE p1();
 END;
+$$
 CREATE OR REPLACE PACKAGE BODY pkg1 AS
   TYPE rec0_t IS RECORD (a INT, b VARCHAR(2), c INT);
-  PROCEDURE private_p1(p0 rec0_t) AS
+  PROCEDURE private_p1(pr0 rec0_t) AS
   BEGIN
-    NULL;
+    SELECT pr0.a || pr0.b || pr0.c;
   END;
   PROCEDURE p1 AS
+    r0 rec0_t := (1,'ab',2);
   BEGIN
-    CALL private_p1(a0);
+    private_p1(r0);
   END;
 END;
 $$
 DELIMITER ;
+CALL pkg1.p1;
 ```
 
 ### Using RECORDs as a Function Return Type
@@ -236,19 +262,23 @@ DELIMITER $$
 CREATE OR REPLACE PACKAGE pkg1 AS
   PROCEDURE p1();
 END;
+$$
 CREATE OR REPLACE PACKAGE BODY pkg1 AS
   TYPE rec0_t IS RECORD (a INT, b VARCHAR(2), c INT);
   FUNCTION private_f1() RETURN rec0_t AS
   BEGIN
-    RETURN NULL;
+    RETURN rec0_t(1,'ab',2);
   END;
-  PROCEDURE p1() AS
+  PROCEDURE p1 AS
+    r0 rec0_t;
   BEGIN
-    DO private_f1();
+    r0:= private_f1();
+    SELECT r0.a || r0.b || r0.c;
   END;
 END;
 $$
 DELIMITER ;
+CALL pkg1.p1;
 ```
 
 ### Requirement
@@ -257,9 +287,13 @@ This feature requires Oracle SQL mode at package creation time. The SQL mode is 
 
 ## REF CURSOR Types
 
-MariaDB supports Oracle-compatible `REF CURSOR` type declarations as a part of the `DECLARE TYPE` statement. A `REF CURSOR` is a cursor variable that can refer to a query result set and be passed across program blocks, such as stored procedures or functions.
+MariaDB supports Oracle-compatible [`REF CURSOR`](#overview) type declarations as a part of the `DECLARE TYPE` statement. The examples in this section declare `REF CURSOR` types inside a `CREATE PACKAGE BODY`.
 
 `REF CURSOR` types must be specified with a `TYPE` declaration before any variables of that type can be declared. It can be defined as weak or strong based on whether a return type is specified.
+
+{% hint style="info" %}
+Support for `TYPE` declarations in the package specification (`CREATE PACKAGE`), in addition to the package body (`CREATE PACKAGE BODY`), is planned for MariaDB 13.1 and may change before release. The two are expected to behave slightly differently; this section describes declarations in the package body.
+{% endhint %}
 
 ### Syntax
 
@@ -284,7 +318,7 @@ TYPE weak_cursor IS REF CURSOR; -- weak type: no RETURN clause
 A strong `REF CURSOR` type is defined by a `RETURN` clause that defines the row structure the cursor must return.
 
 ```sql
-TYPE storong_cursor IS REF CURSOR RETURN employees%ROWTYPE;  -- strong type
+TYPE strong_cursor IS REF CURSOR RETURN employees%ROWTYPE;  -- strong type
 ```
 
 ### Supported RETURN Types


### PR DESCRIPTION
Records that from MariaDB 13.0.1, types defined with DECLARE TYPE can be used as stored routine parameters and as function RETURN types, with a warning hint covering the two limitations: associative array types are rejected (ERROR 4079), and a type declared in a package body is not visible to standalone routines (ERROR 1221).

Also corrects the page's version hint, which claimed a single 12.1 introduction, to list the three declaration forms and their actual releases (RECORD 11.8.1, associative arrays 12.0.1, REF CURSOR 13.0.1).

Reworks the runnable examples: adds the SET sql_mode=ORACLE and DELIMITER lines they need, fixes an unterminated block, and replaces dbms_output.put_line calls with SELECT. Fixes two typos in identifiers (table_of_peson_t, storong_cursor) and tightens the associative array and RECORD syntax descriptions.


## DOCS-6031: RECORD in routine parameters and function RETURN — reviewer follow-up

This PR addresses Alexander Barkov's review comments on the original GitBook commit (266844d), plus additional issues found while verifying every SQL example on this page against a locally built MariaDB server (pinned to origin/main @ 0ee34e07, MariaDB 13.1.0-alpha).

### Verification approach

All SQL examples on this page were run against a real MariaDB server built from source (not just checked against grammar/source reading), per Barkov's repeated request to "run the script in MariaDB." This caught several failures that a static read would have missed — see below.

### Barkov's review comments — addressed

| # | Comment | Fix |
|---|---|---|
| 1 | "Previously" → clarify version | Changed to "Before MariaDB 13.0.1" |
| 2 | `[NOT NULL]`/`DEFAULT` not supported in `TYPE...IS RECORD` | Removed from syntax block — confirmed unsupported by grammar (`sql_yacc.yy`) and by execution (`ERROR 1064`) |
| 3 | Only `%TYPE` supported, not `%ROWTYPE`, for RECORD fields | Updated bullet; RECORD fields only support scalar types |
| 4 | Remove "improves compatibility" sentence (noise) | Deleted |
| 5 | "stored procedures" → "stored routines" | Updated — confirmed both procedures and functions are affected by the grammar change |
| 6 | `a0` undeclared in parameter example | Declared the variable properly; example now runs and returns `1ab2` |
| 7 | `DO private_f1()` fails; add `CALL pkg1.p1()` | Rewrote to assign the RECORD return value to a variable instead of `DO`; added the missing `CALL`. Confirmed working. |
| 8 | REF CURSOR section needs to clarify it's describing package-body scope, given MDEV-39587 (13.1) adds package-spec `TYPE` declarations with different behavior | Added a scoping sentence + an info hint noting the 13.1 package-spec behavior is planned but may change before release (kept deliberately non-committal since 13.1 is unreleased) |
| 9 | Remove REF CURSOR definition sentence; link to the manual section describing REF CURSORs instead | **See note below** — linked to the page's Overview section instead of the `#ref-cursor-types` anchor Barkov initially suggested |

### Note on comment 9 — linking to `Overview` instead of `REF CURSOR` Types

Barkov's suggested anchor (`#ref-cursor-types`) actually points to the same section this sentence sits in — linking there would be circular (the paragraph would link back to itself). Since the definition sentence is also being removed here, I linked to the page's **Overview** section instead, which already contains a near-identical definition of REF 
CURSOR. This preserves the reader's ability to find the definition without a self-referencing link. Flagging this explicitly for review since it's a small deviation from what was literally requested — happy to adjust if a different target is preferred.

### Additional issues found during verification (beyond the original 9 comments)

While testing every example on the page, several more examples failed when actually run, even after applying the fixes above:

- **Associative array examples used `dbms_output.put_line`**, which   isn't a real MariaDB feature — it's test-suite scaffolding, not something available to users. Replaced with plain `SELECT` statements (10 call sites total; fixed all in this ticket's scope).
- **Anonymous blocks used a bare `/` with no `DELIMITER`**, causing the   MariaDB client to split on `;` and throw cascading errors. Added proper `DELIMITER` handling to all affected examples in scope.
- **`TO_CHAR(<number>)`** doesn't work in MariaDB (only accepts   date/time/string types, unlike Oracle) — removed in favor of string concatenation, which was already sufficient for the example.
- **`INDEX BY <table>.<column>%TYPE`** isn't valid — the `INDEX BY` clause only accepts plain scalar types, not anchored types. Fixed to use a plain type.
- **Overview syntax block was missing the mandatory `IS` keyword** —   fixed; the block as originally written would throw `ERROR 1064`.
- **Overview bullets described the wrong operand** (`type_name` vs. the element type) — corrected.
- **`DROP TABLE persons;`** fails on a clean server — added `IF EXISTS`. Fixed two typos: `table_of_peson_t` → `table_of_person_t`, `storong_cursor` → `strong_cursor`.
- Corrected the version availability hint at the top of the page — it claimed everything was "available from MariaDB 12.1," which is wrong for every feature described (RECORD → 11.8.1, associative arrays → 12.0.1, REF CURSOR → 13.0.1).
- Added two previously undocumented limitations: associative arrays cannot be used as routine parameters or return types, and package-body types are not visible to standalone routines.

### Deferred to a follow-up ticket (out of scope here)

- `PLS_INTEGER` (line ~39) doesn't exist in MariaDB — the example is   explicitly framed as Oracle syntax, so likely intentional, but worth a follow-up decision.
- The six REF CURSOR examples further down the page (owned by DOCS-6030) have the same `DBMS_OUTPUT`/`DELIMITER` issues found here, but weren't touched since they belong to a different ticket's scope.

### Testing

All corrected examples were executed against a MariaDB server built from `origin/main` @ `0ee34e07` (13.1.0-alpha) in `sql_mode=ORACLE`. Exact error messages quoted above (e.g., `ERROR 1241 (21000)`) were reproduced from the unfixed page text before applying each fix.

cc @abarkov for review, especially on the comment 9 link target note above.

---

Note: this PR also touches #878's section (additive only).

As part of resolving the semantic overlap with the merged PR #878 (DOCS-6256 / MDEV-39587, "Package-Wide Types", MariaDB 13.1), this update adds one cross-reference paragraph inside #878's ## Package-Wide Types section. It points back to this page's ### RECORD Types in Package Routine Parameters and Function RETURN section, so the two "where can this type be used" areas link to each other rather than each reading as the complete story.

This is additive only — no existing text, examples, or tables in the Package-Wide Types section were changed or removed. The added paragraph reads:

> For using a RECORD type as a parameter or RETURN type inside its declaring package — available from MariaDB 13.0.1, without qualified names — see RECORD Types in Package Routine Parameters and Function RETURN (#record-types-in-package-routine-parameters-and-function-return).