### PR TITLE
DOCS-6435 Fix doubled URL path for old MaxScale versions

### DIFF
--- a/maxscale/SUMMARY.md
+++ b/maxscale/SUMMARY.md
@@ -143,8 +143,6 @@
 
 * [Documentation No Longer Available](documentation-no-longer-available.md)
 
-## Old MaxScale Versions
-
 * [Old MaxScale Versions](maxscale-old-versions/README.md)
   * [MariaDB MaxScale 25.01](maxscale-old-versions/mariadb-maxscale-25-01/README.md)
     * [MaxScale 25.01 Contents](maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-2501-contents.md)


### PR DESCRIPTION
Follow-up to #918, which merged 20 minutes ago. Step 3 of the plan agreed with Johan Wikman on [DOCS-6435](https://mariadbcorp.atlassian.net/browse/DOCS-6435?focusedCommentId=1131921) specified that the four surviving MaxScale versions move to `https://mariadb.com/docs/maxscale/maxscale-old-versions`. They published one segment deeper than that:

```
live now:  /docs/maxscale/old-maxscale-versions/maxscale-old-versions/mariadb-maxscale-23-02/…
planned:   /docs/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/…
```

## Why

**GitBook prepends a `SUMMARY.md` group heading's slug to the published path of every page under that group, and collapses the segment only when it equals the next one.**

`## Old MaxScale Versions` slugifies to `old-maxscale-versions`. The directory is `maxscale-old-versions`. Same words, different order, so no collapse — and the segment is duplicated in meaning if not in spelling.

The old `## MaxScale Archive` group concealed this for as long as the tree lived there: its slug *did* equal its directory (`maxscale-archive`), so it collapsed, and the published path looked as though it were simply the file path. Every other group heading in the repo has the same accidental property — I checked all of them, and `Old MaxScale Versions` is the first whose slug does not match its directory. That is why this had never surfaced before.

## The fix

Delete the heading. **Nothing is lost:**

* The page immediately below it carries the identical label, so the sidebar currently renders *Old MaxScale Versions* twice, once as a group header and once as the page.
* It was the **only** `##` group heading in the MaxScale space, so the rest of the space is already ungrouped and this makes it consistent.
* The nav label agreed with Johan survives untouched as the page title.

The alternative — renaming the directory to `old-maxscale-versions` so the slugs collapse — keeps a redundant header and costs another 409-file rename for a URL that is no better.

## Effect on links and redirects

* **Repo links are unaffected.** Every internal reference is a relative file path; nav position is not a file path. `git grep` for the doubled form returns nothing.
* **GitBook re-creates its internal redirects on the move**, as it did for step 3 — old `/maxscale/maxscale-archive/archive/…` URLs currently 307 to the doubled path, and the page IDs do not change, so they will follow to the corrected path. I will probe them after the sync rather than assume it, the same way step 3 was verified.
* **The four wildcard rules** covering the retired 21.06/22.08 URLs are untouched: their sources are `/maxscale/maxscale-archive/archive/mariadb-maxscale-{21-06,22.08}` and their destination is a `site-page` reference.
* The doubled URLs have been live for minutes and are linked from nowhere.

## Checks

`maxscale/SUMMARY.md`: 551 entries, 0 pointing at a missing file — unchanged from #918. codespell clean with the CI-exact invocation. The diff is the removal of one heading and its blank line.

[DOCS-6435]: https://mariadbcorp.atlassian.net/browse/DOCS-6435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ