### PR TITLE
DOCS-6484 Label BACKUP STAGE sections by version, not CS vs ES

### DIFF
--- a/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-and-backup-stage-commands.md
+++ b/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-and-backup-stage-commands.md
@@ -8,13 +8,19 @@ description: >-
 
 {% include "../../../.gitbook/includes/mariadb-backup-was-previous....md" %}
 
-The [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage.md) statements make it possible to make an efficient external backup tool. How `mariadb-backup` uses these statements depends on whether you are using the version that is bundled with MariaDB Community Server or the version that is bundled with MariaDB Enterprise Server.
+The [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage.md) statements make it possible to make an efficient external backup tool. How `mariadb-backup` uses these statements depends on the version of MariaDB Server it is bundled with.
+
+Every release of MariaDB Enterprise Server uses all of the `BACKUP STAGE` statements. MariaDB Community Server originally used only two of them, and gained the same behavior in MariaDB Community Server 10.11.8, 11.0.6, 11.1.5, 11.2.4, and 11.4.2, and in every release since. See [MDEV-32932](https://jira.mariadb.org/browse/MDEV-32932).
+
+{% hint style="info" %}
+The change landed in a maintenance release of each series, so the version series alone does not tell you which behavior you get. Releases before those listed above, all releases in the 10.6 series and earlier, and all releases in the 11.3 series use the two-statement behavior.
+{% endhint %}
 
 {% include "../../../.gitbook/includes/for-a-complete-list-of-mari....md" %}
 
-## `BACKUP STAGE` in MariaDB Community Server
+## `BACKUP STAGE` Before MariaDB Community Server 10.11.8
 
-The [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage.md) statements are supported. However, the version of `mariadb-backup` that is bundled with MariaDB Community Server does not yet use the `BACKUP STAGE` statement in the most efficient way. `mariadb-backup` simply executes the following `BACKUP STAGE` statement to lock the database:
+In these releases, the [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage.md) statements are supported, but `mariadb-backup` does not use them in the most efficient way. It simply executes the following `BACKUP STAGE` statements to lock the database:
 
 ```sql
 BACKUP STAGE START;
@@ -28,31 +34,31 @@ BACKUP STAGE END;
 ```
 
 {% hint style="info" %}
-To use a version of `mariadb-backup` that uses the [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage.md) statements in the most efficient way, use MariaDB Backup bundled with MariaDB Enterprise Server.
+To use a version of `mariadb-backup` that uses the [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage.md) statements in the most efficient way, upgrade to MariaDB Community Server 10.11.8, 11.0.6, 11.1.5, 11.2.4, or 11.4.2 or later, or use MariaDB Enterprise Server.
 {% endhint %}
 
-### Tasks Performed Prior to `BACKUP STAGE` in MariaDB Community Server
+### Tasks Performed Prior to `BACKUP STAGE`
 
 * Copy some transactional tables.
   * InnoDB (i.e. `ibdataN` and file extensions `.ibd` and `.isl`)
 * Copy the tail of some transaction logs.
   * The tail of the InnoDB redo log (i.e. `ib_logfileN` files) are copied for InnoDB tables.
 
-### `BACKUP STAGE START` in MariaDB Community Server
+### `BACKUP STAGE START`
 
-`mariadb-backup` from MariaDB Community Server does not perform any tasks in the `START` stage.
+`mariadb-backup` does not perform any tasks in the `START` stage.
 
-### `BACKUP STAGE FLUSH` in MariaDB Community Server
+### `BACKUP STAGE FLUSH`
 
-`mariadb-backup` from MariaDB Community Server does not currently perform any tasks in the `FLUSH` stage.
+`mariadb-backup` does not perform any tasks in the `FLUSH` stage.
 
-### `BACKUP STAGE BLOCK_DDL` in MariaDB Community Server
+### `BACKUP STAGE BLOCK_DDL`
 
-`mariadb-backup` from MariaDB Community Server does not currently perform any tasks in the `BLOCK_DDL` stage.
+`mariadb-backup` does not perform any tasks in the `BLOCK_DDL` stage.
 
-### `BACKUP STAGE BLOCK_COMMIT` in MariaDB Community Server
+### `BACKUP STAGE BLOCK_COMMIT`
 
-`mariadb-backup` from MariaDB Community Server performs the following tasks in the `BLOCK_COMMIT` stage:
+`mariadb-backup` performs the following tasks in the `BLOCK_COMMIT` stage:
 
 * Copy other files.
   * i.e. file extensions `.frm`, `.isl`, `.TRG`, `.TRN`, `.opt`, `.par`
@@ -69,19 +75,19 @@ To use a version of `mariadb-backup` that uses the [BACKUP STAGE](../../../refer
 * Save the binary log position to `xtrabackup_binlog_info`.
 * Save the Galera Cluster state information to `xtrabackup_galera_info`.
 
-### `BACKUP STAGE END` in MariaDB Community Server
+### `BACKUP STAGE END`
 
-`mariadb-backup` from MariaDB Community Server performs the following tasks in the `END` stage:
+`mariadb-backup` performs the following tasks in the `END` stage:
 
 * Copy the MyRocks checkpoint into the backup.
 
-## `BACKUP STAGE` in MariaDB Enterprise Server
+## `BACKUP STAGE` in MariaDB Enterprise Server and MariaDB Community Server 10.11.8 and Later
 
-The following sections describe how the MariaDB Backup version of mariadb-backup that is bundled with MariaDB Enterprise Server uses each [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage.md) statement in an efficient way.
+The following sections describe how `mariadb-backup` uses each [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage.md) statement in an efficient way.
 
-### `BACKUP STAGE START` in MariaDB Enterprise Server
+### `BACKUP STAGE START`
 
-`mariadb-backup` from MariaDB Enterprise Server performs the following tasks in the `START` stage:
+`mariadb-backup` performs the following tasks in the `START` stage:
 
 * Copy all transactional tables.
   * InnoDB (i.e. `ibdataN` and file extensions `.ibd` and `.isl`)
@@ -90,9 +96,9 @@ The following sections describe how the MariaDB Backup version of mariadb-backup
   * The tail of the InnoDB redo log (i.e. `ib_logfileN` files) are copied for InnoDB tables.
   * The tail of the Aria redo log (i.e. `aria_log.N` files) are copied for Aria tables.
 
-### `BACKUP STAGE FLUSH` in MariaDB Enterprise Server
+### `BACKUP STAGE FLUSH`
 
-mariadb-backup from MariaDB Enterprise Server performs the following tasks in the `FLUSH` stage:
+`mariadb-backup` performs the following tasks in the `FLUSH` stage:
 
 * Copy all non-transactional tables that are not in use. This list of used tables is found with `SHOW OPEN TABLES`.
   * `MyISAM` (i.e. file extensions `.MYD` and `.MYI`)
@@ -103,9 +109,9 @@ mariadb-backup from MariaDB Enterprise Server performs the following tasks in th
   * The tail of the InnoDB redo log (i.e. `ib_logfileN` files) are copied for InnoDB tables.
   * The tail of the Aria redo log (i.e. `aria_log.N` files) are copied for Aria tables.
 
-### `BACKUP STAGE BLOCK_DDL` in MariaDB Enterprise Server
+### `BACKUP STAGE BLOCK_DDL`
 
-`mariadb-backup` from MariaDB Enterprise Server performs the following tasks in the `BLOCK_DDL` stage:
+`mariadb-backup` performs the following tasks in the `BLOCK_DDL` stage:
 
 * Copy other files.
   * i.e. file extensions `.frm`, `.isl`, `.TRG`, `.TRN`, `.opt`, `.par`
@@ -126,9 +132,9 @@ mariadb-backup from MariaDB Enterprise Server performs the following tasks in th
   * The tail of the InnoDB redo log (i.e. `ib_logfileN` files) are copied for InnoDB tables.
   * The tail of the Aria redo log (i.e. `aria_log.N` files) are copied for Aria tables.
 
-### `BACKUP STAGE BLOCK_COMMIT` in MariaDB Enterprise Server
+### `BACKUP STAGE BLOCK_COMMIT`
 
-`mariadb-backup` from MariaDB Enterprise Server performs the following tasks in the `BLOCK_COMMIT` stage:
+`mariadb-backup` performs the following tasks in the `BLOCK_COMMIT` stage:
 
 * Create a MyRocks checkpoint using the rocksdb\_create\_checkpoint system variable.
 * Copy changes to system log tables.
@@ -145,9 +151,9 @@ mariadb-backup from MariaDB Enterprise Server performs the following tasks in th
 * Save the binary log position to `xtrabackup_binlog_info`.
 * Save the Galera Cluster state information to `xtrabackup_galera_info`.
 
-### `BACKUP STAGE END` in MariaDB Enterprise Server
+### `BACKUP STAGE END`
 
-`mariadb-backup` from MariaDB Enterprise Server performs the following tasks in the `END` stage:
+`mariadb-backup` performs the following tasks in the `END` stage:
 
 * Copy the MyRocks checkpoint into the backup.
 

--- a/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-options.md
+++ b/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-options.md
@@ -1195,7 +1195,7 @@ Used internally to prepare a backup.
 
 When backing up Percona Server, mariadb-backup would use backup locks by default. To be specific, backup locks refers to the `LOCK TABLES FOR BACKUP` and `LOCK BINLOG FOR BACKUP` statements. This option can be used to disable support for Percona Server's backup locks. This option has no effect when the server does not support Percona's backup locks.
 
-Deprecated and has no effect from [MariaDB 10.11.8](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/10.11.8), [MariaDB 11.0.6](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.0/11.0.6), [MariaDB 11.1.5](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.1/11.1.5) and [MariaDB 11.2.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.2/11.2.4) as MariaDB now always uses backup locks for better performance. See [MDEV-32932](https://jira.mariadb.org/browse/MDEV-32932).
+Deprecated and has no effect from [MariaDB 10.11.8](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/10.11.8), [MariaDB 11.0.6](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.0/11.0.6), [MariaDB 11.1.5](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.1/11.1.5), [MariaDB 11.2.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.2/11.2.4) and [MariaDB 11.4.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/11.4/11.4.2) as MariaDB now always uses backup locks for better performance. See [MDEV-32932](https://jira.mariadb.org/browse/MDEV-32932).
 
 ```bash
 mariadb-backup --backup --no-backup-locks
@@ -1366,7 +1366,7 @@ mariadb-backup --backup --rsync
 
 This option is not compatible with the `--stream` option.
 
-Deprecated and has no effect from [MariaDB 10.11.8](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/10.11.8), [MariaDB 11.0.6](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.0/11.0.6), [MariaDB 11.1.5](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.1/11.1.5) and [MariaDB 11.2.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.2/11.2.4) as rsync will not work on tables that are in use. See [MDEV-32932](https://jira.mariadb.org/browse/MDEV-32932).
+Deprecated and has no effect from [MariaDB 10.11.8](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/10.11.8), [MariaDB 11.0.6](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.0/11.0.6), [MariaDB 11.1.5](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.1/11.1.5), [MariaDB 11.2.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.2/11.2.4) and [MariaDB 11.4.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/11.4/11.4.2) as rsync will not work on tables that are in use. See [MDEV-32932](https://jira.mariadb.org/browse/MDEV-32932).
 
 ### `--safe-slave-backup`
 


### PR DESCRIPTION
Requested by Monty in Slack: the `mariadb-backup and BACKUP STAGE` page splits its content into "BACKUP STAGE in MariaDB Community Server" and "BACKUP STAGE in MariaDB Enterprise Server", which is no longer the real distinction. Since [MDEV-32932](https://jira.mariadb.org/browse/MDEV-32932) ("Port backup features from ES") the Community Server build of `mariadb-backup` uses the same efficient staging Enterprise Server has used since MENT-9 in 2020 — so the page presented current Community Server behavior as an Enterprise-only feature.

Monty asked for the labels "before 10.11" / "starting from 10.11". Fact-checking against source shows the direction is right but **both** version labels are wrong, so this PR uses corrected boundaries.

## What changed

`mariadb-backup-and-backup-stage-commands.md`

- `## BACKUP STAGE in MariaDB Community Server` → `## BACKUP STAGE Before MariaDB Community Server 10.11.8`
- `## BACKUP STAGE in MariaDB Enterprise Server` → `## BACKUP STAGE in MariaDB Enterprise Server and MariaDB Community Server 10.11.8 and Later`
- Dropped the repeated "in MariaDB Community Server" / "in MariaDB Enterprise Server" from all twelve `###` sub-headings and from the prose beneath them, as requested.
- New intro paragraph plus a hint stating that the change landed in a **maintenance release of each series**, so the series alone does not tell you which behavior you get.
- Reworded the hint that told readers to switch to Enterprise Server for efficient staging — no longer the only option.
- Removed two instances of "does not currently perform", now that the section is explicitly historical.

The task lists themselves are unchanged: they were checked stage by stage against source and are accurate for both Enterprise Server and Community Server 10.11.8+.

## Version boundaries (verified against source)

| Series | First release with the efficient staging |
|---|---|
| 10.11 | **10.11.8** — 10.11.0 through 10.11.7 use the old behavior |
| 11.0 / 11.1 / 11.2 | 11.0.6 / 11.1.5 / 11.2.4 |
| 11.3 | never — the whole series was EOL'd on the old behavior |
| 11.4 | **11.4.2** — 11.4.0 and 11.4.1 use the old behavior |
| 11.5 and later | 11.5.1 and every release since |
| 10.6 and earlier | never (checked at `mariadb-10.6.28`, the latest 10.6) |

So a bare "starting from 10.11" would mislabel 10.11.0–10.11.7, all of 11.3, and 11.4.0/11.4.1.

Evidence: `BACKUP STAGE BLOCK_DDL` is absent from `extra/mariabackup/backup_mysql.cc` at tag `mariadb-10.11.7` and present at `mariadb-10.11.8`; absent at `mariadb-11.4.1` and present at `mariadb-11.4.2`. Introduced by commit `1c55b845e0f`. Corroborated by our own release notes for 10.11.8, 11.0.6, 11.1.5, 11.2.4 and 11.4.2, and by the existing deprecation notes on the options page.

On the Enterprise Server side there is no 10.11 line, and the efficient staging predates the Community Server port by about four years (MENT-9 landed on the 10.2/10.3/10.4 enterprise branches in January 2020), so that heading carries no version qualifier.

## Drive-by fixes

- `mariadb-backup-options.md`: the `--no-backup-locks` and `--rsync` deprecation notes listed 10.11.8, 11.0.6, 11.1.5 and 11.2.4 but omitted **11.4.2**, which also carries MDEV-32932. Added.

## Notes for review

- Heading changes are at `##`/`###` level only, so no published URLs change and no GitBook redirects are needed. Section anchors do change; a repo-wide grep found no inbound links to `#backup-stage-in-mariadb-community-server` or `#backup-stage-in-mariadb-enterprise-server` — all four references point at the page itself.
- The `###` sub-headings are now identical in both sections, so GitBook will disambiguate the second set's anchors. That is the direct consequence of dropping the product name, which was the request.
- `codespell` and `lychee` pass locally on both changed files.

Ticket: https://mariadbcorp.atlassian.net/browse/DOCS-6484

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MDEV-32932]: https://mdb2026-sandbox.atlassian.net/browse/MDEV-32932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ