### PR TITLE
DOCS-6381 Fix dead relative links in the MaxScale documentation spaces

### DIFF
--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/maxscale-mariadb-monitor-usage/maxscale-mariadb-monitor-usage-aurora-monitor/designing-for-maxscales-aurora-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/maxscale-mariadb-monitor-usage/maxscale-mariadb-monitor-usage-aurora-monitor/designing-for-maxscales-aurora-monitor.md
@@ -4,11 +4,7 @@
 
 ## Overview
 
-MaxScale's [Aurora Monitor (auroramon)](broken-reference) monitors the status of Aurora cluster replicas.
-
-## EXTERNAL REFERENCES
-
-Additional information is available [here](broken-reference).
+MaxScale's [Aurora Monitor (auroramon)](../../mariadb-maxscale-2106-maxscale-2106-aurora-monitor.md) monitors the status of Aurora cluster replicas.
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/maxscale-mariadb-monitor-usage/maxscale-mariadb-monitor-usage-aurora-monitor/understanding-maxscales-aurora-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/maxscale-mariadb-monitor-usage/maxscale-mariadb-monitor-usage-aurora-monitor/understanding-maxscales-aurora-monitor.md
@@ -1,10 +1,10 @@
 # Understanding MaxScale's Aurora Monitor
 
-MaxScale's [Aurora Monitor (auroramon)](broken-reference) monitors the status of Aurora cluster replicas.
+MaxScale's [Aurora Monitor (auroramon)](../../mariadb-maxscale-2106-maxscale-2106-aurora-monitor.md) monitors the status of Aurora cluster replicas.
 
 ## What Does the Aurora Monitor Support?
 
-The [Aurora Monitor (auroramon)](broken-reference) supports:
+The [Aurora Monitor (auroramon)](../../mariadb-maxscale-2106-maxscale-2106-aurora-monitor.md) supports:
 
 * Monitoring replicas in Amazon Aurora deployments
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/maxscale-mariadb-monitor-usage/maxscale-mariadb-monitor-usage-mariadb-monitor/designing-for-maxscales-mariadb-monitor.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-21-06-monitors/maxscale-mariadb-monitor-usage/maxscale-mariadb-monitor-usage-mariadb-monitor/designing-for-maxscales-mariadb-monitor.md
@@ -7,8 +7,6 @@ This page contains topics that need to be considered when designing applications
 * [How does MariaDB Monitor perform automatic failover?](using-automatic-failover-with-maxscales-mariadb-monitor.md)
 * [How does the MariaDB Monitor use cooperative locking in a highly available MaxScale deployment?](using-cooperative-locking-for-ha-with-maxscales-mariadb-monitor.md)
 
-Additional information is available [here](broken-reference).
-
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-2106-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-2106-contents.md
@@ -9,7 +9,7 @@ Anything referring to MaxScale 6 applies to MaxScale 21.06.
 ### About MariaDB MaxScale
 
 * [About MariaDB MaxScale](mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-about-mariadb-maxscale.md)
-* [Changelog]({release-notes}/maxscale/21.06/21.06-changelog)
+* [Changelog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/21.06/21.06-changelog)
 * [Limitations](mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale.md)
 
 ### Getting Started

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-2106-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-2106-maxscale-2106-contents.md
@@ -9,7 +9,7 @@ Anything referring to MaxScale 6 applies to MaxScale 21.06.
 ### About MariaDB MaxScale
 
 * [About MariaDB MaxScale](mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-about-mariadb-maxscale.md)
-* [Changelog](broken-reference)
+* [Changelog]({release-notes}/maxscale/21.06/21.06-changelog)
 * [Limitations](mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale.md)
 
 ### Getting Started

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-about-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-about-mariadb-maxscale.md
@@ -47,7 +47,7 @@ building from source code, is included in the [MariaDB MaxScale Installation\
 Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-installation-guide.md).
 
 The same guide also provides basic information on running MariaDB MaxScale. More
-detailed information about configuring MariaDB MaxScale can be found in the [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/).
+detailed information about configuring MariaDB MaxScale can be found in the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md).
 
 CC BY-SA / Gnu FDL
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-authentication-modules.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-authentication-modules.md
@@ -5,7 +5,7 @@
 ## Authentication Modules
 
 This document describes general MySQL protocol authentication in MaxScale. For\
-REST-api authentication, see the [configuration guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/) and the [REST-api guide](../../../../../en/mariadb-maxscale-2208-maxscale-rest-api/).
+REST-api authentication, see the [configuration guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) and the [REST-api guide](../mariadb-maxscale-2208--rest-api/README.md).
 
 Similar to the MariaDB Server, MaxScale uses authentication plugins to implement
 different authentication schemes for incoming clients. The same plugins also
@@ -38,7 +38,7 @@ communicating the first failure to the client. This transparent user data update
 does not always work, in which case the client should try to log in again.
 
 As the UAM is shared between all listeners of a service, its settings are
-defined in the service configuration. For more information, search the [configuration guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/)
+defined in the service configuration. For more information, search the [configuration guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md)
 for _users\_refresh\_time_, _users\_refresh\_interval_ and\_auth\_all\_servers\_. Other settings which affect how the UAM connects to backends
 are the global settings _auth\_connect\_timeout_ and _local\_address_, and
 the various server-level ssl-settings.
@@ -86,7 +86,7 @@ Option 1 limits the passwords for user accounts with shared usernames. Such
 accounts must use the same password since they will effectively share the\
 MaxScale-to-backend user account. Option 2 requires server support.
 
-See [MaxScale Troubleshooting](../../../../maxscale-versions/maxscale-troubleshooting.md)
+See [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 for additional information on how to solve authentication issues.
 
 #### Wildcard database grants
@@ -110,7 +110,7 @@ authenticator_options=skip_authentication=true,lower_case_table_names=1
 
 #### `skip_authentication`
 
-* Type: [boolean](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#booleans)
+* Type: [boolean](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#booleans)
 * Mandatory: No
 * Dynamic: No
 * Default: `false`
@@ -137,7 +137,7 @@ authenticator_options=skip_authentication=true
 
 #### `match_host`
 
-* Type: [boolean](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#booleans)
+* Type: [boolean](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#booleans)
 * Mandatory: No
 * Dynamic: No
 * Default: `true`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-gssapi-client-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-gssapi-client-authenticator.md
@@ -68,7 +68,7 @@ authenticator_options=principal_name=mymariadb@EXAMPLE.COM,gssapi_keytab_path=/h
 
 ### Implementation details
 
-Read the [Authentication Modules](../../../../../en/mariadb-maxscale-2208-maxscale-2208-authentication-modules/) document for more
+Read the [Authentication Modules](mariadb-maxscale-2208-authentication-modules.md) document for more
 details on how authentication modules work in MaxScale.
 
 #### GSSAPI authentication

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-mysql-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-mysql-authenticator.md
@@ -15,7 +15,7 @@ listener.
 
 #### `log_password_mismatch`
 
-* Type: [boolean](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#booleans)
+* Type: [boolean](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#booleans)
 * Mandatory: No
 * Dynamic: No
 * Default: `false`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-installing-mariadb-maxscale-using-a-tarball.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-installing-mariadb-maxscale-using-a-tarball.md
@@ -64,7 +64,7 @@ $ sudo chown maxscale /var/cache/maxscale
 
 The following step is to create the MariaDB MaxScale configuration file `/etc/maxscale.cnf`.\
 The file `etc/maxscale.cnf.template` can be used as a base.\
-Please refer to [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/) for details.
+Please refer to [Configuration Guide](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) for details.
 
 When the configuration file has been created, MariaDB MaxScale can be started.
 
@@ -98,7 +98,7 @@ $ tar -xzvf maxscale-x.y.z.OS.tar.gz
 
 The next step is to create the MaxScale configuration file `maxscale-x.y.z/etc/maxscale.cnf`.\
 The file `maxscale-x.y.z/etc/maxscale.cnf.template` can be used as a base.\
-Please refer to [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/) for details.
+Please refer to [Configuration Guide](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) for details.
 
 When the configuration file has been created, MariaDB MaxScale can be started.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-installation-guide.md
@@ -80,7 +80,7 @@ cat /proc/sys/vm/overcommit_memory
 steps in configuring your MariaDB MaxScale installation. Follow this tutorial
 to learn how to configure and start using MaxScale.
 
-For a detailed list of all configuration parameters, refer to the [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/) and the module specific documents
+For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md) and the module specific documents
 listed in the [Documentation Contents](https://mariadb.com/kb/en/mariadb-maxscale-2208-maxscale-2208-contents/#routers).
 
 ### Encrypting Passwords

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-mariadb-protocol-module.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-protocols/mariadb-maxscale-2208-mariadb-protocol-module.md
@@ -31,7 +31,7 @@ For the MariaDB protocol module, the prefix is always `mariadbprotocol`.
 
 #### `allow_replication`
 
-* Type: [boolean](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/#booleans)
+* Type: [boolean](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md#booleans)
 * Mandatory: No
 * Dynamic: Yes
 * Default: true

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-configuring-servers.md
@@ -34,7 +34,7 @@ to the server section. To enable server certificate verification, add`ssl_verify
 The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line
 client.
 
-For more information about TLS, refer to the [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/).
+For more information about TLS, refer to the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md).
 
 CC BY-SA / Gnu FDL
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-rest-api-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-rest-api-tutorial.md
@@ -356,7 +356,7 @@ objects.
 
 ### Further Reading
 
-The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../../../../../en/mariadb-maxscale-2208-maxscale-rest-api/).
+The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../mariadb-maxscale-2208--rest-api/README.md).
 
 The `maxctrl` command line client is self-documenting and the `maxctrl help`
 command is a good tool for exploring the various commands that are available in

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-setting-up-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-setting-up-mariadb-maxscale.md
@@ -170,7 +170,7 @@ when using a read-write-splitting configuration.
 MariaDB MaxScale is now ready to start accepting client connections and route queries to
 the backend cluster.
 
-More options can be found in the [Configuration Guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/),[readwritesplit module documentation](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md) and [readconnroute module documentation](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readconnroute.md).
+More options can be found in the [Configuration Guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md),[readwritesplit module documentation](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readwritesplit.md) and [readconnroute module documentation](../mariadb-maxscale-2208-routers/mariadb-maxscale-2208-readconnroute.md).
 
 For more information about MaxCtrl and how to secure it, see the [REST-API Tutorial](mariadb-maxscale-2208-rest-api-tutorial.md).
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-simple-sharding-with-two-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-tutorials/mariadb-maxscale-2208-simple-sharding-with-two-servers.md
@@ -12,7 +12,7 @@ MariaDB MaxScale will appear to the client as a database server with the combina
 
 This document is designed as a simple tutorial on schema-based sharding using MariaDB MaxScale in an environment in which you have two servers. The object of this tutorial is to have a system that, to the client side, acts like a single MariaDB database but actually is sharded between the two servers.
 
-The database users should be configured according to [the configuration guide](../../../../../en/maxscale-2208-getting-started-mariadb-maxscale-configuration-guide/). The [MaxScale Tutorial](mariadb-maxscale-2208-setting-up-mariadb-maxscale.md) contains easy to follow instructions on how to set up MaxScale.
+The database users should be configured according to [the configuration guide](../mariadb-maxscale-2208-getting-started/mariadb-maxscale-2208-mariadb-maxscale-configuration-guide.md). The [MaxScale Tutorial](mariadb-maxscale-2208-setting-up-mariadb-maxscale.md) contains easy to follow instructions on how to set up MaxScale.
 
 This tutorial will assume the user is using of the binary distributions available and has installed this in the default location. The process of configuring MariaDB MaxScale will be covered within this document. The installation and configuration of the MariaDB servers will not be covered in-depth.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-14-to-20.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-14-to-20.md
@@ -7,7 +7,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 1.4 to 2.0.
 
-For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
+For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/22.08/22.08-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-14-to-20.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-14-to-20.md
@@ -7,7 +7,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 1.4 to 2.0.
 
-For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
+For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -7,7 +7,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 2.0 to 2.1.
 
-For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
+For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -7,7 +7,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 2.0 to 2.1.
 
-For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
+For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/22.08/22.08-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-21-to-22.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-21-to-22.md
@@ -7,7 +7,7 @@
 This document describes possible issues upgrading MariaDB MaxScale from version\
 2.1 to 2.2.
 
-For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
+For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current configuration
 file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-21-to-22.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-21-to-22.md
@@ -7,7 +7,7 @@
 This document describes possible issues upgrading MariaDB MaxScale from version\
 2.1 to 2.2.
 
-For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
+For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current configuration
 file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-22-to-23.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-22-to-23.md
@@ -8,7 +8,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.2 to 2.3.
 
 For more information about MariaDB MaxScale 2.3, please refer
-to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
+to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-22-to-23.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-22-to-23.md
@@ -8,7 +8,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.2 to 2.3.
 
 For more information about MariaDB MaxScale 2.3, please refer
-to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
+to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-23-to-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-23-to-24.md
@@ -8,7 +8,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.3 to 2.4.
 
 For more information about MariaDB MaxScale 2.4, please refer
-to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
+to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-23-to-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-23-to-24.md
@@ -8,7 +8,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.3 to 2.4.
 
 For more information about MariaDB MaxScale 2.4, please refer
-to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
+to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.4 to 2.5.
 
-For more information about MaxScale 2.5, refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
+For more information about MaxScale 2.5, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be
 backed up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.4 to 2.5.
 
-For more information about MaxScale 2.5, refer to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
+For more information about MaxScale 2.5, refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be
 backed up.
@@ -21,7 +21,7 @@ no longer be used.
 ### Authentication
 
 The credentials used by services now require additional grants. For a full list
-of required grants, refer to the [protocol documentation](../../../../../en/mariadb-maxscale-2208-maxscale-2208-authentication-modules/#required-grants).
+of required grants, refer to the [protocol documentation](../mariadb-maxscale-2208-authenticators/mariadb-maxscale-2208-authentication-modules.md#required-grants).
 
 ### MariaDB-Monitor
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-25-to-6.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-25-to-6.md
@@ -15,7 +15,7 @@ versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was
 followed by the maintenance release 2.5.2. 6.1, the first GA version of MaxScale\
 6, will be followed by the maintenance release 6.2.
 
-For more information about MaxScale 6, refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
+For more information about MaxScale 6, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-25-to-6.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-25-to-6.md
@@ -15,7 +15,7 @@ versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was
 followed by the maintenance release 2.5.2. 6.1, the first GA version of MaxScale\
 6, will be followed by the maintenance release 6.2.
 
-For more information about MaxScale 6, refer to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
+For more information about MaxScale 6, refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-6-to-2208.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-6-to-2208.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 6 to 22.08.
 
-For more information about MaxScale 22.08, refer to the [ChangeLog](../../../../../en/mariadb-maxscale-2208-maxscale-2208-changelog/).
+For more information about MaxScale 22.08, refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-6-to-2208.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-upgrading/mariadb-maxscale-2208-upgrading-mariadb-maxscale-from-6-to-2208.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 6 to 22.08.
 
-For more information about MaxScale 22.08, refer to the [ChangeLog]({release-notes}/maxscale/22.08/22.08-changelog).
+For more information about MaxScale 22.08, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/22.08/22.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-14-to-20.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-14-to-20.md
@@ -3,7 +3,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 1.4 to 2.0.
 
-For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog](broken-reference).
+For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-14-to-20.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-14-to-20.md
@@ -3,7 +3,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 1.4 to 2.0.
 
-For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
+For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -3,7 +3,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 2.0 to 2.1.
 
-For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
+For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -3,7 +3,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 2.0 to 2.1.
 
-For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog](broken-reference).
+For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-21-to-22.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-21-to-22.md
@@ -3,7 +3,7 @@
 This document describes possible issues upgrading MariaDB MaxScale from version\
 2.1 to 2.2.
 
-For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog](broken-reference).
+For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, we recommend you back up your current configuration
 file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-21-to-22.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-21-to-22.md
@@ -3,7 +3,7 @@
 This document describes possible issues upgrading MariaDB MaxScale from version\
 2.1 to 2.2.
 
-For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
+For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, we recommend you back up your current configuration
 file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-22-to-23.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-22-to-23.md
@@ -4,7 +4,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.2 to 2.3.
 
 For more information about MariaDB MaxScale 2.3, please refer
-to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
+to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-22-to-23.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-22-to-23.md
@@ -4,7 +4,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.2 to 2.3.
 
 For more information about MariaDB MaxScale 2.3, please refer
-to the [ChangeLog](broken-reference).
+to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md
@@ -3,7 +3,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 22.08 to 23.02.
 
-For more information about MaxScale 23.02, refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
+For more information about MaxScale 23.02, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md
@@ -3,7 +3,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 22.08 to 23.02.
 
-For more information about MaxScale 23.02, refer to the [ChangeLog](broken-reference).
+For more information about MaxScale 23.02, refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-23-to-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-23-to-24.md
@@ -4,7 +4,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.3 to 2.4.
 
 For more information about MariaDB MaxScale 2.4, please refer
-to the [ChangeLog](broken-reference).
+to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-23-to-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-23-to-24.md
@@ -4,7 +4,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.3 to 2.4.
 
 For more information about MariaDB MaxScale 2.4, please refer
-to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
+to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -3,7 +3,7 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.4 to 2.5.
 
-For more information about MaxScale 2.5, refer to the [ChangeLog](broken-reference).
+For more information about MaxScale 2.5, refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, any existing configuration files should be
 backed up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -3,7 +3,7 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.4 to 2.5.
 
-For more information about MaxScale 2.5, refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
+For more information about MaxScale 2.5, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, any existing configuration files should be
 backed up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-25-to-6.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-25-to-6.md
@@ -11,7 +11,7 @@ versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was
 followed by the maintenance release 2.5.2. 6.1, the first GA version of MaxScale\
 6, will be followed by the maintenance release 6.2.
 
-For more information about MaxScale 6, refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
+For more information about MaxScale 6, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-25-to-6.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-25-to-6.md
@@ -11,7 +11,7 @@ versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was
 followed by the maintenance release 2.5.2. 6.1, the first GA version of MaxScale\
 6, will be followed by the maintenance release 6.2.
 
-For more information about MaxScale 6, refer to the [ChangeLog](broken-reference).
+For more information about MaxScale 6, refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208.md
@@ -3,7 +3,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 6 to 22.08.
 
-For more information about MaxScale 22.08, refer to the [ChangeLog](broken-reference).
+For more information about MaxScale 22.08, refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208.md
@@ -3,7 +3,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 6 to 22.08.
 
-For more information about MaxScale 22.08, refer to the [ChangeLog]({release-notes}/maxscale/23.02/23.02-changelog).
+For more information about MaxScale 22.08, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-2302-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-2302-contents.md
@@ -3,7 +3,7 @@
 ### About MariaDB MaxScale
 
 * [About MariaDB MaxScale](mariadb-maxscale-23-02-about/mariadb-maxscale-2302-about-mariadb-maxscale.md)
-* [Changelog]({release-notes}/maxscale/23.02/23.02-changelog)
+* [Changelog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog)
 * [Limitations](mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md)
 
 ### Getting Started

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-2302-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-2302-contents.md
@@ -3,7 +3,7 @@
 ### About MariaDB MaxScale
 
 * [About MariaDB MaxScale](mariadb-maxscale-23-02-about/mariadb-maxscale-2302-about-mariadb-maxscale.md)
-* [Changelog](broken-reference)
+* [Changelog]({release-notes}/maxscale/23.02/23.02-changelog)
 * [Limitations](mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md)
 
 ### Getting Started

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-about-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-about-mariadb-maxscale.md
@@ -47,7 +47,7 @@ building from source code, is included in the [MariaDB MaxScale Installation\
 Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-installation-guide.md).
 
 The same guide also provides basic information on running MariaDB MaxScale. More
-detailed information about configuring MariaDB MaxScale can be found in the [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/).
+detailed information about configuring MariaDB MaxScale can be found in the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md).
 
 CC BY-SA / Gnu FDL
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md
@@ -5,12 +5,12 @@
 ## Authentication Modules
 
 This document describes general MySQL protocol authentication in MaxScale. For\
-REST-api authentication, see the [configuration guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/) and the [REST-api guide](../../../../../en/mariadb-maxscale-2308-maxscale-rest-api/).
+REST-api authentication, see the [configuration guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) and the [REST-api guide](../mariadb-maxscale-23-08-rest-api/README.md).
 
 Similar to the MariaDB Server, MaxScale uses authentication plugins to implement
 different authentication schemes for incoming clients. The same plugins also
 handle authenticating the clients to backend servers. The authentication plugins
-available in MaxScale are [standard MySQL password](../../../../../en/mariadbmysql-authenticator/),[GSSAPI](mariadb-maxscale-2308-gssapi-client-authenticator.md) and [pluggable authentication modules (PAM)](mariadb-maxscale-2308-pam-authenticator.md).
+available in MaxScale are [standard MySQL password](mariadb-maxscale-2308-mariadbmysql-authenticator.md),[GSSAPI](mariadb-maxscale-2308-gssapi-client-authenticator.md) and [pluggable authentication modules (PAM)](mariadb-maxscale-2308-pam-authenticator.md).
 
 Most of the authentication processing is performed on the protocol level, before
 handing it over to one of the plugins. This shared part is described in this
@@ -38,7 +38,7 @@ communicating the first failure to the client. This transparent user data update
 does not always work, in which case the client should try to log in again.
 
 As the UAM is shared between all listeners of a service, its settings are
-defined in the service configuration. For more information, search the [configuration guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/)
+defined in the service configuration. For more information, search the [configuration guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)
 for _users\_refresh\_time_, _users\_refresh\_interval_ and\_auth\_all\_servers\_. Other settings which affect how the UAM connects to backends
 are the global settings _auth\_connect\_timeout_ and _local\_address_, and
 the various server-level ssl-settings.
@@ -86,7 +86,7 @@ Option 1 limits the passwords for user accounts with shared usernames. Such
 accounts must use the same password since they will effectively share the\
 MaxScale-to-backend user account. Option 2 requires server support.
 
-See [MaxScale Troubleshooting](../../../../maxscale-versions/maxscale-troubleshooting.md)
+See [MaxScale Troubleshooting](../../../../maxscale-management/maxscale-troubleshooting.md)
 for additional information on how to solve authentication issues.
 
 #### Wildcard database grants
@@ -110,7 +110,7 @@ authenticator_options=skip_authentication=true,lower_case_table_names=1
 
 #### `skip_authentication`
 
-* Type: [boolean](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#booleans)
+* Type: [boolean](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#booleans)
 * Mandatory: No
 * Dynamic: No
 * Default: `false`
@@ -137,7 +137,7 @@ authenticator_options=skip_authentication=true
 
 #### `match_host`
 
-* Type: [boolean](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#booleans)
+* Type: [boolean](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#booleans)
 * Mandatory: No
 * Dynamic: No
 * Default: `true`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-mariadbmysql-authenticator.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-mariadbmysql-authenticator.md
@@ -49,7 +49,7 @@ ssl=true
 
 #### `log_password_mismatch`
 
-* Type: [boolean](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#booleans)
+* Type: [boolean](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#booleans)
 * Mandatory: No
 * Dynamic: No
 * Default: `false`

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-installing-mariadb-maxscale-using-a-tarball.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-installing-mariadb-maxscale-using-a-tarball.md
@@ -65,7 +65,7 @@ $ sudo chown maxscale /var/cache/maxscale
 
 The following step is to create the MariaDB MaxScale configuration file `/etc/maxscale.cnf`.\
 The file `etc/maxscale.cnf.template` can be used as a base.\
-Please refer to [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/) for details.
+Please refer to [Configuration Guide](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) for details.
 
 When the configuration file has been created, MariaDB MaxScale can be started.
 
@@ -99,7 +99,7 @@ $ tar -xzvf maxscale-x.y.z.OS.tar.gz
 
 The next step is to create the MaxScale configuration file `maxscale-x.y.z/etc/maxscale.cnf`.\
 The file `maxscale-x.y.z/etc/maxscale.cnf.template` can be used as a base.\
-Please refer to [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/) for details.
+Please refer to [Configuration Guide](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) for details.
 
 When the configuration file has been created, MariaDB MaxScale can be started.
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-installation-guide.md
@@ -80,7 +80,7 @@ cat /proc/sys/vm/overcommit_memory
 steps in configuring your MariaDB MaxScale installation. Follow this tutorial
 to learn how to configure and start using MaxScale.
 
-For a detailed list of all configuration parameters, refer to the [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/) and the module specific documents
+For a detailed list of all configuration parameters, refer to the [Configuration Guide](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md) and the module specific documents
 listed in the [Documentation Contents](https://mariadb.com/kb/en/mariadb-maxscale-2308-maxscale-2308-contents/#routers).
 
 ### Encrypting Passwords

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-configuring-servers.md
@@ -34,7 +34,7 @@ to the server section. To enable server certificate verification, add`ssl_verify
 The `ssl` and `ssl_verify_peer_certificate` parameters are similar to the`--ssl` and `--ssl-verify-server-cert` options of the `mysql` command line
 client.
 
-For more information about TLS, refer to the [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/).
+For more information about TLS, refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md).
 
 CC BY-SA / Gnu FDL
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-rest-api-tutorial.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-rest-api-tutorial.md
@@ -356,7 +356,7 @@ objects.
 
 ### Further Reading
 
-The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../../../../../en/mariadb-maxscale-2308-maxscale-rest-api/).
+The full list of all available endpoints in MaxScale can be found in the [REST API documentation](../mariadb-maxscale-23-08-rest-api/README.md).
 
 The `maxctrl` command line client is self-documenting and the `maxctrl help`
 command is a good tool for exploring the various commands that are available in

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-setting-up-mariadb-maxscale.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-setting-up-mariadb-maxscale.md
@@ -170,7 +170,7 @@ when using a read-write-splitting configuration.
 MariaDB MaxScale is now ready to start accepting client connections and route queries to
 the backend cluster.
 
-More options can be found in the [Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/),[readwritesplit module documentation](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md) and [readconnroute module documentation](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readconnroute.md).
+More options can be found in the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md),[readwritesplit module documentation](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md) and [readconnroute module documentation](../mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readconnroute.md).
 
 For more information about MaxCtrl and how to secure it, see the [REST-API Tutorial](mariadb-maxscale-2308-rest-api-tutorial.md).
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-simple-sharding-with-two-servers.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-simple-sharding-with-two-servers.md
@@ -31,7 +31,7 @@ apt -y install maxscale
 ### Creating Users
 
 This tutorial uses a broader set of grants than is required for the sake of
-brevity and backwards compatibility. For the minimal set of grants, refer to the [MaxScale Configuration Guide](../../../../../en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/).
+brevity and backwards compatibility. For the minimal set of grants, refer to the [MaxScale Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md).
 
 All MaxScale configurations require at least two accounts: one for reading
 authentication data and another for monitoring the state of the

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-14-to-20.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-14-to-20.md
@@ -7,7 +7,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 1.4 to 2.0.
 
-For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog](broken-reference).
+For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-14-to-20.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-14-to-20.md
@@ -7,7 +7,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 1.4 to 2.0.
 
-For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+For more information about MariaDB MaxScale 2.0, please refer to [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -7,7 +7,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 2.0 to 2.1.
 
-For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog](broken-reference).
+For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -7,7 +7,7 @@
 This document describes particular issues to take into account when upgrading\
 MariaDB MaxScale from version 2.0 to 2.1.
 
-For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+For more information about MariaDB MaxScale 2.1, please refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 ### Installation
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-21-to-22.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-21-to-22.md
@@ -7,7 +7,7 @@
 This document describes possible issues upgrading MariaDB MaxScale from version\
 2.1 to 2.2.
 
-For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog](broken-reference).
+For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current configuration
 file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-21-to-22.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-21-to-22.md
@@ -7,7 +7,7 @@
 This document describes possible issues upgrading MariaDB MaxScale from version\
 2.1 to 2.2.
 
-For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+For more information about MariaDB MaxScale 2.2, please refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current configuration
 file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-22-to-23.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-22-to-23.md
@@ -8,7 +8,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.2 to 2.3.
 
 For more information about MariaDB MaxScale 2.3, please refer
-to the [ChangeLog](broken-reference).
+to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-22-to-23.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-22-to-23.md
@@ -8,7 +8,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.2 to 2.3.
 
 For more information about MariaDB MaxScale 2.3, please refer
-to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2208-to-2302.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2208-to-2302.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 22.08 to 23.02.
 
-For more information about MaxScale 23.02, refer to the [ChangeLog](broken-reference).
+For more information about MaxScale 23.02, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2208-to-2302.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2208-to-2302.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 22.08 to 23.02.
 
-For more information about MaxScale 23.02, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+For more information about MaxScale 23.02, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-23-to-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-23-to-24.md
@@ -8,7 +8,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.3 to 2.4.
 
 For more information about MariaDB MaxScale 2.4, please refer
-to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-23-to-24.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-23-to-24.md
@@ -8,7 +8,7 @@ This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.3 to 2.4.
 
 For more information about MariaDB MaxScale 2.4, please refer
-to the [ChangeLog](broken-reference).
+to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, we recommend you back up your current
 configuration file.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2302-to-2308.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2302-to-2308.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 23.02 to 23.08.
 
-For more information about MaxScale 23.08, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+For more information about MaxScale 23.08, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2302-to-2308.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-2302-to-2308.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 23.02 to 23.08.
 
-For more information about MaxScale 23.08, refer to the [ChangeLog](broken-reference).
+For more information about MaxScale 23.08, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.4 to 2.5.
 
-For more information about MaxScale 2.5, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+For more information about MaxScale 2.5, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be
 backed up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB\
 MaxScale from version 2.4 to 2.5.
 
-For more information about MaxScale 2.5, refer to the [ChangeLog](broken-reference).
+For more information about MaxScale 2.5, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be
 backed up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-25-to-6.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-25-to-6.md
@@ -15,7 +15,7 @@ versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was
 followed by the maintenance release 2.5.2. 6.1, the first GA version of MaxScale\
 6, will be followed by the maintenance release 6.2.
 
-For more information about MaxScale 6, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+For more information about MaxScale 6, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-25-to-6.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-25-to-6.md
@@ -15,7 +15,7 @@ versioned. For instance, 2.5.1, the first GA version of MaxScale 2.5, was
 followed by the maintenance release 2.5.2. 6.1, the first GA version of MaxScale\
 6, will be followed by the maintenance release 6.2.
 
-For more information about MaxScale 6, refer to the [ChangeLog](broken-reference).
+For more information about MaxScale 6, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-6-to-2208.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-6-to-2208.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 6 to 22.08.
 
-For more information about MaxScale 22.08, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
+For more information about MaxScale 22.08, refer to the [ChangeLog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-6-to-2208.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-6-to-2208.md
@@ -7,7 +7,7 @@
 This document describes possible issues when upgrading MariaDB MaxScale from
 version 6 to 22.08.
 
-For more information about MaxScale 22.08, refer to the [ChangeLog](broken-reference).
+For more information about MaxScale 22.08, refer to the [ChangeLog]({release-notes}/maxscale/23.08/23.08-changelog).
 
 Before starting the upgrade, any existing configuration files should be backed
 up.

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-2308-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-2308-contents.md
@@ -107,7 +107,7 @@ Documentation for MaxScale protocol modules.
 
 The MaxScale CDC Connector provides a C++ API for consuming data from a CDC system.
 
-* [CDC Connector](../../../maxscale-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-connectors/mariadb-maxscale-2308-maxscale-cdc-connector.md)
+* CDC Connector
 
 ### Authenticators
 

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-2501-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-2501-contents.md
@@ -6,9 +6,9 @@
 
 ### About MariaDB MaxScale
 
-* [About MariaDB MaxScale](broken-reference/)
-* [Changelog](broken-reference)
-* [Limitations](broken-reference/)
+* [About MariaDB MaxScale](maxscale-25-01-about.md)
+* [Changelog]({release-notes}/maxscale/25.01/25.01-changelog)
+* [Limitations](../../../maxscale-management/mariadb-maxscale-limitations-guide.md)
 
 ### Getting Started
 
@@ -19,7 +19,7 @@
 
 ### Upgrading MariaDB MaxScale
 
-* [Upgrading MaxScale](broken-reference)
+* [Upgrading MaxScale](../../../maxscale-management/deployment/upgrading-maxscale/upgrade-to-maxscale-25.01.md)
 
 ### Reference
 
@@ -119,7 +119,7 @@ The MaxScale CDC Connector provides a C++ API for consuming data from a CDC syst
 
 ### Authenticators
 
-A short description of the authentication module type can be found in the [Authentication Modules](broken-reference/)
+A short description of the authentication module type can be found in the [Authentication Modules](mariadb-maxscale-25-01-authenticators/README.md)
 document.
 
 * [MariaDB/MySQL Authenticator](mariadb-maxscale-25-01-authenticators/mariadb-maxscale-2501-maxscale-2501-mariadbmysql-authenticator.md)

--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-2501-contents.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-2501-contents.md
@@ -7,7 +7,7 @@
 ### About MariaDB MaxScale
 
 * [About MariaDB MaxScale](maxscale-25-01-about.md)
-* [Changelog]({release-notes}/maxscale/25.01/25.01-changelog)
+* [Changelog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/25.01/25.01-changelog)
 * [Limitations](../../../maxscale-management/mariadb-maxscale-limitations-guide.md)
 
 ### Getting Started

--- a/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
+++ b/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
@@ -888,7 +888,7 @@ If the connection to the server where a transaction is being executed is lost wh
 
 Any changes to the session state (e.g. autocommit state, SQL mode) done inside a transaction will remain in effect even if the connection to the server where the transaction is being executed fails. When readwritesplit creates a new connection to a server to replay the transaction, it will first restore the session state by executing all session commands that were executed. This means that if the session state is changed mid-transaction in a way that affects the results, transaction replay will fail.
 
-The following partial transaction demonstrates the problem by using [`SQL_MODE`](../../../server/server-management/variables-and-modes/sql-mode.md) inside a transaction.
+The following partial transaction demonstrates the problem by using [`SQL_MODE`]({server}/server-management/variables-and-modes/sql_mode) inside a transaction.
 
 ```
 SET SQL_MODE='';            -- A session command

--- a/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
+++ b/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
@@ -888,7 +888,7 @@ If the connection to the server where a transaction is being executed is lost wh
 
 Any changes to the session state (e.g. autocommit state, SQL mode) done inside a transaction will remain in effect even if the connection to the server where the transaction is being executed fails. When readwritesplit creates a new connection to a server to replay the transaction, it will first restore the session state by executing all session commands that were executed. This means that if the session state is changed mid-transaction in a way that affects the results, transaction replay will fail.
 
-The following partial transaction demonstrates the problem by using [`SQL_MODE`]({server}/server-management/variables-and-modes/sql_mode) inside a transaction.
+The following partial transaction demonstrates the problem by using [`SQL_MODE`](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) inside a transaction.
 
 ```
 SET SQL_MODE='';            -- A session command

--- a/release-notes/maxscale/21.06/21.06.16.md
+++ b/release-notes/maxscale/21.06/21.06.16.md
@@ -46,7 +46,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ## Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ## Packaging
 

--- a/release-notes/maxscale/21.06/21.06.16.md
+++ b/release-notes/maxscale/21.06/21.06.16.md
@@ -46,7 +46,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ## Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ## Packaging
 

--- a/release-notes/maxscale/21.06/21.06.17.md
+++ b/release-notes/maxscale/21.06/21.06.17.md
@@ -37,7 +37,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/21.06/21.06.17.md
+++ b/release-notes/maxscale/21.06/21.06.17.md
@@ -37,7 +37,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/21.06/21.06.18.md
+++ b/release-notes/maxscale/21.06/21.06.18.md
@@ -60,7 +60,7 @@ a dependency on node that earlier was not present. In this version of MaxScale,
 maxctrl is again a native executable without that dependency.
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/21.06/21.06.18.md
+++ b/release-notes/maxscale/21.06/21.06.18.md
@@ -60,7 +60,7 @@ a dependency on node that earlier was not present. In this version of MaxScale,
 maxctrl is again a native executable without that dependency.
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/21.06/21.06.19.md
+++ b/release-notes/maxscale/21.06/21.06.19.md
@@ -46,7 +46,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/21.06/21.06.19.md
+++ b/release-notes/maxscale/21.06/21.06.19.md
@@ -46,7 +46,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-about/mariadb-maxscale-2106-maxscale-2106-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/21.06/21.06.20.md
+++ b/release-notes/maxscale/21.06/21.06.20.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 21.06.20, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](broken-reference/) for this MaxScale version.
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-upgrading/mariadb-maxscale-2106-maxscale-2106-upgrading-mariadb-maxscale) for this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
 

--- a/release-notes/maxscale/21.06/21.06.20.md
+++ b/release-notes/maxscale/21.06/21.06.20.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 21.06.20, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-upgrading/mariadb-maxscale-2106-maxscale-2106-upgrading-mariadb-maxscale) for this MaxScale version.
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-21-06/mariadb-maxscale-21-06-upgrading/mariadb-maxscale-2106-maxscale-2106-upgrading-mariadb-maxscale) for this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
 

--- a/release-notes/maxscale/22.08/22.08.1.md
+++ b/release-notes/maxscale/22.08/22.08.1.md
@@ -36,7 +36,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.1.md
+++ b/release-notes/maxscale/22.08/22.08.1.md
@@ -36,7 +36,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.10.md
+++ b/release-notes/maxscale/22.08/22.08.10.md
@@ -21,7 +21,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.10.md
+++ b/release-notes/maxscale/22.08/22.08.10.md
@@ -21,7 +21,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.11.md
+++ b/release-notes/maxscale/22.08/22.08.11.md
@@ -24,7 +24,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.11.md
+++ b/release-notes/maxscale/22.08/22.08.11.md
@@ -24,7 +24,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.12.md
+++ b/release-notes/maxscale/22.08/22.08.12.md
@@ -65,7 +65,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.12.md
+++ b/release-notes/maxscale/22.08/22.08.12.md
@@ -65,7 +65,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.13.md
+++ b/release-notes/maxscale/22.08/22.08.13.md
@@ -44,7 +44,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.13.md
+++ b/release-notes/maxscale/22.08/22.08.13.md
@@ -44,7 +44,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.14.md
+++ b/release-notes/maxscale/22.08/22.08.14.md
@@ -42,7 +42,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.14.md
+++ b/release-notes/maxscale/22.08/22.08.14.md
@@ -42,7 +42,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.15.md
+++ b/release-notes/maxscale/22.08/22.08.15.md
@@ -66,7 +66,7 @@ a dependency on node that earlier was not present. In this version of MaxScale,
 maxctrl is again a native executable without that dependency.
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.15.md
+++ b/release-notes/maxscale/22.08/22.08.15.md
@@ -66,7 +66,7 @@ a dependency on node that earlier was not present. In this version of MaxScale,
 maxctrl is again a native executable without that dependency.
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.16.md
+++ b/release-notes/maxscale/22.08/22.08.16.md
@@ -51,7 +51,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.16.md
+++ b/release-notes/maxscale/22.08/22.08.16.md
@@ -51,7 +51,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.17.md
+++ b/release-notes/maxscale/22.08/22.08.17.md
@@ -35,7 +35,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 
 ### Known Issues and Limitations
 
-There are some limitations and known issues within this version of MaxScale. For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+There are some limitations and known issues within this version of MaxScale. For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.17.md
+++ b/release-notes/maxscale/22.08/22.08.17.md
@@ -35,7 +35,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 
 ### Known Issues and Limitations
 
-There are some limitations and known issues within this version of MaxScale. For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+There are some limitations and known issues within this version of MaxScale. For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.18.md
+++ b/release-notes/maxscale/22.08/22.08.18.md
@@ -23,7 +23,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 * [MXS-5911](https://jira.mariadb.org/browse/MXS-5911) Upgrade Connector/C to 3.3.16 and 3.4.6
 * [MXS-5897](https://jira.mariadb.org/browse/MXS-5897) Failing COM\_STMT\_PREPAREs that don't generate an ID aren't discarded from the history
 * [MXS-5865](https://jira.mariadb.org/browse/MXS-5865) Run-time modification of users\_refresh\_time and users\_refresh\_interval are not immediately taken into use
-* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (std::length\_error in maxbase::load\_file[std::string](std::string)) on Ubuntu 24.04
+* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (`std::length_error` in `maxbase::load_file<std::string>(std::string)`) on Ubuntu 24.04
 * [MXS-5769](https://jira.mariadb.org/browse/MXS-5769) Watchdog timeout diagnostics are not detailed enough
 * [MXS-5760](https://jira.mariadb.org/browse/MXS-5760) Authentication failure on all backends does not immediately close sessions
 * [MXS-5733](https://jira.mariadb.org/browse/MXS-5733) MaxScale allows unlimited COM\_CHANGE\_USER attempts

--- a/release-notes/maxscale/22.08/22.08.2.md
+++ b/release-notes/maxscale/22.08/22.08.2.md
@@ -63,7 +63,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.2.md
+++ b/release-notes/maxscale/22.08/22.08.2.md
@@ -63,7 +63,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.3.md
+++ b/release-notes/maxscale/22.08/22.08.3.md
@@ -43,7 +43,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.3.md
+++ b/release-notes/maxscale/22.08/22.08.3.md
@@ -43,7 +43,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.4.md
+++ b/release-notes/maxscale/22.08/22.08.4.md
@@ -37,7 +37,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.4.md
+++ b/release-notes/maxscale/22.08/22.08.4.md
@@ -37,7 +37,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.5.md
+++ b/release-notes/maxscale/22.08/22.08.5.md
@@ -43,7 +43,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.5.md
+++ b/release-notes/maxscale/22.08/22.08.5.md
@@ -43,7 +43,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.6.md
+++ b/release-notes/maxscale/22.08/22.08.6.md
@@ -36,7 +36,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.6.md
+++ b/release-notes/maxscale/22.08/22.08.6.md
@@ -36,7 +36,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.7.md
+++ b/release-notes/maxscale/22.08/22.08.7.md
@@ -46,7 +46,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.7.md
+++ b/release-notes/maxscale/22.08/22.08.7.md
@@ -46,7 +46,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.8.md
+++ b/release-notes/maxscale/22.08/22.08.8.md
@@ -39,7 +39,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.8.md
+++ b/release-notes/maxscale/22.08/22.08.8.md
@@ -39,7 +39,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.9.md
+++ b/release-notes/maxscale/22.08/22.08.9.md
@@ -63,7 +63,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/22.08/22.08.9.md
+++ b/release-notes/maxscale/22.08/22.08.9.md
@@ -63,7 +63,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-22.08/mariadb-maxscale-2208-about/mariadb-maxscale-2208-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.0.md
+++ b/release-notes/maxscale/23.02/23.02.0.md
@@ -67,40 +67,40 @@ For more information on the new API functions, refer to the SQL resource [docume
 #### [MXS-3003](https://jira.mariadb.org/browse/MXS-3003) Support inbound proxy protocol
 
 MaxScale can read an inbound proxy protocol header and relay the information to
-backends. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide#proxy_protocol_networks)
+backends. See [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide#proxy_protocol_networks)
 for more information.
 
 #### [MXS-3262](https://jira.mariadb.org/browse/MXS-3262) Add create-backup and restore-from-backup commands to MariaDB-Monitor
 
 These commands backup and restore database contents to/from an external drive.\
-See [monitor documentation]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor#backup-operations)
+See [monitor documentation](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor#backup-operations)
 for more information.
 
 #### [MXS-3269](https://jira.mariadb.org/browse/MXS-3260) Make it possible to change at runtime the number of threads used by MaxScale
 
 It is now possible to change at runtime the number of threads MaxScale
-uses for routing client traffic. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide#threads-1)
+uses for routing client traffic. See [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide#threads-1)
 for more information.
 
 #### [MXS-3708](https://jira.mariadb.org/browse/MXS-3708) Cache runtime modification
 
-Some configuration parameters, most notable the [rules]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache#rules),
+Some configuration parameters, most notable the [rules](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache#rules),
 can now be changed at runtime.
 
 #### [MXS-3827](https://jira.mariadb.org/browse/MXS-3827) Audit log for the REST API
 
-The REST-API calls to MaxScale can now be logged. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide#administration-audit-file)
+The REST-API calls to MaxScale can now be logged. See [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide#administration-audit-file)
 for more information.
 
 #### [MXS-4106](https://jira.mariadb.org/browse/MXS-4106) Redis authentication
 
-Authentication can be enabled when Redis is used as the cache storage. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache#storage_redis) for more information.
+Authentication can be enabled when Redis is used as the cache storage. See [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache#storage_redis) for more information.
 
 #### [MXS-4107](https://jira.mariadb.org/browse/MXS-4107) TLS encrypted Redis connections
 
 SSL/TLS can now be used in the communication between MaxScale and
 the Redis server when the latter is used as the storage for the
-cache. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache#storage_redis) for more information.
+cache. See [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache#storage_redis) for more information.
 
 #### [MXS-4182](https://jira.mariadb.org/browse/MXS-4182) Session load indicator
 
@@ -110,7 +110,7 @@ during the previous 30 seconds.
 
 #### [MXS-4270](https://jira.mariadb.org/browse/MXS-4270) ed25519 authentication support
 
-MariaDB Server ed25519 authentication plugin support added. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-ed25519-authenticator) for more information.
+MariaDB Server ed25519 authentication plugin support added. See [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-ed25519-authenticator) for more information.
 
 #### [MXS-4320](https://jira.mariadb.org/browse/MXS-4320) Let maxctrl show datetime values using local client timezone
 
@@ -126,7 +126,7 @@ The most notable ones are listed here:
 
 * [MXS-4013](https://jira.mariadb.org/browse/MXS-4013) Add Views, Functions, and Indexes to the Query Editor schema sidebar.
 * [MXS-4285](https://jira.mariadb.org/browse/MXS-4285) Store user preferences.
-* [MXS-4430](https://jira.mariadb.org/browse/MXS-4430) ETL/Data Migration service GUI. Instructions on using it can be found [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-using-maxgui-tutorial#workspace)
+* [MXS-4430](https://jira.mariadb.org/browse/MXS-4430) ETL/Data Migration service GUI. Instructions on using it can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-using-maxgui-tutorial#workspace)
 
 ### Bug fixes
 
@@ -135,7 +135,7 @@ The most notable ones are listed here:
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.0.md
+++ b/release-notes/maxscale/23.02/23.02.0.md
@@ -67,40 +67,40 @@ For more information on the new API functions, refer to the SQL resource [docume
 #### [MXS-3003](https://jira.mariadb.org/browse/MXS-3003) Support inbound proxy protocol
 
 MaxScale can read an inbound proxy protocol header and relay the information to
-backends. See [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#proxy_protocol_networks)
+backends. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide#proxy_protocol_networks)
 for more information.
 
 #### [MXS-3262](https://jira.mariadb.org/browse/MXS-3262) Add create-backup and restore-from-backup commands to MariaDB-Monitor
 
 These commands backup and restore database contents to/from an external drive.\
-See [monitor documentation](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md#backup-operations)
+See [monitor documentation]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor#backup-operations)
 for more information.
 
 #### [MXS-3269](https://jira.mariadb.org/browse/MXS-3260) Make it possible to change at runtime the number of threads used by MaxScale
 
 It is now possible to change at runtime the number of threads MaxScale
-uses for routing client traffic. See [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#threads-1)
+uses for routing client traffic. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide#threads-1)
 for more information.
 
 #### [MXS-3708](https://jira.mariadb.org/browse/MXS-3708) Cache runtime modification
 
-Some configuration parameters, most notable the [rules](../mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache.md#rules),
+Some configuration parameters, most notable the [rules]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache#rules),
 can now be changed at runtime.
 
 #### [MXS-3827](https://jira.mariadb.org/browse/MXS-3827) Audit log for the REST API
 
-The REST-API calls to MaxScale can now be logged. See [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#administration-audit-file)
+The REST-API calls to MaxScale can now be logged. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide#administration-audit-file)
 for more information.
 
 #### [MXS-4106](https://jira.mariadb.org/browse/MXS-4106) Redis authentication
 
-Authentication can be enabled when Redis is used as the cache storage. See [here](../mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache.md#storage_redis) for more information.
+Authentication can be enabled when Redis is used as the cache storage. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache#storage_redis) for more information.
 
 #### [MXS-4107](https://jira.mariadb.org/browse/MXS-4107) TLS encrypted Redis connections
 
 SSL/TLS can now be used in the communication between MaxScale and
 the Redis server when the latter is used as the storage for the
-cache. See [here](../mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache.md#storage_redis) for more information.
+cache. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache#storage_redis) for more information.
 
 #### [MXS-4182](https://jira.mariadb.org/browse/MXS-4182) Session load indicator
 
@@ -110,7 +110,7 @@ during the previous 30 seconds.
 
 #### [MXS-4270](https://jira.mariadb.org/browse/MXS-4270) ed25519 authentication support
 
-MariaDB Server ed25519 authentication plugin support added. See [here](../mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-ed25519-authenticator.md) for more information.
+MariaDB Server ed25519 authentication plugin support added. See [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-authenticators/mariadb-maxscale-2302-ed25519-authenticator) for more information.
 
 #### [MXS-4320](https://jira.mariadb.org/browse/MXS-4320) Let maxctrl show datetime values using local client timezone
 
@@ -126,7 +126,7 @@ The most notable ones are listed here:
 
 * [MXS-4013](https://jira.mariadb.org/browse/MXS-4013) Add Views, Functions, and Indexes to the Query Editor schema sidebar.
 * [MXS-4285](https://jira.mariadb.org/browse/MXS-4285) Store user preferences.
-* [MXS-4430](https://jira.mariadb.org/browse/MXS-4430) ETL/Data Migration service GUI. Instructions on using it can be found [here](../mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-using-maxgui-tutorial.md#workspace)
+* [MXS-4430](https://jira.mariadb.org/browse/MXS-4430) ETL/Data Migration service GUI. Instructions on using it can be found [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-using-maxgui-tutorial#workspace)
 
 ### Bug fixes
 
@@ -135,7 +135,7 @@ The most notable ones are listed here:
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.1.md
+++ b/release-notes/maxscale/23.02/23.02.1.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.1, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -29,7 +29,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.1.md
+++ b/release-notes/maxscale/23.02/23.02.1.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.1, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -29,7 +29,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.10.md
+++ b/release-notes/maxscale/23.02/23.02.10.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.10, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -49,7 +49,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.10.md
+++ b/release-notes/maxscale/23.02/23.02.10.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.10, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -49,7 +49,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.11.md
+++ b/release-notes/maxscale/23.02/23.02.11.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.11, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -45,7 +45,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.11.md
+++ b/release-notes/maxscale/23.02/23.02.11.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.11, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -45,7 +45,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.12.md
+++ b/release-notes/maxscale/23.02/23.02.12.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.12, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -71,7 +71,7 @@ a dependency on node that earlier was not present. In this version of MaxScale,
 maxctrl is again a native executable without that dependency.
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.12.md
+++ b/release-notes/maxscale/23.02/23.02.12.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.12, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -71,7 +71,7 @@ a dependency on node that earlier was not present. In this version of MaxScale,
 maxctrl is again a native executable without that dependency.
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.13.md
+++ b/release-notes/maxscale/23.02/23.02.13.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.13, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -50,7 +50,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.13.md
+++ b/release-notes/maxscale/23.02/23.02.13.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.13, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -50,7 +50,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.15.md
+++ b/release-notes/maxscale/23.02/23.02.15.md
@@ -24,7 +24,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 * [MXS-5910](https://jira.mariadb.org/browse/MXS-5910) Error 1047 when trying to run semi-sync replication through Maxscale
 * [MXS-5897](https://jira.mariadb.org/browse/MXS-5897) Failing COM\_STMT\_PREPAREs that don't generate an ID aren't discarded from the history
 * [MXS-5865](https://jira.mariadb.org/browse/MXS-5865) Run-time modification of users\_refresh\_time and users\_refresh\_interval are not immediately taken into use
-* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (std::length\_error in maxbase::load\_file[std::string](std::string)) on Ubuntu 24.04
+* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (`std::length_error` in `maxbase::load_file<std::string>(std::string)`) on Ubuntu 24.04
 * [MXS-5769](https://jira.mariadb.org/browse/MXS-5769) Watchdog timeout diagnostics are not detailed enough
 * [MXS-5760](https://jira.mariadb.org/browse/MXS-5760) Authentication failure on all backends does not immediately close sessions
 * [MXS-5733](https://jira.mariadb.org/browse/MXS-5733) MaxScale allows unlimited COM\_CHANGE\_USER attempts

--- a/release-notes/maxscale/23.02/23.02.2.md
+++ b/release-notes/maxscale/23.02/23.02.2.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.2, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -40,7 +40,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.2.md
+++ b/release-notes/maxscale/23.02/23.02.2.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.2, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -40,7 +40,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.3.md
+++ b/release-notes/maxscale/23.02/23.02.3.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.3, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -46,7 +46,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.3.md
+++ b/release-notes/maxscale/23.02/23.02.3.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.3, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -46,7 +46,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.4.md
+++ b/release-notes/maxscale/23.02/23.02.4.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.4, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -41,7 +41,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.4.md
+++ b/release-notes/maxscale/23.02/23.02.4.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.4, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -41,7 +41,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.5.md
+++ b/release-notes/maxscale/23.02/23.02.5.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.5, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -66,7 +66,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.5.md
+++ b/release-notes/maxscale/23.02/23.02.5.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.5, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -66,7 +66,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.6.md
+++ b/release-notes/maxscale/23.02/23.02.6.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.6, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -22,7 +22,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.6.md
+++ b/release-notes/maxscale/23.02/23.02.6.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.6, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -22,7 +22,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.7.md
+++ b/release-notes/maxscale/23.02/23.02.7.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.7, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -24,7 +24,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.7.md
+++ b/release-notes/maxscale/23.02/23.02.7.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.7, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -24,7 +24,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.8.md
+++ b/release-notes/maxscale/23.02/23.02.8.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.8, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -22,7 +22,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.8.md
+++ b/release-notes/maxscale/23.02/23.02.8.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.8, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -22,7 +22,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.9.md
+++ b/release-notes/maxscale/23.02/23.02.9.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.9, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -63,7 +63,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.02/23.02.9.md
+++ b/release-notes/maxscale/23.02/23.02.9.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 23.02.9, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](../mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302.md) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-2208-to-2302) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
@@ -63,7 +63,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23-02/mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.0.md
+++ b/release-notes/maxscale/23.08/23.08.0.md
@@ -20,7 +20,7 @@ During switchover, MariaDB-Monitor creates a new connection to the master with
 a long timeout, ignoring the limit of `backend_read_timeout`. This reduces the
 probability of long commands such as `set global read_only=1` timing out. When
 kicking out super and read-only admin users, monitor prevent writes with\
-"flush tables with read lock". See [monitor documentation](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md#operation-details)
+"flush tables with read lock". See [monitor documentation]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor#operation-details)
 for more information.
 
 #### [MXS-4385](https://jira.mariadb.org/browse/MXS-4385) No newlines in logged messages
@@ -66,13 +66,13 @@ e.g. `SELECT.*.*FROM.*.*t1`.
 The NoSQL protocol module now supports internal caching. Since this
 cache uses keys created from NoSQL protocol requests and stores NoSQL
 protocol responses, it is more efficient than the regular cache filter.\
-More information about this functionality can be found [here](../mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md#caching).
+More information about this functionality can be found [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module#caching).
 
 #### [MXS-3983](https://jira.mariadb.org/browse/MXS-3983) Add switchover-force command
 
 This version of switchover performs the switch even if the primary server is
 unresponsive i.e. responds to pings but does not perform any commands in a
-reasonable time. May lead to diverging replication on the old primary. See [monitor documentation](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md#operation-details)
+reasonable time. May lead to diverging replication on the old primary. See [monitor documentation]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor#operation-details)
 for more information.
 
 #### [MXS-4123](https://jira.mariadb.org/browse/MXS-4123) Fast universal causal reads
@@ -127,7 +127,7 @@ when the connection to the server was lost.
 
 #### [MXS-4506](https://jira.mariadb.org/browse/MXS-4506) Add passthrough authentication support for Xpand LDAP
 
-Passthrough authentication mode for MariaDBAuth-module. See [authenticator documentation](../../../en/mariadbmysql-authenticator/#clear_pw_passthrough) for more information.
+Passthrough authentication mode for MariaDBAuth-module. See [authenticator documentation]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-mariadbmysql-authenticator#clear_pw_passthrough) for more information.
 
 #### [MXS-4549](https://jira.mariadb.org/browse/MXS-4549) Queries with partially returned results can be replayed
 
@@ -137,7 +137,7 @@ query and discard the already delivered part of the result.
 
 #### [MXS-4618](https://jira.mariadb.org/browse/MXS-4618) LOAD DATA LOCAL INFILE from S3
 
-The [LDI filter](../../../en/maxscale-23-08-ldi-filter/) adds support for `LOAD DATA LOCAL INFILE`
+The [LDI filter]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-maxscale-2308-ldi-filter) adds support for `LOAD DATA LOCAL INFILE`
 from S3 compatible storage.
 
 #### [MXS-4635](https://jira.mariadb.org/browse/MXS-4635) Early connection metadata
@@ -156,8 +156,8 @@ speeds up connection creation.
 #### [MXS-4637](https://jira.mariadb.org/browse/MXS-4637) Bootstrap process for Xpand should be region-aware
 
 It is now possible to limit the nodes the Xpand monitor dynamically detects
-to those residing in a specific region. See [region\_name](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor.md#region_name)
-and [region\_oid](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor.md#region_oid) for more information.
+to those residing in a specific region. See [region\_name]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor#region_name)
+and [region\_oid]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor#region_oid) for more information.
 
 #### MaxGUI
 
@@ -165,9 +165,9 @@ Numerous additions have been added and improvements made to MaxGUI.\
 The most notable ones are listed here:
 
 * [MXS-3735](https://jira.mariadb.org/browse/MXS-3735) Add ERD modeler to the
-  workspace. Instructions on using it can be found [here](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial.md#create-an-erd).
+  workspace. Instructions on using it can be found [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial#create-an-erd).
 * [MXS-3991](https://jira.mariadb.org/browse/MXS-3991) Show schema objects
-  insights. Instructions on using it can be found [here](../mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial.md#show-object-creation-statement-and-insights-info).
+  insights. Instructions on using it can be found [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial#show-object-creation-statement-and-insights-info).
 * [MXS-4364](https://jira.mariadb.org/browse/MXS-4364) Auto choose active schema for new query tab.
 
 ### Bug fixes
@@ -177,7 +177,7 @@ The most notable ones are listed here:
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.0.md
+++ b/release-notes/maxscale/23.08/23.08.0.md
@@ -20,7 +20,7 @@ During switchover, MariaDB-Monitor creates a new connection to the master with
 a long timeout, ignoring the limit of `backend_read_timeout`. This reduces the
 probability of long commands such as `set global read_only=1` timing out. When
 kicking out super and read-only admin users, monitor prevent writes with\
-"flush tables with read lock". See [monitor documentation]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor#operation-details)
+"flush tables with read lock". See [monitor documentation](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor#operation-details)
 for more information.
 
 #### [MXS-4385](https://jira.mariadb.org/browse/MXS-4385) No newlines in logged messages
@@ -66,13 +66,13 @@ e.g. `SELECT.*.*FROM.*.*t1`.
 The NoSQL protocol module now supports internal caching. Since this
 cache uses keys created from NoSQL protocol requests and stores NoSQL
 protocol responses, it is more efficient than the regular cache filter.\
-More information about this functionality can be found [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module#caching).
+More information about this functionality can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module#caching).
 
 #### [MXS-3983](https://jira.mariadb.org/browse/MXS-3983) Add switchover-force command
 
 This version of switchover performs the switch even if the primary server is
 unresponsive i.e. responds to pings but does not perform any commands in a
-reasonable time. May lead to diverging replication on the old primary. See [monitor documentation]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor#operation-details)
+reasonable time. May lead to diverging replication on the old primary. See [monitor documentation](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor#operation-details)
 for more information.
 
 #### [MXS-4123](https://jira.mariadb.org/browse/MXS-4123) Fast universal causal reads
@@ -127,7 +127,7 @@ when the connection to the server was lost.
 
 #### [MXS-4506](https://jira.mariadb.org/browse/MXS-4506) Add passthrough authentication support for Xpand LDAP
 
-Passthrough authentication mode for MariaDBAuth-module. See [authenticator documentation]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-mariadbmysql-authenticator#clear_pw_passthrough) for more information.
+Passthrough authentication mode for MariaDBAuth-module. See [authenticator documentation](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-mariadbmysql-authenticator#clear_pw_passthrough) for more information.
 
 #### [MXS-4549](https://jira.mariadb.org/browse/MXS-4549) Queries with partially returned results can be replayed
 
@@ -137,7 +137,7 @@ query and discard the already delivered part of the result.
 
 #### [MXS-4618](https://jira.mariadb.org/browse/MXS-4618) LOAD DATA LOCAL INFILE from S3
 
-The [LDI filter]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-maxscale-2308-ldi-filter) adds support for `LOAD DATA LOCAL INFILE`
+The [LDI filter](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-maxscale-2308-ldi-filter) adds support for `LOAD DATA LOCAL INFILE`
 from S3 compatible storage.
 
 #### [MXS-4635](https://jira.mariadb.org/browse/MXS-4635) Early connection metadata
@@ -156,8 +156,8 @@ speeds up connection creation.
 #### [MXS-4637](https://jira.mariadb.org/browse/MXS-4637) Bootstrap process for Xpand should be region-aware
 
 It is now possible to limit the nodes the Xpand monitor dynamically detects
-to those residing in a specific region. See [region\_name]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor#region_name)
-and [region\_oid]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor#region_oid) for more information.
+to those residing in a specific region. See [region\_name](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor#region_name)
+and [region\_oid](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-xpand-monitor#region_oid) for more information.
 
 #### MaxGUI
 
@@ -165,9 +165,9 @@ Numerous additions have been added and improvements made to MaxGUI.\
 The most notable ones are listed here:
 
 * [MXS-3735](https://jira.mariadb.org/browse/MXS-3735) Add ERD modeler to the
-  workspace. Instructions on using it can be found [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial#create-an-erd).
+  workspace. Instructions on using it can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial#create-an-erd).
 * [MXS-3991](https://jira.mariadb.org/browse/MXS-3991) Show schema objects
-  insights. Instructions on using it can be found [here]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial#show-object-creation-statement-and-insights-info).
+  insights. Instructions on using it can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial#show-object-creation-statement-and-insights-info).
 * [MXS-4364](https://jira.mariadb.org/browse/MXS-4364) Auto choose active schema for new query tab.
 
 ### Bug fixes
@@ -177,7 +177,7 @@ The most notable ones are listed here:
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.1.md
+++ b/release-notes/maxscale/23.08/23.08.1.md
@@ -36,7 +36,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.1.md
+++ b/release-notes/maxscale/23.08/23.08.1.md
@@ -36,7 +36,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.11.md
+++ b/release-notes/maxscale/23.08/23.08.11.md
@@ -24,7 +24,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 * [MXS-5910](https://jira.mariadb.org/browse/MXS-5910) Error 1047 when trying to run semi-sync replication through Maxscale
 * [MXS-5897](https://jira.mariadb.org/browse/MXS-5897) Failing COM\_STMT\_PREPAREs that don't generate an ID aren't discarded from the history
 * [MXS-5865](https://jira.mariadb.org/browse/MXS-5865) Run-time modification of users\_refresh\_time and users\_refresh\_interval are not immediately taken into use
-* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (std::length\_error in maxbase::load\_file[std::string](std::string)) on Ubuntu 24.04
+* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (`std::length_error` in `maxbase::load_file<std::string>(std::string)`) on Ubuntu 24.04
 * [MXS-5769](https://jira.mariadb.org/browse/MXS-5769) Watchdog timeout diagnostics are not detailed enough
 * [MXS-5760](https://jira.mariadb.org/browse/MXS-5760) Authentication failure on all backends does not immediately close sessions
 * [MXS-5733](https://jira.mariadb.org/browse/MXS-5733) MaxScale allows unlimited COM\_CHANGE\_USER attempts

--- a/release-notes/maxscale/23.08/23.08.2.md
+++ b/release-notes/maxscale/23.08/23.08.2.md
@@ -65,7 +65,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.2.md
+++ b/release-notes/maxscale/23.08/23.08.2.md
@@ -65,7 +65,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.3.md
+++ b/release-notes/maxscale/23.08/23.08.3.md
@@ -24,7 +24,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.3.md
+++ b/release-notes/maxscale/23.08/23.08.3.md
@@ -24,7 +24,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.4.md
+++ b/release-notes/maxscale/23.08/23.08.4.md
@@ -36,7 +36,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.4.md
+++ b/release-notes/maxscale/23.08/23.08.4.md
@@ -36,7 +36,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.5.md
+++ b/release-notes/maxscale/23.08/23.08.5.md
@@ -79,7 +79,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.5.md
+++ b/release-notes/maxscale/23.08/23.08.5.md
@@ -79,7 +79,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.6.md
+++ b/release-notes/maxscale/23.08/23.08.6.md
@@ -55,7 +55,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.6.md
+++ b/release-notes/maxscale/23.08/23.08.6.md
@@ -55,7 +55,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.7.md
+++ b/release-notes/maxscale/23.08/23.08.7.md
@@ -55,7 +55,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.7.md
+++ b/release-notes/maxscale/23.08/23.08.7.md
@@ -55,7 +55,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.8.md
+++ b/release-notes/maxscale/23.08/23.08.8.md
@@ -77,7 +77,7 @@ a dependency on node that earlier was not present. In this version of MaxScale,
 maxctrl is again a native executable without that dependency.
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.8.md
+++ b/release-notes/maxscale/23.08/23.08.8.md
@@ -77,7 +77,7 @@ a dependency on node that earlier was not present. In this version of MaxScale,
 maxctrl is again a native executable without that dependency.
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.9.md
+++ b/release-notes/maxscale/23.08/23.08.9.md
@@ -57,7 +57,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/23.08/23.08.9.md
+++ b/release-notes/maxscale/23.08/23.08.9.md
@@ -57,7 +57,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/24.02/24.02.5.md
+++ b/release-notes/maxscale/24.02/24.02.5.md
@@ -66,7 +66,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale) document.
+For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/24.02/24.02.5.md
+++ b/release-notes/maxscale/24.02/24.02.5.md
@@ -66,7 +66,7 @@ report on [our Jira](https://jira.mariadb.org/projects/MXS).
 ### Known Issues and Limitations
 
 There are some limitations and known issues within this version of MaxScale.\
-For more information, please refer to the [Limitations](../maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging
 

--- a/release-notes/maxscale/24.02/24.02.6.md
+++ b/release-notes/maxscale/24.02/24.02.6.md
@@ -36,7 +36,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 
 ### Known Issues and Limitations <a href="#known-issues-and-limitations" id="known-issues-and-limitations"></a>
 
-There are some limitations and known issues within this version of MaxScale. For more information, please refer to the [Limitations](../maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale.md) document.
+There are some limitations and known issues within this version of MaxScale. For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging <a href="#packaging" id="packaging"></a>
 

--- a/release-notes/maxscale/24.02/24.02.6.md
+++ b/release-notes/maxscale/24.02/24.02.6.md
@@ -36,7 +36,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 
 ### Known Issues and Limitations <a href="#known-issues-and-limitations" id="known-issues-and-limitations"></a>
 
-There are some limitations and known issues within this version of MaxScale. For more information, please refer to the [Limitations]({maxscale}/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale) document.
+There are some limitations and known issues within this version of MaxScale. For more information, please refer to the [Limitations](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale) document.
 
 ### Packaging <a href="#packaging" id="packaging"></a>
 

--- a/release-notes/maxscale/24.02/24.02.7.md
+++ b/release-notes/maxscale/24.02/24.02.7.md
@@ -26,7 +26,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 * [MXS-5897](https://jira.mariadb.org/browse/MXS-5897) Failing COM\_STMT\_PREPAREs that don't generate an ID aren't discarded from the history
 * [MXS-5882](https://jira.mariadb.org/browse/MXS-5882) Initial config not stored for servers
 * [MXS-5865](https://jira.mariadb.org/browse/MXS-5865) Run-time modification of users\_refresh\_time and users\_refresh\_interval are not immediately taken into use
-* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (std::length\_error in maxbase::load\_file[std::string](std::string)) on Ubuntu 24.04
+* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (`std::length_error` in `maxbase::load_file<std::string>(std::string)`) on Ubuntu 24.04
 * [MXS-5769](https://jira.mariadb.org/browse/MXS-5769) Watchdog timeout diagnostics are not detailed enough
 * [MXS-5760](https://jira.mariadb.org/browse/MXS-5760) Authentication failure on all backends does not immediately close sessions
 * [MXS-5733](https://jira.mariadb.org/browse/MXS-5733) MaxScale allows unlimited COM\_CHANGE\_USER attempts

--- a/release-notes/maxscale/25.01/25.01.1.md
+++ b/release-notes/maxscale/25.01/25.01.1.md
@@ -28,11 +28,11 @@ If MaxScale is running in a container, it will adapt to amount of resources (CPU
 
 ### [MXS-4761](https://jira.mariadb.org/browse/MXS-4761) Diff - Router for comparing different servers
 
-Diff is a router using which the behaviour of two servers can be compared. Please see [Diff](../../mariadb-maxscale-release-notes/Routers/Diff.md) for more information.
+Diff is a router using which the behaviour of two servers can be compared. Please see [Diff]({maxscale}/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers) for more information.
 
 ### [MXS-4791](https://jira.mariadb.org/browse/MXS-4761) Workload Capture and Replay
 
-A number of components using which a live workload can be captured and later replayed. Please see [Wcar](../../mariadb-maxscale-release-notes/Filters/Wcar.md) for more information.
+A number of components using which a live workload can be captured and later replayed. Please see [Wcar]({maxscale}/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-workload-capture-and-replay) for more information.
 
 ### [MXS-4842](https://jira.mariadb.org/browse/MXS-4842) Safe failover and safe auto\_failover
 

--- a/release-notes/maxscale/25.01/25.01.1.md
+++ b/release-notes/maxscale/25.01/25.01.1.md
@@ -28,11 +28,11 @@ If MaxScale is running in a container, it will adapt to amount of resources (CPU
 
 ### [MXS-4761](https://jira.mariadb.org/browse/MXS-4761) Diff - Router for comparing different servers
 
-Diff is a router using which the behaviour of two servers can be compared. Please see [Diff]({maxscale}/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers) for more information.
+Diff is a router using which the behaviour of two servers can be compared. Please see [Diff](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers) for more information.
 
 ### [MXS-4791](https://jira.mariadb.org/browse/MXS-4761) Workload Capture and Replay
 
-A number of components using which a live workload can be captured and later replayed. Please see [Wcar]({maxscale}/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-workload-capture-and-replay) for more information.
+A number of components using which a live workload can be captured and later replayed. Please see [Wcar](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-archive/archive/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-workload-capture-and-replay) for more information.
 
 ### [MXS-4842](https://jira.mariadb.org/browse/MXS-4842) Safe failover and safe auto\_failover
 

--- a/release-notes/maxscale/25.01/25.01.4.md
+++ b/release-notes/maxscale/25.01/25.01.4.md
@@ -25,7 +25,7 @@ For any problems you encounter, please consider submitting a bug report on [our 
 * [MXS-5897](https://jira.mariadb.org/browse/MXS-5897) Failing COM\_STMT\_PREPAREs that don't generate an ID aren't discarded from the history
 * [MXS-5882](https://jira.mariadb.org/browse/MXS-5882) Initial config not stored for servers
 * [MXS-5865](https://jira.mariadb.org/browse/MXS-5865) Run-time modification of users\_refresh\_time and users\_refresh\_interval are not immediately taken into use
-* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (std::length\_error in maxbase::load\_file[std::string](std::string)) on Ubuntu 24.04
+* [MXS-5837](https://jira.mariadb.org/browse/MXS-5837) MaxScale 24.02.5 crashes with fatal signal 6 (`std::length_error` in `maxbase::load_file<std::string>(std::string)`) on Ubuntu 24.04
 * [MXS-5769](https://jira.mariadb.org/browse/MXS-5769) Watchdog timeout diagnostics are not detailed enough
 * [MXS-5760](https://jira.mariadb.org/browse/MXS-5760) Authentication failure on all backends does not immediately close sessions
 * [MXS-5733](https://jira.mariadb.org/browse/MXS-5733) MaxScale allows unlimited COM\_CHANGE\_USER attempts


### PR DESCRIPTION
Closes [DOCS-6381](https://mariadbcorp.atlassian.net/browse/DOCS-6381).

## Re-baselined scope

The ticket's inventory was stale. **DOCS-6366** (PR #820) touched 288 archive files and had to clear their lychee errors as a side effect, which absorbed most of this ticket's population. Measured on current `main`:

| | Ticket | Actual |
|---|---|---|
| Dead relative links | 600 | **161** |
| Files | 188 | **109** |
| Legacy `../../../../../en/<slug>/` | 458 | 42 |
| `broken-reference` | 41 | 32 |
| Retired `docs-server/blob/test/` links | 25 | **0** (already gone) |

Counted by path-resolved enumeration (GitBook-style: `foo`, `foo/`, `foo.md`, `foo/README.md` all count as resolving), not prefix matching.

## What changed — 158 retargeted, 3 unlinked

**78 — release-notes → archive prefix.** The dominant population. `release-notes/maxscale/23.02/23.02.0.md` carried links like `../mariadb-maxscale-23-02-about/…-limitations-….md`, which resolved relative to the *release-notes* tree after the `maxscale-versions/` → `maxscale-archive/archive/` move. Each link already named the version-correct archive page, and that page exists, so **only the prefix changed** — the intended destination is preserved. These cross a space boundary, so they become `{maxscale}/…` aliases, matching the form already used by the ~100 sibling links in the same files.

**42 — legacy KB `/en/` paths**, collapsing to just 8 distinct slugs, every one version-consistent with its source file (2208 slugs only in 22.08 files, 2308 only in 23.08).

**32 — `broken-reference` stubs**, resolved by link text within the version directory.

**5 — C++ signature mis-parsed as a link.** `maxbase::load\_file[std::string](std::string)` in five MXS-5837 changelog entries is a Markdown mis-parse of `maxbase::load_file<std::string>(std::string)`. Restored as code spans, which both fixes the link and makes the signature render correctly.

**4 — assorted stale paths**, including one cross-space link that pointed at `server/…/sql-mode.md` (the real page is `sql_mode.md`, with an underscore).

### The ChangeLog family resolves to the release-notes space

27 `[ChangeLog]` links across the 22.08 / 23.02 / 23.08 upgrading pages and three contents pages. Worth calling out because the obvious target is wrong: `maxscale/maxscale-archive/archive/mariadb-maxscale-23{-02,.08}/maxscale-23.0*-changelog.md` **are 2-line empty stubs** (a heading and nothing else), while `release-notes/maxscale/<series>/<series>-changelog.md` carries the real content for all six series. Retargeting to the archive stubs would have pointed 27 links at blank pages.

The same check caught the 25.01 `[Upgrading MaxScale]` entry: the archive's `maxscale-25-01-upgrading.md` is a heading plus a marketo form with no child pages, so that link goes to the live `upgrade-to-maxscale-25.01` guide instead (25.01 is the current series).

The 22.08 evidence is what made this resolvable: all eight of its ChangeLog links pointed at the *same* series-changelog URL regardless of which version the sentence named ("about MaxScale 2.0… refer to the ChangeLog"), so the original destination was the series changelog, not a per-version page.

### The 3 unlinks

Standing rule — no correct target exists, so keep the text rather than invent a destination:

- **23.08 CDC Connector** — a genuine gap. Every other series (21.06, 22.08, 23.02, 24.02, 25.01) has this page; 23.08's is absent from the tree and its nav entry points at the section README. Kept as text, since it is the only bullet under its intro sentence. *(Side finding: `maxscale/SUMMARY.md:355-356` has two entries with different labels pointing at that same README — the DOCS-6445 mis-target signature. Left alone; it needs the missing page, not a nav edit.)*
- **2 × "Additional information is available here."** under an `EXTERNAL REFERENCES` heading in two 21.06 monitor pages. The external target is unrecoverable and there is no resolved twin anywhere in the repo, so the sentence — which existed only to carry the link — is dropped, along with the heading it left empty.

## Verification

- **Path-resolved rescan: 168 → 7.** All 7 remaining are inside code fences (a KafkaCDC `exclude=db1 [.](accounts|users)` regex example) — not links, and invisible to lychee. Confirmed by a fence-aware pass. *These are a real content bug (a stray space vs. the adjacent `match=db1[.]`), but a content bug, not a link one — see follow-ups.*
- **Every target verified against the space's `SUMMARY.md` nav**, not the filesystem, because GitBook derives page URLs from nav position. All 76 cluster-A targets and all 26 distinct alias targets: in nav.
- **Every target content-checked.** This is what caught the empty changelog stubs; nav membership alone would have passed them.
- **`doc-lint.sh` on all 109 files: 1975 OK, 0 errors, 112 excluded.** The 112 excluded are exactly the 112 alias-link occurrences (lychee skips anything containing `{`), all nav-verified above.
- **Canary-checked.** A `[404]` link on a live host was added, the run went to `Errors 1` / exit 1, then it was removed — proving lychee actually ran and saw the changed files, rather than silently no-oping.
- **codespell** (CI-exact invocation): clean.
- Zero pre-existing rot surfaced across 109 files, so no drive-by fixes were needed.

## Follow-ups worth filing separately

1. **166 `mariadb.com/kb/` links across 87 files in these trees are soft-404s.** They return **200** and redirect to `https://mariadb.com/docs?q=<slug>` — a search page — so lychee will never flag them, but readers land nowhere. 10 of them happened to share slugs with links fixed here; I deliberately left all 166 alone rather than fix an arbitrary 6%.
2. **The two empty archive changelog stubs** (`maxscale-23.02-changelog.md`, `maxscale-23.08-changelog.md`) are in nav but blank, duplicating the real release-notes pages.
3. **26 absolute `mariadb.com/docs/maxscale/maxscale-versions/…` URLs** still use the retired container name. These *work* — GitBook redirects them — but land on the section landing rather than the exact page. Not touched, per "preserve the destination of links that already work."
4. **The 22.08 archive has no changelog page** while 23.02 and 23.08 do (as empty stubs) — the series changelog only exists in release-notes.

No prose or structural changes beyond the two dead sentences noted above; the archive tree is intentionally frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6381]: https://mariadbcorp.atlassian.net/browse/DOCS-6381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ