### PR TITLE
DOCS-6468 Repoint 5.1/5.2 "changelogs" links at the Server changelogs

### DIFF
--- a/release-notes/community-server/changelogs/changelogs-mariadb-51-series/mariadb-5142-changelog.md
+++ b/release-notes/community-server/changelogs/changelogs-mariadb-51-series/mariadb-5142-changelog.md
@@ -8,7 +8,7 @@ See the [MariaDB 5.1.42 Release Notes](../../old-releases/5.1/5.1.42.md) for the
 highlights of this release.
 
 MariaDB-5.1.42 is based on MySQL-5.1.42, and in addition to the changes listed
-in previous [changelogs](../../../connectors/odbc/changelogs/) it includes the following changes and bug fixes:
+in previous [changelogs](../README.md) it includes the following changes and bug fixes:
 
 * Includes MySQL 5.1.42
 * Includes [XtraDB](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/innodb) 1.0.6-9

--- a/release-notes/community-server/changelogs/changelogs-mariadb-51-series/mariadb-5144-changelog.md
+++ b/release-notes/community-server/changelogs/changelogs-mariadb-51-series/mariadb-5144-changelog.md
@@ -9,7 +9,7 @@ highlights of this release.
 
 [MariaDB 5.1.44](../../old-releases/5.1/5.1.44.md) is based on MySQL 5.1.44 and includes all changes made since\
 MySQL 5.1.42, including MySQL 5.1.43. In addition to the changes listed in
-previous [changelogs](../../../connectors/odbc/changelogs/) it includes the following changes and bug fixes:
+previous [changelogs](../README.md) it includes the following changes and bug fixes:
 
 * fixed a reported performance problem with MariaDB internal temporary tables
 * don't crash on failing to load a plugin with newer\

--- a/release-notes/community-server/old-releases/5.1/5.1.42.md
+++ b/release-notes/community-server/old-releases/5.1/5.1.42.md
@@ -17,7 +17,7 @@ MariaDB is kept up to date with the latest MySQL release from the same branch.[M
 In most respects MariaDB will work exactly as MySQL: all commands, interfaces,
 libraries and APIs that exist in MySQL also exist in MariaDB.
 
-In addition to the differences noted in previous [release notes](README.md) and [changelogs](../../../connectors/odbc/changelogs/), the main differences between\
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main differences between
 MariaDB and MySQL are:
 
 ## Includes MySQL 5.1.42

--- a/release-notes/community-server/old-releases/5.1/5.1.44.md
+++ b/release-notes/community-server/old-releases/5.1/5.1.44.md
@@ -12,7 +12,7 @@ list of the changes in this release.
 In most respects MariaDB will work exactly as MySQL: all commands, interfaces,
 libraries and APIs that exist in MySQL also exist in MariaDB.
 
-In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../../connectors/odbc/changelogs/), the main differences
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main differences
 between MariaDB and MySQL are:
 
 ## Includes MySQL 5.1.44

--- a/release-notes/community-server/old-releases/5.1/5.1.47.md
+++ b/release-notes/community-server/old-releases/5.1/5.1.47.md
@@ -11,7 +11,7 @@ For a list of every change made in this release, see the [changelog](../../chang
 In most respects [MariaDB](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV) will work exactly as MySQL: all commands,
 interfaces, libraries and APIs that exist in MySQL also exist in MariaDB.
 
-In addition to the differences noted in previous release notes and [changelogs](../../../connectors/odbc/changelogs/), the main
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main
 differences between MariaDB and MySQL are:
 
 ## Includes MySQL 5.1.47

--- a/release-notes/community-server/old-releases/5.1/5.1.49.md
+++ b/release-notes/community-server/old-releases/5.1/5.1.49.md
@@ -11,7 +11,7 @@ For a list of every change made in this release, see the [Changelog](../../chang
 In most respects [MariaDB](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV) will work exactly as MySQL: all commands,
 interfaces, libraries and APIs that exist in MySQL also exist in MariaDB.
 
-In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../../connectors/odbc/changelogs/), the main differences
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main differences
 between MariaDB and MySQL are:
 
 ## Includes MySQL 5.1.49

--- a/release-notes/community-server/old-releases/5.1/5.1.50.md
+++ b/release-notes/community-server/old-releases/5.1/5.1.50.md
@@ -11,7 +11,7 @@ For a list of every change made in this release, see the [Changelog](../../chang
 In most respects [MariaDB](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV) will work exactly as MySQL: all commands,
 interfaces, libraries and APIs that exist in MySQL also exist in MariaDB.
 
-In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../../connectors/odbc/changelogs/), the main
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main
 differences between MariaDB and MySQL are:
 
 ## Includes MySQL 5.1.50

--- a/release-notes/community-server/old-releases/5.1/5.1.51.md
+++ b/release-notes/community-server/old-releases/5.1/5.1.51.md
@@ -11,7 +11,7 @@ For a list of every change made in this release, see the [Changelog](../../chang
 In most respects [MariaDB](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV) will work exactly as MySQL: all commands,
 interfaces, libraries and APIs that exist in MySQL also exist in MariaDB.
 
-In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../../connectors/odbc/changelogs/), the main
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main
 differences between MariaDB and MySQL are:
 
 ## Includes MySQL 5.1.51

--- a/release-notes/community-server/old-releases/5.1/5.1.53.md
+++ b/release-notes/community-server/old-releases/5.1/5.1.53.md
@@ -11,7 +11,7 @@ For a list of every change made in this release, see the [Changelog](../../chang
 In most respects [MariaDB](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV) will work exactly as MySQL: all commands,
 interfaces, libraries and APIs that exist in MySQL also exist in MariaDB.
 
-In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../../connectors/odbc/changelogs/), the main
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main
 differences between MariaDB and MySQL are:
 
 ## Includes MySQL 5.1.53

--- a/release-notes/community-server/old-releases/5.1/5.1.55.md
+++ b/release-notes/community-server/old-releases/5.1/5.1.55.md
@@ -15,7 +15,7 @@ For a list of every change made in [MariaDB 5.1.55](5.1.55.md), see the [Changel
 In most respects [MariaDB](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1) will work exactly as MySQL: all commands,
 interfaces, libraries and APIs that exist in MySQL also exist in MariaDB.
 
-In addition to the differences noted in previous [release notes](../../../README.md) and [changelogs](../../../connectors/odbc/changelogs/), the main
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main
 differences between MariaDB and MySQL are:
 
 ## Includes MySQL 5.1.55

--- a/release-notes/community-server/old-releases/5.2/5.2.2.md
+++ b/release-notes/community-server/old-releases/5.2/5.2.2.md
@@ -11,7 +11,7 @@ This is a [gamma release](../../about/release-criteria.md). In general this mean
 In most respects [MariaDB](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV) will work exactly as MySQL: all commands,
 interfaces, libraries and APIs that exist in MySQL also exist in MariaDB.
 
-In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../../connectors/odbc/changelogs/), the main new things in this version of [MariaDB 5.2](changes-improvements-in-mariadb-5-2.md) are:
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main new things in this version of [MariaDB 5.2](changes-improvements-in-mariadb-5-2.md) are:
 
 ## Includes [MariaDB 5.1.50](../5.1/5.1.50.md)
 

--- a/release-notes/community-server/old-releases/5.2/5.2.3.md
+++ b/release-notes/community-server/old-releases/5.2/5.2.3.md
@@ -23,7 +23,7 @@ interfaces, libraries and APIs that exist in MySQL also exist in MariaDB.
 
 ## Bugs Fixing
 
-In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../../connectors/odbc/changelogs/), the main focus of this
+In addition to the differences noted in previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md), the main focus of this
 release was on fixing bugs. No new features were added to this release of [MariaDB 5.2](changes-improvements-in-mariadb-5-2.md). The [changelog](../../changelogs/changelogs-mariadb-52-series/mariadb-522-changelog.md) has details on the specific bugs which were fixed.
 
 {% include "../../../.gitbook/includes/announce.md" %}

--- a/release-notes/community-server/old-releases/5.2/5.2.7.md
+++ b/release-notes/community-server/old-releases/5.2/5.2.7.md
@@ -13,7 +13,7 @@ usage. A "stable" MariaDB release is equivalent to a MySQL "GA" release.
 For a high-level description of [MariaDB 5.2.7](5.2.7.md) see the [What is MariaDB 5.2](changes-improvements-in-mariadb-5-2.md) page.
 
 For a list of every change made in [MariaDB 5.2.7](5.2.7.md), including the various bugs
-that were fixed and links to detailed information on each push, see the [MariaDB 5.2.7 Changelog](../../changelogs/changelogs-mariadb-52-series/mariadb-527-changelog.md). See previous [release notes](../../README.md) and [changelogs](../../../connectors/odbc/changelogs/) for changes made in previous
+that were fixed and links to detailed information on each push, see the [MariaDB 5.2.7 Changelog](../../changelogs/changelogs-mariadb-52-series/mariadb-527-changelog.md). See previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md) for changes made in previous
 versions of MariaDB.
 
 In most respects [MariaDB](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV) will work exactly as MySQL: all commands,

--- a/release-notes/community-server/old-releases/5.2/5.2.8.md
+++ b/release-notes/community-server/old-releases/5.2/5.2.8.md
@@ -13,7 +13,7 @@ usage. A "stable" MariaDB release is equivalent to a MySQL "GA" release.
 For a high-level description of [MariaDB 5.2.8](5.2.8.md) see the [What is MariaDB 5.2](changes-improvements-in-mariadb-5-2.md) page.
 
 For a list of every change made in [MariaDB 5.2.8](5.2.8.md), including the various bugs
-that were fixed and links to detailed information on each push, see the [MariaDB 5.2.8 Changelog](../../changelogs/changelogs-mariadb-52-series/mariadb-528-changelog.md). See previous [release notes](../../README.md) and [changelogs](../../../connectors/odbc/changelogs/) for changes made in previous
+that were fixed and links to detailed information on each push, see the [MariaDB 5.2.8 Changelog](../../changelogs/changelogs-mariadb-52-series/mariadb-528-changelog.md). See previous [release notes](../../README.md) and [changelogs](../../changelogs/README.md) for changes made in previous
 versions of MariaDB.
 
 In most respects [MariaDB](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV) will work exactly as MySQL: all commands,


### PR DESCRIPTION
[DOCS-6468](https://mariadbcorp.atlassian.net/browse/DOCS-6468) · 14 files, 14 lines

## The problem

Fourteen MariaDB 5.1 and 5.2 pages carried this sentence:

> In addition to the differences noted in previous [release notes](…) and [changelogs](../../../connectors/odbc/changelogs/), the main differences between MariaDB and MySQL are:

That relative path resolves to `release-notes/connectors/odbc/changelogs/` — the **Connector/ODBC** changelogs. **CI is blind to it**: the path resolves, so lychee reports OK. This is the DOCS-6445 class (a link that works but points at the wrong page).

## The fix

All 14 now point at the Community Server changelogs landing, `release-notes/community-server/changelogs/README.md`:

| Tree | Files | New target |
| --- | --- | --- |
| `community-server/old-releases/5.1/` | 8 (5.1.42, .44, .47, .49, .50, .51, .53, .55) | `../../changelogs/README.md` |
| `community-server/old-releases/5.2/` | 4 (5.2.2, .3, .7, .8) | `../../changelogs/README.md` |
| `community-server/changelogs/changelogs-mariadb-51-series/` | 2 (5142, 5144 changelog) | `../README.md` |

The per-series directories carry no `README.md`, so the changelogs landing is the right granularity — there is no per-series index to link instead.

## Drive-by fixes

The sentence's other half, the `[release notes]` link, had been resolved three different ways by three different sweeps, so the twelve sibling pages disagreed:

- `5.1.42.md` — `README.md` (the 5.1 series index), set by DOCS-6457's drive-by repair
- `5.1.55.md` — `../../../README.md` (the entire Release Notes space, covering connectors, MaxScale and ES)
- `5.1.47.md` — unlinked entirely by DOCS-6430

All three normalized to `../../README.md`, the Community Server release-notes landing that DOCS-6385 set on the other nine. Both halves of the sentence now point at the matching Community Server landing on all twelve pages. Also removed one mid-sentence trailing-backslash hard break on `5.1.42.md:20`.

## Verification

- `grep -rn '\[changelogs\](\.\./\.\./\.\./connectors/odbc/changelogs'` → **0** repo-wide
- The other 67 `connectors/odbc/changelogs` occurrences are untouched and **correct** — `release-notes/SUMMARY.md` nav entries and the Connector/ODBC release notes linking their own changelogs
- `doc-lint.sh` exits 0 over the 12 CI-in-scope files; lychee clean on all 14
- The 4 codespell hits on the two `*-changelog.md` files are pre-existing and **out of CI scope** — `codespell.yml` excludes `release-notes/**/changelogs/**` and `release-notes/**/*-changelog.md` on purpose, because changelogs transcribe upstream commit messages verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6468]: https://mariadbcorp.atlassian.net/browse/DOCS-6468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ