### PR TITLE
DOCS-6499 Repair 36 dead heading anchors in connector docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ research/
 # Anchored to the repo root so it cannot shadow a documentation page path:
 /dist/
 /pdf/__pycache__/
+/.claude/hooks/__pycache__/

--- a/connectors/mariadb-connector-c/configuring-mariadb-connectorc-with-option-files.md
+++ b/connectors/mariadb-connector-c/configuring-mariadb-connectorc-with-option-files.md
@@ -556,7 +556,7 @@ Unlike most options, `init-command` is a **multi-element** option. Each occurren
 
 **`ssl-passphrase`**
 
-* Description: Specify a passphrase for a passphrase-protected private key, as configured by the [ssl-key](configuring-mariadb-connectorc-with-option-files.md#ssl-key) option.
+* Description: Specify a passphrase for a passphrase-protected private key, as configured by the `ssl-key` option.
   * This option is only supported if the connector was built with OpenSSL or GnuTLS. If the connector was built with Schannel, then this option is not supported. See [TLS and Cryptography Libraries Used by MariaDB](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/tls-and-cryptography-libraries-used-by-mariadb) for more information about which libraries are used on which platforms.
 * mysql\_optionsv: `MARIADB_OPT_TLS_PASSPHRASE`
 * Data Type: `string`

--- a/connectors/mariadb-connector-j/failover-and-high-availability-with-mariadb-connector-j-for-2x-driver.md
+++ b/connectors/mariadb-connector-j/failover-and-high-availability-with-mariadb-connector-j-for-2x-driver.md
@@ -109,9 +109,9 @@ The failure can be multiple fail causes. When a failure occurs, many things will
     The query that was read-only will be relaunched, and the connector will not throw any exception.\
     A "failover" thread will be launched to attempt to reconnect a slave host.\
     (If the query was a prepared query, this query will be re-prepared before execution.)
-  * If the master connection is not active, the driver will attempt to create a new master or slave connection with a [connection loop](failover-and-high-availability-with-mariadb-connector-j-for-2x-driver.md#connection-loop).\
+  * If the master connection is not active, the driver will attempt to create a new master or slave connection with a [connection loop](failover-and-high-availability-with-mariadb-connector-j-for-2x-driver.md#standard-failover).\
     If any connection is found, the query will be relaunched; if not, an SQLException with sqlState like “08XXX” will be thrown.
-* If the failure relates to a master connection, the driver will attempt to create a new master connection with a [connection loop](failover-and-high-availability-with-mariadb-connector-j-for-2x-driver.md#connection-loop), so the connection object will be immediately reusable.\\
+* If the failure relates to a master connection, the driver will attempt to create a new master connection with a [connection loop](failover-and-high-availability-with-mariadb-connector-j-for-2x-driver.md#standard-failover), so the connection object will be immediately reusable.\\
   * On failure, an SQLException with be thrown with SQLState "08XXX". If using a pool, this connection will be discarded.
   * on success,
     * if possible query will be relaunched without throwing error (if was using a slave connection, or was a SELECT query not in a transaction for example).
@@ -180,7 +180,7 @@ jdbc:(mysql|mariadb):[replication:|sequential:|loadbalance:|aurora:]//<hostDescr
 The standard option "connectTimeout" defines the socket connection timeout. By default, this option is set to 30000 ms (30 seconds).
 
 Since there are many servers, setting this option to a small amount of time make sense.\
-During the [connection loop phase](failover-and-high-availability-with-mariadb-connector-j-for-2x-driver.md#connection-loop), the driver will try to connect to the server sequentially until the creation of an active connection.
+During the [connection loop phase](failover-and-high-availability-with-mariadb-connector-j-for-2x-driver.md#standard-failover), the driver will try to connect to the server sequentially until the creation of an active connection.
 
 Set this option to a small value (such as 2000ms - to be set according to your environment) which will permit rejecting a faulty server quickly.
 

--- a/connectors/mariadb-connector-nodejs/connector-nodejs-callback-api.md
+++ b/connectors/mariadb-connector-nodejs/connector-nodejs-callback-api.md
@@ -71,7 +71,7 @@ Previous options `supportBigNumbers` and `bigNumberStrings` still exist for comp
 
 **Other considerations**
 
-MySQL has an experimental syntax permitting the use of `??` characters as a placeholder to escape ID. This isn't implemented in the MariaDB driver, permitting the same query syntax for [Connection.query](connector-nodejs-callback-api.md#connectionquerysql-values---promise) and [Connection.execute](connector-nodejs-callback-api.md#connectionexecutesql-values--promise).
+MySQL has an experimental syntax permitting the use of `??` characters as a placeholder to escape ID. This isn't implemented in the MariaDB driver, permitting the same query syntax for [Connection.query](connector-nodejs-callback-api.md#connection.query-sql-values-callback-greater-than-emitter) and [Connection.execute](connector-nodejs-promise-api.md#connection.execute-sql-values-promise).
 
 Example:
 
@@ -197,7 +197,7 @@ The Connector with the Callback API is similar to the one using Promise, but wit
 
 **Connection:**
 
-* [`connection.query(sql [, values][, callback]) → Emitter`](connector-nodejs-callback-api.md#connectionquerysql-values-callback---emitter): Executes a [query](connector-nodejs-callback-api.md#query).
+* [`connection.query(sql [, values][, callback]) → Emitter`](connector-nodejs-callback-api.md#connection.query-sql-values-callback-greater-than-emitter): Executes a query.
 * [`connection.batch(sql, values [, callback])`](connector-nodejs-callback-api.md#connection.batch-sql-values-callback): fast batch processing.
 * [`connection.beginTransaction([callback])`](connector-nodejs-callback-api.md#connection.begintransaction-callback): Begins a transaction
 * [`connection.commit([callback])`](connector-nodejs-callback-api.md#connection.commit-callback): Commit the current transaction, if any.
@@ -205,7 +205,7 @@ The Connector with the Callback API is similar to the one using Promise, but wit
 * [`connection.changeUser(options [, callback])`](connector-nodejs-callback-api.md#connection.changeuser-options-callback): Changes the current connection user.
 * [`connection.ping([callback])`](connector-nodejs-callback-api.md#connection.ping-callback): Sends an empty packet to the server to check that connection is active.
 * [`connection.end([callback])`](connector-nodejs-callback-api.md#connection.end-callback): Gracefully closes the connection.
-* [`connection.reset([callback])`](connector-nodejs-callback-api.md#connectionreset): reset current connection state.
+* [`connection.reset([callback])`](connector-nodejs-callback-api.md#connection.reset-callback): reset current connection state.
 * [`connection.isValid() → boolean`](connector-nodejs-callback-api.md#connection.isvalid-boolean): Checks that the connection is active without checking socket state.
 * [`connection.destroy()`](connector-nodejs-callback-api.md#connection.destroy): Forces the connection to close.
 * [`connection.escape(value) → String`](connector-nodejs-callback-api.md#connection.escape-value-string): escape parameter
@@ -458,7 +458,7 @@ console.log(mariadb.defaultOptions({ timezone: '+00:00' }));
 > Returns an Emitter object that can emit four different types of event:
 >
 > * error: Emits an [Error](connector-nodejs-callback-api.md#error) object, when query failed.
-> * fields: Emits when column metadata from the result-set are received (parameter is an array of [Metadata fields](connector-nodejs-callback-api.md#metadata-field)).
+> * fields: Emits when column metadata from the result-set are received (parameter is an array of [Metadata fields](connector-nodejs-promise-api.md#connection.query-sql-values-greater-than-promise)).
 > * data: Emits each time a row is received (parameter is a row).
 > * end: Emits when the query ends (no parameter).
 
@@ -772,7 +772,7 @@ escape per type:
 * JSON: Stringification of JSON, or if `permitSetMultiParamEntries` is enable, key escaped as identifier + value
 * String: escaped value, (\u0000, ', ", \b, \n, \r, \t, \u001A, and \ characters are escaped with '')
 
-Escape is done for [sql\_mode](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) value without NO\_BACKSLASH\_ESCAPES that disable \ escaping (default); Escaping API are meant to prevent [SQL injection](https://en.wikipedia.org/wiki/SQL_injection). However, privilege the use of [`connection.query(sql [, values][, callback])`](connector-nodejs-callback-api.md#connectionquerysql-values-callback---emitter) and avoid building the command manually.
+Escape is done for [sql\_mode](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) value without NO\_BACKSLASH\_ESCAPES that disable \ escaping (default); Escaping API are meant to prevent [SQL injection](https://en.wikipedia.org/wiki/SQL_injection). However, privilege the use of [`connection.query(sql [, values][, callback])`](connector-nodejs-callback-api.md#connection.query-sql-values-callback-greater-than-emitter) and avoid building the command manually.
 
 ```javascript
 const myColVar = "let'go";

--- a/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api.md
+++ b/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api.md
@@ -85,7 +85,7 @@ Previous options `supportBigNumbers` and `bigNumberStrings` still exist for comp
 
 **Other considerations**
 
-mysql has an experimental syntax permitting the use of `??` characters as placeholder to escape id. This isn't implemented in the MariaDB driver, permitting the same query syntax for [Connection.query](connector-nodejs-promise-api.md#connectionquerysql-values---promise) and [Connection.execute](connector-nodejs-promise-api.md#connection.execute-sql-values-promise).
+mysql has an experimental syntax permitting the use of `??` characters as placeholder to escape id. This isn't implemented in the MariaDB driver, permitting the same query syntax for [Connection.query](connector-nodejs-promise-api.md#connection.query-sql-values-greater-than-promise) and [Connection.execute](connector-nodejs-promise-api.md#connection.execute-sql-values-promise).
 
 example:
 
@@ -164,7 +164,7 @@ Using 'auto' or setting specific timezone solves timezone correction. Please be 
 
 **IANA timezone / offset**
 
-When using IANA timezone, the connector will set the connection timezone to the timezone. This can throw an error on connection if timezone is unknown by the server (see [mariadb timezone documentation](connector-nodejs-promise-api.md#timezone-consideration), timezone tables might be not initialized) If you are sure the server is using that timezone, this step can be skipped with the option `skipSetTimezone`.
+When using IANA timezone, the connector will set the connection timezone to the timezone. This can throw an error on connection if timezone is unknown by the server (see [mariadb timezone documentation]({server}/reference/data-types/string-data-types/character-sets/internationalization-and-localization/time-zones), timezone tables might be not initialized) If you are sure the server is using that timezone, this step can be skipped with the option `skipSetTimezone`.
 
 If the timezone corresponds to JavaScript default timezone, then no conversion will be done.
 
@@ -261,7 +261,7 @@ By default, the Connector returns `BIGINT` column values (and `insertId`) as Jav
 
 **Connection:**
 
-* [`connection.query(sql [, values]) → Promise`](connector-nodejs-promise-api.md#connectionquerysql-values---promise): Executes a query.
+* [`connection.query(sql [, values]) → Promise`](connector-nodejs-promise-api.md#connection.query-sql-values-greater-than-promise): Executes a query.
 * [`connection.queryStream(sql [, values]) → Emitter`](connector-nodejs-promise-api.md#connection.querystream-sql-values-emitter): Executes a query, returning an emitter object to stream rows.
 * [`connection.prepare(sql) → Promise`](connector-nodejs-promise-api.md#connection.prepare-sql-promise): Prepares a query.
 * [`connection.execute(sql [, values]) → Promise`](connector-nodejs-promise-api.md#connection.execute-sql-values-promise): Prepare and Executes a query.
@@ -312,7 +312,7 @@ By default, the Connector returns `BIGINT` column values (and `insertId`) as Jav
 
 #### `createConnection(options) → Promise`
 
-> * `options`: _JSON/String_ [connection option documentation](connector-nodejs-promise-api.md#connection-options)
+> * `options`: _JSON/String_ [connection option documentation](node-js-connection-options.md)
 >
 > Returns a promise that:
 >
@@ -392,7 +392,7 @@ const conn = await mariadb.createConnection({
 
 #### `createPool(options) → Pool`
 
-> * `options`: _JSON/String_ [pool options](connector-nodejs-promise-api.md#pool-options)
+> * `options`: _JSON/String_ pool options
 >
 > Returns a [Pool](connector-nodejs-promise-api.md#pool-api) object,
 
@@ -419,7 +419,7 @@ try {
 
 **Pool options**
 
-Pool options include [connection option documentation](connector-nodejs-promise-api.md#connection-options) that will be used when creating new connections.
+Pool options include [connection option documentation](node-js-connection-options.md) that will be used when creating new connections.
 
 Specific options for pools are:
 
@@ -438,7 +438,7 @@ Specific options for pools are:
 
 #### `createPoolCluster(options) → PoolCluster`
 
-> * `options`: _JSON_ [poolCluster options](connector-nodejs-promise-api.md#poolCluster-options)
+> * `options`: _JSON_ poolCluster options
 >
 > Returns a [PoolCluster](connector-nodejs-promise-api.md#pool-cluster-api) object,
 
@@ -464,7 +464,7 @@ try {
 
 **PoolCluster options**
 
-Pool cluster options include [pool option documentation](connector-nodejs-promise-api.md#pool-options) that will be used when creating new pools.
+Pool cluster options include [pool option documentation](connector-nodejs-promise-api.md#createpool-options-pool) that will be used when creating new pools.
 
 Specific options for a pool cluster are:
 
@@ -477,7 +477,7 @@ Specific options for a pool cluster are:
 
 #### `importFile(options) → Promise`
 
-> * `options`: _JSON/String_ [connection option documentation](connector-nodejs-promise-api.md#connection-options) + one additional options `file`
+> * `options`: _JSON/String_ [connection option documentation](node-js-connection-options.md) + one additional options `file`
 >
 > Returns a promise that:
 >
@@ -502,7 +502,7 @@ try {
 
 #### `defaultOptions(options) → Json`
 
-> * `options`: _JSON/String_ [connection option documentation](connector-nodejs-promise-api.md#connection-options) (non-mandatory)
+> * `options`: _JSON/String_ [connection option documentation](node-js-connection-options.md) (non-mandatory)
 >
 > Returns a JSON value containing options default value.
 
@@ -562,7 +562,7 @@ When connecting through [MaxScale](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBs
 >
 > Returns a promise that:
 >
-> * resolves with a JSON object for update/insert/delete or a [result-set](connector-nodejs-promise-api.md#result-set-array) object for a result-set.
+> * resolves with a JSON object for update/insert/delete or a result-set object for a result-set.
 > * rejects with an [Error](connector-nodejs-promise-api.md#error).
 
 Sends a query to a database and return a result as a Promise.
@@ -636,7 +636,7 @@ const res = await connection.query('INSERT INTO animals(name) value (?)', ['sea 
 
 When executing a `SELECT` statement, the method returns the result-set as an array of JSON objects. Each object in the array represents a row from the result-set, with column names as property keys.
 
-The result also includes a special non-enumerable `meta` property containing an array of [column metadata](connector-nodejs-promise-api.md#column-metadata) information.
+The result also includes a special non-enumerable `meta` property containing an array of column metadata information.
 
 ```javascript
 const res = await connection.query('select * from animals');
@@ -770,7 +770,7 @@ Whether you want the Connector to retrieve date values as strings, rather than `
 
 _boolean, default: false_
 
-Whether the query should return JavaScript ES2020 [BigInt](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/data-types/numeric-data-types/bigint) for [BIGINT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/data-types/numeric-data-types/bigint) data type. This ensures having the expected value even for value > 2^53 (see [safe](node-js-connection-options.md#big-integer-support) range). This option can be set at query level, overriding the connection-level value.
+Whether the query should return JavaScript ES2020 [BigInt](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/data-types/numeric-data-types/bigint) for [BIGINT](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/data-types/numeric-data-types/bigint) data type. This ensures having the expected value even for value > 2^53 (see [safe](node-js-connection-options.md#essential-options) range). This option can be set at query level, overriding the connection-level value.
 
 this option is for compatibility for driver version < 3
 
@@ -885,7 +885,7 @@ const meta = rows.meta;
 > Returns an Emitter object that emits different types of events:
 >
 > * error: Emits an [`Error`](connector-nodejs-promise-api.md#error) object when the query fails. (No `"end"` event will then be emitted).
-> * fields: Emits when column metadata from the result-set are received (the parameter is an array of [Metadata](connector-nodejs-promise-api.md#metadata-field) fields).
+> * fields: Emits when column metadata from the result-set are received (the parameter is an array of [Metadata](connector-nodejs-promise-api.md#connection.query-sql-values-greater-than-promise) fields).
 > * data: Emits each time a row is received (parameter is a row).
 > * end: Emits when the query ends (no parameter). > a method: close(): permits closing stream (since 3.0)
 
@@ -983,7 +983,7 @@ stream.pipeline(
 >
 > Returns a promise that :
 >
-> * resolves with a [Prepare](connector-nodejs-promise-api.md#prepareobject) object.
+> * resolves with a `Prepare` object.
 > * rejects with an [Error](connector-nodejs-promise-api.md#error).
 
 This permits to [PREPARE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/prepared-statements/prepare-statement) a command that permits to be executed many times. After use, prepare.close() method MUST be call, in order to properly close object.
@@ -1006,7 +1006,7 @@ Public methods :
 >
 > Returns a promise that :
 >
-> * resolves with a JSON object for update/insert/delete or a [result-set](connector-nodejs-promise-api.md#result-set-array) object for a result-set.
+> * resolves with a JSON object for update/insert/delete or a [result-set](connector-nodejs-promise-api.md#connection.query-sql-values-greater-than-promise) object for a result-set.
 > * rejects with an [Error](connector-nodejs-promise-api.md#error).
 
 **`executeStream(values) → Promise`**
@@ -1083,10 +1083,10 @@ prepare.close();
 >
 > Returns a promise that :
 >
-> * resolves with a JSON object for update/insert/delete or a [result-set](connector-nodejs-promise-api.md#result-set-array) object for a result-set.
+> * resolves with a JSON object for update/insert/delete or a [result-set](connector-nodejs-promise-api.md#connection.query-sql-values-greater-than-promise) object for a result-set.
 > * rejects with an [Error](connector-nodejs-promise-api.md#error).
 
-This is quite similar to [`connection.query(sql [, values]) → Promise`](connector-nodejs-promise-api.md#connectionquerysql-values---promise) method, with a few differences: Execute will in fact [PREPARE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/prepared-statements/prepare-statement) + [EXECUTE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/prepared-statements/execute-statement) + [CLOSE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/programmatic-compound-statements/programmatic-compound-statements-cursors/close) command.
+This is quite similar to [`connection.query(sql [, values]) → Promise`](connector-nodejs-promise-api.md#connection.query-sql-values-greater-than-promise) method, with a few differences: Execute will in fact [PREPARE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/prepared-statements/prepare-statement) + [EXECUTE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/prepared-statements/execute-statement) + [CLOSE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/programmatic-compound-statements/programmatic-compound-statements-cursors/close) command.
 
 It makes sense to use this only if the command often is used and if prepare cache is enabled (default). If a PREPARE result is already in cache, only [EXECUTE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/prepared-statements/execute-statement) The command is executed. MariaDB server 10.6 even avoids resending result-set metadata if not changed since, permitting even faster results.
 
@@ -1241,7 +1241,7 @@ try {
 
 #### `connection.changeUser(options) → Promise`
 
-> * `options`: _JSON_, subset of [connection option dod](connector-nodejs-promise-api.md#connection-options)atabase/charset = database/charset / password/user
+> * `options`: _JSON_, subset of [connection option dod](node-js-connection-options.md)atabase/charset = database/charset / password/user
 >
 > Returns a promise that :
 >
@@ -1389,7 +1389,7 @@ escape per type:
 * String: escaped value, (\u0000, ', ", \b, \n, \r, \t, \u001A, and \ characters are escaped with '')
 
 Escape is done for [sql\_mode](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/sql_mode) value without NO\_BACKSLASH\_ESCAPES that disable \ escaping (default);\
-Escaping API are meant to prevent [SQL injection](https://en.wikipedia.org/wiki/SQL_injection). However, privilege the use of [`connection.query(sql [, values]) → Promise`](connector-nodejs-promise-api.md#connectionquerysql-values---promise) and avoid building the command manually.
+Escaping API are meant to prevent [SQL injection](https://en.wikipedia.org/wiki/SQL_injection). However, privilege the use of [`connection.query(sql [, values]) → Promise`](connector-nodejs-promise-api.md#connection.query-sql-values-greater-than-promise) and avoid building the command manually.
 
 ```javascript
 const myColVar = "let'go";
@@ -1690,7 +1690,7 @@ async function transferFunds(fromAccount, toAccount, amount) {
 >
 > Returns a promise that:
 >
-> * resolves with query results (same as [connection.query()](connector-nodejs-promise-api.md#connectionquerysql-values---promise))
+> * resolves with query results (same as [connection.query()](connector-nodejs-promise-api.md#connection.query-sql-values-greater-than-promise))
 > * rejects with an [Error](connector-nodejs-promise-api.md#error)
 
 Executes a query using a connection from the pool. The connection is automatically acquired and released, making this method ideal for simple queries.
@@ -2021,7 +2021,7 @@ When a connection fails, the cluster can automatically retry with another pool m
 
 #### `createPoolCluster(options) → PoolCluster`
 
-> * `options`: _JSON_ [poolCluster options](connector-nodejs-promise-api.md#poolcluster-options)
+> * `options`: _JSON_ [poolCluster options](connector-nodejs-promise-api.md#createpoolcluster-options-poolcluster)
 >
 > Returns a [PoolCluster](connector-nodejs-promise-api.md#pool-cluster-api) object
 
@@ -2065,7 +2065,7 @@ cluster.add('replica2', {
 #### `poolCluster.add(id, config)`
 
 > * `id`: _string_ node identifier. Example: `'primary'`, `'replica1'`
-> * `config`: _JSON_ [pool options](connector-nodejs-promise-api.md#pool-options) to create the pool
+> * `config`: _JSON_ [pool options](connector-nodejs-promise-api.md#createpool-options-pool) to create the pool
 >
 > Returns: void
 

--- a/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api.md
+++ b/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api.md
@@ -164,7 +164,7 @@ Using 'auto' or setting specific timezone solves timezone correction. Please be 
 
 **IANA timezone / offset**
 
-When using IANA timezone, the connector will set the connection timezone to the timezone. This can throw an error on connection if timezone is unknown by the server (see [mariadb timezone documentation]({server}/reference/data-types/string-data-types/character-sets/internationalization-and-localization/time-zones), timezone tables might be not initialized) If you are sure the server is using that timezone, this step can be skipped with the option `skipSetTimezone`.
+When using IANA timezone, the connector will set the connection timezone to the timezone. This can throw an error on connection if timezone is unknown by the server (see [mariadb timezone documentation](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/data-types/string-data-types/character-sets/internationalization-and-localization/time-zones), timezone tables might be not initialized) If you are sure the server is using that timezone, this step can be skipped with the option `skipSetTimezone`.
 
 If the timezone corresponds to JavaScript default timezone, then no conversion will be done.
 

--- a/connectors/mariadb-connector-python/usage.md
+++ b/connectors/mariadb-connector-python/usage.md
@@ -94,7 +94,7 @@ Germany GER Berlin
 Before MariaDB Connector/Python can be used, the MariaDB Connector/Python module must be
 imported.
 Once the mariadb module is loaded, a connection to a database server will be established
-using the method [`connect()`](module.md#mariadb.connect).
+using the method [`connect()`](module.md#connect-args-connectionclass-none-kwargs).
 
 In order to be able to communicate with the database server in the form of SQL statements,
 a cursor object must be created first.

--- a/connectors/other/mariadb-jupyter-kernel/mariadb-juypter-kernel-guide.md
+++ b/connectors/other/mariadb-jupyter-kernel/mariadb-juypter-kernel-guide.md
@@ -28,7 +28,7 @@ If you would love to be able to run SQL against MariaDB data from Jupyter notebo
 
 * [Quick Installation Steps](mariadb-jupyter-kernel-installation.md#quick-installation-steps)
 * [Complete Installation Steps](mariadb-jupyter-kernel-installation.md#complete-installation-steps)
-* [Platforms Coverage](mariadb-jupyter-kernel-installation.md#platforms-coverage)
+* [Platforms Coverage](mariadb-jupyter-kernel-installation.md#platform-coverage)
 
 ### [Configuring the kernel](configuring-the-mariadb-jupyter-kernel.md)
 


### PR DESCRIPTION
The **connectors** slice of [DOCS-6499](https://mariadbcorp.atlassian.net/browse/DOCS-6499) (phase 3b of the dead-anchor campaign). **36 occurrences / 21 decisions / 6 pages**, all live→live.

A `#fragment` whose anchor doesn't exist drops the reader at the *top* of the target page. The link still returns 200, so no CI gate sees it. **Link targets only — no headings added, no prose moved.**

## The finding worth carrying: GitBook publishes anchors for h2–h4 only

`#####` renders as `<p><strong>` with **no `id`**. So promoting a bold block to an h5 heading repairs nothing — it just looks like a heading in source.

Proven two ways: against this PR's own rendered preview, and independently on the **untouched** `tools/mariadb-enterprise-operator/backup-and-restore/pitr.md`, whose three `#####` headings are absent from its live ids while all 18 of its h2–h4 anchors are present.

That makes `.claude/hooks/fragcheck.py` wrong in the optimistic direction — it credits heading levels 2–6, so it reports an h5-derived anchor as resolving when GitBook never publishes one. **Blast radius is nil for the campaign**: the whole tree holds only 3 such headings and no link anywhere targets them, so the 413 baseline stands. Filed separately; noting it here because it is the reason this PR repoints rather than promotes.

## Repairs

| Class | Fix | Occ |
| --- | --- | --- |
| Anchor-form drift | → the current GitBook slug (5× promise, 4× callback) | 9 |
| Bold block, no anchor | → the enclosing h4 that contains the block | 10 |
| Bold block, same section | **unlinked** — the block is in the section already being read | 5 |
| `#connection-options` | → `node-js-connection-options.md`, the dedicated page | 5 |
| `#timezone-consideration` | → the server time-zones docs | 1 |
| `#connection-loop` | → `#standard-failover` (Connector/J) | 3 |
| Misc | Connector/C unlink, Python `connect()`, Jupyter singular/plural | 3 |

Evidence that mattered:

* **Line 88 of the promise page proves the drift target** rather than guessing it — the *same sentence* already carried a live sibling link written in the new form.
* **`#connection-loop` is trap (a) from the ticket's method.** The substring match `#aurora-connection-loop` is wrong: that section is Aurora-specific while this prose is general-driver behaviour, and the real description is an unheaded list item under *Standard failover*.
* **`#connection-options` → the dedicated page** because the promise page's own abbreviated option table ends by pointing exactly there — the page names its own answer.
* **`#timezone-consideration`**: the callback page's twin sentence links straight to the server time-zones docs, so the same-page fragment was simply wrong.
* **The callback page's `#query` is unlinked** because three sibling lines read "Executes a query." with no link — the outlier was the link, not its absence.

## Verification

| Check | Result |
| --- | --- |
| `fragcheck check` — `absent` | **413 → 377**, i.e. −36, exactly the number fixed |
| Connectors findings remaining | **0** |
| `fragcheck new origin/main` | clean — no new dead anchors, no new stolen ids |
| `fragcheck ids` | 0 |
| Fragment-link total | 16,317 → 16,304 — exactly the 13 links that lost a fragment, an *independent* second count |
| Diff invariance | 27/34 line pairs identical once link targets are blanked; the other 7 are the unlinks, 4 byte-identical in visible text |
| `doc-lint.sh` (paths passed) | exit 0 |
| `codespell` (CI-exact) | exit 0 |
| `lychee` (CI-exact args, 400 links) | 0 errors, exit 0 |
| Live rendered HTML | promise page validates **74/74**; every anchor pointed at confirmed present |

Baseline re-measured against current `main` immediately before the final push — the stale-worklist trap that caused phase 3a's rebase conflict.

## Drive-by

`.gitignore` gains `/.claude/hooks/__pycache__/`. The existing rule is path-anchored to `/pdf/`, so running `fragcheck` leaves bytecode that a broad `git add` can commit — which is exactly what happened on this branch's first push.

## Notes for the reviewer

* Every replacement asserted its expected occurrence count **before** a byte was written.
* Two of the ticket's predicted clusters are **already gone**: the MaxScale NoSQL duplicate page pair no longer exists, and `#createUser`/`#mxsAddUser` now return zero findings.
* `tools`' 15 `#volume`/`#issuerreference` occurrences are **not** stale anchors. The CRD generator emits a link for every referenced type but a section only for types it documents, and `Volume`/`IssuerReference` are upstream Kubernetes and cert-manager. That slice is an upstream item, not a repoint.
* Spotted while reading, **not** touched here: the `queryTimeout` row of the promise page's option table links to a retired `maxscale-old-versions` KafkaImporter page — a DOCS-6445-class mistarget, invisible to every linter because it resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6499]: https://mariadbcorp.atlassian.net/browse/DOCS-6499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ