### PR TITLE
DOCS-6397 Restore the lost backslashes in the REGEXP escaping docs

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -29,3 +29,6 @@ bootup
 DROPed
 re-used
 variante
+Nd
+Vai
+respons

--- a/server/reference/sql-functions/string-functions/regular-expressions-functions/pcre.md
+++ b/server/reference/sql-functions/string-functions/regular-expressions-functions/pcre.md
@@ -181,7 +181,7 @@ SELECT '1¼①' RLIKE '^\\p{N}+$';
 | Xuc      | A character than can be represented by a Universal Character Name |
 | Xwd      | Perl word: property Xan or underscore                             |
 
-The property `Xuc` matches any character that can be represented by a Universal Character Name (in C++ and other programming languages). These include `$`, `@`, \`\`\`, and all characters with Unicode code points greater than `U+00A0`, excluding the surrogates `U+D800`..`U+DFFF`.
+The property `Xuc` matches any character that can be represented by a Universal Character Name (in C++ and other programming languages). These include `$`, `@`, the grave accent (`` ` ``), and all characters with Unicode code points greater than `U+00A0`, excluding the surrogates `U+D800`..`U+DFFF`.
 
 **Script Names For \p and \P**
 

--- a/server/reference/sql-functions/string-functions/regular-expressions-functions/regexp.md
+++ b/server/reference/sql-functions/string-functions/regular-expressions-functions/regexp.md
@@ -24,7 +24,7 @@ The negative form [NOT REGEXP](../not-regexp.md) also exists, as an alias for `N
 
 The pattern need not be a literal string. For example, it can be specified as a string expression or table column.
 
-**Note:** Because MariaDB uses the C escape syntax in strings (for example, "\n" to represent the newline character), you must double any "" that you use in your `REGEXP` strings.
+**Note:** Because MariaDB uses the C escape syntax in strings (for example, `\n` to represent the newline character), you must double any backslash (`\`) that you use in your `REGEXP` strings.
 
 `REGEXP` is not case sensitive, except when used with binary strings.
 
@@ -51,7 +51,7 @@ SELECT 'new*\n*line' REGEXP 'new\\*.\\*line';
 +---------------------------------------+
 | 'new*\n*line' REGEXP 'new\\*.\\*line' |
 +---------------------------------------+
-|                                     1 |
+|                                     0 |
 +---------------------------------------+
 
 SELECT 'a' REGEXP 'A', 'a' REGEXP BINARY 'A';
@@ -69,6 +69,8 @@ SELECT 'a' REGEXP '^[a-d]';
 +---------------------+
 ```
 
+In the `'new*\n*line'` example, doubling the backslashes makes the pattern match literal asterisks, but the statement still returns `0`, because `.` does not match a newline character unless the `DOTALL` flag is set with [default\_regex\_flags](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#default_regex_flags).
+
 ### default\_regex\_flags examples
 
 MariaDB uses the [default\_regex\_flags](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#default_regex_flags) variable to address the remaining compatibilities between PCRE and the old regex library.
@@ -77,11 +79,11 @@ The default behavior (multiline match is off)
 
 ```sql
 SELECT 'a\nb\nc' RLIKE '^b$';
-+---------------------------+
-| '(?m)a\nb\nc' RLIKE '^b$' |
-+---------------------------+
-|                         0 |
-+---------------------------+
++-----------------------+
+| 'a\nb\nc' RLIKE '^b$' |
++-----------------------+
+|                     0 |
++-----------------------+
 ```
 
 Enabling the multiline option using the PCRE option syntax:

--- a/server/reference/sql-functions/string-functions/regular-expressions-functions/regular-expressions-overview.md
+++ b/server/reference/sql-functions/string-functions/regular-expressions-functions/regular-expressions-overview.md
@@ -556,16 +556,16 @@ SELECT 'Maria' REGEXP 'Ma[ir]{2}';
 
 ### Escaping
 
-With the large number of special characters, care needs to be taken to properly escape characters. Two backslash characters, \`\` (one for the MariaDB parser, one for the regex library), are required to properly escape a character. For example:
+With the large number of special characters, care needs to be taken to properly escape characters. Two backslash characters, `\\` (one for the MariaDB parser, one for the regex library), are required to properly escape a character. For example:
 
 To match the literal `(Ma`:
 
 ```sql
 SELECT '(Maria)' REGEXP '(Ma';
-ERROR 1139 (42000): Got error 'parentheses not balanced' from regexp
+ERROR 1139 (42000): Regex error 'missing closing parenthesis at offset 3'
 
 SELECT '(Maria)' REGEXP '\(Ma';
-ERROR 1139 (42000): Got error 'parentheses not balanced' from regexp
+ERROR 1139 (42000): Regex error 'missing closing parenthesis at offset 3'
 
 SELECT '(Maria)' REGEXP '\\(Ma';
 +--------------------------+
@@ -599,12 +599,12 @@ SELECT 'Maria' REGEXP 'r\\+';
 |                     0 |
 +-----------------------+
 
-SELECT 'Maria' REGEXP 'r+';
-+---------------------+
-| 'Maria' REGEXP 'r+' |
-+---------------------+
-|                   1 |
-+---------------------+
+SELECT 'Mar+ia' REGEXP 'r\\+';
++------------------------+
+| 'Mar+ia' REGEXP 'r\\+' |
++------------------------+
+|                      1 |
++------------------------+
 ```
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>


### PR DESCRIPTION
Fixes [DOCS-6397](https://mariadbcorp.atlassian.net/browse/DOCS-6397) — reported as GitHub issue #830 by **ToBeFree**.

## The reported defect

The REGEXP page told readers:

> …you must double any **""** that you use in your `REGEXP` strings.

*"Any what? Backslashes, I assume. They're lost in translation, though."* — correct. The Markdown source held `"\"`, and **a backslash before ASCII punctuation is a valid Markdown escape**, so the renderer consumed the backslash and left an empty pair of quotes. The `"\n"` earlier on the same line survived only because `\n` is *not* a valid Markdown escape.

So the fix is not just to put the character back: every literal backslash now sits **inside a code span**, where Markdown escapes are not processed and the next edit to the line cannot eat it again. The sentence also names the character outright.

## Same class, two sibling pages

* **Regular Expressions Overview** — "Two backslash characters, `` `` `` (one for the MariaDB parser, one for the regex library)". The source read `` \`\` `` (two *escaped backticks*), so it rendered as two literal backticks instead of `\\`.
* **PCRE Regular Expressions** — the `\p{Xuc}` character list rendered as ``` ``` ``` instead of the grave accent. Verified: `SELECT '` + "`" + `' RLIKE '^\\p{Xuc}$'` returns `1`, as do `$` and `@`.

## Drive-by fixes

Reading the whole page turned up four factual errors inherited from the KB era. All were executed against a live **MariaDB 12.3.2**, and the version-dependent ones are pinned to server source.

| Page | Was | Now |
|------|-----|-----|
| REGEXP | `'new*\n*line' REGEXP 'new\\*.\\*line'` → `1` | → `0`, plus a sentence explaining why: `.` does not match a newline unless `DOTALL` is set (`sql/sys_vars.cc:7035` maps it to `PCRE2_DOTALL`). The documented `1` is pre-10.0.5 behavior, from before the switch to PCRE. |
| REGEXP | The "multiline match is off" result block was headed `'(?m)a\nb\nc' RLIKE '^b$'` | The header of the statement it actually belongs to. The `(?m)` variant is the *next* example, which returns `1`. |
| Overview | `ERROR 1139 (42000): Got error 'parentheses not balanced' from regexp` | `ERROR 1139 (42000): Regex error 'missing closing parenthesis at offset 3'`. The old wording is **pre-10.5** — replaced by `3b654d54c10` ("longer regex error messages"), first released in `mariadb-10.5.1`, so it was stale for every supported series. Current shape: `errmsg-utf8.txt:3607` + `item_cmpfunc.cc:6325-6331`. |
| Overview | The fourth `r+` example was a **verbatim duplicate** of the second | `SELECT 'Mar+ia' REGEXP 'r\\+'` → `1`, the pay-off case the section was missing. |

Also, three pre-existing codespell hits in `pcre.md`, surfaced only because CI scans changed files — none is a typo, and all three are consistent with the fragments already in the file: `Nd` (Unicode general category), `Vai` (Unicode script name), and `respons` (a deliberate regex alternation branch inside a SQL example, `'(sens|respons)e and \\1ibility'`).

## Not in this PR

The `` \`\` `` signature that produced the two sibling fixes occurs **291 times in 147 files** repo-wide. All but ~11 are in `release-notes/` — mangled code spans around C assertion expressions in changelogs (`Assertion \`\`0'\` failed in …`). That is a bulk ticket of its own, same family as DOCS-6364/6365; the ~11 content pages outside `release-notes/` are listed in the fact-check report.

## Downstream

`regexp.md` feeds `mysql.help_topic` through `help-tables/markdown_extractor.py`. The shipped help text has the correct backslash already (the reported defect is rendering-only) but carries the same wrong `1` result and the same `(?m)` header, so both will be corrected in `HELP REGEXP` at the next help-tables regeneration. The page's `## Syntax` / `## Description` / `## Examples` / `## See Also` structure is unchanged.

## Checks

`doc-lint.sh` exits 0 on all changed files — codespell, lychee and the include resolver all pass locally (both tools installed, so this is not a false pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6397]: https://mariadbcorp.atlassian.net/browse/DOCS-6397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ