### PR TITLE
DOCS-6470 Add a net line-loss guard to doc-lint, fix its mktemp call

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
 # doc-lint.sh — the SINGLE SOURCE OF TRUTH for the codespell + lychee invocations that mirror
-# CI (.github/workflows/codespell.yml and link-check-pr.yml), plus a GitBook include resolver
-# that has no CI counterpart (see below).
+# CI (.github/workflows/codespell.yml and link-check-pr.yml), plus two checks that have no CI
+# counterpart (see below): a GitBook include resolver and a net line-loss guard.
 #
 # The pre-commit hook, the /precommit command, the docs-check skill, and dev-docs/cookbook-pre-pr.md
 # all delegate here instead of re-spelling the flags, so the CI-mirroring options live in exactly
@@ -195,7 +195,11 @@ space_of() {
 
 # `grep | while` puts the loop body in a subshell, so it cannot set `rc` directly — failures are
 # tallied in a temp file instead.
-inc_fail="$(mktemp -t doclint-inc)" || { echo "doc-lint: mktemp failed" >&2; exit 2; }
+# Use a positional template, not `-t <prefix>`: GNU coreutils rejects a `-t` template with no
+# X's ("too few X's in template"), which made this exit 2 on every Linux run — and since it sits
+# before the checks below, it took the include resolver and the shrink guard down with it. The
+# positional form works on both GNU and BSD/macOS mktemp. (Regression from DOCS-6372, f2b5e332c.)
+inc_fail="$(mktemp "${TMPDIR:-/tmp}/doclint-inc.XXXXXX")" || { echo "doc-lint: mktemp failed" >&2; exit 2; }
 trap 'rm -f "$inc_fail"' EXIT
 
 for f in "${files[@]}"; do
@@ -219,5 +223,81 @@ for f in "${files[@]}"; do
   done
 done
 [ -s "$inc_fail" ] && rc=1
+
+# --- net line-loss guard — NO CI counterpart ------------------------------------------------
+# Catches the "silently gutted page" failure: a surviving page loses most of its body while the
+# markup stays valid and every remaining link resolves, so codespell and lychee both PASS.
+#
+# DOCS-6442 is the case this exists for. A retirement campaign (DOCS-5976 Tier B, c6ea5549a)
+# meant to delete ONE {% columns %} content-ref block from the Storage Engines landing page —
+# the block pointing at a folder it was removing — and promote FEDERATED into its place. It
+# deleted 23 of the 24 blocks instead: 298 lines -> 22, 24 content-refs -> 1. SUMMARY.md was
+# untouched, so the nav still listed all 27 engines while the page listed one. Every gate passed;
+# a reader found it two days later, and b36d939 rebuilt the page from SUMMARY.md.
+#
+# The metric is NET loss (pre - post, i.e. deletions minus additions), not raw deletions.
+# Raw deletions flag every reformatting campaign — alias expansion, trailing-backslash removal,
+# changelog normalization — because those rewrite lines rather than remove them. Measured over
+# 300 commits of this repo: raw deletions >40% flags 17 files (mostly those campaigns), net loss
+# >40% flags 4. On c6ea5549a itself the guard yields a ONE-item list at 94%, next-worst 16%.
+#
+# Thresholds and the acknowledgment path are env-overridable:
+#   DOC_LINT_SHRINK_PCT   (40) percent of the pre-image lost, net, before flagging
+#   DOC_LINT_SHRINK_MIN   (20) minimum net lines lost, so tiny files can't trip it
+#   DOC_LINT_SHRINK_FLOOR (30) minimum pre-image size considered at all
+#   DOC_LINT_BASE       (HEAD) revision the pre-image is read from
+#   DOC_LINT_ALLOW_SHRINK     space/comma-separated paths to exempt, or "all"
+#
+# A deliberate large shrink is legitimate (Tier C's Debian README correctly went 70 -> 34 lines
+# when three of its five children were retired), so this gate is meant to be acknowledged, not
+# worked around: name the path in DOC_LINT_ALLOW_SHRINK and say why in the commit message.
+#
+# Compares the WORKING-TREE file against the base revision — the same content codespell and
+# lychee above are checking. When the index and working tree differ, this reflects the working
+# tree, not what is staged.
+
+SHRINK_PCT="${DOC_LINT_SHRINK_PCT:-40}"
+SHRINK_MIN="${DOC_LINT_SHRINK_MIN:-20}"
+SHRINK_FLOOR="${DOC_LINT_SHRINK_FLOOR:-30}"
+SHRINK_BASE="${DOC_LINT_BASE:-HEAD}"
+SHRINK_ALLOW=" ${DOC_LINT_ALLOW_SHRINK:-} "
+SHRINK_ALLOW="${SHRINK_ALLOW//,/ }"
+
+if command -v git >/dev/null 2>&1 \
+   && git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+   && git rev-parse --verify -q "$SHRINK_BASE" >/dev/null 2>&1; then
+  case "$SHRINK_ALLOW" in
+    *" all "*) : ;;   # globally acknowledged — skip the whole check
+    *)
+      for f in "${files[@]}"; do
+        f="${f#./}"
+        case "$SHRINK_ALLOW" in *" $f "*) continue ;; esac
+        # absent from the base revision = a new file, so there is nothing to have lost
+        git cat-file -e "$SHRINK_BASE:$f" 2>/dev/null || continue
+
+        pre=$(git show "$SHRINK_BASE:$f" 2>/dev/null | wc -l | tr -d ' ')
+        post=$(wc -l < "$f" | tr -d ' ')
+        [ "$pre" -lt "$SHRINK_FLOOR" ] && continue
+
+        net=$((pre - post))
+        [ "$net" -lt "$SHRINK_MIN" ] && continue
+
+        if [ "$(awk -v n="$net" -v p="$pre" -v t="$SHRINK_PCT" \
+                    'BEGIN{print (n/p*100 > t) ? 1 : 0}')" = "1" ]; then
+          pctv="$(awk -v n="$net" -v p="$pre" 'BEGIN{printf "%.0f", n/p*100}')"
+          echo "doc-lint: possible gutted page — $f" >&2
+          echo "          lost $net of $pre lines net (${pctv}%) vs $SHRINK_BASE." >&2
+          echo "          Confirm the page still covers everything it should. For a landing page," >&2
+          echo "          compare its content-ref count against the space's SUMMARY.md children —" >&2
+          echo "          SUMMARY.md is authoritative for nav, so a page listing far fewer of its" >&2
+          echo "          children than SUMMARY.md does is the signature of this bug (DOCS-6442)." >&2
+          echo "          Intentional? Re-run with DOC_LINT_ALLOW_SHRINK='$f'" >&2
+          echo "          and say why in the commit message." >&2
+          rc=1
+        fi
+      done
+      ;;
+  esac
+fi
 
 exit "$rc"

--- a/.claude/skills/docs-check/SKILL.md
+++ b/.claude/skills/docs-check/SKILL.md
@@ -37,7 +37,7 @@ Default to the files the user changed. Determine the set in this order:
 
 Run all that apply, then report each as PASS / FAIL / SKIPPED.
 
-### 1–3. Spelling + links + includes — via `doc-lint.sh`
+### 1–4. Spelling + links + includes + gutted pages — via `doc-lint.sh`
 
 Run the **canonical** linter (the single source of truth for the CI-mirroring flags/excludes)
 on the file set, from the repo root:
@@ -64,6 +64,19 @@ on the file set, from the repo root:
   correct the `../` depth, or switch to
   `{% include "https://app.gitbook.com/s/<spaceId>/~/reusable/<reusableId>/" %}` when the snippet
   genuinely lives in another space. Added in DOCS-6372.
+- It also flags a **gutted page** — any file that lost more than 40% of its lines *net*
+  (deletions minus additions; min 20 lines lost, pre-image ≥ 30 lines) against `DOC_LINT_BASE`
+  (default `HEAD`). No CI counterpart, never SKIPs. This catches what the other checks
+  structurally cannot: a page that loses most of its body while the surviving markup stays valid
+  and the remaining links resolve, so codespell and lychee both PASS. DOCS-6442 is the case —
+  a campaign meant to remove one `{% columns %}` content-ref block from the Storage Engines
+  landing page removed 23 of 24 (298 lines → 22, 24 content-refs → 1) with `SUMMARY.md`
+  untouched, so nav listed 27 engines and the page listed one.
+  **Do not silence this by reflex.** Verify the page first: for a landing page, compare its
+  content-ref count with the space's `SUMMARY.md` children (`SUMMARY.md` is authoritative for
+  nav — it is what DOCS-6442 used to rebuild the page). If the shrink is genuinely intended,
+  re-run with `DOC_LINT_ALLOW_SHRINK='<path>'` and tell the user to state the reason in the
+  commit message. Report it as FAIL when unverified, WARN when acknowledged.
 
 The remaining checks below are **best-effort, LLM-performed heuristics** — report them as
 warnings, not hard failures, and **ignore anything inside fenced code blocks (```) or
@@ -122,6 +135,7 @@ docs-check on 3 files:
   codespell ...... PASS
   lychee ......... FAIL (2 broken links — see below)
   includes ....... FAIL (dead include in platform/post-download/x.md:22)
+  gutted pages ... FAIL (storage-engines/README.md lost 93% of its lines net)
   frontmatter .... PASS
   gitbook blocks . FAIL (unclosed {% tabs %} in server/foo.md)
   link style ..... PASS

--- a/dev-docs/cookbook-pre-pr.md
+++ b/dev-docs/cookbook-pre-pr.md
@@ -15,7 +15,7 @@ skill, which runs them for you; this page documents what it does and how to run 
 
 Only the first two can fail your PR; aliases and help-tables are regenerated automatically.
 
-## 1. Spelling + links + includes — `doc-lint.sh`
+## 1. Spelling + links + includes + gutted pages — `doc-lint.sh`
 
 The codespell and lychee invocations that mirror CI live in **one** place,
 `.claude/hooks/doc-lint.sh`. Run it instead of re-typing the flags:
@@ -39,6 +39,33 @@ or one that **crosses a space boundary**. That check has **no CI counterpart** �
 is GitBook template syntax, not a Markdown link, so lychee is blind to it and a dead include just
 renders as nothing, silently dropping a section from the page. It needs no external tool, so it
 never SKIPs. (Added in DOCS-6372, which found two live cases this way.)
+
+Finally, it flags a **gutted page**: any file in the set that lost more than **40%** of its lines
+*net* (deletions minus additions, minimum 20 lines lost, pre-image at least 30 lines) against
+`DOC_LINT_BASE` (default `HEAD`). This has no CI counterpart either, and it exists because the
+other checks are blind to it — when a page loses most of its body but the surviving markup is
+valid and the remaining links resolve, codespell and lychee both PASS. That is exactly what
+happened in DOCS-6442: a retirement campaign meant to delete one `{% columns %}` content-ref
+block from the Storage Engines landing page and deleted 23 of 24 instead (298 lines → 22,
+24 content-refs → 1). `SUMMARY.md` was untouched, so the nav still listed all 27 engines while
+the page listed one; a reader found it two days later.
+
+Net loss is the metric, not raw deletions — raw deletions flag every reformatting campaign (alias
+expansion, hard-break removal, changelog normalization), because those *rewrite* lines. Measured
+over 300 commits of this repo: raw deletions >40% flags 17 files, net loss >40% flags 4.
+
+A big shrink is often correct, so this gate is meant to be **acknowledged, not silenced**:
+
+```bash
+# after confirming the page still covers what it should
+DOC_LINT_ALLOW_SHRINK='path/to/README.md' .claude/hooks/doc-lint.sh <files>
+```
+
+and say why in the commit message. Tunable: `DOC_LINT_SHRINK_PCT`, `DOC_LINT_SHRINK_MIN`,
+`DOC_LINT_SHRINK_FLOOR`, `DOC_LINT_BASE`; `DOC_LINT_ALLOW_SHRINK=all` disables the check.
+For a landing page, the fastest confirmation is to compare its content-ref count against the
+space's `SUMMARY.md` children — `SUMMARY.md` is authoritative for nav, and it is what DOCS-6442
+used to rebuild the page.
 
 - A real term flagged as a typo? Add it to `.codespellignore` (one word per line) — sparingly.
 - The lychee exclude set skips **any URL containing `{` or `%7B`** — which covers `{alias}`


### PR DESCRIPTION
Ticket: [DOCS-6470](https://mariadbcorp.atlassian.net/browse/DOCS-6470)

## Why

DOCS-6442 restored the Storage Engines landing page after DOCS-5976 Tier B (`c6ea5549a`) gutted it. The intended edit was to delete **one** `{% columns %}` content-ref block — the one pointing at the `legacy-storage-engines/` folder being removed — and promote FEDERATED into its place. It deleted 23 of the 24 blocks instead.

|  | Before | After Tier B | After `b36d939` |
|---|---|---|---|
| Lines | 298 | 22 | 310 |
| content-refs | 24 | **1** | 25 |
| `SUMMARY.md` children | 27 | **27** | 27 |

`SUMMARY.md` was never touched, so the nav listed all 27 engines while the page listed one. **Every existing gate passed** — codespell had fewer words to check, lychee found the one surviving link valid, and the pre-commit hook runs only those plus the include resolver. A reader found it two days later.

Same failure class as the dead `{% include %}` bug from DOCS-6372: content silently vanishes, markup stays valid, both linters shrug.

## The guard

Added to `.claude/hooks/doc-lint.sh` beside the include resolver, in its "no CI counterpart" section. Flags any file that lost more than **40% of its lines net** (deletions minus additions), min 20 net lines lost, pre-image ≥ 30 lines, measured against `DOC_LINT_BASE` (default `HEAD`).

**Net loss, not raw deletions** is the design point — raw deletion ratio flags every reformatting campaign (alias expansion, hard-break removal, changelog normalization), because those *rewrite* lines rather than remove them:

| Metric, last 300 commits | Files flagged |
|---|---|
| Raw deletions > 40% | 17 (mostly legitimate reformatting) |
| **Net loss > 40%** | **4** |

On `c6ea5549a` the guard produces a **one-item list** — `storage-engines/README.md` at 93%, next-worst modified file at 16%.

A large shrink is often correct, so this is an acknowledge-gate, not a blocker:

```bash
DOC_LINT_ALLOW_SHRINK='path/to/README.md' .claude/hooks/doc-lint.sh <files>
```

Tunable via `DOC_LINT_SHRINK_PCT`, `DOC_LINT_SHRINK_MIN`, `DOC_LINT_SHRINK_FLOOR`, `DOC_LINT_BASE`; `DOC_LINT_ALLOW_SHRINK=all` disables it.

## Also: doc-lint.sh has been dead on Linux since 2026-08-05

**Please look at this part especially — it has a wider blast radius than the guard.** `doc-lint.sh` exits 2 on *every* invocation under GNU coreutils:

```
mktemp: too few X's in template 'doclint-inc'
doc-lint: mktemp failed
```

GNU `mktemp` rejects a `-t` template with no `X` characters; BSD/macOS accepts it as a prefix. The line came in with `f2b5e332c` (DOCS-6372, 2026-08-05) — 135 commits ago — and sits *before* the checks, so the include resolver that commit added has never run on Linux, and this new guard was unreachable until the fix. Now uses a positional template, which works on GNU and BSD alike.

It went unnoticed because commits in this workflow are made from a shell rather than through the Claude Code Bash tool, so the `PreToolUse` hook path is rarely exercised.

Happy to split this into its own commit/ticket if you'd rather track it separately — it's one line plus its comment.

## Verification

- Real failure caught: 1 of the 45 modified `.md` files in `c6ea5549a` flagged, correct file, `276 of 298 lines net (93%)`, exit 1.
- Edge cases: unchanged file → no flag, exit 0; file absent from base (new page) → skipped; bogus base rev → skipped; non-git directory → skipped; `./`-prefixed paths normalized; comma-separated allowlist; `all`; threshold overrides.
- No false positives across 40 unchanged `README.md` files.
- Include resolver confirmed working again on both failure modes (missing target, cross-space include).
- codespell and lychee confirmed still firing, via a scratch file with a planted typo and a broken link.
- `bash -n` clean. **`shellcheck` was not run** — not installed locally, and the change is all shell, so worth a pass here.

## Follow-ups deliberately not in this PR

1. **Index-coverage warning** — for a README with ≥ 2 content-refs, warn when its content-ref count falls well below its direct-children count. Repo-wide, 212 of 262 index READMEs sit at 0.90–1.05 coverage and only 2 below 0.50; Tier B left this page at 1/27. Needs a small allowlist, hence deferred.
2. **Repetitive-block count assertion in `bulk-campaign`** — when an edit removes k of n repeated blocks, assert n − k remain. The six other READMEs went 13→12, 29→28, 7→6, 34→33, 5→4, 4→3; nothing verified the seventh.
3. **Reconcile stated intent against `--numstat`** before committing. Tier B's own message implied ~84 lines across seven READMEs; the diffstat said 349.
4. **Extend the fact-check report to collateral edits** — a structural invariant on a *surviving* file falls outside the current claim → source → verdict format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6470]: https://mariadbcorp.atlassian.net/browse/DOCS-6470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ