### PR TITLE
DOCS-6384 Fix dead heading anchors on the DOCS-6364 pages

### DIFF
--- a/maxscale/reference/maxscale-monitors/common-monitor-parameters.md
+++ b/maxscale/reference/maxscale-monitors/common-monitor-parameters.md
@@ -44,7 +44,7 @@ Password for the user defined with the `user` parameter. If a server defines the
 * Dynamic: Yes
 * Default: None
 
-[Role](../../../server/security/user-account-management/roles/roles_overview.md) the monitor should activate right after connecting to a server. If empty, no role is set. This setting may be useful if the same username is used for both monitors and services. As monitors and services require different privileges, these privileges can be granted to the monitor and the service roles separately instead of granting them all to the same user. MariaDB Monitor and Galera Monitor currently use this setting. If the monitor is configured to use a role, the role is taken into use even if the server uses a [custom monitor username](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#monitoruser).
+[Role](../../../server/security/user-account-management/roles/roles_overview.md) the monitor should activate right after connecting to a server. If empty, no role is set. This setting may be useful if the same username is used for both monitors and services. As monitors and services require different privileges, these privileges can be granted to the monitor and the service roles separately instead of granting them all to the same user. MariaDB Monitor and Galera Monitor currently use this setting. If the monitor is configured to use a role, the role is taken into use even if the server uses a [custom monitor username](../maxscale-servers.md#monitoruser).
 
 ### `servers`
 
@@ -147,7 +147,7 @@ backend_connect_attempts=1
 * Dynamic: Yes
 * Default: None
 
-This parameter duplicates the `disk_space_threshold` [server parameter](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#disk_space_threshold). If the parameter has _not_ been specified for a server, then the one specified for the monitor is applied.
+This parameter duplicates the `disk_space_threshold` [server parameter](../maxscale-servers.md#disk_space_threshold). If the parameter has _not_ been specified for a server, then the one specified for the monitor is applied.
 
 **NOTE**: Since MariaDB 10.4.7, MariaDB 10.3.17 and MariaDB 10.2.26, the information will be available _only_ if the monitor user has the `FILE` privilege.
 

--- a/maxscale/reference/maxscale-monitors/mariadb-monitor.md
+++ b/maxscale/reference/maxscale-monitors/mariadb-monitor.md
@@ -824,7 +824,7 @@ The following series of events demonstrates failback switchover:
 
 If enabled, the monitor will attempt to switchover a primary server low on disk space with a replica. The switch is only done if a replica without disk space issues is found. If`maintenance_on_low_disk_space` is also enabled, the old primary (now a replica) will be put to maintenance during the next monitor iteration.
 
-For this parameter to have any effect, `disk_space_threshold` must be specified for the [server](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#disk_space_threshold) or the [monitor](common-monitor-parameters.md#disk_space_threshold). Also, [disk\_space\_check\_interval](common-monitor-parameters.md#disk_space_check_interval) must be defined for the monitor.
+For this parameter to have any effect, `disk_space_threshold` must be specified for the [server](../maxscale-servers.md#disk_space_threshold) or the [monitor](common-monitor-parameters.md#disk_space_threshold). Also, [disk\_space\_check\_interval](common-monitor-parameters.md#disk_space_check_interval) must be defined for the monitor.
 
 ```
 switchover_on_low_disk_space=true

--- a/server/reference/sql-statements/data-definition/alter/alter-table/README.md
+++ b/server/reference/sql-statements/data-definition/alter/alter-table/README.md
@@ -325,11 +325,11 @@ Drops a foreign key. See [Foreign Keys](../../../../../ha-and-performance/optimi
 
 ### ADD INDEX
 
-Adds a plain index. Plain indexes are regular indexes that are not unique, and are not acting as a primary key or a foreign key. They are also not the "specialized" `FULLTEXT` or `SPATIAL` indexes. For limits on InnoDB indexes, see [InnoDB Limitations](../../../../../server-usage/storage-engines/innodb/innodb-limitations.md). See [Getting Started with Indexes: Plain Indexes](../../../../../mariadb-quickstart-guides/mariadb-indexes-guide.md#plain-indexes) for more information.
+Adds a plain index. Plain indexes are regular indexes that are not unique, and are not acting as a primary key or a foreign key. They are also not the "specialized" `FULLTEXT` or `SPATIAL` indexes. For limits on InnoDB indexes, see [InnoDB Limitations](../../../../../server-usage/storage-engines/innodb/innodb-limitations.md). See [Getting Started with Indexes: Plain Indexes](../../../../../mariadb-quickstart-guides/mariadb-indexes-guide.md#plain-indexes-regular-indexes) for more information.
 
 ### DROP INDEX
 
-Drops a plain index. Plain indexes are regular indexes that are not unique, and are not acting as a primary key or a foreign key. They are also not the "specialized" `FULLTEXT` or `SPATIAL` indexes. See [Getting Started with Indexes: Plain Indexes](../../../../../mariadb-quickstart-guides/mariadb-indexes-guide.md#plain-indexes) for more information.
+Drops a plain index. Plain indexes are regular indexes that are not unique, and are not acting as a primary key or a foreign key. They are also not the "specialized" `FULLTEXT` or `SPATIAL` indexes. See [Getting Started with Indexes: Plain Indexes](../../../../../mariadb-quickstart-guides/mariadb-indexes-guide.md#plain-indexes-regular-indexes) for more information.
 
 ### ADD UNIQUE INDEX
 

--- a/server/reference/sql-statements/data-definition/create/create-table.md
+++ b/server/reference/sql-statements/data-definition/create/create-table.md
@@ -206,7 +206,7 @@ MariaDB accepts the shortcut format with a `REFERENCES` clause only in `ALTER TA
 CREATE TABLE b(for_key INT REFERENCES a(not_key));
 ```
 
-MariaDB will attempt to apply the constraint. See [Foreign Keys examples](../../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md#references).
+MariaDB will attempt to apply the constraint. See [Foreign Keys examples](../../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md#examples).
 {% endtab %}
 
 {% tab title="< 10.5" %}
@@ -237,7 +237,7 @@ The default value will be used if you [INSERT](../../data-manipulation/inserting
 
 [CURRENT\_TIMESTAMP](../../../sql-functions/date-time-functions/now.md) may also be used as the default value for a [DATETIME](../../../data-types/date-and-time-data-types/datetime.md)
 
-You can use most functions in `DEFAULT`. Expressions should have parentheses around them. If you use a non deterministic function in `DEFAULT` then all inserts to the table will be [replicated](../../../../ha-and-performance/standard-replication/) in [row mode](../../../../server-management/server-monitoring-logs/binary-log/binary-log-formats.md#row-based). You can even refer to earlier columns in the `DEFAULT` expression (excluding `AUTO_INCREMENT` columns):
+You can use most functions in `DEFAULT`. Expressions should have parentheses around them. If you use a non deterministic function in `DEFAULT` then all inserts to the table will be [replicated](../../../../ha-and-performance/standard-replication/) in [row mode](../../../../server-management/server-monitoring-logs/binary-log/binary-log-formats.md#row-based-logging). You can even refer to earlier columns in the `DEFAULT` expression (excluding `AUTO_INCREMENT` columns):
 
 ```sql
 CREATE TABLE t1 (a INT DEFAULT (1+1), b INT DEFAULT (a+1));
@@ -413,7 +413,7 @@ For limits on InnoDB indexes, see [InnoDB Limitations](../../../../server-usage/
 
 Plain indexes are regular indexes that are not unique, and are not acting as a primary key or a foreign key. They are also not the "specialized" `FULLTEXT` or `SPATIAL` indexes.
 
-See [Getting Started with Indexes: Plain Indexes](../../../../mariadb-quickstart-guides/mariadb-indexes-guide.md#plain-indexes) for more information.
+See [Getting Started with Indexes: Plain Indexes](../../../../mariadb-quickstart-guides/mariadb-indexes-guide.md#plain-indexes-regular-indexes) for more information.
 
 #### PRIMARY KEY
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrading-from-mariadb-enterprise-server-10.6-to-11.8.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrading-from-mariadb-enterprise-server-10.6-to-11.8.md
@@ -53,7 +53,7 @@ This ensures the team can maintain 10.6 behavior for applications that aren't re
 
 {% stepper %}
 {% step %}
-**Perform a Controlled Shutdown of 10.6**
+#### Perform a Controlled Shutdown of 10.6
 
 1.  Initiate Fast Shutdown to ensure the InnoDB engine closes cleanly.
 
@@ -68,7 +68,7 @@ This ensures the team can maintain 10.6 behavior for applications that aren't re
 {% endstep %}
 
 {% step %}
-**Purge Legacy 10.6 Packages**
+#### Purge Legacy 10.6 Packages
 
 Remove the old version to prevent package manager conflicts before installing 11.8.
 
@@ -78,7 +78,7 @@ Remove the old version to prevent package manager conflicts before installing 11
 {% endstep %}
 
 {% step %}
-**Switch to 11.8 Enterprise Repositories**
+#### Switch to 11.8 Enterprise Repositories
 
 Download and run the setup script, specifying version `11.8`.
 
@@ -92,7 +92,7 @@ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply --mariadb
 {% endstep %}
 
 {% step %}
-**Install the 11.8 Release Series**
+#### Install the 11.8 Release Series
 
 The repository setup only configures the source; you must explicitly install the new binaries.
 
@@ -103,7 +103,7 @@ The repository setup only configures the source; you must explicitly install the
 {% endstep %}
 
 {% step %}
-**Implement Version-Specific Configuration Changes**
+#### Implement Version-Specific Configuration Changes
 
 {% hint style="info" %}
 Do not apply 11.8-specific variables while the 10.6 service is active. During the package swap, update `my.cnf` to adopt the 11.8 defaults for the [Optimizer Cost Model](upgrading-from-mariadb-enterprise-server-10.6-to-11.8.md#optimizer-cost-model-variables). These variables replace legacy hardcoded logic and are essential for the new engine's performance.
@@ -164,7 +164,7 @@ transaction_read_only    = OFF
 {% endstep %}
 
 {% step %}
-**Bring the Service Online and Finalize Data**
+#### Bring the Service Online and Finalize Data
 
 1. Start the New Service: `sudo systemctl start mariadb`.
 2.  Execute the Data Upgrade Utility: This corrects system table structures and marks data files as compatible with version 11.8.
@@ -395,25 +395,25 @@ You do not need a new machine for reverse replication. You can use an existing 1
 
 {% stepper %}
 {% step %}
-**Isolate a 10.6 Node**
+#### Isolate a 10.6 Node
 
 Before upgrading your entire environment, identify one existing replica to remain on version 10.6. Stop the replication on this node just before you upgrade the Primary to 11.8.
 {% endstep %}
 
 {% step %}
-**Configure 11.8 for Compatibility**
+#### Configure 11.8 for Compatibility
 
 Immediately after installing version 11.8 on your Primary, apply the `rollback_compat.cnf` settings (such as `character_set_collations = ''` and `binlog_checksum = CRC32`).
 {% endstep %}
 
 {% step %}
-**Start 11.8 and Rotate Logs**
+#### Start 11.8 and Rotate Logs
 
 Start the 11.8 service and run `FLUSH LOGS;`. This ensures the Primary begins writing its binary logs in a format the 10.6 replica can understand.
 {% endstep %}
 
 {% step %}
-**Connect the 10.6 Node**
+#### Connect the 10.6 Node
 
 Point your existing 10.6 machine to the new 11.8 Primary. Because the data on the 10.6 node is already consistent with the pre-upgrade state, it can simply "pick up" the new changes from the 11.8 Primary.
 {% endstep %}


### PR DESCRIPTION
Closes the loose end left by DOCS-6364: the 5 verified dead heading anchors the ticket scopes, plus 4 more of the identical class on the pages this already touches.

None of this fails CI today — `link-check` does not pass `--include-fragments`, so heading anchors are unchecked. Reproduce with the ticket's command:

```
lychee --offline --include-fragments --no-progress --exclude '.*\{.*' --exclude '.*%7B.*' <files>
```

## The ticket's 5

| Page | Was | Now |
| --- | --- | --- |
| `alter-table/README.md` ×2 | `mariadb-indexes-guide.md#plain-indexes` | `#plain-indexes-regular-indexes` |
| `maxscale-monitors/mariadb-monitor.md` | `maxscale-configuration-guide.md#disk_space_threshold` | `../maxscale-servers.md#disk_space_threshold` |
| ES 11.8 upgrade page ×2 | `#install-the-11.8-release-series`, `#implement-version-specific-configuration-changes` | anchors now exist — step titles promoted to headings |

**On the MaxScale one I did not follow the ticket's suggested fix.** It proposed retargeting to `common-monitor-parameters.md#disk_space_threshold`, but the sentence deliberately contrasts the two scopes — "must be specified for the **server** or the **monitor**" — and the `[monitor]` half already points there. Retargeting the server half would have collapsed both to one page. `maxscale-servers.md#disk_space_threshold` is the server-parameter home and exists. Confirmed the Configuration Guide documents `disk_space_threshold` **zero** times, so the old target was wrong, not merely stale.

**On the ES page**, the twin page for the same procedure — `upgrade-from-mariadb-community-server-10.6-to-mariadb-enterprise-server-11.8.md` — already writes every step title as `#### Heading`, and its identical sentence at line 304 resolves. So promoting is the house-consistent fix, not an invention. All 10 step titles converted, both steppers, so the page is internally consistent and matches the twin.

## Drive-by fixes (same class, files already in the diff)

* `create-table.md` — `#plain-indexes` (same defect as `alter-table`), `#row-based` → `#row-based-logging`, and a "Foreign Keys examples" link pointing at a nonexistent `#references` → `#examples`.
* `common-monitor-parameters.md` — `maxscale-configuration-guide.md#monitoruser`, same wrong-page class as `disk_space_threshold`; the guide documents `monitoruser` zero times, `maxscale-servers.md` does.

## Verification

Fragment-aware run on the changed set: **16 errors → 13**, and all 13 are proven tool artifacts, not defects:

* **11** — the directory-style links (`.../alter/alter-table#anchor`, no `/README.md`) the ticket already scopes out; lychee cannot resolve a directory to its `README.md` for fragment extraction.
* **2 (new finding)** — **lychee's slugger strips dots from headings; GitBook keeps them.** `#install-the-11.8-release-series` and `#create-table-...-select` are flagged but correct. Proof: the twin page's `#install-mariadb-enterprise-server-11.8` is flagged by the same run, yet the live page carries `id="install-mariadb-enterprise-server-11.8"`; likewise the live CREATE TABLE page carries `id="create-table-...-select"`. Anything containing a version number is exposed to this, so **do not "fix" a dotted anchor on lychee's word** — check the rendered page.

codespell (CI-exact invocation) clean; `doc-lint.sh` exits 0 over all 5 files. Every heading target was verified against the file, and the two dotted ones against the rendered site.