### PR TITLE
DO NOT MERGE: DOCS-6481 GNU sed probe

### DIFF
--- a/.claude/skills/gitbook-format/SKILL.md
+++ b/.claude/skills/gitbook-format/SKILL.md
@@ -119,7 +119,7 @@ content inline rather than inventing an include.
 ### 6. Links
 
 - **Same space** → relative `.md` path: `[CREATE TABLE](reference/.../create-table.md)`.
-- **Other space** → alias: `[MaxScale](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/readme)`. Alias table:
+- **Other space** → alias: `[MaxScale]({maxscale}/readme)`. Alias table:
   `dev-docs/link-aliases.md`.
 - **Convert** raw `https://app.gitbook.com/...` URLs and hard-coded cross-space URLs into the
   appropriate alias. **Never** expand an existing `{alias}` into a URL — the CI Action does that.

--- a/.github/workflows/expand-gitbook-aliases.yml
+++ b/.github/workflows/expand-gitbook-aliases.yml
@@ -19,28 +19,40 @@ jobs:
       - name: Expand GitBook aliases (Stable Version)
         run: |
           set -e
-          echo "Expanding GitBook aliases while excluding protected files..."
+          echo "Expanding GitBook aliases in link targets, excluding protected files..."
 
+          # An alias is only rewritten where it is a link target: directly after a
+          # Markdown link's "](", after a content-ref's url=", or after an HTML
+          # href=". An alias-looking string anywhere else in the prose is left
+          # alone, because it is not always an alias -- the ColumnStore CMAPI
+          # pages document https://{server}:{port}/cmapi/{version}/{route}/{command},
+          # where {server} is a hostname placeholder, and expanding it would
+          # produce https://https://app.gitbook.com/o/...:{port}/cmapi/...
+          #
+          # A trailing "/" is deliberately NOT required: about 15% of aliased
+          # links target a space root, as in [Galera]({galera}), and requiring
+          # the slash would silently stop expanding them.
           find . -type f -name "*.md" \
             ! -path "./dev-docs/*" \
             ! -path "./.claude/*" \
-            ! -name "README.md" \
+            ! -path "./README.md" \
+            ! -path "./pdf/README.md" \
             ! -name "CONTRIBUTING.md" \
             ! -path "*/general-resources/about/readme/about-links.md" \
-            -exec sed -i \
-            -e 's|{server}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV|g' \
-            -e 's|{galera}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7|g' \
-            -e 's|{maxscale}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX|g' \
-            -e 's|{analytics}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14|g' \
-            -e 's|{columnstore}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/2I4jZ8pGq8bT4w5n3q6r|g' \
-            -e 's|{skysql}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd|g' \
-            -e 's|{home}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1|g' \
-            -e 's|{platform}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/JqgUabdZsoY5EiaJmqgn|g' \
-            -e 's|{connectors}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L|g' \
-            -e 's|{tools}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD|g' \
-            -e 's|{mariadb-cloud}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd|g' \
-            -e 's|{release-notes}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb|g' \
-            -e 's|{general-resources}|https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/WCInJQ9cmGjq1lsTG91E/about/readme|g' \
+            -exec sed -E -i \
+            -e 's#(\]\(|url="|href=")[{]server[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV#g' \
+            -e 's#(\]\(|url="|href=")[{]galera[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7#g' \
+            -e 's#(\]\(|url="|href=")[{]maxscale[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX#g' \
+            -e 's#(\]\(|url="|href=")[{]analytics[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14#g' \
+            -e 's#(\]\(|url="|href=")[{]columnstore[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/2I4jZ8pGq8bT4w5n3q6r#g' \
+            -e 's#(\]\(|url="|href=")[{]skysql[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd#g' \
+            -e 's#(\]\(|url="|href=")[{]home[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1#g' \
+            -e 's#(\]\(|url="|href=")[{]platform[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/JqgUabdZsoY5EiaJmqgn#g' \
+            -e 's#(\]\(|url="|href=")[{]connectors[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L#g' \
+            -e 's#(\]\(|url="|href=")[{]tools[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD#g' \
+            -e 's#(\]\(|url="|href=")[{]mariadb-cloud[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd#g' \
+            -e 's#(\]\(|url="|href=")[{]release-notes[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb#g' \
+            -e 's#(\]\(|url="|href=")[{]general-resources[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/WCInJQ9cmGjq1lsTG91E/about/readme#g' \
             {} +
 
           echo "Git status after expansion:"

--- a/dev-docs/gitbook-syntax.md
+++ b/dev-docs/gitbook-syntax.md
@@ -201,5 +201,5 @@ Markdown tables. Notes from the GitBook Editing guide:
 
 - **Within the same space:** relative Markdown link to the `.md` file
   — `[CREATE TABLE](reference/.../create-table.md)`.
-- **To another space:** a link alias — `[MaxScale](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/readme)`. See `link-aliases.md`.
+- **To another space:** a link alias — `[MaxScale]({maxscale}/readme)`. See `link-aliases.md`.
 - Never paste raw `https://app.gitbook.com/...` URLs.

--- a/dev-docs/link-aliases.md
+++ b/dev-docs/link-aliases.md
@@ -13,10 +13,10 @@ to the real URL when the PR is merged.
 Example:
 
 ```
-[Securing Communications](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/galera-security/securing-communications-in-galera-cluster)
+[Securing Communications]({galera}/galera-security/securing-communications-in-galera-cluster)
 ```
 
-The `expand-gitbook-aliases.yml` Action rewrites `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7` to the full
+The `expand-gitbook-aliases.yml` Action rewrites `{galera}` to the full
 `https://app.gitbook.com/...` URL on the PR branch automatically. The expansion is committed
 back to the PR branch as `docs: expand GitBook aliases` from the `github-actions` bot — expect
 that follow-up commit to appear shortly after opening or pushing to a PR.
@@ -25,19 +25,19 @@ that follow-up commit to appear shortly after opening or pushing to a PR.
 
 | Alias | Target space |
 |-------|--------------|
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1` | Home / Landing |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV` | MariaDB Server |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX` | MariaDB MaxScale |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7` | Galera Cluster |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14` | Analytics (ColumnStore) |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/2I4jZ8pGq8bT4w5n3q6r` | ColumnStore |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L` | Connectors (Java, ODBC, etc.) |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd` | MariaDB Cloud (also the target of the legacy `skysql` alias — SkySQL was renamed MariaDB Cloud) |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/JqgUabdZsoY5EiaJmqgn` | MariaDB Enterprise Platform |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd` | MariaDB Cloud |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD` | Tools |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb` | Release Notes |
-| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/WCInJQ9cmGjq1lsTG91E/about/readme` | General Resources |
+| `{home}` | Home / Landing |
+| `{server}` | MariaDB Server |
+| `{maxscale}` | MariaDB MaxScale |
+| `{galera}` | Galera Cluster |
+| `{analytics}` | Analytics (ColumnStore) |
+| `{columnstore}` | ColumnStore |
+| `{connectors}` | Connectors (Java, ODBC, etc.) |
+| `{skysql}` | MariaDB Cloud (legacy alias — SkySQL was renamed MariaDB Cloud) |
+| `{platform}` | MariaDB Enterprise Platform |
+| `{mariadb-cloud}` | MariaDB Cloud |
+| `{tools}` | Tools |
+| `{release-notes}` | Release Notes |
+| `{general-resources}` | General Resources |
 
 ## Rules for agents
 
@@ -49,6 +49,18 @@ that follow-up commit to appear shortly after opening or pushing to a PR.
   expected. They work on the published site after expansion.
 - **Don't validate aliased links locally.** The link-checker (lychee) is configured to skip
   anything containing `{` (and its `%7B` encoding), so aliases never trip CI.
-- A few files are intentionally **excluded from alias expansion** by the Action:
-  `README.md`, `CONTRIBUTING.md`, and `general-resources/about/readme/about-links.md`.
-  Don't rely on alias expansion in those.
+- **Only a link target is expanded.** The Action rewrites an alias when it appears directly
+  after a Markdown link's `](`, after a content-ref's `url="`, or after an HTML `href="`.
+  An alias-looking string anywhere else — in prose, in a table cell, in a code sample — is
+  left exactly as written. So `` `{server}` `` in a sentence is safe, and the ColumnStore
+  CMAPI pages can keep documenting `https://{server}:{port}/cmapi/{version}/{route}/{command}`,
+  where `{server}` is a hostname placeholder rather than a docs alias.
+- Aliases **do work on landing pages.** Every space and section landing page is a
+  `README.md`, and the Action used to skip those by filename, so an alias written there was
+  silently left unexpanded — GitBook then read it as a repository path and emitted a
+  plausible-looking `github.com/...` URL that 404s. Fixed in DOCS-6481.
+- A few files are intentionally **excluded from alias expansion** by the Action, because they
+  discuss the alias mechanism rather than use it: the repository's own `README.md` and
+  `pdf/README.md`, `CONTRIBUTING.md`, everything under `dev-docs/` and `.claude/`, and
+  `general-resources/about/readme/about-links.md`. Don't rely on alias expansion in those —
+  write the raw `https://app.gitbook.com/o/<org>/s/<space>/path` URL instead.

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -132,9 +132,9 @@ the source encodes them (`15%20(1).PNG`) while the filesystem does not.
 
 ### Cross-space links must be un-expanded first
 
-`expand-gitbook-aliases.yml` rewrites every `{server}`-style alias into an
-app.gitbook.com **editor** URL and commits that back to the branch. So in any
-checkout, a cross-space link already looks like:
+`expand-gitbook-aliases.yml` rewrites every `{server}`-style alias that sits in a
+link target into an app.gitbook.com **editor** URL and commits that back to the
+branch. So in any checkout, a cross-space link already looks like:
 
 ```
 https://app.gitbook.com/o/<org>/s/SsmexDFPv2xG2OTyO5yV/server-management/…

--- a/server/.alias-probe/probe.md
+++ b/server/.alias-probe/probe.md
@@ -1,0 +1,14 @@
+---
+description: Temporary probe for DOCS-6481. Not for merge.
+---
+
+# Alias Expansion Probe
+
+- link with path: [Backup]({server}/server-usage/backup-and-restore/mariadb-backup)
+- link to space root: [Galera]({galera})
+- anchored: [Options]({server}/page#no-backup-locks)
+- html href: <td><a href="{maxscale}/readme">MaxScale</a></td>
+- content-ref: {% content-ref url="{release-notes}/community-server/changelogs" %}
+- two on a line: [A]({tools}) and [B]({connectors}/x)
+- MUST NOT CHANGE, hostname placeholder: https://{server}:{port}/cmapi/{version}/{route}/{command}
+- MUST NOT CHANGE, prose: the `{server}` alias in a sentence

--- a/server/.alias-probe/probe.md
+++ b/server/.alias-probe/probe.md
@@ -4,11 +4,11 @@ description: Temporary probe for DOCS-6481. Not for merge.
 
 # Alias Expansion Probe
 
-- link with path: [Backup]({server}/server-usage/backup-and-restore/mariadb-backup)
-- link to space root: [Galera]({galera})
-- anchored: [Options]({server}/page#no-backup-locks)
-- html href: <td><a href="{maxscale}/readme">MaxScale</a></td>
-- content-ref: {% content-ref url="{release-notes}/community-server/changelogs" %}
-- two on a line: [A]({tools}) and [B]({connectors}/x)
+- link with path: [Backup](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-usage/backup-and-restore/mariadb-backup)
+- link to space root: [Galera](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7)
+- anchored: [Options](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/page#no-backup-locks)
+- html href: <td><a href="https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/readme">MaxScale</a></td>
+- content-ref: {% content-ref url="https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/community-server/changelogs" %}
+- two on a line: [A](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD) and [B](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/x)
 - MUST NOT CHANGE, hostname placeholder: https://{server}:{port}/cmapi/{version}/{route}/{command}
 - MUST NOT CHANGE, prose: the `{server}` alias in a sentence


### PR DESCRIPTION
Throwaway PR. Verifies the DOCS-6481 link-aware alias expansion actually matches under GNU sed on ubuntu-latest. Will be closed and the branch deleted once the bot's expansion commit is inspected. Not for review, not for merge.