### PR TITLE
Correct the jira skill's Sprint field note

### DIFF
--- a/.claude/skills/jira/SKILL.md
+++ b/.claude/skills/jira/SKILL.md
@@ -62,8 +62,8 @@ but trust the live list):
 Only **`summary`** is required (plus `project`). `priority` defaults to Major. **No
 components, no fix versions, no mandatory custom fields.** Optional: `description`, `priority`,
 `labels`, and assignee (set via the `assignee_account_id` param). A Sprint field
-(`customfield_10021`) exists but is a team-managed board field — don't set it on create (it
-usually 400s); add the sprint from the board afterward.
+(`customfield_10021`) exists but is a team-managed board field — don't set it on create; add it
+with a follow-up `editJiraIssue` instead, which works reliably.
 
 ## Setup — verify the connection reaches MariaDB (MANDATORY, run first)
 
@@ -148,9 +148,17 @@ File a new DOCS ticket. Because the project requires only `summary`, this is lig
    - **Assignee:** set via the tool's top-level `assignee_account_id` param (e.g. the current
      user from `atlassianUserInfo()`), **not** via `additional_fields`.
    - **Priority / labels:** only add to `additional_fields` when the user asked.
-   - **Sprint:** do **not** set on create. `customfield_10021` is a team-managed board field and
-     setting it at create time typically fails (400) unless the issue is already on the active
-     sprint — assign the sprint from the board afterward if needed.
+   - **Sprint:** do **not** set on create — `customfield_10021` is a team-managed board field.
+     Add it **after** creating, with a follow-up `editJiraIssue` passing a **bare integer**:
+     `fields={"customfield_10021": 4380}`. This is the proven route; don't send the user to the
+     board UI. New DOCS tickets go on the **current** sprint by default.
+     - Get the sprint id by reading the field off any ticket already on it —
+       `getJiraIssue(cloudId, "DOCS-XXXX", fields=["customfield_10021"])`. Note the read shape is
+       an **array of objects** (`[{"id": 4380, "name": "DOCS Sprint September 4", "state":
+       "active", ...}]`) even though the write takes the bare integer; pick the entry whose
+       `state` is `active`.
+     - **Verify by reading the field back** after the edit — a rejected sprint value does not
+       always surface as an error on the edit call.
    - If any field id is rejected, run `getJiraIssueTypeMetaWithFields(cloudId, projectIdOrKey="DOCS", issueTypeId="10083")` and use the live id.
 5. **Confirm**: `Ticket / Type / Priority / URL`.
 


### PR DESCRIPTION
## What

`.claude/skills/jira/SKILL.md` claimed that setting the Sprint field (`customfield_10021`) at create time "usually 400s", and told the reader to *"add the sprint from the board afterward"* — i.e. by hand, in the board UI.

The first half is the right instruction for the wrong reason, and the second half sends you to the UI for something the API does fine. A **follow-up `editJiraIssue` with a bare integer** works reliably, and is the route actually used on every DOCS ticket since DOCS-6398.

## Changes

Two spots, both in `.claude/skills/jira/SKILL.md` — the claim appears nowhere else in the repo (`grep -rn customfield_10021 --include='*.md'` → this file only):

- **`### Create fields (Task)`** — replaced "it usually 400s / add the sprint from the board afterward" with the follow-up-edit route.
- **Procedure: CREATE, step 4** — spelled out the mechanism: `fields={"customfield_10021": 4380}`, how to obtain the sprint id, and to read the field back afterward.

Also records the asymmetry that costs a minute every time otherwise: **the write takes a bare integer, the read comes back as an array of sprint objects** — verified just now against DOCS-6496, whose field reads `[{"id": 4380, "name": "DOCS Sprint September 4", "state": "active", ...}]`.

Keeping the "don't set it on create" advice as-is — nothing here re-tests that, so the change is only to what you do *instead*.

## Checks

`codespell` (CI-exact invocation) and `.claude/hooks/doc-lint.sh` both exit 0 on the changed file. No page content touched, so no GitBook sync surface.

No ticket — a one-line correction spun out of DOCS-6399, deliberately kept out of PR #833 to keep that PR single-purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)