### PR TITLE
DOCS-6305 Document log_slow_max_query_length system variable

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
@@ -1240,6 +1240,17 @@ The suffix can be upper or lower-case.
 * Valid Values:
   * `admin`, `filesort`, `filesort_on_disk`, `filesort_priority_queue`, `full_join`, `full_scan`, `not_using_index`, `query_cache`, `query_cache_miss`, `tmp_table`, `tmp_table_on_disk`
 
+#### `log_slow_max_query_length`
+
+* Description: Queries whose text is longer than this many bytes are not written to the [slow query log](../../../server-management/server-monitoring-logs/slow-query-log/). The entire statement is skipped — it is not truncated — which keeps statements carrying very large `TEXT` or `BLOB` literals out of the log. The default, `4294967295` (the maximum value), effectively means no limit.
+* Command line: `--log-slow-max-query-length=#`
+* Scope: Global, Session
+* Dynamic: Yes
+* Data Type: `numeric`
+* Default Value: `4294967295`
+* Range: `1` to `4294967295`
+* Introduced: MariaDB 13.1.1
+
 #### `log_slow_max_warnings`
 
 * Description: Max numbers of warnings printed to slow query log per statement


### PR DESCRIPTION
Documents the `log_slow_max_query_length` system variable (MDEV-33463, 13.1.x).

Queries whose text exceeds the configured byte length are skipped from the slow query log entirely — not truncated — per the maintainers' design decision (MDEV-33463 comment 329371). Default is the maximum value, i.e. no limit.

Source-verified against server @ ff09eefb (origin/main); fact-check report on the ticket.


Add a reference entry for the log_slow_max_query_length system variable (MDEV-33463, 13.1.x). Queries longer than the configured byte length are skipped from the slow query log entirely, not truncated. Default is the maximum value (no limit).


🤖 Generated with [Claude Code](https://claude.com/claude-code)