### PR TITLE
DOCS-6487 probe (throwaway, do not merge)

### DIFF
--- a/server/.alias-probe/probe.md
+++ b/server/.alias-probe/probe.md
@@ -20,3 +20,8 @@ Must be left alone:
 https://{server}:{port}/cmapi/{version}/{route}/{command}
 The `{server}` alias in a sentence.
 [ExternalRef]: https://{host}/path
+
+Unknown aliases (must fail the check):
+
+[Typo]({maxscsale}/readme)
+[NewSpace]: {kubernetes-operator}/install

--- a/server/.alias-probe/probe.md
+++ b/server/.alias-probe/probe.md
@@ -2,18 +2,18 @@
 
 Inline forms, regression check:
 
-[Backup]({server}/server-usage/backing-up-and-restoring-databases)
-[Galera]({galera})
-[Anchor]({server}/page#no-backup-locks)
-<a href="{maxscale}/readme">MaxScale</a>
-{% content-ref url="{release-notes}/x" %}
-[A]({tools}) and [B]({connectors}/x)
+[Backup](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-usage/backing-up-and-restoring-databases)
+[Galera](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7)
+[Anchor](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/page#no-backup-locks)
+<a href="https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/readme">MaxScale</a>
+{% content-ref url="https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/x" %}
+[A](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD) and [B](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/x)
 
 Reference-style definitions, the new form:
 
-[RefDef]: {galera}/galera-security/securing-communications-in-galera-cluster
-[RefRoot]: {tools}
-   [RefIndented]: {release-notes}/maxscale/25.01/25.01-changelog
+[RefDef]: https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/galera-security/securing-communications-in-galera-cluster
+[RefRoot]: https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD
+   [RefIndented]: https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/maxscale/25.01/25.01-changelog
 
 Must be left alone:
 

--- a/server/.alias-probe/probe.md
+++ b/server/.alias-probe/probe.md
@@ -1,0 +1,22 @@
+# GNU sed probe (throwaway)
+
+Inline forms, regression check:
+
+[Backup]({server}/server-usage/backing-up-and-restoring-databases)
+[Galera]({galera})
+[Anchor]({server}/page#no-backup-locks)
+<a href="{maxscale}/readme">MaxScale</a>
+{% content-ref url="{release-notes}/x" %}
+[A]({tools}) and [B]({connectors}/x)
+
+Reference-style definitions, the new form:
+
+[RefDef]: {galera}/galera-security/securing-communications-in-galera-cluster
+[RefRoot]: {tools}
+   [RefIndented]: {release-notes}/maxscale/25.01/25.01-changelog
+
+Must be left alone:
+
+https://{server}:{port}/cmapi/{version}/{route}/{command}
+The `{server}` alias in a sentence.
+[ExternalRef]: https://{host}/path


### PR DESCRIPTION
Throwaway probe for #929: proves under real GNU sed that reference-style definitions expand and that the abstention cases are untouched. Stage 2 adds an unknown alias to prove the new check actually fails. Will be closed and the branch deleted.