### PR TITLE
DOCS-6497 Clear 259 dead anchors in archived MaxScale docs (phase 3a)

### DIFF
--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-cache.md
@@ -29,10 +29,10 @@ That is, in default mode the cache effectively causes the system to behave
 as if the _isolation level_ would be `READ COMMITTED`, irrespective of what
 the isolation level of the backends actually is.
 
-The default behaviour can be altered using the configuration parameter [cache\_in\_transactions](mariadb-maxscale-2302-cache.md#cache_in_transactions).
+The default behaviour can be altered using the configuration parameter cache\_in\_transactions.
 
 By default it is assumed that all `SELECT` statements are cacheable, which
-means that also statements like `SELECT LOCALTIME` are cached. Please check [selects](mariadb-maxscale-2302-cache.md#selects) for how to change the default behaviour.
+means that also statements like `SELECT LOCALTIME` are cached. Please check selects for how to change the default behaviour.
 
 ### Limitations
 
@@ -58,7 +58,7 @@ Please read the section [Security](mariadb-maxscale-2302-cache.md#security-1) fo
 
 However, from 2.5 onwards it is possible to configure the cache to cache
 the data of each user separately, which effectively means that there can
-be no unintended sharing. Please see [users](mariadb-maxscale-2302-cache.md#users) for how to change
+be no unintended sharing. Please see users for how to change
 the default behaviour.
 
 #### `information_schema`
@@ -91,7 +91,7 @@ INSERT INTO t SET a=42;
 ```
 
 will cause the cache entry containing the result of that SELECT to be
-invalidated even if the INSERT actually does not affect it. Please see [invalidate](mariadb-maxscale-2302-cache.md#invalidate) for how to enable the invalidation.
+invalidated even if the INSERT actually does not affect it. Please see invalidate for how to enable the invalidation.
 
 When invalidation has been enabled MaxScale must be able to completely
 parse a SELECT statement for its results to be stored in the cache. The
@@ -107,7 +107,7 @@ entire cache. The reason is that unless MaxScale can completely parse
 the statement it cannot know what tables are modified and hence not what
 cache entries should be invalidated. Consequently, to prevent stale data
 from being returned, the entire cache is cleared. The default behaviour
-can be changed using the configuration parameter [clear\_cache\_on\_parse\_errors](mariadb-maxscale-2302-cache.md#clear_cache_on_parse_errors).
+can be changed using the configuration parameter clear\_cache\_on\_parse\_errors.
 
 Note that what threading approach is used has a big impact on the
 invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2302-cache.md#threads-users-and-invalidation)
@@ -115,7 +115,7 @@ for how the threading approach affects the invalidation.
 
 Note also that since the invalidation may not, depending on how the
 cache has been configured, be visible to all sessions of all users, it
-is still important to configure a reasonable [soft](mariadb-maxscale-2302-cache.md#soft_ttl) and [hard](mariadb-maxscale-2302-cache.md#hard_ttl) TTL.
+is still important to configure a reasonable soft and hard TTL.
 
 #### Best Efforts
 
@@ -243,7 +243,7 @@ nested parameters.
 
 _Hard time to live_; the maximum amount of time the cached
 result is used before it is discarded and the result is fetched from the
-backend (and cached). See also [soft\_ttl](mariadb-maxscale-2302-cache.md#soft_ttl).
+backend (and cached). See also soft\_ttl.
 
 ```
 hard_ttl=60s
@@ -260,7 +260,7 @@ _Soft time to live_; the amount of time - in seconds - the cached result is
 used before it is refreshed from the server. When `soft_ttl` has passed, the
 result will be refreshed when the _first_ client requests the value.
 
-However, as long as [hard\_ttl](mariadb-maxscale-2302-cache.md#hard_ttl) has not passed, _all_ other clients
+However, as long as hard\_ttl has not passed, _all_ other clients
 requesting the same value will use the result from the cache while it is being
 fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`
 has passed, even if several clients request the same value at the same time,
@@ -1346,7 +1346,7 @@ storage=storage_redis
 ```
 
 If `storage_redis` cannot connect to the Redis server, caching will silently
-be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2302-cache.md#timeout)
+be disabled and a connection attempt will be made after a timeout
 interval.
 
 If a timeout error occurs during an operation, reconnecting will be attempted
@@ -1375,7 +1375,7 @@ If no port is provided, then the default port `6379` will be used.
 * Dynamic: No
 * Default: `""`
 
-Please see [authentication](mariadb-maxscale-2302-cache.md#authentication) for more information.
+Please see authentication for more information.
 
 **`password`**
 
@@ -1384,7 +1384,7 @@ Please see [authentication](mariadb-maxscale-2302-cache.md#authentication) for m
 * Dynamic: No
 * Default: `""`
 
-Please see [authentication](mariadb-maxscale-2302-cache.md#authentication) for more information.
+Please see authentication for more information.
 
 **`ssl`**
 
@@ -1393,7 +1393,7 @@ Please see [authentication](mariadb-maxscale-2302-cache.md#authentication) for m
 * Dynamic: No
 * Default: `false`
 
-Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_cert`**
 
@@ -1405,7 +1405,7 @@ Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
 The SSL client certificate that MaxScale should use with the Redis
 server. The certificate must match the key defined in `ssl_key`.
 
-Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_key`**
 
@@ -1416,7 +1416,7 @@ Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
 
 The SSL client private key MaxScale should use with the Redis server.
 
-Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_ca`**
 
@@ -1428,7 +1428,7 @@ Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
 The Certificate Authority (CA) certificate for the CA that signed the
 certificate specified with `ssl_cert`.
 
-Please see [ssl](mariadb-maxscale-2302-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **Authentication**
 
@@ -1497,7 +1497,7 @@ $ redis-cli flushall
 The data in the redis server is _not_ encrypted. Consequently, _anybody_ with
 access to the redis server has access to the cached data.
 
-Unless [SSL](mariadb-maxscale-2302-cache.md#ssl) has been enabled, _anybody_ with access to the network has
+Unless SSL has been enabled, _anybody_ with access to the network has
 access to the cached data.
 
 ### Example

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-consistent-critical-read-filter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-consistent-critical-read-filter.md
@@ -90,7 +90,7 @@ modifying SQL statement is processed, the counter is reset to the value of_count
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+These [regular expression settings](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)
 control which statements trigger statement re-routing. Only non-SELECT statements are
 inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works
 similarly.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-masking.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-masking.md
@@ -52,28 +52,28 @@ that use functions in conjunction with columns that should be masked.\
 Allowing function usage provides a way for circumventing the masking,
 unless a firewall filter is separately configured and installed.
 
-Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2302-masking.md#prevent_function_usage)
+Please see the configuration parameter prevent\_function\_usage
 for how to change the default behaviour.
 
 From MaxScale 2.3.5 onwards, the masking filter will check the
 definition of user variables and reject statements that define a user
 variable using a statement that refers to columns that should be masked.
 
-Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2302-masking.md#check_user_variables)
+Please see the configuration parameter check\_user\_variables
 for how to change the default behaviour.
 
 From MaxScale 2.3.5 onwards, the masking filter will examine unions
 and if the second or subsequent SELECT refer to columns that should
 be masked, the statement will be rejected.
 
-Please see the configuration parameter [check\_unions](mariadb-maxscale-2302-masking.md#check_unions)
+Please see the configuration parameter check\_unions
 for how to change the default behaviour.
 
 From MaxScale 2.3.5 onwards, the masking filter will examine subqueries
 and if a subquery refers to columns that should be masked, the statement
 will be rejected.
 
-Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2302-masking.md#check_subqueries)
+Please see the configuration parameter check\_subqueries
 for how to change the default behaviour.
 
 Note that in order to ensure that it is not possible to get access to
@@ -92,7 +92,7 @@ to get access to the cleartext version of a masked field `ssn`.
 From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that
 cannot be fully parsed.
 
-Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2302-masking.md#require_fully_parsed)
+Please see the configuration parameter require\_fully\_parsed
 for how to change the default behaviour.
 
 From MaxScale 2.3.7 onwards, the masking filter will treat any strings

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-named-server-filter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-named-server-filter.md
@@ -80,7 +80,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-[Regular expression options](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+[Regular expression options](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)
 for `matchXY`.
 
 #### `targetXY`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-regex-filter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-regex-filter.md
@@ -58,7 +58,7 @@ options=case
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-The _options_-parameter affects how the patterns are compiled as [usual](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters).
+The _options_-parameter affects how the patterns are compiled as [usual](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md).
 
 #### `replace`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-top-filter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-filters/mariadb-maxscale-2302-top-filter.md
@@ -69,7 +69,7 @@ count=30
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+[Limits](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 ```
@@ -85,7 +85,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+[Limits](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 **`options`**
@@ -96,7 +96,7 @@ the queries logged by the filter.
 * Values: `ignorecase`, `case`, `extended`
 * Default: `case`
 
-[Regular expression options](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+[Regular expression options](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)
 for `match` and `exclude`.
 
 **`source`**

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md
@@ -1396,7 +1396,7 @@ the MaxScale log.
 
 #### `writeq_high_water`
 
-* Type: [size](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#size)
+* Type: size
 * Mandatory: No
 * Dynamic: Yes
 * Default: `65536`
@@ -1419,7 +1419,7 @@ to 0.
 
 #### `writeq_low_water`
 
-* Type: [size](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#size)
+* Type: size
 * Mandatory: No
 * Dynamic: Yes
 * Default: `1024`
@@ -2981,7 +2981,7 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+This setting together with monitorpasswd define server-specific
 credentials for monitoring the server. Monitors typically use the credentials in their
 own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
@@ -3277,7 +3277,7 @@ the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-
 command to server A telling it to replicate from server B, the setting value
 from MaxScale configuration for server A would be used.
 
-See [MariaDB Monitor documentation](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md#replication_custom_options)
+See [MariaDB Monitor documentation](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md)
 for more information.
 
 ### Monitor
@@ -3391,7 +3391,7 @@ authenticator specific documentation for more details.
 
 #### `sql_mode`
 
-* Type: [enum](mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#enumeration)
+* Type: enum
 * Mandatory: No
 * Dynamic: Yes
 * Values: `default`, `oracle`
@@ -3952,8 +3952,8 @@ configuration at runtime.
 * MaxCtrl
 * [create](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md#create)
 * [destroy](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md#destroy)
-* [add](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md#add)
-* [remove](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md#remove)
+* [add](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md)
+* [remove](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md)
 * [alter](../mariadb-maxscale-23-02-reference/mariadb-maxscale-2302-maxctrl.md#alter)
 * [REST API](../mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md) documentation
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md
@@ -113,7 +113,7 @@ changed significantly and the primary should be re-selected, although the old
 primary may still be the best choice.
 
 The primary change described above is different from failover and switchover
-described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2302-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
+described in section Failover, switchover and auto-rejoin.\
 A primary change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a primary change on their own.
@@ -425,11 +425,11 @@ see [general monitor documentation](https://mariadb.com/kb/en/node:mariadb-maxsc
 Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster
 modification. The operations implemented are:
 
-* [failover](mariadb-maxscale-2302-mariadb-monitor.md#failover), which replaces a failed primary with a replica
-* [switchover](mariadb-maxscale-2302-mariadb-monitor.md#switchover), which swaps a running primary with a replica
-* [async-switchover](mariadb-maxscale-2302-mariadb-monitor.md#queued-switchover), which schedules a switchover and returns
-* [rejoin](mariadb-maxscale-2302-mariadb-monitor.md#rejoin), which directs servers to replicate from the primary
-* [reset-replication](mariadb-maxscale-2302-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and
+* failover, which replaces a failed primary with a replica
+* switchover, which swaps a running primary with a replica
+* async-switchover, which schedules a switchover and returns
+* rejoin, which directs servers to replicate from the primary
+* reset-replication (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
 See [operation details](mariadb-maxscale-2302-mariadb-monitor.md#operation-details) for more information on the
@@ -854,9 +854,9 @@ This effectively enforces a 1-primary-N-replicas topology. The current primary
 itself is not redirected, so it can continue to replicate from an external
 primary. Rejoin is also not performed on any server that is replicating from
 multiple sources, as this indicates a complicated topology (this rule is
-overridden by [enforce\_simple\_topology](mariadb-maxscale-2302-mariadb-monitor.md#enforce_simple_topology)).
+overridden by enforce\_simple\_topology).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2302-mariadb-monitor.md#auto_failover) to redirect
+This feature is often paired with auto\_failover to redirect
 the former primary when it comes back online. Sometimes this kind of rejoin will
 fail as the old primary may have transactions that were never replicated to the
 current one. See [limitations](mariadb-maxscale-2302-mariadb-monitor.md#limitations-and-requirements) for more
@@ -1008,7 +1008,7 @@ further automatic modifications to the misbehaving cluster.
 * Dynamic: Yes
 * Default: `true`
 
-Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and [master\_failure\_timeout](mariadb-maxscale-2302-mariadb-monitor.md#master_failure_timeout) defines the timeout.
+Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and master\_failure\_timeout defines the timeout.
 
 The primary failure timeout is specified as documented [here](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
 is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-maxscale-2302-mariadb-protocol-module.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-maxscale-2302-mariadb-protocol-module.md
@@ -5,7 +5,7 @@ The `mariadbprotocol` module implements the MariaDB client-server protocol.
 The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all
 aliases to `mariadbprotocol`.
 
-* [MariaDB Protocol Module](mariadb-maxscale-2302-maxscale-2302-mariadb-protocol-module.md#mariadb-protocol-module)
+* MariaDB Protocol Module
   * [Configuration](mariadb-maxscale-2302-maxscale-2302-mariadb-protocol-module.md#configuration)
     * [allow\_replication](mariadb-maxscale-2302-maxscale-2302-mariadb-protocol-module.md#allow_replication)
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-nosql-protocol-module.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-nosql-protocol-module.md
@@ -329,7 +329,7 @@ bootstrapping implicitly is much more convenient.
 
 In order to enable authorization you need to have NoSQL users and
 those can be created with [createUser](mariadb-maxscale-2302-nosql-protocol-module.md#createuser) or added
-with [mxsAddUser](mariadb-maxscale-2302-nosql-protocol-module.md#addUser).
+with mxsAddUser.
 
 If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
@@ -1368,9 +1368,9 @@ The following fields are relevant.
 | query         | document | Optional. The query predicate.                                                                                                                            |
 | sort          | document | Optional. The sort specification used when the document is selected.                                                                                      |
 | remove        | boolean  | Mandatory, if update is not specified. If true, the document will be deleted.                                                                             |
-| update        | document | Mandatory, if remove is not specified. See [Update.behavior](mariadb-maxscale-2302-nosql-protocol-module.md#behavior) for details.                        |
+| update        | document | Mandatory, if remove is not specified. See Update.behavior for details.                        |
 | new           | boolean  | Optional. If true the modified document and not the original document is returned. If remove is specified, then the original document is always returned. |
-| fields        | document | Optional. Specified which fields to return. See [Find.projection](mariadb-maxscale-2302-nosql-protocol-module.md#projection) for details.                 |
+| fields        | document | Optional. Specified which fields to return. See Find.projection for details.                 |
 | upsert        | boolean  | Optional. If true then a document will be created, if one is not found.                                                                                   |
 
 All other fields are ignored.
@@ -2039,7 +2039,7 @@ an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2302-nosql-protocol-module.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**
@@ -2399,7 +2399,7 @@ The command has the following fields:
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2302-nosql-protocol-module.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-rest-api.md
@@ -233,7 +233,7 @@ parameters. Parameters are given in the HTTP query string:`https://localhost:898
   For example, if the object stored in `data[0]` has a value pointed by the
   given JSON pointer and that value compares equal to the given JSON value,
   the array row is kept in the result. Examples for filtering expression can
-  be found [here](mariadb-maxscale-2302-rest-api.md#filter-expression-examples).\
+  be found here.\
   A practical use for this parameter is to return only sessions for a
   particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
   be used. Note the double quotes around the `"RW-Split-Router"`, they are

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avrorouter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-avrorouter.md
@@ -171,7 +171,7 @@ refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specificat
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+These [regular expression settings](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md)
 filter events for processing depending on table names. Avrorouter does not support the\_options\_-parameter for regular expressions.
 
 To prevent excessive matching of similarly named tables, surround each table

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md
@@ -690,7 +690,7 @@ If a client connection modifies the database and `causal_reads` is enabled, any
 subsequent reads performed on replica servers will be done in a manner that
 prevents replication lag from affecting the results.
 
-The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2302-readwritesplit.md#implementation-of-causal_reads) for more
+The following table contains a comparison of the modes. Read the implementation of causal\_reads for more
 information on what a sync consists of and why minimizing the number of them is
 important.
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-tutorials/mariadb-maxscale-2302-using-maxgui-tutorial.md
@@ -254,7 +254,7 @@ available options, right-click on the editor to show the context menu.
 
 Every executed query will be saved in the browser's storage (IndexedDB).\
 Query history can be seen in the `History/Snippets` tab.\
-To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2302-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)
+To re-execute a query, follow the same step to insert an object into the editor
 and click the execute query button in the editor.
 
 **Create query snippet**

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md
@@ -33,10 +33,10 @@ That is, in default mode the cache effectively causes the system to behave
 as if the _isolation level_ would be `READ COMMITTED`, irrespective of what
 the isolation level of the backends actually is.
 
-The default behaviour can be altered using the configuration parameter [cache\_in\_transactions](mariadb-maxscale-2308-cache.md#cache_in_transactions).
+The default behaviour can be altered using the configuration parameter cache\_in\_transactions.
 
 By default it is assumed that all `SELECT` statements are cacheable, which
-means that also statements like `SELECT LOCALTIME` are cached. Please check [selects](mariadb-maxscale-2308-cache.md#selects) for how to change the default behaviour.
+means that also statements like `SELECT LOCALTIME` are cached. Please check selects for how to change the default behaviour.
 
 ### Limitations
 
@@ -62,7 +62,7 @@ Please read the section [Security](mariadb-maxscale-2308-cache.md#security-1) fo
 
 However, from 2.5 onwards it is possible to configure the cache to cache
 the data of each user separately, which effectively means that there can
-be no unintended sharing. Please see [users](mariadb-maxscale-2308-cache.md#users) for how to change
+be no unintended sharing. Please see users for how to change
 the default behaviour.
 
 #### `information_schema`
@@ -95,7 +95,7 @@ INSERT INTO t SET a=42;
 ```
 
 will cause the cache entry containing the result of that SELECT to be
-invalidated even if the INSERT actually does not affect it. Please see [invalidate](mariadb-maxscale-2308-cache.md#invalidate) for how to enable the invalidation.
+invalidated even if the INSERT actually does not affect it. Please see invalidate for how to enable the invalidation.
 
 When invalidation has been enabled MaxScale must be able to completely
 parse a SELECT statement for its results to be stored in the cache. The
@@ -111,7 +111,7 @@ entire cache. The reason is that unless MaxScale can completely parse
 the statement it cannot know what tables are modified and hence not what
 cache entries should be invalidated. Consequently, to prevent stale data
 from being returned, the entire cache is cleared. The default behaviour
-can be changed using the configuration parameter [clear\_cache\_on\_parse\_errors](mariadb-maxscale-2308-cache.md#clear_cache_on_parse_errors).
+can be changed using the configuration parameter clear\_cache\_on\_parse\_errors.
 
 Note that what threading approach is used has a big impact on the
 invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2308-cache.md#threads-users-and-invalidation)
@@ -119,7 +119,7 @@ for how the threading approach affects the invalidation.
 
 Note also that since the invalidation may not, depending on how the
 cache has been configured, be visible to all sessions of all users, it
-is still important to configure a reasonable [soft](mariadb-maxscale-2308-cache.md#soft_ttl) and [hard](mariadb-maxscale-2308-cache.md#hard_ttl) TTL.
+is still important to configure a reasonable soft and hard TTL.
 
 #### Best Efforts
 
@@ -247,7 +247,7 @@ nested parameters.
 
 _Hard time to live_; the maximum amount of time the cached
 result is used before it is discarded and the result is fetched from the
-backend (and cached). See also [soft\_ttl](mariadb-maxscale-2308-cache.md#soft_ttl).
+backend (and cached). See also soft\_ttl.
 
 ```
 hard_ttl=60s
@@ -264,7 +264,7 @@ _Soft time to live_; the amount of time - in seconds - the cached result is
 used before it is refreshed from the server. When `soft_ttl` has passed, the
 result will be refreshed when the _first_ client requests the value.
 
-However, as long as [hard\_ttl](mariadb-maxscale-2308-cache.md#hard_ttl) has not passed, _all_ other clients
+However, as long as hard\_ttl has not passed, _all_ other clients
 requesting the same value will use the result from the cache while it is being
 fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`
 has passed, even if several clients request the same value at the same time,
@@ -1350,7 +1350,7 @@ storage=storage_redis
 ```
 
 If `storage_redis` cannot connect to the Redis server, caching will silently
-be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2308-cache.md#timeout)
+be disabled and a connection attempt will be made after a timeout
 interval.
 
 If a timeout error occurs during an operation, reconnecting will be attempted
@@ -1379,7 +1379,7 @@ If no port is provided, then the default port `6379` will be used.
 * Dynamic: No
 * Default: `""`
 
-Please see [authentication](mariadb-maxscale-2308-cache.md#authentication) for more information.
+Please see authentication for more information.
 
 **`password`**
 
@@ -1388,7 +1388,7 @@ Please see [authentication](mariadb-maxscale-2308-cache.md#authentication) for m
 * Dynamic: No
 * Default: `""`
 
-Please see [authentication](mariadb-maxscale-2308-cache.md#authentication) for more information.
+Please see authentication for more information.
 
 **`ssl`**
 
@@ -1397,7 +1397,7 @@ Please see [authentication](mariadb-maxscale-2308-cache.md#authentication) for m
 * Dynamic: No
 * Default: `false`
 
-Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_cert`**
 
@@ -1409,7 +1409,7 @@ Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
 The SSL client certificate that MaxScale should use with the Redis
 server. The certificate must match the key defined in `ssl_key`.
 
-Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_key`**
 
@@ -1420,7 +1420,7 @@ Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
 
 The SSL client private key MaxScale should use with the Redis server.
 
-Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_ca`**
 
@@ -1432,7 +1432,7 @@ Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
 The Certificate Authority (CA) certificate for the CA that signed the
 certificate specified with `ssl_cert`.
 
-Please see [ssl](mariadb-maxscale-2308-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **Authentication**
 
@@ -1501,7 +1501,7 @@ $ redis-cli flushall
 The data in the redis server is _not_ encrypted. Consequently, _anybody_ with
 access to the redis server has access to the cached data.
 
-Unless [SSL](mariadb-maxscale-2308-cache.md#ssl) has been enabled, _anybody_ with access to the network has
+Unless SSL has been enabled, _anybody_ with access to the network has
 access to the cached data.
 
 ### Example

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-consistent-critical-read-filter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-consistent-critical-read-filter.md
@@ -94,7 +94,7 @@ modifying SQL statement is processed, the counter is reset to the value of_count
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+These [regular expression settings](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)
 control which statements trigger statement re-routing. Only non-SELECT statements are
 inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works
 similarly.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-masking.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-masking.md
@@ -56,28 +56,28 @@ that use functions in conjunction with columns that should be masked.\
 Allowing function usage provides a way for circumventing the masking,
 unless a firewall filter is separately configured and installed.
 
-Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2308-masking.md#prevent_function_usage)
+Please see the configuration parameter prevent\_function\_usage
 for how to change the default behaviour.
 
 From MaxScale 2.3.5 onwards, the masking filter will check the
 definition of user variables and reject statements that define a user
 variable using a statement that refers to columns that should be masked.
 
-Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2308-masking.md#check_user_variables)
+Please see the configuration parameter check\_user\_variables
 for how to change the default behaviour.
 
 From MaxScale 2.3.5 onwards, the masking filter will examine unions
 and if the second or subsequent SELECT refer to columns that should
 be masked, the statement will be rejected.
 
-Please see the configuration parameter [check\_unions](mariadb-maxscale-2308-masking.md#check_unions)
+Please see the configuration parameter check\_unions
 for how to change the default behaviour.
 
 From MaxScale 2.3.5 onwards, the masking filter will examine subqueries
 and if a subquery refers to columns that should be masked, the statement
 will be rejected.
 
-Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2308-masking.md#check_subqueries)
+Please see the configuration parameter check\_subqueries
 for how to change the default behaviour.
 
 Note that in order to ensure that it is not possible to get access to
@@ -96,7 +96,7 @@ to get access to the cleartext version of a masked field `ssn`.
 From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that
 cannot be fully parsed.
 
-Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2308-masking.md#require_fully_parsed)
+Please see the configuration parameter require\_fully\_parsed
 for how to change the default behaviour.
 
 From MaxScale 2.3.7 onwards, the masking filter will treat any strings

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-named-server-filter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-named-server-filter.md
@@ -84,7 +84,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-[Regular expression options](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+[Regular expression options](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)
 for `matchXY`.
 
 #### `targetXY`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-regex-filter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-regex-filter.md
@@ -60,7 +60,7 @@ options=case
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-The _options_-parameter affects how the patterns are compiled as [usual](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters).
+The _options_-parameter affects how the patterns are compiled as [usual](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md).
 
 #### `replace`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-top-filter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-top-filter.md
@@ -73,7 +73,7 @@ count=30
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+[Limits](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 ```
@@ -89,7 +89,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-[Limits](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+[Limits](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)
 the queries logged by the filter.
 
 **`options`**
@@ -100,7 +100,7 @@ the queries logged by the filter.
 * Values: `ignorecase`, `case`, `extended`
 * Default: `case`
 
-[Regular expression options](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters)
+[Regular expression options](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md)
 for `match` and `exclude`.
 
 **`source`**

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md
@@ -1353,7 +1353,7 @@ the MaxScale log.
 
 #### `writeq_high_water`
 
-* Type: [size](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#size)
+* Type: size
 * Mandatory: No
 * Dynamic: Yes
 * Default: `65536`
@@ -1376,7 +1376,7 @@ MaxScale 23.02 and earlier, also `writeq_low_water` had to be non-zero.
 
 #### `writeq_low_water`
 
-* Type: [size](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#size)
+* Type: size
 * Mandatory: No
 * Dynamic: Yes
 * Default: `1024`
@@ -2996,7 +2996,7 @@ Either _address_ or _socket_ must be defined, but not both.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+This setting together with monitorpasswd define server-specific
 credentials for monitoring the server. Monitors typically use the credentials in their
 own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
@@ -3292,7 +3292,7 @@ the source of the replication. That is, if monitor sends a "CHANGE MASTER TO"-
 command to server A telling it to replicate from server B, the setting value
 from MaxScale configuration for server A would be used.
 
-See [MariaDB Monitor documentation](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md#replication_custom_options)
+See [MariaDB Monitor documentation](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md)
 for more information.
 
 ### Monitor
@@ -3407,7 +3407,7 @@ authenticator specific documentation for more details.
 
 #### `sql_mode`
 
-* Type: [enum](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#enumeration)
+* Type: enum
 * Mandatory: No
 * Dynamic: Yes
 * Values: `default`, `oracle`
@@ -4108,8 +4108,8 @@ configuration at runtime.
 * MaxCtrl
 * [create](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md#create)
 * [destroy](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md#destroy)
-* [add](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md#add)
-* [remove](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md#remove)
+* [add](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md)
+* [remove](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md)
 * [alter](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-maxctrl.md#alter)
 * [REST API](../mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md) documentation
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md
@@ -124,7 +124,7 @@ changed significantly and the primary should be re-selected, although the old
 primary may still be the best choice.
 
 The primary change described above is different from failover and switchover
-described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2308-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
+described in section Failover, switchover and auto-rejoin.\
 A primary change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a primary change on their own.
@@ -443,13 +443,13 @@ see [general monitor documentation](https://mariadb.com/kb/en/node:mariadb-maxsc
 Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster
 modification. The operations implemented are:
 
-* [failover](mariadb-maxscale-2308-mariadb-monitor.md#failover), which replaces a failed primary with a replica
-* [switchover](mariadb-maxscale-2308-mariadb-monitor.md#switchover), which swaps a running primary with a replica
-* [switchover-force](mariadb-maxscale-2308-mariadb-monitor.md#switchover-force), which swaps a running primary with a replica, ignoring
+* failover, which replaces a failed primary with a replica
+* switchover, which swaps a running primary with a replica
+* switchover-force, which swaps a running primary with a replica, ignoring
   most errors. Can break replication.
-* [async-switchover](mariadb-maxscale-2308-mariadb-monitor.md#queued-switchover), which schedules a switchover and returns
-* [rejoin](mariadb-maxscale-2308-mariadb-monitor.md#rejoin), which directs servers to replicate from the primary
-* [reset-replication](mariadb-maxscale-2308-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and
+* async-switchover, which schedules a switchover and returns
+* rejoin, which directs servers to replicate from the primary
+* reset-replication (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
 See [operation details](mariadb-maxscale-2308-mariadb-monitor.md#operation-details) for more information on the
@@ -890,9 +890,9 @@ This effectively enforces a 1-primary-N-replicas topology. The current primary
 itself is not redirected, so it can continue to replicate from an external
 primary. Rejoin is also not performed on any server that is replicating from
 multiple sources, as this indicates a complicated topology (this rule is
-overridden by [enforce\_simple\_topology](mariadb-maxscale-2308-mariadb-monitor.md#enforce_simple_topology)).
+overridden by enforce\_simple\_topology).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2308-mariadb-monitor.md#auto_failover) to redirect
+This feature is often paired with auto\_failover to redirect
 the former primary when it comes back online. Sometimes this kind of rejoin will
 fail as the old primary may have transactions that were never replicated to the
 current one. See [limitations](mariadb-maxscale-2308-mariadb-monitor.md#limitations-and-requirements) for more
@@ -1044,7 +1044,7 @@ further automatic modifications to the misbehaving cluster.
 * Dynamic: Yes
 * Default: `true`
 
-Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and [master\_failure\_timeout](mariadb-maxscale-2308-mariadb-monitor.md#master_failure_timeout) defines the timeout.
+Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and master\_failure\_timeout defines the timeout.
 
 The primary failure timeout is specified as documented [here](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations). If no explicit unit
 is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md
@@ -333,7 +333,7 @@ bootstrapping implicitly is much more convenient.
 
 In order to enable authorization you need to have NoSQL users and
 those can be created with [createUser](mariadb-maxscale-2308-nosql-protocol-module.md#createuser) or added
-with [mxsAddUser](mariadb-maxscale-2308-nosql-protocol-module.md#addUser).
+with mxsAddUser.
 
 If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
@@ -1383,9 +1383,9 @@ The following fields are relevant.
 | query         | document | Optional. The query predicate.                                                                                                                            |
 | sort          | document | Optional. The sort specification used when the document is selected.                                                                                      |
 | remove        | boolean  | Mandatory, if update is not specified. If true, the document will be deleted.                                                                             |
-| update        | document | Mandatory, if remove is not specified. See [Update.behavior](mariadb-maxscale-2308-nosql-protocol-module.md#behavior) for details.                        |
+| update        | document | Mandatory, if remove is not specified. See Update.behavior for details.                        |
 | new           | boolean  | Optional. If true the modified document and not the original document is returned. If remove is specified, then the original document is always returned. |
-| fields        | document | Optional. Specified which fields to return. See [Find.projection](mariadb-maxscale-2308-nosql-protocol-module.md#projection) for details.                 |
+| fields        | document | Optional. Specified which fields to return. See Find.projection for details.                 |
 | upsert        | boolean  | Optional. If true then a document will be created, if one is not found.                                                                                   |
 
 All other fields are ignored.
@@ -2054,7 +2054,7 @@ an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2308-nosql-protocol-module.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**
@@ -2414,7 +2414,7 @@ The command has the following fields:
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2308-nosql-protocol-module.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md
@@ -237,7 +237,7 @@ parameters. Parameters are given in the HTTP query string:`https://localhost:898
   For example, if the object stored in `data[0]` has a value pointed by the
   given JSON pointer and that value compares equal to the given JSON value,
   the array row is kept in the result. Examples for filtering expression can
-  be found [here](mariadb-maxscale-2308-rest-api.md#filter-expression-examples).\
+  be found here.\
   A practical use for this parameter is to return only sessions for a
   particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
   be used. Note the double quotes around the `"RW-Split-Router"`, they are

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
@@ -763,7 +763,7 @@ If a client connection modifies the database and `causal_reads` is enabled, any
 subsequent reads performed on replica servers will be done in a manner that
 prevents replication lag from affecting the results.
 
-The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2308-readwritesplit.md#implementation-of-causal_reads) for more
+The following table contains a comparison of the modes. Read the implementation of causal\_reads for more
 information on what a sync consists of and why minimizing the number of them is
 important.
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial.md
@@ -229,7 +229,7 @@ There are two ways to quickly insert an object to the editor:
 
 **Show object creation statement and insights info**
 
-To view the statement that creates the given object in the [Schemas objects sidebar](mariadb-maxscale-2308-using-maxgui-tutorial.md#schemas-objects-sidebar), right-clicking on schema or table node and
+To view the statement that creates the given object in the Schemas objects sidebar, right-clicking on schema or table node and
 select the `View Insights` option. For other objects such as view, stored
 procedure, function and trigger, select the `Show Create` option.
 
@@ -247,7 +247,7 @@ available options, right-click on the editor to show the context menu.
 
 Every executed query will be saved in the browser's storage (IndexedDB).\
 Query history can be seen in the `History/Snippets` tab.\
-To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2308-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)
+To re-execute a query, follow the same step to insert an object into the editor
 and click the execute query button in the editor.
 
 **Create query snippet**

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-cache.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-cache.md
@@ -29,10 +29,10 @@ That is, in default mode the cache effectively causes the system to behave
 as if the _isolation level_ would be `READ COMMITTED`, irrespective of what
 the isolation level of the backends actually is.
 
-The default behaviour can be altered using the configuration parameter [cache\_in\_transactions](mariadb-maxscale-2402-cache.md#cache_in_transactions).
+The default behaviour can be altered using the configuration parameter cache\_in\_transactions.
 
 By default it is assumed that all `SELECT` statements are cacheable, which
-means that also statements like `SELECT LOCALTIME` are cached. Please check [selects](mariadb-maxscale-2402-cache.md#selects) for how to change the default behaviour.
+means that also statements like `SELECT LOCALTIME` are cached. Please check selects for how to change the default behaviour.
 
 ### Limitations
 
@@ -58,7 +58,7 @@ Please read the section [Security](mariadb-maxscale-2402-cache.md#security-1) fo
 
 However, from 2.5 onwards it is possible to configure the cache to cache
 the data of each user separately, which effectively means that there can
-be no unintended sharing. Please see [users](mariadb-maxscale-2402-cache.md#users) for how to change
+be no unintended sharing. Please see users for how to change
 the default behaviour.
 
 #### `information_schema`
@@ -91,7 +91,7 @@ INSERT INTO t SET a=42;
 ```
 
 will cause the cache entry containing the result of that SELECT to be
-invalidated even if the INSERT actually does not affect it. Please see [invalidate](mariadb-maxscale-2402-cache.md#invalidate) for how to enable the invalidation.
+invalidated even if the INSERT actually does not affect it. Please see invalidate for how to enable the invalidation.
 
 When invalidation has been enabled MaxScale must be able to completely
 parse a SELECT statement for its results to be stored in the cache. The
@@ -107,7 +107,7 @@ entire cache. The reason is that unless MaxScale can completely parse
 the statement it cannot know what tables are modified and hence not what
 cache entries should be invalidated. Consequently, to prevent stale data
 from being returned, the entire cache is cleared. The default behaviour
-can be changed using the configuration parameter [clear\_cache\_on\_parse\_errors](mariadb-maxscale-2402-cache.md#clear_cache_on_parse_errors).
+can be changed using the configuration parameter clear\_cache\_on\_parse\_errors.
 
 Note that what threading approach is used has a big impact on the
 invalidation. Please see [Threads, Users and Invalidation](mariadb-maxscale-2402-cache.md#threads-users-and-invalidation)
@@ -115,7 +115,7 @@ for how the threading approach affects the invalidation.
 
 Note also that since the invalidation may not, depending on how the
 cache has been configured, be visible to all sessions of all users, it
-is still important to configure a reasonable [soft](mariadb-maxscale-2402-cache.md#soft_ttl) and [hard](mariadb-maxscale-2402-cache.md#hard_ttl) TTL.
+is still important to configure a reasonable soft and hard TTL.
 
 #### Best Efforts
 
@@ -243,7 +243,7 @@ nested parameters.
 
 _Hard time to live_; the maximum amount of time the cached
 result is used before it is discarded and the result is fetched from the
-backend (and cached). See also [soft\_ttl](mariadb-maxscale-2402-cache.md#soft_ttl).
+backend (and cached). See also soft\_ttl.
 
 ```
 hard_ttl=60s
@@ -260,7 +260,7 @@ _Soft time to live_; the amount of time - in seconds - the cached result is
 used before it is refreshed from the server. When `soft_ttl` has passed, the
 result will be refreshed when the _first_ client requests the value.
 
-However, as long as [hard\_ttl](mariadb-maxscale-2402-cache.md#hard_ttl) has not passed, _all_ other clients
+However, as long as hard\_ttl has not passed, _all_ other clients
 requesting the same value will use the result from the cache while it is being
 fetched from the backend. That is, as long as `soft_ttl` but not `hard_ttl`
 has passed, even if several clients request the same value at the same time,
@@ -1346,7 +1346,7 @@ storage=storage_redis
 ```
 
 If `storage_redis` cannot connect to the Redis server, caching will silently
-be disabled and a connection attempt will be made after a [timeout](mariadb-maxscale-2402-cache.md#timeout)
+be disabled and a connection attempt will be made after a timeout
 interval.
 
 If a timeout error occurs during an operation, reconnecting will be attempted
@@ -1375,7 +1375,7 @@ If no port is provided, then the default port `6379` will be used.
 * Dynamic: No
 * Default: `""`
 
-Please see [authentication](mariadb-maxscale-2402-cache.md#authentication) for more information.
+Please see authentication for more information.
 
 **`password`**
 
@@ -1384,7 +1384,7 @@ Please see [authentication](mariadb-maxscale-2402-cache.md#authentication) for m
 * Dynamic: No
 * Default: `""`
 
-Please see [authentication](mariadb-maxscale-2402-cache.md#authentication) for more information.
+Please see authentication for more information.
 
 **`ssl`**
 
@@ -1393,7 +1393,7 @@ Please see [authentication](mariadb-maxscale-2402-cache.md#authentication) for m
 * Dynamic: No
 * Default: `false`
 
-Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_cert`**
 
@@ -1405,7 +1405,7 @@ Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
 The SSL client certificate that MaxScale should use with the Redis
 server. The certificate must match the key defined in `ssl_key`.
 
-Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_key`**
 
@@ -1416,7 +1416,7 @@ Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
 
 The SSL client private key MaxScale should use with the Redis server.
 
-Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_ca`**
 
@@ -1428,7 +1428,7 @@ Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
 The Certificate Authority (CA) certificate for the CA that signed the
 certificate specified with `ssl_cert`.
 
-Please see [ssl](mariadb-maxscale-2402-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **Authentication**
 
@@ -1497,7 +1497,7 @@ $ redis-cli flushall
 The data in the redis server is _not_ encrypted. Consequently, _anybody_ with
 access to the redis server has access to the cached data.
 
-Unless [SSL](mariadb-maxscale-2402-cache.md#ssl) has been enabled, _anybody_ with access to the network has
+Unless SSL has been enabled, _anybody_ with access to the network has
 access to the cached data.
 
 ### Example

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-masking.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02filters/mariadb-maxscale-2402-maxscale-2402-masking.md
@@ -52,28 +52,28 @@ that use functions in conjunction with columns that should be masked.\
 Allowing function usage provides a way for circumventing the masking,
 unless a firewall filter is separately configured and installed.
 
-Please see the configuration parameter [prevent\_function\_usage](mariadb-maxscale-2402-maxscale-2402-masking.md#prevent_function_usage)
+Please see the configuration parameter prevent\_function\_usage
 for how to change the default behaviour.
 
 From MaxScale 2.3.5 onwards, the masking filter will check the
 definition of user variables and reject statements that define a user
 variable using a statement that refers to columns that should be masked.
 
-Please see the configuration parameter [check\_user\_variables](mariadb-maxscale-2402-maxscale-2402-masking.md#check_user_variables)
+Please see the configuration parameter check\_user\_variables
 for how to change the default behaviour.
 
 From MaxScale 2.3.5 onwards, the masking filter will examine unions
 and if the second or subsequent SELECT refer to columns that should
 be masked, the statement will be rejected.
 
-Please see the configuration parameter [check\_unions](mariadb-maxscale-2402-maxscale-2402-masking.md#check_unions)
+Please see the configuration parameter check\_unions
 for how to change the default behaviour.
 
 From MaxScale 2.3.5 onwards, the masking filter will examine subqueries
 and if a subquery refers to columns that should be masked, the statement
 will be rejected.
 
-Please see the configuration parameter [check\_subqueries](mariadb-maxscale-2402-maxscale-2402-masking.md#check_subqueries)
+Please see the configuration parameter check\_subqueries
 for how to change the default behaviour.
 
 Note that in order to ensure that it is not possible to get access to
@@ -92,7 +92,7 @@ to get access to the cleartext version of a masked field `ssn`.
 From MaxScale 2.3.5 onwards, the masking filter will, if any of the`prevent_function_usage`, `check_user_variables`, `check_unions` or`check_subqueries` parameters is set to true, block statements that
 cannot be fully parsed.
 
-Please see the configuration parameter [require\_fully\_parsed](mariadb-maxscale-2402-maxscale-2402-masking.md#require_fully_parsed)
+Please see the configuration parameter require\_fully\_parsed
 for how to change the default behaviour.
 
 From MaxScale 2.3.7 onwards, the masking filter will treat any strings

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md
@@ -1364,7 +1364,7 @@ the MaxScale log.
 
 #### `writeq_high_water`
 
-* Type: [size](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#size)
+* Type: size
 * Mandatory: No
 * Dynamic: Yes
 * Default: `65536`
@@ -1387,7 +1387,7 @@ MaxScale 23.02 and earlier, also `writeq_low_water` had to be non-zero.
 
 #### `writeq_low_water`
 
-* Type: [size](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#size)
+* Type: size
 * Mandatory: No
 * Dynamic: Yes
 * Default: `1024`
@@ -3065,7 +3065,7 @@ for more information.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+This setting together with monitorpasswd define server-specific
 credentials for monitoring the server. Monitors typically use the credentials in their
 own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
@@ -3476,7 +3476,7 @@ authenticator specific documentation for more details.
 
 #### `sql_mode`
 
-* Type: [enum](mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#enumeration)
+* Type: enum
 * Mandatory: No
 * Dynamic: Yes
 * Values: `default`, `oracle`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md
@@ -120,7 +120,7 @@ changed significantly and the primary should be re-selected, although the old
 primary may still be the best choice.
 
 The primary change described above is different from failover and switchover
-described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
+described in section Failover, switchover and auto-rejoin.\
 A primary change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a primary change on their own.
@@ -457,13 +457,13 @@ see [general monitor documentation](https://mariadb.com/kb/en/node:maxscale-24-0
 Starting with MaxScale 2.2.1, MariaDB Monitor supports replication cluster
 modification. The operations implemented are:
 
-* [failover](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#failover), which replaces a failed primary with a replica
-* [switchover](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#switchover), which swaps a running primary with a replica
-* [switchover-force](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#switchover-force), which swaps a running primary with a replica, ignoring
+* failover, which replaces a failed primary with a replica
+* switchover, which swaps a running primary with a replica
+* switchover-force, which swaps a running primary with a replica, ignoring
   most errors. Can break replication.
-* [async-switchover](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#queued-switchover), which schedules a switchover and returns
-* [rejoin](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#rejoin), which directs servers to replicate from the primary
-* [reset-replication](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and
+* async-switchover, which schedules a switchover and returns
+* rejoin, which directs servers to replicate from the primary
+* reset-replication (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
 See [operation details](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#operation-details) for more information on the
@@ -904,9 +904,9 @@ This effectively enforces a 1-primary-N-replicas topology. The current primary
 itself is not redirected, so it can continue to replicate from an external
 primary. Rejoin is also not performed on any server that is replicating from
 multiple sources, as this indicates a complicated topology (this rule is
-overridden by [enforce\_simple\_topology](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#enforce_simple_topology)).
+overridden by enforce\_simple\_topology).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#auto_failover) to redirect
+This feature is often paired with auto\_failover to redirect
 the former primary when it comes back online. Sometimes this kind of rejoin will
 fail as the old primary may have transactions that were never replicated to the
 current one. See [limitations](mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#limitations-and-requirements) for more

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-mariadb-protocol-module.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-mariadb-protocol-module.md
@@ -5,7 +5,7 @@ The `mariadbprotocol` module implements the MariaDB client-server protocol.
 The legacy protocol names `mysqlclient`, `mariadb` and `mariadbclient` are all
 aliases to `mariadbprotocol`.
 
-* [MariaDB Protocol Module](mariadb-maxscale-2402-maxscale-2402-mariadb-protocol-module.md#mariadb-protocol-module)
+* MariaDB Protocol Module
   * [Configuration](mariadb-maxscale-2402-maxscale-2402-mariadb-protocol-module.md#configuration)
     * [allow\_replication](mariadb-maxscale-2402-maxscale-2402-mariadb-protocol-module.md#allow_replication)
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02protocols/mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md
@@ -333,7 +333,7 @@ bootstrapping implicitly is much more convenient.
 
 In order to enable authorization you need to have NoSQL users and
 those can be created with [createUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#createuser) or added
-with [mxsAddUser](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#addUser).
+with mxsAddUser.
 
 If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
@@ -1383,9 +1383,9 @@ The following fields are relevant.
 | query         | document | Optional. The query predicate.                                                                                                                            |
 | sort          | document | Optional. The sort specification used when the document is selected.                                                                                      |
 | remove        | boolean  | Mandatory, if update is not specified. If true, the document will be deleted.                                                                             |
-| update        | document | Mandatory, if remove is not specified. See [Update.behavior](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#behavior) for details.          |
+| update        | document | Mandatory, if remove is not specified. See Update.behavior for details.          |
 | new           | boolean  | Optional. If true the modified document and not the original document is returned. If remove is specified, then the original document is always returned. |
-| fields        | document | Optional. Specified which fields to return. See [Find.projection](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#projection) for details.   |
+| fields        | document | Optional. Specified which fields to return. See Find.projection for details.   |
 | upsert        | boolean  | Optional. If true then a document will be created, if one is not found.                                                                                   |
 
 All other fields are ignored.
@@ -2054,7 +2054,7 @@ an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**
@@ -2414,7 +2414,7 @@ The command has the following fields:
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2402-maxscale-2402-nosql-protocol-module.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-rest-api.md
@@ -233,7 +233,7 @@ parameters. Parameters are given in the HTTP query string:`https://localhost:898
   For example, if the object stored in `data[0]` has a value pointed by the
   given JSON pointer and that value compares equal to the given JSON value,
   the array row is kept in the result. Examples for filtering expression can
-  be found [here](mariadb-maxscale-2402-maxscale-2402-rest-api.md#filter-expression-examples).\
+  be found here.\
   A practical use for this parameter is to return only sessions for a
   particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
   be used. Note the double quotes around the `"RW-Split-Router"`, they are

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
@@ -710,7 +710,7 @@ If a client connection modifies the database and `causal_reads` is enabled, any
 subsequent reads performed on replica servers will be done in a manner that
 prevents replication lag from affecting the results.
 
-The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2402-maxscale-2402-readwritesplit.md#implementation-of-causal_reads) for more
+The following table contains a comparison of the modes. Read the implementation of causal\_reads for more
 information on what a sync consists of and why minimizing the number of them is
 important.
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md
@@ -243,7 +243,7 @@ There are two ways to quickly insert an object to the editor:
 
 **Show object creation statement and insights info**
 
-To view the statement that creates the given object in the [Schemas objects sidebar](mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md#schemas-objects-sidebar), right-clicking on schema or table node and
+To view the statement that creates the given object in the Schemas objects sidebar, right-clicking on schema or table node and
 select the `View Insights` option. For other objects such as view, stored
 procedure, function and trigger, select the `Show Create` option.
 
@@ -261,7 +261,7 @@ available options, right-click on the editor to show the context menu.
 
 Every executed query will be saved in the browser's storage (IndexedDB).\
 Query history can be seen in the `History/Snippets` tab.\
-To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2402-maxscale-2402-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)
+To re-execute a query, follow the same step to insert an object into the editor
 and click the execute query button in the editor.
 
 **Create query snippet**

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-filters/mariadb-maxscale-2501-maxscale-2501-cache.md
@@ -1377,7 +1377,7 @@ If no port is provided, then the default port `6379` will be used.
 * Dynamic: No
 * Default: `""`
 
-Please see [authentication](mariadb-maxscale-2501-maxscale-2501-cache.md#authentication) for more information.
+Please see authentication for more information.
 
 **`password`**
 
@@ -1386,7 +1386,7 @@ Please see [authentication](mariadb-maxscale-2501-maxscale-2501-cache.md#authent
 * Dynamic: No
 * Default: `""`
 
-Please see [authentication](mariadb-maxscale-2501-maxscale-2501-cache.md#authentication) for more information.
+Please see authentication for more information.
 
 **`ssl`**
 
@@ -1395,7 +1395,7 @@ Please see [authentication](mariadb-maxscale-2501-maxscale-2501-cache.md#authent
 * Dynamic: No
 * Default: `false`
 
-Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_cert`**
 
@@ -1407,7 +1407,7 @@ Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more in
 The SSL client certificate that MaxScale should use with the Redis
 server. The certificate must match the key defined in `ssl_key`.
 
-Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_key`**
 
@@ -1418,7 +1418,7 @@ Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more in
 
 The SSL client private key MaxScale should use with the Redis server.
 
-Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **`ssl_ca`**
 
@@ -1430,7 +1430,7 @@ Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more in
 The Certificate Authority (CA) certificate for the CA that signed the
 certificate specified with `ssl_cert`.
 
-Please see [ssl](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl-1) for more information.
+Please see ssl for more information.
 
 **Authentication**
 
@@ -1499,7 +1499,7 @@ $ redis-cli flushall
 The data in the redis server is _not_ encrypted. Consequently, _anybody_ with
 access to the redis server has access to the cached data.
 
-Unless [SSL](mariadb-maxscale-2501-maxscale-2501-cache.md#ssl) has been enabled, _anybody_ with access to the network has
+Unless SSL has been enabled, _anybody_ with access to the network has
 access to the cached data.
 
 ### Example

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md
@@ -1435,7 +1435,7 @@ the MaxScale log.
 
 #### `writeq_high_water`
 
-* Type: [size](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#size)
+* Type: size
 * Mandatory: No
 * Dynamic: Yes
 * Default: `65536`
@@ -1458,7 +1458,7 @@ MaxScale 23.02 and earlier, also `writeq_low_water` had to be non-zero.
 
 #### `writeq_low_water`
 
-* Type: [size](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#size)
+* Type: size
 * Mandatory: No
 * Dynamic: Yes
 * Default: `1024`
@@ -3180,7 +3180,7 @@ for more information.
 * Dynamic: Yes
 * Default: None
 
-This setting together with [monitorpasswd](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#monitorpasswd) define server-specific
+This setting together with monitorpasswd define server-specific
 credentials for monitoring the server. Monitors typically use the credentials in their
 own configuration sections to connect to all servers. If server-specific settings are
 given, the monitor uses those instead.
@@ -3594,7 +3594,7 @@ authenticator specific documentation for more details.
 
 #### `sql_mode`
 
-* Type: [enum](mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#enumeration)
+* Type: enum
 * Mandatory: No
 * Dynamic: Yes
 * Values: `default`, `oracle`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md
@@ -15,7 +15,7 @@ the MongoDB® client library and application.
 
 ### Configuring
 
-There are a number of [parameters](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#parameters) with which the behavior
+There are a number of parameters with which the behavior
 of _nosqlprotocol_ can be adjusted. A minimal configuration looks
 like:
 
@@ -303,15 +303,15 @@ require.
 
 | Command                                                                                                   | Role      |
 | --------------------------------------------------------------------------------------------------------- | --------- |
-| [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser)                   | userAdmin |
-| [dropUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#dropUser)                       | userAdmin |
-| [grantRolesToUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#grantRolesToUser)       | userAdmin |
-| [revokeRolesFromUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#revokeRolesFromUser) | userAdmin |
-| [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser)                   | userAdmin |
-| [mxsRemoveUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsRemoveUser)             | userAdmin |
-| [mxsUpdateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsUpdateUser)             | userAdmin |
-| [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#updateUser)                   | userAdmin |
-| [usersInfo](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#usersInfo)                     | userAdmin |
+| createUser                   | userAdmin |
+| dropUser                       | userAdmin |
+| grantRolesToUser       | userAdmin |
+| revokeRolesFromUser | userAdmin |
+| mxsAddUser                   | userAdmin |
+| mxsRemoveUser             | userAdmin |
+| mxsUpdateUser             | userAdmin |
+| updateUser                   | userAdmin |
+| usersInfo                     | userAdmin |
 
 It is important to note that even if nosqlprotocol authorization
 is enabled, the MariaDB server has the final word. That is, even if the
@@ -330,8 +330,8 @@ bootstrapping implicitly is much more convenient.
 **Explicit bootstrapping**
 
 In order to enable authorization you need to have NoSQL users and
-those can be created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) or added
-with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#addUser).
+those can be created with createUser or added
+with mxsAddUser.
 
 If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
@@ -408,7 +408,7 @@ network traffic.
 
 However, when a user is created or added (or the password is changed),
 the password will be transferred in _cleartext_. To prevent eavesdropping,
-create/add users when connecting over a domain socket, or use [TLS/SSL](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#tlsssl)
+create/add users when connecting over a domain socket, or use TLS/SSL
 
 **Implicit bootstrapping**
 
@@ -445,7 +445,7 @@ the `user` and `password` settings and they can be removed.
 
 **Grants**
 
-When a NoSQL user is created using [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser)
+When a NoSQL user is created using createUser
 the MariaDB grants are obtained from the specified NoSQL roles
 as explained [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#roles-and-privileges).
 
@@ -728,8 +728,8 @@ So as to be able to connect to the MariaDB server on behalf of
 clients, nosqlprotocol must know their password. As the password
 is not transferred to nosqlprotocol during the authentication in
 a way that could be used when logging into MariaDB, the password
-must be stored when the user is created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser)
-or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser).
+must be stored when the user is created with createUser
+or added with mxsAddUser.
 
 Note that the password is not stored in cleartext but as three
 different hashes; hashed with sha1 for use with MariaDB, salted
@@ -913,7 +913,7 @@ Specifies whether the client always must authenticate. If authentication is requ
 it does not matter whether `user` and `password` have been specified, the client must
 authenticate.
 
-Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser),
+Authentication should not be required before users have been created with createUser or added with mxsAddUser,
 with authentication being optional and authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -976,8 +976,8 @@ Specifies the _password_ of `authentication_user`.
 * Default: `false`
 
 Specifies whether nosqlprotocol itself should perform authorization in the context
-of the commands [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsUpdateUser). Authorization should not be enabled before users
-have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#mxsAddUser)
+of the commands mxsAddUser, mxsRemoveUser and mxsUpdateUser. Authorization should not be enabled before users
+have been created with createUser or added with mxsAddUser
 with authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -1071,7 +1071,7 @@ Enumeration values:
   the behavior is as in the `default` case.
 
 What combination of `ordered_insert_behavior` and `ordered` (in the insert command
-document) is used, has an impact on the performance. Please see the discussion at [insert](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#insert).
+document) is used, has an impact on the performance. Please see the discussion at insert.
 
 #### `cursor_timeout`
 
@@ -1468,9 +1468,9 @@ The following fields are relevant.
 | query         | document | Optional. The query predicate.                                                                                                                            |
 | sort          | document | Optional. The sort specification used when the document is selected.                                                                                      |
 | remove        | boolean  | Mandatory, if update is not specified. If true, the document will be deleted.                                                                             |
-| update        | document | Mandatory, if remove is not specified. See [Update.behavior](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#behavior) for details.        |
+| update        | document | Mandatory, if remove is not specified. See Update.behavior for details.        |
 | new           | boolean  | Optional. If true the modified document and not the original document is returned. If remove is specified, then the original document is always returned. |
-| fields        | document | Optional. Specified which fields to return. See [Find.projection](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#projection) for details. |
+| fields        | document | Optional. Specified which fields to return. See Find.projection for details. |
 | upsert        | boolean  | Optional. If true then a document will be created, if one is not found.                                                                                   |
 
 All other fields are ignored.
@@ -2095,7 +2095,7 @@ The following document will always be returned:
 **mxsAddUser**
 
 The `mxsAddUser` command adds an _existing_ MariaDB user to the local
-nosqlprotocol account database. Use [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#createUser) if the\
+nosqlprotocol account database. Use createUser if the\
 MariaDB user should be created as well.
 
 Note that the `mxsAddUser` command does not check that the user exists
@@ -2139,7 +2139,7 @@ an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**
@@ -2387,7 +2387,7 @@ collections or not. For example:
 **mxsRemoveUser**
 
 The `mxsRemoveUser` removes a user from the local nosqlprotocol account
-database. Use [dropUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#dropUser) if the MariaDB user should be dropped
+database. Use dropUser if the MariaDB user should be dropped
 as well.
 
 **Syntax**
@@ -2506,7 +2506,7 @@ the session. For example:
 **mxsUpdateUser**
 
 The `mxsUpdateUser` command updates a user in the local nosqlprotocol
-account database. Use [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#updateUser) to update MariaDB user
+account database. Use updateUser to update MariaDB user
 as well.
 
 Note that the `mxsUpdateUser` command does not check that the changed
@@ -2547,7 +2547,7 @@ The command has the following fields:
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**
@@ -2640,9 +2640,9 @@ data from the cache, the less valuable result will be evicted first.
 
 The responses of the following commands are cached.
 
-* [count](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#count)
-* [distinct](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#distinct)
-* [find](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module-1.md#find), provided all found documents can be returned in one response,
+* count
+* distinct
+* find, provided all found documents can be returned in one response,
   i.e., if `singleBatch` is `true` or `batchSize` is large enough.
 
 ### Compatibility

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-protocols/mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md
@@ -15,7 +15,7 @@ the MongoDB® client library and application.
 
 ### Configuring
 
-There are a number of [parameters](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#parameters) with which the behavior
+There are a number of parameters with which the behavior
 of _nosqlprotocol_ can be adjusted. A minimal configuration looks
 like:
 
@@ -303,15 +303,15 @@ require.
 
 | Command                                                                                                 | Role      |
 | ------------------------------------------------------------------------------------------------------- | --------- |
-| [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser)                   | userAdmin |
-| [dropUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#dropUser)                       | userAdmin |
-| [grantRolesToUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#grantRolesToUser)       | userAdmin |
-| [revokeRolesFromUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#revokeRolesFromUser) | userAdmin |
-| [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser)                   | userAdmin |
-| [mxsRemoveUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsRemoveUser)             | userAdmin |
-| [mxsUpdateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsUpdateUser)             | userAdmin |
-| [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#updateUser)                   | userAdmin |
-| [usersInfo](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#usersInfo)                     | userAdmin |
+| createUser                   | userAdmin |
+| dropUser                       | userAdmin |
+| grantRolesToUser       | userAdmin |
+| revokeRolesFromUser | userAdmin |
+| mxsAddUser                   | userAdmin |
+| mxsRemoveUser             | userAdmin |
+| mxsUpdateUser             | userAdmin |
+| updateUser                   | userAdmin |
+| usersInfo                     | userAdmin |
 
 It is important to note that even if nosqlprotocol authorization
 is enabled, the MariaDB server has the final word. That is, even if the
@@ -330,8 +330,8 @@ bootstrapping implicitly is much more convenient.
 **Explicit bootstrapping**
 
 In order to enable authorization you need to have NoSQL users and
-those can be created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) or added
-with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#addUser).
+those can be created with createUser or added
+with mxsAddUser.
 
 If you want to _create_ a user, then you first need to configure
 nosqlprotocol with credentials that are sufficient for creating a user:
@@ -408,7 +408,7 @@ network traffic.
 
 However, when a user is created or added (or the password is changed),
 the password will be transferred in _cleartext_. To prevent eavesdropping,
-create/add users when connecting over a domain socket, or use [TLS/SSL](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#tlsssl)
+create/add users when connecting over a domain socket, or use TLS/SSL
 
 **Implicit bootstrapping**
 
@@ -445,7 +445,7 @@ the `user` and `password` settings and they can be removed.
 
 **Grants**
 
-When a NoSQL user is created using [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser)
+When a NoSQL user is created using createUser
 the MariaDB grants are obtained from the specified NoSQL roles
 as explained [here](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#roles-and-privileges).
 
@@ -728,8 +728,8 @@ So as to be able to connect to the MariaDB server on behalf of
 clients, nosqlprotocol must know their password. As the password
 is not transferred to nosqlprotocol during the authentication in
 a way that could be used when logging into MariaDB, the password
-must be stored when the user is created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser)
-or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser).
+must be stored when the user is created with createUser
+or added with mxsAddUser.
 
 Note that the password is not stored in cleartext but as three
 different hashes; hashed with sha1 for use with MariaDB, salted
@@ -913,7 +913,7 @@ Specifies whether the client always must authenticate. If authentication is requ
 it does not matter whether `user` and `password` have been specified, the client must
 authenticate.
 
-Authentication should not be required before users have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser),
+Authentication should not be required before users have been created with createUser or added with mxsAddUser,
 with authentication being optional and authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -976,8 +976,8 @@ Specifies the _password_ of `authentication_user`.
 * Default: `false`
 
 Specifies whether nosqlprotocol itself should perform authorization in the context
-of the commands [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser), [mxsRemoveUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsRemoveUser) and [mxsUpdateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsUpdateUser). Authorization should not be enabled before users
-have been created with [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) or added with [mxsAddUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#mxsAddUser)
+of the commands mxsAddUser, mxsRemoveUser and mxsUpdateUser. Authorization should not be enabled before users
+have been created with createUser or added with mxsAddUser
 with authorization being disabled.
 
 NOTE: All client activity is _always_ subject to authorization performed by the\
@@ -1071,7 +1071,7 @@ Enumeration values:
   the behavior is as in the `default` case.
 
 What combination of `ordered_insert_behavior` and `ordered` (in the insert command
-document) is used, has an impact on the performance. Please see the discussion at [insert](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#insert).
+document) is used, has an impact on the performance. Please see the discussion at insert.
 
 #### `cursor_timeout`
 
@@ -1468,9 +1468,9 @@ The following fields are relevant.
 | query         | document | Optional. The query predicate.                                                                                                                            |
 | sort          | document | Optional. The sort specification used when the document is selected.                                                                                      |
 | remove        | boolean  | Mandatory, if update is not specified. If true, the document will be deleted.                                                                             |
-| update        | document | Mandatory, if remove is not specified. See [Update.behavior](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#behavior) for details.          |
+| update        | document | Mandatory, if remove is not specified. See Update.behavior for details.          |
 | new           | boolean  | Optional. If true the modified document and not the original document is returned. If remove is specified, then the original document is always returned. |
-| fields        | document | Optional. Specified which fields to return. See [Find.projection](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#projection) for details.   |
+| fields        | document | Optional. Specified which fields to return. See Find.projection for details.   |
 | upsert        | boolean  | Optional. If true then a document will be created, if one is not found.                                                                                   |
 
 All other fields are ignored.
@@ -2095,7 +2095,7 @@ The following document will always be returned:
 **mxsAddUser**
 
 The `mxsAddUser` command adds an _existing_ MariaDB user to the local
-nosqlprotocol account database. Use [createUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#createUser) if the\
+nosqlprotocol account database. Use createUser if the\
 MariaDB user should be created as well.
 
 Note that the `mxsAddUser` command does not check that the user exists
@@ -2139,7 +2139,7 @@ an existing user in the MariaDB server and the value of `pwd` should be
 that user's password in cleartext.
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**
@@ -2387,7 +2387,7 @@ collections or not. For example:
 **mxsRemoveUser**
 
 The `mxsRemoveUser` removes a user from the local nosqlprotocol account
-database. Use [dropUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#dropUser) if the MariaDB user should be dropped
+database. Use dropUser if the MariaDB user should be dropped
 as well.
 
 **Syntax**
@@ -2506,7 +2506,7 @@ the session. For example:
 **mxsUpdateUser**
 
 The `mxsUpdateUser` command updates a user in the local nosqlprotocol
-account database. Use [updateUser](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#updateUser) to update MariaDB user
+account database. Use updateUser to update MariaDB user
 as well.
 
 Note that the `mxsUpdateUser` command does not check that the changed
@@ -2547,7 +2547,7 @@ The command has the following fields:
 | digestPassword | boolean  | Optional. If specified, must be true.                                                                                                                                    |
 
 The `roles` array should contain roles that a compatible with the
-grants of the user. Please check [roles and grants](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#roles_and_grants)
+grants of the user. Please check roles and grants
 for a discussion on how to map roles map to grants.
 
 **Returns**
@@ -2640,9 +2640,9 @@ data from the cache, the less valuable result will be evicted first.
 
 The responses of the following commands are cached.
 
-* [count](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#count)
-* [distinct](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#distinct)
-* [find](mariadb-maxscale-2501-maxscale-2501-nosql-protocol-module.md#find), provided all found documents can be returned in one response,
+* count
+* distinct
+* find, provided all found documents can be returned in one response,
   i.e., if `singleBatch` is `true` or `batchSize` is large enough.
 
 ### Compatibility

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-rest-api.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-rest-api.md
@@ -235,7 +235,7 @@ parameters. Parameters are given in the HTTP query string:`https://localhost:898
   For example, if the object stored in `data[0]` has a value pointed by the
   given JSON pointer and that value compares equal to the given JSON value,
   the array row is kept in the result. Examples for filtering expression can
-  be found [here](mariadb-maxscale-2501-maxscale-2501-rest-api.md#filter-expression-examples).\
+  be found here.\
   A practical use for this parameter is to return only sessions for a
   particular service. For example, to return sessions for the`RW-Split-Router` service, the`filter=/relationships/services/data/0/id="RW-Split-Router"` parameter can
   be used. Note the double quotes around the `"RW-Split-Router"`, they are

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md
@@ -63,13 +63,13 @@ the [output](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-serve
 #### QPS
 
 While running, Diff will also collect QPS information over a sliding
-window whose size is defined by [qps\_period](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#qps_period).
+window whose size is defined by qps\_period.
 
 #### Reporting
 
 Diff produces two kinds of output:
 
-* Output that is generated when Diff terminates or upon [request](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#summary). That output can be visualized as explained [here](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#visualizing).
+* Output that is generated when Diff terminates or upon request. That output can be visualized as explained [here](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#visualizing).
 * [Optionally](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#report) Diff can continuously report queries whose
   responses from _main_ and other _differ_ as described [here](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#discrepancies).
 
@@ -397,7 +397,7 @@ the command line which by default should be.
 In the case of the example above, the directory where the output files
 are created would be `/var/lib/maxscale/diff/MyService`. And the files
 to be used when visualizing would be called something like`MyServer1_2024-05-07_140323.json` and`MariaDB_112_2024-05-07_140323.json`. The timestamp will be different
-every time [summary](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#summary) is executed.
+every time summary is executed.
 
 ```
 maxvisualize MyServer1_2024-05-07_140323.json MariaDB_112_2024-05-07_140323.json
@@ -509,7 +509,7 @@ Specifies the service Diff will modify.
 
 #### `explain`
 
-* Type: [enum](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#enumerations)
+* Type: enum
 * Mandatory: No
 * Dynamic: Yes
 * Values: `none`, `other`, \`both'
@@ -551,7 +551,7 @@ are skipped to bring it back in line with _main_.
 
 #### `on_error`
 
-* Type: [enum](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#enumerations)
+* Type: enum
 * Mandatory: No
 * Dynamic: Yes
 * Values: `close`, `ignore`
@@ -580,12 +580,12 @@ calculating the width and number of bins of the histogram.
 * Default: 15m
 
 Specifies the size of the sliding window during which QPS is calculated
-and stored. When a [summary](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#summary) is requested, the QPS information
+and stored. When a summary is requested, the QPS information
 will also be saved.
 
 #### `report`
 
-* Type: [enum](mariadb-maxscale-2501-maxscale-2501-diff-router-for-comparing-servers.md#enumerations)
+* Type: enum
 * Mandatory: No
 * Dynamic: Yes
 * Values: `always`, `on_discrepancy`, `never`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
@@ -698,7 +698,7 @@ If a client connection modifies the database and `causal_reads` is enabled, any
 subsequent reads performed on replica servers will be done in a manner that
 prevents replication lag from affecting the results.
 
-The following table contains a comparison of the modes. Read the [implementation of causal\_reads](mariadb-maxscale-2501-maxscale-2501-readwritesplit.md#implementation-of-causal_reads) for more
+The following table contains a comparison of the modes. Read the implementation of causal\_reads for more
 information on what a sync consists of and why minimizing the number of them is
 important.
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-tutorials/mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md
@@ -298,7 +298,7 @@ There are two ways to quickly insert an object to the editor:
 
 **Show object creation statement and insights info**
 
-To view the statement that creates the given object in the [Schemas objects sidebar](mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md#schemas-objects-sidebar), right-clicking on schema or table node and
+To view the statement that creates the given object in the Schemas objects sidebar, right-clicking on schema or table node and
 select the `View Insights` option. For other objects such as view, stored
 procedure, function and trigger, select the `Show Create` option.
 
@@ -333,7 +333,7 @@ the `DELIMITER` command to change the delimiter.
 
 Every executed query will be saved in the browser's storage (IndexedDB).\
 Query history can be seen in the `History/Snippets` tab.\
-To re-execute a query, follow the same step to [insert an object into the editor](mariadb-maxscale-2501-maxscale-2501-using-maxgui-tutorial.md#quickly-insert-an-object-into-the-editor)
+To re-execute a query, follow the same step to insert an object into the editor
 and click the execute query button in the editor.
 
 **Create query snippet**

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md
@@ -120,7 +120,7 @@ changed significantly and the primary should be re-selected, although the old
 primary may still be the best choice.
 
 The primary change described above is different from failover and switchover
-described in section [Failover, switchover and auto-rejoin](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failover,-switchover-and-auto-rejoin).\
+described in section Failover, switchover and auto-rejoin.\
 A primary change only modifies the server roles inside MaxScale but does not
 modify the cluster other than changing the targets of read and write queries.\
 Failover and switchover perform a primary change on their own.
@@ -457,15 +457,15 @@ see [general monitor documentation](https://mariadb.com/kb/en/node:maxscale-25-0
 MariaDB Monitor can perform several operations that modify the replication
 topology. The supported operations are:
 
-* [failover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failover), which replaces a failed primary with a replica
-* [failover-safe](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failover-safe), which replaces a failed primary with a replica
+* failover, which replaces a failed primary with a replica
+* failover-safe, which replaces a failed primary with a replica
   only if no data is clearly lost
-* [switchover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#switchover), which swaps a running primary with a replica
-* [switchover-force](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#switchover-force), which swaps a running primary with a replica, ignoring
+* switchover, which swaps a running primary with a replica
+* switchover-force, which swaps a running primary with a replica, ignoring
   most errors. Can break replication.
-* [async-switchover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#queued-switchover), which schedules a switchover and returns
-* [rejoin](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#rejoin), which directs servers to replicate from the primary
-* [reset-replication](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#reset-replication) (added in MaxScale 2.3.0), which deletes binary logs and
+* async-switchover, which schedules a switchover and returns
+* rejoin, which directs servers to replicate from the primary
+* reset-replication (added in MaxScale 2.3.0), which deletes binary logs and
   resets gtid:s
 
 See [operation details](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#operation-details) for more information on the
@@ -927,7 +927,7 @@ primary.
 * Default: `false`
 
 Enable automatic primary failover. `true`, `on`, `yes` and `1` enable normal
-failover. `false`, `off`, `no` and `0` disable the feature. `safe` enables [safe failover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#failover-safe).
+failover. `false`, `off`, `no` and `0` disable the feature. `safe` enables safe failover.
 
 When automatic failover is enabled, MaxScale
 will elect a new primary server for the cluster if the old primary goes down. A
@@ -958,9 +958,9 @@ This effectively enforces a 1-primary-N-replicas topology. The current primary
 itself is not redirected, so it can continue to replicate from an external
 primary. Rejoin is also not performed on any server that is replicating from
 multiple sources, as this indicates a complicated topology (this rule is
-overridden by [enforce\_simple\_topology](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#enforce_simple_topology)).
+overridden by enforce\_simple\_topology).
 
-This feature is often paired with [auto\_failover](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#auto_failover) to redirect
+This feature is often paired with auto\_failover to redirect
 the former primary when it comes back online. Sometimes this kind of rejoin will
 fail as the old primary may have transactions that were never replicated to the
 current one. See [limitations](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#limitations-and-requirements) for more
@@ -1054,7 +1054,7 @@ encrypted with the same key to avoid erroneous decryption.
 * Dynamic: Yes
 * Default: None
 
-See [replication\_user](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#replication_user)
+See replication\_user
 
 **`replication_master_ssl`**
 
@@ -1126,7 +1126,7 @@ even if the duration is longer than a second.
 * Dynamic: Yes
 * Default: `true`
 
-Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and [master\_failure\_timeout](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#master_failure_timeout) defines the timeout.
+Enable additional primary failure verification for automatic failover.`verify_master_failure` enables this feature and master\_failure\_timeout defines the timeout.
 
 The primary failure timeout is specified as documented [here](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md). If no explicit unit
 is provided, the value is interpreted as seconds in MaxScale 2.4. In subsequent
@@ -1230,7 +1230,7 @@ demotion_sql_file=/home/root/scripts/demotion.sql
 * Dynamic: Yes
 * Default: None
 
-See [promotion\_sql\_file](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#promotion_sql_file).
+See promotion\_sql\_file.
 
 **`handle_events`**
 
@@ -1507,9 +1507,9 @@ configure this feature.
 
 If enabled (value > 0s), the monitor will perform a write test on the primary
 server if its gtid\_binlog\_pos has not changed within the configured interval.\
-This test inserts one row to the table configured in [write\_test\_table](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#write_test_table). If the insert fails or does not complete
+This test inserts one row to the table configured in write\_test\_table. If the insert fails or does not complete
 within [backend\_read\_timeout](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md),
-the server fails the write test. What happens after that depends on [write\_test\_fail\_action](mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md#write_test_fail_action).
+the server fails the write test. What happens after that depends on write\_test\_fail\_action.
 
 ```
 write_test_interval=20s


### PR DESCRIPTION
Phase 3a of [DOCS-6497](https://mariadbcorp.atlassian.net/browse/DOCS-6497): the `maxscale-old-versions/` slice — the MaxScale generations retired under DOCS-6435. **693 dead heading anchors → 434**, across 44 files. The largest single slice of the residual bucket, and the one the ticket flagged as needing a policy decision first.

Rebased onto `main` after [#941](https://github.com/mariadb-corporation/mariadb-docs/pull/941) and [#942](https://github.com/mariadb-corporation/mariadb-docs/pull/942) landed, so the baseline here is main's current 693, not the original 830.

## Policy applied

Strip the fragment and keep the link, rather than spending per-link judgement on which section of a retired doc a link once meant.

| | before | after |
| --- | --- | --- |
| cross-page (19) | `[text](other-page.md#dead)` | `[text](other-page.md)` |
| same-page (240) | `[text](this-page.md#dead)` | `text` |

Same-page links are **unlinked** rather than fragment-stripped: stripping would leave a link to the page the reader is already on, which looks broken in a different way, and "keep the link to the right page" is already satisfied when the right page is the current one. 240 of 259 are same-page, so that shape dominates the diff.

## The archive is hermetic

Worth stating because it is what makes an archive-specific policy safe: **every one of these 259 links has both endpoints inside `maxscale-old-versions/`.** There is no archived→live or live→archived dead anchor anywhere in the repo, so this cannot affect a single live page. The applier **asserts** this rather than assuming it, and aborts if a live page ever links into the archive.

## Root cause — these are not typos

The KB had these parameter and command names as **headings**; the GitBook migration demoted them to **bold paragraphs**. On `mariadb-maxscale-2302-mariadb-monitor.md`, `**Failover**` is body text under `#### Operation details`, so `#failover` cannot resolve — and the same goes for `#createUser`, `#mxsAddUser`, `#soft_ttl`, `#ssl-1` and the rest.

Promoting them back would repair the anchors properly, but that is a large content change spread across four retired generations — exactly the investment the archive policy declines. By generation: **25-01 106, 23-02 54, 23.08 54, 24-02 45**.

This also resolves the **4 `#failover` links deferred from phase 1** (they sit on archived pages) and confirms the phase-1 reading of them: the entire cluster-manipulation bullet list was dead, not just one bullet, because the section headings no longer exist.

## Verification

- `fragcheck.py check`: **693 → 434** exactly, with `absent` falling 672 → 413 and the `footnote` class untouched at 21.
- **Independent second count**: the checked-link total also falls by exactly 259 (16,576 → 16,317), since all 259 stop being fragment links.
- `fragcheck.py new origin/main`: clean — *no new dead heading anchors, no stolen heading ids.*
- **Reported-vs-matched equality** on all 259 occurrences before any write, with a negative lookahead on every match.
- **Reader-visible-text proof on every changed line**: collapsing `[label](url)` to `label`, all 248 changed line-pairs are **byte-identical**. Not one character of visible text moved — both transforms preserve exactly what the reader sees.
- `doc-lint.sh` and `codespell` (CI-exact invocation) exit 0 on all 44 files.
- All 259 links were plain Markdown links; the classifier found **0** HTML `href=` or `url=` forms, so no attribute-shaped links were missed.

## Conflict resolution against #941

Three links dropped out of this PR during the rebase, and the reason is worth recording: on the 23-02, 23.08 and 24-02 cache pages, **#941 and this branch had both edited the same line** —

```
- See [Storage](mariadb-maxscale-2302-cache.md#storage-1) for what storage modules are available.   (base)
+ See [Storage](mariadb-maxscale-2302-cache.md#storage)   for what storage modules are available.   (#941: repaired)
+ See Storage for what storage modules are available.                                              (3a: unlinked)
```

**#941's repair wins.** Phase 3a's inventory was computed against pre-#941 main, where `#storage-1` was dead; #941 then repointed it to `#storage`, which is live. A working link beats an unlink, so the archive policy correctly does not apply to a link that someone has since fixed. Only the conflicting line was resolved — every other phase-3a edit in those three files is preserved, which is why the file count stays at 44 while the slice goes 262 → 259.

## What remains on DOCS-6497 after this

**413 absent + 21 footnote.** The 413 are all live→live and are the genuine judgement work, to be split by space. The 21 footnote findings are **not dead links** — GitBook rewrites `#user-content-fn-N` into an annotation at render time and no href survives, so they render as working tooltips. See the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6497]: https://mariadbcorp.atlassian.net/browse/DOCS-6497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
