### PR TITLE
DOCS-6484 Correct the older-behavior scope on the BACKUP STAGE page

### DIFF
--- a/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-and-backup-stage-commands.md
+++ b/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-and-backup-stage-commands.md
@@ -13,7 +13,7 @@ The [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statemen
 Every release of MariaDB Enterprise Server uses all of the `BACKUP STAGE` statements. MariaDB Community Server originally used only two of them, and gained the same behavior in MariaDB Community Server 10.11.8, 11.0.6, 11.1.5, 11.2.4, and 11.4.2, and in every release since. See [MDEV-32932](https://jira.mariadb.org/browse/MDEV-32932).
 
 {% hint style="info" %}
-The change landed in a maintenance release of each series, so the version series alone does not tell you which behavior you get. Releases before those listed above, all releases in the 10.6 series and earlier, and all releases in the 11.3 series use the two-statement behavior.
+The change landed in a maintenance release of each series, so the version series alone does not tell you which behavior you get. Releases before those listed above use the older behavior, as do all releases in the 10.6 series and earlier and all releases in the 11.3 series.
 {% endhint %}
 
 {% include "../../../.gitbook/includes/for-a-complete-list-of-mari....md" %}

--- a/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-and-backup-stage-commands.md
+++ b/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-and-backup-stage-commands.md
@@ -10,7 +10,7 @@ description: >-
 
 The [BACKUP STAGE](../../../reference/sql-statements/administrative-sql-statements/backup-commands/backup-stage.md) statements make it possible to make an efficient external backup tool. How `mariadb-backup` uses these statements depends on the version of MariaDB Server it is bundled with.
 
-Every release of MariaDB Enterprise Server uses all of the `BACKUP STAGE` statements. MariaDB Community Server originally used only two of them, and gained the same behavior in MariaDB Community Server 10.11.8, 11.0.6, 11.1.5, 11.2.4, and 11.4.2, and in every release since. See [MDEV-32932](https://jira.mariadb.org/browse/MDEV-32932).
+Every release of MariaDB Enterprise Server uses all of the `BACKUP STAGE` statements to do the work described below. MariaDB Community Server gained the same behavior in MariaDB Community Server 10.11.8, 11.0.6, 11.1.5, 11.2.4, and 11.4.2, and in every release since. See [MDEV-32932](https://jira.mariadb.org/browse/MDEV-32932).
 
 {% hint style="info" %}
 The change landed in a maintenance release of each series, so the version series alone does not tell you which behavior you get. Releases before those listed above use the older behavior, as do all releases in the 10.6 series and earlier and all releases in the 11.3 series.


### PR DESCRIPTION
Follow-up to #924, which merged with only its first commit. A second commit correcting a factual over-generalization was pushed to that branch but never picked up by the PR — GitHub still had the old `headRefOid` at merge time — so `main` currently carries the wrong wording. This PR carries that fix, plus one more instance of the same defect found while re-checking.

## The defect

The page had two sentences characterizing what *all* pre-MDEV-32932 releases did. Both are wrong for a range of older releases, because `mariadb-backup`'s `BACKUP STAGE` usage changed three times, not once:

| When | Change | Statements issued |
|---|---|---|
| 10.4.1 (2018-12-18) | MDEV-17308 — use `BACKUP STAGE` instead of `FTWRL` | all five, but no per-stage work |
| 10.4.22 / 10.5.13 / **10.6.5** (2021-11-05) | MDEV-19712 — "backup stages commented out" | `START` + `BLOCK_COMMIT` + `END` |
| 10.11.8 / 11.0.6 / 11.1.5 / 11.2.4 / 11.4.2 (2024-05) | MDEV-32932 — port from Enterprise Server | all five, **with** the per-stage copying logic |

Verified with `git cat-file` on `extra/mariabackup/backup_mysql.cc`: `mariadb-10.6.4` emits START/FLUSH/BLOCK_DDL/BLOCK_COMMIT/END; `mariadb-10.6.5` emits only START/BLOCK_COMMIT/END.

So the middle row is what the page's "Before 10.11.8" section describes — correct for everything still in the field (10.6.5+ and 10.11.0–10.11.7), but not for the 2018–2021 releases in the first row.

## Changes

Two one-line wording fixes, both in `mariadb-backup-and-backup-stage-commands.md`:

- **The hint:** "…all releases in the 10.6 series and earlier … use the **two-statement behavior**" → "**use the older behavior**". True for every pre-MDEV-32932 release regardless of how many statements it issued.
- **The intro:** dropped "MariaDB Community Server **originally used only two of them**", which is false for 10.4.1–10.4.21, 10.5.0–10.5.12 and 10.6.0–10.6.4. The sentence now states when Community Server gained the behavior instead of characterizing what every earlier release did.

No change to the stage task lists, the headings, or the section structure — all of that merged correctly in #924.

## Note for review

The 2018–2021 releases in the first row are all long EOL, so no reader is affected in practice. The fix is about not asserting a sweeping "all releases … did X" that source contradicts.

Ticket: https://mariadbcorp.atlassian.net/browse/DOCS-6484 (still in Review; not closing it until this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
