### PR TITLE
DOCS-6448 Note third-party storage engines as contributions

### DIFF
--- a/server/server-usage/storage-engines/choosing-the-right-storage-engine.md
+++ b/server/server-usage/storage-engines/choosing-the-right-storage-engine.md
@@ -8,6 +8,10 @@ description: >-
 
 A high-level overview of the main reasons for choosing a particular storage engine:
 
+{% hint style="info" %}
+CONNECT, Mroonga, MyRocks, OQGRAPH, SphinxSE, and VIDEX are community contributions, developed and maintained by their respective contributors. Each of those engines' pages says who maintains it.
+{% endhint %}
+
 ## Topic List
 
 ### General Purpose

--- a/server/server-usage/storage-engines/connect/README.md
+++ b/server/server-usage/storage-engines/connect/README.md
@@ -4,6 +4,10 @@ description: The CONNECT storage engine.
 
 # CONNECT
 
+{% hint style="info" %}
+CONNECT is a community contribution to MariaDB Server, developed and maintained by its contributor, Olivier Bertrand.
+{% endhint %}
+
 You can download a PDF version of the CONNECT documentation (1.7.0003):
 
 {% file src="../../../.gitbook/assets/connect_1_7_03.pdf" %}

--- a/server/server-usage/storage-engines/machine-learning-with-mindsdb.md
+++ b/server/server-usage/storage-engines/machine-learning-with-mindsdb.md
@@ -6,6 +6,10 @@ description: >-
 
 # Machine Learning with MindsDB
 
+{% hint style="info" %}
+MindsDB is third-party software, not developed or maintained by MariaDB and not included with MariaDB Server. MariaDB doesn't test, validate, or support it. Refer to its own documentation and license terms.
+{% endhint %}
+
 ## Overview
 
 [MindsDB](https://docs.mindsdb.com/) is a third-party application that interfaces with MariaDB Server to provide Machine Learning capabilities through SQL. The interface is done via the [Connect Storage Engine](connect/).

--- a/server/server-usage/storage-engines/mroonga/README.md
+++ b/server/server-usage/storage-engines/mroonga/README.md
@@ -6,6 +6,10 @@ description: >-
 
 # Mroonga
 
+{% hint style="info" %}
+Mroonga is a community contribution to MariaDB Server, developed and maintained by the Mroonga project.
+{% endhint %}
+
 {% columns %}
 {% column %}
 {% content-ref url="mroonga-overview.md" %}

--- a/server/server-usage/storage-engines/myrocks/README.md
+++ b/server/server-usage/storage-engines/myrocks/README.md
@@ -7,6 +7,10 @@ description: >-
 
 # MyRocks
 
+{% hint style="info" %}
+MyRocks is a community contribution to MariaDB Server. It is based on RocksDB and on Facebook's MyRocks, which are developed and maintained upstream, outside MariaDB.
+{% endhint %}
+
 {% columns %}
 {% column %}
 {% content-ref url="about-myrocks-for-mariadb.md" %}

--- a/server/server-usage/storage-engines/oqgraph-storage-engine/README.md
+++ b/server/server-usage/storage-engines/oqgraph-storage-engine/README.md
@@ -7,6 +7,10 @@ description: >-
 
 # OQGRAPH
 
+{% hint style="info" %}
+OQGRAPH is a community contribution to MariaDB Server, developed and maintained by its contributors: Arjen Lentz and Antony T Curtis of Open Query, and Andrew McDonnell.
+{% endhint %}
+
 {% columns %}
 {% column %}
 {% content-ref url="oqgraph-overview.md" %}

--- a/server/server-usage/storage-engines/sphinx-storage-engine/README.md
+++ b/server/server-usage/storage-engines/sphinx-storage-engine/README.md
@@ -7,6 +7,10 @@ description: >-
 
 # SphinxSE
 
+{% hint style="info" %}
+SphinxSE is a community contribution to MariaDB Server, developed and maintained by the Sphinx developers. The Sphinx search daemon that it connects to is separate software, and isn't part of MariaDB Server.
+{% endhint %}
+
 {% columns %}
 {% column %}
 {% content-ref url="about-sphinxse.md" %}

--- a/server/server-usage/storage-engines/videx-storage-engine.md
+++ b/server/server-usage/storage-engines/videx-storage-engine.md
@@ -7,7 +7,7 @@ description: >-
 # VIDEX Storage Engine
 
 {% hint style="info" %}
-This storage engine is available from MariaDB 12.3.
+VIDEX is a community contribution to MariaDB Server, developed and maintained by ByteDance. This storage engine is available from MariaDB 12.3.
 {% endhint %}
 
 This document explains how to install and use **VIDEX** with MariaDB, including:


### PR DESCRIPTION
Adds the third-party notice to the storage engine pages, in the toned-down form agreed with **Oleksandr Byelkin** (storage engines) and **Ralf Gebhardt** (PM) in [this ticket comment](https://mariadbcorp.atlassian.net/browse/DOCS-6448?focusedCommentId=1131121): the engine is *a contribution, maintained by its contributor(s)* — with **no claim about MariaDB support**, unlike the client-page notice from DOCS-6443.

## Pages changed (8)

Six engines, per their classification — one notice on each engine's landing page, not on all 95 pages in those subtrees:

| Page | Maintainer named |
|---|---|
| `connect/README.md` | Olivier Bertrand |
| `mroonga/README.md` | The Mroonga project |
| `myrocks/README.md` | upstream RocksDB / Facebook's MyRocks |
| `oqgraph-storage-engine/README.md` | Arjen Lentz & Antony T Curtis (Open Query), Andrew McDonnell |
| `sphinx-storage-engine/README.md` | The Sphinx developers |
| `videx-storage-engine.md` | ByteDance |

Plus:

- `machine-learning-with-mindsdb.md` — keeps the **DOCS-6443 client wording** verbatim, because MindsDB is an external application reached through CONNECT, not a contributed engine, so "not included with MariaDB Server" is accurate there.
- `choosing-the-right-storage-engine.md` — one aggregate notice listing the six, answering the ticket's open question. See below.

Each maintainer name comes from that plugin's declared author in the server source, which is also what a user sees in `SHOW PLUGINS` / `information_schema.PLUGINS` — not from my own recollection.

## Three judgment calls, easy to drop if you disagree

1. **DuckDB gets no notice.** The ticket listed it under "uncontroversial scope", but the sign-off classifies `duckdb/` as *"our (but separate department)"*. The page agrees: the engine is MariaDB-written, borrowing its design from AliSQL and linking against upstream DuckDB. Its existing `Experimental — for evaluation only` hint is untouched.
2. **MyRocks wording is hedged on purpose.** `about-myrocks-for-mariadb.md` says MyRocks "has been extended by the MariaDB engineering team" and is merged with upstream under Sergei Petrunia's lead — so "maintained by its contributors" would contradict the page. The notice instead says it is *based on* RocksDB and Facebook's MyRocks, which are maintained upstream. Worth a second look from Oleksandr, since the classification and the page pull in different directions.
3. **The aggregate notice went on `choosing-the-right-storage-engine.md` but not on the storage-engines landing page.** The comparison page is where a reader picks; the landing page is a list of nav cards with no engine claims of its own.

Not in scope: TideSQL, whose page doesn't exist yet.

## Checks

`doc-lint.sh` clean on all 8 files, and **verified to have actually run** — a planted 404 canary produced `138 Total / 137 OK / 1 Error`, so the clean result is real and these pages carry no pre-existing link rot.

Ticket: https://mariadbcorp.atlassian.net/browse/DOCS-6448

🤖 Generated with [Claude Code](https://claude.com/claude-code)