### PR TITLE
DOCS-6435 Fix Changelog links on the version landing pages

### DIFF
--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/README.md
@@ -1591,7 +1591,7 @@ $ sudo systemctl start mariadb
 
 #### Test Local Client Connections
 
-Use [MariaDB Client]({server}/clients-and-utilities/mariadb-client/mariadb-command-line-client) to test the local connection to the Enterprise Server node.
+Use [MariaDB Client](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/mariadb-client/mariadb-command-line-client) to test the local connection to the Enterprise Server node.
 
 This action is performed **on each Enterprise ColumnStore node**:
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/README.md
@@ -1961,7 +1961,7 @@ INSERT INTO test.contacts (first_name, last_name, email)
 $ sudo mariadb
 ```
 
-4. Execute a [SELECT]({server}/reference/sql-statements/data-manipulation/selecting-data/select) query to retrieve the data:
+4. Execute a [SELECT](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/selecting-data/select) query to retrieve the data:
 
 ```sql
 SELECT * FROM test.contacts;

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/README.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/README.md
@@ -15,7 +15,7 @@ MariaDB MaxScale 23.02 is a **bug-fix release**. It receives bug fixes until its
 | Page | Description |
 | --- | --- |
 | [About MariaDB MaxScale](mariadb-maxscale-23-02-about/mariadb-maxscale-2302-about-mariadb-maxscale.md) | MariaDB MaxScale is a database proxy that forwards database statements to one or more database servers. |
-| [Changelog]({release-notes}/maxscale/23.02/23.02-changelog) | Every change in each 23.02 point release, in the release notes. |
+| [Changelog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.02/23.02-changelog) | Every change in each 23.02 point release, in the release notes. |
 | [Limitations](mariadb-maxscale-23-02-about/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale.md) | This document lists known issues and limitations in MariaDB MaxScale and its plugins. |
 
 ## Getting Started

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/README.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/README.md
@@ -15,7 +15,7 @@ MariaDB MaxScale 23.08 is a **bug-fix release**. It receives bug fixes until its
 | Page | Description |
 | --- | --- |
 | [About MariaDB MaxScale](mariadb-maxscale-23-08-about/mariadb-maxscale-2308-about-mariadb-maxscale.md) | MariaDB MaxScale is a database proxy that forwards database statements to one or more database servers. |
-| [Changelog]({release-notes}/maxscale/23.08/23.08-changelog) | Every change in each 23.08 point release, in the release notes. |
+| [Changelog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/23.08/23.08-changelog) | Every change in each 23.08 point release, in the release notes. |
 | [Limitations](mariadb-maxscale-23-08-about/mariadb-maxscale-2308-limitations-and-known-issues-within-mariadb-maxscale.md) | This document lists known issues and limitations in MariaDB MaxScale and its plugins. |
 
 ## Getting Started

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/README.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/README.md
@@ -15,7 +15,7 @@ MariaDB MaxScale 24.02 is a **bug-fix release**. It receives bug fixes until its
 | Page | Description |
 | --- | --- |
 | [About MariaDB MaxScale](maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-about-mariadb-maxscale.md) | MariaDB MaxScale is a database proxy that forwards database statements to one or more database servers. |
-| [Changelog]({release-notes}/maxscale/24.02/24.02-changelog) | Every change in each 24.02 point release, in the release notes. |
+| [Changelog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/24.02/24.02-changelog) | Every change in each 24.02 point release, in the release notes. |
 | [Limitations](maxscale-24-02about/mariadb-maxscale-2402-maxscale-2402-limitations-and-known-issues-within-mariadb-maxscale.md) | This document lists known issues and limitations in MariaDB MaxScale and its plugins. |
 
 ## Getting Started

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/README.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/README.md
@@ -16,7 +16,7 @@ MariaDB MaxScale 25.01 is a **bug-fix release**. It receives bug fixes until its
 | Page | Description |
 | --- | --- |
 | [About MariaDB MaxScale](maxscale-25-01-about.md) | What MariaDB MaxScale is and what it does. |
-| [Changelog]({release-notes}/maxscale/25.01/25.01-changelog) | Every change in each 25.01 point release, in the release notes. |
+| [Changelog](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/25.01/25.01-changelog) | Every change in each 25.01 point release, in the release notes. |
 | [Limitations](../../maxscale-management/mariadb-maxscale-limitations-guide.md) | Review the current constraints of MariaDB MaxScale. This document lists known issues regarding transaction parsing, protocol support, and specific module limitations. |
 
 ## Getting Started


### PR DESCRIPTION
The Changelog link on each of the four *Old MaxScale Versions* landing pages was dead, e.g. on [MariaDB MaxScale 25.01](https://mariadb.com/docs/maxscale/maxscale-old-versions/mariadb-maxscale-25-01). Reported by Stefan after #922 went live.

## What was wrong

The links were written with the `{release-notes}` alias, per the house rule. **But the alias-expansion workflow skips every file named `README.md`** — `.github/workflows/expand-gitbook-aliases.yml` line 26, `! -name "README.md"` — and a GitBook space landing page *is* a `README.md`. So the alias was never expanded, and GitBook fell back to treating it as a relative repository path:

```
href="https://github.com/mariadb-corporation/mariadb-docs/tree/main/maxscale/
      maxscale-old-versions/mariadb-maxscale-25-01/%7Brelease-notes%7D/
      maxscale/25.01/25.01-changelog"
```

That URL 404s. Worth noting how it stayed invisible: **lychee excludes any URL containing a brace** (`--exclude '.*\{.*'`), so an unexpanded alias passes the link check by construction, and the rendered form is a valid-looking github.com URL that no local check ever looks at.

## The fix

Use the expanded `app.gitbook.com` form directly, which is what **16 other `README.md` files in this repo already do** — it is the established workaround for the exclusion:

```diff
-| [Changelog]({release-notes}/maxscale/25.01/25.01-changelog) | … |
+| [Changelog](https://app.gitbook.com/o/…/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/25.01/25.01-changelog) | … |
```

Verified: all four destinations return 200 on the published site.

## Drive-by: the same defect in two ColumnStore guides

I checked every alias occurrence in every `README.md` in the repo. There are 15, and only **6 are link targets** — the four above plus two in the ColumnStore install guides, both pre-existing and broken the same way:

* `analytics/…/single-node-s3/README.md` — the SELECT link
* `analytics/…/multnode-localstorage/README.md` — the MariaDB Client link

The other nine are not links. Four of them are `https://{server}:{port}/cmapi/{version}/{route}/{command}` — **`{server}` there is a hostname placeholder in an API URL template, not a docs alias**, so touching it would have broken working examples. Those are left exactly as they are, as are the six in `pdf/README.md`, which is repository tooling documentation rather than a published page.

## Checks

codespell CI-exact: clean. lychee with the workflow's excludes: **431 links, 0 errors** — including the two 2,000-line ColumnStore guides, which brought no pre-existing breakage with them.

## Follow-up worth considering separately

The root cause is that `! -name "README.md"` matches **every** README in the repo, not just the root one, which means **no GitBook space or section landing page can ever use an alias**. Narrowing it to `! -path "./README.md"` (plus the existing `dev-docs`/`.claude` exclusions) would fix the class rather than these six instances. That changes CI behavior repo-wide, so I have not done it here — happy to file it as its own ticket.