### PR TITLE
DOCS-6454 Fix wrong nouns and broken sentence in Stored Procedure Overview

### DIFF
--- a/server/server-usage/stored-routines/stored-procedures/stored-procedure-overview.md
+++ b/server/server-usage/stored-routines/stored-procedures/stored-procedure-overview.md
@@ -24,7 +24,7 @@ CREATE PROCEDURE Reset_animal_count()
 DELIMITER ;
 ```
 
-First, the delimiter is changed, since the function definition will contain the regular semicolon delimiter. The procedure is named `Reset_animal_count`. `MODIFIES SQL DATA` indicates that the procedure will perform a write action of sorts, and modify data. It's for advisory purposes only. Finally, there's the actual SQL statement - an UPDATE.
+First, the delimiter is changed, since the procedure definition will contain the regular semicolon delimiter. The procedure is named `Reset_animal_count`. `MODIFIES SQL DATA` indicates that the procedure will perform a write action of sorts, and modify data. It's for advisory purposes only. Finally, there's the actual SQL statement - an `UPDATE`.
 
 ```sql
 SELECT * FROM animal_count;
@@ -69,13 +69,13 @@ CREATE PROCEDURE
 
 See [CREATE PROCEDURE](create-procedure.md) for full syntax details.
 
-## Why use Stored Procedures?
+## Why Use Stored Procedures?
 
 Security is a key reason. Banks commonly use stored procedures so that applications and users don't have direct access to the tables. Stored procedures are also useful in an environment where multiple languages and clients are all used to perform the same operations.
 
-## Stored Procedure listings and definitions
+## Stored Procedure Listings and Definitions
 
-To find which stored functions are running on the server, use [SHOW PROCEDURE STATUS](../../../reference/sql-statements/administrative-sql-statements/show/show-procedure-status.md).
+To find which stored procedures are defined on the server, use [SHOW PROCEDURE STATUS](../../../reference/sql-statements/administrative-sql-statements/show/show-procedure-status.md).
 
 ```sql
 SHOW PROCEDURE STATUS\G
@@ -124,11 +124,11 @@ collation_connection: utf8_general_ci
 
 To drop a stored procedure, use the [DROP PROCEDURE](drop-procedure.md) statement.
 
-```
+```sql
 DROP PROCEDURE Reset_animal_count;
 ```
 
-To change the characteristics of a stored procedure, use [ALTER PROCEDURE](alter-procedure.md). However, you cannot change the parameters or body of a stored procedure using this statement; to make such changes, you must drop and re-create the procedure using [CREATE OR REPLACE PROCEDURE](create-procedure.md#or-replace) (which retains existing privileges), or DROP PROCEDURE followed CREATE PROCEDURE .
+To change the characteristics of a stored procedure, use [ALTER PROCEDURE](alter-procedure.md). However, you cannot change the parameters or body of a stored procedure using this statement; to make such changes, you must drop and re-create the procedure using [CREATE OR REPLACE PROCEDURE](create-procedure.md#or-replace) (which retains existing privileges), or [DROP PROCEDURE](drop-procedure.md) followed by [CREATE PROCEDURE](create-procedure.md).
 
 ## Permissions in Stored Procedures
 


### PR DESCRIPTION
Follow-up to community PR #888 (David Liu), which removed the invalid parentheses from this page's `DROP PROCEDURE` example. Reading the whole page for that review turned up five more defects. Ticket: [DOCS-6454](https://mariadbcorp.atlassian.net/browse/DOCS-6454).

## Wrong

**`SHOW PROCEDURE STATUS` was described as listing "stored functions" that are "running".** Both halves were wrong. It lists **procedures** — `SHOW FUNCTION STATUS` is the separate statement for functions, as [`show-procedure-status.md`](../blob/main/server/reference/sql-statements/administrative-sql-statements/show/show-procedure-status.md) itself says — and it lists routines **defined** in the catalog, not ones currently executing. Now: "To find which stored procedures are defined on the server".

**A `CREATE PROCEDURE` walkthrough called it "the function definition".** Now "procedure definition". The same sentence's bare `UPDATE` is now inline code, matching the rest of the page.

## Presentation

- **An unterminated sentence:** "…or DROP PROCEDURE followed CREATE PROCEDURE ." — missing "by", stray space before the period, and both statement names bare where every other mention on the page is a link. Now reads "…or [DROP PROCEDURE](…) followed by [CREATE PROCEDURE](…)."
- **Bare ` ``` ` fence** on the `DROP PROCEDURE` example → ` ```sql `, matching the page's other nine blocks.
- **Heading case:** "Why use Stored Procedures?" → "Why Use Stored Procedures?", "Stored Procedure listings and definitions" → "Stored Procedure Listings and Definitions".

## Scope

One file. No heading that anything links to changed — the two retitled headings have no inbound anchor links, and no link target changed, so there is no redirect or nav impact.

## Checks

`doc-lint.sh` clean (codespell + lychee). Verified the linter actually executed rather than trusting its silence: a canary run with a planted 404 reported `12 Total / 11 OK / 1 Error`, the 11 confirming this page's links — including the two newly added relative links — all resolve.

[DOCS-6454]: https://mariadbcorp.atlassian.net/browse/DOCS-6454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ