### PR TITLE
DOCS-6492 Remove eight copy-pasted heading anchors

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -239,10 +239,23 @@ done
 # are dead. `.claude/hooks/fragcheck.py` implements GitBook's rules instead, validated at
 # 4,599/4,599 anchors against the rendered pages (DOCS-6491).
 #
+# It also gates a third rot that no link checker can see at all — including fragcheck itself
+# when it is only looking for dead anchors. A heading line duplicated for a new section keeps
+# the original's `<a href="#x" id="x">`, GitBook honours the explicit id over the text slug, and
+# the two sections then share one anchor: the second dedupes to `-1` and neither owns the anchor
+# a reader expects. Every link still resolves, just to the wrong section, so this is a semantic
+# mismatch rather than a broken link (DOCS-6492). A heading whose explicit id is a deliberate
+# historical KB alias for its own text is NOT flagged — only an id that belongs to a different
+# heading on the same page. That distinction is the whole check: 48 headings differ from their
+# text slug, but only 8 were defects, so flagging the wide class would be a 6x overstatement.
+#
 # Two deliberate design choices:
 #   1. It reports only anchors that are dead NOW but resolved at $LINT_BASE. The repo carries
 #      ~1,272 pre-existing dead anchors, so a plain check would turn every unrelated PR red on
-#      breakage it did not introduce (the `broken-reference` trap — see the lychee section).
+#      breakage it did not introduce (the `broken-reference` trap — see the lychee section). The
+#      stolen-id class is diffed against $LINT_BASE for the same reason: it stands at 0 today,
+#      but this repo is also edited from the GitBook UI, so an absolute check would fail
+#      unrelated PRs the moment a GITBOOK-* commit introduced one case.
 #   2. It scans the whole tree, not just "${files[@]}". Renaming a heading breaks inbound links
 #      from pages the commit never touched, and a changed-files check cannot see those. The two
 #      passes cost ~14s; set DOC_LINT_SKIP_FRAGMENTS=1 to skip when iterating.

--- a/.claude/hooks/fragcheck.py
+++ b/.claude/hooks/fragcheck.py
@@ -34,14 +34,20 @@ THE SLUG RULES  (each derived from a rendered id="..." on mariadb.com/docs)
 
 MODES
     fragcheck.py check [path ...]        dead anchors under each path (default: repo)
-    fragcheck.py new <rev> [path ...]    only anchors that <rev> had fine -- the gate
+    fragcheck.py new <rev> [path ...]    only what <rev> had fine -- the gate
+    fragcheck.py ids [path ...]          headings publishing another heading's anchor
     fragcheck.py anchors <file.md>       the anchors one file publishes
     fragcheck.py validate <file.md> ...  compare computed anchors to the live page
 
-`new` is what doc-lint.sh calls: it scans the whole tree twice (once here, once in
+`new` is what doc-lint.sh calls. It scans the whole tree twice (once here, once in
 a throwaway worktree at <rev>) and reports only the difference, so the repo's
 pre-existing dead anchors stay out of the way while a heading rename that breaks
-inbound links from untouched pages still fails.
+inbound links from untouched pages still fails. It gates two classes:
+
+    * anchors that <rev> resolved and the working tree does not (a rename)
+    * headings that took over another heading's explicit id (`ids`, DOCS-6492) --
+      invisible to every link checker, this one included, because the anchors all
+      exist and resolve; they just land on the wrong section
 """
 import os
 import re
@@ -107,12 +113,11 @@ def gitbook_slug(heading):
     return s[:MAX_SLUG]
 
 
-def anchors_of(path):
-    """Anchors a markdown file publishes, in document order."""
-    seen = Counter()
+def headings_of(path):
+    """(line_no, raw_text, explicit_id_or_None) for each level-2..6 heading."""
     out = []
     in_fence = False
-    for line in read(path).splitlines():
+    for n, line in enumerate(read(path).splitlines(), 1):
         if FENCE.match(line):
             in_fence = not in_fence
             continue
@@ -122,12 +127,54 @@ def anchors_of(path):
         if not m or len(m.group(1)) == 1:
             continue
         explicit = HEADING_ID.search(m.group(2))
-        base = explicit.group(1) if explicit else gitbook_slug(m.group(2))
+        out.append((n, m.group(2), explicit.group(1) if explicit else None))
+    return out
+
+
+def anchors_of(path):
+    """Anchors a markdown file publishes, in document order."""
+    seen = Counter()
+    out = []
+    for _, text, explicit in headings_of(path):
+        base = explicit if explicit else gitbook_slug(text)
         if not base:
             continue
         n = seen[base]
         seen[base] += 1
         out.append(base if n == 0 else f'{base}-{n}')
+    return out
+
+
+def stolen_ids(path):
+    """Headings whose explicit id is the slug of a DIFFERENT heading here.
+
+    The wide class -- an explicit id that merely differs from the heading's own
+    text slug -- is 48 cases on this repo and mostly BENIGN: 40 are historical
+    KB anchors deliberately kept so old inbound links keep resolving
+    (#choosing-mariabackup-for-ssts, the #overview_h2 set on the wsrep variable
+    pages). Only the narrow case is a defect: the id belongs to another heading
+    on the same page, because a heading line was duplicated for a new section
+    and its text edited while the anchor markup was not. GitBook honours the
+    explicit id, so the two sections share one anchor, the loser dedupes to -1,
+    and the anchor a reader expects for either section does not exist at all
+    (DOCS-6492).
+
+    Flagging all 48 would be a 6x overstatement -- DOCS-6413's failure mode.
+    """
+    heads = headings_of(path)
+    own = {}
+    for n, text, _ in heads:
+        own.setdefault(gitbook_slug(text), n)
+    out = []
+    for n, text, explicit in heads:
+        if not explicit:
+            continue
+        mine = gitbook_slug(text)
+        if explicit == mine:
+            continue
+        other = own.get(explicit)
+        if other is not None and other != n:
+            out.append((n, mine, explicit, other))
     return out
 
 
@@ -247,7 +294,32 @@ def check(paths, base):
     return checked, findings, unresolved
 
 
+def scan_ids(paths, base):
+    """Every stolen-id finding under each path, as (file, line, own, id, other)."""
+    out = []
+    for root in paths:
+        for f in md_files(root, base):
+            for line, mine, stolen, other in stolen_ids(f):
+                out.append((relpath(f, base), line, mine, stolen, other))
+    return out
+
+
 # ------------------------------------------------------- reporting / gate
+
+def describe_id(finding):
+    src, line, mine, stolen, other = finding
+    return (f'{src}:{line}: publishes #{stolen}, which is line {other}\'s '
+            f'anchor, instead of its own #{mine}')
+
+
+STOLEN_HELP = (
+    '\n          A heading line duplicated for a new section keeps the original\'s\n'
+    '          <a href="#x" id="x">, so both sections publish one anchor, the second\n'
+    '          dedupes to -1, and neither owns the anchor a reader expects\n'
+    '          (DOCS-6492). Delete the copied markup from the new heading — it then\n'
+    '          falls back to its own text slug. A deliberate historical alias is not\n'
+    '          flagged: only an id that belongs to another heading on the same page.')
+
 
 def describe(finding):
     src, line, frag, tgt, bucket, fix = finding
@@ -274,6 +346,18 @@ def cmd_check(args):
     return 0
 
 
+def cmd_ids(args):
+    """List every heading carrying another heading's anchor (absolute, not diffed)."""
+    root = repo_root(args[0] if args else '.')
+    found = scan_ids([pathlib.Path(a) for a in args] or [root], root)
+    for f in found:
+        print('STOLEN ' + describe_id(f))
+    print(f'\nids: {len(found)} heading(s) publishing another heading\'s anchor')
+    if found:
+        print(STOLEN_HELP)
+    return 1 if found else 0
+
+
 def cmd_new(args):
     """Report anchors dead in the working tree that were fine at <rev>."""
     if not args:
@@ -281,7 +365,9 @@ def cmd_new(args):
         return 2
     rev, paths = args[0], args[1:]
     root = repo_root(paths[0] if paths else '.')
-    _, now, _ = check([pathlib.Path(p) for p in paths] or [root], root)
+    roots = [pathlib.Path(p) for p in paths] or [root]
+    _, now, _ = check(roots, root)
+    now_ids = scan_ids(roots, root)
 
     tmp = tempfile.mkdtemp(prefix='fragcheck-base-')
     worktree = os.path.join(tmp, 'base')
@@ -298,6 +384,7 @@ def cmd_new(args):
         # keys that can never match the working tree's relative ones.
         base_root = pathlib.Path(worktree).resolve()
         _, before, _ = check([base_root], base_root)
+        before_ids = scan_ids([base_root], base_root)
     finally:
         subprocess.run(['git', '-C', str(root), 'worktree', 'remove', '--force',
                         worktree], capture_output=True)
@@ -306,20 +393,40 @@ def cmd_new(args):
     def key(f):
         return (f[0], f[3], f[2])      # source, target, fragment -- not the line
 
+    def idkey(f):
+        return (f[0], f[2], f[3])      # file, own slug, stolen id -- not the line
+
+    rc = 0
     was_dead = {key(f) for f in before}
     fresh = [f for f in now if key(f) not in was_dead]
-    if not fresh:
+    if fresh:
+        rc = 1
+        print(f'fragcheck: {len(fresh)} heading anchor(s) that {rev} resolved are now dead:',
+              file=sys.stderr)
+        for f in fresh:
+            print('  ' + describe(f), file=sys.stderr)
+        print('\n          A renamed heading breaks every inbound link to its old anchor,\n'
+              '          including links from pages this commit never touched. Either restore\n'
+              '          the heading text or retarget the links listed above.', file=sys.stderr)
+
+    # Diffed against <rev> for the same reason as the dead anchors: this repo is
+    # also edited from the GitBook UI, so an absolute check would fail unrelated
+    # PRs the moment a GITBOOK-* commit introduced one case.
+    was_stolen = {idkey(f) for f in before_ids}
+    fresh_ids = [f for f in now_ids if idkey(f) not in was_stolen]
+    if fresh_ids:
+        rc = 1
+        print(f'fragcheck: {len(fresh_ids)} heading(s) now carry another heading\'s '
+              f'anchor:', file=sys.stderr)
+        for f in fresh_ids:
+            print('  ' + describe_id(f), file=sys.stderr)
+        print(STOLEN_HELP, file=sys.stderr)
+
+    if not rc:
         print(f'fragcheck: no new dead heading anchors vs {rev} '
-              f'({len(now)} pre-existing, unchanged)')
-        return 0
-    print(f'fragcheck: {len(fresh)} heading anchor(s) that {rev} resolved are now dead:',
-          file=sys.stderr)
-    for f in fresh:
-        print('  ' + describe(f), file=sys.stderr)
-    print('\n          A renamed heading breaks every inbound link to its old anchor,\n'
-          '          including links from pages this commit never touched. Either restore\n'
-          '          the heading text or retarget the links listed above.', file=sys.stderr)
-    return 1
+              f'({len(now)} pre-existing, unchanged); no new stolen heading ids '
+              f'({len(now_ids)} pre-existing)')
+    return rc
 
 
 # ------------------------------------------------------------- live validate
@@ -377,6 +484,8 @@ def main():
         return cmd_validate(args)
     if mode == 'new':
         return cmd_new(args)
+    if mode == 'ids':
+        return cmd_ids(args)
     if mode == 'check':
         return cmd_check(args)
     print(__doc__, file=sys.stderr)

--- a/.claude/skills/docs-check/SKILL.md
+++ b/.claude/skills/docs-check/SKILL.md
@@ -77,6 +77,16 @@ on the file set, from the repo root:
   page, or with `.claude/hooks/fragcheck.py validate <file>`. Needs python3 and a git work tree;
   missing either is a SKIP. Costs ~14s, so `DOC_LINT_SKIP_FRAGMENTS=1` skips it while iterating.
   Added in DOCS-6491.
+- The same gate catches a heading that publishes **another heading's** anchor. Duplicate a
+  heading line for a new section, edit its text but leave its `<a href="#x" id="x">` behind, and
+  GitBook honours that explicit id over the text slug: the two sections share one anchor, the
+  second dedupes to `-1`, and neither owns the anchor a reader expects. Every link still
+  resolves, just to the wrong section, so no link checker — this one included — can see it from
+  the links alone. `.claude/hooks/fragcheck.py ids` lists them. **A heading whose explicit id is
+  a deliberate historical KB anchor for its own text is not flagged, and must not be
+  "normalised"** — those ids exist to keep old inbound links working, and rewriting them breaks
+  exactly what they preserve. On `main` 48 headings differed from their text slug and only 8 were
+  defects, so treating the wide class as the bug would be a 6× overstatement. Added in DOCS-6492.
 - It also flags a **gutted page** — any file that lost more than 40% of its lines *net*
   (deletions minus additions; min 20 lines lost, pre-image ≥ 30 lines) against `DOC_LINT_BASE`
   (default `HEAD`). No CI counterpart, never SKIPs. This catches what the other checks

--- a/dev-docs/cookbook-pre-pr.md
+++ b/dev-docs/cookbook-pre-pr.md
@@ -53,8 +53,18 @@ resolves live) while missing 213 anchors that really are dead. Never delete a do
 an anchor to satisfy it; check the rendered page instead, or run
 `.claude/hooks/fragcheck.py validate <file>`, which compares computed anchors against the ids
 the live site emits. `.claude/hooks/fragcheck.py check` prints the whole current inventory with a
-suggested target for each mechanically fixable one. Needs python3 and a git work tree — either
-missing is a SKIP — and costs about 14 seconds:
+suggested target for each mechanically fixable one.
+
+The same gate catches one thing no link checker can: a heading that publishes **another
+heading's** anchor. Duplicate a heading line for a new section, edit its text but leave its
+`<a href="#x" id="x">` behind, and GitBook honours that explicit id over the text slug — the two
+sections share one anchor, the second dedupes to `-1`, and neither owns the anchor a reader
+expects. Every link still resolves, just to the wrong section (DOCS-6492), which is exactly why
+no checker sees it. `.claude/hooks/fragcheck.py ids` lists them. A heading whose explicit id is a
+deliberate historical KB anchor for its own text is **not** flagged, and must not be
+"normalised" — those ids exist to keep old inbound links working.
+
+Needs python3 and a git work tree — either missing is a SKIP — and costs about 14 seconds:
 
 ```bash
 # skip it while iterating on wording

--- a/release-notes/community-server/old-releases/12.1/changes-and-improvements-in-mariadb-12.1.md
+++ b/release-notes/community-server/old-releases/12.1/changes-and-improvements-in-mariadb-12.1.md
@@ -49,7 +49,7 @@ MariaDB 12.1 is a [rolling release](../../about/release-model.md). It is an evol
 * [mariadb-dump](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump) now supports [wildcards](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump#l-wildcards) with the `-L` or `--wildcards` option ([MDEV-21376](https://jira.mariadb.org/browse/MDEV-21376))
 * [Foreign key](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys) constraint names no longer need to be unique per database, only per table ([MDEV-28933](https://jira.mariadb.org/browse/MDEV-28933)) ([blog post](https://mariadb.org/per-table-unique-foreign-key-constraint-names-new-feature-in-mariadb-12-1/))
 
-### Development release only <a href="#miscellaneous" id="miscellaneous"></a>
+### Development Release Only
 
 This feature was only available in the 12.1 development releases, and will be implemented in a later series.
 

--- a/release-notes/community-server/old-releases/12.2/mariadb-12.2-changes-and-improvements.md
+++ b/release-notes/community-server/old-releases/12.2/mariadb-12.2-changes-and-improvements.md
@@ -33,7 +33,7 @@ MariaDB 12.2 is a [rolling release](../../about/release-model.md). It is an evol
 * Add [INFORMATION\_SCHEMA.TRIGGERED\_UPDATE\_COLUMNS](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/system-tables/information-schema/information-schema-tables/information-schema-triggered_update_columns) ([MDEV-36996](https://jira.mariadb.org/browse/MDEV-36996))
 * Implement [INFORMATION\_SCHEMA.PARAMETERS](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/system-tables/information-schema/information-schema-tables/information-schema-parameters-table).PARAMETER\_DEFAULT column ([MDEV-37054](https://jira.mariadb.org/browse/MDEV-37054))
 
-### Preview release only <a href="#miscellaneous" id="miscellaneous"></a>
+### Preview Release Only
 
 These features needed further testing and will be implemented in a future series.
 

--- a/release-notes/enterprise-server/11.8/11.8.3-1.md
+++ b/release-notes/enterprise-server/11.8/11.8.3-1.md
@@ -52,7 +52,7 @@ MariaDB Enterprise Server 11.8 continues to expand its native vector search capa
 * **NEW SHOW CREATE SERVER**: Recreate server objects similar to [SHOW CREATE TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/administrative-sql-statements/show/show-create-table).
 * **DBMS\_OUTPUT:** Messages submitted by `DBMS_OUTPUT.PUT_LINE()` are not sent to the client until the sending subprogram or trigger completes.
 
-## Performance Improvements <a href="#data-types-and-compatibility" id="data-types-and-compatibility"></a>
+## Performance Improvements
 
 * Optimization that makes vector search 30-50% faster (more details in the [Vector Search](11.8.3-1.md#vector-search) section)
 * Segmented key cache for [Aria storage engine](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/aria)
@@ -209,7 +209,7 @@ MariaDB Enterprise Server 11.8 continues to expand its native vector search capa
 * **Galera Information Schema:** New Information Schema table [WSREP\_CONNECTIONS](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/system-tables/information-schema/information-schema-tables/information-schema-wsrep_connections).
 * **Galera Information Schema:** New Information Schema [WSREP\_CERT\_KEYS](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/system-tables/information-schema/information-schema-tables/information-schema-wsrep_cert_keys) and [WSREP\_CERT\_KEYS\_HISTORY](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/system-tables/information-schema/information-schema-tables/information-schema-wsrep_cert_keys_history) tables.
 
-## PL/SQL <a href="#tool-improvements" id="tool-improvements"></a>
+## PL/SQL
 
 Support for Oracle-stype `INDEX BY` tables (associative arrays) was backported from [MariaDB 12.1](../../community-server/old-releases/12.1/changes-and-improvements-in-mariadb-12.1.md) in stored routines and anonymous blocks, with this declaration syntax:
 

--- a/release-notes/enterprise-server/11.8/whats-new.md
+++ b/release-notes/enterprise-server/11.8/whats-new.md
@@ -60,7 +60,7 @@ MariaDB Enterprise Server 11.8 continues to expand its native vector search capa
 * **NEW SHOW CREATE SERVER**: Recreate server objects similar to [SHOW CREATE TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/administrative-sql-statements/show/show-create-table)
 * **DBMS\_OUTPUT:** Messages submitted by `DBMS_OUTPUT.PUT_LINE()` are not sent to the client until the sending subprogram or trigger completes
 
-## Performance Improvements <a href="#data-types-and-compatibility" id="data-types-and-compatibility"></a>
+## Performance Improvements
 
 * Optimization that makes vector search 30-50% faster (more details in the [Vector Search](whats-new.md#vector-search) section)
 * Segmented key cache for [Aria storage engine](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/aria)
@@ -219,7 +219,7 @@ MariaDB Enterprise Server 11.8 continues to expand its native vector search capa
 * **Galera Information Schema:** New Information Schema table [WSREP\_CONNECTIONS](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/system-tables/information-schema/information-schema-tables/information-schema-wsrep_connections)
 * **Galera Information Schema:** New Information Schema [WSREP\_CERT\_KEYS](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/system-tables/information-schema/information-schema-tables/information-schema-wsrep_cert_keys) and [WSREP\_CERT\_KEYS\_HISTORY](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/system-tables/information-schema/information-schema-tables/information-schema-wsrep_cert_keys_history) tables
 
-## PL/SQL <a href="#tool-improvements" id="tool-improvements"></a>
+## PL/SQL
 
 Support for Oracle-stype `INDEX BY` tables (associative arrays) was backported from [MariaDB 12.1](../../community-server/old-releases/12.1/changes-and-improvements-in-mariadb-12.1.md) in stored routines and anonymous blocks, with this declaration syntax:
 

--- a/release-notes/enterprise-server/old-releases/10.5/changelog-10.5.29-23.md
+++ b/release-notes/enterprise-server/old-releases/10.5/changelog-10.5.29-23.md
@@ -8,7 +8,7 @@ MariaDB Enterprise Server 10.5.29-23 is a maintenance release of [MariaDB Enterp
 
 MariaDB Enterprise Server 10.5.29-23 was released on 11 Jun 2025.
 
-## Changes <a href="#issues-fixed" id="issues-fixed"></a>
+## Changes
 
 ### Issues Fixed <a href="#issues-fixed" id="issues-fixed"></a>
 

--- a/server/mariadb-quickstart-guides/mariadb-connection-troubleshooting-guide.md
+++ b/server/mariadb-quickstart-guides/mariadb-connection-troubleshooting-guide.md
@@ -251,7 +251,7 @@ Example output showing the problem:
 
       Ensure this doesn't break other intended anonymous access, if any.
 
-## MariaDB Authentication Tutorial <a href="#see-also" id="see-also"></a>
+## MariaDB Authentication Tutorial
 
 {% columns %}
 {% column %}


### PR DESCRIPTION
Fixes [DOCS-6492](https://mariadbcorp.atlassian.net/browse/DOCS-6492).

## The defect

Eight headings across six pages carry an explicit `<a href="#x" id="x"></a>` that belongs to a **different heading on the same page** — a heading line was duplicated for a new section and its text edited, but the anchor markup was not. GitBook honours an explicit id over the text slug, so two sections end up sharing one anchor: whichever comes first claims it, the other dedupes to `-1`, and the anchor a reader would expect for either section does not exist at all.

Reader-visible today: `release-notes/enterprise-server/11.4/11.4.4-2.md:955` links _utf8mb4_ to `../11.8/whats-new.md#data-types-and-compatibility`, which lands on **Performance Improvements**, one section early. Anyone using a heading's "copy link" control on these pages also walks away with a wrong anchor or a `-1` artifact — and a `-1` suffix silently moves if the page is ever reordered (the anchor-flip hazard from DOCS-6484).

| file:line | heading | id it carried | that id belongs to |
| --- | --- | --- | --- |
| `.../11.8/whats-new.md:63` | Performance Improvements | `#data-types-and-compatibility` | line 71 |
| `.../11.8/whats-new.md:222` | PL/SQL | `#tool-improvements` | line 246 |
| `.../11.8/11.8.3-1.md:55` | Performance Improvements | `#data-types-and-compatibility` | line 62 |
| `.../11.8/11.8.3-1.md:212` | PL/SQL | `#tool-improvements` | line 236 |
| `.../12.1/changes-and-improvements-in-mariadb-12.1.md:52` | Development release only | `#miscellaneous` | line 45 |
| `.../12.2/mariadb-12.2-changes-and-improvements.md:36` | Preview release only | `#miscellaneous` | line 30 |
| `.../10.5/changelog-10.5.29-23.md:11` | Changes | `#issues-fixed` | line 13 |
| `.../mariadb-connection-troubleshooting-guide.md:254` | MariaDB Authentication Tutorial | `#see-also` | line 279 |

## The fix

Delete the copy-pasted markup from the **wrong** heading and leave the correct heading's alone. The wrong heading then falls back to its own text slug, and the correct section reclaims the plain anchor with no `-1`. The `11.4.4-2.md` link is repaired with no edit on its side. Eight lines, no prose changes.

## Verification

- The explicit-id audit goes from **8 STOLEN → 0**, with the 40 legitimate aliases untouched.
- All 16 affected anchors recomputed with `fragcheck.py`'s slugger: every one resolves, none dedupes.
- `fragcheck.py new HEAD`: no new dead heading anchors, 1,272 pre-existing unchanged. (This class is invisible to it by construction — the anchors all existed, they just pointed at the wrong section — so an unchanged count is the expected result, not evidence of a no-op.)
- `doc-lint.sh` on the changed paths: clean. codespell CI-exact: clean.
- Grepped the corpus for `#data-types-and-compatibility-1`, `#tool-improvements-1`, `#miscellaneous-1`, `#issues-fixed-1`, `#see-also-1`: **no inbound links**, so the disappearing artifacts need no redirects. Nothing linked to the six anchors this change creates either.

## Not in scope

The same audit finds 40 headings in 25 files whose explicit id differs from their own text slug — historical KB anchors deliberately preserved so old inbound links keep working (`#choosing-mariabackup-for-ssts`, `#installing-socat-on-rhelcentos`, the `#overview_h2` set on the `wsrep` variable pages). Rewriting those would break exactly the links they exist to keep. Only the eight cases above, where the id belongs to a *different* heading, are defects.

## Drive-by fixes

- "Development release only" and "Preview release only" retitled to Title Case per house style. Slugs are lowercased, so the anchors are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6492]: https://mariadbcorp.atlassian.net/browse/DOCS-6492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

## Second commit: gating the class (`205f094f4`)

The class this PR clears is invisible to every link checker, `fragcheck.py` included — the anchors all exist and resolve, just to the wrong section — so nothing would stop it recurring the next time a release-notes page is cloned for a new version, which is how all eight cases arose.

`fragcheck.py ids` now reports headings whose explicit `<a id="...">` is the slug of a **different** heading on the same page, and `new <rev>` gates it alongside the dead-anchor diff, so `doc-lint.sh` picks it up through the call it already makes. `doc-lint.sh`, `docs-check/SKILL.md` and `cookbook-pre-pr.md` document it.

Two design points, both load-bearing:

- **Only the narrow class is flagged.** 48 headings here carry an explicit id differing from their own text slug; 40 are historical KB anchors deliberately kept so old inbound links keep resolving. Flagging the wide class would be a 6× overstatement — DOCS-6413's failure mode.
- **Diffed against `<rev>`, not absolute,** even though the corpus is at 0 today. This repo is also edited from the GitBook UI, so an absolute check would fail unrelated PRs the moment a `GITBOOK-*` commit introduced one case — the `broken-reference` trap.

Verified in both directions rather than trusting a green run:

- `ids` on a worktree at the pre-fix revision reports **exactly the eight** known cases and exits 1 — an independent reimplementation agreeing with the standalone audit line-for-line.
- Planting one stolen id makes `doc-lint.sh` **exit 1** and name it.
- Planting an **alias-shaped** id (differs from the text slug, matches no other heading) is correctly **ignored** — the false-positive test that matters here.
- `anchors_of()` was refactored onto a shared `headings_of()` helper; the dead-anchor inventory is unchanged at **1,272** across the same five buckets (825 absent, 315 punctuation, 109 case-only, 21 footnote, 2 dash-count), which is the regression check on that refactor.
