### PR TITLE
DOCS-6449 Fix rotted external links on client and utility pages

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -128,6 +128,9 @@ if command -v lychee >/dev/null 2>&1; then
       --exclude 'www\.fsf\.org' \
       --exclude 'dba\.stackexchange\.com' \
       --exclude 'askubuntu\.com' \
+      --exclude 'valentina-db\.com' \
+      --exclude 'docs\.moodle\.org' \
+      --exclude 'www\.sqlmaestro\.com' \
       "${files[@]}" 2>&1)"; then
     # Mirror the workflow's failIfEmpty: false — lychee exits non-zero with
     # "No links were found" when the changed files contain no links, which is a

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -148,6 +148,18 @@ jobs:
           # and askubuntu.com answer 403 to any non-browser client (Stack
           # Exchange requires JS), and www.fsf.org fails lychee's connection
           # while serving 200 to a browser User-Agent. All are valid for readers.
+          #
+          # DOCS-6449 (2026-08-18): three vendor/doc hosts cited from
+          # server/clients-and-utilities/ that block automated clients, proven
+          # alive by the challenge each one serves rather than by a status code.
+          # valentina-db.com and www.sqlmaestro.com both sit behind Sucuri
+          # CloudProxy and return its "Javascript is required" interstitial (403
+          # and 307 respectively). docs.moodle.org answers with
+          # "Cf-Mitigated: challenge" from Cloudflare. A browser User-Agent does
+          # NOT get past any of the three, so there is no resolved URL to
+          # substitute -- unlike codex.wordpress.org, which was retired by
+          # WordPress and so got repointed at wordpress.org/documentation
+          # instead of excluded.
           args: >-
             --no-progress
             --exclude 'bazaar\.launchpad\.net'
@@ -213,6 +225,9 @@ jobs:
             --exclude 'www\.fsf\.org'
             --exclude 'dba\.stackexchange\.com'
             --exclude 'askubuntu\.com'
+            --exclude 'valentina-db\.com'
+            --exclude 'docs\.moodle\.org'
+            --exclude 'www\.sqlmaestro\.com'
             ${{ steps.list.outputs.files }}
           fail: true
           # Don't error when the changed files contain no links to check. lychee

--- a/server/clients-and-utilities/server-client-software/applications-supporting-mariadb.md
+++ b/server/clients-and-utilities/server-client-software/applications-supporting-mariadb.md
@@ -10,7 +10,7 @@ description: >-
 The projects listed on this page are third-party software, not developed or maintained by MariaDB. MariaDB doesn't test, validate, or support them. Refer to each project's own documentation and license terms.
 {% endhint %}
 
-This page lists projects which officially implement MariaDB's enhanced features, or state that they work with MariaDB. If you know of a project which officially supports MariaDB and it isn't listed here, please let us know in the comments.
+This page lists projects which officially implement MariaDB's enhanced features, or state that they work with MariaDB. If you know of a project which officially supports MariaDB and it isn't listed here, please let us know.
 
 {% hint style="info" %}
 Note: Every project we know of which works with MySQL also works with MariaDB. This page is just to point out projects which officially support MariaDB (e.g. by mentioning MariaDB in their documentation or setup instructions).
@@ -21,16 +21,14 @@ Note: Every project we know of which works with MySQL also works with MariaDB. T
 * [dbForge Studio](https://www.devart.com/dbforge/mysql/studio/mariadb-gui-client.html) is a versatile and feature-rich IDE designed for MySQL and MariaDB professionals. It fully supports all individual features of MariaDB, such as support for Packages and Sequences, and other specificities.
 * [Dynamic Active Record](https://github.com/tom--/yii2-dynamic-ar) - The yii2-dynamic-ar extension uses MariaDB dynamic columns to add NoSQL-like documents to Yii 2 Framework's Active Record ORM.
 * [ocelotgui](https://ocelot.ca/) - supports [MariaDB 10.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.2/what-is-mariadb-102) [window functions](../../reference/sql-functions/special-functions/window-functions/).
-* [Shard-query](https://mariadb.com/kb/en/) has special support for [MariaDB 10.0](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.0/changes-improvements-in-mariadb-10-0) features
 * [SQL Maestro for MySQL](https://www.sqlmaestro.com/products/mysql/maestro/) is a database management tool that provides direct support for a number of MariaDB features like [roles](../../security/user-account-management/roles/), [check constraints](../../reference/sql-statements/data-definition/constraint.md#check-constraint-expressions), and [virtual columns](../../reference/sql-statements/data-definition/create/generated-columns.md).
 
 ## Officially Supports MariaDB
 
-* [Alfresco](https://docs.alfresco.com/5.0/concepts/mariadb-config.html) - Alfresco is for Enterprise Content Management and Business Process Management and it supports running with MariaDB Server.
+* [Alfresco](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Configure/Databases/MySQL-and-MariaDB) - Alfresco is for Enterprise Content Management and Business Process Management and it supports running with MariaDB Server.
 * [Bitbucket by Atlassian](https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html)
-* [Codeship](https://documentation.codeship.com/pro/getting-started/services-and-databases/)
 * [Dataedo](https://dataedo.com) - Database documentation tool with rich-text fields and ERD creator.
-* [DBeaver](https://dbeaver.jkiss.org/) - free convenient cross-platform and cross-database Java GUI client which supports special MySQL/MariaDB features.
+* [DBeaver](https://dbeaver.io/) - free convenient cross-platform and cross-database Java GUI client which supports special MySQL/MariaDB features.
 * [dbForge Edge](https://www.devart.com/dbforge/edge/) is a multidatabase solution for MariaDB/MySQL, SQL Server, Oracle, and PostgreSQL. It includes a full-featured IDE for MariaDB, covering all key tasks in database development, design, management, and administration.
 * [dbForge Compare Bundle](https://www.devart.com/dbforge/mysql/compare-bundle/) - contains two separate tools, dbForge Schema Compare and dbForge Data Compare.
 * [dbForge Data Compare](https://www.devart.com/dbforge/mysql/datacompare/) - data comparison and synchronization tool.
@@ -44,48 +42,42 @@ Note: Every project we know of which works with MySQL also works with MariaDB. T
 * [Devart Excel Add-ins for MySQL](https://www.devart.com/excel-addins/mysql.html) - connect Microsoft Excel to MariaDB and MySQL and work with data like with usual Excel worksheets
 * [Drupal](https://drupal.org/requirements)
 * [ERBuilder Data Modeler](https://soft-builder.com/erbuilder-data-modeler) - Data modeling tool for multiple databases platforms including MariaDB, MySQL, and more. Free and commercial versions available.
-* [eZ](https://doc.ez.no/pages/viewpage.action?pageId=31429536)
-* [Flyway](https://flywaydb.org/)
+* [Flyway](https://www.red-gate.com/products/flyway/)
 * [Friendica](https://github.com/friendica/friendica/wiki/Using-MariaDB-With-Friendica)
 * [Geeklog](https://www.geeklog.net/) ([installation requirements](https://www.geeklog.net/docs/english/install.html#installation_requirements))
-* [ImpressCMS,a community-developed content-management system](https://impresscms.org)
-* [Jelastic - Java in the cloud](https://jelastic.com/docs/connection-to-mariadb)
-* [Kajona³ - Open Source Content Management Framework](https://www.kajona.de/) ([support announcement](https://www.kajona.de/newsdetails.Kajona-running-with-MariaDB.newsDetail.20ba9f14ce4227452730.en.html))
+* [Ibexa DXP, formerly eZ Platform](https://doc.ibexa.co/en/latest/getting_started/requirements/)
+* [ImpressCMS, a community-developed content-management system](https://impresscms.org)
 * [Matomo](https://matomo.org/) – Matomo is an open-source web analytics platform that prioritizes user privacy and data ownership, providing a powerful, GDPR-compliant alternative to Google Analytics.
 * [MediaWiki](https://www.mediawiki.org/) ([installation guide](https://www.mediawiki.org/wiki/Manual:Installation_guide))
-* [MicroStrategy](https://www2.microstrategy.com/producthelp/current/FunctionsRef/Content/FuncRef/Maria_DB.htm)
+* [MicroStrategy](https://www2.strategy.com/producthelp/current/FunctionsRef/Content/FuncRef/Maria_DB.htm)
 * [Moodle](https://docs.moodle.org/dev/Moodle_architecture#Requirements)
 * [Moon Modeler](https://www.datensen.com) - database design tool for MariaDB
 * [Mroonga](https://mroonga.org/en/blog/2016/10/29/mroonga-6.10.html)
 * [mycli](https://mycli.net) - command line interface for MariaDB with auto-completion and syntax highlighting.
 * [MySQL Data Access Components](https://www.devart.com/mydac/) - the library of components for direct access to MariaDB and MySQL from Delphi
 * [Neor Profile SQL](https://www.profilesql.com/)
-* [ownCloud](https://owncloud.org/) ([documentation](https://doc.owncloud.org/server/5.0/admin_manual/configuration/configuration_database.html))
+* [ownCloud](https://owncloud.com/) ([documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/database/linux_database_configuration.html))
 * [phpMyAdmin](https://www.phpmyadmin.net/documentation/)
-* [Plone](https://plone.org/) ([documentation](https://plone.org/documentation/kb/plone-and-mariadb))
+* [Plone](https://plone.org/)
 * [Querious](https://www.araelium.com/querious) - Mac OS X database administration tool
 * [RAD Studio (Embarcadero)](https://www.embarcadero.com/products/rad-studio/whats-new-in-10-2-tokyo) supports MariaDB from RAD Studio 10.2 Tokyo
 * [Replication Manager for MariaDB and MySQL](https://github.com/tanji/replication-manager) - High Availability solution to manage MariaDB Server 10.0+ GTID-based replication topologies
-* [SafeNet ProtectFile rom Gemalto](https://data-protection-updates.gemalto.com/2015/05/01/customer-release-notes-available-for-safenet-protectfile-windows-and-linux-v8-1/)
-* [SaltOS](https://www.saltos.net/)
+* [SafeNet ProtectFile from Gemalto](https://data-protection-updates.gemalto.com/2015/05/01/customer-release-notes-available-for-safenet-protectfile-windows-and-linux-v8-1/)
+* [SaltOS](https://www.saltos.org/)
 * [sequelize](https://github.com/sequelize/sequelize) - Dialect object-relationship-mapper for node.js.
 * [Skyvia](https://skyvia.com) - Cloud service for data integration, management and backup
-* [SQLTool Pro](https://www.sqltoolpro.com/)
 * [SSIS Data Flow Components for MySQL](https://www.devart.com/ssis/) - set of components for SQL Server Integration Services packages that allow loading data from MariaDB and MySQL in SSIS Data Flows
-* [Talend](https://www.talend.com/products/specifications-data-integration/)
-* [TransProCloud](https://wiki.tonybaldwin.info/doku.php?id=hax:transprocloud:start)
+* [Talend](https://help.qlik.com/talend/en-US/connectors-guide/Cloud/databases)
 * [12PRESS](https://tonybaldwin.github.io/12press/) - an online FLOSS meeting and events schedule presentation platform for 12-Step recovery fellowships (AA, NA, Alanon, etc.), their regions and area service committees, etc.
 * [Travis CI](https://docs.travis-ci.com/user/database-setup/#MariaDB)
 * [UI Bakery](https://uibakery.io) - Low-code development platform for building web applications on top of MariaDB data ([integration page](https://uibakery.io/integrations/mariadb), [documentation](https://docs.uibakery.io/data-sources/data-sources/mariadb))
 * [Universal Data Access Components](https://www.devart.com/unidac/) - the library of non-visual cross-database data access components for Delphi that includes support for MariaDB and MySQL
 * [Valentina Reports & Reports Server](https://valentina-db.com/en/reports-for-mariadb) - Reports Server on macOS, Windows and Linux and deployable app solution using MariaDB as data source
 * [Valentina Studio](https://valentina-db.com/en/studio-for-mariadb) - Database GUI on macOS, Windows and Linux. Free & Pro versions.
-* [WordPress](https://wordpress.org/) ([glossary](https://codex.wordpress.org/Glossary#MariaDB) from [install](https://codex.wordpress.org/Installing_WordPress) documentation)
+* [WordPress](https://wordpress.org/) ([glossary](https://wordpress.org/documentation/article/wordpress-glossary/#mariadb) from [install](https://developer.wordpress.org/advanced-administration/before-install/howto-install/) documentation)
 * [WPИ-XM](https://wpn-xm.org/)
 * [XAMPP](https://www.apachefriends.org/) ([announcement](https://www.apachefriends.org/blog/new_xampp_20151113.html))
-* [Wercker](https://devcenter.wercker.com/docs/services/mariadb)
 * [Yii](https://www.yiiframework.com/) ([Yii 1.1 guide](https://www.yiiframework.com/doc/guide/1.1/en/database.ar#establishing-db-connection) and [Yii 2.0 guide](https://www.yiiframework.com/doc-2.0/guide-db-dao.html))
-* [Zarafa](https://community.zarafa.com/) 7.2 onwards comes with MariaDB support [release notes](https://community.zarafa.com/pg/blog/read/28061/720-final-has-arrived)
 * [Zend Framework](https://framework.zend.com/) ([Zend\_Db\_Adapter](https://framework.zend.com/manual/1.11/en/zend.db.adapter.html))
 
 ## See Also

--- a/server/clients-and-utilities/server-client-software/mariadb-foundation.md
+++ b/server/clients-and-utilities/server-client-software/mariadb-foundation.md
@@ -21,13 +21,13 @@ That MariaDB be actively developed in the community and to:
 * Keep MariaDB compatible with MySQL.
 * Maintain mariadb.org.
 
-If you are using MariaDB in production and want to ensure that MariaDB is always actively developed, then you should sponsor or become a [member of the MariaDB foundation!](https://mariadb.org/donate/).
+If you are using MariaDB in production and want to ensure that MariaDB is always actively developed, then you should sponsor or become a [member of the MariaDB Foundation!](https://mariadb.org/sponsor/).
 
 It's the MariaDB Foundation that ensures that all community patches, including MySQL source code, are merged into MariaDB. It also does the builds and QA of MariaDB and provides a lot of the [MariaDB documentation](https://mariadb.com/docs).
 
-We are very grateful to our [current members and sponsors](https://mariadb.org/en/supporters) who are making this work possible!
+We are very grateful to our [current members and sponsors](https://mariadb.org/about/#sponsors) who are making this work possible!
 
-More information about the Foundation can be found on the [MariaDB foundation website](https://mariadb.org/en/foundation/).
+More information about the Foundation can be found on the [MariaDB Foundation website](https://mariadb.org/about/#about-mariadb-foundation).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 


### PR DESCRIPTION
Closes [DOCS-6449](https://mariadbcorp.atlassian.net/browse/DOCS-6449).

Clears all **21** `link-check` failures in `server/clients-and-utilities/` — the pre-existing rot that turned DOCS-6443's PR #887 red.

## Re-baseline first

The ticket says 25 failures in 5 files. On `main` today it is **21 failures in 3 files**: DOCS-6450's PR #889 already cleared the DBeaver and Sequel Pro pages as drive-bys.

| File | Was | Now |
|---|---|---|
| `server-client-software/applications-supporting-mariadb.md` | 17 | 0 |
| `graphical-and-enhanced-clients/valentina-studio.md` | 3 | 0 |
| `server-client-software/mariadb-foundation.md` | 1 | 0 |

Whole-tree verification, CI-mirroring invocation: **1,336 links / 791 unique / 0 errors**.

## `applications-supporting-mariadb.md`

I probed all 80 external URLs on this page twice — bare, and with a browser User-Agent following redirects. Beyond the 17 CI failures, **21 more redirect**, and 7 of those redirects hide a dead product that CI cannot see. So the page needed an editorial pass, not just link repair. Per Stefan's call: prune what is gone, repair the rest.

**8 entries dropped** — product or host no longer exists:

| Entry | Evidence |
|---|---|
| Zarafa | `community.zarafa.com` and `zarafa.com` both unreachable; successors (Kopano, grommunio) do not claim MariaDB support |
| Wercker | devcenter dead; `wercker.com` now redirects to an Oracle container-registry page |
| SQLTool Pro | host unreachable over both http and https |
| TransProCloud | `wiki.tonybaldwin.info` unreachable (the same author's 12PRESS entry is live, and stays) |
| Codeship | redirects to a CloudBees page literally titled *Codeship EOL* |
| Jelastic | redirects to Virtuozzo marketing with no MariaDB instructions |
| Kajona | site gone — `kajona.de` redirects to a bare GitHub org, and the MariaDB support announcement it cited is gone |
| Shard-query | its link pointed at **our own retired KB** (`mariadb.com/kb/en/` → the `/docs?q=` soft-404); project dormant since 2022 and self-described as "MySQL tools" |

**10 links repointed** at verified targets:

| Entry | New target | Verified by |
|---|---|---|
| WordPress ×2 | `wordpress.org/documentation/article/wordpress-glossary/#mariadb`, `developer.wordpress.org/…/howto-install/` | Codex retired by WordPress; glossary has 13 MariaDB mentions and an `id="mariadb"` anchor |
| ownCloud ×2 | `owncloud.com`, `doc.owncloud.com/server/latest/…/linux_database_configuration.html` | 14 MariaDB mentions |
| eZ → **Ibexa DXP** | `doc.ibexa.co/en/latest/getting_started/requirements/` | states "MariaDB 10.11+ or 11.4"; entry renamed and moved to keep the list alphabetical |
| Talend | `help.qlik.com/talend/en-US/connectors-guide/Cloud/databases` | Talend is now Qlik; MariaDB listed |
| MicroStrategy | `www2.strategy.com/…/Maria_DB.htm` | rebranded to Strategy; same path, renders "Maria DB" function reference |
| Flyway | `red-gate.com/products/flyway/` | now a Red Gate product; 3 MariaDB mentions |
| SaltOS | `www.saltos.org` | **not dead** — moved from `.net`; see below |
| Alfresco | `docs.hyland.com/r/Alfresco/…/Configure/Databases/MySQL-and-MariaDB` | acquired by Hyland; see caveat below |
| DBeaver | `dbeaver.io` | see deviation below |

**1 link unlinked:** Plone keeps `plone.org` (live) but loses its `(documentation)` sub-link — `plone.org/documentation` is itself a 404, so there is no replacement. Same call as DOCS-6446.

## Two findings worth flagging

**A timeout is not a death certificate.** SaltOS was on the drop list off a lychee timeout. In fact `http://www.saltos.net/` **redirects to `https://www.saltos.org/`** — the project moved, and only the `.net` HTTPS endpoint is broken, which is exactly what makes lychee time out. Repointed, entry kept. Every other drop candidate got the same second look before deletion.

**`docs.hyland.com` returns 200 for any path.** It serves an identical 2,373-byte app shell — including for pure gibberish, which I control-tested. So its 200 proves nothing, and the Alfresco link is verified by the search index's page title instead ("MySQL and MariaDB — Alfresco Content Services"), not by status code. It is version-pinned to 23.4 for that reason. This is the ticket's own "HTTP 200 is not proof" note biting in a new place.

## Excludes, not rewrites

Three hosts are alive behind bot protection, so there is no resolved URL to substitute. Added to **both** `link-check-pr.yml` and `doc-lint.sh` (66 patterns each, identical and in the same order — verified):

- `valentina-db.com`, `www.sqlmaestro.com` — both behind **Sucuri CloudProxy**, serving its "Javascript is required" interstitial
- `docs.moodle.org` — Cloudflare, `Cf-Mitigated: challenge`

A browser User-Agent does **not** get past any of the three, which corrects the ticket's claim that they serve 200 to a browser. The classification still holds, just on different evidence: the challenge body, not the status code.

**`codex.wordpress.org` was excluded from the exclude list on purpose.** The ticket grouped it with the bot-blocked hosts, but the Codex was *retired* by WordPress and its content has live successors — so it got repointed. Excluding it would have preserved two dead links.

## One deviation from the agreed plan

The plan had **DBeaver dropped** ("has its own page already"). I **repointed it to `dbeaver.io`** instead: many entries on this list also have their own page in this tree (dbForge, DbVisualizer, Valentina, Querious, Moon Modeler…), so dropping DBeaver alone would be inconsistent, and DBeaver is alive and genuinely MariaDB-supporting. One line to flip in review if you disagree.

## Drive-bys

- `mariadb-foundation.md`: two redirecting `mariadb.org` links updated. `mariadb.org/en/supporters` currently 301s to `/about/supporters/`, which lands on `/about/#stakeholders` — **a fragment that does not exist on the page**; now points straight at `#sponsors`. `donate/` → `sponsor/`. Also "MariaDB foundation" → "MariaDB Foundation" ×2.
- Typo: "SafeNet ProtectFile **rom** Gemalto" → "from".
- `ImpressCMS,a` → `ImpressCMS, a`.
- Removed "please let us know **in the comments**" — a KB-era artifact; GitBook pages have no comments.

## Deliberately not touched

- **~10 purely cosmetic redirects** (`drupal.org`→`www.drupal.org`, `mycli.net`→`www.mycli.net`, MediaWiki, phpMyAdmin, Devart, UI Bakery, Yii, soft-builder trailing slash…). They work, they are not misleading, and rewriting them would add review surface for zero reader benefit.
- **`soft-builder.com/features/`** — flaky, not rotted, per the ticket.
- **`code.launchpad.net/~maria-captains`** in `getting-the-mariadb-source-code.md` reported a **503 on one run only**. It was absent from the baseline, returns 200 on three straight retries, and sits in a file this PR does not touch — my own repeated sweeps rate-limiting Launchpad. Not fixed, by design.

## Checks

`codespell` (CI-exact invocation) and `doc-lint.sh` both pass on the changed files; the whole-tree lychee run is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6449]: https://mariadbcorp.atlassian.net/browse/DOCS-6449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ