### PR TITLE
DOCS-6487 Expand aliases in reference-style link definitions, and fail CI on an unknown alias

### DIFF
--- a/.github/workflows/expand-gitbook-aliases.yml
+++ b/.github/workflows/expand-gitbook-aliases.yml
@@ -21,17 +21,21 @@ jobs:
           set -e
           echo "Expanding GitBook aliases in link targets, excluding protected files..."
 
-          # An alias is only rewritten where it is a link target: directly after a
-          # Markdown link's "](", after a content-ref's url=", or after an HTML
-          # href=". An alias-looking string anywhere else in the prose is left
-          # alone, because it is not always an alias -- the ColumnStore CMAPI
-          # pages document https://{server}:{port}/cmapi/{version}/{route}/{command},
+          # An alias is only rewritten where it is a link target: directly after
+          # a Markdown link's "](", after a reference-style link definition's
+          # "]:", after a content-ref's url=", or after an HTML href=". An
+          # alias-looking string anywhere else in the prose is left alone,
+          # because it is not always an alias -- the ColumnStore CMAPI pages
+          # document https://{server}:{port}/cmapi/{version}/{route}/{command},
           # where {server} is a hostname placeholder, and expanding it would
           # produce https://https://app.gitbook.com/o/...:{port}/cmapi/...
           #
           # A trailing "/" is deliberately NOT required: about 15% of aliased
           # links target a space root, as in [Galera]({galera}), and requiring
           # the slash would silently stop expanding them.
+          #
+          # Keep the prefix group in sync with the "Fail on an unexpanded alias"
+          # step below, which reports what this step could not expand.
           find . -type f -name "*.md" \
             ! -path "./dev-docs/*" \
             ! -path "./.claude/*" \
@@ -40,19 +44,19 @@ jobs:
             ! -name "CONTRIBUTING.md" \
             ! -path "*/general-resources/about/readme/about-links.md" \
             -exec sed -E -i \
-            -e 's#(\]\(|url="|href=")[{]server[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV#g' \
-            -e 's#(\]\(|url="|href=")[{]galera[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7#g' \
-            -e 's#(\]\(|url="|href=")[{]maxscale[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX#g' \
-            -e 's#(\]\(|url="|href=")[{]analytics[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14#g' \
-            -e 's#(\]\(|url="|href=")[{]columnstore[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/2I4jZ8pGq8bT4w5n3q6r#g' \
-            -e 's#(\]\(|url="|href=")[{]skysql[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd#g' \
-            -e 's#(\]\(|url="|href=")[{]home[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1#g' \
-            -e 's#(\]\(|url="|href=")[{]platform[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/JqgUabdZsoY5EiaJmqgn#g' \
-            -e 's#(\]\(|url="|href=")[{]connectors[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L#g' \
-            -e 's#(\]\(|url="|href=")[{]tools[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD#g' \
-            -e 's#(\]\(|url="|href=")[{]mariadb-cloud[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd#g' \
-            -e 's#(\]\(|url="|href=")[{]release-notes[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb#g' \
-            -e 's#(\]\(|url="|href=")[{]general-resources[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/WCInJQ9cmGjq1lsTG91E/about/readme#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]server[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]galera[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]maxscale[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]analytics[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]columnstore[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/2I4jZ8pGq8bT4w5n3q6r#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]skysql[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]home[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]platform[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/JqgUabdZsoY5EiaJmqgn#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]connectors[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]tools[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]mariadb-cloud[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]release-notes[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb#g' \
+            -e 's#(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{]general-resources[}]#\1https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/WCInJQ9cmGjq1lsTG91E/about/readme#g' \
             {} +
 
           echo "Git status after expansion:"
@@ -73,3 +77,40 @@ jobs:
           echo "Pushing to PR branch: $BRANCH"
 
           git push origin HEAD:$BRANCH
+      - name: Fail on an unexpanded alias
+        run: |
+          # An alias-looking string still sitting in a link target after the
+          # expansion above is a name this workflow does not know -- a typo, or
+          # a new space nobody added to the list. Nothing downstream catches
+          # it: GitBook publishes the unexpanded target as a plausible-looking
+          # github.com URL that 404s, and lychee skips it because
+          # link-check-pr.yml excludes any URL containing a brace. So fail
+          # here, which is the only place an author sees it.
+          #
+          # This runs after the push so the legitimate expansions are still
+          # committed to the PR branch when it fails.
+          #
+          # The file list matches the expansion step deliberately. The excluded
+          # files hold aliases as documentation examples, so a check covering
+          # them would need an allowlist of nearly everything it scans, and a
+          # broader pattern would fire on the CMAPI hostname placeholders.
+          LEFTOVER=$(find . -type f -name "*.md" \
+            ! -path "./dev-docs/*" \
+            ! -path "./.claude/*" \
+            ! -path "./README.md" \
+            ! -path "./pdf/README.md" \
+            ! -name "CONTRIBUTING.md" \
+            ! -path "*/general-resources/about/readme/about-links.md" \
+            -print0 \
+            | xargs -0 grep -nE '(^[[:space:]]*\[[^]]*\]:[[:space:]]*|\]\(|url="|href=")[{][A-Za-z0-9_-]+[}]' || true)
+
+          if [ -n "$LEFTOVER" ]; then
+            echo "::error::Unknown GitBook alias left unexpanded in a link target"
+            echo "$LEFTOVER"
+            echo
+            echo "An alias must be one of the names in dev-docs/link-aliases.md."
+            echo "To add a space, add it to the expansion step in this workflow."
+            exit 1
+          fi
+
+          echo "No unexpanded aliases."

--- a/dev-docs/link-aliases.md
+++ b/dev-docs/link-aliases.md
@@ -16,6 +16,12 @@ Example:
 [Securing Communications]({galera}/galera-security/securing-communications-in-galera-cluster)
 ```
 
+A reference-style link definition works the same way:
+
+```
+[Securing Communications]: {galera}/galera-security/securing-communications-in-galera-cluster
+```
+
 The `expand-gitbook-aliases.yml` Action rewrites `{galera}` to the full
 `https://app.gitbook.com/...` URL on the PR branch automatically. The expansion is committed
 back to the PR branch as `docs: expand GitBook aliases` from the `github-actions` bot — expect
@@ -50,11 +56,17 @@ that follow-up commit to appear shortly after opening or pushing to a PR.
 - **Don't validate aliased links locally.** The link-checker (lychee) is configured to skip
   anything containing `{` (and its `%7B` encoding), so aliases never trip CI.
 - **Only a link target is expanded.** The Action rewrites an alias when it appears directly
-  after a Markdown link's `](`, after a content-ref's `url="`, or after an HTML `href="`.
-  An alias-looking string anywhere else — in prose, in a table cell, in a code sample — is
-  left exactly as written. So `` `{server}` `` in a sentence is safe, and the ColumnStore
-  CMAPI pages can keep documenting `https://{server}:{port}/cmapi/{version}/{route}/{command}`,
-  where `{server}` is a hostname placeholder rather than a docs alias.
+  after a Markdown link's `](`, after a reference-style link definition's `]:`, after a
+  content-ref's `url="`, or after an HTML `href="`. An alias-looking string anywhere else — in
+  prose, in a table cell, in a code sample — is left exactly as written. So `` `{server}` ``
+  in a sentence is safe, and the ColumnStore CMAPI pages can keep documenting
+  `https://{server}:{port}/cmapi/{version}/{route}/{command}`, where `{server}` is a hostname
+  placeholder rather than a docs alias.
+- **Use one of the aliases in the table above — a name the Action doesn't know now fails CI.**
+  Anything still sitting in a link target after the expansion runs is reported by the
+  `expand-links` check with its file and line, because an unknown alias cannot be caught later:
+  GitBook publishes it as a plausible-looking `github.com/...` URL that 404s, and lychee skips
+  it. If a new space needs an alias, add it to `expand-gitbook-aliases.yml`.
 - Aliases **do work on landing pages.** Every space and section landing page is a
   `README.md`, and the Action used to skip those by filename, so an alias written there was
   silently left unexpanded — GitBook then read it as a repository path and emitted a


### PR DESCRIPTION
Two follow-ups to DOCS-6481, both in `.github/workflows/expand-gitbook-aliases.yml`. Jira: [DOCS-6487](https://mariadbcorp.atlassian.net/browse/DOCS-6487).

## 1. Reference-style link definitions now expand

DOCS-6481 matched an alias after a Markdown `](`, a content-ref `url="` or an HTML `href="`. Those are the only forms **in use**, but not the only valid ones — a reference-style definition puts the target after `]:`:

```
[Securing Communications]: {galera}/galera-security/securing-communications-in-galera-cluster
```

**47 files already use that form** for ordinary links, so it is established practice here. None carries an alias yet, and none ever has, so this changes nothing today — it closes the hole before someone falls in. An alias written there fails exactly as silently as the bug DOCS-6481 fixed: GitBook publishes the unexpanded target as a plausible-looking `github.com/...` URL that 404s, and lychee skips it because `link-check-pr.yml` excludes any URL containing a brace.

The new alternative allows leading whitespace (so an indented definition inside a list expands) and requires nothing after the alias (so a space-root target expands, as with the inline form).

## 2. An unknown alias now fails the job

An alias surviving the expansion means the name isn't one of the thirteen this workflow knows — a typo, or a new space nobody added. Nothing downstream catches it, for the same two reasons above. The new step runs **after** the push, so legitimate expansions are still committed when it fails, and it reports file and line.

**Its expected yield is low, stated deliberately so nobody over-values it.** Across every added line in every commit ever to touch a `.md`: **3,779** link-position aliases, and exactly **one** distinct unknown alias name — the literal `{alias}` placeholder, 3 occurrences, all in excluded files. Nobody has ever typo'd one. This is insurance, most plausibly against a new space added without a matching `sed` line.

Two constraints shaped it: it lives in the existing `expand-links` job, because a separate workflow triggered by the bot's push returns `action_required` and would need manual approval on every aliased PR; and it scans the same file list as the `sed`, because the excluded files hold aliases as documentation examples and a broader pattern fires on the four ColumnStore CMAPI pages where `{server}` is a hostname placeholder.

## Verification

**This PR's own green `expand-links` check proves nothing about either change** — the tree holds no link-position aliases, so a pattern matching nothing and a check that never fires both look identical to working ones. Both step bodies were therefore extracted programmatically from the workflow rather than retyped, and run directly:

| Test | Result |
|---|---|
| Expansion over the whole tree | **no-op, 0 files** — the added alternative over-matches nothing in 9,668 files |
| Check over the whole tree | passes |
| Fixture: reference-style, indented and space-root definitions | all expand |
| Fixture: CMAPI template, backticked prose, table cell, definition pointing at a real URL with a different placeholder | untouched |
| Fixture: typo'd alias + unknown space | check **exits 1**, naming both lines |
| History: ref-def-position aliases ever authored | **0** — so the additive change cannot regress a past expansion |

Local `sed` is BSD; braces stay POSIX bracket expressions and the anchor sits inside the alternation, which POSIX defines as an anchor at the start of a subexpression. A probe PR under real GNU sed follows, as with #928 for DOCS-6481 — including the check's failure path, since a check that never fires is indistinguishable from a broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6487]: https://mariadbcorp.atlassian.net/browse/DOCS-6487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ