### PR TITLE
DOCS-6481 Make GitBook alias expansion link-aware so landing pages work

### DIFF
--- a/.claude/skills/gitbook-format/SKILL.md
+++ b/.claude/skills/gitbook-format/SKILL.md
@@ -119,7 +119,7 @@ content inline rather than inventing an include.
 ### 6. Links
 
 - **Same space** → relative `.md` path: `[CREATE TABLE](reference/.../create-table.md)`.
-- **Other space** → alias: `[MaxScale](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/readme)`. Alias table:
+- **Other space** → alias: `[MaxScale]({maxscale}/readme)`. Alias table:
   `dev-docs/link-aliases.md`.
 - **Convert** raw `https://app.gitbook.com/...` URLs and hard-coded cross-space URLs into the
   appropriate alias. **Never** expand an existing `{alias}` into a URL — the CI Action does that.

--- a/.github/workflows/expand-gitbook-aliases.yml
+++ b/.github/workflows/expand-gitbook-aliases.yml
@@ -19,28 +19,40 @@ jobs:
       - name: Expand GitBook aliases (Stable Version)
         run: |
           set -e
-          echo "Expanding GitBook aliases while excluding protected files..."
+          echo "Expanding GitBook aliases in link targets, excluding protected files..."
 
+          # An alias is only rewritten where it is a link target: directly after a
+          # Markdown link's "](", after a content-ref's url=", or after an HTML
+          # href=". An alias-looking string anywhere else in the prose is left
+          # alone, because it is not always an alias -- the ColumnStore CMAPI
+          # pages document https://{server}:{port}/cmapi/{version}/{route}/{command},
+          # where {server} is a hostname placeholder, and expanding it would
+          # produce https://https://app.gitbook.com/o/...:{port}/cmapi/...
+          #
+          # A trailing "/" is deliberately NOT required: about 15% of aliased
+          # links target a space root, as in [Galera]({galera}), and requiring
+          # the slash would silently stop expanding them.
           find . -type f -name "*.md" \
             ! -path "./dev-docs/*" \
             ! -path "./.claude/*" \
-            ! -name "README.md" \
+            ! -path "./README.md" \
+            ! -path "./pdf/README.md" \
             ! -name "CONTRIBUTING.md" \
             ! -path "*/general-resources/about/readme/about-links.md" \
-            -exec sed -i \
-            -e 's|{server}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV|g' \
-            -e 's|{galera}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7|g' \
-            -e 's|{maxscale}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX|g' \
-            -e 's|{analytics}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14|g' \
-            -e 's|{columnstore}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/2I4jZ8pGq8bT4w5n3q6r|g' \
-            -e 's|{skysql}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd|g' \
-            -e 's|{home}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1|g' \
-            -e 's|{platform}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/JqgUabdZsoY5EiaJmqgn|g' \
-            -e 's|{connectors}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L|g' \
-            -e 's|{tools}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD|g' \
-            -e 's|{mariadb-cloud}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd|g' \
-            -e 's|{release-notes}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb|g' \
-            -e 's|{general-resources}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/WCInJQ9cmGjq1lsTG91E/about/readme|g' \
+            -exec sed -E -i \
+            -e 's#(\]\(|url="|href=")[{]server[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV#g' \
+            -e 's#(\]\(|url="|href=")[{]galera[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7#g' \
+            -e 's#(\]\(|url="|href=")[{]maxscale[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX#g' \
+            -e 's#(\]\(|url="|href=")[{]analytics[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14#g' \
+            -e 's#(\]\(|url="|href=")[{]columnstore[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/2I4jZ8pGq8bT4w5n3q6r#g' \
+            -e 's#(\]\(|url="|href=")[{]skysql[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd#g' \
+            -e 's#(\]\(|url="|href=")[{]home[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1#g' \
+            -e 's#(\]\(|url="|href=")[{]platform[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/JqgUabdZsoY5EiaJmqgn#g' \
+            -e 's#(\]\(|url="|href=")[{]connectors[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L#g' \
+            -e 's#(\]\(|url="|href=")[{]tools[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD#g' \
+            -e 's#(\]\(|url="|href=")[{]mariadb-cloud[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd#g' \
+            -e 's#(\]\(|url="|href=")[{]release-notes[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb#g' \
+            -e 's#(\]\(|url="|href=")[{]general-resources[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/WCInJQ9cmGjq1lsTG91E/about/readme#g' \
             {} +
 
           echo "Git status after expansion:"

--- a/dev-docs/gitbook-syntax.md
+++ b/dev-docs/gitbook-syntax.md
@@ -201,5 +201,5 @@ Markdown tables. Notes from the GitBook Editing guide:
 
 - **Within the same space:** relative Markdown link to the `.md` file
   — `[CREATE TABLE](reference/.../create-table.md)`.
-- **To another space:** a link alias — `[MaxScale](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/readme)`. See `link-aliases.md`.
+- **To another space:** a link alias — `[MaxScale]({maxscale}/readme)`. See `link-aliases.md`.
 - Never paste raw `https://app.gitbook.com/...` URLs.

--- a/dev-docs/link-aliases.md
+++ b/dev-docs/link-aliases.md
@@ -13,10 +13,10 @@ to the real URL when the PR is merged.
 Example:
 
 ```
-[Securing Communications](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/galera-security/securing-communications-in-galera-cluster)
+[Securing Communications]({galera}/galera-security/securing-communications-in-galera-cluster)
 ```
 
-The `expand-gitbook-aliases.yml` Action rewrites `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7` to the full
+The `expand-gitbook-aliases.yml` Action rewrites `{galera}` to the full
 `https://app.gitbook.com/...` URL on the PR branch automatically. The expansion is committed
 back to the PR branch as `docs: expand GitBook aliases` from the `github-actions` bot — expect
 that follow-up commit to appear shortly after opening or pushing to a PR.
@@ -25,19 +25,19 @@ that follow-up commit to appear shortly after opening or pushing to a PR.
 
 | Alias | Target space |
 |-------|--------------|
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1` | Home / Landing |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV` | MariaDB Server |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX` | MariaDB MaxScale |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7` | Galera Cluster |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14` | Analytics (ColumnStore) |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/2I4jZ8pGq8bT4w5n3q6r` | ColumnStore |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L` | Connectors (Java, ODBC, etc.) |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd` | MariaDB Cloud (also the target of the legacy `skysql` alias — SkySQL was renamed MariaDB Cloud) |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/JqgUabdZsoY5EiaJmqgn` | MariaDB Enterprise Platform |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd` | MariaDB Cloud |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD` | Tools |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb` | Release Notes |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/WCInJQ9cmGjq1lsTG91E/about/readme` | General Resources |
+| `{home}` | Home / Landing |
+| `{server}` | MariaDB Server |
+| `{maxscale}` | MariaDB MaxScale |
+| `{galera}` | Galera Cluster |
+| `{analytics}` | Analytics (ColumnStore) |
+| `{columnstore}` | ColumnStore |
+| `{connectors}` | Connectors (Java, ODBC, etc.) |
+| `{skysql}` | MariaDB Cloud (legacy alias — SkySQL was renamed MariaDB Cloud) |
+| `{platform}` | MariaDB Enterprise Platform |
+| `{mariadb-cloud}` | MariaDB Cloud |
+| `{tools}` | Tools |
+| `{release-notes}` | Release Notes |
+| `{general-resources}` | General Resources |
 
 ## Rules for agents
 
@@ -49,6 +49,18 @@ that follow-up commit to appear shortly after opening or pushing to a PR.
   expected. They work on the published site after expansion.
 - **Don't validate aliased links locally.** The link-checker (lychee) is configured to skip
   anything containing `{` (and its `%7B` encoding), so aliases never trip CI.
-- A few files are intentionally **excluded from alias expansion** by the Action:
-  `README.md`, `CONTRIBUTING.md`, and `general-resources/about/readme/about-links.md`.
-  Don't rely on alias expansion in those.
+- **Only a link target is expanded.** The Action rewrites an alias when it appears directly
+  after a Markdown link's `](`, after a content-ref's `url="`, or after an HTML `href="`.
+  An alias-looking string anywhere else — in prose, in a table cell, in a code sample — is
+  left exactly as written. So `` `{server}` `` in a sentence is safe, and the ColumnStore
+  CMAPI pages can keep documenting `https://{server}:{port}/cmapi/{version}/{route}/{command}`,
+  where `{server}` is a hostname placeholder rather than a docs alias.
+- Aliases **do work on landing pages.** Every space and section landing page is a
+  `README.md`, and the Action used to skip those by filename, so an alias written there was
+  silently left unexpanded — GitBook then read it as a repository path and emitted a
+  plausible-looking `github.com/...` URL that 404s. Fixed in DOCS-6481.
+- A few files are intentionally **excluded from alias expansion** by the Action, because they
+  discuss the alias mechanism rather than use it: the repository's own `README.md` and
+  `pdf/README.md`, `CONTRIBUTING.md`, everything under `dev-docs/` and `.claude/`, and
+  `general-resources/about/readme/about-links.md`. Don't rely on alias expansion in those —
+  write the raw `https://app.gitbook.com/o/<org>/s/<space>/path` URL instead.

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -132,9 +132,9 @@ the source encodes them (`15%20(1).PNG`) while the filesystem does not.
 
 ### Cross-space links must be un-expanded first
 
-`expand-gitbook-aliases.yml` rewrites every `{server}`-style alias into an
-app.gitbook.com **editor** URL and commits that back to the branch. So in any
-checkout, a cross-space link already looks like:
+`expand-gitbook-aliases.yml` rewrites every `{server}`-style alias that sits in a
+link target into an app.gitbook.com **editor** URL and commits that back to the
+branch. So in any checkout, a cross-space link already looks like:
 
 ```
 https://app.gitbook.com/o/<org>/s/SsmexDFPv2xG2OTyO5yV/server-management/…


### PR DESCRIPTION
Fixes the alias-expansion Action so a `{space}` alias works on a landing page, and repairs the docs the Action corrupted. [DOCS-6481](https://mariadbcorp.atlassian.net/browse/DOCS-6481).

## 1. The Action skipped every landing page

`! -name "README.md"` matches by **filename**, so it excluded every `README.md` in the repo — and every GitBook space and section landing page *is* a `README.md`. An alias written on a landing page was never expanded, and nothing caught it: GitBook read the unexpanded target as a repository path and emitted a plausible-looking `github.com/...` URL that 404s, while lychee skipped it because `link-check-pr.yml` excludes any URL containing a brace. DOCS-6435's four dead Changelog links were found by a human clicking one.

The exclusion existed because the `sed` was a **blind global replace**, so the fix is to make the replacement **link-aware** first: an alias is rewritten only where it is a link target — directly after a Markdown link's `](`, a content-ref's `url="`, or an HTML `href="`. With the blind replacement gone, the exclusion narrows to the repository's own `README.md` safely.

**The ticket's suggested pattern `](\{alias\}/` would have caused a silent regression.** Replaying the 42 alias-expansion commits in history, **557 of 3,700 expanded links (15%) target a space root** — `[Galera]({galera})`, no trailing path — so requiring the slash would have quietly stopped expanding all of them. The rule is prefix-anchored only.

Braces are matched as POSIX bracket expressions (`[{]server[}]`) rather than `\{server\}` so the pattern behaves identically under BSD and GNU `sed`, which also made it testable locally.

## 2. The Action had corrupted the docs that define the aliases

Commit `40c543ffc` (2026-06-12), before the `dev-docs/` and `.claude/` exclusions existed, expanded the placeholders in the three files documenting the mechanism. The exclusions were added afterwards so it cannot recur, but the damage was never reverted and was still in `main`.

`dev-docs/link-aliases.md` had lost the entire left column of its **Available aliases** table, so the canonical reference no longer said which alias maps to which space. Worse, `dev-docs/gitbook-syntax.md` and `.claude/skills/gitbook-format/SKILL.md` ended up **instructing the opposite of the rule, with the anti-pattern as the worked example** — "a link alias — `[MaxScale](https://app.gitbook.com/...)`" sitting directly above "Never paste raw `app.gitbook.com` URLs", in the skill whose job is converting raw URLs *into* aliases.

Restored **per hunk, not by reverting**: `628742a84` (DOCS-6371) later edited the already-expanded `{skysql}` row to repoint it from Release Notes to MariaDB Cloud, and a revert would have undone that. Each of the 13 rows was matched back to its alias by both table position and space ID against the workflow; the `{skysql}` row keeps its DOCS-6371 target and takes the wording already in `CONTRIBUTING.md`. With placeholders restored, the two rows sharing one space ID read as `{skysql}` and `{mariadb-cloud}` instead of looking like a duplicate.

The excluded-files list in `link-aliases.md` was also two entries out of date (it omitted `dev-docs/` and `.claude/`) — the first thing anyone narrowing that exclusion would read.

## Verification

The `find`/`sed` command was **extracted from the workflow file** and executed, so these test the real command rather than a retyped copy.

| Test | Result |
|---|---|
| Fixture: link with path, link to space root, `url="`, `href="`, anchored target, two aliases on one line | all 6 expand |
| Fixture: landing-page `README.md` links | now expand (the bug) |
| Fixture: CMAPI template, `pdf/README.md`, alias tables, backticked prose, all excluded files | untouched |
| Replay over all 42 historical bot commits | **1350 of 1360 files byte-identical**; all 10 differences are documentation the old rule corrupted |
| New rule over the whole current tree | **no-op, 0 files changed** |
| Naive fix (global `sed` + narrowed exclusion) over the whole tree | corrupts **5 files**, e.g. `https://https://app.gitbook.com/...:{port}/cmapi/...` |
| 13 alias→URL mappings vs `origin/main` | identical, none added or dropped |
| `doc-lint.sh` on the 4 changed `.md` files (codespell + lychee both installed) | exit 0 |

Since this PR edits the Action itself, the `expand-links` check on it is a live test: it should report **"No alias replacements needed."** and leave the restored placeholders in `dev-docs/` and `.claude/` intact.

## Not done — one item from the ticket, with a reason

The ticket suggests *"consider dropping lychee's `--exclude '.*\{.*'` so an unexpanded alias fails CI"*. **This is not safe as stated.** `link-check-pr.yml` and `expand-gitbook-aliases.yml` both trigger on `pull_request` and run in parallel, so link-check sees the tree *before* expansion. Dropping the exclude would make link-check fail on every PR containing an alias, and the bot's expansion commit gates the re-run as `action_required` needing manual approval. Catching the class needs a separate check that runs after expansion, not a change to this exclude — happy to file that if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6481]: https://mariadbcorp.atlassian.net/browse/DOCS-6481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ