### PR TITLE
DOCS-6226 Document --flashback row-decode error reporting

### DIFF
--- a/server/server-management/server-monitoring-logs/binary-log/flashback.md
+++ b/server/server-management/server-monitoring-logs/binary-log/flashback.md
@@ -54,6 +54,31 @@ A common use case for Flashback is the following scenario:
 * Invoke [mariadb-binlog](../../../clients-and-utilities/logging-tools/mariadb-binlog/) to find the exact log position of the first offending operation after the state you want to revert to.
 * Run `mariadb-binlog --flashback --start-position=xyz | mariadb` to pipe the output of `mariadb-binlog` directly to the `mariadb` client, or save the output to a file and then direct the file to the command-line client.
 
+## Error Reporting
+
+If `mariadb-binlog --flashback` cannot decode a row image while reversing an event, it writes a diagnostic to standard error and exits with status 1:
+
+```
+Error decoding row image while converting event for --flashback (could not determine field length): event=Delete_rows_v1, column=1, column_type=252, metadata=5
+```
+
+```
+Error decoding row image while converting event for --flashback (field extends past row buffer): event=Delete_rows_v1, column=1
+```
+
+The parenthesized reason is one of:
+
+* `could not determine field length` — the column's type and metadata, as recorded in the table map event, do not yield a field length. The message also reports `column_type` and `metadata`.
+* `field extends past row buffer` — the decoded field length runs past the end of the row image.
+
+Either reason means the event cannot be reversed, for example because the binary log is corrupt or was written by a server whose row format `mariadb-binlog` cannot decode.
+
+`column` is the zero-based column index within the row image. For `UPDATE` events the message also states which image failed, for example `event=Update_rows (before image)`. The event name is the _converted_ event type, so an `INSERT` that could not be reversed is reported as a `Delete_rows` event.
+
+{% hint style="info" %}
+Before MariaDB 13.1, both conditions were reported as `Error row length: 0`, which identified neither the event nor the column.
+{% endhint %}
+
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}


### PR DESCRIPTION
[DOCS-6226](https://mariadbcorp.atlassian.net/browse/DOCS-6226) · [MDEV-20749](https://jira.mariadb.org/browse/MDEV-20749) · Release Series 13.1

MDEV-20749 replaced `mariadb-binlog --flashback`'s terse `Error row length: 0` with a diagnostic that names the failure reason, the event, the image (for `UPDATE` events) and the column. This adds an **Error Reporting** section to the Flashback page.

One page changed: `server/server-management/server-monitoring-logs/binary-log/flashback.md` (+25 lines, new section before the licence footer).

## What the section covers

- The two reason strings — `could not determine field length` and `field extends past row buffer` — with sample output copied verbatim from the new mtr result files.
- What `column`, `column_type` and `metadata` mean, and that `column` is zero-based.
- That `UPDATE` events additionally report `(before image)` / `(after image)`.
- That the reported event name is the **flashback-converted** type, so a failed `INSERT` reversal shows up as a `Delete_rows` event — the single most confusing part of the new message.
- A `{% hint style="info" %}` noting the pre-13.1 message.

## Verification

Verified against `mariadb-server @ da18481158c81ca94689702073c3e04aad85a6a3` (ref `main`, `VERSION` 13.1.0 alpha — currently `origin/main` HEAD). Fix commits: `2129804256b` (monthdev, reviewed by Brandon Nesterenko and Georgi Kodinov) and the style addendum `da18481158c` (Georgi Kodinov).

| Claim | Evidence |
|---|---|
| Both messages, written to stderr | `sql/log_event_client.cc:1450-1466` |
| `column_type` / `metadata` on the bad-length case | `sql/log_event_client.cc:1448-1457` |
| `column` is the zero-based image index | loop index `i`; `mdev_20749_bad_field_length.result` reports `column=1` for the second column |
| `(before image)` / `(after image)` on UPDATE only | `sql/log_event_client.cc:1442-1447` |
| Reported name is the converted event type | `sql/log_event_client.cc:1741-1745, 1770`; `sql/log_event.cc:665-670`; an `INSERT` yields `event=Delete_rows_v1` in `mdev_20749_truncated.result` |
| Exit status 1 | `sql/log_event_client.cc:1769-1773`; both `mdev_20749_*.test` files assert `--error 1` |
| Pre-13.1 wording was `Error row length: 0` | `sql/log_event_client.cc @ 2129804256b^` |

One sentence is **not** source-provable and is hedged with "for example": that a decode failure typically means a corrupt binary log *or one written by a server whose row format `mariadb-binlog` cannot decode*. The corruption half matches the source comment at `log_event_client.cc:1460`; the other half comes from the MDEV-20749 report, where a MySQL 8.0 binary log hit this code path.

Full fact-check report is posted to the Jira ticket.

## Known expiry

[MDEV-40236](https://jira.mariadb.org/browse/MDEV-40236) (`0200fd905fb`, "Generalize `--flashback` error messages for non-flashback") exists **only on `origin/MDEV-20749`**, not in `main`. If it lands it drops `--flashback` from these message strings, and this section will need a refresh. Not documented here.

## Checks

`codespell`, `lychee` and the structural checks all pass locally via `.claude/hooks/doc-lint.sh`. No links added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MDEV-20749]: https://mdb2026-sandbox.atlassian.net/browse/MDEV-20749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MDEV-40236]: https://mdb2026-sandbox.atlassian.net/browse/MDEV-40236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOCS-6226]: https://mariadbcorp.atlassian.net/browse/DOCS-6226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ